### PR TITLE
Agent connections: added, listed, changed, removed — and their secrets sealed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@ TEST_DATABASE_URL=postgres://egma:egma@localhost:5433/egma
 # reach your instance. `openssl rand -base64 32` is a fine way to make one.
 EGMA_AUTH_SECRET=
 
+# What connection credentials are encrypted with before they are stored: 32
+# random bytes written as 64 hex characters. `openssl rand -hex 32` makes one.
+# The compose file has a development default; change it before anybody else
+# can reach your instance. Back it up alongside the database — the stored
+# credentials are unrecoverable without it, and a backup of one without the
+# other is half a backup.
+EGMA_ENCRYPTION_KEY=
+
 # Where a browser reaches this instance. The pages and the API answer on one
 # origin, so this is both of them, and it is always your own — nothing about
 # logging in reaches a domain egma runs.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -17,11 +17,11 @@ export type Config = {
   readonly authSecret: string;
   /**
    * What connection credentials are sealed under before they touch a row —
-   * 32 random bytes as 64 hex characters (`openssl rand -hex 32`), per
-   * ADR-0003. Malformed or absent means the service will not start: a
-   * deployment that stored customers' provider keys under a weak or missing
-   * key would be quietly under-encrypted, which is the one failure nobody
-   * notices until the database leaks.
+   * 32 random bytes as 64 hex characters (`openssl rand -hex 32`). Malformed
+   * or absent means the service will not start: a deployment that stored
+   * customers' provider keys under a weak or missing key would be quietly
+   * under-encrypted, which is the one failure nobody notices until the
+   * database leaks.
    */
   readonly encryptionKey: string;
   /**

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -16,6 +16,15 @@ export type Config = {
   /** What sessions are signed with. Absent means the service will not start. */
   readonly authSecret: string;
   /**
+   * What connection credentials are sealed under before they touch a row —
+   * 32 random bytes as 64 hex characters (`openssl rand -hex 32`), per
+   * ADR-0003. Malformed or absent means the service will not start: a
+   * deployment that stored customers' provider keys under a weak or missing
+   * key would be quietly under-encrypted, which is the one failure nobody
+   * notices until the database leaks.
+   */
+  readonly encryptionKey: string;
+  /**
    * One organization on this deployment, and the first person to sign up claims
    * it. Sentry's flag, and Sentry's reason: without it anyone who can reach the
    * URL signs up, joins the only organization, and — because everyone defaults
@@ -124,6 +133,20 @@ export function loadConfig(
     );
   }
 
+  // Length and alphabet, not just presence: a 32-character passphrase has the
+  // right byte count and a fraction of the entropy, and must be refused
+  // rather than accepted quietly.
+  const encryptionKey = environment.EGMA_ENCRYPTION_KEY?.trim();
+  if (!encryptionKey || !/^[0-9a-f]{64}$/i.test(encryptionKey)) {
+    throw new Error(
+      "EGMA_ENCRYPTION_KEY is required: 32 random bytes written as 64 hex " +
+        "characters — `openssl rand -hex 32` makes one. Connection " +
+        "credentials are sealed under it before they touch the database. " +
+        "Back it up alongside the database; a backup of one without the " +
+        "other is half a backup.",
+    );
+  }
+
   const port = Number(environment.PORT ?? 3100);
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     throw new Error(`PORT is not a usable port number: ${environment.PORT}`);
@@ -152,6 +175,7 @@ export function loadConfig(
     port,
     baseUrl: baseUrl.replace(/\/+$/, ""),
     authSecret,
+    encryptionKey,
     singleOrganization: flag(environment, "EGMA_SINGLE_ORGANIZATION", true),
     trustProxy: flag(environment, "EGMA_TRUST_PROXY", false),
     rateLimitPerMinute,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,7 +9,10 @@ const config = loadConfig();
 // manual step, and two instances starting at once cannot both apply.
 const migrations = await runMigrations(config.databaseUrl);
 
-connect({ databaseUrl: config.databaseUrl });
+connect({
+  databaseUrl: config.databaseUrl,
+  encryptionKey: config.encryptionKey,
+});
 
 const { app } = buildApi({ config });
 app.log.info(

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -18,19 +18,34 @@ import {
 const enough = {
   DATABASE_URL: "postgres://x/y",
   EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
+  EGMA_ENCRYPTION_KEY: "0123456789abcdef".repeat(4),
 };
 
 describe("configuration", () => {
   it("refuses to start without a database to talk to", () => {
-    expect(() => loadConfig({ EGMA_AUTH_SECRET: "s" })).toThrow(
+    expect(() => loadConfig({ ...enough, DATABASE_URL: "" })).toThrow(
       /DATABASE_URL is required/,
     );
   });
 
   it("refuses to start without a secret to sign sessions with", () => {
-    expect(() => loadConfig({ DATABASE_URL: "postgres://x/y" })).toThrow(
+    expect(() => loadConfig({ ...enough, EGMA_AUTH_SECRET: "" })).toThrow(
       /EGMA_AUTH_SECRET is required/,
     );
+  });
+
+  it("refuses to start without a well-formed encryption key", () => {
+    expect(() => loadConfig({ ...enough, EGMA_ENCRYPTION_KEY: "" })).toThrow(
+      /EGMA_ENCRYPTION_KEY is required/,
+    );
+    // The right length and a fraction of the entropy: a passphrase is refused
+    // on its alphabet, not waved through on its byte count.
+    expect(() =>
+      loadConfig({
+        ...enough,
+        EGMA_ENCRYPTION_KEY: "not-hex-but-sixty-four-characters-long-oh-dear!!".padEnd(64, "x"),
+      }),
+    ).toThrow(/64 hex characters/);
   });
 
   it("refuses a port that is not a port", () => {

--- a/apps/api/test/login.browser.test.ts
+++ b/apps/api/test/login.browser.test.ts
@@ -71,6 +71,7 @@ async function startApi(databaseUrl: string, apiPort: number, baseUrl: string) {
     config: loadConfig({
       DATABASE_URL: databaseUrl,
       EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
+      EGMA_ENCRYPTION_KEY: "0123456789abcdef".repeat(4),
       EGMA_BASE_URL: baseUrl,
       EGMA_SINGLE_ORGANIZATION: "false",
     }),

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -8,6 +8,7 @@ import { buildApi } from "../../src/server.ts";
 import type { Identity } from "../../src/auth/better-auth.ts";
 import {
   createMigratedDatabase,
+  TEST_ENCRYPTION_KEY,
   type MigratedDatabase,
 } from "../../../../packages/db/test/support/database.ts";
 
@@ -46,6 +47,7 @@ export function testConfig(overrides: Partial<Config> = {}): Config {
     ...loadConfig({
       DATABASE_URL: "postgres://unused/unused",
       EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
+      EGMA_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
       EGMA_BASE_URL: "http://localhost:3101",
     }),
     ...overrides,
@@ -57,7 +59,11 @@ export async function createApi(
   options: TestApiOptions = {},
 ): Promise<TestApi> {
   const database = await createMigratedDatabase(label);
-  connect({ databaseUrl: database.url, maxConnections: 4 });
+  connect({
+    databaseUrl: database.url,
+    maxConnections: 4,
+    encryptionKey: TEST_ENCRYPTION_KEY,
+  });
 
   const mail: Email[] = [];
   const emailSender: EmailSender = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,9 @@ services:
       # instance that anybody else can reach needs its own; see .env.example.
       EGMA_AUTH_SECRET: ${EGMA_AUTH_SECRET:-development-only-change-this-before-anybody-else-can-reach-it}
       # Seals connection credentials before they reach the database. The
-      # default is a development one; make your own with `openssl rand -hex
-      # 32`, and back it up alongside the database — losing it loses every
-      # stored credential.
+      # default is a development one and every instance that anybody else can
+      # reach needs its own — `openssl rand -hex 32` makes one. Back it up
+      # alongside the database; losing it loses every stored credential.
       EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
       # Where a browser reaches this instance. The pages and the API answer on
       # one origin, and that origin is the self-hoster's own.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       # Signs session cookies. The default is a development one and every
       # instance that anybody else can reach needs its own; see .env.example.
       EGMA_AUTH_SECRET: ${EGMA_AUTH_SECRET:-development-only-change-this-before-anybody-else-can-reach-it}
+      # Seals connection credentials before they reach the database. The
+      # default is a development one; make your own with `openssl rand -hex
+      # 32`, and back it up alongside the database — losing it loses every
+      # stored credential.
+      EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
       # Where a browser reaches this instance. The pages and the API answer on
       # one origin, and that origin is the self-hoster's own.
       EGMA_BASE_URL: ${EGMA_BASE_URL:-http://localhost:3101}

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -243,31 +243,39 @@ async function visibleAgent(
 }
 
 /**
- * The shape guard on every read. Stored jsonb comes back `unknown`, and a row
- * somebody hand-edited must fail here, loudly and naming itself, rather than
- * leak into a caller as a config that isn't one. Shape only, deliberately:
- * the registry's demands may tighten later, and an old row must stay readable
- * exactly as it was written.
+ * The shape guard on every read of stored key-value data. Jsonb — and an
+ * opened envelope — comes back `unknown`, and a row somebody hand-edited must
+ * fail here, loudly and naming itself, rather than leak into a caller as a
+ * shape it isn't. Shape only, deliberately: the registry's demands may
+ * tighten later, and an old row must stay readable exactly as it was written.
  */
+function stringRecordFromRow(
+  value: unknown,
+  malformed: () => Error,
+): Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw malformed();
+  }
+  const record: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") throw malformed();
+    record[key] = entry;
+  }
+  return record;
+}
+
 function configFromRow(
   value: unknown,
   connectionId: string,
 ): Record<string, string> {
-  const malformed = () =>
-    new Error(
-      `connection ${connectionId} holds config in a shape egma never writes; ` +
-        `the row needs repairing before anybody can read it`,
-    );
-
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw malformed();
-  }
-  const config: Record<string, string> = {};
-  for (const [key, entry] of Object.entries(value)) {
-    if (typeof entry !== "string") throw malformed();
-    config[key] = entry;
-  }
-  return config;
+  return stringRecordFromRow(
+    value,
+    () =>
+      new Error(
+        `connection ${connectionId} holds config in a shape egma never ` +
+          `writes; the row needs repairing before anybody can read it`,
+      ),
+  );
 }
 
 type ConnectionRow = {
@@ -304,13 +312,13 @@ function connectionFromRow(row: ConnectionRow): Connection {
 }
 
 /**
- * A new connection with everything the registry decides settled: modality
- * checked against the type, config gated key by key, credentials sealed or
- * refused, topology derived. Pure validation — nothing here touches the
- * database, so a bad payload dies before anything is written, wherever the
- * caller is in a transaction.
+ * A new connection once the registry has had its say: modality checked
+ * against the type, config gated key by key, credentials sealed or refused,
+ * topology derived. The name may still be absent — defaulting it takes a
+ * read, and this shape exists so that read can wait for the insert's own
+ * transaction.
  */
-function admitConnection(input: NewConnection): {
+type AdmittedConnection = {
   readonly name: string | undefined;
   readonly type: ConnectionType;
   readonly modality: Modality;
@@ -319,7 +327,13 @@ function admitConnection(input: NewConnection): {
   readonly config: Record<string, string>;
   readonly credentials: string | null;
   readonly credentialsHint: string | null;
-} {
+};
+
+/**
+ * Pure validation — nothing here touches the database, so a bad payload dies
+ * before anything is written, wherever the caller is in a transaction.
+ */
+function admitConnection(input: NewConnection): AdmittedConnection {
   const descriptor = descriptorOf(input.type);
   const modality = validModality(input.type, input.modality);
   const config = validConfig(input.type, input.config);
@@ -366,6 +380,21 @@ async function freeDefaultName(
 }
 
 /**
+ * The refusal both connection writes share, for the moment the database says
+ * a living connection already holds the name.
+ */
+function refusingHeldConnectionName(name: string): (error: unknown) => never {
+  return (error: unknown) => {
+    if (lostToConstraint(error, "connection_agent_id_name_unique")) {
+      throw new Error(
+        `a connection named "${name}" already exists on this agent`,
+      );
+    }
+    throw error;
+  };
+}
+
+/**
  * The insert both create paths share, wherever the caller is in a
  * transaction. The input has already passed `admitConnection`; this owns the
  * name default and the friendly refusal when a living connection holds the
@@ -375,7 +404,7 @@ async function insertConnection(
   on: Queryable,
   auth: AuthContext,
   home: { readonly id: string; readonly projectId: string },
-  admitted: ReturnType<typeof admitConnection>,
+  admitted: AdmittedConnection,
 ): Promise<Connection> {
   const name =
     admitted.name ?? (await freeDefaultName(on, home.id, admitted.type));
@@ -398,14 +427,7 @@ async function insertConnection(
       createdBy: auth.userId,
     })
     .returning(CONNECTION_COLUMNS)
-    .catch((error: unknown) => {
-      if (lostToConstraint(error, "connection_agent_id_name_unique")) {
-        throw new Error(
-          `a connection named "${name}" already exists on this agent`,
-        );
-      }
-      throw error;
-    });
+    .catch(refusingHeldConnectionName(name));
 
   if (inserted === undefined) throw new Error("the connection was not written");
   return connectionFromRow(inserted);
@@ -631,14 +653,14 @@ export async function updateConnection(
     })
     .where(theConnection(auth, agentId, connectionId))
     .returning(CONNECTION_COLUMNS)
-    .catch((error: unknown) => {
-      if (lostToConstraint(error, "connection_agent_id_name_unique")) {
-        throw new Error(
-          `a connection named "${name}" already exists on this agent`,
-        );
-      }
-      throw error;
-    });
+    .catch(
+      // Only a name change can lose to the name constraint.
+      name === undefined
+        ? (error: unknown) => {
+            throw error;
+          }
+        : refusingHeldConnectionName(name),
+    );
 
   return updated === undefined ? undefined : connectionFromRow(updated);
 }
@@ -701,19 +723,12 @@ export async function resolveConnectionCredentials(
   if (row === undefined) return undefined;
   if (row.credentials === null) return null;
 
-  const opened = openCredentials(row.credentials);
-  const malformed = () =>
-    new Error(
-      `connection ${row.id} holds credentials in a shape egma never writes; ` +
-        `the row needs repairing before anybody can use it`,
-    );
-  if (typeof opened !== "object" || opened === null || Array.isArray(opened)) {
-    throw malformed();
-  }
-  const credentials: Record<string, string> = {};
-  for (const [key, value] of Object.entries(opened)) {
-    if (typeof value !== "string") throw malformed();
-    credentials[key] = value;
-  }
-  return credentials;
+  return stringRecordFromRow(
+    openCredentials(row.credentials),
+    () =>
+      new Error(
+        `connection ${row.id} holds credentials in a shape egma never ` +
+          `writes; the row needs repairing before anybody can use it`,
+      ),
+  );
 }

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -1,8 +1,21 @@
 import { newId } from "@egma/ids";
-import { and, eq, isNull, type SQL } from "drizzle-orm";
+import { and, asc, eq, isNull, type SQL } from "drizzle-orm";
 
-import { db } from "../client.ts";
-import { agent } from "../schema/agents.ts";
+import { db, type Queryable } from "../client.ts";
+import {
+  agent,
+  connection,
+  type ConnectionType,
+  type Modality,
+  type Topology,
+} from "../schema/agents.ts";
+import { openCredentials, sealCredentials } from "../sealing.ts";
+import {
+  descriptorOf,
+  validConfig,
+  validCredentials,
+  validModality,
+} from "./connection-registry.ts";
 import type { AuthContext } from "./context.ts";
 import { ProjectOutsideOrganizationError } from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
@@ -10,24 +23,91 @@ import { isProjectOfOrganization } from "./projects.ts";
 import { within } from "./within.ts";
 
 /**
- * Reading and writing agents — what an agent is is the schema file's story
- * (`schema/agents.ts`); this file is how one is reached.
+ * Reading and writing agents and their connections — what they are is the
+ * schema file's story (`schema/agents.ts`); this file is how they are reached.
  *
- * The agent is the aggregate root of the factory: when the connection verbs
- * arrive they will live here too, every one of them taking the agent's id,
- * because a connection is how you reach an agent and there is no path to one
- * that doesn't name its agent first.
+ * The agent is the aggregate root of the factory: every connection verb takes
+ * the agent's id, because a connection is how you reach an agent and there is
+ * no path to one that doesn't name its agent first. A connection named through
+ * the wrong agent — or the wrong customer — answers exactly what a connection
+ * that doesn't exist answers.
  *
  * Project scoping works as the digital-human factory's does. A context acting
  * in a project writes and reads there; a context acting in none — an
- * organization-scoped credential — reads the whole customer and creates
- * nothing, because an agent belongs to a project and a credential for the
- * whole customer is acting in none.
+ * organization-scoped credential — reaches the whole customer. It creates no
+ * agent, because an agent belongs to a project and a credential for the whole
+ * customer is acting in none; the connection verbs it may use, because a
+ * connection lands in the project its agent already names.
+ *
+ * Credentials pass through here exactly twice: sealed on the way in (create
+ * and whole-object rotation), and unsealed in `resolveConnectionCredentials`,
+ * the one door to the plaintext. Every read shape omits the field entirely,
+ * so leaking a secret through a serializer is a compile error rather than a
+ * review catch.
  */
+
+export type NewConnection = {
+  /** Defaults from the type (`retell-1`), so onboarding never stalls. */
+  readonly name?: string | undefined;
+  readonly type: ConnectionType;
+  readonly modality: Modality;
+  /** A label (`staging`, `production`), never a level in the hierarchy. */
+  readonly environment?: string | undefined;
+  /** Validated per type at the door: what to reach, never how to prove. */
+  readonly config: Readonly<Record<string, unknown>>;
+  /** Required or refused per type; sealed before it touches the row. */
+  readonly credentials?: Readonly<Record<string, unknown>> | undefined;
+};
+
+export type Connection = {
+  readonly id: string;
+  readonly agentId: string;
+  readonly projectId: string;
+  readonly name: string;
+  readonly type: ConnectionType;
+  readonly modality: Modality;
+  /** Derived from the type, never caller-supplied. */
+  readonly topology: Topology;
+  readonly environment: string | null;
+  readonly config: Readonly<Record<string, string>>;
+  /** The last characters of the sealed secret, or null where none belongs. */
+  readonly credentialsHint: string | null;
+  /** Runtime-discovered, never caller-declared; null until discovery exists. */
+  readonly capabilities: unknown;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};
+
+/**
+ * What an edit may touch. Type and modality are deliberately absent: changing
+ * what a connection *is* is a new connection, and mutating it in place would
+ * attribute yesterday's chat results to something that is now a phone number.
+ * Credentials replace whole or stay untouched — never a merge, so plaintext
+ * never round-trips out for editing. Absent means keep.
+ */
+export type ConnectionChanges = {
+  readonly name?: string | undefined;
+  readonly environment?: string | null | undefined;
+  readonly config?: Readonly<Record<string, unknown>> | undefined;
+  readonly credentials?: Readonly<Record<string, unknown>> | undefined;
+};
+
+export type RemovedConnection = {
+  readonly id: string;
+  readonly agentId: string;
+  readonly name: string;
+  readonly deletedAt: Date;
+};
 
 export type NewAgent = {
   readonly name: string;
   readonly description?: string | undefined;
+  /**
+   * The optional first connection, written in the same transaction — the
+   * happy onboarding path never produces an unreachable agent, and a bad
+   * connection payload leaves no agent behind.
+   */
+  readonly connection?: NewConnection | undefined;
 };
 
 export type Agent = {
@@ -39,7 +119,13 @@ export type Agent = {
   readonly updatedAt: Date;
 };
 
+/** What `createAgent` answers: the agent, wired if the create asked for it. */
+export type CreatedAgent = Agent & {
+  readonly connection?: Connection;
+};
+
 const notDeleted: SQL = isNull(agent.deletedAt);
+const connectionNotDeleted: SQL = isNull(connection.deletedAt);
 
 /** An answer's columns, and no more — the tenant-free view. */
 const COLUMNS = {
@@ -51,25 +137,42 @@ const COLUMNS = {
   updatedAt: agent.updatedAt,
 } as const;
 
+/** A connection as any read answers it. The sealed envelope has no row here. */
+const CONNECTION_COLUMNS = {
+  id: connection.id,
+  agentId: connection.agentId,
+  projectId: connection.projectId,
+  name: connection.name,
+  type: connection.type,
+  modality: connection.modality,
+  topology: connection.topology,
+  environment: connection.environment,
+  config: connection.config,
+  credentialsHint: connection.credentialsHint,
+  capabilities: connection.capabilities,
+  createdAt: connection.createdAt,
+  updatedAt: connection.updatedAt,
+} as const;
+
 /**
  * The name as it will be stored: trimmed, because a handle that participates
  * in a uniqueness check must not get around it on invisible characters.
  */
-function validName(name: string): string {
+function validName(name: string, what: string): string {
   const trimmed = name.trim();
   if (trimmed === "") {
-    throw new Error("an agent needs a name");
+    throw new Error(`${what} needs a name`);
   }
   return trimmed;
 }
 
 /**
- * Whether this write lost to a live agent already holding the name. Read from
+ * Whether this write lost to a live row already holding the name. Read from
  * the constraint's own name, walking the `cause` chain because the query layer
  * may hand the driver's error back wrapped — recognising it by message
  * substring would break silently the day the text changed.
  */
-function nameAlreadyAlive(error: unknown): boolean {
+function lostToConstraint(error: unknown, constraint: string): boolean {
   for (
     let at: unknown = error, depth = 0;
     at !== undefined && at !== null && depth < 4;
@@ -77,7 +180,7 @@ function nameAlreadyAlive(error: unknown): boolean {
   ) {
     if (typeof at !== "object") break;
     const carrier = at as { constraint?: unknown; cause?: unknown };
-    if (carrier.constraint === "agent_project_id_name_unique") return true;
+    if (carrier.constraint === constraint) return true;
     at = carrier.cause;
   }
   return false;
@@ -99,10 +202,219 @@ function theAgent(auth: AuthContext, id: string): SQL {
   );
 }
 
+/**
+ * The named connection, alive, on this agent, within the caller's tenancy.
+ * Callers have already walked through `visibleAgent`, so the agent side —
+ * alive, in scope — is settled; this pins the connection to it, and the
+ * `agent_id` equality is what makes another agent's connection unreachable.
+ */
+function theConnection(
+  auth: AuthContext,
+  agentId: string,
+  connectionId: string,
+): SQL {
+  return within(
+    auth,
+    connection,
+    and(
+      eq(connection.id, connectionId),
+      eq(connection.agentId, agentId),
+      connectionNotDeleted,
+    ),
+  );
+}
+
+/**
+ * The one door every connection verb walks through first. A connection is
+ * reached only through its agent, so an agent the caller cannot see — another
+ * customer's, another project's, a deleted one — makes every connection under
+ * it answer as if it did not exist.
+ */
+async function visibleAgent(
+  auth: AuthContext,
+  agentId: string,
+): Promise<{ id: string; projectId: string } | undefined> {
+  const [row] = await db()
+    .select({ id: agent.id, projectId: agent.projectId })
+    .from(agent)
+    .where(theAgent(auth, agentId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * The shape guard on every read. Stored jsonb comes back `unknown`, and a row
+ * somebody hand-edited must fail here, loudly and naming itself, rather than
+ * leak into a caller as a config that isn't one. Shape only, deliberately:
+ * the registry's demands may tighten later, and an old row must stay readable
+ * exactly as it was written.
+ */
+function configFromRow(
+  value: unknown,
+  connectionId: string,
+): Record<string, string> {
+  const malformed = () =>
+    new Error(
+      `connection ${connectionId} holds config in a shape egma never writes; ` +
+        `the row needs repairing before anybody can read it`,
+    );
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw malformed();
+  }
+  const config: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") throw malformed();
+    config[key] = entry;
+  }
+  return config;
+}
+
+type ConnectionRow = {
+  readonly id: string;
+  readonly agentId: string;
+  readonly projectId: string;
+  readonly name: string;
+  readonly type: string;
+  readonly modality: string;
+  readonly topology: string;
+  readonly environment: string | null;
+  readonly config: unknown;
+  readonly credentialsHint: string | null;
+  readonly capabilities: unknown;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};
+
+/**
+ * A selected row as the caller sees it. The three enumerated columns are
+ * narrowed by assertion because the schema's CHECK constraints already refuse
+ * anything outside the lists — a value the assertion would get wrong cannot be
+ * in the table.
+ */
+function connectionFromRow(row: ConnectionRow): Connection {
+  return {
+    ...row,
+    type: row.type as ConnectionType,
+    modality: row.modality as Modality,
+    topology: row.topology as Topology,
+    config: configFromRow(row.config, row.id),
+    capabilities: row.capabilities ?? null,
+  };
+}
+
+/**
+ * A new connection with everything the registry decides settled: modality
+ * checked against the type, config gated key by key, credentials sealed or
+ * refused, topology derived. Pure validation — nothing here touches the
+ * database, so a bad payload dies before anything is written, wherever the
+ * caller is in a transaction.
+ */
+function admitConnection(input: NewConnection): {
+  readonly name: string | undefined;
+  readonly type: ConnectionType;
+  readonly modality: Modality;
+  readonly topology: Topology;
+  readonly environment: string | null;
+  readonly config: Record<string, string>;
+  readonly credentials: string | null;
+  readonly credentialsHint: string | null;
+} {
+  const descriptor = descriptorOf(input.type);
+  const modality = validModality(input.type, input.modality);
+  const config = validConfig(input.type, input.config);
+  const sealed = validCredentials(input.type, input.credentials);
+
+  return {
+    name:
+      input.name === undefined
+        ? undefined
+        : validName(input.name, "a connection"),
+    type: input.type,
+    modality,
+    topology: descriptor.topology,
+    environment: input.environment ?? null,
+    config,
+    credentials: sealed === null ? null : sealCredentials(sealed.sealed),
+    credentialsHint: sealed === null ? null : sealed.hint,
+  };
+}
+
+/**
+ * The smallest free `<type>-<n>` among the agent's living names, so an unnamed
+ * add always lands — a removed connection's number comes back into play the
+ * same way its name does.
+ */
+async function freeDefaultName(
+  on: Queryable,
+  agentId: string,
+  type: ConnectionType,
+): Promise<string> {
+  const taken = new Set(
+    (
+      await on
+        .select({ name: connection.name })
+        .from(connection)
+        .where(and(eq(connection.agentId, agentId), connectionNotDeleted))
+    ).map((row) => row.name),
+  );
+
+  for (let n = 1; ; n += 1) {
+    const candidate = `${type}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * The insert both create paths share, wherever the caller is in a
+ * transaction. The input has already passed `admitConnection`; this owns the
+ * name default and the friendly refusal when a living connection holds the
+ * name already.
+ */
+async function insertConnection(
+  on: Queryable,
+  auth: AuthContext,
+  home: { readonly id: string; readonly projectId: string },
+  admitted: ReturnType<typeof admitConnection>,
+): Promise<Connection> {
+  const name =
+    admitted.name ?? (await freeDefaultName(on, home.id, admitted.type));
+
+  const [inserted] = await on
+    .insert(connection)
+    .values({
+      id: newId("con"),
+      organizationId: auth.organizationId,
+      projectId: home.projectId,
+      agentId: home.id,
+      name,
+      type: admitted.type,
+      modality: admitted.modality,
+      topology: admitted.topology,
+      environment: admitted.environment,
+      config: admitted.config,
+      credentials: admitted.credentials,
+      credentialsHint: admitted.credentialsHint,
+      createdBy: auth.userId,
+    })
+    .returning(CONNECTION_COLUMNS)
+    .catch((error: unknown) => {
+      if (lostToConstraint(error, "connection_agent_id_name_unique")) {
+        throw new Error(
+          `a connection named "${name}" already exists on this agent`,
+        );
+      }
+      throw error;
+    });
+
+  if (inserted === undefined) throw new Error("the connection was not written");
+  return connectionFromRow(inserted);
+}
+
 export async function createAgent(
   auth: AuthContext,
   input: NewAgent,
-): Promise<Agent> {
+): Promise<CreatedAgent> {
   authorize(auth, "configure_agents", here(auth));
 
   const { projectId } = auth;
@@ -113,35 +425,57 @@ export async function createAgent(
   }
 
   // Everything answerable without the database is answered first; only an
-  // input worth writing costs the project-membership read below.
-  const name = validName(input.name);
+  // input worth writing costs the project-membership read below, and a bad
+  // inline connection dies before there is an agent to orphan.
+  const name = validName(input.name, "an agent");
+  const inline =
+    input.connection === undefined
+      ? undefined
+      : admitConnection(input.connection);
 
   if (!(await isProjectOfOrganization(auth, projectId))) {
     throw new ProjectOutsideOrganizationError(auth.organizationId, projectId);
   }
 
-  const [inserted] = await db()
-    .insert(agent)
-    .values({
-      id: newId("agt"),
-      organizationId: auth.organizationId,
-      projectId,
-      name,
-      description: input.description ?? null,
-      createdBy: auth.userId,
-    })
-    .returning(COLUMNS)
-    .catch((error: unknown) => {
-      if (nameAlreadyAlive(error)) {
-        throw new Error(
-          `an agent named "${name}" already exists in this project`,
-        );
-      }
-      throw error;
-    });
+  const insertAgent = async (on: Queryable): Promise<Agent> => {
+    const [inserted] = await on
+      .insert(agent)
+      .values({
+        id: newId("agt"),
+        organizationId: auth.organizationId,
+        projectId,
+        name,
+        description: input.description ?? null,
+        createdBy: auth.userId,
+      })
+      .returning(COLUMNS)
+      .catch((error: unknown) => {
+        if (lostToConstraint(error, "agent_project_id_name_unique")) {
+          throw new Error(
+            `an agent named "${name}" already exists in this project`,
+          );
+        }
+        throw error;
+      });
 
-  if (inserted === undefined) throw new Error("the agent was not written");
-  return inserted;
+    if (inserted === undefined) throw new Error("the agent was not written");
+    return inserted;
+  };
+
+  if (inline === undefined) return insertAgent(db());
+
+  // Both rows or neither: the transaction is what makes the happy onboarding
+  // path unable to produce an agent its own connection failed to reach.
+  return db().transaction(async (tx) => {
+    const identity = await insertAgent(tx);
+    const wired = await insertConnection(
+      tx,
+      auth,
+      { id: identity.id, projectId },
+      inline,
+    );
+    return { ...identity, connection: wired };
+  });
 }
 
 export async function getAgent(
@@ -156,4 +490,230 @@ export async function getAgent(
     .where(theAgent(auth, id))
     .limit(1);
   return row;
+}
+
+/**
+ * A connection attached to an agent the caller can already see. Answers
+ * `undefined` when the agent is out of reach, exactly as fetching the agent
+ * would — the caller cannot tell an invisible agent from an absent one, and
+ * neither can this.
+ */
+export async function addConnection(
+  auth: AuthContext,
+  agentId: string,
+  input: NewConnection,
+): Promise<Connection | undefined> {
+  authorize(auth, "configure_agents", here(auth));
+
+  const admitted = admitConnection(input);
+
+  const home = await visibleAgent(auth, agentId);
+  if (home === undefined) return undefined;
+
+  return insertConnection(db(), auth, home, admitted);
+}
+
+export async function getConnection(
+  auth: AuthContext,
+  agentId: string,
+  connectionId: string,
+): Promise<Connection | undefined> {
+  authorize(auth, "read", here(auth));
+
+  if ((await visibleAgent(auth, agentId)) === undefined) return undefined;
+
+  const [row] = await db()
+    .select(CONNECTION_COLUMNS)
+    .from(connection)
+    .where(theConnection(auth, agentId, connectionId))
+    .limit(1);
+
+  return row === undefined ? undefined : connectionFromRow(row);
+}
+
+/**
+ * The agent's living connections, oldest first — the ids are time-sortable,
+ * so this is the order they were attached in. A whole page, deliberately: an
+ * agent holds a handful of connections, not thousands, and `undefined` for an
+ * unreachable agent is a different answer than `[]` for an unwired one.
+ */
+export async function listConnections(
+  auth: AuthContext,
+  agentId: string,
+): Promise<readonly Connection[] | undefined> {
+  authorize(auth, "read", here(auth));
+
+  if ((await visibleAgent(auth, agentId)) === undefined) return undefined;
+
+  const rows = await db()
+    .select(CONNECTION_COLUMNS)
+    .from(connection)
+    .where(
+      within(
+        auth,
+        connection,
+        and(eq(connection.agentId, agentId), connectionNotDeleted),
+      ),
+    )
+    .orderBy(asc(connection.id));
+
+  return rows.map(connectionFromRow);
+}
+
+/**
+ * One door for every change. Name, environment and config write in place —
+ * config checked whole against the registry entry for the row's own type — and
+ * credentials replace whole or stay untouched, resealed under a fresh IV with
+ * the hint moved along. Editing what the caller cannot see returns what
+ * reading it would have: `undefined`, with nothing disturbed.
+ */
+export async function updateConnection(
+  auth: AuthContext,
+  agentId: string,
+  connectionId: string,
+  changes: ConnectionChanges,
+): Promise<Connection | undefined> {
+  authorize(auth, "configure_agents", here(auth));
+
+  // The changes type has no such fields, but a caller reaching this from
+  // looser code — a request body, a spread — must hear the rule, not watch
+  // an edit quietly drop half its payload.
+  for (const immutable of ["type", "modality", "topology"] as const) {
+    if (immutable in changes) {
+      throw new Error(
+        `a connection's ${immutable} never changes: what a connection is, ` +
+          `is a new connection`,
+      );
+    }
+  }
+
+  const name =
+    changes.name === undefined
+      ? undefined
+      : validName(changes.name, "a connection");
+
+  if ((await visibleAgent(auth, agentId)) === undefined) return undefined;
+
+  const [current] = await db()
+    .select({ id: connection.id, type: connection.type })
+    .from(connection)
+    .where(theConnection(auth, agentId, connectionId))
+    .limit(1);
+  if (current === undefined) return undefined;
+
+  // The registry rules are the row's own type's — which cannot have changed
+  // since the read above, because nothing can change it at all.
+  const type = current.type as ConnectionType;
+  const config =
+    changes.config === undefined
+      ? undefined
+      : validConfig(type, changes.config);
+  const sealed =
+    changes.credentials === undefined
+      ? undefined
+      : validCredentials(type, changes.credentials);
+
+  const [updated] = await db()
+    .update(connection)
+    .set({
+      ...(name === undefined ? {} : { name }),
+      ...(changes.environment === undefined
+        ? {}
+        : { environment: changes.environment }),
+      ...(config === undefined ? {} : { config }),
+      ...(sealed === undefined || sealed === null
+        ? {}
+        : {
+            credentials: sealCredentials(sealed.sealed),
+            credentialsHint: sealed.hint,
+          }),
+      updatedAt: new Date(),
+    })
+    .where(theConnection(auth, agentId, connectionId))
+    .returning(CONNECTION_COLUMNS)
+    .catch((error: unknown) => {
+      if (lostToConstraint(error, "connection_agent_id_name_unique")) {
+        throw new Error(
+          `a connection named "${name}" already exists on this agent`,
+        );
+      }
+      throw error;
+    });
+
+  return updated === undefined ? undefined : connectionFromRow(updated);
+}
+
+/**
+ * The soft-delete marker, and only the marker. The connection vanishes from
+ * fetch and list at once and its name returns to the living; the row stays
+ * for the deletion worker. The agent is untouched — an agent with no
+ * connections is legal, so removing the last one is never refused for being
+ * the last.
+ */
+export async function removeConnection(
+  auth: AuthContext,
+  agentId: string,
+  connectionId: string,
+): Promise<RemovedConnection | undefined> {
+  authorize(auth, "configure_agents", here(auth));
+
+  if ((await visibleAgent(auth, agentId)) === undefined) return undefined;
+
+  const deletedAt = new Date();
+  const [row] = await db()
+    .update(connection)
+    .set({ deletedAt, updatedAt: deletedAt })
+    .where(theConnection(auth, agentId, connectionId))
+    .returning({
+      id: connection.id,
+      agentId: connection.agentId,
+      name: connection.name,
+    });
+
+  if (row === undefined) return undefined;
+  return { ...row, deletedAt };
+}
+
+/**
+ * The one door to the plaintext, and the simulation runtime is who knocks:
+ * handed `(agent_id, connection_id)` when a run starts, it answers the
+ * decrypted credentials object — or `null` for a type where the customer
+ * supplies no secret, or `undefined` for a connection out of the caller's
+ * reach. Nothing else in the codebase can decrypt, and the gate is the
+ * run-starter's permission rather than the reader's, because resolving a
+ * credential *is* starting to act with it.
+ */
+export async function resolveConnectionCredentials(
+  auth: AuthContext,
+  agentId: string,
+  connectionId: string,
+): Promise<Readonly<Record<string, string>> | null | undefined> {
+  authorize(auth, "start_and_cancel_runs", here(auth));
+
+  if ((await visibleAgent(auth, agentId)) === undefined) return undefined;
+
+  const [row] = await db()
+    .select({ id: connection.id, credentials: connection.credentials })
+    .from(connection)
+    .where(theConnection(auth, agentId, connectionId))
+    .limit(1);
+
+  if (row === undefined) return undefined;
+  if (row.credentials === null) return null;
+
+  const opened = openCredentials(row.credentials);
+  const malformed = () =>
+    new Error(
+      `connection ${row.id} holds credentials in a shape egma never writes; ` +
+        `the row needs repairing before anybody can use it`,
+    );
+  if (typeof opened !== "object" || opened === null || Array.isArray(opened)) {
+    throw malformed();
+  }
+  const credentials: Record<string, string> = {};
+  for (const [key, value] of Object.entries(opened)) {
+    if (typeof value !== "string") throw malformed();
+    credentials[key] = value;
+  }
+  return credentials;
 }

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -219,7 +219,11 @@ export function validCredentials(
   const sealed: Record<string, string> = {};
   for (const field of rule.fields) {
     const value = (credentials as Record<string, unknown>)[field];
-    if (typeof value !== "string" || value.trim() === "") {
+    // Stored trimmed, like every config gate: a key pasted with whitespace
+    // would pass the checks, seal the padding, and fail at the provider with
+    // nothing to say the stored value was the problem.
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (trimmed === "") {
       throw new Error(
         `a ${type} connection's credentials need ${field} to be a non-empty string`,
       );
@@ -227,13 +231,13 @@ export function validCredentials(
     // Real provider keys are tens of characters, so anything this short is a
     // paste gone wrong — and the stored last-4 hint must stay a hint, never
     // most of the secret it hints at.
-    if (value.trim().length < SHORTEST_CREDENTIAL) {
+    if (trimmed.length < SHORTEST_CREDENTIAL) {
       throw new Error(
         `a ${type} connection's credentials need ${field} to be at least ` +
           `${SHORTEST_CREDENTIAL} characters`,
       );
     }
-    sealed[field] = value;
+    sealed[field] = trimmed;
   }
 
   return { sealed, hint: sealed[rule.hintField]?.slice(-4) ?? "" };

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -75,6 +75,9 @@ function nonEmptyString(key: string, value: unknown): string {
  */
 const E164 = /^\+[1-9]\d{1,14}$/;
 
+/** The floor under a credential field, so the last-4 hint stays a hint. */
+const SHORTEST_CREDENTIAL = 8;
+
 function e164PhoneNumber(key: string, value: unknown): string {
   const candidate = typeof value === "string" ? value.trim() : "";
   if (!E164.test(candidate)) {
@@ -219,6 +222,15 @@ export function validCredentials(
     if (typeof value !== "string" || value.trim() === "") {
       throw new Error(
         `a ${type} connection's credentials need ${field} to be a non-empty string`,
+      );
+    }
+    // Real provider keys are tens of characters, so anything this short is a
+    // paste gone wrong — and the stored last-4 hint must stay a hint, never
+    // most of the secret it hints at.
+    if (value.trim().length < SHORTEST_CREDENTIAL) {
+      throw new Error(
+        `a ${type} connection's credentials need ${field} to be at least ` +
+          `${SHORTEST_CREDENTIAL} characters`,
       );
     }
     sealed[field] = value;

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -1,0 +1,228 @@
+import {
+  CONNECTION_TYPES,
+  MODALITIES,
+  type ConnectionType,
+  type Modality,
+  type Topology,
+} from "../schema/agents.ts";
+
+/**
+ * What each connection type is made of. The registry is code, not a table,
+ * because a table could claim types the code cannot run: an entry lands here
+ * in the same commit as its adapter, following the `VOICE_PROVIDERS`
+ * precedent.
+ *
+ * It drives everything the access layer decides about a connection at the
+ * door — which modalities the type speaks, the topology it implies (derived,
+ * never caller-supplied: it predicts who moves first when a simulation
+ * starts, and a caller's guess would just be wrong), which config keys are
+ * demanded and how each is checked, and whether a credential is required or
+ * refused outright. Every failure is named at create, so a typo surfaces
+ * immediately rather than at run time.
+ *
+ * The map is `Record<ConnectionType, …>`, so it cannot drift from the schema:
+ * a type added to `CONNECTION_TYPES` refuses to build until it is described
+ * here, and an entry describing a type the schema's CHECK would reject cannot
+ * be written at all.
+ */
+
+/**
+ * One config key's gate. Takes what the caller sent under `key` — absent
+ * arrives as `undefined` — and answers the value as it will be stored, or
+ * throws naming the key.
+ */
+type ConfigGate = (key: string, value: unknown) => string;
+
+/**
+ * Whether the customer hands over a secret for this type, and what it holds.
+ *
+ * Required and forbidden are the only two cases on purpose: a credential
+ * supplied where none belongs is rejected rather than stored and silently
+ * ignored, because a caller who sent one believes it matters.
+ */
+export type CredentialRule =
+  | {
+      readonly required: true;
+      /** Exactly these keys, each a non-empty string. */
+      readonly fields: readonly string[];
+      /** The field whose last characters become the stored display hint. */
+      readonly hintField: string;
+    }
+  | {
+      readonly required: false;
+      /** Why not, told to the caller who supplied one anyway. */
+      readonly refusal: string;
+    };
+
+export type ConnectionDescriptor = {
+  readonly modalities: readonly Modality[];
+  readonly topology: Topology;
+  readonly config: Readonly<Record<string, ConfigGate>>;
+  readonly credentials: CredentialRule;
+};
+
+function nonEmptyString(key: string, value: unknown): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`the config's ${key} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+/**
+ * E.164: a plus, then up to fifteen digits with no leading zero. The strictest
+ * format every telephony provider agrees on, checked here so a run never dials
+ * a number that could not exist.
+ */
+const E164 = /^\+[1-9]\d{1,14}$/;
+
+function e164PhoneNumber(key: string, value: unknown): string {
+  const candidate = typeof value === "string" ? value.trim() : "";
+  if (!E164.test(candidate)) {
+    throw new Error(
+      `the config's ${key} must be an E.164 phone number, which looks like ` +
+        `+15551234567`,
+    );
+  }
+  return candidate;
+}
+
+export const CONNECTION_REGISTRY: Readonly<
+  Record<ConnectionType, ConnectionDescriptor>
+> = {
+  retell: {
+    modalities: ["chat", "voice"],
+    topology: "hosted-broker",
+    config: { retellAgentId: nonEmptyString },
+    credentials: { required: true, fields: ["apiKey"], hintField: "apiKey" },
+  },
+  phone: {
+    modalities: ["voice"],
+    topology: "egma-dials-in",
+    config: { phoneNumber: e164PhoneNumber },
+    credentials: {
+      required: false,
+      refusal:
+        "a phone connection takes no credential: the customer supplies a " +
+        "public number, and egma dials it with its own telephony " +
+        "configuration",
+    },
+  },
+};
+
+/** The descriptor, or a refusal naming what egma actually supports. */
+export function descriptorOf(type: string): ConnectionDescriptor {
+  const descriptor = CONNECTION_REGISTRY[type as ConnectionType];
+  if (descriptor === undefined) {
+    throw new Error(
+      `"${type}" is not a connection type egma knows; expected one of ` +
+        CONNECTION_TYPES.join(", "),
+    );
+  }
+  return descriptor;
+}
+
+/** The modality checked against the type's own list, so `phone` + `chat` dies here. */
+export function validModality(type: ConnectionType, modality: string): Modality {
+  const descriptor = descriptorOf(type);
+  if (!descriptor.modalities.includes(modality as Modality)) {
+    const speaks = descriptor.modalities.join(" or ");
+    if (!MODALITIES.includes(modality as Modality)) {
+      throw new Error(
+        `"${modality}" is not a modality; a ${type} connection speaks ${speaks}`,
+      );
+    }
+    throw new Error(
+      `a ${type} connection speaks ${speaks}, and this one was asked for ${modality}`,
+    );
+  }
+  return modality as Modality;
+}
+
+/**
+ * The config as it will be stored: every demanded key present and checked,
+ * every unknown key refused by name. Refusing unknowns is what turns a typo'd
+ * key into an error at create rather than a demanded key "missing" at run
+ * time.
+ */
+export function validConfig(
+  type: ConnectionType,
+  config: unknown,
+): Record<string, string> {
+  const gates = descriptorOf(type).config;
+  const demanded = Object.keys(gates);
+
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    throw new Error(
+      `a ${type} connection's config is an object holding ${demanded.join(", ")}`,
+    );
+  }
+
+  for (const key of Object.keys(config)) {
+    if (!(key in gates)) {
+      throw new Error(
+        `a ${type} connection's config has no key "${key}"; it holds ` +
+          demanded.join(", "),
+      );
+    }
+  }
+
+  const stored: Record<string, string> = {};
+  for (const [key, gate] of Object.entries(gates)) {
+    const value = (config as Record<string, unknown>)[key];
+    if (value === undefined) {
+      throw new Error(`a ${type} connection's config needs ${key}`);
+    }
+    stored[key] = gate(key, value);
+  }
+  return stored;
+}
+
+/**
+ * The credentials as they will be sealed, plus the display hint — or null for
+ * a type where the customer supplies no secret. A credential handed to such a
+ * type is refused with the type's own reason, never stored and never silently
+ * dropped.
+ */
+export function validCredentials(
+  type: ConnectionType,
+  credentials: unknown,
+): { readonly sealed: Record<string, string>; readonly hint: string } | null {
+  const rule = descriptorOf(type).credentials;
+
+  if (!rule.required) {
+    if (credentials !== undefined) throw new Error(rule.refusal);
+    return null;
+  }
+
+  const shape = `{ ${rule.fields.join(", ")} }`;
+  if (
+    credentials === undefined ||
+    typeof credentials !== "object" ||
+    credentials === null ||
+    Array.isArray(credentials)
+  ) {
+    throw new Error(`a ${type} connection needs credentials shaped ${shape}`);
+  }
+
+  for (const key of Object.keys(credentials)) {
+    if (!rule.fields.includes(key)) {
+      throw new Error(
+        `a ${type} connection's credentials have no key "${key}"; they are ` +
+          `shaped ${shape}`,
+      );
+    }
+  }
+
+  const sealed: Record<string, string> = {};
+  for (const field of rule.fields) {
+    const value = (credentials as Record<string, unknown>)[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new Error(
+        `a ${type} connection's credentials need ${field} to be a non-empty string`,
+      );
+    }
+    sealed[field] = value;
+  }
+
+  return { sealed, hint: sealed[rule.hintField]?.slice(-4) ?? "" };
+}

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -131,11 +131,27 @@ export {
 } from "./device-authorizations.ts";
 
 export {
+  addConnection,
   createAgent,
   getAgent,
+  getConnection,
+  listConnections,
+  removeConnection,
+  resolveConnectionCredentials,
+  updateConnection,
   type Agent,
+  type Connection,
+  type ConnectionChanges,
+  type CreatedAgent,
   type NewAgent,
+  type NewConnection,
+  type RemovedConnection,
 } from "./agents.ts";
+export type {
+  ConnectionType,
+  Modality,
+  Topology,
+} from "../schema/agents.ts";
 
 export {
   cloneDigitalHuman,

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import pg from "pg";
 
 import * as schema from "./schema/index.ts";
+import { holdMasterKey, releaseMasterKey } from "./sealing.ts";
 
 /**
  * The Postgres pool is private to this module and is never exported. Reaching
@@ -14,10 +15,21 @@ let database: ReturnType<typeof drizzle<typeof schema>> | undefined;
 export type ConnectOptions = {
   readonly databaseUrl: string;
   readonly maxConnections?: number;
+  /**
+   * `EGMA_ENCRYPTION_KEY`: 32 random bytes as 64 hex characters, under which
+   * connection credentials are sealed before they touch a row (ADR-0003). It
+   * arrives here — the same door the database URL does — and a malformed one
+   * refuses to connect at all, so a misconfigured deployment is loud at boot.
+   * Without one, everything runs except sealing and unsealing a credential.
+   */
+  readonly encryptionKey?: string;
 };
 
 export function connect(options: ConnectOptions): void {
   if (pool !== undefined) throw new Error("already connected to Postgres");
+  if (options.encryptionKey !== undefined) {
+    holdMasterKey(options.encryptionKey);
+  }
   pool = new pg.Pool({
     connectionString: options.databaseUrl,
     max: options.maxConnections ?? 10,
@@ -29,6 +41,7 @@ export async function disconnect(): Promise<void> {
   const open = pool;
   pool = undefined;
   database = undefined;
+  releaseMasterKey();
   await open?.end();
 }
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -17,10 +17,10 @@ export type ConnectOptions = {
   readonly maxConnections?: number;
   /**
    * `EGMA_ENCRYPTION_KEY`: 32 random bytes as 64 hex characters, under which
-   * connection credentials are sealed before they touch a row (ADR-0003). It
-   * arrives here — the same door the database URL does — and a malformed one
-   * refuses to connect at all, so a misconfigured deployment is loud at boot.
-   * Without one, everything runs except sealing and unsealing a credential.
+   * connection credentials are sealed before they touch a row. It arrives
+   * here — the same door the database URL does — and a malformed one refuses
+   * to connect at all, so a misconfigured deployment is loud at boot. Without
+   * one, everything runs except sealing and unsealing a credential.
    */
   readonly encryptionKey?: string;
 };

--- a/packages/db/src/sealing.ts
+++ b/packages/db/src/sealing.ts
@@ -1,0 +1,127 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from "node:crypto";
+
+/**
+ * How a customer's provider credential is sealed before it touches a row, and
+ * the one place it is ever unsealed. The whole decision is ADR-0003; the shape
+ * of it here:
+ *
+ * A connection's credential cannot be hashed — egma must replay it to the
+ * provider every time a simulation starts — so it is encrypted in this process
+ * under a master key that lives beside the process and never in the database.
+ * A stolen backup, a misconfigured replica, anyone who can run a query: all of
+ * them see ciphertext and hold no key.
+ *
+ * The stored value is a versioned envelope, `v1.<iv>.<ciphertext>.<tag>`, with
+ * a fresh random IV per write. The version stamp is what makes a future
+ * algorithm change — or a KMS-wrapped `v2` — a data migration rather than a
+ * format guess.
+ *
+ * The key arrives through `connect()`, the same door the database URL does,
+ * and is held privately here. It is 32 random bytes written as 64 hex
+ * characters (`openssl rand -hex 32`), and the check below enforces length
+ * *and* alphabet rather than presence: a 32-character passphrase has the right
+ * byte count and a fraction of the entropy, and must be refused, not accepted
+ * quietly.
+ */
+
+/** AES-256-GCM: the key is 32 bytes, written as 64 hex characters. */
+const KEY_PATTERN = /^[0-9a-f]{64}$/i;
+
+/** GCM's standard nonce size. Random per write; never reused with one key. */
+const IV_BYTES = 12;
+
+const VERSION = "v1";
+
+let masterKey: Buffer | undefined;
+
+/**
+ * Refuses anything that is not exactly 32 bytes of hex, so a misconfigured
+ * deployment is loud at boot rather than quietly under-encrypted. Called by
+ * `connect()`; nothing else holds the key.
+ */
+export function holdMasterKey(key: string): void {
+  if (!KEY_PATTERN.test(key)) {
+    throw new Error(
+      "EGMA_ENCRYPTION_KEY must be 32 random bytes written as 64 hex " +
+        "characters — `openssl rand -hex 32` makes one. A passphrase has " +
+        "the right length and a fraction of the entropy, so it is refused " +
+        "rather than accepted quietly.",
+    );
+  }
+  masterKey = Buffer.from(key, "hex");
+}
+
+/** Called by `disconnect()`, so a closed process holds nothing. */
+export function releaseMasterKey(): void {
+  masterKey = undefined;
+}
+
+function theMasterKey(): Buffer {
+  if (masterKey === undefined) {
+    throw new Error(
+      "sealing a credential needs the master key, and connect() was given " +
+        "none. Set EGMA_ENCRYPTION_KEY and pass it as `encryptionKey`.",
+    );
+  }
+  return masterKey;
+}
+
+/**
+ * The credentials object as it will be stored: sealed whole, one envelope per
+ * row. Sealed as JSON so rotation can only ever replace the whole object —
+ * there is no format in which a single field could be edited in place.
+ */
+export function sealCredentials(credentials: unknown): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", theMasterKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(credentials), "utf8"),
+    cipher.final(),
+  ]);
+
+  return [
+    VERSION,
+    iv.toString("base64url"),
+    ciphertext.toString("base64url"),
+    cipher.getAuthTag().toString("base64url"),
+  ].join(".");
+}
+
+/**
+ * The envelope opened and parsed. GCM authenticates before it decrypts, so a
+ * row that was tampered with — or sealed under a different key — fails here
+ * loudly rather than replaying garbage to a provider.
+ */
+export function openCredentials(envelope: string): unknown {
+  const [version, iv, ciphertext, tag, ...extra] = envelope.split(".");
+  if (
+    version !== VERSION ||
+    iv === undefined ||
+    ciphertext === undefined ||
+    tag === undefined ||
+    extra.length > 0
+  ) {
+    throw new Error(
+      `a sealed credential looks like ${VERSION}.<iv>.<ciphertext>.<tag>, ` +
+        "and this row holds something else; it needs repairing before " +
+        "anybody can use it",
+    );
+  }
+
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    theMasterKey(),
+    Buffer.from(iv, "base64url"),
+  );
+  decipher.setAuthTag(Buffer.from(tag, "base64url"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(ciphertext, "base64url")),
+    decipher.final(),
+  ]);
+
+  return JSON.parse(plaintext.toString("utf8"));
+}

--- a/packages/db/src/sealing.ts
+++ b/packages/db/src/sealing.ts
@@ -6,8 +6,7 @@ import {
 
 /**
  * How a customer's provider credential is sealed before it touches a row, and
- * the one place it is ever unsealed. The whole decision is ADR-0003; the shape
- * of it here:
+ * the one place it is ever unsealed.
  *
  * A connection's credential cannot be hashed — egma must replay it to the
  * provider every time a simulation starts — so it is encrypted in this process

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -330,6 +330,23 @@ describe("the sealed credential", () => {
     ).rejects.toThrow(NotPermittedError);
   });
 
+  it("stores the key trimmed, so a padded paste still authenticates", async () => {
+    const agentId = await agentNamed("Padded Key");
+    const added = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ credentials: { apiKey: "  retell-secret-padded-1234  " } }),
+    );
+
+    expect(added?.credentialsHint).toBe("1234");
+    const resolved = await resolveConnectionCredentials(
+      actingAsAcme(),
+      agentId,
+      added?.id ?? "",
+    );
+    expect(resolved).toEqual({ apiKey: "retell-secret-padded-1234" });
+  });
+
   it("rotates by replacing the object whole, resealing envelope and hint", async () => {
     const agentId = await agentNamed("Rotated");
     const added = await addConnection(actingAsAcme(), agentId, retellConnection());

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -243,6 +243,18 @@ describe("what the registry refuses at the door, by name", () => {
       ),
     ).rejects.toThrow(/needs credentials/);
   });
+
+  it("refuses a credential so short its last-4 hint would give it away", async () => {
+    const agentId = await agentNamed("Tiny Secret");
+
+    await expect(
+      addConnection(
+        actingAsAcme(),
+        agentId,
+        retellConnection({ credentials: { apiKey: "abcd" } }),
+      ),
+    ).rejects.toThrow(/at least 8 characters/);
+  });
 });
 
 describe("the sealed credential", () => {
@@ -493,6 +505,9 @@ describe("reaching a connection through the wrong door", () => {
     ).toBeUndefined();
     expect(
       await removeConnection(actingAsAcme(), neighbour, added?.id ?? ""),
+    ).toBeUndefined();
+    expect(
+      await resolveConnectionCredentials(actingAsAcme(), neighbour, added?.id ?? ""),
     ).toBeUndefined();
   });
 

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -1,0 +1,599 @@
+import { isId, newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  addConnection,
+  createAgent,
+  getConnection,
+  listConnections,
+  NotPermittedError,
+  removeConnection,
+  resolveConnectionCredentials,
+  updateConnection,
+  type AuthContext,
+  type NewConnection,
+  type Role,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * Every assertion goes through the factory functions — the seam — except the
+ * reads of the raw `credentials` column, which bypass the module on purpose:
+ * the whole claim under test is that what the module writes is ciphertext and
+ * what it answers never includes it, and only a read the module cannot dress
+ * up can say so.
+ */
+
+let database: MigratedDatabase;
+
+const acme = {
+  organization: newId("org"),
+  project: newId("prj"),
+  secondProject: newId("prj"),
+};
+const globex = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+const grace = newId("usr");
+
+function actingAsAcme(role: Role = "member"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+function actingAsGlobex(): AuthContext {
+  return {
+    userId: grace,
+    organizationId: globex.organization,
+    projectId: globex.project,
+    role: "member",
+    via: "session",
+  };
+}
+
+/** A live retell payload, spread-and-overridden by the case at hand. */
+function retellConnection(overrides: Partial<NewConnection> = {}): NewConnection {
+  return {
+    name: `retell-${newId("con").slice(-8)}`,
+    type: "retell",
+    modality: "chat",
+    config: { retellAgentId: "agent_in_retell_1" },
+    credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    ...overrides,
+  };
+}
+
+async function agentNamed(name: string): Promise<string> {
+  const created = await createAgent(actingAsAcme(), { name });
+  return created.id;
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("connections");
+
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+    { id: acme.secondProject, slug: "outbound" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedUser(database, grace, "grace@globex.example");
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("adding a connection", () => {
+  it("returns a con_ id and fetch round-trips every non-secret field", async () => {
+    const agentId = await agentNamed("Round Trip");
+
+    const added = await addConnection(actingAsAcme(), agentId, {
+      name: "staging",
+      type: "retell",
+      modality: "voice",
+      environment: "staging",
+      config: { retellAgentId: "agent_abc" },
+      credentials: { apiKey: "sk-retell-000011112222WXYZ" },
+    });
+
+    expect(added).toBeDefined();
+    expect(isId("con", added?.id ?? "")).toBe(true);
+
+    const fetched = await getConnection(actingAsAcme(), agentId, added?.id ?? "");
+    expect(fetched).toMatchObject({
+      agentId,
+      name: "staging",
+      type: "retell",
+      modality: "voice",
+      topology: "hosted-broker",
+      environment: "staging",
+      config: { retellAgentId: "agent_abc" },
+      credentialsHint: "WXYZ",
+      capabilities: null,
+    });
+  });
+
+  it("derives the topology from the type, so a phone connection dials in", async () => {
+    const agentId = await agentNamed("Topology");
+
+    const added = await addConnection(actingAsAcme(), agentId, {
+      name: "production-line",
+      type: "phone",
+      modality: "voice",
+      config: { phoneNumber: "+15551234567" },
+    });
+
+    expect(added?.topology).toBe("egma-dials-in");
+    expect(added?.credentialsHint).toBeNull();
+  });
+
+  it("defaults the name from the type, and again for the next one", async () => {
+    const agentId = await agentNamed("Unnamed");
+
+    const first = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: undefined }),
+    );
+    const second = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: undefined }),
+    );
+
+    expect(first?.name).toBe("retell-1");
+    expect(second?.name).toBe("retell-2");
+  });
+
+  it("is allowed to a member and refused to a viewer", async () => {
+    const agentId = await agentNamed("Permissions");
+
+    await expect(
+      addConnection(actingAsAcme("viewer"), agentId, retellConnection()),
+    ).rejects.toThrow(NotPermittedError);
+  });
+});
+
+describe("what the registry refuses at the door, by name", () => {
+  it("refuses phone + chat: a phone connection speaks voice", async () => {
+    const agentId = await agentNamed("Modality Rules");
+
+    await expect(
+      addConnection(actingAsAcme(), agentId, {
+        name: "impossible",
+        type: "phone",
+        modality: "chat",
+        config: { phoneNumber: "+15551234567" },
+      }),
+    ).rejects.toThrow(/phone connection speaks voice/);
+  });
+
+  it("refuses an unknown config key by its name", async () => {
+    const agentId = await agentNamed("Config Typo");
+
+    await expect(
+      addConnection(
+        actingAsAcme(),
+        agentId,
+        retellConnection({
+          config: { retellAgentId: "agent_abc", retellAgentld: "typo" },
+        }),
+      ),
+    ).rejects.toThrow(/"retellAgentld"/);
+  });
+
+  it("refuses a retell connection missing retellAgentId, naming it", async () => {
+    const agentId = await agentNamed("Config Missing");
+
+    await expect(
+      addConnection(actingAsAcme(), agentId, retellConnection({ config: {} })),
+    ).rejects.toThrow(/retellAgentId/);
+  });
+
+  it("refuses a phone number that is not E.164", async () => {
+    const agentId = await agentNamed("Bad Number");
+
+    await expect(
+      addConnection(actingAsAcme(), agentId, {
+        name: "landline",
+        type: "phone",
+        modality: "voice",
+        config: { phoneNumber: "555-1234" },
+      }),
+    ).rejects.toThrow(/E\.164/);
+  });
+
+  it("refuses a credential on a phone connection rather than ignoring it", async () => {
+    const agentId = await agentNamed("Uncredentialed");
+
+    await expect(
+      addConnection(actingAsAcme(), agentId, {
+        name: "with-secret",
+        type: "phone",
+        modality: "voice",
+        config: { phoneNumber: "+15551234567" },
+        credentials: { apiKey: "should-not-be-here" },
+      }),
+    ).rejects.toThrow(/takes no credential/);
+
+    // Refused means not stored: nothing landed under that name.
+    expect(await listConnections(actingAsAcme(), agentId)).toEqual([]);
+  });
+
+  it("refuses a retell connection with no credentials at all", async () => {
+    const agentId = await agentNamed("Keyless");
+
+    await expect(
+      addConnection(
+        actingAsAcme(),
+        agentId,
+        retellConnection({ credentials: undefined }),
+      ),
+    ).rejects.toThrow(/needs credentials/);
+  });
+});
+
+describe("the sealed credential", () => {
+  it("never appears in any read; the last-4 hint does", async () => {
+    const agentId = await agentNamed("Sealed Reads");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    const fetched = await getConnection(actingAsAcme(), agentId, added?.id ?? "");
+    const [listed] = (await listConnections(actingAsAcme(), agentId)) ?? [];
+
+    for (const shape of [added, fetched, listed]) {
+      expect(shape).toBeDefined();
+      expect(shape).not.toHaveProperty("credentials");
+      expect(shape?.credentialsHint).toBe("WXYZ");
+    }
+  });
+
+  it("lands in the row as a v1. envelope, not as the key", async () => {
+    const agentId = await agentNamed("Sealed Row");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    const { rows } = await database.sql<{
+      credentials: string;
+      credentials_hint: string;
+    }>("select credentials, credentials_hint from connection where id = $1", [
+      added?.id,
+    ]);
+
+    expect(rows[0]?.credentials).toMatch(/^v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(rows[0]?.credentials).not.toContain("retell-secret");
+    expect(rows[0]?.credentials_hint).toBe("WXYZ");
+  });
+
+  it("round-trips through the resolver, the one door to the plaintext", async () => {
+    const agentId = await agentNamed("Resolved");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    const resolved = await resolveConnectionCredentials(
+      actingAsAcme(),
+      agentId,
+      added?.id ?? "",
+    );
+    expect(resolved).toEqual({ apiKey: "retell-secret-A1B2C3D4WXYZ" });
+  });
+
+  it("resolves to null for a type that holds no secret", async () => {
+    const agentId = await agentNamed("Resolved Phone");
+    const added = await addConnection(actingAsAcme(), agentId, {
+      name: "hotline",
+      type: "phone",
+      modality: "voice",
+      config: { phoneNumber: "+15559876543" },
+    });
+
+    const resolved = await resolveConnectionCredentials(
+      actingAsAcme(),
+      agentId,
+      added?.id ?? "",
+    );
+    expect(resolved).toBeNull();
+  });
+
+  it("refuses the resolver to a viewer, who cannot start a run", async () => {
+    const agentId = await agentNamed("Resolver Gate");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    await expect(
+      resolveConnectionCredentials(
+        actingAsAcme("viewer"),
+        agentId,
+        added?.id ?? "",
+      ),
+    ).rejects.toThrow(NotPermittedError);
+  });
+
+  it("rotates by replacing the object whole, resealing envelope and hint", async () => {
+    const agentId = await agentNamed("Rotated");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    const before = await database.sql<{ credentials: string }>(
+      "select credentials from connection where id = $1",
+      [added?.id],
+    );
+
+    const rotated = await updateConnection(actingAsAcme(), agentId, added?.id ?? "", {
+      credentials: { apiKey: "retell-secret-rotated-9999ABCD" },
+    });
+    expect(rotated?.credentialsHint).toBe("ABCD");
+
+    const after = await database.sql<{ credentials: string }>(
+      "select credentials from connection where id = $1",
+      [added?.id],
+    );
+    expect(after.rows[0]?.credentials).not.toBe(before.rows[0]?.credentials);
+
+    const resolved = await resolveConnectionCredentials(
+      actingAsAcme(),
+      agentId,
+      added?.id ?? "",
+    );
+    expect(resolved).toEqual({ apiKey: "retell-secret-rotated-9999ABCD" });
+  });
+});
+
+describe("updating a connection", () => {
+  it("changes name, environment and config; absent means keep", async () => {
+    const agentId = await agentNamed("Edited");
+    const added = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: "before", environment: "staging" }),
+    );
+
+    const renamed = await updateConnection(actingAsAcme(), agentId, added?.id ?? "", {
+      name: "after",
+      config: { retellAgentId: "agent_replacement" },
+    });
+
+    expect(renamed?.name).toBe("after");
+    expect(renamed?.environment).toBe("staging");
+    expect(renamed?.config).toEqual({ retellAgentId: "agent_replacement" });
+
+    const cleared = await updateConnection(actingAsAcme(), agentId, added?.id ?? "", {
+      environment: null,
+    });
+    expect(cleared?.environment).toBeNull();
+  });
+
+  it("checks a config change against the type's own registry entry", async () => {
+    const agentId = await agentNamed("Edited Config");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    await expect(
+      updateConnection(actingAsAcme(), agentId, added?.id ?? "", {
+        config: { phoneNumber: "+15551234567" },
+      }),
+    ).rejects.toThrow(/"phoneNumber"/);
+  });
+
+  it("refuses to change type or modality: that is a new connection", async () => {
+    const agentId = await agentNamed("Immutable");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    await expect(
+      updateConnection(actingAsAcme(), agentId, added?.id ?? "", {
+        type: "phone",
+      } as never),
+    ).rejects.toThrow(/new connection/);
+
+    await expect(
+      updateConnection(actingAsAcme(), agentId, added?.id ?? "", {
+        modality: "voice",
+      } as never),
+    ).rejects.toThrow(/new connection/);
+
+    const untouched = await getConnection(actingAsAcme(), agentId, added?.id ?? "");
+    expect(untouched?.type).toBe("retell");
+    expect(untouched?.modality).toBe("chat");
+  });
+});
+
+describe("a connection's name", () => {
+  it("is stored trimmed and refused while another living connection holds it", async () => {
+    const agentId = await agentNamed("Named");
+
+    const padded = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: "  staging  " }),
+    );
+    expect(padded?.name).toBe("staging");
+
+    await expect(
+      addConnection(actingAsAcme(), agentId, retellConnection({ name: "staging" })),
+    ).rejects.toThrow(/already/);
+  });
+
+  it("is welcome on another agent of the same project", async () => {
+    const first = await agentNamed("First Owner");
+    const second = await agentNamed("Second Owner");
+
+    await addConnection(actingAsAcme(), first, retellConnection({ name: "ci" }));
+    const twin = await addConnection(
+      actingAsAcme(),
+      second,
+      retellConnection({ name: "ci" }),
+    );
+    expect(twin?.name).toBe("ci");
+  });
+
+  it("is released by a removed connection", async () => {
+    const agentId = await agentNamed("Recycler");
+
+    const retiring = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: "staging" }),
+    );
+    await removeConnection(actingAsAcme(), agentId, retiring?.id ?? "");
+
+    const successor = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: "staging" }),
+    );
+    expect(successor?.name).toBe("staging");
+    expect(successor?.id).not.toBe(retiring?.id);
+  });
+});
+
+describe("removing a connection", () => {
+  it("vanishes from fetch and list, and answers what was removed", async () => {
+    const agentId = await agentNamed("Shrinking");
+    const keeper = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: "keeper" }),
+    );
+    const goner = await addConnection(
+      actingAsAcme(),
+      agentId,
+      retellConnection({ name: "goner" }),
+    );
+
+    const removed = await removeConnection(actingAsAcme(), agentId, goner?.id ?? "");
+    expect(removed?.id).toBe(goner?.id);
+    expect(removed?.deletedAt).toBeInstanceOf(Date);
+
+    expect(await getConnection(actingAsAcme(), agentId, goner?.id ?? "")).toBeUndefined();
+    const remaining = await listConnections(actingAsAcme(), agentId);
+    expect(remaining?.map((connection) => connection.id)).toEqual([keeper?.id]);
+  });
+});
+
+describe("reaching a connection through the wrong door", () => {
+  it("is unreachable through another agent, even of the same project", async () => {
+    const home = await agentNamed("Home");
+    const neighbour = await agentNamed("Neighbour");
+    const added = await addConnection(actingAsAcme(), home, retellConnection());
+
+    expect(
+      await getConnection(actingAsAcme(), neighbour, added?.id ?? ""),
+    ).toBeUndefined();
+    expect(
+      await updateConnection(actingAsAcme(), neighbour, added?.id ?? "", {
+        name: "hijacked",
+      }),
+    ).toBeUndefined();
+    expect(
+      await removeConnection(actingAsAcme(), neighbour, added?.id ?? ""),
+    ).toBeUndefined();
+  });
+
+  it("is unreachable under another organization's auth context, every verb", async () => {
+    const agentId = await agentNamed("Acme's Alone");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    expect(
+      await addConnection(actingAsGlobex(), agentId, retellConnection()),
+    ).toBeUndefined();
+    expect(await listConnections(actingAsGlobex(), agentId)).toBeUndefined();
+    expect(
+      await getConnection(actingAsGlobex(), agentId, added?.id ?? ""),
+    ).toBeUndefined();
+    expect(
+      await updateConnection(actingAsGlobex(), agentId, added?.id ?? "", {
+        name: "stolen",
+      }),
+    ).toBeUndefined();
+    expect(
+      await removeConnection(actingAsGlobex(), agentId, added?.id ?? ""),
+    ).toBeUndefined();
+    expect(
+      await resolveConnectionCredentials(actingAsGlobex(), agentId, added?.id ?? ""),
+    ).toBeUndefined();
+  });
+
+  it("reaches the whole customer for a credential acting in no project", async () => {
+    const agentId = await agentNamed("Org Wide Wiring");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    const wholeCustomer = { ...actingAsAcme(), projectId: undefined };
+    const fetched = await getConnection(wholeCustomer, agentId, added?.id ?? "");
+    expect(fetched?.id).toBe(added?.id);
+  });
+
+  it("vanishes with its agent: a deleted agent's connections answer nothing", async () => {
+    const agentId = await agentNamed("Doomed");
+    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
+
+    // The agent's delete verb is the next issue's; until then the mark is made
+    // by hand.
+    await database.sql("update agent set deleted_at = now() where id = $1", [
+      agentId,
+    ]);
+
+    expect(await listConnections(actingAsAcme(), agentId)).toBeUndefined();
+    expect(
+      await getConnection(actingAsAcme(), agentId, added?.id ?? ""),
+    ).toBeUndefined();
+  });
+});
+
+describe("creating an agent with its first connection inline", () => {
+  it("writes both rows in one motion and answers both ids", async () => {
+    const created = await createAgent(actingAsAcme(), {
+      name: "Wired From Birth",
+      connection: retellConnection({ name: "day-one" }),
+    });
+
+    expect(isId("agt", created.id)).toBe(true);
+    expect(isId("con", created.connection?.id ?? "")).toBe(true);
+    expect(created.connection?.agentId).toBe(created.id);
+
+    const listed = await listConnections(actingAsAcme(), created.id);
+    expect(listed?.map((connection) => connection.name)).toEqual(["day-one"]);
+  });
+
+  it("defaults the inline connection's name from its type", async () => {
+    const created = await createAgent(actingAsAcme(), {
+      name: "Wired Namelessly",
+      connection: retellConnection({ name: undefined }),
+    });
+
+    expect(created.connection?.name).toBe("retell-1");
+  });
+
+  it("leaves no agent behind when the connection payload is bad", async () => {
+    await expect(
+      createAgent(actingAsAcme(), {
+        name: "Atomic",
+        connection: retellConnection({ config: {} }),
+      }),
+    ).rejects.toThrow(/retellAgentId/);
+
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from agent where name = 'Atomic'",
+    );
+    expect(rows[0]?.count).toBe("0");
+
+    // And the name is genuinely free: the create can be retried, fixed.
+    const retried = await createAgent(actingAsAcme(), {
+      name: "Atomic",
+      connection: retellConnection(),
+    });
+    expect(retried.connection).toBeDefined();
+  });
+
+  it("still creates an agent with no connection at all", async () => {
+    const created = await createAgent(actingAsAcme(), { name: "Unwired" });
+    expect(created.connection).toBeUndefined();
+    expect(await listConnections(actingAsAcme(), created.id)).toEqual([]);
+  });
+});

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -53,6 +53,7 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
 
 /** Everything that touches a customer's data. All of it needs the context. */
 const CONTEXT_REQUIRING = [
+  "addConnection",
   "changeRole",
   "cloneDigitalHuman",
   "createAgent",
@@ -64,9 +65,11 @@ const CONTEXT_REQUIRING = [
   "deleteDigitalHuman",
   "editDigitalHuman",
   "getAgent",
+  "getConnection",
   "getDigitalHuman",
   "getDigitalHumanVersion",
   "listApiKeys",
+  "listConnections",
   "listDigitalHumans",
   "listMembers",
   "listPendingInvitations",
@@ -75,8 +78,11 @@ const CONTEXT_REQUIRING = [
   "readOrganizationSettings",
   "readProject",
   "recordDeviceAuthorization",
+  "removeConnection",
   "removeMember",
+  "resolveConnectionCredentials",
   "revokeApiKey",
+  "updateConnection",
   "updateOrganizationSettings",
 ];
 

--- a/packages/db/test/permissions.test.ts
+++ b/packages/db/test/permissions.test.ts
@@ -110,7 +110,6 @@ describe("the action list", () => {
  * exist yet. Never both, and never neither.
  */
 const NOT_YET_REACHABLE: Readonly<Record<string, string>> = {
-  start_and_cancel_runs: "nothing can start a run yet",
   delete_run_data: "there is no run data to delete yet",
   delete_organization: "deleting an organization is designed and not built",
 };

--- a/packages/db/test/support/database.ts
+++ b/packages/db/test/support/database.ts
@@ -89,6 +89,13 @@ export async function createMigratedDatabase(
 }
 
 /**
+ * The master key the connected module seals credentials under in tests. Fixed
+ * and well-formed — 32 bytes as 64 hex characters — because the tests assert
+ * what sealing does, never that this particular key is secret.
+ */
+export const TEST_ENCRYPTION_KEY = "0123456789abcdef".repeat(4);
+
+/**
  * A migrated database that the data-access module is connected to, for the
  * tests that go through it. The raw `sql` handle stays available so a test can
  * check what actually landed in the table without asking the module to tell it.
@@ -97,7 +104,7 @@ export async function createConnectedDatabase(
   label: string,
 ): Promise<MigratedDatabase> {
   const database = await createMigratedDatabase(label);
-  connect({ databaseUrl: database.url });
+  connect({ databaseUrl: database.url, encryptionKey: TEST_ENCRYPTION_KEY });
 
   return {
     ...database,


### PR DESCRIPTION
A developer can now attach connections to their agent and manage them, always through the agent: `addConnection`, `getConnection`, `listConnections`, `updateConnection`, `removeConnection` — every verb takes the agent's id, and a connection reached through the wrong agent or the wrong customer answers exactly what a connection that doesn't exist answers.

## What's here

- **A type registry drives the door** (`connection-registry.ts`). One descriptor per connection type — allowed modalities, implied topology, config keys with per-key gates, credential rule. `retell` speaks chat or voice through a hosted broker and demands `retellAgentId` plus an API key; `phone` speaks voice only, egma dials in, demands an E.164 `phoneNumber`, and **refuses** any credential outright rather than storing and ignoring it. Unknown config keys are refused by name, topology is derived and never caller-supplied, and the registry is `Record<ConnectionType, …>` so it cannot drift from the schema's CHECK list.
- **Credentials are sealed before they touch the row** (`sealing.ts`, per the encryption design). AES-256-GCM under `EGMA_ENCRYPTION_KEY` (32 bytes as 64 hex characters, validated for length *and* alphabet at boot), stored as a versioned envelope `v1.<iv>.<ciphertext>.<tag>` with a fresh IV per write. No read shape has a credentials field at all — leaking via a serializer is a compile error — and a last-4 hint is all any read gets. Rotation replaces the object whole, so plaintext never round-trips out.
- **One door to the plaintext**: `resolveConnectionCredentials`, gated on the run-starter's permission, answering the decrypted object for `retell`, `null` for `phone`, and `undefined` for anything out of reach. Nothing else in the codebase can decrypt.
- **`createAgent` gains its optional inline first connection**, written in the same transaction: a bad connection payload leaves no agent behind, and the happy onboarding path can't produce an unreachable agent.
- **Names**: required in the schema, defaultable at the door (`retell-1`, then `retell-2`), trimmed, unique per agent among the living, released by removal. **Type and modality are immutable** after create — changing what a connection *is* is a new connection, and an attempt is refused out loud.

## Testing

31 new tests in `packages/db/test/connections.test.ts`, at the factory-function seam against real Postgres — including raw-row reads that bypass the module on purpose to show the stored value is a `v1.` envelope and never the key. Full suite: 446 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)