### PR TITLE
The simulation contract exists before either of its speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ packages/db     The data-access module: schema, migrations, and every read
                 and write there is.
 packages/ids    The identifier generator.
 packages/lint   Build-time rules that hold the boundaries in place.
+packages/simulation-contract
+                The versioned JSON contract between the control plane and the
+                simulator: a schema per direction, golden fixtures beside
+                them, and the suite that holds both to the fixtures.
 ```
 
 The two processes answer on **one origin**. The web application proxies the

--- a/packages/simulation-contract/fixtures/report/invalid/completed-claiming-never-ran.json
+++ b/packages/simulation-contract/fixtures/report/invalid/completed-claiming-never-ran.json
@@ -1,0 +1,21 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWES",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000501",
+      "at": "2026-08-05T09:01:02.339000Z",
+      "status": "completed",
+      "reason": null,
+      "facts": {
+        "ending": "agent_never_joined",
+        "started_at": "2026-08-05T09:00:12.000000Z",
+        "ended_at": "2026-08-05T09:01:02.339000Z",
+        "turn_count": 0,
+        "audio": null,
+        "provider_reference": null
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/invalid/completed-without-facts.json
+++ b/packages/simulation-contract/fixtures/report/invalid/completed-without-facts.json
@@ -1,0 +1,13 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000008",
+      "at": "2026-08-05T09:02:10.551000Z",
+      "status": "completed",
+      "reason": null
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/invalid/credentials-echoed.json
+++ b/packages/simulation-contract/fixtures/report/invalid/credentials-echoed.json
@@ -1,0 +1,27 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "connection": {
+    "type": "retell",
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000008",
+      "at": "2026-08-05T09:02:10.551000Z",
+      "status": "completed",
+      "reason": null,
+      "facts": {
+        "ending": "persona_concluded",
+        "started_at": "2026-08-05T09:00:00.000000Z",
+        "ended_at": "2026-08-05T09:02:10.551000Z",
+        "turn_count": 14,
+        "audio": null,
+        "provider_reference": "chat_5d1f9a3b7c"
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/invalid/failed-without-reason.json
+++ b/packages/simulation-contract/fixtures/report/invalid/failed-without-reason.json
@@ -1,0 +1,21 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWES",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000201",
+      "at": "2026-08-05T09:01:02.339000Z",
+      "status": "failed",
+      "reason": null,
+      "facts": {
+        "ending": "error",
+        "started_at": "2026-08-05T09:00:12.000000Z",
+        "ended_at": "2026-08-05T09:01:02.339000Z",
+        "turn_count": 0,
+        "audio": null,
+        "provider_reference": null
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/invalid/running-with-facts.json
+++ b/packages/simulation-contract/fixtures/report/invalid/running-with-facts.json
@@ -1,0 +1,21 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000001",
+      "at": "2026-08-05T09:00:00.000000Z",
+      "status": "running",
+      "reason": null,
+      "facts": {
+        "ending": "persona_concluded",
+        "started_at": "2026-08-05T09:00:00.000000Z",
+        "ended_at": "2026-08-05T09:02:10.551000Z",
+        "turn_count": 14,
+        "audio": null,
+        "provider_reference": null
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/invalid/unknown-event-kind.json
+++ b/packages/simulation-contract/fixtures/report/invalid/unknown-event-kind.json
@@ -1,0 +1,12 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "verdict",
+      "event_id": "evt-000401",
+      "at": "2026-08-05T09:02:10.551000Z",
+      "passed": true
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/canceled.json
+++ b/packages/simulation-contract/fixtures/report/valid/canceled.json
@@ -1,0 +1,21 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000301",
+      "at": "2026-08-05T09:01:15.008000Z",
+      "status": "canceled",
+      "reason": "cancel directive received on the heartbeat and honored",
+      "facts": {
+        "ending": "canceled",
+        "started_at": "2026-08-05T09:00:00.000000Z",
+        "ended_at": "2026-08-05T09:01:15.008000Z",
+        "turn_count": 6,
+        "audio": null,
+        "provider_reference": "chat_5d1f9a3b7c"
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/completed-chat.json
+++ b/packages/simulation-contract/fixtures/report/valid/completed-chat.json
@@ -1,0 +1,21 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000008",
+      "at": "2026-08-05T09:02:10.551000Z",
+      "status": "completed",
+      "reason": null,
+      "facts": {
+        "ending": "persona_concluded",
+        "started_at": "2026-08-05T09:00:00.000000Z",
+        "ended_at": "2026-08-05T09:02:10.551000Z",
+        "turn_count": 14,
+        "audio": null,
+        "provider_reference": "chat_5d1f9a3b7c"
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/completed-voice.json
+++ b/packages/simulation-contract/fixtures/report/valid/completed-voice.json
@@ -1,0 +1,24 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWES",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000101",
+      "at": "2026-08-05T09:04:32.007000Z",
+      "status": "completed",
+      "reason": null,
+      "facts": {
+        "ending": "agent_ended",
+        "started_at": "2026-08-05T09:00:12.000000Z",
+        "ended_at": "2026-08-05T09:04:32.007000Z",
+        "turn_count": 22,
+        "audio": {
+          "measured_sample_rate_hz": 8000,
+          "recording": "sim_01K3XQ7M4E8YB2FVN0H9TZQWES/dual-channel.wav"
+        },
+        "provider_reference": "CA7e2b9c1d4f6a8e0b2d4f6a8e0b2d4f6a"
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/failed-agent-never-joined.json
+++ b/packages/simulation-contract/fixtures/report/valid/failed-agent-never-joined.json
@@ -1,0 +1,21 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWES",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000201",
+      "at": "2026-08-05T09:01:02.339000Z",
+      "status": "failed",
+      "reason": "the agent never joined: the dial completed but no agent audio arrived within the join deadline",
+      "facts": {
+        "ending": "agent_never_joined",
+        "started_at": "2026-08-05T09:00:12.000000Z",
+        "ended_at": "2026-08-05T09:01:02.339000Z",
+        "turn_count": 0,
+        "audio": null,
+        "provider_reference": "CA1a3c5e7f9b1d3f5a7c9e1b3d5f7a9c1e"
+      }
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/status-running.json
+++ b/packages/simulation-contract/fixtures/report/valid/status-running.json
@@ -1,0 +1,13 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "status",
+      "event_id": "evt-000001",
+      "at": "2026-08-05T09:00:00.000000Z",
+      "status": "running",
+      "reason": null
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/timing.json
+++ b/packages/simulation-contract/fixtures/report/valid/timing.json
@@ -1,0 +1,20 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "timing",
+      "event_id": "evt-000006",
+      "at": "2026-08-05T09:00:01.214000Z",
+      "measure": "first_response_latency",
+      "milliseconds": 1214
+    },
+    {
+      "kind": "timing",
+      "event_id": "evt-000007",
+      "at": "2026-08-05T09:00:11.480000Z",
+      "measure": "turn_response_latency",
+      "milliseconds": 862.5
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/tool-call.json
+++ b/packages/simulation-contract/fixtures/report/valid/tool-call.json
@@ -1,0 +1,20 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "tool_call",
+      "event_id": "evt-000004",
+      "at": "2026-08-05T09:00:41.377000Z",
+      "name": "reschedule_appointment",
+      "arguments": "{\"appointment_id\":\"apt-88213\",\"from\":\"2026-08-11T15:00:00Z\",\"to\":\"2026-08-13T15:00:00Z\"}"
+    },
+    {
+      "kind": "tool_call",
+      "event_id": "evt-000005",
+      "at": "2026-08-05T09:00:44.020000Z",
+      "name": "send_confirmation_sms",
+      "arguments": null
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/report/valid/transcript-turns.json
+++ b/packages/simulation-contract/fixtures/report/valid/transcript-turns.json
@@ -1,0 +1,22 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "events": [
+    {
+      "kind": "turn",
+      "event_id": "evt-000002",
+      "speaker": "agent",
+      "text": "Thanks for reaching Lakeside Dental, how can I help today?",
+      "started_at": "2026-08-05T09:00:01.214000Z",
+      "ended_at": null
+    },
+    {
+      "kind": "turn",
+      "event_id": "evt-000003",
+      "speaker": "human",
+      "text": "Oh, hello — I'm so sorry, I need to move my cleaning. It's on Tuesday, I think? Could we do Thursday instead?",
+      "started_at": "2026-08-05T09:00:07.902000Z",
+      "ended_at": null
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/spec/invalid/limits-missing.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/limits-missing.json
@@ -1,0 +1,28 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "modality": "chat",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "A spec with no limits would let one simulation run forever.",
+      "language": "en-US",
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "warm-alto-2",
+        "speed": 0.9
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Move a dental cleaning from Tuesday to Thursday."
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/invalid/limits-missing.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/limits-missing.json
@@ -13,7 +13,7 @@
   },
   "persona": {
     "traits": {
-      "personality": "A spec with no limits would let one simulation run forever.",
+      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
       "language": "en-US",
       "voice": {
         "provider": "cartesia",

--- a/packages/simulation-contract/fixtures/spec/invalid/modality-unknown.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/modality-unknown.json
@@ -13,7 +13,7 @@
   },
   "persona": {
     "traits": {
-      "personality": "The modality is a closed pair; a third one is a contract change, not a fixture.",
+      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
       "language": "en-US",
       "voice": {
         "provider": "cartesia",

--- a/packages/simulation-contract/fixtures/spec/invalid/modality-unknown.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/modality-unknown.json
@@ -1,0 +1,32 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "modality": "email",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "The modality is a closed pair; a third one is a contract change, not a fixture.",
+      "language": "en-US",
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "warm-alto-2",
+        "speed": 0.9
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Move a dental cleaning from Tuesday to Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/invalid/unknown-field.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/unknown-field.json
@@ -13,7 +13,7 @@
   },
   "persona": {
     "traits": {
-      "personality": "A field this schema does not name is a drift between the two sides, and drift is what the closed root exists to catch.",
+      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
       "language": "en-US",
       "voice": {
         "provider": "cartesia",

--- a/packages/simulation-contract/fixtures/spec/invalid/unknown-field.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/unknown-field.json
@@ -1,0 +1,33 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "modality": "chat",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "A field this schema does not name is a drift between the two sides, and drift is what the closed root exists to catch.",
+      "language": "en-US",
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "warm-alto-2",
+        "speed": 0.9
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Move a dental cleaning from Tuesday to Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "agent_id": "agt_01K3XQ7M4E8YB2FVN0H9TZQWER"
+}

--- a/packages/simulation-contract/fixtures/spec/invalid/wrong-contract-version.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/wrong-contract-version.json
@@ -13,7 +13,7 @@
   },
   "persona": {
     "traits": {
-      "personality": "A version this schema does not speak must be refused, never guessed at.",
+      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
       "language": "en-US",
       "voice": {
         "provider": "cartesia",

--- a/packages/simulation-contract/fixtures/spec/invalid/wrong-contract-version.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/wrong-contract-version.json
@@ -1,0 +1,32 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "modality": "chat",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "A version this schema does not speak must be refused, never guessed at.",
+      "language": "en-US",
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "warm-alto-2",
+        "speed": 0.9
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Move a dental cleaning from Tuesday to Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/valid/chat-retell.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-retell.json
@@ -1,0 +1,32 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "modality": "chat",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+      "language": "en-US",
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "warm-alto-2",
+        "speed": 0.9
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "You booked a dental cleaning for next Tuesday and need to move it to Thursday the same week. You do not remember the exact time of the original appointment. Conclude once the new time has been read back to you."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/valid/voice-phone.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-phone.json
@@ -1,0 +1,30 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWES",
+  "modality": "voice",
+  "connection": {
+    "type": "phone",
+    "config": {
+      "phoneNumber": "+15551234567"
+    },
+    "credentials": null
+  },
+  "persona": {
+    "traits": {
+      "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "brisk-tenor-7",
+        "speed": 1.15
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your card was charged twice for the same order this morning. You want the duplicate charge reversed and a confirmation number before you hang up. If asked to stay on hold for more than a moment, push back once, then accept."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  }
+}

--- a/packages/simulation-contract/package.json
+++ b/packages/simulation-contract/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@egma/simulation-contract",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "The versioned JSON contract between the control plane and the simulator: the spec and report schemas, with golden fixtures beside them.",
+  "devDependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
+  }
+}

--- a/packages/simulation-contract/schemas/simulation-report.v1.schema.json
+++ b/packages/simulation-contract/schemas/simulation-report.v1.schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:egma:simulation-contract:report:v1",
+  "title": "Simulation report",
+  "description": "The report direction of the simulation contract: what the simulator tells the control plane about one simulation, as it happens. One document carries one or more events, persisted whole to the simulator's write-ahead log before sending, so delivery is at-least-once and the control plane dedups on event ids. Every object in this schema is closed and no property is credential-shaped: a report carrying the spec's credential material cannot validate. That is deliberate, and the contract's test suites hold this schema to it.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "simulation_id", "events"],
+  "properties": {
+    "contract_version": {
+      "description": "Which version of the simulation contract this document speaks. The control plane refuses a report whose version it does not implement.",
+      "type": "integer",
+      "const": 1
+    },
+    "simulation_id": {
+      "description": "The simulation this report is about, echoed verbatim from the spec that was claimed. Opaque to the simulator: never parsed, never minted, never rewritten.",
+      "type": "string",
+      "minLength": 1
+    },
+    "events": {
+      "description": "What happened, in the order the simulator observed it. Events are reported as they happen; a resent document replays the same events byte-identically, ids and timestamps included.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/event" }
+    }
+  },
+  "$defs": {
+    "moment": {
+      "description": "An instant, RFC 3339 with a UTC offset, stamped when the moment happened and replayed byte-identically on every resend — never re-derived at send time, because a drifted timestamp defeats the store's only duplicate guard.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "event_id": {
+      "description": "The event's identity, minted by the simulator at the moment the event happens, unique within the simulation, and stable across resends. The control plane dedups on it, which is what lets delivery be at-least-once without ever double-writing a fact.",
+      "type": "string",
+      "minLength": 1
+    },
+    "event": {
+      "description": "One observed fact about the simulation, written once, complete — there is no patch-after-the-fact in this direction. The status transitions come in four shapes, one per status the simulator may report, so that what each transition must carry is spelled out rather than implied: `claimed` never appears among them, because claiming is the control plane's own act, stamped when it answers the claim.",
+      "oneOf": [
+        { "$ref": "#/$defs/running_event" },
+        { "$ref": "#/$defs/completed_event" },
+        { "$ref": "#/$defs/failed_event" },
+        { "$ref": "#/$defs/canceled_event" },
+        { "$ref": "#/$defs/turn_event" },
+        { "$ref": "#/$defs/tool_call_event" },
+        { "$ref": "#/$defs/timing_event" }
+      ]
+    },
+    "running_event": {
+      "description": "The simulator began conducting the simulation. Running carries no terminal facts — this object being closed is what says so.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "event_id", "at", "status", "reason"],
+      "properties": {
+        "kind": { "const": "status" },
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "at": { "$ref": "#/$defs/moment" },
+        "status": { "const": "running" },
+        "reason": {
+          "description": "Why, as prose for a person reading the record, or null where beginning speaks for itself.",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "completed_event": {
+      "description": "The simulation ran and ended. The terminal facts arrive on the transition, atomically — there is no moment where a simulation is terminal but factless.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "event_id", "at", "status", "reason", "facts"],
+      "properties": {
+        "kind": { "const": "status" },
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "at": { "$ref": "#/$defs/moment" },
+        "status": { "const": "completed" },
+        "reason": {
+          "description": "Why, as prose for a person reading the record, or null where the facts speak for themselves.",
+          "type": ["string", "null"]
+        },
+        "facts": { "$ref": "#/$defs/completed_facts" }
+      }
+    },
+    "failed_event": {
+      "description": "The simulator could not honestly finish the simulation. Failed is about conducting, never about the agent's conduct — an agent that behaved badly still completes, and the graders judge it later.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "event_id", "at", "status", "reason", "facts"],
+      "properties": {
+        "kind": { "const": "status" },
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "at": { "$ref": "#/$defs/moment" },
+        "status": { "const": "failed" },
+        "reason": {
+          "description": "Why it failed, as prose for a person reading the record. Never null here: a failure with no reason is a record nobody can act on.",
+          "type": "string",
+          "minLength": 1
+        },
+        "facts": { "$ref": "#/$defs/failed_facts" }
+      }
+    },
+    "canceled_event": {
+      "description": "A cancel directive stopped the simulation. The directive travels on a heartbeat response; this transition is the simulator honoring it.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "event_id", "at", "status", "reason", "facts"],
+      "properties": {
+        "kind": { "const": "status" },
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "at": { "$ref": "#/$defs/moment" },
+        "status": { "const": "canceled" },
+        "reason": {
+          "description": "Why, as prose for a person reading the record — where the cancel came from, if the directive said — or null.",
+          "type": ["string", "null"]
+        },
+        "facts": { "$ref": "#/$defs/canceled_facts" }
+      }
+    },
+    "completed_facts": {
+      "description": "The terminal facts of a simulation that ran and ended. Written once, never edited afterwards: everything needed to read the simulation later without asking the connection — which is editable — what it looked like at the time. A completed simulation ended deliberately, so its endings are the deliberate ones.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ending",
+        "started_at",
+        "ended_at",
+        "turn_count",
+        "audio",
+        "provider_reference"
+      ],
+      "properties": {
+        "ending": {
+          "description": "How the simulation ended. `persona_concluded`: the persona decided the scenario was done and ended it. `agent_ended`: the agent ended the exchange. `limit_reached`: a limit from the spec tripped — deliberate, and never graded as the agent failing.",
+          "type": "string",
+          "enum": ["persona_concluded", "agent_ended", "limit_reached"]
+        },
+        "started_at": {
+          "description": "When the simulator began conducting this simulation — the moment the `running` transition reported.",
+          "$ref": "#/$defs/moment"
+        },
+        "ended_at": {
+          "description": "When it was over. Durations are this minus started_at; nothing re-measures them later.",
+          "$ref": "#/$defs/moment"
+        },
+        "turn_count": {
+          "description": "How many transcript turns the simulation reached, both speakers counted — the same turns reported as turn events.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "audio": {
+          "description": "The measured audio band and the recording, for voice; null for chat, where there is no audio to measure.",
+          "oneOf": [{ "$ref": "#/$defs/audio_band" }, { "type": "null" }]
+        },
+        "provider_reference": { "$ref": "#/$defs/provider_reference" }
+      }
+    },
+    "failed_facts": {
+      "description": "The terminal facts of a simulation the simulator could not honestly finish. Its endings all mean 'the test never ran' or 'the test broke' — and none of them is ever graded as the agent failing.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ending",
+        "started_at",
+        "ended_at",
+        "turn_count",
+        "audio",
+        "provider_reference"
+      ],
+      "properties": {
+        "ending": {
+          "description": "How the simulation ended. `agent_never_joined`: the way in opened but no agent turned up, so nothing was tested. `not_answered`: the simulator reached out and nothing picked up, so nothing was tested. `error`: the simulator hit a fault it could not conduct through.",
+          "type": "string",
+          "enum": ["agent_never_joined", "not_answered", "error"]
+        },
+        "started_at": {
+          "description": "When the simulator began conducting this simulation — the moment the `running` transition reported.",
+          "$ref": "#/$defs/moment"
+        },
+        "ended_at": {
+          "description": "When it was over. Durations are this minus started_at; nothing re-measures them later.",
+          "$ref": "#/$defs/moment"
+        },
+        "turn_count": {
+          "description": "How many transcript turns the simulation reached, both speakers counted — the same turns reported as turn events.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "audio": {
+          "description": "The measured audio band and the recording, for voice; null for chat, where there is no audio to measure.",
+          "oneOf": [{ "$ref": "#/$defs/audio_band" }, { "type": "null" }]
+        },
+        "provider_reference": { "$ref": "#/$defs/provider_reference" }
+      }
+    },
+    "canceled_facts": {
+      "description": "The terminal facts of a simulation a cancel directive stopped. The one ending says so; everything else is what had happened by then.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ending",
+        "started_at",
+        "ended_at",
+        "turn_count",
+        "audio",
+        "provider_reference"
+      ],
+      "properties": {
+        "ending": {
+          "description": "How the simulation ended: a cancel directive stopped it.",
+          "type": "string",
+          "enum": ["canceled"]
+        },
+        "started_at": {
+          "description": "When the simulator began conducting this simulation — the moment the `running` transition reported.",
+          "$ref": "#/$defs/moment"
+        },
+        "ended_at": {
+          "description": "When it was over. Durations are this minus started_at; nothing re-measures them later.",
+          "$ref": "#/$defs/moment"
+        },
+        "turn_count": {
+          "description": "How many transcript turns the simulation reached, both speakers counted — the same turns reported as turn events.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "audio": {
+          "description": "The measured audio band and the recording, for voice; null for chat, where there is no audio to measure.",
+          "oneOf": [{ "$ref": "#/$defs/audio_band" }, { "type": "null" }]
+        },
+        "provider_reference": { "$ref": "#/$defs/provider_reference" }
+      }
+    },
+    "provider_reference": {
+      "description": "The platform's own identifier for this exchange on the connection's side — a Retell chat id, a telephony provider's id for the dialed leg. The only join between egma's record and the agent's own telemetry, since no trace context crosses an audio channel. Null when the plug has none to offer.",
+      "type": ["string", "null"]
+    },
+    "audio_band": {
+      "description": "What the audio actually was, measured at execution and frozen here. The connection declares a band in its config, but connections are editable and unversioned — so the measured band lives on the simulation, or a later edit would silently rewrite what old results meant.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["measured_sample_rate_hz", "recording"],
+      "properties": {
+        "measured_sample_rate_hz": {
+          "description": "The sample rate the simulator actually heard, negotiated or measured, never copied from configuration. 8 kHz telephony and 48 kHz WebRTC are different units: the narrow band strips what audio graders read and inflates every latency number, so scores across bands are not comparable.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "recording": {
+          "description": "An opaque reference to the dual-channel recording the simulator wrote to the blob store — one side per channel, so each speaker can be heard alone when a transcript looks wrong. Resolved by the control plane; never a URL, never carries how to fetch it.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "turn_event": {
+      "description": "One transcript turn, written once, complete, when the turn is over.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "event_id",
+        "speaker",
+        "text",
+        "started_at",
+        "ended_at"
+      ],
+      "properties": {
+        "kind": { "const": "turn" },
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "speaker": {
+          "description": "Whose turn it was: `human` is the persona's side of the transcript, `agent` is the agent under test. The transcript's two labels, exactly.",
+          "type": "string",
+          "enum": ["human", "agent"]
+        },
+        "text": {
+          "description": "What was said, as text — spoken and transcribed on voice, sent verbatim on chat. May be empty for a turn that carried no words.",
+          "type": "string"
+        },
+        "started_at": {
+          "description": "When the turn began.",
+          "$ref": "#/$defs/moment"
+        },
+        "ended_at": {
+          "description": "When the turn finished, or null for a turn that was one instant — a chat message has no duration.",
+          "oneOf": [{ "$ref": "#/$defs/moment" }, { "type": "null" }]
+        }
+      }
+    },
+    "tool_call_event": {
+      "description": "The agent under test called a tool, as observed from egma's side of the connection — reported where the platform exposes it, which is how the outcome gets populated. Never the persona's doing: the persona has no tools.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "event_id", "at", "name", "arguments"],
+      "properties": {
+        "kind": { "const": "tool_call" },
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "at": { "$ref": "#/$defs/moment" },
+        "name": {
+          "description": "The tool's name, exactly as the platform reported it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "arguments": {
+          "description": "The arguments, JSON-encoded, exactly as observed — or null where the platform reports the invocation but not its arguments. A string deliberately: it keeps every object in this schema closed, and the observed bytes are the fact worth keeping.",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "timing_event": {
+      "description": "One measurement. A metric measures and a grader judges; nothing in this direction is a verdict.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "event_id", "at", "measure", "milliseconds"],
+      "properties": {
+        "kind": { "const": "timing" },
+        "event_id": { "$ref": "#/$defs/event_id" },
+        "at": { "$ref": "#/$defs/moment" },
+        "measure": {
+          "description": "What was measured, named in snake_case — `first_response_latency`, `turn_response_latency`. An open vocabulary: measures are emitted for every simulation whether or not anyone asked, and new ones join without a contract change.",
+          "type": "string",
+          "minLength": 1
+        },
+        "milliseconds": {
+          "description": "The measurement, in milliseconds.",
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/packages/simulation-contract/schemas/simulation-spec.v1.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v1.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:egma:simulation-contract:spec:v1",
+  "title": "Simulation spec",
+  "description": "The spec direction of the simulation contract: what the control plane hands the simulator when a queued simulation is claimed. The spec is fully flattened — the simulator receives no identifiers to resolve, no database to ask, and everything it needs to conduct one simulation from birth to a terminal report. This is the only direction credential material ever travels; the report schema (urn:egma:simulation-contract:report:v1) structurally forbids it coming back.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "simulation_id",
+    "modality",
+    "connection",
+    "persona",
+    "scenario",
+    "limits"
+  ],
+  "properties": {
+    "contract_version": {
+      "description": "Which version of the simulation contract this document speaks. A simulator refuses a spec whose version it does not implement; it never guesses at fields it does not know.",
+      "type": "integer",
+      "const": 1
+    },
+    "simulation_id": {
+      "description": "The simulation this spec conducts, echoed verbatim on every report about it. Opaque to the simulator: never parsed, never minted, never rewritten.",
+      "type": "string",
+      "minLength": 1
+    },
+    "modality": {
+      "description": "Which layer is under test. Chat exercises the agent's harness — prompt, reasoning, tools; voice exercises the harness plus the speech stack. The modality selects the pipeline legs; the persona brain is the same for both.",
+      "type": "string",
+      "enum": ["chat", "voice"]
+    },
+    "connection": {
+      "description": "How the simulator reaches the agent under test, resolved by the control plane from the connection the run named. The simulator selects its platform plug by `type` and hands the plug the config and credentials whole.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "config", "credentials"],
+      "properties": {
+        "type": {
+          "description": "The connection type, from the platform's open, growing list — `retell`, `phone`, and whatever lands next. Deliberately not an enum here: the list grows one plug at a time, and a simulator holding no plug for a type refuses the claim at runtime rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "config": {
+          "description": "The non-secret reach configuration, exactly as stored on the connection — what to reach, never how to prove. Its keys belong to the plug for `type`; this schema does not know them.",
+          "type": "object"
+        },
+        "credentials": {
+          "description": "The resolved secret material for this connection, unsealed by the control plane for exactly this hand-off, or null for types where the customer supplies no secret. The simulator holds it in memory for the simulation, hands it only to the plug, and never logs, persists, or reports it. No report document has anywhere to put it.",
+          "oneOf": [{ "type": "object" }, { "type": "null" }]
+        }
+      }
+    },
+    "persona": {
+      "description": "Who does the talking on the human side of the transcript.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["traits"],
+      "properties": {
+        "traits": {
+          "description": "The persona's authored traits, exactly as saved on the version the run pinned — today personality, language, and the concrete voice. Passed through opaquely: what a persona is made of is authoring's business, and the simulator composes these with the scenario instructions into the persona brain's system prompt.",
+          "type": "object"
+        }
+      }
+    },
+    "scenario": {
+      "description": "What the persona wants on this occasion — the situation, from the test's own content. The persona says who; the scenario says why they are here today.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["instructions"],
+      "properties": {
+        "instructions": {
+          "description": "The scenario as instructions to the persona brain: the goal, the circumstances, and anything the persona knows going in.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "limits": {
+      "description": "The walls around one simulation. A limit tripping ends the simulation deliberately, reported with ending `limit_reached` — which is never the agent failing, and never graded as if it were.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_duration_seconds", "max_turns"],
+      "properties": {
+        "max_duration_seconds": {
+          "description": "The most wall-clock seconds the simulation may run, measured from when the simulator begins conducting it.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_turns": {
+          "description": "The most transcript turns the simulation may reach, counting both speakers.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -1,0 +1,329 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Ajv2020 } from "ajv/dist/2020.js";
+import ajvFormats from "ajv-formats";
+import type { FormatsPlugin } from "ajv-formats";
+import { describe, expect, it } from "vitest";
+
+// ajv-formats ships CommonJS whose module.exports is the plugin function
+// itself; under NodeNext TypeScript types the default import as a namespace,
+// so the callable gets its name here.
+const addFormats = ajvFormats as unknown as FormatsPlugin;
+
+/**
+ * The simulation contract, held to its own golden fixtures.
+ *
+ * The two schemas under `schemas/` are the one meeting point between the
+ * TypeScript control plane and the Python simulator. This suite is the
+ * TypeScript half of the guarantee that the two sides cannot drift apart
+ * silently: every fixture under `fixtures/<direction>/valid` must validate,
+ * every fixture under `fixtures/<direction>/invalid` must be rejected, and the
+ * simulator's own suite reads the same files. An incompatible edit to a schema
+ * or a fixture fails this suite, and this suite runs in CI.
+ *
+ * The fixtures are read from disk rather than imported, deliberately: they are
+ * plain files with no TypeScript identity, because the other reader of these
+ * bytes is not TypeScript.
+ */
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+async function readJson(
+  ...segments: string[]
+): Promise<Record<string, unknown>> {
+  const raw = await readFile(path.join(packageRoot, ...segments), "utf8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+type Fixture = {
+  readonly name: string;
+  readonly document: Record<string, unknown>;
+};
+
+async function fixturesUnder(
+  direction: "spec" | "report",
+  expectation: "valid" | "invalid",
+): Promise<Fixture[]> {
+  const directory = path.join(packageRoot, "fixtures", direction, expectation);
+  const names = (await readdir(directory))
+    .filter((name) => name.endsWith(".json"))
+    .sort();
+  return Promise.all(
+    names.map(async (name) => ({
+      name,
+      document: await readJson("fixtures", direction, expectation, name),
+    })),
+  );
+}
+
+const ajv = new Ajv2020({ strict: true, allErrors: true });
+addFormats(ajv);
+
+const specSchema = await readJson("schemas", "simulation-spec.v1.schema.json");
+const reportSchema = await readJson(
+  "schemas",
+  "simulation-report.v1.schema.json",
+);
+
+// Compiling is itself part of the suite's job: a schema that is not valid
+// 2020-12, or that trips Ajv's strict mode, fails before any fixture is read.
+const validators = {
+  spec: ajv.compile(specSchema),
+  report: ajv.compile(reportSchema),
+} as const;
+
+/**
+ * Why each deliberately invalid fixture is invalid, as a fragment the
+ * validation errors must contain. Every invalid fixture must have an entry:
+ * a fixture rejected for an unintended reason — a typo, a stray field — would
+ * otherwise pass as "rejected" while testing nothing.
+ */
+const EXPECTED_REJECTION: Record<string, string> = {
+  "spec/limits-missing.json": "limits",
+  "spec/modality-unknown.json": "modality",
+  "spec/unknown-field.json": "must NOT have additional properties",
+  "spec/wrong-contract-version.json": "contract_version",
+  "report/completed-claiming-never-ran.json": "ending",
+  "report/completed-without-facts.json": "facts",
+  "report/credentials-echoed.json": "must NOT have additional properties",
+  "report/failed-without-reason.json": "reason",
+  "report/running-with-facts.json": "must NOT have additional properties",
+  "report/unknown-event-kind.json": "kind",
+};
+
+describe("the two schemas, as one contract", () => {
+  it("pin the same contract version, so the directions cannot drift apart", () => {
+    const versionOf = (schema: Record<string, unknown>): unknown =>
+      (
+        (schema.properties as Record<string, Record<string, unknown>>)
+          .contract_version as Record<string, unknown>
+      ).const;
+    expect(versionOf(specSchema)).toBe(1);
+    expect(versionOf(reportSchema)).toBe(1);
+  });
+
+  it("each carry an identity a $ref or an error message can name", () => {
+    expect(specSchema.$id).toBe("urn:egma:simulation-contract:spec:v1");
+    expect(reportSchema.$id).toBe("urn:egma:simulation-contract:report:v1");
+  });
+
+  /**
+   * The terminal facts are written once per status variant so that each
+   * spells out the endings it may honestly claim. The price of writing them
+   * out is that they could drift apart; this pins them identical everywhere
+   * except the ending.
+   */
+  it("holds the three terminal-facts shapes identical, apart from their endings", () => {
+    const defs = reportSchema.$defs as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const stripped = ["completed_facts", "failed_facts", "canceled_facts"].map(
+      (name) => {
+        const clone = structuredClone(defs[name]) as Record<string, unknown>;
+        delete clone.description;
+        (clone.properties as Record<string, unknown>).ending = "<varies>";
+        return clone;
+      },
+    );
+    expect(stripped[1]).toEqual(stripped[0]);
+    expect(stripped[2]).toEqual(stripped[0]);
+  });
+
+  it("gives each terminal status its own endings, sharing none", () => {
+    const defs = reportSchema.$defs as Record<string, Record<string, unknown>>;
+    const endings = ["completed_facts", "failed_facts", "canceled_facts"].flatMap(
+      (name) => {
+        const properties = defs[name]?.properties as Record<
+          string,
+          Record<string, unknown>
+        >;
+        return properties.ending?.enum as string[];
+      },
+    );
+    expect(new Set(endings).size).toBe(endings.length);
+  });
+});
+
+for (const direction of ["spec", "report"] as const) {
+  describe(`the ${direction} direction`, () => {
+    it("accepts every valid golden fixture", async () => {
+      const all = await fixturesUnder(direction, "valid");
+      expect(all.length).toBeGreaterThan(0);
+
+      for (const fixture of all) {
+        const validate = validators[direction];
+        const answer = validate(fixture.document);
+        expect(
+          answer,
+          `${fixture.name}: ${ajv.errorsText(validate.errors)}`,
+        ).toBe(true);
+      }
+    });
+
+    it("rejects every deliberately invalid fixture, for the reason it is wrong", async () => {
+      const all = await fixturesUnder(direction, "invalid");
+      expect(all.length).toBeGreaterThan(0);
+
+      for (const fixture of all) {
+        const validate = validators[direction];
+        const answer = validate(fixture.document);
+        expect(answer, `${fixture.name} was accepted`).toBe(false);
+
+        const expected = EXPECTED_REJECTION[`${direction}/${fixture.name}`];
+        expect(
+          expected,
+          `${fixture.name} has no entry in EXPECTED_REJECTION saying why it is invalid`,
+        ).toBeDefined();
+        expect(ajv.errorsText(validate.errors)).toContain(expected);
+      }
+    });
+  });
+}
+
+describe("what the golden fixtures cover", () => {
+  it("shows the spec direction in both modalities", async () => {
+    const specs = await fixturesUnder("spec", "valid");
+    const modalities = new Set(specs.map((fixture) => fixture.document.modality));
+    expect(modalities).toEqual(new Set(["chat", "voice"]));
+  });
+
+  it("shows every report event kind, and every terminal status", async () => {
+    const reports = await fixturesUnder("report", "valid");
+    const events = reports.flatMap(
+      (fixture) => fixture.document.events as Record<string, unknown>[],
+    );
+
+    const kinds = new Set(events.map((event) => event.kind));
+    expect(kinds).toEqual(new Set(["status", "turn", "tool_call", "timing"]));
+
+    const statuses = new Set(
+      events
+        .filter((event) => event.kind === "status")
+        .map((event) => event.status),
+    );
+    expect(statuses).toEqual(
+      new Set(["running", "completed", "failed", "canceled"]),
+    );
+  });
+
+  it("shows a measured audio band on a voice report, and its absence on chat", async () => {
+    const reports = await fixturesUnder("report", "valid");
+    const facts = reports
+      .flatMap((fixture) => fixture.document.events as Record<string, unknown>[])
+      .filter((event) => event.facts !== undefined)
+      .map((event) => event.facts as Record<string, unknown>);
+
+    const bands = facts.map((terminal) => terminal.audio);
+    expect(bands).toContain(null);
+    expect(bands.some((audio) => audio !== null && audio !== undefined)).toBe(
+      true,
+    );
+  });
+});
+
+/**
+ * Credentials travel in exactly one direction: the spec. The report schema
+ * does not merely lack a credentials field — it is written so that no document
+ * carrying one can validate, which is what "structurally forbids" means. These
+ * tests hold the schema itself to that shape, so an edit that opened a slot
+ * would fail here before any fixture had to catch it.
+ */
+describe("the report schema structurally forbids credential material", () => {
+  /** Every subschema in the document, with the path it sits at. */
+  function* subschemas(
+    node: unknown,
+    at: string,
+  ): Generator<{ at: string; schema: Record<string, unknown> }> {
+    if (Array.isArray(node)) {
+      for (const [index, child] of node.entries()) {
+        yield* subschemas(child, `${at}/${index}`);
+      }
+      return;
+    }
+    if (typeof node !== "object" || node === null) return;
+    yield { at, schema: node as Record<string, unknown> };
+    for (const [key, child] of Object.entries(node)) {
+      yield* subschemas(child, `${at}/${key}`);
+    }
+  }
+
+  it("closes every object it defines", () => {
+    for (const { at, schema } of subschemas(reportSchema, "#")) {
+      if (schema.type !== "object") continue;
+      expect(
+        schema.additionalProperties,
+        `${at} is an open object; every report object must enumerate its properties`,
+      ).toBe(false);
+    }
+  });
+
+  it("names no property a credential could hide under", () => {
+    const suspicious = /credential|secret|password|token|api[_-]?key|authorization|bearer/i;
+    for (const { at, schema } of subschemas(reportSchema, "#")) {
+      if (typeof schema.properties !== "object" || schema.properties === null) {
+        continue;
+      }
+      for (const name of Object.keys(schema.properties)) {
+        expect(
+          suspicious.test(name),
+          `${at}/properties/${name} looks like a slot for credential material`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("rejects a report smuggling the spec's credential block, wherever it rides", async () => {
+    const spec = await readJson("fixtures", "spec", "valid", "chat-retell.json");
+    const connection = spec.connection as Record<string, unknown>;
+    expect(connection.credentials).toBeDefined();
+
+    const carried = await readJson(
+      "fixtures",
+      "report",
+      "valid",
+      "completed-chat.json",
+    );
+
+    const smuggled: Record<string, unknown>[] = [
+      // On the envelope, as the whole connection block or the secret alone.
+      { ...carried, connection },
+      { ...carried, credentials: connection.credentials },
+      // On an event.
+      {
+        ...carried,
+        events: (carried.events as Record<string, unknown>[]).map((event) => ({
+          ...event,
+          credentials: connection.credentials,
+        })),
+      },
+      // Inside the terminal facts.
+      {
+        ...carried,
+        events: (carried.events as Record<string, unknown>[]).map((event) =>
+          event.facts === undefined
+            ? event
+            : {
+                ...event,
+                facts: {
+                  ...(event.facts as Record<string, unknown>),
+                  credentials: connection.credentials,
+                },
+              },
+        ),
+      },
+    ];
+
+    for (const [index, document] of smuggled.entries()) {
+      const answer = validators.report(document);
+      expect(answer, `variant ${index} validated with credentials aboard`).toBe(
+        false,
+      );
+      expect(ajv.errorsText(validators.report.errors)).toContain(
+        "must NOT have additional properties",
+      );
+    }
+  });
+});

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -75,22 +75,65 @@ const validators = {
 } as const;
 
 /**
- * Why each deliberately invalid fixture is invalid, as a fragment the
- * validation errors must contain. Every invalid fixture must have an entry:
- * a fixture rejected for an unintended reason — a typo, a stray field — would
- * otherwise pass as "rejected" while testing nothing.
+ * Why each deliberately invalid fixture is invalid: the exact place Ajv must
+ * point at, and the keyword that must fail there. A substring check over the
+ * pooled error text would be looser than it reads — under a oneOf, Ajv
+ * reports every branch's complaints, and a fragment can match a branch the
+ * fixture was never aimed at. The map is also the inventory: a fixture
+ * without an entry, or an entry whose fixture is gone, fails the suite.
  */
-const EXPECTED_REJECTION: Record<string, string> = {
-  "spec/limits-missing.json": "limits",
-  "spec/modality-unknown.json": "modality",
-  "spec/unknown-field.json": "must NOT have additional properties",
-  "spec/wrong-contract-version.json": "contract_version",
-  "report/completed-claiming-never-ran.json": "ending",
-  "report/completed-without-facts.json": "facts",
-  "report/credentials-echoed.json": "must NOT have additional properties",
-  "report/failed-without-reason.json": "reason",
-  "report/running-with-facts.json": "must NOT have additional properties",
-  "report/unknown-event-kind.json": "kind",
+type Rejection = {
+  /** The instance path the decisive error sits at. */
+  readonly at: string;
+  /** The JSON Schema keyword that must have failed there. */
+  readonly keyword: string;
+  /** The missing or offending property, where the keyword names one. */
+  readonly property?: string;
+};
+
+const EXPECTED_REJECTION: Record<string, Rejection> = {
+  "spec/limits-missing.json": {
+    at: "",
+    keyword: "required",
+    property: "limits",
+  },
+  "spec/modality-unknown.json": { at: "/modality", keyword: "enum" },
+  "spec/unknown-field.json": {
+    at: "",
+    keyword: "additionalProperties",
+    property: "agent_id",
+  },
+  "spec/wrong-contract-version.json": {
+    at: "/contract_version",
+    keyword: "const",
+  },
+  "report/completed-claiming-never-ran.json": {
+    at: "/events/0/facts/ending",
+    keyword: "enum",
+  },
+  "report/completed-without-facts.json": {
+    at: "/events/0",
+    keyword: "required",
+    property: "facts",
+  },
+  "report/credentials-echoed.json": {
+    at: "",
+    keyword: "additionalProperties",
+    property: "connection",
+  },
+  "report/failed-without-reason.json": {
+    at: "/events/0/reason",
+    keyword: "type",
+  },
+  "report/running-with-facts.json": {
+    at: "/events/0",
+    keyword: "additionalProperties",
+    property: "facts",
+  },
+  "report/unknown-event-kind.json": {
+    at: "/events/0/kind",
+    keyword: "const",
+  },
 };
 
 describe("the two schemas, as one contract", () => {
@@ -163,21 +206,40 @@ for (const direction of ["spec", "report"] as const) {
       }
     });
 
-    it("rejects every deliberately invalid fixture, for the reason it is wrong", async () => {
+    it("rejects every deliberately invalid fixture, at the place it is wrong", async () => {
       const all = await fixturesUnder(direction, "invalid");
-      expect(all.length).toBeGreaterThan(0);
+
+      // The pin holds both ways: a fixture with no entry fails here, and so
+      // does an entry whose fixture was deleted — the invalid coverage can
+      // no more silently shrink than the valid coverage can.
+      const expected = Object.keys(EXPECTED_REJECTION)
+        .filter((key) => key.startsWith(`${direction}/`))
+        .sort();
+      expect(all.map((fixture) => `${direction}/${fixture.name}`)).toEqual(
+        expected,
+      );
 
       for (const fixture of all) {
         const validate = validators[direction];
-        const answer = validate(fixture.document);
-        expect(answer, `${fixture.name} was accepted`).toBe(false);
+        expect(validate(fixture.document), `${fixture.name} was accepted`).toBe(
+          false,
+        );
 
-        const expected = EXPECTED_REJECTION[`${direction}/${fixture.name}`];
+        const rejection = EXPECTED_REJECTION[`${direction}/${fixture.name}`];
+        if (rejection === undefined) continue; // unreachable: the sets matched
+        const decisive = (validate.errors ?? []).some(
+          (error) =>
+            error.instancePath === rejection.at &&
+            error.keyword === rejection.keyword &&
+            (rejection.property === undefined ||
+              error.params.missingProperty === rejection.property ||
+              error.params.additionalProperty === rejection.property),
+        );
         expect(
-          expected,
-          `${fixture.name} has no entry in EXPECTED_REJECTION saying why it is invalid`,
-        ).toBeDefined();
-        expect(ajv.errorsText(validate.errors)).toContain(expected);
+          decisive,
+          `${fixture.name}: no ${rejection.keyword} error at "${rejection.at}"; ` +
+            `the errors were: ${ajv.errorsText(validate.errors)}`,
+        ).toBe(true);
       }
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,15 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/simulation-contract:
+    devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+
 packages:
 
   '@better-auth/core@1.6.25':


### PR DESCRIPTION
## What this is

The versioned JSON contract between the TypeScript control plane and the Python simulator, as a new workspace package: `packages/simulation-contract`.

- **Two schemas, draft 2020-12, `contract_version: 1`, every field documented in the schema itself.** `simulation-spec.v1.schema.json` is what the control plane hands the simulator when a queued simulation is claimed — fully flattened: simulation id, modality, connection (type + non-secret config + resolved credentials), persona traits as authored, scenario instructions, and hard limits. `simulation-report.v1.schema.json` is what the simulator says back: status transitions with reasons, timestamped transcript turns, tool-call and timing events, and terminal facts (ending, durations, measured audio band, artifact reference) riding the terminal transition atomically.
- **Golden fixtures live beside the schemas** — a chat spec, a voice spec, every report event kind and terminal status, and deliberately invalid documents for both directions. They are plain files read from disk, because their other reader is not TypeScript: the simulator's Python suite will validate against the same bytes.
- **Credentials travel in exactly one direction.** They appear only in the spec. Every object in the report schema is closed and no property is credential-shaped, so a report carrying them cannot validate — and the suite holds the schema itself to that shape (every object closed, no credential-named property, smuggle-injection rejected at envelope, event, and facts level).
- **The suite runs in CI** via the root vitest globs and `tsconfig.tests.json`; an incompatible edit to a schema or a fixture fails it. Meta-tests pin fixture coverage, hold the three terminal-facts shapes identical apart from their endings, and keep each status's endings disjoint — `completed` can never claim the test never ran.

## Test plan

- `npx vitest run packages/simulation-contract` — 14 tests.
- Full suite: 40 files, 763 tests, green.
- `pnpm typecheck` clean; mutation-checked the structural tests (opening an object or adding a credential-shaped property fails the suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)