### PR TITLE
Address two of Greptile's findings on the factory PR

### DIFF
--- a/packages/db/src/access/digital-humans.ts
+++ b/packages/db/src/access/digital-humans.ts
@@ -117,11 +117,14 @@ export async function createDigitalHuman(
       "a digital human belongs to a project, and this credential is for the whole organization and acting in none",
     );
   }
+
+  // Everything answerable without the database is answered first; only an
+  // input worth writing costs the project-membership read below.
+  validateNewDigitalHuman(input);
+
   if (!(await isProjectOfOrganization(auth, projectId))) {
     throw new ProjectOutsideOrganizationError(auth.organizationId, projectId);
   }
-
-  validateNewDigitalHuman(input);
 
   const id = newId("dh");
   const versionId = newId("dhv");

--- a/packages/db/test/support/database.ts
+++ b/packages/db/test/support/database.ts
@@ -135,15 +135,15 @@ export async function openSingleConnection(
 
 /**
  * The Postgres error code a failed constraint arrived as. Walks the `cause`
- * chain, because a query layer may wrap the driver's error in its own.
+ * chain, because a query layer may wrap the driver's error in its own. The
+ * walk is capped, so a circular chain cannot hang the test process.
  */
 export function errorCodeOf(error: unknown): string | undefined {
-  for (
-    let current = error;
-    typeof current === "object" && current !== null;
-    current = (current as { cause?: unknown }).cause
-  ) {
+  let current = error;
+  for (let depth = 0; depth < 10; depth += 1) {
+    if (typeof current !== "object" || current === null) return undefined;
     if ("code" in current) return String((current as { code: unknown }).code);
+    current = (current as { cause?: unknown }).cause;
   }
   return undefined;
 }


### PR DESCRIPTION
Follow-up to #2, addressing [Greptile's review](https://github.com/egma-ai/egma/pull/2#pullrequestreview-4839042873).

- **Validation before the database trip** — `validateNewDigitalHuman` now runs before the `isProjectOfOrganization` read, so an invalid input is refused without touching the database. No behavior change beyond ordering; all existing tests pass unchanged.
- **Depth cap in `errorCodeOf`** — the `cause`-chain walk stops after 10 links, so a circular chain can no longer hang the test process.

**Deliberately not here:** Greptile's third finding (the unchecked `as DigitalHumanTraits` cast on read). Ticket 02 — in progress — adds the version-history read paths, which is where a single parse-on-read guard covers every reader at once. Putting it here would collide with that branch mid-flight. @ ticket-02 author: please pick it up there.

355/355 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)