### PR TITLE
The digital-human factory: create and fetch, on the settled two-table shape

### DIFF
--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -98,6 +98,8 @@ describe("the provider's footprint on the schema", () => {
     "account",
     "api_key",
     "device_code",
+    "digital_human",
+    "digital_human_version",
     "invitation",
     "membership",
     "organization",

--- a/packages/db/migrations/0003_digital_humans.sql
+++ b/packages/db/migrations/0003_digital_humans.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "digital_human" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"project_id" text COLLATE "C" NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"current_version_id" text COLLATE "C" NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"created_by" text COLLATE "C",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "digital_human_id_prefix" CHECK ("digital_human"."id" ~ '^dh_[0-9A-HJKMNP-TV-Z]{26}$')
+);
+--> statement-breakpoint
+CREATE TABLE "digital_human_version" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"digital_human_id" text COLLATE "C" NOT NULL,
+	"version" integer NOT NULL,
+	"traits" jsonb NOT NULL,
+	"created_by" text COLLATE "C",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "digital_human_version_digital_human_id_version_unique" UNIQUE("digital_human_id","version"),
+	CONSTRAINT "digital_human_version_id_prefix" CHECK ("digital_human_version"."id" ~ '^dhv_[0-9A-HJKMNP-TV-Z]{26}$')
+);
+--> statement-breakpoint
+ALTER TABLE "digital_human" ADD CONSTRAINT "digital_human_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+-- DEFERRABLE is written here by hand: the schema source cannot express it, and
+-- without it the identity row could never be inserted ahead of the version row
+-- it points at. Carry this clause forward if this constraint is ever recreated.
+ALTER TABLE "digital_human" ADD CONSTRAINT "digital_human_current_version_id_digital_human_version_id_fk" FOREIGN KEY ("current_version_id") REFERENCES "public"."digital_human_version"("id") ON DELETE no action ON UPDATE no action DEFERRABLE INITIALLY DEFERRED;--> statement-breakpoint
+ALTER TABLE "digital_human" ADD CONSTRAINT "digital_human_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "digital_human" ADD CONSTRAINT "digital_human_project_organization_fk" FOREIGN KEY ("project_id","organization_id") REFERENCES "public"."project"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "digital_human_version" ADD CONSTRAINT "digital_human_version_digital_human_id_digital_human_id_fk" FOREIGN KEY ("digital_human_id") REFERENCES "public"."digital_human"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "digital_human_version" ADD CONSTRAINT "digital_human_version_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "digital_human_organization_id_project_id_idx" ON "digital_human" USING btree ("organization_id","project_id") WHERE "digital_human"."deleted_at" is null;

--- a/packages/db/migrations/meta/0003_snapshot.json
+++ b/packages/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1565 @@
+{
+  "id": "df01ff33-9185-490e-b168-82a137f6f7fd",
+  "prevId": "636dc596-f5f3-4822-a5d4-fa7c72ee5b41",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.digital_human": {
+      "name": "digital_human",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "digital_human_organization_id_project_id_idx": {
+          "name": "digital_human_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"digital_human\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_human_organization_id_organization_id_fk": {
+          "name": "digital_human_organization_id_organization_id_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "digital_human_current_version_id_digital_human_version_id_fk": {
+          "name": "digital_human_current_version_id_digital_human_version_id_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "digital_human_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "digital_human_created_by_user_id_fk": {
+          "name": "digital_human_created_by_user_id_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "digital_human_project_organization_fk": {
+          "name": "digital_human_project_organization_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "digital_human_id_prefix": {
+          "name": "digital_human_id_prefix",
+          "value": "\"digital_human\".\"id\" ~ '^dh_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.digital_human_version": {
+      "name": "digital_human_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "digital_human_id": {
+          "name": "digital_human_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "digital_human_version_digital_human_id_digital_human_id_fk": {
+          "name": "digital_human_version_digital_human_id_digital_human_id_fk",
+          "tableFrom": "digital_human_version",
+          "tableTo": "digital_human",
+          "columnsFrom": [
+            "digital_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "digital_human_version_created_by_user_id_fk": {
+          "name": "digital_human_version_created_by_user_id_fk",
+          "tableFrom": "digital_human_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "digital_human_version_digital_human_id_version_unique": {
+          "name": "digital_human_version_digital_human_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "digital_human_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "digital_human_version_id_prefix": {
+          "name": "digital_human_version_id_prefix",
+          "value": "\"digital_human_version\".\"id\" ~ '^dhv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1785615109589,
       "tag": "0002_device_authorization_target",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785680979881,
+      "tag": "0003_digital_humans",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/digital-humans.ts
+++ b/packages/db/src/access/digital-humans.ts
@@ -1,0 +1,195 @@
+import { newId } from "@egma/ids";
+import { and, eq, isNull, type SQL } from "drizzle-orm";
+
+import { db } from "../client.ts";
+import {
+  digitalHuman,
+  digitalHumanVersion,
+} from "../schema/digital-humans.ts";
+import type { AuthContext } from "./context.ts";
+import { ProjectOutsideOrganizationError } from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+import { isProjectOfOrganization } from "./projects.ts";
+import { within } from "./within.ts";
+
+/**
+ * Reading and writing digital humans — what they are is the schema file's
+ * story (`schema/digital-humans.ts`); this file is how they are reached.
+ *
+ * The first project-scoped entity, so the first table where `within` narrows
+ * by the project as well as the organization. A context acting in a project
+ * writes and reads there; a context acting in none — an organization-scoped
+ * credential — reads the whole customer and creates nothing, because a
+ * digital human belongs to a project and a credential for the whole customer
+ * is acting in none.
+ */
+
+/** The mouths egma knows how to ask for. Grows one entry at a time. */
+export const VOICE_PROVIDERS = ["elevenlabs", "cartesia", "openai"] as const;
+export type VoiceProvider = (typeof VOICE_PROVIDERS)[number];
+
+/**
+ * Who the digital human is. The voice is concrete — provider, that provider's
+ * catalog id, and pace — so the same digital human sounds identical on every
+ * future simulation; a described voice would let two runs cast two people.
+ */
+export type DigitalHumanTraits = {
+  readonly personality: string;
+  readonly language: string;
+  readonly voice: {
+    readonly provider: VoiceProvider;
+    readonly voiceId: string;
+    readonly speed: number;
+  };
+};
+
+export type NewDigitalHuman = {
+  readonly name: string;
+  readonly description?: string | undefined;
+  readonly traits: DigitalHumanTraits;
+};
+
+export type DigitalHuman = {
+  readonly id: string;
+  readonly projectId: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly version: number;
+  readonly traits: DigitalHumanTraits;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};
+
+const notDeleted: SQL = isNull(digitalHuman.deletedAt);
+
+/** An answer's columns, and no more — the hash-free, tenant-free view. */
+const COLUMNS = {
+  id: digitalHuman.id,
+  projectId: digitalHuman.projectId,
+  name: digitalHuman.name,
+  description: digitalHuman.description,
+  createdAt: digitalHuman.createdAt,
+  updatedAt: digitalHuman.updatedAt,
+} as const;
+
+/** Speech only stays intelligible so far from natural pace. */
+const SPEED_RANGE = { slowest: 0.5, fastest: 2 } as const;
+
+function validateNewDigitalHuman(input: NewDigitalHuman): void {
+  if (input.name.trim() === "") {
+    throw new Error("a digital human needs a name");
+  }
+  if (input.traits.personality.trim() === "") {
+    throw new Error("a digital human needs a personality");
+  }
+  if (input.traits.language.trim() === "") {
+    throw new Error("a digital human needs a language");
+  }
+  const { provider, voiceId, speed } = input.traits.voice;
+  if (!VOICE_PROVIDERS.includes(provider)) {
+    throw new Error(
+      `"${provider}" is not a voice provider egma knows; expected one of ${VOICE_PROVIDERS.join(", ")}`,
+    );
+  }
+  if (voiceId.trim() === "") {
+    throw new Error("a digital human needs a voice id from its provider");
+  }
+  if (
+    !Number.isFinite(speed) ||
+    speed < SPEED_RANGE.slowest ||
+    speed > SPEED_RANGE.fastest
+  ) {
+    throw new Error(
+      `speaking speed must be between ${SPEED_RANGE.slowest} and ${SPEED_RANGE.fastest}`,
+    );
+  }
+}
+
+export async function createDigitalHuman(
+  auth: AuthContext,
+  input: NewDigitalHuman,
+): Promise<DigitalHuman> {
+  authorize(auth, "author_definitions", here(auth));
+
+  const { projectId } = auth;
+  if (projectId === undefined) {
+    throw new Error(
+      "a digital human belongs to a project, and this credential is for the whole organization and acting in none",
+    );
+  }
+  if (!(await isProjectOfOrganization(auth, projectId))) {
+    throw new ProjectOutsideOrganizationError(auth.organizationId, projectId);
+  }
+
+  validateNewDigitalHuman(input);
+
+  const id = newId("dh");
+  const versionId = newId("dhv");
+
+  const inserted = await db().transaction(async (tx) => {
+    // The identity row goes first, naming a version that does not exist yet;
+    // the pointer's constraint is deferred, so Postgres checks it at commit.
+    const [identity] = await tx
+      .insert(digitalHuman)
+      .values({
+        id,
+        organizationId: auth.organizationId,
+        projectId,
+        name: input.name,
+        description: input.description ?? null,
+        currentVersionId: versionId,
+        createdBy: auth.userId,
+      })
+      .returning(COLUMNS);
+
+    await tx.insert(digitalHumanVersion).values({
+      id: versionId,
+      digitalHumanId: id,
+      version: 1,
+      traits: input.traits,
+      createdBy: auth.userId,
+    });
+
+    return identity;
+  });
+
+  if (inserted === undefined) throw new Error("the digital human was not written");
+
+  return { ...inserted, version: 1, traits: input.traits };
+}
+
+export async function getDigitalHuman(
+  auth: AuthContext,
+  id: string,
+): Promise<DigitalHuman | undefined> {
+  authorize(auth, "read", here(auth));
+
+  // Acting in a project narrows to it; acting in none reads the customer.
+  const inActingProject =
+    auth.projectId === undefined
+      ? undefined
+      : eq(digitalHuman.projectId, auth.projectId);
+
+  const [row] = await db()
+    .select({
+      ...COLUMNS,
+      version: digitalHumanVersion.version,
+      traits: digitalHumanVersion.traits,
+    })
+    .from(digitalHuman)
+    .innerJoin(
+      digitalHumanVersion,
+      eq(digitalHuman.currentVersionId, digitalHumanVersion.id),
+    )
+    .where(
+      within(
+        auth,
+        digitalHuman,
+        and(eq(digitalHuman.id, id), notDeleted, inActingProject),
+      ),
+    )
+    .limit(1);
+
+  if (row === undefined) return undefined;
+  return { ...row, traits: row.traits as DigitalHumanTraits };
+}

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -129,3 +129,13 @@ export {
   type DeviceAuthorization,
   type DeviceAuthorizationTarget,
 } from "./device-authorizations.ts";
+
+export {
+  createDigitalHuman,
+  getDigitalHuman,
+  VOICE_PROVIDERS,
+  type DigitalHuman,
+  type DigitalHumanTraits,
+  type NewDigitalHuman,
+  type VoiceProvider,
+} from "./digital-humans.ts";

--- a/packages/db/src/schema/digital-humans.ts
+++ b/packages/db/src/schema/digital-humans.ts
@@ -1,0 +1,95 @@
+import { sql } from "drizzle-orm";
+import {
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  unique,
+  type AnyPgColumn,
+} from "drizzle-orm/pg-core";
+
+import { organization, project } from "./tenancy.ts";
+import { user } from "./identity.ts";
+import { createdAt, idText, moment, prefixCheck, updatedAt } from "./columns.ts";
+
+/**
+ * A digital human is the person an agent gets tested against: synthetic, and
+ * reusable across any number of tests. These tables hold who they are —
+ * nothing about what they want on a given occasion (the test's business) and
+ * nothing about how the agent under test is reached.
+ *
+ * Two tables so that two different things can be pointed at. A test names the
+ * identity row — this digital human, however they currently behave. A run
+ * pins a version row — this digital human, frozen exactly as they were when
+ * the simulation happened, so editing today never rewrites what an old result
+ * meant. Renames touch the identity row only; behavior lives in the version.
+ */
+
+export const digitalHuman = pgTable(
+  "digital_human",
+  {
+    id: idText("id").primaryKey(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    projectId: idText("project_id").notNull(),
+    name: text("name").notNull(),
+    description: text("description"),
+    /**
+     * Circular with the version table on purpose; the constraint is deferred
+     * so create can insert both rows in one transaction.
+     */
+    currentVersionId: idText("current_version_id")
+      .notNull()
+      .references((): AnyPgColumn => digitalHumanVersion.id),
+    deletedAt: moment("deleted_at"),
+    createdBy: idText("created_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("digital_human_id_prefix", table.id, "dh"),
+    // The pairing, not each column on its own: a digital human cannot name
+    // one organization and another organization's project.
+    foreignKey({
+      name: "digital_human_project_organization_fk",
+      columns: [table.projectId, table.organizationId],
+      foreignColumns: [project.id, project.organizationId],
+    }).onDelete("cascade"),
+    index("digital_human_organization_id_project_id_idx")
+      .on(table.organizationId, table.projectId)
+      .where(sql`${table.deletedAt} is null`),
+  ],
+);
+
+export const digitalHumanVersion = pgTable(
+  "digital_human_version",
+  {
+    id: idText("id").primaryKey(),
+    digitalHumanId: idText("digital_human_id")
+      .notNull()
+      .references(() => digitalHuman.id, { onDelete: "cascade" }),
+    version: integer("version").notNull(),
+    /**
+     * Deliberately jsonb: what a digital human is made of is still settling,
+     * and a field promoted to a column later is a cheap migration. Today:
+     * personality, language, and the concrete voice.
+     */
+    traits: jsonb("traits").notNull(),
+    createdBy: idText("created_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    prefixCheck("digital_human_version_id_prefix", table.id, "dhv"),
+    unique("digital_human_version_digital_human_id_version_unique").on(
+      table.digitalHumanId,
+      table.version,
+    ),
+  ],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -2,3 +2,4 @@ export * from "./columns.ts";
 export * from "./identity.ts";
 export * from "./tenancy.ts";
 export * from "./device.ts";
+export * from "./digital-humans.ts";

--- a/packages/db/src/scripts/digital-human.ts
+++ b/packages/db/src/scripts/digital-human.ts
@@ -1,0 +1,149 @@
+import { parseArgs } from "node:util";
+
+import { newId } from "@egma/ids";
+import { eq } from "drizzle-orm";
+
+import { connect, disconnect, db } from "../client.ts";
+import {
+  createDigitalHuman,
+  getDigitalHuman,
+  VOICE_PROVIDERS,
+  type VoiceProvider,
+} from "../access/digital-humans.ts";
+import type { AuthContext } from "../access/context.ts";
+import { projectsOf } from "../access/projects.ts";
+import { provisionOrganization } from "../access/provisioning.ts";
+import { runMigrations } from "../migrate.ts";
+import { organization, user } from "../schema/index.ts";
+
+/**
+ * Drives the digital-human factory from a terminal, until the real front door
+ * (the API) exists. Signup does not reach a terminal yet either, so the script
+ * keeps one development organization of its own — provisioned through the same
+ * front door signup will use — and acts in it as its admin.
+ *
+ *   node packages/db/dist/scripts/digital-human.js create \
+ *     --name "Impatient Rita" \
+ *     --personality "70, hard of hearing, gets louder when mishears." \
+ *     --voice-id EXAVITQu4vr4xnSDxMaL
+ *
+ *   node packages/db/dist/scripts/digital-human.js get dh_…
+ */
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgres://egma:egma@localhost:5433/egma";
+
+const DEV_SLUG = "factory-dev";
+const DEV_EMAIL = "factory@dev.local";
+
+async function actAsDevelopmentTenant(): Promise<AuthContext> {
+  await db()
+    .insert(user)
+    .values({ id: newId("usr"), email: DEV_EMAIL })
+    .onConflictDoNothing({ target: user.email });
+  const [developer] = await db()
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.email, DEV_EMAIL));
+  if (developer === undefined) throw new Error("the development user vanished");
+
+  const existing = await db()
+    .select({ id: organization.id })
+    .from(organization)
+    .where(eq(organization.slug, DEV_SLUG));
+
+  const provisioned =
+    existing.length > 0
+      ? undefined
+      : await provisionOrganization({
+          ownerUserId: developer.id,
+          organizationName: "Factory dev",
+          organizationSlug: DEV_SLUG,
+          projectName: "Default",
+          projectSlug: "default",
+        });
+
+  const organizationId = existing[0]?.id ?? provisioned?.organizationId;
+  if (organizationId === undefined) throw new Error("no development organization");
+
+  const [firstProject] = await projectsOf(organizationId);
+  if (firstProject === undefined) throw new Error("no development project");
+
+  return {
+    userId: developer.id,
+    organizationId,
+    projectId: firstProject.id,
+    role: "admin",
+    via: "session",
+  };
+}
+
+function usage(): never {
+  console.error(
+    [
+      "usage:",
+      "  digital-human.js create --name <name> --personality <text>",
+      "    [--description <text>] [--language en-US]",
+      `    [--voice-provider ${VOICE_PROVIDERS.join("|")}] [--voice-id <id>] [--speed 1.0]`,
+      "  digital-human.js get <dh_id>",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const [command, ...rest] = process.argv.slice(2);
+
+  await runMigrations(DATABASE_URL);
+  connect({ databaseUrl: DATABASE_URL, maxConnections: 2 });
+
+  const auth = await actAsDevelopmentTenant();
+
+  if (command === "create") {
+    const { values } = parseArgs({
+      args: rest,
+      options: {
+        name: { type: "string" },
+        description: { type: "string" },
+        personality: { type: "string" },
+        language: { type: "string", default: "en-US" },
+        "voice-provider": { type: "string", default: "elevenlabs" },
+        "voice-id": { type: "string", default: "EXAVITQu4vr4xnSDxMaL" },
+        speed: { type: "string", default: "1.0" },
+      },
+    });
+    if (values.name === undefined || values.personality === undefined) usage();
+
+    const created = await createDigitalHuman(auth, {
+      name: values.name,
+      description: values.description,
+      traits: {
+        personality: values.personality,
+        language: values.language,
+        voice: {
+          provider: values["voice-provider"] as VoiceProvider,
+          voiceId: values["voice-id"],
+          speed: Number(values.speed),
+        },
+      },
+    });
+    console.log(JSON.stringify(created, null, 2));
+  } else if (command === "get") {
+    const [id] = rest;
+    if (id === undefined) usage();
+    const found = await getDigitalHuman(auth, id);
+    if (found === undefined) {
+      console.error(`no digital human ${id} in the development project`);
+      process.exit(1);
+    }
+    console.log(JSON.stringify(found, null, 2));
+  } else {
+    usage();
+  }
+}
+
+try {
+  await main();
+} finally {
+  await disconnect();
+}

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -55,9 +55,11 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
 const CONTEXT_REQUIRING = [
   "changeRole",
   "createApiKey",
+  "createDigitalHuman",
   "createInvitation",
   "createProject",
   "deactivateUser",
+  "getDigitalHuman",
   "listApiKeys",
   "listMembers",
   "listPendingInvitations",
@@ -91,6 +93,7 @@ const VALUES = [
   "NotPermittedError",
   "ProjectOutsideOrganizationError",
   "VIA",
+  "VOICE_PROVIDERS",
   "schema",
 ];
 

--- a/packages/db/test/digital-humans.test.ts
+++ b/packages/db/test/digital-humans.test.ts
@@ -1,0 +1,269 @@
+import { isId, newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createDigitalHuman,
+  getDigitalHuman,
+  NotPermittedError,
+  ProjectOutsideOrganizationError,
+  type AuthContext,
+  type Role,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  errorCodeOf,
+  openSingleConnection,
+  POSTGRES_ERROR,
+  type MigratedDatabase,
+} from "./support/database.ts";
+
+/**
+ * The factory functions are the seam: every assertion goes through create and
+ * get, never through table internals. Raw SQL appears only in fixtures (signup
+ * provisioning has its own tests), in row counts proving what a failed create
+ * left behind, and in the one insert that bypasses the module on purpose to
+ * show the database refuses what the module never attempts.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const globex = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+
+function actingAsAcme(role: Role = "member"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+const rita = {
+  name: "Impatient Rita",
+  description: "Elderly regular, books by phone only",
+  traits: {
+    personality:
+      "Rita is 70, hard of hearing, answers questions with stories, and gets louder when the agent mishears her.",
+    language: "en-US",
+    voice: { provider: "elevenlabs", voiceId: "EXAVITQu4vr4xnSDxMaL", speed: 0.9 },
+  },
+} as const;
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("digital_humans");
+
+  for (const tenant of [acme, globex]) {
+    await database.sql(
+      "insert into organization (id, name, slug) values ($1, $2, $2)",
+      [tenant.organization, tenant.organization.slice(-8)],
+    );
+    await database.sql(
+      "insert into project (id, organization_id, name, slug) values ($1, $2, 'Default', 'default')",
+      [tenant.project, tenant.organization],
+    );
+  }
+  await database.sql('insert into "user" (id, email) values ($1, $2)', [
+    ada,
+    "ada@acme.example",
+  ]);
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+async function rowCounts(): Promise<{ humans: number; versions: number }> {
+  const humans = await database.sql<{ count: string }>(
+    "select count(*) as count from digital_human",
+  );
+  const versions = await database.sql<{ count: string }>(
+    "select count(*) as count from digital_human_version",
+  );
+  return {
+    humans: Number(humans.rows[0]?.count),
+    versions: Number(versions.rows[0]?.count),
+  };
+}
+
+describe("creating a digital human", () => {
+  it("returns a dh_ id and fetch round-trips every input", async () => {
+    const created = await createDigitalHuman(actingAsAcme(), rita);
+
+    expect(isId("dh", created.id)).toBe(true);
+
+    const fetched = await getDigitalHuman(actingAsAcme(), created.id);
+    expect(fetched).toBeDefined();
+    expect(fetched?.name).toBe(rita.name);
+    expect(fetched?.description).toBe(rita.description);
+    expect(fetched?.version).toBe(1);
+    expect(fetched?.traits).toEqual(rita.traits);
+    expect(fetched?.projectId).toBe(acme.project);
+  });
+
+  it("is allowed to a member and refused to a viewer, per the permission table", async () => {
+    await expect(
+      createDigitalHuman(actingAsAcme("viewer"), rita),
+    ).rejects.toThrow(NotPermittedError);
+
+    const fetchedByViewer = await createDigitalHuman(actingAsAcme("member"), rita)
+      .then((created) => getDigitalHuman(actingAsAcme("viewer"), created.id));
+    expect(fetchedByViewer?.name).toBe(rita.name);
+  });
+
+  it("is refused to a credential acting in no project", async () => {
+    await expect(
+      createDigitalHuman(
+        { ...actingAsAcme(), projectId: undefined },
+        rita,
+      ),
+    ).rejects.toThrow(/project/);
+  });
+
+  it("cannot commit halfway: an identity row without its version dies at commit", async () => {
+    // The factory writes both rows in one transaction, so a create that fails
+    // between the two inserts leaves nothing. That guarantee is the deferred
+    // pointer constraint, and this proves it where it lives — at commit, in
+    // the database, for a writer that is not the factory.
+    const connection = await openSingleConnection(database.url);
+    try {
+      const orphan = newId("dh");
+      await connection.sql("begin");
+      await connection.sql(
+        `insert into digital_human
+           (id, organization_id, project_id, name, current_version_id)
+         values ($1, $2, $3, 'Halfway', $4)`,
+        [orphan, acme.organization, acme.project, newId("dhv")],
+      );
+
+      await expect(connection.sql("commit")).rejects.toSatisfy(
+        (error) => errorCodeOf(error) === POSTGRES_ERROR.foreignKeyViolation,
+      );
+
+      const { rows } = await database.sql(
+        "select 1 from digital_human where id = $1",
+        [orphan],
+      );
+      expect(rows).toEqual([]);
+    } finally {
+      await connection.close();
+    }
+  });
+});
+
+describe("a credential for the whole organization", () => {
+  it("reads a project's digital humans without acting in the project", async () => {
+    const created = await createDigitalHuman(actingAsAcme(), rita);
+
+    const wholeCustomer = { ...actingAsAcme(), projectId: undefined };
+    const fetched = await getDigitalHuman(wholeCustomer, created.id);
+    expect(fetched?.id).toBe(created.id);
+    expect(fetched?.projectId).toBe(acme.project);
+  });
+});
+
+describe("a digital human that fails validation", () => {
+  it("is refused for a missing name, and no rows are left behind", async () => {
+    const before = await rowCounts();
+
+    await expect(
+      createDigitalHuman(actingAsAcme(), { ...rita, name: "   " }),
+    ).rejects.toThrow(/name/);
+
+    expect(await rowCounts()).toEqual(before);
+  });
+
+  it("is refused for an empty personality", async () => {
+    const before = await rowCounts();
+
+    await expect(
+      createDigitalHuman(actingAsAcme(), {
+        ...rita,
+        traits: { ...rita.traits, personality: "" },
+      }),
+    ).rejects.toThrow(/personality/);
+
+    expect(await rowCounts()).toEqual(before);
+  });
+
+  it("is refused for a voice provider egma does not know", async () => {
+    const before = await rowCounts();
+
+    await expect(
+      createDigitalHuman(actingAsAcme(), {
+        ...rita,
+        traits: {
+          ...rita.traits,
+          voice: { ...rita.traits.voice, provider: "acme-voices" as never },
+        },
+      }),
+    ).rejects.toThrow(/provider/);
+
+    expect(await rowCounts()).toEqual(before);
+  });
+
+  it("is refused for an empty language", async () => {
+    await expect(
+      createDigitalHuman(actingAsAcme(), {
+        ...rita,
+        traits: { ...rita.traits, language: " " },
+      }),
+    ).rejects.toThrow(/language/);
+  });
+
+  it("is refused for a speaking speed outside the intelligible range", async () => {
+    await expect(
+      createDigitalHuman(actingAsAcme(), {
+        ...rita,
+        traits: {
+          ...rita.traits,
+          voice: { ...rita.traits.voice, speed: 5 },
+        },
+      }),
+    ).rejects.toThrow(/speed/);
+  });
+});
+
+describe("tenancy", () => {
+  it("refuses a context pairing one organization with another's project, leaving no rows", async () => {
+    const before = await rowCounts();
+
+    await expect(
+      createDigitalHuman(
+        { ...actingAsAcme(), projectId: globex.project },
+        rita,
+      ),
+    ).rejects.toThrow(ProjectOutsideOrganizationError);
+
+    expect(await rowCounts()).toEqual(before);
+  });
+
+  it("returns nothing when another organization asks for my digital human", async () => {
+    const created = await createDigitalHuman(actingAsAcme(), rita);
+
+    const actingAsGlobex: AuthContext = {
+      userId: newId("usr"),
+      organizationId: globex.organization,
+      projectId: globex.project,
+      role: "member",
+      via: "session",
+    };
+    expect(await getDigitalHuman(actingAsGlobex, created.id)).toBeUndefined();
+  });
+
+  it("refuses the mismatched pairing even for raw SQL that bypasses the module", async () => {
+    await expect(
+      database.sql(
+        `insert into digital_human
+           (id, organization_id, project_id, name, current_version_id)
+         values ($1, $2, $3, 'Smuggled', $4)`,
+        [newId("dh"), acme.organization, globex.project, newId("dhv")],
+      ),
+    ).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.foreignKeyViolation,
+    );
+  });
+});

--- a/packages/db/test/permissions.test.ts
+++ b/packages/db/test/permissions.test.ts
@@ -110,8 +110,6 @@ describe("the action list", () => {
  * exist yet. Never both, and never neither.
  */
 const NOT_YET_REACHABLE: Readonly<Record<string, string>> = {
-  author_definitions:
-    "nothing can write a test, a digital human, a grader or a suite yet",
   configure_agents: "nothing can register an agent or a connection yet",
   start_and_cancel_runs: "nothing can start a run yet",
   delete_run_data: "there is no run data to delete yet",

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -14,7 +14,11 @@ import { createMigratedDatabase, type MigratedDatabase } from "./support/databas
 
 const IDENTIFIER_SQL_TYPE = 'text COLLATE "C"';
 
-/** The identity and tenancy tables. The product and execution tables arrive with their first caller. */
+/**
+ * The tables built so far: identity and tenancy from the control-plane pass,
+ * then each product table as its first caller arrives — digital humans came
+ * with the factory.
+ */
 const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   user: "usr",
   session: "ses",
@@ -27,6 +31,8 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   membership: "mbr",
   invitation: "inv",
   api_key: "key",
+  digital_human: "dh",
+  digital_human_version: "dhv",
 };
 
 const declaredTables = (Object.values(schema) as unknown[])

--- a/packages/db/test/support/database.ts
+++ b/packages/db/test/support/database.ts
@@ -108,11 +108,44 @@ export async function createConnectedDatabase(
   };
 }
 
-/** The Postgres error code a failed constraint arrived as. */
+export type SingleConnection = {
+  /** Raw SQL on one connection, so `begin` and `commit` mean something. */
+  sql<Row extends pg.QueryResultRow = pg.QueryResultRow>(
+    text: string,
+    values?: readonly unknown[],
+  ): Promise<pg.QueryResult<Row>>;
+  close(): Promise<void>;
+};
+
+/**
+ * One connection, held open, for the tests that need a transaction of their
+ * own — a pool routes each statement wherever it likes, which makes `begin`
+ * and `commit` land on different sessions.
+ */
+export async function openSingleConnection(
+  url: string,
+): Promise<SingleConnection> {
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+  return {
+    sql: (text, values) => client.query(text, values as unknown[] | undefined),
+    close: () => client.end(),
+  };
+}
+
+/**
+ * The Postgres error code a failed constraint arrived as. Walks the `cause`
+ * chain, because a query layer may wrap the driver's error in its own.
+ */
 export function errorCodeOf(error: unknown): string | undefined {
-  return typeof error === "object" && error !== null && "code" in error
-    ? String((error as { code: unknown }).code)
-    : undefined;
+  for (
+    let current = error;
+    typeof current === "object" && current !== null;
+    current = (current as { cause?: unknown }).cause
+  ) {
+    if ("code" in current) return String((current as { code: unknown }).code);
+  }
+  return undefined;
 }
 
 export const POSTGRES_ERROR = {


### PR DESCRIPTION
## What this is

Ticket 01 of the digital-humans effort (spec and tickets: egma-planning PR #1). The first product tables — `digital_human` and `digital_human_version` — arrive with their first caller: `createDigitalHuman` and `getDigitalHuman` in the data-access module, plus a terminal script to drive them until the API exists.

## Shape

- **Two tables, the settled versioning pattern.** The identity row is what tests will name ("Rita, however she currently behaves"); the version row is what runs will pin ("Rita frozen as she was"). Creation writes both in one transaction over a `DEFERRABLE INITIALLY DEFERRED` pointer constraint — the deferrable clause is hand-added to the migration SQL (drizzle can't express it) and commented as deliberate.
- **Traits** (`jsonb`, per the settled fog rule): personality paragraph, language, and a concrete voice — provider from a short allowed list, that provider's catalog id, speed — so a digital human is acoustically reproducible across future runs.
- **Tenancy**: both columns NOT NULL plus the composite FK to `project(id, organization_id)`, same three lines as `api_key`. A mismatched pairing is refused by Postgres even for writers that bypass the module (tested).
- **Permissions**: `author_definitions` (member/admin) on create, `read` on get — the first real call sites for `author_definitions`, so its row leaves `NOT_YET_REACHABLE` in the permission test. Viewer-refused/member-allowed is tested.
- **Org-scoped credentials** (context with no project) read the whole customer and create nothing, per `within()`'s documented rule — both tested.

## Deliberate-act lists widened

The three guard-rail enumerations were each updated on purpose: the data-access surface test (+`createDigitalHuman`, `getDigitalHuman`, `VOICE_PROVIDERS`), the provider-footprint table list, and `schema-shape`'s canonical table→prefix map.

## Also in here

- `errorCodeOf` in test support now walks the `cause` chain (drizzle wraps driver errors).
- `openSingleConnection` in test support, for the commit-fails-at-the-deferred-constraint test (the lint rule rightly refused `pg` in a test file).
- Migration is `0003` — `0002` was taken by device-authorization while this was in flight.

## Verification

355/355 tests pass (21 files), typecheck clean, lint rules live. Script proven against a fresh local database: provisions a `factory-dev` organization through `provisionOrganization`, creates Rita, fetches her back.

Out of scope, per the tickets: edit/versioning no-ops (ticket 02), list/clone/delete (ticket 03), and everything simulator-shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)