### PR TITLE
Add sign-out endpoint and UI button

### DIFF
--- a/apps/api/src/auth/better-auth.ts
+++ b/apps/api/src/auth/better-auth.ts
@@ -105,6 +105,76 @@ async function refusalsBecomeAnswers<T>(work: () => Promise<T>): Promise<T> {
 }
 
 /**
+ * The prefix on every cookie the provider sets, as one value rather than as a
+ * string in two places that could drift apart.
+ */
+const COOKIE_PREFIX = "egma";
+
+/** What the provider calls the cookie it carries a session in. */
+const SESSION_COOKIE = `${COOKIE_PREFIX}.session_token`;
+
+/** The same cookie on an instance served over https, which the provider marks. */
+const SECURE_SESSION_COOKIE = `__Secure-${SESSION_COOKIE}`;
+
+/**
+ * What a browser is carrying, in the two strings egma needs in order to end it.
+ */
+export type BrowserSession = {
+  /** The token the session row is keyed on, which is what the seam revokes. */
+  readonly token: string;
+  /** A `set-cookie` line that takes the cookie back out of the browser. */
+  readonly expired: string;
+};
+
+/** Percent-decoding a value a stranger sent, without it being able to throw. */
+function decoded(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * The session a browser request is carrying, or nothing.
+ *
+ * Two of the provider's conventions are needed to read one, and both are known
+ * here and nowhere else: it signs the cookie it sets, so the value is the token
+ * with an HMAC appended after a dot, and it marks the name `__Secure-` when the
+ * instance is served over https. What leaves this file is a token and a header
+ * line — egma's own strings — so the seam still takes a token and the route that
+ * signs somebody out learns nothing about who set the cookie.
+ */
+export function browserSessionIn(request: Request): BrowserSession | null {
+  const header = request.headers.get("cookie");
+  if (header === null) return null;
+
+  for (const pair of header.split(";")) {
+    const at = pair.indexOf("=");
+    if (at === -1) continue;
+
+    const name = pair.slice(0, at).trim();
+    if (name !== SESSION_COOKIE && name !== SECURE_SESSION_COOKIE) continue;
+
+    // The token itself is alphanumeric, so the first dot is where the signature
+    // begins and everything before it is what the row is keyed on.
+    const token = decoded(pair.slice(at + 1).trim()).split(".")[0] ?? "";
+    if (token === "") return null;
+
+    return {
+      token,
+      // The same attributes it was set with, which is what a browser matches on
+      // — and `Secure` is not optional on a `__Secure-` name.
+      expired:
+        `${name}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax` +
+        (name === SECURE_SESSION_COOKIE ? "; Secure" : ""),
+    };
+  }
+
+  return null;
+}
+
+/**
  * What a failed token exchange means, said in egma's four words.
  *
  * RFC 8628 gives the transport six error codes and egma's seam has four
@@ -178,7 +248,7 @@ export function createIdentity(options: IdentityOptions): Identity {
       // The cookie a person can see in their own browser says egma, not the
       // name of the library that happens to set it. A provider swap must not
       // be visible in a cookie name.
-      cookiePrefix: "egma",
+      cookiePrefix: COOKIE_PREFIX,
 
       database: {
         // One generator for every table, egma's and the provider's alike. An

--- a/apps/api/src/routes/sign-out.ts
+++ b/apps/api/src/routes/sign-out.ts
@@ -1,0 +1,44 @@
+import type { FastifyInstance } from "fastify";
+
+import { browserSessionIn } from "../auth/better-auth.ts";
+import type { SessionIdentityProvider } from "../auth/seam.ts";
+import { toWebRequest } from "../http/web-handler.ts";
+
+/**
+ * Stopping being somebody.
+ *
+ * This is the other half of what a browser needs from the seam — `resolveIdentity`
+ * says who this is, `revokeSession` ends it — and it goes through the seam rather
+ * than at the provider's own sign-out endpoint. Relaying is right for signing up
+ * and for the device flow, where the provider owns the mechanics and egma is
+ * adding to them; ending a session is a question egma asks the provider, and the
+ * seam is what egma asks provider questions through.
+ *
+ * The session is destroyed where it is actually kept, so it is over for every
+ * copy of the cookie rather than for the browser that clicked. Expiring the
+ * cookie afterwards is tidiness rather than the mechanism: it names a row that
+ * no longer exists, and would resolve to nobody either way.
+ *
+ * Signing out when nobody is signed in is not a refusal. There is nothing to do
+ * and the thing being asked for is already true, and answering 401 would mean a
+ * person whose session expired in a tab is told they cannot leave.
+ *
+ * Nothing here checks where the request came from, because the cookie already
+ * does: it is `SameSite=Lax`, so a cross-site form post arrives without it and
+ * finds no session to end.
+ */
+export async function signOutRoutes(
+  app: FastifyInstance,
+  options: { readonly provider: SessionIdentityProvider },
+): Promise<void> {
+  app.post("/api/sign-out", async (request, reply) => {
+    const carried = browserSessionIn(toWebRequest(request));
+
+    if (carried !== null) {
+      await options.provider.revokeSession(carried.token);
+      reply.header("set-cookie", carried.expired);
+    }
+
+    return reply.send({ signed_out: true });
+  });
+}

--- a/apps/api/src/routes/signup.ts
+++ b/apps/api/src/routes/signup.ts
@@ -117,6 +117,13 @@ export async function signupRoutes(
               // It came from the origin it is configured for, because that is
               // the only origin egma is served on.
               origin: options.baseUrl,
+              // The provider budgets signups per caller, and this header is
+              // where it looks for who is calling. The address is the one
+              // Fastify already resolved under the proxy setting — never the
+              // caller's own claim, which would let anybody pick their own
+              // budget. Without it, every relayed signup is one anonymous
+              // caller sharing one budget for the whole instance.
+              "x-forwarded-for": request.ip,
             },
             body: JSON.stringify({ email, password, name }),
           }),

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -13,6 +13,7 @@ import { deviceRoutes } from "./routes/device.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { meRoutes } from "./routes/me.ts";
 import { memberRoutes } from "./routes/members.ts";
+import { signOutRoutes } from "./routes/sign-out.ts";
 import { signupRoutes } from "./routes/signup.ts";
 import { fixedWindowRateLimit, type RateLimit } from "./http/rate-limit.ts";
 import { webHandler } from "./http/web-handler.ts";
@@ -114,6 +115,8 @@ export function buildApi(options: ServerOptions): Api {
   });
 
   void app.register(meRoutes, { provider: identity.provider });
+
+  void app.register(signOutRoutes, { provider: identity.provider });
 
   void app.register(deviceRoutes, {
     identity,

--- a/apps/api/test/sign-out.test.ts
+++ b/apps/api/test/sign-out.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { cookiesFrom, createApi, type TestApi } from "./support/api.ts";
+
+/**
+ * Signing out, over HTTP, because that is where the guarantee lives: whatever
+ * the route does internally, the thing being promised is that the cookie a
+ * browser is holding stops being worth anything on the very next request.
+ *
+ * There is a browser test in this directory covering one end-to-end path, and
+ * it is deliberately not grown here. What a browser would add is that a button
+ * exists; what matters is what the button causes, and that is this.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+/** Somebody signed up and signed in, and the cookie their browser now holds. */
+async function signedIn(email: string, organizationName: string): Promise<string> {
+  const created = await api.app.inject({
+    method: "POST",
+    url: "/api/signup",
+    payload: { email, password: "a-long-enough-password", organizationName },
+  });
+  expect(created.statusCode).toBe(201);
+  return cookiesFrom(created.headers["set-cookie"]);
+}
+
+async function whoIsThis(cookie: string | null): Promise<number> {
+  const asked = await api.app.inject({
+    method: "GET",
+    url: "/api/me",
+    ...(cookie === null ? {} : { headers: { cookie } }),
+  });
+  return asked.statusCode;
+}
+
+async function sessionCount(): Promise<number> {
+  const { rows } = await api.database.sql<{ held: string }>(
+    "select count(*)::text as held from session",
+  );
+  return Number(rows[0]?.held ?? "-1");
+}
+
+describe("signing out", () => {
+  it("succeeds for a signed-in browser, and that session then resolves to nobody", async () => {
+    api = await createApi("sign_out_ends_it");
+    const cookie = await signedIn("ada@acme.example", "Acme");
+
+    expect(await whoIsThis(cookie)).toBe(200);
+
+    const out = await api.app.inject({
+      method: "POST",
+      url: "/api/sign-out",
+      headers: { cookie },
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.json()).toEqual({ signed_out: true });
+
+    // The same cookie, unchanged, on the very next request.
+    expect(await whoIsThis(cookie)).toBe(401);
+  });
+
+  /**
+   * Ending it where it is kept rather than only in the browser that clicked, so
+   * a copy of the cookie taken somewhere else is over too.
+   */
+  it("takes the session out of the database rather than leaving a dead one behind", async () => {
+    api = await createApi("sign_out_row");
+    const cookie = await signedIn("ada@acme.example", "Acme");
+    expect(await sessionCount()).toBe(1);
+
+    const out = await api.app.inject({
+      method: "POST",
+      url: "/api/sign-out",
+      headers: { cookie },
+    });
+    expect(out.statusCode).toBe(200);
+
+    expect(await sessionCount()).toBe(0);
+  });
+
+  it("takes the cookie back out of the browser as well", async () => {
+    api = await createApi("sign_out_cookie");
+    const cookie = await signedIn("ada@acme.example", "Acme");
+
+    const out = await api.app.inject({
+      method: "POST",
+      url: "/api/sign-out",
+      headers: { cookie },
+    });
+
+    const cleared = [out.headers["set-cookie"] ?? []].flat();
+    expect(cleared).toHaveLength(1);
+    expect(cleared[0]).toContain("egma.session_token=;");
+    expect(cleared[0]).toContain("Max-Age=0");
+    expect(cleared[0]).toContain("HttpOnly");
+  });
+
+  /**
+   * Nothing to do is not a refusal. A person whose session already went away —
+   * in another tab, or by expiring — is not told they may not leave.
+   */
+  it("is not an error for somebody who was not signed in", async () => {
+    api = await createApi("sign_out_nobody");
+    const cookie = await signedIn("ada@acme.example", "Acme");
+
+    const out = await api.app.inject({ method: "POST", url: "/api/sign-out" });
+    expect(out.statusCode).toBe(200);
+    expect(out.json()).toEqual({ signed_out: true });
+
+    // And nobody else's was ended on the way past.
+    expect(await sessionCount()).toBe(1);
+    expect(await whoIsThis(cookie)).toBe(200);
+  });
+
+  it("ends the session it was sent with, and nobody else's", async () => {
+    api = await createApi("sign_out_only_mine");
+    const ada = await signedIn("ada@acme.example", "Acme");
+    const grace = await signedIn("grace@globex.example", "Globex");
+
+    const out = await api.app.inject({
+      method: "POST",
+      url: "/api/sign-out",
+      headers: { cookie: ada },
+    });
+    expect(out.statusCode).toBe(200);
+
+    expect(await whoIsThis(ada)).toBe(401);
+    expect(await whoIsThis(grace)).toBe(200);
+  });
+
+  /**
+   * A signed cookie that was never signed here names no session, so there is
+   * nothing to end — and in particular no way to end somebody else's by
+   * guessing at the token inside one.
+   */
+  it("ends nothing at all for a cookie that was never signed here", async () => {
+    api = await createApi("sign_out_forged");
+    const cookie = await signedIn("ada@acme.example", "Acme");
+
+    const out = await api.app.inject({
+      method: "POST",
+      url: "/api/sign-out",
+      headers: { cookie: "egma.session_token=not-a-real-token" },
+    });
+    expect(out.statusCode).toBe(200);
+
+    expect(await sessionCount()).toBe(1);
+    expect(await whoIsThis(cookie)).toBe(200);
+  });
+});

--- a/apps/api/test/signup.test.ts
+++ b/apps/api/test/signup.test.ts
@@ -381,6 +381,33 @@ describe("a self-hosted instance", () => {
   });
 });
 
+describe("the caller behind a relayed signup", () => {
+  it("is known to the provider by their own address, not as one shared nobody", async () => {
+    api = await createApi("signup_caller_address");
+
+    const response = await api.app.inject({
+      method: "POST",
+      url: "/api/signup",
+      remoteAddress: "203.0.113.9",
+      payload: {
+        email: "ada@acme.example",
+        password: "a-long-enough-password",
+        organizationName: "Acme",
+      },
+    });
+    expect(response.statusCode).toBe(201);
+
+    // The address on the session the provider issued is the caller's own.
+    // The same resolution feeds the provider's per-caller signup budget, so
+    // an address lost in the relay would mean every signup on the instance
+    // shares one budget — a handful per ten seconds, total.
+    const { rows } = await api.database.sql<{ ip_address: string | null }>(
+      "select ip_address from session",
+    );
+    expect(rows).toEqual([{ ip_address: "203.0.113.9" }]);
+  });
+});
+
 describe("a person with one organization and one project", () => {
   it("is offered nothing to pick between", async () => {
     api = await createApi("signup_cardinality");

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -49,6 +49,22 @@ export default function Home() {
     };
   }, []);
 
+  /**
+   * The one control a signed-in person needs that is not a link. The API ends
+   * the session where it is kept; reloading is what makes this page stop showing
+   * somebody as signed in, and it happens whether or not the call was answered
+   * — a person who clicked sign out is not left looking at their own email
+   * address because the API was unreachable.
+   */
+  async function signOut(): Promise<void> {
+    try {
+      await fetch("/api/sign-out", { method: "POST" });
+    } catch {
+      // Nothing to say. The reload below is the whole of what this page can do.
+    }
+    window.location.assign("/");
+  }
+
   if (state.status === "loading") return <Card title="egma">Loading…</Card>;
 
   if (state.status === "signed-out") {
@@ -81,6 +97,18 @@ export default function Home() {
       )}
 
       <Fact label="Your role" value={organization?.role ?? "—"} />
+
+      <p style={styles.aside}>
+        <button
+          type="button"
+          style={{ fontFamily: "inherit" }}
+          onClick={() => {
+            void signOut();
+          }}
+        >
+          Sign out
+        </button>
+      </p>
 
       <p style={styles.aside}>
         <a href="/members">People</a> — invite a colleague, or change what

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -32,6 +32,7 @@ const config: NextConfig = {
           destination: `${api}/api/signup/:path*`,
         },
         { source: "/api/me", destination: `${api}/api/me` },
+        { source: "/api/sign-out", destination: `${api}/api/sign-out` },
         {
           source: "/api/device/:path*",
           destination: `${api}/api/device/:path*`,

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -258,6 +258,20 @@ describe("the pages", () => {
     expect(members).toContain('fetch("/api/members")');
   });
 
+  /**
+   * Somewhere to click, and a path that reaches the API rather than this
+   * process. Without the rewrite the button would post at Next, which has no
+   * such route, and signing out would 404 while looking like a product bug.
+   */
+  it("give a signed-in person somewhere to sign out, at a path this instance rewrites", async () => {
+    const rewrites = await readFile(path.join(WEB, "next.config.ts"), "utf8");
+    const home = await readFile(path.join(WEB, "app/page.tsx"), "utf8");
+
+    expect(rewrites).toContain("/api/sign-out");
+    expect(home).toContain('fetch("/api/sign-out"');
+    expect(home).toContain("Sign out");
+  });
+
   it("reach the API for the device flow at paths this instance rewrites", async () => {
     const rewrites = await readFile(path.join(WEB, "next.config.ts"), "utf8");
     const approve = await readFile(


### PR DESCRIPTION
## Summary
Implements session sign-out functionality by adding a new `/api/sign-out` endpoint and a corresponding sign-out button in the web UI. The endpoint revokes the session at the database level and clears the session cookie from the browser.

## Key Changes

- **New sign-out route** (`apps/api/src/routes/sign-out.ts`): POST endpoint that extracts the session token from the request cookie, revokes it via the identity provider, and returns an expired cookie header to clear the browser's session token.

- **Session extraction utility** (`apps/auth/better-auth.ts`): Added `browserSessionIn()` function to parse the session token from signed cookies, handling both HTTP and HTTPS cookie variants (`egma.session_token` and `__Secure-egma.session_token`). Extracted cookie prefix as a constant to avoid duplication.

- **Web UI sign-out button** (`apps/web/app/page.tsx`): Added a sign-out button for authenticated users that calls the API endpoint and reloads the page, ensuring the UI reflects the signed-out state regardless of API response.

- **Route registration** (`apps/api/src/server.ts`): Registered the new sign-out route with the Fastify app.

- **Next.js rewrite** (`apps/web/next.config.ts`): Added rewrite rule to forward `/api/sign-out` requests to the API server.

- **Comprehensive test coverage** (`apps/api/test/sign-out.test.ts`): Added 6 test cases covering: successful sign-out, session deletion from database, cookie expiration, unsigned-in requests, isolation between users, and forged cookie handling.

- **Additional test** (`apps/api/test/signup.test.ts`): Added test verifying that caller IP addresses are correctly forwarded to the provider during signup.

- **Signup IP forwarding** (`apps/api/src/routes/signup.ts`): Added `x-forwarded-for` header to relay the caller's IP address to the provider, ensuring signup rate limits are applied per-caller rather than per-instance.

## Implementation Details

- Session revocation happens at the database level (not just cookie expiration), so all copies of a stolen cookie become invalid immediately.
- The endpoint returns 200 for both authenticated and unauthenticated requests, preventing information leakage and avoiding UX issues when sessions expire in other tabs.
- Cookie clearing includes all necessary attributes (`Path`, `Max-Age=0`, `HttpOnly`, `SameSite=Lax`, and `Secure` for HTTPS) to ensure proper browser handling.
- The implementation relies on `SameSite=Lax` cookie protection to prevent CSRF attacks, so no additional CSRF checks are needed.

https://claude.ai/code/session_01JGnKtv3e8Lf7EH4B5LKw3Z