### PR TITLE
Fix the two standards findings on the versioning branch

### DIFF
--- a/packages/db/src/access/digital-humans.ts
+++ b/packages/db/src/access/digital-humans.ts
@@ -341,10 +341,10 @@ export async function editDigitalHuman(
     if (locked === undefined) return undefined;
     const { currentVersionId, ...current } = locked;
 
-    // The one `where` in this file that starts from a bare `eq` rather than
-    // `within`: the id it names just came off the tenancy-checked row locked
-    // above, in this same transaction, so the predicate cannot reach further
-    // than that check already did.
+    // This select and the update below are the two `where`s in this file that
+    // start from a bare `eq` rather than `within`: each names an id that just
+    // came off the tenancy-checked row locked above, in this same transaction,
+    // so neither predicate can reach further than that check already did.
     const [currentVersion] = await tx
       .select({
         id: digitalHumanVersion.id,
@@ -418,7 +418,7 @@ export async function editDigitalHuman(
  * One frozen version, by its own `dhv_` id — the read a run uses to stay
  * interpretable after the digital human moves on. Deliberately no deleted
  * filter: versions outlive their digital human's deletion, so a run that
- * pinned one can always say exactly who called.
+ * pinned one can always say exactly who the digital human was.
  */
 export async function getDigitalHumanVersion(
   auth: AuthContext,


### PR DESCRIPTION
Targets `feature/digital-humans` (PR #5), not main — it fixes the two hard violations the standards review found on that branch:

1. **Banned vocabulary** — `getDigitalHumanVersion`'s docstring said a pinned run "can always say exactly who *called*". `call`/`caller` are banned in the domain glossary (half of future simulations will be chats); it now reads "who the digital human was".
2. **False uniqueness claim** — the comment marking "the one `where` in this file that starts from a bare `eq`" sat above the first of *two* such clauses (the current-version select and the identity update). It now covers both and explains why both are safe.

Comment-only changes; typecheck clean, all 27 tests on the branch pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)