### PR TITLE
The agent factory: agent and connection tables, create and fetch

### DIFF
--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -96,7 +96,9 @@ describe("the provider's footprint on the schema", () => {
   /** Every table egma's own migrations create, and the whole of it. */
   const EGMA_TABLES = [
     "account",
+    "agent",
     "api_key",
+    "connection",
     "device_code",
     "digital_human",
     "digital_human_version",

--- a/packages/db/migrations/0004_agents.sql
+++ b/packages/db/migrations/0004_agents.sql
@@ -1,0 +1,50 @@
+CREATE TABLE "agent" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"project_id" text COLLATE "C" NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"deleted_at" timestamp with time zone,
+	"created_by" text COLLATE "C",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "agent_id_prefix" CHECK ("agent"."id" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$')
+);
+--> statement-breakpoint
+CREATE TABLE "connection" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"project_id" text COLLATE "C" NOT NULL,
+	"agent_id" text COLLATE "C" NOT NULL,
+	"name" text NOT NULL,
+	"type" text NOT NULL,
+	"modality" text NOT NULL,
+	"topology" text NOT NULL,
+	"environment" text,
+	"config" jsonb NOT NULL,
+	"credentials" text,
+	"credentials_hint" text,
+	"capabilities" jsonb,
+	"deleted_at" timestamp with time zone,
+	"created_by" text COLLATE "C",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "connection_id_agent_id_unique" UNIQUE("id","agent_id"),
+	CONSTRAINT "connection_id_prefix" CHECK ("connection"."id" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "connection_type_allowed" CHECK ("connection"."type" in ('retell', 'phone')),
+	CONSTRAINT "connection_modality_allowed" CHECK ("connection"."modality" in ('voice', 'chat')),
+	CONSTRAINT "connection_topology_allowed" CHECK ("connection"."topology" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')),
+	CONSTRAINT "connection_credentials_hint_agrees" CHECK (("connection"."credentials" is null) = ("connection"."credentials_hint" is null))
+);
+--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "agent_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "agent_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "agent_project_organization_fk" FOREIGN KEY ("project_id","organization_id") REFERENCES "public"."project"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connection" ADD CONSTRAINT "connection_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connection" ADD CONSTRAINT "connection_agent_id_agent_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agent"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connection" ADD CONSTRAINT "connection_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connection" ADD CONSTRAINT "connection_project_organization_fk" FOREIGN KEY ("project_id","organization_id") REFERENCES "public"."project"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_project_id_name_unique" ON "agent" USING btree ("project_id","name") WHERE "agent"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "agent_organization_id_project_id_idx" ON "agent" USING btree ("organization_id","project_id") WHERE "agent"."deleted_at" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "connection_agent_id_name_unique" ON "connection" USING btree ("agent_id","name") WHERE "connection"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "connection_agent_id_idx" ON "connection" USING btree ("agent_id") WHERE "connection"."deleted_at" is null;

--- a/packages/db/migrations/0004_agents.sql
+++ b/packages/db/migrations/0004_agents.sql
@@ -8,6 +8,7 @@ CREATE TABLE "agent" (
 	"created_by" text COLLATE "C",
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "agent_id_project_id_unique" UNIQUE("id","project_id"),
 	CONSTRAINT "agent_id_prefix" CHECK ("agent"."id" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$')
 );
 --> statement-breakpoint
@@ -44,6 +45,7 @@ ALTER TABLE "connection" ADD CONSTRAINT "connection_organization_id_organization
 ALTER TABLE "connection" ADD CONSTRAINT "connection_agent_id_agent_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agent"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "connection" ADD CONSTRAINT "connection_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "connection" ADD CONSTRAINT "connection_project_organization_fk" FOREIGN KEY ("project_id","organization_id") REFERENCES "public"."project"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connection" ADD CONSTRAINT "connection_agent_project_fk" FOREIGN KEY ("agent_id","project_id") REFERENCES "public"."agent"("id","project_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "agent_project_id_name_unique" ON "agent" USING btree ("project_id","name") WHERE "agent"."deleted_at" is null;--> statement-breakpoint
 CREATE INDEX "agent_organization_id_project_id_idx" ON "agent" USING btree ("organization_id","project_id") WHERE "agent"."deleted_at" is null;--> statement-breakpoint
 CREATE UNIQUE INDEX "connection_agent_id_name_unique" ON "connection" USING btree ("agent_id","name") WHERE "connection"."deleted_at" is null;--> statement-breakpoint

--- a/packages/db/migrations/meta/0004_snapshot.json
+++ b/packages/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1967 @@
+{
+  "id": "fcda3c65-8152-49f8-a1f6-562f08c0f892",
+  "prevId": "df01ff33-9185-490e-b168-82a137f6f7fd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.digital_human": {
+      "name": "digital_human",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "digital_human_organization_id_project_id_idx": {
+          "name": "digital_human_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"digital_human\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_human_organization_id_organization_id_fk": {
+          "name": "digital_human_organization_id_organization_id_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "digital_human_current_version_id_digital_human_version_id_fk": {
+          "name": "digital_human_current_version_id_digital_human_version_id_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "digital_human_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "digital_human_created_by_user_id_fk": {
+          "name": "digital_human_created_by_user_id_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "digital_human_project_organization_fk": {
+          "name": "digital_human_project_organization_fk",
+          "tableFrom": "digital_human",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "digital_human_id_prefix": {
+          "name": "digital_human_id_prefix",
+          "value": "\"digital_human\".\"id\" ~ '^dh_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.digital_human_version": {
+      "name": "digital_human_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "digital_human_id": {
+          "name": "digital_human_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "digital_human_version_digital_human_id_digital_human_id_fk": {
+          "name": "digital_human_version_digital_human_id_digital_human_id_fk",
+          "tableFrom": "digital_human_version",
+          "tableTo": "digital_human",
+          "columnsFrom": [
+            "digital_human_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "digital_human_version_created_by_user_id_fk": {
+          "name": "digital_human_version_created_by_user_id_fk",
+          "tableFrom": "digital_human_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "digital_human_version_digital_human_id_version_unique": {
+          "name": "digital_human_version_digital_human_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "digital_human_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "digital_human_version_id_prefix": {
+          "name": "digital_human_version_id_prefix",
+          "value": "\"digital_human_version\".\"id\" ~ '^dhv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0004_snapshot.json
+++ b/packages/db/migrations/meta/0004_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "fcda3c65-8152-49f8-a1f6-562f08c0f892",
+  "id": "36454b5d-c2c4-4cd2-9bd7-fe40c6f83b03",
   "prevId": "df01ff33-9185-490e-b168-82a137f6f7fd",
   "version": "7",
   "dialect": "postgresql",
@@ -1701,7 +1701,16 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {
         "agent_id_prefix": {
@@ -1911,6 +1920,21 @@
           "columnsTo": [
             "id",
             "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
           ],
           "onDelete": "cascade",
           "onUpdate": "no action"

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -33,7 +33,7 @@
     {
       "idx": 4,
       "version": "7",
-      "when": 1785813513919,
+      "when": 1785816408700,
       "tag": "0004_agents",
       "breakpoints": true
     }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1785680979881,
       "tag": "0003_digital_humans",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1785813513919,
+      "tag": "0004_agents",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -51,10 +51,16 @@ const COLUMNS = {
   updatedAt: agent.updatedAt,
 } as const;
 
-function validateName(name: string): void {
-  if (name.trim() === "") {
+/**
+ * The name as it will be stored: trimmed, because a handle that participates
+ * in a uniqueness check must not get around it on invisible characters.
+ */
+function validName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed === "") {
     throw new Error("an agent needs a name");
   }
+  return trimmed;
 }
 
 /**
@@ -108,7 +114,7 @@ export async function createAgent(
 
   // Everything answerable without the database is answered first; only an
   // input worth writing costs the project-membership read below.
-  validateName(input.name);
+  const name = validName(input.name);
 
   if (!(await isProjectOfOrganization(auth, projectId))) {
     throw new ProjectOutsideOrganizationError(auth.organizationId, projectId);
@@ -120,7 +126,7 @@ export async function createAgent(
       id: newId("agt"),
       organizationId: auth.organizationId,
       projectId,
-      name: input.name,
+      name,
       description: input.description ?? null,
       createdBy: auth.userId,
     })
@@ -128,7 +134,7 @@ export async function createAgent(
     .catch((error: unknown) => {
       if (nameAlreadyAlive(error)) {
         throw new Error(
-          `an agent named "${input.name}" already exists in this project`,
+          `an agent named "${name}" already exists in this project`,
         );
       }
       throw error;

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -1,0 +1,153 @@
+import { newId } from "@egma/ids";
+import { and, eq, isNull, type SQL } from "drizzle-orm";
+
+import { db } from "../client.ts";
+import { agent } from "../schema/agents.ts";
+import type { AuthContext } from "./context.ts";
+import { ProjectOutsideOrganizationError } from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+import { isProjectOfOrganization } from "./projects.ts";
+import { within } from "./within.ts";
+
+/**
+ * Reading and writing agents — what an agent is is the schema file's story
+ * (`schema/agents.ts`); this file is how one is reached.
+ *
+ * The agent is the aggregate root of the factory: when the connection verbs
+ * arrive they will live here too, every one of them taking the agent's id,
+ * because a connection is how you reach an agent and there is no path to one
+ * that doesn't name its agent first.
+ *
+ * Project scoping works as the digital-human factory's does. A context acting
+ * in a project writes and reads there; a context acting in none — an
+ * organization-scoped credential — reads the whole customer and creates
+ * nothing, because an agent belongs to a project and a credential for the
+ * whole customer is acting in none.
+ */
+
+export type NewAgent = {
+  readonly name: string;
+  readonly description?: string | undefined;
+};
+
+export type Agent = {
+  readonly id: string;
+  readonly projectId: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};
+
+const notDeleted: SQL = isNull(agent.deletedAt);
+
+/** An answer's columns, and no more — the tenant-free view. */
+const COLUMNS = {
+  id: agent.id,
+  projectId: agent.projectId,
+  name: agent.name,
+  description: agent.description,
+  createdAt: agent.createdAt,
+  updatedAt: agent.updatedAt,
+} as const;
+
+function validateName(name: string): void {
+  if (name.trim() === "") {
+    throw new Error("an agent needs a name");
+  }
+}
+
+/**
+ * Whether this write lost to a live agent already holding the name. Read from
+ * the constraint's own name, walking the `cause` chain because the query layer
+ * may hand the driver's error back wrapped — recognising it by message
+ * substring would break silently the day the text changed.
+ */
+function nameAlreadyAlive(error: unknown): boolean {
+  for (
+    let at: unknown = error, depth = 0;
+    at !== undefined && at !== null && depth < 4;
+    depth += 1
+  ) {
+    if (typeof at !== "object") break;
+    const carrier = at as { constraint?: unknown; cause?: unknown };
+    if (carrier.constraint === "agent_project_id_name_unique") return true;
+    at = carrier.cause;
+  }
+  return false;
+}
+
+/** Acting in a project narrows to it; acting in none reaches the customer. */
+function inActingProject(auth: AuthContext): SQL | undefined {
+  return auth.projectId === undefined
+    ? undefined
+    : eq(agent.projectId, auth.projectId);
+}
+
+/** The named agent, alive, within the caller's tenancy and scope. */
+function theAgent(auth: AuthContext, id: string): SQL {
+  return within(
+    auth,
+    agent,
+    and(eq(agent.id, id), notDeleted, inActingProject(auth)),
+  );
+}
+
+export async function createAgent(
+  auth: AuthContext,
+  input: NewAgent,
+): Promise<Agent> {
+  authorize(auth, "configure_agents", here(auth));
+
+  const { projectId } = auth;
+  if (projectId === undefined) {
+    throw new Error(
+      "an agent belongs to a project, and this credential is for the whole organization and acting in none",
+    );
+  }
+
+  // Everything answerable without the database is answered first; only an
+  // input worth writing costs the project-membership read below.
+  validateName(input.name);
+
+  if (!(await isProjectOfOrganization(auth, projectId))) {
+    throw new ProjectOutsideOrganizationError(auth.organizationId, projectId);
+  }
+
+  const [inserted] = await db()
+    .insert(agent)
+    .values({
+      id: newId("agt"),
+      organizationId: auth.organizationId,
+      projectId,
+      name: input.name,
+      description: input.description ?? null,
+      createdBy: auth.userId,
+    })
+    .returning(COLUMNS)
+    .catch((error: unknown) => {
+      if (nameAlreadyAlive(error)) {
+        throw new Error(
+          `an agent named "${input.name}" already exists in this project`,
+        );
+      }
+      throw error;
+    });
+
+  if (inserted === undefined) throw new Error("the agent was not written");
+  return inserted;
+}
+
+export async function getAgent(
+  auth: AuthContext,
+  id: string,
+): Promise<Agent | undefined> {
+  authorize(auth, "read", here(auth));
+
+  const [row] = await db()
+    .select(COLUMNS)
+    .from(agent)
+    .where(theAgent(auth, id))
+    .limit(1);
+  return row;
+}

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -131,6 +131,13 @@ export {
 } from "./device-authorizations.ts";
 
 export {
+  createAgent,
+  getAgent,
+  type Agent,
+  type NewAgent,
+} from "./agents.ts";
+
+export {
   cloneDigitalHuman,
   createDigitalHuman,
   deleteDigitalHuman,

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -86,6 +86,9 @@ export const agent = pgTable(
       columns: [table.projectId, table.organizationId],
       foreignColumns: [project.id, project.organizationId],
     }).onDelete("cascade"),
+    // Looks redundant next to the primary key; it is the composite-foreign-key
+    // target that makes an agent/connection project mismatch unrepresentable.
+    unique("agent_id_project_id_unique").on(table.id, table.projectId),
     // Partial, so a deleted agent releases its name to the living.
     uniqueIndex("agent_project_id_name_unique")
       .on(table.projectId, table.name)
@@ -148,6 +151,15 @@ export const connection = pgTable(
       name: "connection_project_organization_fk",
       columns: [table.projectId, table.organizationId],
       foreignColumns: [project.id, project.organizationId],
+    }).onDelete("cascade"),
+    // The pairing again, one level down: a connection cannot name one project
+    // and another project's agent. With both rows' own project/organization
+    // pairs already pinned above, matching the agent's project is what makes
+    // the whole tenancy triangle agree.
+    foreignKey({
+      name: "connection_agent_project_fk",
+      columns: [table.agentId, table.projectId],
+      foreignColumns: [agent.id, agent.projectId],
     }).onDelete("cascade"),
     // Inert today; the composite-FK target that lets the future run table
     // prove its (agent_id, connection_id) actually pair.

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -121,7 +121,7 @@ export const connection = pgTable(
      * one opener is the access layer's credential resolver.
      */
     credentials: text("credentials"),
-    /** The last characters of the secret, kept so a human can tell keys apart. */
+    /** The last characters of the secret, kept so a person can tell keys apart. */
     credentialsHint: text("credentials_hint"),
     /**
      * What this specific target turned out to support — discovered by the

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -49,7 +49,7 @@ export const MODALITIES = ["voice", "chat"] as const;
 export type Modality = (typeof MODALITIES)[number];
 
 /**
- * Who moves first when a conversation starts. Derived from the type by the
+ * Who moves first when a simulation starts. Derived from the type by the
  * access layer, never supplied by a caller — it predicts whether an agent on a
  * laptop is reachable, and a caller's guess would just be wrong.
  */

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -1,0 +1,163 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  unique,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+
+import { organization, project } from "./tenancy.ts";
+import { user } from "./identity.ts";
+import {
+  createdAt,
+  idText,
+  moment,
+  oneOf,
+  prefixCheck,
+  updatedAt,
+} from "./columns.ts";
+
+/**
+ * The agent is the customer's voice agent — the thing egma is establishing
+ * trust in, and the identity every test result accumulates against. A
+ * connection is how egma reaches one: the same logical agent might be a Retell
+ * chat endpoint in CI, a Retell web call in staging, and a phone number in
+ * production, and its history must stay under one identity through all of
+ * them. So the platform lives entirely on the connection and never on the
+ * agent — a team that migrates frameworks keeps their agent and its record.
+ *
+ * Deliberately unversioned, both tables. egma versions what egma authors, and
+ * an agent's real content — prompt, model, tools — lives on the provider's
+ * side or in the customer's own repo, where egma cannot freeze it. The table
+ * is shaped so an `agent_version` pair can arrive later (the digital-human
+ * pattern) without touching anything that references `agent`.
+ */
+
+/** The ways egma can reach an agent today. Grows one adapter at a time. */
+export const CONNECTION_TYPES = ["retell", "phone"] as const;
+export type ConnectionType = (typeof CONNECTION_TYPES)[number];
+
+/**
+ * Which layer is under test: chat exercises the harness (prompt, reasoning,
+ * tools); voice exercises the harness plus the speech stack.
+ */
+export const MODALITIES = ["voice", "chat"] as const;
+export type Modality = (typeof MODALITIES)[number];
+
+/**
+ * Who moves first when a conversation starts. Derived from the type by the
+ * access layer, never supplied by a caller — it predicts whether an agent on a
+ * laptop is reachable, and a caller's guess would just be wrong.
+ */
+export const TOPOLOGIES = [
+  "agent-dials-out",
+  "hosted-broker",
+  "egma-dials-in",
+] as const;
+export type Topology = (typeof TOPOLOGIES)[number];
+
+export const agent = pgTable(
+  "agent",
+  {
+    id: idText("id").primaryKey(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    projectId: idText("project_id").notNull(),
+    name: text("name").notNull(),
+    description: text("description"),
+    deletedAt: moment("deleted_at"),
+    createdBy: idText("created_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("agent_id_prefix", table.id, "agt"),
+    // The pairing, not each column on its own: an agent cannot name one
+    // organization and another organization's project.
+    foreignKey({
+      name: "agent_project_organization_fk",
+      columns: [table.projectId, table.organizationId],
+      foreignColumns: [project.id, project.organizationId],
+    }).onDelete("cascade"),
+    // Partial, so a deleted agent releases its name to the living.
+    uniqueIndex("agent_project_id_name_unique")
+      .on(table.projectId, table.name)
+      .where(sql`${table.deletedAt} is null`),
+    index("agent_organization_id_project_id_idx")
+      .on(table.organizationId, table.projectId)
+      .where(sql`${table.deletedAt} is null`),
+  ],
+);
+
+export const connection = pgTable(
+  "connection",
+  {
+    id: idText("id").primaryKey(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    projectId: idText("project_id").notNull(),
+    agentId: idText("agent_id")
+      .notNull()
+      .references(() => agent.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    type: text("type").notNull(),
+    modality: text("modality").notNull(),
+    topology: text("topology").notNull(),
+    /** A label (`staging`, `production`), never a level in the hierarchy. */
+    environment: text("environment"),
+    /** Non-secret, validated per type at the door: what to reach, never how to prove. */
+    config: jsonb("config").notNull(),
+    /**
+     * The sealed envelope (`v1.<iv>.<ciphertext>.<tag>`), or null for types
+     * where the customer supplies no secret. Never selected by any read; the
+     * one opener is the access layer's credential resolver.
+     */
+    credentials: text("credentials"),
+    /** The last characters of the secret, kept so a human can tell keys apart. */
+    credentialsHint: text("credentials_hint"),
+    /**
+     * What this specific target turned out to support — discovered by the
+     * runtime, never declared by a caller. Null until discovery exists.
+     */
+    capabilities: jsonb("capabilities"),
+    deletedAt: moment("deleted_at"),
+    createdBy: idText("created_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("connection_id_prefix", table.id, "con"),
+    oneOf("connection_type_allowed", table.type, [...CONNECTION_TYPES]),
+    oneOf("connection_modality_allowed", table.modality, [...MODALITIES]),
+    oneOf("connection_topology_allowed", table.topology, [...TOPOLOGIES]),
+    check(
+      "connection_credentials_hint_agrees",
+      sql`(${table.credentials} is null) = (${table.credentialsHint} is null)`,
+    ),
+    foreignKey({
+      name: "connection_project_organization_fk",
+      columns: [table.projectId, table.organizationId],
+      foreignColumns: [project.id, project.organizationId],
+    }).onDelete("cascade"),
+    // Inert today; the composite-FK target that lets the future run table
+    // prove its (agent_id, connection_id) actually pair.
+    unique("connection_id_agent_id_unique").on(table.id, table.agentId),
+    // Partial, so a removed connection releases its name.
+    uniqueIndex("connection_agent_id_name_unique")
+      .on(table.agentId, table.name)
+      .where(sql`${table.deletedAt} is null`),
+    index("connection_agent_id_idx")
+      .on(table.agentId)
+      .where(sql`${table.deletedAt} is null`),
+  ],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -3,3 +3,4 @@ export * from "./identity.ts";
 export * from "./tenancy.ts";
 export * from "./device.ts";
 export * from "./digital-humans.ts";
+export * from "./agents.ts";

--- a/packages/db/test/agents.test.ts
+++ b/packages/db/test/agents.test.ts
@@ -231,6 +231,58 @@ describe("the database itself", () => {
     );
   });
 
+  it("rejects a connection row whose credentials and hint disagree", async () => {
+    const sealed = await createAgent(actingAsAcme(), { name: "Sealed" });
+
+    const halfSealed = (credentials: string | null, hint: string | null) =>
+      database.sql(
+        `insert into connection
+           (id, organization_id, project_id, agent_id, name, type, modality, topology, config, credentials, credentials_hint)
+         values ($1, $2, $3, $4, $5, 'retell', 'chat', 'hosted-broker', '{}', $6, $7)`,
+        [
+          newId("con"),
+          acme.organization,
+          acme.project,
+          sealed.id,
+          credentials === null ? "hint-alone" : "envelope-alone",
+          credentials,
+          hint,
+        ],
+      );
+
+    await expect(halfSealed("v1.iv.ciphertext.tag", null)).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.checkViolation,
+    );
+    await expect(halfSealed(null, "wxyz")).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.checkViolation,
+    );
+  });
+
+  it("refuses a second live connection holding a name, and a removed one releases it", async () => {
+    const wired = await createAgent(actingAsAcme(), { name: "Wired" });
+
+    const staging = (id: string) =>
+      database.sql(
+        `insert into connection
+           (id, organization_id, project_id, agent_id, name, type, modality, topology, config)
+         values ($1, $2, $3, $4, 'staging', 'retell', 'chat', 'hosted-broker', '{}')`,
+        [id, acme.organization, acme.project, wired.id],
+      );
+
+    const first = newId("con");
+    await staging(first);
+
+    await expect(staging(newId("con"))).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.uniqueViolation,
+    );
+
+    await database.sql(
+      "update connection set deleted_at = now() where id = $1",
+      [first],
+    );
+    await expect(staging(newId("con"))).resolves.toBeDefined();
+  });
+
   it("carries UNIQUE (id, agent_id) on connection — the future run table's composite-FK target", async () => {
     const { rows } = await database.sql<{ definition: string }>(
       `select pg_get_constraintdef(oid) as definition

--- a/packages/db/test/agents.test.ts
+++ b/packages/db/test/agents.test.ts
@@ -1,0 +1,237 @@
+import { isId, newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createAgent,
+  getAgent,
+  NotPermittedError,
+  ProjectOutsideOrganizationError,
+  type AuthContext,
+  type Role,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  errorCodeOf,
+  POSTGRES_ERROR,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * The factory functions are the seam: every assertion goes through create and
+ * get, never through table internals. Raw SQL appears only in fixtures, in the
+ * soft-delete marks that stand in for ticket 03's delete verb, and in the
+ * inserts that bypass the module on purpose to show the database refuses what
+ * the module never attempts.
+ */
+
+let database: MigratedDatabase;
+
+const acme = {
+  organization: newId("org"),
+  project: newId("prj"),
+  secondProject: newId("prj"),
+};
+const globex = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+const grace = newId("usr");
+
+function actingAsAcme(role: Role = "member"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+function actingAsGlobex(): AuthContext {
+  return {
+    userId: grace,
+    organizationId: globex.organization,
+    projectId: globex.project,
+    role: "member",
+    via: "session",
+  };
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("agents");
+
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+    { id: acme.secondProject, slug: "outbound" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedUser(database, grace, "grace@globex.example");
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("creating an agent", () => {
+  it("returns an agt_ id and fetch round-trips name and description", async () => {
+    const created = await createAgent(actingAsAcme(), {
+      name: "Front Desk",
+      description: "Books appointments for the clinic",
+    });
+
+    expect(isId("agt", created.id)).toBe(true);
+
+    const fetched = await getAgent(actingAsAcme(), created.id);
+    expect(fetched).toBeDefined();
+    expect(fetched?.name).toBe("Front Desk");
+    expect(fetched?.description).toBe("Books appointments for the clinic");
+    expect(fetched?.projectId).toBe(acme.project);
+  });
+
+  it("takes no description as none: the fetch answers null", async () => {
+    const created = await createAgent(actingAsAcme(), { name: "Terse" });
+
+    const fetched = await getAgent(actingAsAcme(), created.id);
+    expect(fetched?.description).toBeNull();
+  });
+
+  it("needs a name that is more than whitespace", async () => {
+    await expect(createAgent(actingAsAcme(), { name: "   " })).rejects.toThrow(
+      /name/,
+    );
+  });
+
+  it("is allowed to a member and refused to a viewer, per the permission table", async () => {
+    await expect(
+      createAgent(actingAsAcme("viewer"), { name: "Viewer's Try" }),
+    ).rejects.toThrow(NotPermittedError);
+
+    const fetchedByViewer = await createAgent(actingAsAcme("member"), {
+      name: "Member's Agent",
+    }).then((created) => getAgent(actingAsAcme("viewer"), created.id));
+    expect(fetchedByViewer?.name).toBe("Member's Agent");
+  });
+
+  it("is refused to a credential acting in no project", async () => {
+    await expect(
+      createAgent({ ...actingAsAcme(), projectId: undefined }, { name: "Nowhere" }),
+    ).rejects.toThrow(/project/);
+  });
+
+  it("is refused when the acting project belongs to another customer", async () => {
+    await expect(
+      createAgent(
+        { ...actingAsAcme(), projectId: globex.project },
+        { name: "Stray" },
+      ),
+    ).rejects.toThrow(ProjectOutsideOrganizationError);
+  });
+});
+
+describe("an agent's name", () => {
+  it("is refused while another live agent in the project holds it", async () => {
+    await createAgent(actingAsAcme(), { name: "Reception" });
+
+    await expect(
+      createAgent(actingAsAcme(), { name: "Reception" }),
+    ).rejects.toThrow(/already/);
+  });
+
+  it("is welcome in another project of the same customer", async () => {
+    await createAgent(actingAsAcme(), { name: "Concierge" });
+
+    const inOtherProject = await createAgent(
+      { ...actingAsAcme(), projectId: acme.secondProject },
+      { name: "Concierge" },
+    );
+    expect(inOtherProject.projectId).toBe(acme.secondProject);
+  });
+
+  it("is welcome in another customer's project", async () => {
+    await createAgent(actingAsAcme(), { name: "Switchboard" });
+
+    const elsewhere = await createAgent(actingAsGlobex(), {
+      name: "Switchboard",
+    });
+    expect(elsewhere.projectId).toBe(globex.project);
+  });
+
+  it("is released by a deleted agent, which also vanishes from fetch", async () => {
+    const retiring = await createAgent(actingAsAcme(), { name: "Retiring" });
+
+    // Ticket 03 brings the delete verb; until then the mark is made by hand.
+    await database.sql("update agent set deleted_at = now() where id = $1", [
+      retiring.id,
+    ]);
+
+    expect(await getAgent(actingAsAcme(), retiring.id)).toBeUndefined();
+
+    const successor = await createAgent(actingAsAcme(), { name: "Retiring" });
+    expect(successor.id).not.toBe(retiring.id);
+  });
+});
+
+describe("fetching an agent", () => {
+  it("returns nothing under another organization's auth context", async () => {
+    const created = await createAgent(actingAsAcme(), { name: "Acme Only" });
+
+    expect(await getAgent(actingAsGlobex(), created.id)).toBeUndefined();
+  });
+
+  it("reaches the whole customer for a credential acting in no project", async () => {
+    const created = await createAgent(actingAsAcme(), { name: "Org Wide" });
+
+    const wholeCustomer = { ...actingAsAcme(), projectId: undefined };
+    const fetched = await getAgent(wholeCustomer, created.id);
+    expect(fetched?.id).toBe(created.id);
+    expect(fetched?.projectId).toBe(acme.project);
+  });
+
+  it("returns nothing from a project the caller is not acting in", async () => {
+    const created = await createAgent(actingAsAcme(), { name: "Project Bound" });
+
+    const actingElsewhere = { ...actingAsAcme(), projectId: acme.secondProject };
+    expect(await getAgent(actingElsewhere, created.id)).toBeUndefined();
+  });
+});
+
+describe("the database itself", () => {
+  it("rejects an agent row pairing one customer with another customer's project", async () => {
+    await expect(
+      database.sql(
+        `insert into agent (id, organization_id, project_id, name)
+         values ($1, $2, $3, 'Mismatched')`,
+        [newId("agt"), acme.organization, globex.project],
+      ),
+    ).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.foreignKeyViolation,
+    );
+  });
+
+  it("rejects a connection row pairing one customer with another customer's project", async () => {
+    const anchor = await createAgent(actingAsAcme(), { name: "Anchor" });
+
+    await expect(
+      database.sql(
+        `insert into connection
+           (id, organization_id, project_id, agent_id, name, type, modality, topology, config)
+         values ($1, $2, $3, $4, 'staging', 'retell', 'chat', 'hosted-broker', '{}')`,
+        [newId("con"), acme.organization, globex.project, anchor.id],
+      ),
+    ).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.foreignKeyViolation,
+    );
+  });
+
+  it("carries UNIQUE (id, agent_id) on connection — the future run table's composite-FK target", async () => {
+    const { rows } = await database.sql<{ definition: string }>(
+      `select pg_get_constraintdef(oid) as definition
+         from pg_constraint
+        where conname = 'connection_id_agent_id_unique'`,
+    );
+    expect(rows[0]?.definition).toBe("UNIQUE (id, agent_id)");
+  });
+});

--- a/packages/db/test/agents.test.ts
+++ b/packages/db/test/agents.test.ts
@@ -104,6 +104,15 @@ describe("creating an agent", () => {
     );
   });
 
+  it("stores the name trimmed, so padding cannot slip past the uniqueness rule", async () => {
+    const created = await createAgent(actingAsAcme(), { name: "  Padded  " });
+    expect(created.name).toBe("Padded");
+
+    await expect(
+      createAgent(actingAsAcme(), { name: "Padded" }),
+    ).rejects.toThrow(/already/);
+  });
+
   it("is allowed to a member and refused to a viewer, per the permission table", async () => {
     await expect(
       createAgent(actingAsAcme("viewer"), { name: "Viewer's Try" }),
@@ -225,6 +234,24 @@ describe("the database itself", () => {
            (id, organization_id, project_id, agent_id, name, type, modality, topology, config)
          values ($1, $2, $3, $4, 'staging', 'retell', 'chat', 'hosted-broker', '{}')`,
         [newId("con"), acme.organization, globex.project, anchor.id],
+      ),
+    ).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.foreignKeyViolation,
+    );
+  });
+
+  it("rejects a connection row naming one project and another project's agent", async () => {
+    // The sharp case: the organization, the project pair, and the agent all
+    // exist — every single-column reference is satisfied, and only the
+    // agent/project pairing is wrong.
+    const homed = await createAgent(actingAsAcme(), { name: "Homed" });
+
+    await expect(
+      database.sql(
+        `insert into connection
+           (id, organization_id, project_id, agent_id, name, type, modality, topology, config)
+         values ($1, $2, $3, $4, 'astray', 'retell', 'chat', 'hosted-broker', '{}')`,
+        [newId("con"), acme.organization, acme.secondProject, homed.id],
       ),
     ).rejects.toSatisfy(
       (error) => errorCodeOf(error) === POSTGRES_ERROR.foreignKeyViolation,

--- a/packages/db/test/agents.test.ts
+++ b/packages/db/test/agents.test.ts
@@ -21,9 +21,9 @@ import { seedOrganization, seedUser } from "./support/tenancy.ts";
 /**
  * The factory functions are the seam: every assertion goes through create and
  * get, never through table internals. Raw SQL appears only in fixtures, in the
- * soft-delete marks that stand in for ticket 03's delete verb, and in the
- * inserts that bypass the module on purpose to show the database refuses what
- * the module never attempts.
+ * soft-delete marks made by hand because the delete verb has not landed yet,
+ * and in the inserts that bypass the module on purpose to show the database
+ * refuses what the module never attempts.
  */
 
 let database: MigratedDatabase;
@@ -116,8 +116,13 @@ describe("creating an agent", () => {
   });
 
   it("is refused to a credential acting in no project", async () => {
+    // The context an organization-scoped API key resolves to: the whole
+    // customer, acting in no project.
     await expect(
-      createAgent({ ...actingAsAcme(), projectId: undefined }, { name: "Nowhere" }),
+      createAgent(
+        { ...actingAsAcme(), projectId: undefined, via: "api_key" },
+        { name: "Nowhere" },
+      ),
     ).rejects.toThrow(/project/);
   });
 
@@ -162,7 +167,7 @@ describe("an agent's name", () => {
   it("is released by a deleted agent, which also vanishes from fetch", async () => {
     const retiring = await createAgent(actingAsAcme(), { name: "Retiring" });
 
-    // Ticket 03 brings the delete verb; until then the mark is made by hand.
+    // The delete verb has not landed yet; until then the mark is made by hand.
     await database.sql("update agent set deleted_at = now() where id = $1", [
       retiring.id,
     ]);

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -55,6 +55,7 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
 const CONTEXT_REQUIRING = [
   "changeRole",
   "cloneDigitalHuman",
+  "createAgent",
   "createApiKey",
   "createDigitalHuman",
   "createInvitation",
@@ -62,6 +63,7 @@ const CONTEXT_REQUIRING = [
   "deactivateUser",
   "deleteDigitalHuman",
   "editDigitalHuman",
+  "getAgent",
   "getDigitalHuman",
   "getDigitalHumanVersion",
   "listApiKeys",

--- a/packages/db/test/permissions.test.ts
+++ b/packages/db/test/permissions.test.ts
@@ -110,7 +110,6 @@ describe("the action list", () => {
  * exist yet. Never both, and never neither.
  */
 const NOT_YET_REACHABLE: Readonly<Record<string, string>> = {
-  configure_agents: "nothing can register an agent or a connection yet",
   start_and_cancel_runs: "nothing can start a run yet",
   delete_run_data: "there is no run data to delete yet",
   delete_organization: "deleting an organization is designed and not built",

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -33,6 +33,8 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   api_key: "key",
   digital_human: "dh",
   digital_human_version: "dhv",
+  agent: "agt",
+  connection: "con",
 };
 
 const declaredTables = (Object.values(schema) as unknown[])
@@ -207,6 +209,9 @@ describe("every enumerated value", () => {
       { table: "invitation", column: "role" },
       { table: "api_key", column: "scope" },
       { table: "device_code", column: "status" },
+      { table: "connection", column: "type" },
+      { table: "connection", column: "modality" },
+      { table: "connection", column: "topology" },
     ];
 
     const { rows } = await database.sql<{


### PR DESCRIPTION
## What this is

The registration layer for the customer's agent — the identity every test result accumulates against. A developer registers an agent with a name and an optional description and gets back its `agt_` id; fetching that id returns the agent. An agent with no connections is legal, so registration never waits on credentials.

## What's inside

**One migration, both tables.** `agent` and `connection` land together so later work is verbs only, no schema changes:

- Both tables carry the tenancy pair (`organization_id`, `project_id`) with the composite foreign key to `project (id, organization_id)` — the database itself rejects a row pairing one customer with another customer's project, same as `api_key` and `digital_human` already do.
- Prefix checks pin `agt_` / `con_` ids to their tables.
- `connection` carries CHECKs for its type (`retell`, `phone`), modality (`voice`, `chat`), and topology, plus a null-agreement check between the sealed credentials and their last-4 display hint.
- Names are unique per scope as partial indexes (`WHERE deleted_at IS NULL`), so a deleted agent or removed connection releases its name.
- `UNIQUE (id, agent_id)` on `connection` is inert today on purpose: it is the composite-FK target that will let a run row prove its connection actually belongs to its agent. It stays a plain constraint because Postgres cannot point a foreign key at a partial index.

**Two verbs.** `createAgent` and `getAgent` in a new `access/agents.ts`, agent-rooted and shaped exactly like the digital-human factory: `AuthContext` first argument, tenancy predicates injected by the module, `configure_agents` to create (refused to a viewer, and to a credential acting in no project), `read` to fetch, soft-deleted rows invisible everywhere. Duplicate names are recognized from the constraint's own name, never by matching message text. Connection verbs and the agent's lifecycle (list/update/delete) follow separately; this PR deliberately adds only new files plus the index/test touchpoints.

## Tests

16 new tests against real Postgres cover the round-trip, the name rules (taken in-project, free across projects and customers, released by deletion), the permission refusals, cross-tenant invisibility, the database-level pairing rejection on both tables, and the presence of the future composite-FK target. The schema-shape, data-access-surface, permission, and provider-seam guard tests all know the new names. Full suite: 410 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)