### PR TITLE
Prototype: paste one thing with egma init

### DIFF
--- a/apps/api/src/routes/factory.ts
+++ b/apps/api/src/routes/factory.ts
@@ -1,0 +1,431 @@
+import {
+  addConnection,
+  createAgent,
+  createTest,
+  findRetellAgents,
+  getAgent,
+  getConnection,
+  getDefaultPersona,
+  getTest,
+  InvalidInputError,
+  listAgents,
+  listConnections,
+  listTests,
+  NotPermittedError,
+  ProjectOutsideOrganizationError,
+  ResourceConflictError,
+  schema,
+  type Agent,
+  type Connection,
+  type ConnectionType,
+  type Modality,
+  type NewConnection,
+  type Persona,
+  type Test,
+} from "@egma/db";
+import { isId } from "@egma/ids";
+import type { FastifyInstance, FastifyReply } from "fastify";
+
+import type { SessionIdentityProvider } from "../auth/seam.ts";
+import { credentialed, requesterOf } from "../http/credentialed.ts";
+import type { RateLimit } from "../http/rate-limit.ts";
+
+/**
+ * The small resource surface the first repository onboarding flow composes.
+ *
+ * There is no onboarding-shaped write here. A CLI creates and reads the same
+ * agent, connection and test resources every other client will use. Keeping
+ * the composition at the edge makes a failed or interrupted setup resumable
+ * without teaching the API about a particular terminal flow.
+ */
+
+export type FactoryRoutesOptions = {
+  readonly provider: SessionIdentityProvider;
+  readonly rateLimit: RateLimit;
+};
+
+type Body = Record<string, unknown>;
+
+class InvalidRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidRequestError";
+  }
+}
+
+function invalid(message: string): never {
+  throw new InvalidRequestError(message);
+}
+
+function record(value: unknown): Body {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    invalid("the request body must be a JSON object");
+  }
+  return value as Body;
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function optionalText(value: unknown): string | undefined {
+  const candidate = text(value);
+  return candidate === "" ? undefined : candidate;
+}
+
+function optionalString(input: Body, field: string): string | undefined {
+  const value = input[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim() === "") {
+    invalid(`${field} must be a non-empty string when it is supplied`);
+  }
+  return value.trim();
+}
+
+function strings(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    invalid(`${field} must be a list of strings`);
+  }
+  const found = value.map((entry) => entry.trim());
+  if (found.some((entry) => entry === "")) {
+    invalid(`${field} must not contain an empty string`);
+  }
+  return found;
+}
+
+function nonEmptyStrings(value: unknown, field: string): string[] {
+  const found = strings(value, field);
+  if (found.length === 0) invalid(`${field} must contain at least one item`);
+  return found;
+}
+
+function page(query: unknown, cursorKind: "agt" | "tst"): {
+  readonly limit?: number;
+  readonly cursor?: string;
+  readonly name?: string;
+} {
+  const input = record(query);
+  const rawLimit = optionalText(input.limit);
+  const limit = rawLimit === undefined ? undefined : Number(rawLimit);
+  const cursor = optionalText(input.cursor);
+  const name = optionalText(input.name);
+  if (
+    limit !== undefined &&
+    (!Number.isInteger(limit) || limit < 1 || limit > 200)
+  ) {
+    invalid("limit must be an integer between 1 and 200");
+  }
+  if (cursor !== undefined && !isId(cursorKind, cursor)) {
+    invalid(`cursor must be a ${cursorKind} id`);
+  }
+  return {
+    ...(limit === undefined ? {} : { limit }),
+    ...(cursor === undefined ? {} : { cursor }),
+    ...(name === undefined ? {} : { name }),
+  };
+}
+
+function connectionFrom(value: unknown): NewConnection {
+  const input = record(value);
+  const type = text(input.type);
+  const modality = text(input.modality);
+  if (!schema.CONNECTION_TYPES.includes(type as ConnectionType)) {
+    invalid(`type must be one of ${schema.CONNECTION_TYPES.join(", ")}`);
+  }
+  if (!schema.MODALITIES.includes(modality as Modality)) {
+    invalid(`modality must be one of ${schema.MODALITIES.join(", ")}`);
+  }
+  if (type === "phone" && modality !== "voice") {
+    invalid("a phone connection must use the voice modality");
+  }
+  const name = optionalString(input, "name");
+  const environment = optionalString(input, "environment");
+  const config = record(input.config);
+  const credentials =
+    input.credentials === undefined ? undefined : record(input.credentials);
+  if (type === "retell") {
+    if (
+      Object.keys(config).length !== 1 ||
+      optionalText(config.retellAgentId) === undefined
+    ) {
+      invalid("a retell connection config must contain retellAgentId");
+    }
+    if (
+      credentials === undefined ||
+      Object.keys(credentials).length !== 1 ||
+      (optionalText(credentials.apiKey)?.length ?? 0) < 8
+    ) {
+      invalid("retell credentials must contain an apiKey of at least 8 characters");
+    }
+  }
+  if (type === "phone") {
+    if (
+      Object.keys(config).length !== 1 ||
+      !/^\+[1-9]\d{1,14}$/u.test(text(config.phoneNumber))
+    ) {
+      invalid("a phone connection config must contain an E.164 phoneNumber");
+    }
+    if (credentials !== undefined) {
+      invalid("a phone connection does not take credentials");
+    }
+  }
+  return {
+    ...(name === undefined ? {} : { name }),
+    type: type as ConnectionType,
+    modality: modality as Modality,
+    ...(environment === undefined ? {} : { environment }),
+    config,
+    ...(credentials === undefined ? {} : { credentials }),
+  };
+}
+
+function requiredText(value: unknown, field: string): string {
+  const found = text(value);
+  if (found === "") invalid(`${field} must not be empty`);
+  return found;
+}
+
+function describedAgent(agent: Agent): Record<string, unknown> {
+  return {
+    id: agent.id,
+    project_id: agent.projectId,
+    name: agent.name,
+    description: agent.description,
+    created_at: agent.createdAt,
+    updated_at: agent.updatedAt,
+  };
+}
+
+function describedConnection(connection: Connection): Record<string, unknown> {
+  return {
+    id: connection.id,
+    agent_id: connection.agentId,
+    project_id: connection.projectId,
+    name: connection.name,
+    type: connection.type,
+    modality: connection.modality,
+    topology: connection.topology,
+    environment: connection.environment,
+    config: connection.config,
+    credentials_hint: connection.credentialsHint,
+    capabilities: connection.capabilities,
+    created_at: connection.createdAt,
+    updated_at: connection.updatedAt,
+  };
+}
+
+function describedTest(test: Test): Record<string, unknown> {
+  return {
+    id: test.id,
+    project_id: test.projectId,
+    name: test.name,
+    description: test.description,
+    version: test.version,
+    version_id: test.versionId,
+    scenario: test.scenario,
+    expected_behaviors: test.expectedBehaviors,
+    personas: test.personas.map((persona) => ({
+      id: persona.id,
+      name: persona.name,
+      deleted_at: persona.deletedAt,
+    })),
+    created_at: test.createdAt,
+    updated_at: test.updatedAt,
+  };
+}
+
+function describedPersona(persona: Persona): Record<string, unknown> {
+  return {
+    id: persona.id,
+    project_id: persona.projectId,
+    name: persona.name,
+    description: persona.description,
+    version: persona.version,
+    version_id: persona.versionId,
+    traits: persona.traits,
+    created_at: persona.createdAt,
+    updated_at: persona.updatedAt,
+  };
+}
+
+function missing(reply: FastifyReply, kind: string, id: string): FastifyReply {
+  return reply.code(404).send({
+    error: `no_such_${kind}`,
+    message: `no ${kind} ${id} is visible in this project`,
+  });
+}
+
+export async function factoryRoutes(
+  app: FastifyInstance,
+  options: FactoryRoutesOptions,
+): Promise<void> {
+  credentialed(app, options);
+
+  app.get("/v1/personas/default", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const found = await getDefaultPersona(auth);
+    return found === undefined
+      ? missing(reply, "default_persona", "default")
+      : reply.send(describedPersona(found));
+  });
+
+  app.get("/v1/agents", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const found = await listAgents(auth, page(request.query, "agt"));
+    return reply.send({
+      items: found.items.map(describedAgent),
+      next_cursor: found.nextCursor ?? null,
+    });
+  });
+
+  app.get("/v1/agents/retell/:retellAgentId", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { retellAgentId } = request.params as { retellAgentId: string };
+    const found = await findRetellAgents(auth, retellAgentId);
+    return reply.send({
+      items: found.map((agent) => ({
+        ...describedAgent(agent),
+        connection: describedConnection(agent.connection),
+      })),
+    });
+  });
+
+  app.post("/v1/agents", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const body = record(request.body ?? {});
+    const description = optionalString(body, "description");
+    const created = await createAgent(auth, {
+      name: requiredText(body.name, "name"),
+      ...(description === undefined ? {} : { description }),
+      ...(body.connection === undefined
+        ? {}
+        : { connection: connectionFrom(body.connection) }),
+    });
+    return reply.code(201).send({
+      ...describedAgent(created),
+      ...(created.connection === undefined
+        ? {}
+        : { connection: describedConnection(created.connection) }),
+    });
+  });
+
+  app.get("/v1/agents/:agentId", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { agentId } = request.params as { agentId: string };
+    const found = await getAgent(auth, agentId);
+    return found === undefined
+      ? missing(reply, "agent", agentId)
+      : reply.send(describedAgent(found));
+  });
+
+  app.get("/v1/agents/:agentId/connections", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { agentId } = request.params as { agentId: string };
+    const found = await listConnections(auth, agentId);
+    return found === undefined
+      ? missing(reply, "agent", agentId)
+      : reply.send({ items: found.map(describedConnection) });
+  });
+
+  app.post("/v1/agents/:agentId/connections", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { agentId } = request.params as { agentId: string };
+    const created = await addConnection(
+      auth,
+      agentId,
+      connectionFrom(request.body ?? {}),
+    );
+    return created === undefined
+      ? missing(reply, "agent", agentId)
+      : reply.code(201).send(describedConnection(created));
+  });
+
+  app.get(
+    "/v1/agents/:agentId/connections/:connectionId",
+    async (request, reply) => {
+      const { auth } = requesterOf(request);
+      const { agentId, connectionId } = request.params as {
+        agentId: string;
+        connectionId: string;
+      };
+      const found = await getConnection(auth, agentId, connectionId);
+      return found === undefined
+        ? missing(reply, "connection", connectionId)
+        : reply.send(describedConnection(found));
+    },
+  );
+
+  app.get("/v1/tests", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const found = await listTests(auth, page(request.query, "tst"));
+    return reply.send({
+      items: found.items.map(describedTest),
+      next_cursor: found.nextCursor ?? null,
+    });
+  });
+
+  app.post("/v1/tests", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const body = record(request.body ?? {});
+    const description = optionalString(body, "description");
+    const idempotencyKey = optionalString(body, "idempotency_key");
+    const personaIds =
+      body.persona_ids === undefined
+        ? undefined
+        : strings(body.persona_ids, "persona_ids");
+    if (personaIds !== undefined) {
+      const seen = new Set<string>();
+      for (const id of personaIds) {
+        if (!isId("prs", id)) invalid(`"${id}" is not a persona id`);
+        if (seen.has(id)) invalid(`persona ${id} is named twice`);
+        seen.add(id);
+      }
+    }
+    const created = await createTest(auth, {
+      name: requiredText(body.name, "name"),
+      ...(description === undefined ? {} : { description }),
+      scenario: requiredText(body.scenario, "scenario"),
+      ...(idempotencyKey === undefined ? {} : { idempotencyKey }),
+      expectedBehaviors: nonEmptyStrings(
+        body.expected_behaviors,
+        "expected_behaviors",
+      ),
+      ...(personaIds === undefined ? {} : { personaIds }),
+    });
+    return reply.code(201).send(describedTest(created));
+  });
+
+  app.get("/v1/tests/:testId", async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { testId } = request.params as { testId: string };
+    const found = await getTest(auth, testId);
+    return found === undefined
+      ? missing(reply, "test", testId)
+      : reply.send(describedTest(found));
+  });
+
+  app.setErrorHandler(async (error, _request, reply) => {
+    if (error instanceof InvalidRequestError || error instanceof InvalidInputError) {
+      return reply
+        .code(400)
+        .send({ error: "invalid_request", message: error.message });
+    }
+    if (error instanceof ResourceConflictError) {
+      return reply
+        .code(409)
+        .send({ error: "resource_conflict", message: error.message });
+    }
+    if (error instanceof NotPermittedError) {
+      return reply
+        .code(403)
+        .send({ error: "not_permitted", message: error.message });
+    }
+    if (error instanceof ProjectOutsideOrganizationError) {
+      return reply.code(403).send({
+        error: "project_outside_organization",
+        message: error.message,
+      });
+    }
+    throw error;
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -10,6 +10,7 @@ import {
 import { admitIdentity, onIdentityCreated } from "./auth/provisioning.ts";
 import { apiKeyRoutes } from "./routes/api-keys.ts";
 import { deviceRoutes } from "./routes/device.ts";
+import { factoryRoutes } from "./routes/factory.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { meRoutes } from "./routes/me.ts";
 import { memberRoutes } from "./routes/members.ts";
@@ -175,6 +176,11 @@ export function buildApi(options: ServerOptions): Api {
   // list and a transcript are ordinary JSON responses, and the parser the door
   // replaces is one they want back.
   void app.register(traceReadRoutes, {
+    provider: identity.provider,
+    rateLimit,
+  });
+
+  void app.register(factoryRoutes, {
     provider: identity.provider,
     rateLimit,
   });

--- a/apps/api/test/factory-routes.test.ts
+++ b/apps/api/test/factory-routes.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { newId } from "@egma/ids";
+
+import { cookiesFrom, createApi, type TestApi } from "./support/api.ts";
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+type Person = {
+  readonly cookie: string;
+};
+
+async function signUp(email: string, organizationName: string): Promise<Person> {
+  const response = await api.app.inject({
+    method: "POST",
+    url: "/api/signup",
+    payload: { email, password: "a-long-enough-password", organizationName },
+  });
+  expect(response.statusCode, response.body).toBe(201);
+  return { cookie: cookiesFrom(response.headers["set-cookie"]) };
+}
+
+async function viewerOf(host: Person, email: string): Promise<Person> {
+  const invited = await api.app.inject({
+    method: "POST",
+    url: "/api/invitations",
+    headers: { cookie: host.cookie },
+    payload: { email, role: "viewer" },
+  });
+  expect(invited.statusCode, invited.body).toBe(201);
+  const token = new URL(
+    (invited.json() as { accept_url: string }).accept_url,
+  ).searchParams.get("token");
+  const joined = await api.app.inject({
+    method: "POST",
+    url: "/api/signup",
+    payload: {
+      email,
+      password: "a-long-enough-password",
+      invitationToken: token,
+    },
+  });
+  expect(joined.statusCode, joined.body).toBe(201);
+  return { cookie: cookiesFrom(joined.headers["set-cookie"]) };
+}
+
+const retellConnection = {
+  name: "retell-chat",
+  type: "retell",
+  modality: "chat",
+  environment: "development",
+  config: { retellAgentId: "agent_external_123" },
+  credentials: { apiKey: "retell_secret_123456" },
+} as const;
+
+describe("the first factory API", () => {
+  it("requires a credential on every resource list", async () => {
+    api = await createApi("factory_anonymous");
+
+    for (const url of ["/v1/agents", "/v1/tests"]) {
+      const response = await api.app.inject({ method: "GET", url });
+      expect(response.statusCode, url).toBe(401);
+      expect(response.json()).toMatchObject({ error: "not_authenticated" });
+    }
+  });
+
+  it("lets a viewer read but never author agents or tests", async () => {
+    api = await createApi("factory_viewer");
+    const owner = await signUp("ada@acme.example", "Acme");
+    const viewer = await viewerOf(owner, "vic@acme.example");
+
+    const listed = await api.app.inject({
+      method: "GET",
+      url: "/v1/agents",
+      headers: { cookie: viewer.cookie },
+    });
+    expect(listed.statusCode).toBe(200);
+
+    for (const request of [
+      { url: "/v1/agents", payload: { name: "Front desk" } },
+      {
+        url: "/v1/tests",
+        payload: {
+          name: "First call",
+          scenario: "A caller asks for an appointment.",
+          expected_behaviors: ["Offers a time"],
+        },
+      },
+    ]) {
+      const response = await api.app.inject({
+        method: "POST",
+        url: request.url,
+        headers: { cookie: viewer.cookie },
+        payload: request.payload,
+      });
+      expect(response.statusCode, request.url).toBe(403);
+      expect(response.json()).toMatchObject({ error: "not_permitted" });
+    }
+  });
+
+  it("keeps projects apart and never returns a submitted provider secret", async () => {
+    api = await createApi("factory_tenancy_secret");
+    const acme = await signUp("ada@acme.example", "Acme");
+    const globex = await signUp("grace@globex.example", "Globex");
+
+    const created = await api.app.inject({
+      method: "POST",
+      url: "/v1/agents",
+      headers: { cookie: acme.cookie },
+      payload: { name: "Front desk", connection: retellConnection },
+    });
+    expect(created.statusCode, created.body).toBe(201);
+    expect(created.body).not.toContain(retellConnection.credentials.apiKey);
+    expect(created.json()).toHaveProperty("project_id");
+    expect(created.json()).not.toHaveProperty("projectId");
+    const body = created.json() as {
+      id: string;
+      connection: { id: string };
+    };
+
+    const fetched = await api.app.inject({
+      method: "GET",
+      url: `/v1/agents/${body.id}/connections/${body.connection.id}`,
+      headers: { cookie: acme.cookie },
+    });
+    expect(fetched.statusCode).toBe(200);
+    expect(fetched.body).not.toContain(retellConnection.credentials.apiKey);
+    expect(fetched.json()).not.toHaveProperty("credentials");
+
+    const byProvider = await api.app.inject({
+      method: "GET",
+      url: `/v1/agents/retell/${retellConnection.config.retellAgentId}`,
+      headers: { cookie: acme.cookie },
+    });
+    expect(byProvider.statusCode).toBe(200);
+    expect(
+      (byProvider.json() as { items: { id: string }[] }).items.map(
+        (agent) => agent.id,
+      ),
+    ).toEqual([body.id]);
+
+    const defaultPersona = await api.app.inject({
+      method: "GET",
+      url: "/v1/personas/default",
+      headers: { cookie: acme.cookie },
+    });
+    expect(defaultPersona.statusCode).toBe(200);
+    expect(defaultPersona.json()).toMatchObject({
+      id: expect.stringMatching(/^prs_/),
+      project_id: expect.stringMatching(/^prj_/),
+    });
+
+    const foreign = await api.app.inject({
+      method: "GET",
+      url: `/v1/agents/${body.id}`,
+      headers: { cookie: globex.cookie },
+    });
+    expect(foreign.statusCode).toBe(404);
+    expect(foreign.json()).toMatchObject({ error: "no_such_agent" });
+  });
+
+  it("returns a stable 400 for bad input and writes no partial resources", async () => {
+    api = await createApi("factory_invalid");
+    const owner = await signUp("ada@acme.example", "Acme");
+    const before = await api.database.sql<{ agents: string; tests: string }>(
+      `select
+         (select count(*) from agent) as agents,
+         (select count(*) from test) as tests`,
+    );
+
+    const requests = [
+      { method: "POST", url: "/v1/agents", payload: [] },
+      { method: "POST", url: "/v1/agents", payload: { name: "One", description: 42 } },
+      {
+        method: "POST",
+        url: "/v1/agents",
+        payload: {
+          name: "Front desk",
+          connection: { ...retellConnection, config: {} },
+        },
+      },
+      {
+        method: "POST",
+        url: "/v1/tests",
+        payload: { name: "First call", scenario: "A caller asks." },
+      },
+      {
+        method: "POST",
+        url: "/v1/tests",
+        payload: {
+          name: "First call",
+          scenario: "A caller asks.",
+          expected_behaviors: ["Answers"],
+          persona_ids: [newId("prs")],
+        },
+      },
+      { method: "GET", url: "/v1/agents?limit=abc" },
+    ] as const;
+
+    for (const request of requests) {
+      const response = await api.app.inject({
+        ...request,
+        headers: { cookie: owner.cookie },
+      });
+      expect(response.statusCode, `${request.method} ${request.url}`).toBe(400);
+      expect(response.json()).toMatchObject({ error: "invalid_request" });
+    }
+
+    const after = await api.database.sql<{ agents: string; tests: string }>(
+      `select
+         (select count(*) from agent) as agents,
+         (select count(*) from test) as tests`,
+    );
+    expect(after.rows).toEqual(before.rows);
+  });
+
+  it("uses 409 for a valid create whose live name is already taken", async () => {
+    api = await createApi("factory_conflict");
+    const owner = await signUp("ada@acme.example", "Acme");
+    const first = await api.app.inject({
+      method: "POST",
+      url: "/v1/agents",
+      headers: { cookie: owner.cookie },
+      payload: { name: "Front desk" },
+    });
+    expect(first.statusCode).toBe(201);
+
+    const duplicate = await api.app.inject({
+      method: "POST",
+      url: "/v1/agents",
+      headers: { cookie: owner.cookie },
+      payload: { name: "Front desk" },
+    });
+    expect(duplicate.statusCode).toBe(409);
+    expect(duplicate.json()).toMatchObject({ error: "resource_conflict" });
+
+    const listed = await api.app.inject({
+      method: "GET",
+      url: "/v1/agents?name=Front%20desk",
+      headers: { cookie: owner.cookie },
+    });
+    expect(listed.json()).toMatchObject({ next_cursor: null });
+  });
+
+  it("serializes concurrent onboarding test creates by idempotency key", async () => {
+    api = await createApi("factory_idempotent_test");
+    const owner = await signUp("ada@acme.example", "Acme");
+    const request = () =>
+      api.app.inject({
+        method: "POST",
+        url: "/v1/tests",
+        headers: { cookie: owner.cookie },
+        payload: {
+          name: "First simulation",
+          scenario: "A caller asks for the next appointment.",
+          expected_behaviors: ["Offers a time"],
+          idempotency_key: "egma-init:agent_external_123",
+        },
+      });
+
+    const [first, second] = await Promise.all([request(), request()]);
+    expect(first.statusCode, first.body).toBe(201);
+    expect(second.statusCode, second.body).toBe(201);
+    expect((first.json() as { id: string }).id).toBe(
+      (second.json() as { id: string }).id,
+    );
+    const counted = await api.database.sql<{ count: string }>(
+      "select count(*) as count from test",
+    );
+    expect(counted.rows).toEqual([{ count: "1" }]);
+  });
+});

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,47 @@
+# Egma CLI prototype
+
+This prototype creates the first Egma agent, Retell connection and test from an
+`egma-receptionist` repository. It reuses the project's seeded persona. It does
+not change Retell, upload source code or start a simulation.
+
+Build Egma and start the local deployment:
+
+```bash
+pnpm install
+pnpm build
+docker compose up -d --build
+```
+
+Authenticate once. The API key is stored outside the repository:
+
+```bash
+pnpm egma auth login
+```
+
+From the Egma checkout, preview one target agent:
+
+```bash
+pnpm egma init \
+  --cwd /path/to/egma-receptionist \
+  --tenant suncrest \
+  --agent front-desk-flow-v1 \
+  --scenario 'The caller wants to move an existing appointment.' \
+  --expect 'The agent verifies the existing appointment before offering a new time.' \
+  --plan
+```
+
+After approval, replace `--plan` with `--apply`. The command writes a
+non-secret `.egma/project.yaml` receipt in the target repository. Run the same
+command again to confirm that all resource IDs are reused.
+
+Install the bundled Agent Skill in the target repository:
+
+```bash
+pnpm egma skill install --cwd /path/to/egma-receptionist
+```
+
+Use `--json` on plan, apply and status commands for coding-agent workflows.
+
+The prototype composes the ordinary resource API described in
+[`docs/factory-api.md`](../../docs/factory-api.md). That contract is part of
+the prototype and can change before the first simulation path is accepted.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@egma/cli",
+  "version": "0.0.0-prototype",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "egma": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1"
+  }
+}

--- a/apps/cli/skills/egma-init/SKILL.md
+++ b/apps/cli/skills/egma-init/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: egma-init
+description: Create the first Egma agent, Retell connection, and default-persona test from an egma-receptionist repository.
+---
+
+# Egma first test
+
+Use this skill when the user wants to connect an existing `egma-receptionist`
+Retell agent to Egma or create its first test.
+
+## Boundaries
+
+- Use the `egma` CLI for every read and write.
+- Do not read, print, or ask the user to paste Retell or Egma credentials.
+- Do not call the Retell API directly. The CLI reads the repository environment
+  without returning secret values.
+- Do not change the Retell agent, upload source code, or start a simulation.
+- Keep the test scenario separate from the expected behavior. The simulated
+  caller must not see the expected behavior.
+- Show the complete plan and get one clear approval before apply.
+
+## Flow
+
+1. Inspect `tenants/*/agents/*` and choose the Retell agent the user means. If
+   more than one is plausible, ask one short selection question.
+2. Propose one narrow happy-path scenario and one observable expected behavior
+   from the selected agent's local prompt or flow.
+3. Run:
+
+   ```bash
+   egma init --tenant <tenant> --agent <agent> \
+     --scenario '<what the caller wants>' \
+     --expect '<what the tested agent must do>' \
+     --plan --json
+   ```
+
+4. Explain the returned plan in plain language. State that Retell will not
+   change, source code will not upload, and no simulation will start.
+5. After the user approves that exact plan, run the same command with
+   `--apply --yes --json` instead of `--plan --json`.
+6. Report the agent, connection, test, and persona IDs. Say `created, not run`.
+   Show the exact next command returned by the CLI.
+7. Run `egma init status --json` to confirm the receipt reads back.
+
+On a rerun, use the same inputs. The CLI must return the same IDs and mark the
+resources as reused.

--- a/apps/cli/src/auth.ts
+++ b/apps/cli/src/auth.ts
@@ -1,0 +1,169 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { egmaBaseUrl } from "./egma-api.ts";
+
+const DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+type StoredCredential = {
+  readonly version: 1;
+  readonly base_url: string;
+  readonly access_token: string;
+  readonly api_key_id: string;
+  readonly organization_id: string;
+  readonly project_id: string;
+};
+
+type DeviceGrant = {
+  readonly device_code: string;
+  readonly user_code: string;
+  readonly verification_uri: string;
+  readonly verification_uri_complete: string;
+  readonly expires_in: number;
+  readonly interval: number;
+};
+
+type TokenAnswer = {
+  readonly access_token: string;
+  readonly api_key_id: string;
+  readonly organization_id: string;
+  readonly project_id: string;
+  readonly error?: string;
+  readonly error_description?: string;
+};
+
+function credentialPath(): string {
+  const configHome =
+    process.env.EGMA_CONFIG_HOME ??
+    process.env.XDG_CONFIG_HOME ??
+    path.join(os.homedir(), ".config");
+  return path.join(configHome, "egma", "credentials.json");
+}
+
+async function storedCredential(baseUrl: string): Promise<StoredCredential | null> {
+  try {
+    const parsed = JSON.parse(await readFile(credentialPath(), "utf8")) as StoredCredential;
+    return parsed.version === 1 && parsed.base_url === baseUrl ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveApiKey(baseUrl: string): Promise<string | null> {
+  const origin = egmaBaseUrl(baseUrl);
+  const fromEnvironment = process.env.EGMA_API_KEY?.trim();
+  if (fromEnvironment) return fromEnvironment;
+  return (await storedCredential(origin))?.access_token ?? null;
+}
+
+function openBrowser(url: string): void {
+  let command: string;
+  let args: string[];
+  if (process.platform === "darwin") {
+    command = "open";
+    args = [url];
+  } else if (process.platform === "win32") {
+    command = "rundll32.exe";
+    args = ["url.dll,FileProtocolHandler", url];
+  } else {
+    command = "xdg-open";
+    args = [url];
+  }
+  const child = spawn(command, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.on("error", () => {
+    // The complete address is already printed, so a missing opener is harmless.
+  });
+  child.unref();
+}
+
+async function json<T>(response: Response): Promise<T> {
+  const body = (await response.json().catch(() => ({}))) as T & {
+    readonly message?: string;
+  };
+  if (!response.ok) {
+    throw new Error(body.message ?? `Egma answered HTTP ${response.status}`);
+  }
+  return body;
+}
+
+async function wait(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export async function login(baseUrl: string): Promise<{
+  readonly apiKeyId: string;
+  readonly projectId: string;
+}> {
+  const origin = egmaBaseUrl(baseUrl);
+  const grant = await json<DeviceGrant>(
+    await fetch(`${origin}/api/device/code`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ client_id: "egma-cli" }),
+    }),
+  );
+  const verificationUrl = egmaBaseUrl(grant.verification_uri_complete);
+
+  process.stdout.write(
+    [
+      "Open this address to approve the terminal:",
+      verificationUrl,
+      `Code: ${grant.user_code}`,
+      "",
+    ].join("\n"),
+  );
+  try {
+    openBrowser(verificationUrl);
+  } catch {
+    // Printing the complete address is the reliable path. Opening it is a help.
+  }
+
+  const began = Date.now();
+  let interval = grant.interval * 1_000;
+  for (;;) {
+    if (Date.now() - began >= grant.expires_in * 1_000) {
+      throw new Error("the device login expired; run `egma auth login` again");
+    }
+    await wait(interval);
+    const response = await fetch(`${origin}/api/device/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: DEVICE_GRANT,
+        device_code: grant.device_code,
+      }),
+    });
+    const answer = (await response.json().catch(() => ({}))) as TokenAnswer;
+    if (!response.ok) {
+      if (answer.error === "authorization_pending") continue;
+      if (answer.error === "slow_down") {
+        interval += 5_000;
+        continue;
+      }
+      throw new Error(
+        answer.error_description ?? answer.error ?? "device login failed",
+      );
+    }
+
+    const saved: StoredCredential = {
+      version: 1,
+      base_url: origin,
+      access_token: answer.access_token,
+      api_key_id: answer.api_key_id,
+      organization_id: answer.organization_id,
+      project_id: answer.project_id,
+    };
+    const file = credentialPath();
+    await mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+    await writeFile(file, `${JSON.stringify(saved, null, 2)}\n`, {
+      mode: 0o600,
+    });
+    await chmod(file, 0o600);
+    return { apiKeyId: saved.api_key_id, projectId: saved.project_id };
+  }
+}

--- a/apps/cli/src/egma-api.ts
+++ b/apps/cli/src/egma-api.ts
@@ -1,0 +1,271 @@
+import type {
+  Agent,
+  Connection,
+  CreatedAgent,
+  Page,
+  Persona,
+  Test,
+} from "./types.ts";
+
+type Json = Record<string, unknown>;
+type WirePage<T> = { readonly items: readonly T[]; readonly next_cursor: string | null };
+type WireAgent = {
+  readonly id: string;
+  readonly project_id: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly connection?: WireConnection;
+};
+type WireConnection = {
+  readonly id: string;
+  readonly agent_id: string;
+  readonly project_id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly modality: string;
+  readonly config: Readonly<Record<string, string>>;
+  readonly credentials_hint: string | null;
+};
+type WireTest = {
+  readonly id: string;
+  readonly project_id: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly version: number;
+  readonly version_id: string;
+  readonly scenario: string;
+  readonly expected_behaviors: readonly string[];
+  readonly personas: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly deleted_at: string | null;
+  }[];
+};
+type WirePersona = {
+  readonly id: string;
+  readonly project_id: string;
+  readonly name: string;
+};
+
+function agentFrom(value: WireAgent): Agent {
+  return {
+    id: value.id,
+    projectId: value.project_id,
+    name: value.name,
+    description: value.description,
+  };
+}
+
+function connectionFrom(value: WireConnection): Connection {
+  return {
+    id: value.id,
+    agentId: value.agent_id,
+    projectId: value.project_id,
+    name: value.name,
+    type: value.type,
+    modality: value.modality,
+    config: value.config,
+    credentialsHint: value.credentials_hint,
+  };
+}
+
+function testFrom(value: WireTest): Test {
+  return {
+    id: value.id,
+    projectId: value.project_id,
+    name: value.name,
+    description: value.description,
+    version: value.version,
+    versionId: value.version_id,
+    scenario: value.scenario,
+    expectedBehaviors: value.expected_behaviors,
+    personas: value.personas.map((persona) => ({
+      id: persona.id,
+      name: persona.name,
+      deletedAt: persona.deleted_at,
+    })),
+  };
+}
+
+function personaFrom(value: WirePersona): Persona {
+  return { id: value.id, projectId: value.project_id, name: value.name };
+}
+
+/**
+ * A credential may leave the machine only over TLS. Loopback HTTP stays useful
+ * for local development, where there is no network hop to protect.
+ */
+export function egmaBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`"${value}" is not a valid Egma base URL`);
+  }
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error(
+      "the Egma base URL must use HTTPS, except for a local development server",
+    );
+  }
+  if (url.username !== "" || url.password !== "") {
+    throw new Error("the Egma base URL must not contain a username or password");
+  }
+  return url.toString().replace(/\/+$/u, "");
+}
+
+export class EgmaApiError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+
+  constructor(status: number, body: unknown) {
+    const answer =
+      typeof body === "object" && body !== null
+        ? (body as { error?: unknown; message?: unknown })
+        : {};
+    const message =
+      typeof answer.message === "string"
+        ? answer.message
+        : `Egma answered HTTP ${status}`;
+    super(message);
+    this.name = "EgmaApiError";
+    this.status = status;
+    this.code = typeof answer.error === "string" ? answer.error : undefined;
+  }
+}
+
+export class EgmaApi {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+
+  constructor(baseUrl: string, apiKey: string) {
+    this.baseUrl = egmaBaseUrl(baseUrl);
+    this.apiKey = apiKey;
+  }
+
+  private async request<T>(
+    method: "GET" | "POST",
+    route: string,
+    body?: Json,
+  ): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${route}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        accept: "application/json",
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const answer = (await response.json().catch(() => ({}))) as unknown;
+    if (!response.ok) throw new EgmaApiError(response.status, answer);
+    return answer as T;
+  }
+
+  async listAgents(cursor?: string, name?: string): Promise<Page<Agent>> {
+    const query = new URLSearchParams({ limit: "200" });
+    if (cursor !== undefined) query.set("cursor", cursor);
+    if (name !== undefined) query.set("name", name);
+    const found = await this.request<WirePage<WireAgent>>(
+      "GET",
+      `/v1/agents?${query.toString()}`,
+    );
+    return {
+      items: found.items.map(agentFrom),
+      ...(found.next_cursor === null ? {} : { nextCursor: found.next_cursor }),
+    };
+  }
+
+  async getAgent(id: string): Promise<Agent> {
+    return agentFrom(
+      await this.request("GET", `/v1/agents/${encodeURIComponent(id)}`),
+    );
+  }
+
+  async findRetellAgents(retellAgentId: string): Promise<CreatedAgent[]> {
+    const found = await this.request<{ readonly items: WireAgent[] }>(
+      "GET",
+      `/v1/agents/retell/${encodeURIComponent(retellAgentId)}`,
+    );
+    return found.items.map((agent) => ({
+      ...agentFrom(agent),
+      ...(agent.connection === undefined
+        ? {}
+        : { connection: connectionFrom(agent.connection) }),
+    }));
+  }
+
+  async createAgent(input: Json): Promise<CreatedAgent> {
+    const created = await this.request<WireAgent>("POST", "/v1/agents", input);
+    return {
+      ...agentFrom(created),
+      ...(created.connection === undefined
+        ? {}
+        : { connection: connectionFrom(created.connection) }),
+    };
+  }
+
+  async listConnections(
+    agentId: string,
+  ): Promise<{ readonly items: Connection[] }> {
+    const found = await this.request<{ readonly items: WireConnection[] }>(
+      "GET",
+      `/v1/agents/${encodeURIComponent(agentId)}/connections`,
+    );
+    return { items: found.items.map(connectionFrom) };
+  }
+
+  async getConnection(
+    agentId: string,
+    connectionId: string,
+  ): Promise<Connection> {
+    return connectionFrom(
+      await this.request(
+        "GET",
+        `/v1/agents/${encodeURIComponent(agentId)}/connections/${encodeURIComponent(connectionId)}`,
+      ),
+    );
+  }
+
+  async createConnection(agentId: string, input: Json): Promise<Connection> {
+    return connectionFrom(
+      await this.request(
+        "POST",
+        `/v1/agents/${encodeURIComponent(agentId)}/connections`,
+        input,
+      ),
+    );
+  }
+
+  async listTests(cursor?: string, name?: string): Promise<Page<Test>> {
+    const query = new URLSearchParams({ limit: "200" });
+    if (cursor !== undefined) query.set("cursor", cursor);
+    if (name !== undefined) query.set("name", name);
+    const found = await this.request<WirePage<WireTest>>(
+      "GET",
+      `/v1/tests?${query.toString()}`,
+    );
+    return {
+      items: found.items.map(testFrom),
+      ...(found.next_cursor === null ? {} : { nextCursor: found.next_cursor }),
+    };
+  }
+
+  async getTest(id: string): Promise<Test> {
+    return testFrom(
+      await this.request("GET", `/v1/tests/${encodeURIComponent(id)}`),
+    );
+  }
+
+  async createTest(input: Json): Promise<Test> {
+    return testFrom(await this.request("POST", "/v1/tests", input));
+  }
+
+  async getDefaultPersona(): Promise<Persona> {
+    return personaFrom(await this.request("GET", "/v1/personas/default"));
+  }
+
+  listApiKeys(): Promise<unknown> {
+    return this.request("GET", "/api/keys");
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import { parseArgs } from "node:util";
+
+import { login, resolveApiKey } from "./auth.ts";
+import { EgmaApi } from "./egma-api.ts";
+import { runInit, runInitStatus } from "./init.ts";
+import { readReceipt } from "./receipt.ts";
+import { installSkill } from "./skill.ts";
+
+function usage(exitCode = 2): never {
+  process.stderr.write(
+    [
+      "egma prototype",
+      "",
+      "usage:",
+      "  egma auth login [--base-url <url>]",
+      "  egma auth status [--base-url <url>]",
+      "  egma init [--tenant <slug> --agent <slug>] [--plan | --apply]",
+      "            [--scenario <text>] [--expect <text> ...] [--json]",
+      "  egma init status [--json]",
+      "  egma agent get <id>",
+      "  egma connection get <id> [--agent-id <id>]",
+      "  egma test get <id>",
+      "  egma skill install [--force]",
+      "",
+      "Run `egma init` from the root of egma-receptionist.",
+    ].join("\n"),
+  );
+  process.exit(exitCode);
+}
+
+const parsed = parseArgs({
+  args: process.argv.slice(2),
+  allowPositionals: true,
+  strict: true,
+  options: {
+    "base-url": { type: "string" },
+    cwd: { type: "string" },
+    tenant: { type: "string" },
+    agent: { type: "string" },
+    "agent-id": { type: "string" },
+    "retell-agent-id": { type: "string" },
+    scenario: { type: "string" },
+    expect: { type: "string", multiple: true },
+    "test-name": { type: "string" },
+    plan: { type: "boolean" },
+    apply: { type: "boolean" },
+    resume: { type: "boolean" },
+    yes: { type: "boolean", short: "y" },
+    json: { type: "boolean" },
+    force: { type: "boolean" },
+    help: { type: "boolean", short: "h" },
+  },
+});
+
+if (parsed.values.help === true) usage(0);
+
+const [area, action, id] = parsed.positionals;
+const baseUrl =
+  parsed.values["base-url"] ??
+  process.env.EGMA_API_URL ??
+  "http://localhost:3100";
+const cwd = parsed.values.cwd ?? process.cwd();
+const json = parsed.values.json === true;
+
+async function api(): Promise<EgmaApi> {
+  const key = await resolveApiKey(baseUrl);
+  if (key === null) throw new Error("Egma is not authenticated; run `egma auth login`");
+  return new EgmaApi(baseUrl, key);
+}
+
+async function main(): Promise<void> {
+  if (area === "auth" && action === "login") {
+    const result = await login(baseUrl);
+    process.stdout.write(
+      json
+        ? `${JSON.stringify({ kind: "egma.auth.login", ...result }, null, 2)}\n`
+        : `Authenticated for project ${result.projectId}. The credential is stored outside the repository.\n`,
+    );
+    return;
+  }
+
+  if (area === "auth" && action === "status") {
+    const client = await api();
+    await client.listApiKeys();
+    process.stdout.write(
+      json
+        ? `${JSON.stringify({ kind: "egma.auth.status", authenticated: true }, null, 2)}\n`
+        : "Authenticated.\n",
+    );
+    return;
+  }
+
+  if (area === "init" && action === "status") {
+    await runInitStatus({ cwd, baseUrl, json });
+    return;
+  }
+
+  if (area === "init") {
+    if (parsed.values.plan === true && parsed.values.apply === true) {
+      throw new Error("choose --plan or --apply, not both");
+    }
+    await runInit({
+      cwd,
+      baseUrl,
+      ...(parsed.values.tenant === undefined
+        ? {}
+        : { tenant: parsed.values.tenant }),
+      ...(parsed.values.agent === undefined
+        ? {}
+        : { agent: parsed.values.agent }),
+      ...(parsed.values["retell-agent-id"] === undefined
+        ? {}
+        : { externalAgentId: parsed.values["retell-agent-id"] }),
+      ...(parsed.values.scenario === undefined
+        ? {}
+        : { scenario: parsed.values.scenario }),
+      ...(parsed.values.expect === undefined
+        ? {}
+        : { expectedBehaviors: parsed.values.expect }),
+      ...(parsed.values["test-name"] === undefined
+        ? {}
+        : { testName: parsed.values["test-name"] }),
+      planOnly: parsed.values.plan === true,
+      apply: parsed.values.apply === true,
+      resume: parsed.values.resume === true,
+      yes: parsed.values.yes === true,
+      json,
+    });
+    return;
+  }
+
+  if (area === "skill" && action === "install") {
+    const target = await installSkill(cwd, parsed.values.force === true);
+    process.stdout.write(
+      json
+        ? `${JSON.stringify({ kind: "egma.skill.install", target }, null, 2)}\n`
+        : `Installed the Egma onboarding skill at ${target}.\n`,
+    );
+    return;
+  }
+
+  if (action === "get" && id !== undefined) {
+    const client = await api();
+    let result: unknown;
+    if (area === "agent") result = await client.getAgent(id);
+    else if (area === "test") result = await client.getTest(id);
+    else if (area === "connection") {
+      const receipt = await readReceipt(cwd);
+      const agentId = parsed.values["agent-id"] ?? receipt?.agentId;
+      if (agentId === undefined) {
+        throw new Error("connection get needs --agent-id or a local Egma receipt");
+      }
+      result = await client.getConnection(agentId, id);
+    } else usage();
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  usage();
+}
+
+main().catch((cause: unknown) => {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  if (json) {
+    process.stderr.write(
+      `${JSON.stringify({ kind: "egma.error", error: message }, null, 2)}\n`,
+    );
+  } else {
+    process.stderr.write(`egma: ${message}\n`);
+  }
+  process.exitCode = 1;
+});

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -1,0 +1,630 @@
+import { createInterface } from "node:readline/promises";
+
+import { login, resolveApiKey } from "./auth.ts";
+import { EgmaApi, EgmaApiError, egmaBaseUrl } from "./egma-api.ts";
+import {
+  discoverRepository,
+  type RepositoryDiscovery,
+} from "./repository.ts";
+import {
+  readReceipt,
+  receiptPath,
+  withInitLock,
+  writeReceipt,
+  type Receipt,
+} from "./receipt.ts";
+import type {
+  Agent,
+  Connection,
+  ResourceAction,
+  Test,
+} from "./types.ts";
+
+export type InitOptions = {
+  readonly cwd: string;
+  readonly baseUrl: string;
+  readonly tenant?: string;
+  readonly agent?: string;
+  readonly externalAgentId?: string;
+  readonly scenario?: string;
+  readonly expectedBehaviors?: readonly string[];
+  readonly testName?: string;
+  readonly planOnly: boolean;
+  readonly apply: boolean;
+  readonly resume: boolean;
+  readonly yes: boolean;
+  readonly json: boolean;
+};
+
+type LocatedAgent = {
+  readonly agent: Agent | null;
+  readonly connection: Connection | null;
+};
+
+type ProposedTest = {
+  readonly name: string;
+  readonly scenario: string;
+  readonly expectedBehaviors: readonly string[];
+};
+
+type InitPlan = {
+  readonly kind: "egma.init.plan";
+  readonly repository: string;
+  readonly dirtyFiles: readonly string[];
+  readonly retell: {
+    readonly tenant: string;
+    readonly agentSlug: string;
+    readonly agentId: string;
+    readonly name: string;
+    readonly engine: string;
+    readonly language: string | null;
+    readonly toolCount: number;
+  };
+  readonly willRead: readonly string[];
+  readonly resources: {
+    readonly agent: { readonly name: string; readonly action: ResourceAction };
+    readonly connection: {
+      readonly name: string;
+      readonly action: ResourceAction;
+    };
+    readonly test: {
+      readonly name: string;
+      readonly action: ResourceAction;
+      readonly scenario: string;
+      readonly expectedBehaviors: readonly string[];
+    };
+    readonly persona: { readonly action: "reuse project default" };
+  };
+  readonly effects: {
+    readonly retellChanges: "none";
+    readonly sourceUpload: false;
+    readonly simulationStarts: false;
+    readonly localWrite: string;
+  };
+};
+
+function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+}
+
+function proposal(discovery: RepositoryDiscovery, options: InitOptions): ProposedTest {
+  return {
+    name:
+      options.testName ??
+      `${discovery.agent.tenant}-${discovery.agent.slug}-first-simulation`,
+    scenario:
+      options.scenario ??
+      "The caller wants to book an appointment and asks for the next available time.",
+    expectedBehaviors:
+      options.expectedBehaviors === undefined || options.expectedBehaviors.length === 0
+        ? [
+            "The agent asks for the information needed to find an appointment and clearly explains the next step.",
+          ]
+        : options.expectedBehaviors,
+  };
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+async function allAgents(api: EgmaApi, name: string): Promise<Agent[]> {
+  const found: Agent[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await api.listAgents(cursor, name);
+    found.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor !== undefined);
+  return found;
+}
+
+async function allTests(api: EgmaApi, name: string): Promise<Test[]> {
+  const found: Test[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await api.listTests(cursor, name);
+    found.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor !== undefined);
+  return found;
+}
+
+async function absentWhenMissing<T>(operation: () => Promise<T>): Promise<T | null> {
+  try {
+    return await operation();
+  } catch (cause) {
+    if (cause instanceof EgmaApiError && cause.status === 404) return null;
+    throw cause;
+  }
+}
+
+async function locateAgent(
+  api: EgmaApi,
+  discovery: RepositoryDiscovery,
+  receipt: Receipt | null,
+): Promise<LocatedAgent> {
+  if (
+    receipt !== null &&
+    receipt.externalAgentId === discovery.agent.externalAgentId
+  ) {
+    const [agent, connection] = await Promise.all([
+      absentWhenMissing(() => api.getAgent(receipt.agentId)),
+      absentWhenMissing(() =>
+        api.getConnection(receipt.agentId, receipt.connectionId),
+      ),
+    ]);
+    if (
+      agent !== null &&
+      connection !== null &&
+      connection.config.retellAgentId === discovery.agent.externalAgentId
+    ) {
+      return { agent, connection };
+    }
+  }
+
+  const providerMatches = await api.findRetellAgents(
+    discovery.agent.externalAgentId,
+  );
+  if (providerMatches.length > 1) {
+    throw new Error(
+      `more than one Egma connection points to Retell agent ${discovery.agent.externalAgentId}; remove the duplicate before continuing`,
+    );
+  }
+  const providerMatch = providerMatches[0];
+  if (providerMatch?.connection !== undefined) {
+    return { agent: providerMatch, connection: providerMatch.connection };
+  }
+
+  const stableName = slug(`${discovery.agent.tenant}-${discovery.agent.slug}`);
+  let nameMatch: Agent | null = null;
+  let nameMatchConnections: readonly Connection[] = [];
+  for (const agent of await allAgents(api, stableName)) {
+    const connections = await api.listConnections(agent.id);
+    if (agent.name === stableName) {
+      nameMatch = agent;
+      nameMatchConnections = connections.items;
+    }
+    const connection = connections.items.find(
+      (candidate) =>
+        candidate.type === "retell" &&
+        candidate.config.retellAgentId === discovery.agent.externalAgentId,
+    );
+    if (connection !== undefined) return { agent, connection };
+  }
+  if (nameMatch !== null && nameMatchConnections.length > 0) {
+    throw new Error(
+      `agent "${stableName}" already exists but none of its connections point to Retell agent ${discovery.agent.externalAgentId}; choose the right repository agent before continuing`,
+    );
+  }
+  return { agent: nameMatch, connection: null };
+}
+
+async function locateTest(
+  api: EgmaApi,
+  proposed: ProposedTest,
+  receipt: Receipt | null,
+): Promise<Test | null> {
+  if (receipt !== null) {
+    const direct = await absentWhenMissing(() => api.getTest(receipt.testId));
+    if (direct !== null) return direct;
+  }
+  return (await allTests(api, proposed.name))[0] ?? null;
+}
+
+function verifyTest(
+  test: Test,
+  proposed: ProposedTest,
+  expectedPersonaId: string,
+): void {
+  if (
+    test.name !== proposed.name ||
+    test.scenario !== proposed.scenario ||
+    !sameStrings(test.expectedBehaviors, proposed.expectedBehaviors)
+  ) {
+    throw new Error(
+      `test "${proposed.name}" already exists with different content; choose another --test-name or review it before continuing`,
+    );
+  }
+  if (test.personas.length !== 1 || test.personas[0] === undefined) {
+    throw new Error(
+      `test "${proposed.name}" does not name exactly one persona, so it cannot be reused as the default-persona test`,
+    );
+  }
+  if (test.personas[0].id !== expectedPersonaId) {
+    throw new Error(
+      `test "${proposed.name}" does not use the project's current default persona`,
+    );
+  }
+  if (test.personas[0].deletedAt !== null) {
+    throw new Error(`test "${proposed.name}" uses a deleted persona`);
+  }
+}
+
+function retellConnection(discovery: RepositoryDiscovery): Record<string, unknown> {
+  return {
+    name: "retell-chat",
+    type: "retell",
+    modality: "chat",
+    environment: "development",
+    config: { retellAgentId: discovery.agent.externalAgentId },
+    credentials: { apiKey: discovery.retellApiKey },
+  };
+}
+
+function renderPlan(plan: InitPlan): string {
+  const dirty =
+    plan.dirtyFiles.length === 0
+      ? "  clean"
+      : plan.dirtyFiles.map((file) => `  ${file}`).join("\n");
+  return [
+    `Found Retell agent: ${plan.retell.name} (${plan.retell.agentId})`,
+    `Repository agent: ${plan.retell.tenant}/${plan.retell.agentSlug}`,
+    `Engine: ${plan.retell.engine}; language: ${plan.retell.language ?? "unknown"}; tools found: ${plan.retell.toolCount}`,
+    "",
+    "Uncommitted repository files:",
+    dirty,
+    "",
+    "Will create or reuse in Egma:",
+    `  Agent       ${plan.resources.agent.name} (${plan.resources.agent.action})`,
+    `  Connection  ${plan.resources.connection.name} (${plan.resources.connection.action})`,
+    `  Test        ${plan.resources.test.name} (${plan.resources.test.action})`,
+    "  Persona     reuse project default",
+    "",
+    "Proposed test:",
+    `  Scenario    ${plan.resources.test.scenario}`,
+    ...plan.resources.test.expectedBehaviors.map(
+      (behavior) => `  Expect      ${behavior}`,
+    ),
+    "",
+    "Will change in Retell:       nothing",
+    "Will upload repository code: no",
+    "Will start a simulation:     no",
+    `Will write locally:           ${plan.effects.localWrite}`,
+  ].join("\n");
+}
+
+async function approve(plan: InitPlan): Promise<boolean> {
+  process.stdout.write(`${renderPlan(plan)}\n\n`);
+  const terminal = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await terminal.question("Continue? [Y/n] ")).trim().toLowerCase();
+    return answer === "" || answer === "y" || answer === "yes";
+  } finally {
+    terminal.close();
+  }
+}
+
+async function authenticatedApi(options: InitOptions): Promise<EgmaApi> {
+  let apiKey = await resolveApiKey(options.baseUrl);
+  if (apiKey === null && process.stdin.isTTY && !options.json) {
+    await login(options.baseUrl);
+    apiKey = await resolveApiKey(options.baseUrl);
+  }
+  if (apiKey === null) {
+    throw new Error(
+      "Egma is not authenticated. Run `egma auth login`, or set EGMA_API_KEY without putting it on the command line.",
+    );
+  }
+  return new EgmaApi(options.baseUrl, apiKey);
+}
+
+function buildPlan(
+  discovery: RepositoryDiscovery,
+  located: LocatedAgent,
+  existingTest: Test | null,
+  proposed: ProposedTest,
+): InitPlan {
+  return {
+    kind: "egma.init.plan",
+    repository: discovery.root,
+    dirtyFiles: discovery.dirtyFiles,
+    retell: {
+      tenant: discovery.agent.tenant,
+      agentSlug: discovery.agent.slug,
+      agentId: discovery.agent.externalAgentId,
+      name: discovery.retell.name,
+      engine: discovery.retell.engine,
+      language: discovery.retell.language,
+      toolCount: discovery.retell.toolCount,
+    },
+    willRead: ["Retell agent settings", `${discovery.retell.engine} definition`],
+    resources: {
+      agent: {
+        name: slug(`${discovery.agent.tenant}-${discovery.agent.slug}`),
+        action: located.agent === null ? "created" : "reused",
+      },
+      connection: {
+        name: "retell-chat",
+        action: located.connection === null ? "created" : "reused",
+      },
+      test: {
+        ...proposed,
+        action: existingTest === null ? "created" : "reused",
+      },
+      persona: { action: "reuse project default" },
+    },
+    effects: {
+      retellChanges: "none",
+      sourceUpload: false,
+      simulationStarts: false,
+      localWrite: receiptPath(discovery.root),
+    },
+  };
+}
+
+async function applyPlan(
+  api: EgmaApi,
+  discovery: RepositoryDiscovery,
+  proposed: ProposedTest,
+  defaultPersonaId: string,
+  plannedAgent: LocatedAgent,
+  plannedTest: Test | null,
+): Promise<{
+  readonly kind: "egma.init.result";
+  readonly resources: {
+    readonly agent: Agent & { readonly action: ResourceAction };
+    readonly connection: Connection & { readonly action: ResourceAction };
+    readonly test: Test & { readonly action: ResourceAction };
+    readonly persona: Test["personas"][number];
+  };
+  readonly receipt: string;
+  readonly simulation: "not run";
+  readonly next: string;
+}> {
+  let located = plannedAgent;
+  let agentAction: ResourceAction = located.agent === null ? "created" : "reused";
+  let connectionAction: ResourceAction =
+    located.connection === null ? "created" : "reused";
+
+  if (located.agent === null) {
+    const created = await api.createAgent({
+      name: slug(`${discovery.agent.tenant}-${discovery.agent.slug}`),
+      description: `Imported from Retell agent ${discovery.retell.name}`,
+      connection: retellConnection(discovery),
+    });
+    if (created.connection === undefined) {
+      throw new Error("Egma created the agent without the requested connection");
+    }
+    located = { agent: created, connection: created.connection };
+  } else if (located.connection === null) {
+    const connection = await api.createConnection(
+      located.agent.id,
+      retellConnection(discovery),
+    );
+    located = { agent: located.agent, connection };
+    agentAction = "reused";
+  }
+
+  if (located.agent === null || located.connection === null) {
+    throw new Error("Egma did not return the agent and connection it created");
+  }
+
+  let test = plannedTest;
+  let testAction: ResourceAction = "reused";
+  if (test === null) {
+    test = await api.createTest({
+      name: proposed.name,
+      description: `First test for ${discovery.retell.name}`,
+      scenario: proposed.scenario,
+      expected_behaviors: [...proposed.expectedBehaviors],
+      idempotency_key: `egma-init:${discovery.agent.externalAgentId}`,
+    });
+    testAction = "created";
+  }
+  verifyTest(test, proposed, defaultPersonaId);
+  if (test.personas[0] === undefined) {
+    throw new Error("the created test has no default persona");
+  }
+
+  const [verifiedAgent, verifiedConnection, verifiedTest] = await Promise.all([
+    api.getAgent(located.agent.id),
+    api.getConnection(located.agent.id, located.connection.id),
+    api.getTest(test.id),
+  ]);
+  verifyTest(verifiedTest, proposed, defaultPersonaId);
+  const persona = verifiedTest.personas[0];
+  if (persona === undefined) throw new Error("the verified test has no default persona");
+  if (
+    verifiedConnection.agentId !== verifiedAgent.id ||
+    verifiedConnection.config.retellAgentId !== discovery.agent.externalAgentId
+  ) {
+    throw new Error("the connection read-back does not point to the selected Retell agent");
+  }
+
+  const file = await writeReceipt(discovery.root, {
+    version: 2,
+    provider: "retell",
+    egmaBaseUrl: api.baseUrl,
+    projectId: verifiedAgent.projectId,
+    externalAgentId: discovery.agent.externalAgentId,
+    agentId: verifiedAgent.id,
+    connectionId: verifiedConnection.id,
+    testId: verifiedTest.id,
+    personaId: persona.id,
+  });
+  return {
+    kind: "egma.init.result",
+    resources: {
+      agent: { ...verifiedAgent, action: agentAction },
+      connection: { ...verifiedConnection, action: connectionAction },
+      test: { ...verifiedTest, action: testAction },
+      persona,
+    },
+    receipt: file,
+    simulation: "not run",
+    next: `egma run create --test ${verifiedTest.id} --agent ${verifiedAgent.id} --connection ${verifiedConnection.id}`,
+  };
+}
+
+function renderResult(result: Awaited<ReturnType<typeof applyPlan>>): string {
+  return [
+    "Egma setup is ready.",
+    "",
+    `  Agent       ${result.resources.agent.id} (${result.resources.agent.action})`,
+    `  Connection  ${result.resources.connection.id} (${result.resources.connection.action})`,
+    `  Test        ${result.resources.test.id} (${result.resources.test.action})`,
+    `  Persona     ${result.resources.persona.id} (reused project default)`,
+    "",
+    `Receipt: ${result.receipt}`,
+    "Simulation: not run",
+    "",
+    "Next command:",
+    `  ${result.next}`,
+  ].join("\n");
+}
+
+export async function runInit(options: InitOptions): Promise<void> {
+  const receipt = await readReceipt(options.cwd);
+  const discovery = await discoverRepository({
+    cwd: options.cwd,
+    ...(options.tenant === undefined ? {} : { tenant: options.tenant }),
+    ...(options.agent === undefined ? {} : { agent: options.agent }),
+    ...(options.externalAgentId === undefined
+      ? {}
+      : { externalAgentId: options.externalAgentId }),
+    ...(receipt === null
+      ? {}
+      : { receiptExternalAgentId: receipt.externalAgentId }),
+    interactive: process.stdin.isTTY && !options.json,
+  });
+  const actualReceipt = await readReceipt(discovery.root);
+  const api = await authenticatedApi(options);
+  await api.listApiKeys();
+  const defaultPersona = await api.getDefaultPersona();
+  const origin = egmaBaseUrl(options.baseUrl);
+  if (
+    actualReceipt?.version === 2 &&
+    actualReceipt.egmaBaseUrl !== origin
+  ) {
+    throw new Error(
+      `this repository is linked to ${actualReceipt.egmaBaseUrl}, not ${origin}`,
+    );
+  }
+  if (
+    actualReceipt?.version === 2 &&
+    actualReceipt.projectId !== defaultPersona.projectId
+  ) {
+    throw new Error(
+      `this repository is linked to project ${actualReceipt.projectId}, not ${defaultPersona.projectId}`,
+    );
+  }
+  const reusableReceipt = actualReceipt?.version === 2 ? actualReceipt : null;
+  const proposed = proposal(discovery, options);
+  const located = await locateAgent(api, discovery, reusableReceipt);
+  const existingTest = await locateTest(api, proposed, reusableReceipt);
+  if (existingTest !== null) {
+    verifyTest(existingTest, proposed, defaultPersona.id);
+  }
+  const plan = buildPlan(discovery, located, existingTest, proposed);
+
+  if (options.planOnly) {
+    process.stdout.write(
+      options.json ? `${JSON.stringify(plan, null, 2)}\n` : `${renderPlan(plan)}\n`,
+    );
+    return;
+  }
+
+  const explicitApply = options.apply || options.resume;
+  if (!explicitApply) {
+    if (!options.json) process.stdout.write(`${renderPlan(plan)}\n`);
+    else process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    throw new Error("the plan was not applied; run again with --apply after approval");
+  }
+  if (!options.yes) {
+    if (!process.stdin.isTTY || options.json) {
+      throw new Error("--apply in a non-interactive terminal also needs --yes");
+    }
+    if (!(await approve(plan))) {
+      process.stdout.write("No changes were made.\n");
+      return;
+    }
+  } else if (!options.json) {
+    process.stdout.write(`${renderPlan(plan)}\n\n`);
+  }
+
+  const result = await withInitLock(discovery.root, async () => {
+    const currentDefault = await api.getDefaultPersona();
+    if (currentDefault.projectId !== defaultPersona.projectId) {
+      throw new Error("the active Egma project changed while init was waiting");
+    }
+    const currentAgent = await locateAgent(api, discovery, reusableReceipt);
+    const currentTest = await locateTest(api, proposed, reusableReceipt);
+    if (currentTest !== null) {
+      verifyTest(currentTest, proposed, currentDefault.id);
+    }
+    return applyPlan(
+      api,
+      discovery,
+      proposed,
+      currentDefault.id,
+      currentAgent,
+      currentTest,
+    );
+  });
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(result, null, 2)}\n`
+      : `${renderResult(result)}\n`,
+  );
+}
+
+export async function runInitStatus(options: {
+  readonly cwd: string;
+  readonly baseUrl: string;
+  readonly json: boolean;
+}): Promise<void> {
+  const root = options.cwd;
+  const receipt = await readReceipt(root);
+  if (receipt === null) throw new Error(`no receipt was found at ${receiptPath(root)}`);
+  const apiKey = await resolveApiKey(options.baseUrl);
+  if (apiKey === null) throw new Error("Egma is not authenticated; run `egma auth login`");
+  const api = new EgmaApi(options.baseUrl, apiKey);
+  if (receipt.version !== 2) {
+    throw new Error("this receipt predates deployment binding; run `egma init --apply` to upgrade it");
+  }
+  if (receipt.egmaBaseUrl !== api.baseUrl) {
+    throw new Error(
+      `this receipt belongs to ${receipt.egmaBaseUrl}, not ${api.baseUrl}`,
+    );
+  }
+  const [agent, connection, test, defaultPersona] = await Promise.all([
+    api.getAgent(receipt.agentId),
+    api.getConnection(receipt.agentId, receipt.connectionId),
+    api.getTest(receipt.testId),
+    api.getDefaultPersona(),
+  ]);
+  if (
+    agent.projectId !== receipt.projectId ||
+    connection.projectId !== receipt.projectId ||
+    test.projectId !== receipt.projectId
+  ) {
+    throw new Error("the receipt resources do not all belong to its recorded project");
+  }
+  if (
+    test.personas.length !== 1 ||
+    test.personas[0]?.id !== receipt.personaId ||
+    test.personas[0]?.id !== defaultPersona.id ||
+    test.personas[0]?.deletedAt !== null
+  ) {
+    throw new Error("the receipt test no longer uses the project's living default persona");
+  }
+  const status = { kind: "egma.init.status", receipt, agent, connection, test };
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(status, null, 2)}\n`
+      : [
+          "Egma receipt is valid.",
+          `  Agent       ${agent.id}`,
+          `  Connection  ${connection.id}`,
+          `  Test        ${test.id}`,
+          `  Persona     ${test.personas[0]?.id ?? "missing"}`,
+          "  Simulation  not run",
+          "",
+        ].join("\n"),
+  );
+}

--- a/apps/cli/src/receipt.ts
+++ b/apps/cli/src/receipt.ts
@@ -1,0 +1,166 @@
+import { mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type Receipt = {
+  readonly version: 1 | 2;
+  readonly provider: "retell";
+  readonly egmaBaseUrl: string | null;
+  readonly projectId: string | null;
+  readonly externalAgentId: string;
+  readonly agentId: string;
+  readonly connectionId: string;
+  readonly testId: string;
+  readonly personaId: string;
+};
+
+export type CurrentReceipt = Omit<
+  Receipt,
+  "version" | "egmaBaseUrl" | "projectId"
+> & {
+  readonly version: 2;
+  readonly egmaBaseUrl: string;
+  readonly projectId: string;
+};
+
+export function receiptPath(repositoryRoot: string): string {
+  return path.join(repositoryRoot, ".egma", "project.yaml");
+}
+
+async function removeDeadInitLock(file: string): Promise<boolean> {
+  let owner: string;
+  try {
+    owner = (await readFile(file, "utf8")).trim();
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw cause;
+  }
+
+  const pid = Number(owner);
+  if (!Number.isSafeInteger(pid) || pid < 1) {
+    throw new Error(
+      `another egma init may be using this repository (${file} has an invalid owner); remove it only if no init process is running`,
+    );
+  }
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (cause) {
+    const code = (cause as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH") return false;
+  }
+
+  try {
+    await unlink(file);
+    return true;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw cause;
+  }
+}
+
+/** Stop two init processes in one checkout from creating the same test twice. */
+export async function withInitLock<T>(
+  repositoryRoot: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const directory = path.join(repositoryRoot, ".egma");
+  const file = path.join(directory, "init.lock");
+  await mkdir(directory, { recursive: true });
+  let handle;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      handle = await open(file, "wx", 0o600);
+      break;
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+      if (attempt === 0 && (await removeDeadInitLock(file))) {
+        continue;
+      }
+      throw new Error(
+        `another egma init is using this repository (${file} is owned by a running process)`,
+      );
+    }
+  }
+  if (handle === undefined) throw new Error(`could not acquire ${file}`);
+  try {
+    await handle.writeFile(`${process.pid}\n`, "utf8");
+    return await operation();
+  } finally {
+    await handle.close();
+    await unlink(file).catch((cause: unknown) => {
+      if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+    });
+  }
+}
+
+export async function readReceipt(repositoryRoot: string): Promise<Receipt | null> {
+  let source: string;
+  try {
+    source = await readFile(receiptPath(repositoryRoot), "utf8");
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw cause;
+  }
+
+  const values = new Map<string, string>();
+  for (const line of source.split(/\r?\n/u)) {
+    const match = /^\s*([a-z_]+):\s*([^#\s]+)\s*$/u.exec(line);
+    if (match?.[1] !== undefined && match[2] !== undefined) {
+      values.set(match[1], match[2]);
+    }
+  }
+  const version = values.get("version");
+  if ((version !== "1" && version !== "2") || values.get("provider") !== "retell") {
+    throw new Error(
+      `${receiptPath(repositoryRoot)} is not an Egma Retell receipt version 1 or 2`,
+    );
+  }
+
+  const required = (key: string): string => {
+    const value = values.get(key);
+    if (value === undefined) {
+      throw new Error(`${receiptPath(repositoryRoot)} is missing ${key}`);
+    }
+    return value;
+  };
+  return {
+    version: version === "2" ? 2 : 1,
+    provider: "retell",
+    egmaBaseUrl: version === "2" ? required("egma_base_url") : null,
+    projectId: version === "2" ? required("project_id") : null,
+    externalAgentId: required("external_agent_id"),
+    agentId: required("agent_id"),
+    connectionId: required("connection_id"),
+    testId: required("test_id"),
+    personaId: required("persona_id"),
+  };
+}
+
+export async function writeReceipt(
+  repositoryRoot: string,
+  receipt: CurrentReceipt,
+): Promise<string> {
+  const file = receiptPath(repositoryRoot);
+  const temporary = `${file}.${process.pid}.tmp`;
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(
+    temporary,
+    [
+      "# Created by egma init. This file contains IDs, not secrets.",
+      "version: 2",
+      "provider: retell",
+      `egma_base_url: ${receipt.egmaBaseUrl}`,
+      `project_id: ${receipt.projectId}`,
+      `external_agent_id: ${receipt.externalAgentId}`,
+      "resources:",
+      `  agent_id: ${receipt.agentId}`,
+      `  connection_id: ${receipt.connectionId}`,
+      `  test_id: ${receipt.testId}`,
+      `  persona_id: ${receipt.personaId}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await rename(temporary, file);
+  return file;
+}

--- a/apps/cli/src/repository.ts
+++ b/apps/cli/src/repository.ts
@@ -1,0 +1,360 @@
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+
+export type RepositoryAgent = {
+  readonly tenant: string;
+  readonly slug: string;
+  readonly directory: string;
+  readonly externalAgentId: string;
+};
+
+export type RetellContext = {
+  readonly name: string;
+  readonly engine: "retell-llm" | "conversation-flow";
+  readonly language: string | null;
+  readonly toolCount: number;
+};
+
+export type RepositoryDiscovery = {
+  readonly root: string;
+  readonly dirtyFiles: readonly string[];
+  readonly agent: RepositoryAgent;
+  readonly retell: RetellContext;
+  readonly retellApiKey: string;
+};
+
+type Candidate = {
+  readonly tenant: string;
+  readonly slug: string;
+  readonly directory: string;
+};
+
+type DiscoveryOptions = {
+  readonly cwd: string;
+  readonly tenant?: string;
+  readonly agent?: string;
+  readonly externalAgentId?: string;
+  readonly receiptExternalAgentId?: string;
+  readonly interactive: boolean;
+};
+
+function run(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, [...args], { cwd, encoding: "utf8" }, (error, stdout) => {
+      if (error !== null) reject(error);
+      else resolve(stdout);
+    });
+  });
+}
+
+function parseEnvironment(source: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const raw of source.split(/\r?\n/u)) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/u.exec(line);
+    if (match?.[1] === undefined || match[2] === undefined) continue;
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    values[match[1]] = value;
+  }
+  return values;
+}
+
+async function localEnvironment(root: string): Promise<Record<string, string>> {
+  const files = [
+    path.join(root, "worker", ".dev.vars"),
+    path.join(root, ".env"),
+  ];
+  for (const file of files) {
+    try {
+      return parseEnvironment(await readFile(file, "utf8"));
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+    }
+  }
+  return {};
+}
+
+function valueOf(environment: Record<string, string>, name: string): string | undefined {
+  return process.env[name]?.trim() || environment[name]?.trim() || undefined;
+}
+
+async function candidatesIn(root: string): Promise<Candidate[]> {
+  const tenantsRoot = path.join(root, "tenants");
+  let tenants;
+  try {
+    tenants = await readdir(tenantsRoot, { withFileTypes: true });
+  } catch {
+    throw new Error(
+      "this prototype supports egma-receptionist repositories with tenants/<tenant>/agents/<agent>",
+    );
+  }
+
+  const found: Candidate[] = [];
+  for (const tenant of tenants) {
+    if (!tenant.isDirectory()) continue;
+    const agentsRoot = path.join(tenantsRoot, tenant.name, "agents");
+    let agents;
+    try {
+      agents = await readdir(agentsRoot, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const agent of agents) {
+      if (!agent.isDirectory()) continue;
+      found.push({
+        tenant: tenant.name,
+        slug: agent.name,
+        directory: path.join(agentsRoot, agent.name),
+      });
+    }
+  }
+  if (found.length === 0) {
+    throw new Error("no Retell agent directories were found under tenants/*/agents/*");
+  }
+  return found.sort((left, right) =>
+    `${left.tenant}/${left.slug}`.localeCompare(`${right.tenant}/${right.slug}`),
+  );
+}
+
+async function externalIdFromSupabase(
+  candidate: Candidate,
+  environment: Record<string, string>,
+): Promise<string | null> {
+  const processUrl = process.env.SUPABASE_URL?.trim();
+  const processKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  if ((processUrl === undefined) !== (processKey === undefined)) {
+    throw new Error(
+      "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must come from the same environment source",
+    );
+  }
+  const baseUrl = processUrl ?? environment.SUPABASE_URL?.trim();
+  const key = processKey ?? environment.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  if (baseUrl === undefined || key === undefined) return null;
+
+  const source = new URL(baseUrl);
+  if (
+    source.protocol !== "https:" &&
+    !(source.protocol === "http:" && ["localhost", "127.0.0.1"].includes(source.hostname))
+  ) {
+    throw new Error("SUPABASE_URL must use HTTPS, except for a local development server");
+  }
+  const url = new URL("/rest/v1/tenant_agents", source);
+  url.searchParams.set("select", "retell_agent_id");
+  url.searchParams.set("tenant_id", `eq.${candidate.tenant}`);
+  url.searchParams.set("slug", `eq.${candidate.slug}`);
+  const response = await fetch(url, {
+    headers: { apikey: key, authorization: `Bearer ${key}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `could not resolve ${candidate.tenant}/${candidate.slug} through its repository configuration (HTTP ${response.status})`,
+    );
+  }
+  const rows = (await response.json()) as Array<{ retell_agent_id?: unknown }>;
+  const id = rows[0]?.retell_agent_id;
+  return typeof id === "string" && id !== "" ? id : null;
+}
+
+function envSegment(value: string): string {
+  return value
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/gu, "_")
+    .replace(/^_+|_+$/gu, "");
+}
+
+function retellKey(
+  candidate: Candidate,
+  environment: Record<string, string>,
+): string {
+  const tenant = envSegment(candidate.tenant);
+  const agent = envSegment(candidate.slug);
+  const names = [
+    `RETELL_API_KEY_${tenant}_${agent}`,
+    `RETELL_API_KEY_${tenant}`,
+    "RETELL_API_KEY",
+  ];
+  for (const name of names) {
+    const value = valueOf(environment, name);
+    if (value !== undefined) return value;
+  }
+  throw new Error(
+    `no Retell credential was found for ${candidate.tenant}/${candidate.slug}; load the repository's environment and run again`,
+  );
+}
+
+async function choose(
+  candidates: readonly RepositoryAgent[],
+  options: DiscoveryOptions,
+): Promise<RepositoryAgent> {
+  const narrowed = candidates.filter(
+    (candidate) =>
+      (options.tenant === undefined || candidate.tenant === options.tenant) &&
+      (options.agent === undefined || candidate.slug === options.agent) &&
+      (options.receiptExternalAgentId === undefined ||
+        candidate.externalAgentId === options.receiptExternalAgentId),
+  );
+  if (narrowed.length === 1) return narrowed[0] as RepositoryAgent;
+  if (narrowed.length === 0) {
+    throw new Error(
+      "no repository agent matches the explicit selector or existing Egma receipt",
+    );
+  }
+
+  if (!options.interactive) {
+    const choices = narrowed
+      .map((candidate) => `  ${candidate.tenant}/${candidate.slug}`)
+      .join("\n");
+    throw new Error(
+      `more than one Retell agent is present. Name one with --tenant and --agent:\n${choices}`,
+    );
+  }
+
+  process.stdout.write("Retell agents found:\n");
+  narrowed.forEach((candidate, index) => {
+    process.stdout.write(`  ${index + 1}. ${candidate.tenant}/${candidate.slug}\n`);
+  });
+  const terminal = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await terminal.question("Choose an agent: ");
+    const selected = narrowed[Number(answer) - 1];
+    if (selected === undefined) throw new Error("that is not one of the listed agents");
+    return selected;
+  } finally {
+    terminal.close();
+  }
+}
+
+function toolCount(definition: Readonly<Record<string, unknown>>): number {
+  let total = 0;
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      total += value.filter(
+        (entry) =>
+          typeof entry === "object" &&
+          entry !== null &&
+          ("type" in entry || "name" in entry),
+      ).length;
+      value.forEach(visit);
+    } else if (typeof value === "object" && value !== null) {
+      Object.values(value).forEach(visit);
+    }
+  };
+  visit(definition.tools);
+  visit(definition.general_tools);
+  return total;
+}
+
+async function retellContext(
+  externalAgentId: string,
+  apiKey: string,
+): Promise<RetellContext> {
+  const headers = { authorization: `Bearer ${apiKey}`, accept: "application/json" };
+  const agentResponse = await fetch(
+    `https://api.retellai.com/get-agent/${encodeURIComponent(externalAgentId)}`,
+    { headers },
+  );
+  if (!agentResponse.ok) {
+    throw new Error(
+      `Retell could not read agent ${externalAgentId} (HTTP ${agentResponse.status})`,
+    );
+  }
+  const agent = (await agentResponse.json()) as Record<string, unknown>;
+  const responseEngine = agent.response_engine as
+    | { type?: unknown; llm_id?: unknown; conversation_flow_id?: unknown }
+    | undefined;
+  const engine = responseEngine?.type;
+  if (engine !== "retell-llm" && engine !== "conversation-flow") {
+    throw new Error(`Retell agent ${externalAgentId} has no supported response engine`);
+  }
+  const definitionId =
+    engine === "retell-llm"
+      ? responseEngine?.llm_id
+      : responseEngine?.conversation_flow_id;
+  if (typeof definitionId !== "string" || definitionId === "") {
+    throw new Error(`Retell agent ${externalAgentId} does not name its ${engine} definition`);
+  }
+  const definitionRoute =
+    engine === "retell-llm" ? "get-retell-llm" : "get-conversation-flow";
+  const definitionResponse = await fetch(
+    `https://api.retellai.com/${definitionRoute}/${encodeURIComponent(definitionId)}`,
+    { headers },
+  );
+  if (!definitionResponse.ok) {
+    throw new Error(
+      `Retell could not read the agent's ${engine} definition (HTTP ${definitionResponse.status})`,
+    );
+  }
+  const definition = (await definitionResponse.json()) as Record<string, unknown>;
+  return {
+    name:
+      typeof agent.agent_name === "string" && agent.agent_name.trim() !== ""
+        ? agent.agent_name.trim()
+        : externalAgentId,
+    engine,
+    language: typeof agent.language === "string" ? agent.language : null,
+    toolCount: toolCount(definition),
+  };
+}
+
+export async function discoverRepository(
+  options: DiscoveryOptions,
+): Promise<RepositoryDiscovery> {
+  let root: string;
+  try {
+    root = (await run("git", ["rev-parse", "--show-toplevel"], options.cwd)).trim();
+  } catch {
+    throw new Error("run egma init inside a Git repository");
+  }
+  const dirtyFiles = (await run("git", ["status", "--short"], root))
+    .split(/\r?\n/u)
+    .filter(Boolean);
+  const environment = await localEnvironment(root);
+  const candidates = (await candidatesIn(root)).filter(
+    (candidate) =>
+      (options.tenant === undefined || candidate.tenant === options.tenant) &&
+      (options.agent === undefined || candidate.slug === options.agent),
+  );
+  if (candidates.length === 0) {
+    throw new Error("the named tenant and agent do not exist in this repository");
+  }
+  const resolved: RepositoryAgent[] = [];
+  for (const candidate of candidates) {
+    const supplied =
+      options.tenant === candidate.tenant && options.agent === candidate.slug
+        ? options.externalAgentId
+        : undefined;
+    const externalAgentId =
+      supplied ?? (await externalIdFromSupabase(candidate, environment));
+    if (externalAgentId !== null && externalAgentId !== undefined) {
+      resolved.push({ ...candidate, externalAgentId });
+    }
+  }
+  if (resolved.length === 0) {
+    throw new Error(
+      "the repository contains agent directories, but no Retell agent ID could be resolved; pass --tenant, --agent and --retell-agent-id",
+    );
+  }
+  const agent = await choose(resolved, options);
+  const apiKey = retellKey(agent, environment);
+  return {
+    root,
+    dirtyFiles,
+    agent,
+    retell: await retellContext(agent.externalAgentId, apiKey),
+    retellApiKey: apiKey,
+  };
+}

--- a/apps/cli/src/skill.ts
+++ b/apps/cli/src/skill.ts
@@ -1,0 +1,22 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export async function installSkill(
+  cwd: string,
+  force: boolean,
+): Promise<string> {
+  const source = path.resolve(import.meta.dirname, "../skills/egma-init/SKILL.md");
+  const target = path.resolve(cwd, ".agents", "skills", "egma-init", "SKILL.md");
+  if (!force) {
+    try {
+      await readFile(target, "utf8");
+      throw new Error(`${target} already exists; use --force to replace it`);
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+    }
+  }
+  const contents = await readFile(source, "utf8");
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, contents, "utf8");
+  return target;
+}

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -1,0 +1,52 @@
+export type Agent = {
+  readonly id: string;
+  readonly projectId: string;
+  readonly name: string;
+  readonly description: string | null;
+};
+
+export type Connection = {
+  readonly id: string;
+  readonly agentId: string;
+  readonly projectId: string;
+  readonly name: string;
+  readonly type: string;
+  readonly modality: string;
+  readonly config: Readonly<Record<string, string>>;
+  readonly credentialsHint: string | null;
+};
+
+export type CreatedAgent = Agent & {
+  readonly connection?: Connection;
+};
+
+export type TestPersona = {
+  readonly id: string;
+  readonly name: string;
+  readonly deletedAt: string | null;
+};
+
+export type Persona = {
+  readonly id: string;
+  readonly projectId: string;
+  readonly name: string;
+};
+
+export type Test = {
+  readonly id: string;
+  readonly projectId: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly version: number;
+  readonly versionId: string;
+  readonly scenario: string;
+  readonly expectedBehaviors: readonly string[];
+  readonly personas: readonly TestPersona[];
+};
+
+export type Page<T> = {
+  readonly items: readonly T[];
+  readonly nextCursor?: string;
+};
+
+export type ResourceAction = "created" | "reused";

--- a/apps/cli/test/egma-api.test.ts
+++ b/apps/cli/test/egma-api.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { EgmaApi, egmaBaseUrl } from "../src/egma-api.ts";
+
+describe("Egma API addresses", () => {
+  it("refuses to send credentials over remote HTTP", () => {
+    expect(() => new EgmaApi("http://egma.example", "egma_sk_secret")).toThrow(
+      /must use HTTPS/,
+    );
+  });
+
+  it("allows HTTP only on loopback development addresses", () => {
+    expect(egmaBaseUrl("http://localhost:3100/")).toBe(
+      "http://localhost:3100",
+    );
+    expect(egmaBaseUrl("http://127.0.0.1:3100/")).toBe(
+      "http://127.0.0.1:3100",
+    );
+    expect(egmaBaseUrl("http://[::1]:3100/")).toBe("http://[::1]:3100");
+  });
+
+  it("accepts HTTPS and rejects embedded credentials", () => {
+    expect(egmaBaseUrl("https://egma.example/")).toBe("https://egma.example");
+    expect(() => egmaBaseUrl("https://name:secret@egma.example")).toThrow(
+      /must not contain/,
+    );
+  });
+});

--- a/apps/cli/test/receipt.test.ts
+++ b/apps/cli/test/receipt.test.ts
@@ -1,0 +1,50 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { withInitLock } from "../src/receipt.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+async function repository(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "egma-init-lock-"));
+  temporaryDirectories.push(directory);
+  await mkdir(path.join(directory, ".egma"));
+  return directory;
+}
+
+describe("the init lock", () => {
+  it("recovers a lock left by a process that no longer exists", async () => {
+    const root = await repository();
+    const lock = path.join(root, ".egma", "init.lock");
+    await writeFile(lock, "2147483647\n", "utf8");
+
+    await expect(withInitLock(root, async () => "applied")).resolves.toBe(
+      "applied",
+    );
+    await expect(readFile(lock, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not take a lock owned by a running process", async () => {
+    const root = await repository();
+    const lock = path.join(root, ".egma", "init.lock");
+    await writeFile(lock, `${process.pid}\n`, "utf8");
+
+    await expect(withInitLock(root, async () => undefined)).rejects.toThrow(
+      "owned by a running process",
+    );
+    await expect(readFile(lock, "utf8")).resolves.toBe(`${process.pid}\n`);
+  });
+});

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/factory-api.md
+++ b/docs/factory-api.md
@@ -1,0 +1,63 @@
+# Factory API prototype
+
+The CLI uses this small JSON API to create and read an agent, its Retell
+connection, the project's default persona and one test. Every route needs a
+session cookie or `Authorization: Bearer egma_sk_...`. A `viewer` can read. A
+`member` or `admin` can create.
+
+This is a prototype contract. Response fields use `snake_case`. List responses
+always include `next_cursor`, which is `null` on the last page. `limit` is an
+integer from 1 through 200. `cursor` is the last ID from the prior page. The
+optional `name` query is an exact match.
+
+## Routes
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/personas/default` | Read the acting project's living default persona. |
+| `GET` | `/v1/agents` | List agents. Supports `limit`, `cursor` and `name`. |
+| `POST` | `/v1/agents` | Create an agent, with an optional first connection. |
+| `GET` | `/v1/agents/:agent_id` | Read one visible agent. |
+| `GET` | `/v1/agents/retell/:retell_agent_id` | Find connections that point to one Retell agent. |
+| `GET` | `/v1/agents/:agent_id/connections` | List an agent's connections. |
+| `POST` | `/v1/agents/:agent_id/connections` | Add a connection. |
+| `GET` | `/v1/agents/:agent_id/connections/:connection_id` | Read one connection. |
+| `GET` | `/v1/tests` | List tests. Supports `limit`, `cursor` and `name`. |
+| `POST` | `/v1/tests` | Create a test. Omit `persona_ids` to use the project default. |
+| `GET` | `/v1/tests/:test_id` | Read one test and its personas. |
+
+An agent create accepts `name`, optional `description`, and optional
+`connection`. A Retell connection is shaped like this:
+
+```json
+{
+  "name": "retell-chat",
+  "type": "retell",
+  "modality": "chat",
+  "environment": "development",
+  "config": { "retellAgentId": "agent_..." },
+  "credentials": { "apiKey": "..." }
+}
+```
+
+The API seals the credential. Responses never contain it. They contain only
+`credentials_hint`.
+
+A test create accepts `name`, optional `description`, `scenario`, a non-empty
+`expected_behaviors` list, optional `persona_ids`, and optional
+`idempotency_key`. Requests with the same idempotency key and test name are
+serialized, so concurrent onboarding commands reuse one test. Ordinary test
+names remain non-unique.
+
+## Errors
+
+Errors use `{ "error": "code", "message": "plain explanation" }`.
+
+| Status | Code | Meaning |
+| --- | --- | --- |
+| `400` | `invalid_request` | A field, cursor or resource reference is invalid. |
+| `401` | `not_authenticated` | No usable session or API key was sent. |
+| `403` | `not_permitted` | The current role cannot take this action. |
+| `404` | `no_such_*` | The resource is absent or outside the acting project. |
+| `409` | `resource_conflict` | A living agent or connection already owns the name. |
+| `429` | `too_many_requests` | The organization used its request budget. |

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   },
   "scripts": {
     "lint": "node packages/lint/src/cli.ts",
-    "build": "pnpm lint && tsc -b packages/ids packages/db packages/lint apps/api",
+    "build": "pnpm lint && tsc -b packages/ids packages/db packages/lint apps/api apps/cli",
     "typecheck": "pnpm build && tsc -p tsconfig.tests.json && pnpm --filter @egma/web typecheck",
-    "clean": "tsc -b --clean packages/ids packages/db packages/lint apps/api",
+    "egma": "node apps/cli/dist/index.js",
+    "clean": "tsc -b --clean packages/ids packages/db packages/lint apps/api apps/cli",
     "db:up": "docker compose up -d --wait postgres clickhouse",
     "db:down": "docker compose down",
     "db:generate": "pnpm --filter @egma/db generate",

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -1,5 +1,5 @@
 import { isId, newId } from "@egma/ids";
-import { and, asc, desc, eq, isNull, lt, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, lt, sql, type SQL } from "drizzle-orm";
 
 import { db, type Queryable } from "../client.ts";
 import {
@@ -17,7 +17,11 @@ import {
   validModality,
 } from "./connection-registry.ts";
 import type { AuthContext } from "./context.ts";
-import { ProjectOutsideOrganizationError } from "./errors.ts";
+import {
+  InvalidInputError,
+  ProjectOutsideOrganizationError,
+  ResourceConflictError,
+} from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
 import { isProjectOfOrganization } from "./projects.ts";
 import { within } from "./within.ts";
@@ -186,7 +190,7 @@ const CONNECTION_COLUMNS = {
 function validName(name: string, what: string): string {
   const trimmed = name.trim();
   if (trimmed === "") {
-    throw new Error(`${what} needs a name`);
+    throw new InvalidInputError(`${what} needs a name`);
   }
   return trimmed;
 }
@@ -411,7 +415,7 @@ async function freeDefaultName(
 function refusingHeldAgentName(name: string): (error: unknown) => never {
   return (error: unknown) => {
     if (lostToConstraint(error, "agent_project_id_name_unique")) {
-      throw new Error(
+      throw new ResourceConflictError(
         `an agent named "${name}" already exists in this project`,
       );
     }
@@ -426,7 +430,7 @@ function refusingHeldAgentName(name: string): (error: unknown) => never {
 function refusingHeldConnectionName(name: string): (error: unknown) => never {
   return (error: unknown) => {
     if (lostToConstraint(error, "connection_agent_id_name_unique")) {
-      throw new Error(
+      throw new ResourceConflictError(
         `a connection named "${name}" already exists on this agent`,
       );
     }
@@ -481,7 +485,7 @@ export async function createAgent(
 
   const { projectId } = auth;
   if (projectId === undefined) {
-    throw new Error(
+    throw new InvalidInputError(
       "an agent belongs to a project, and this credential is for the whole organization and acting in none",
     );
   }
@@ -547,6 +551,37 @@ export async function getAgent(
   return row;
 }
 
+/** Every living Retell connection that points at one provider agent. */
+export async function findRetellAgents(
+  auth: AuthContext,
+  retellAgentId: string,
+): Promise<readonly (Agent & { readonly connection: Connection })[]> {
+  authorize(auth, "read", here(auth));
+  if (retellAgentId.trim() === "") {
+    throw new InvalidInputError("a Retell agent id must not be empty");
+  }
+  const rows = await db()
+    .select({ identity: COLUMNS, wired: CONNECTION_COLUMNS })
+    .from(agent)
+    .innerJoin(
+      connection,
+      and(
+        eq(connection.agentId, agent.id),
+        connectionNotDeleted,
+        eq(connection.type, "retell"),
+        sql`${connection.config} ->> 'retellAgentId' = ${retellAgentId.trim()}`,
+      ),
+    )
+    .where(
+      within(auth, agent, and(notDeleted, inActingProject(auth))),
+    )
+    .orderBy(asc(agent.id), asc(connection.id));
+  return rows.map(({ identity, wired }) => ({
+    ...identity,
+    connection: connectionFromRow(wired),
+  }));
+}
+
 const DEFAULT_PAGE_SIZE = 50;
 const LARGEST_PAGE_SIZE = 200;
 
@@ -566,21 +601,27 @@ export async function listAgents(
   page?: {
     readonly limit?: number | undefined;
     readonly cursor?: string | undefined;
+    readonly name?: string | undefined;
   },
 ): Promise<AgentPage> {
   authorize(auth, "read", here(auth));
 
   const limit = page?.limit ?? DEFAULT_PAGE_SIZE;
   if (!Number.isInteger(limit) || limit < 1 || limit > LARGEST_PAGE_SIZE) {
-    throw new Error(`a page holds between 1 and ${LARGEST_PAGE_SIZE} agents`);
+    throw new InvalidInputError(
+      `a page holds between 1 and ${LARGEST_PAGE_SIZE} agents`,
+    );
   }
   const cursor = page?.cursor;
   if (cursor !== undefined && !isId("agt", cursor)) {
-    throw new Error(`"${cursor}" is not an agent id, so it cannot be a cursor`);
+    throw new InvalidInputError(
+      `"${cursor}" is not an agent id, so it cannot be a cursor`,
+    );
   }
 
   const olderThanCursor =
     cursor === undefined ? undefined : lt(agent.id, cursor);
+  const named = page?.name === undefined ? undefined : eq(agent.name, page.name);
 
   // One row beyond the page answers "is there more?" without a second query.
   const rows = await db()
@@ -590,7 +631,7 @@ export async function listAgents(
       within(
         auth,
         agent,
-        and(notDeleted, inActingProject(auth), olderThanCursor),
+        and(notDeleted, inActingProject(auth), olderThanCursor, named),
       ),
     )
     .orderBy(desc(agent.id))
@@ -672,7 +713,7 @@ export async function deleteAgent(
   authorize(auth, "configure_agents", here(auth));
 
   if (auth.projectId === undefined) {
-    throw new Error(
+    throw new InvalidInputError(
       "deleting an agent happens inside its project, and this credential is for the whole organization and acting in none",
     );
   }
@@ -780,7 +821,7 @@ export async function updateConnection(
   // an edit quietly drop half its payload.
   for (const immutable of ["type", "modality", "topology"] as const) {
     if (immutable in changes) {
-      throw new Error(
+      throw new InvalidInputError(
         `a connection's ${immutable} never changes: what a connection is, ` +
           `is a new connection`,
       );

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -5,6 +5,7 @@ import {
   type Modality,
   type Topology,
 } from "../schema/agents.ts";
+import { InvalidInputError } from "./errors.ts";
 
 /**
  * What each connection type is made of. The registry is code, not a table,
@@ -63,7 +64,7 @@ export type ConnectionDescriptor = {
 
 function nonEmptyString(key: string, value: unknown): string {
   if (typeof value !== "string" || value.trim() === "") {
-    throw new Error(`the config's ${key} must be a non-empty string`);
+    throw new InvalidInputError(`the config's ${key} must be a non-empty string`);
   }
   return value.trim();
 }
@@ -81,7 +82,7 @@ const SHORTEST_CREDENTIAL = 8;
 function e164PhoneNumber(key: string, value: unknown): string {
   const candidate = typeof value === "string" ? value.trim() : "";
   if (!E164.test(candidate)) {
-    throw new Error(
+    throw new InvalidInputError(
       `the config's ${key} must be an E.164 phone number, which looks like ` +
         `+15551234567`,
     );
@@ -116,7 +117,7 @@ export const CONNECTION_REGISTRY: Readonly<
 export function descriptorOf(type: string): ConnectionDescriptor {
   const descriptor = CONNECTION_REGISTRY[type as ConnectionType];
   if (descriptor === undefined) {
-    throw new Error(
+    throw new InvalidInputError(
       `"${type}" is not a connection type egma knows; expected one of ` +
         CONNECTION_TYPES.join(", "),
     );
@@ -130,11 +131,11 @@ export function validModality(type: ConnectionType, modality: string): Modality 
   if (!descriptor.modalities.includes(modality as Modality)) {
     const speaks = descriptor.modalities.join(" or ");
     if (!MODALITIES.includes(modality as Modality)) {
-      throw new Error(
+      throw new InvalidInputError(
         `"${modality}" is not a modality; a ${type} connection speaks ${speaks}`,
       );
     }
-    throw new Error(
+    throw new InvalidInputError(
       `a ${type} connection speaks ${speaks}, and this one was asked for ${modality}`,
     );
   }
@@ -155,14 +156,14 @@ export function validConfig(
   const demanded = Object.keys(gates);
 
   if (typeof config !== "object" || config === null || Array.isArray(config)) {
-    throw new Error(
+    throw new InvalidInputError(
       `a ${type} connection's config is an object holding ${demanded.join(", ")}`,
     );
   }
 
   for (const key of Object.keys(config)) {
     if (!(key in gates)) {
-      throw new Error(
+      throw new InvalidInputError(
         `a ${type} connection's config has no key "${key}"; it holds ` +
           demanded.join(", "),
       );
@@ -173,7 +174,7 @@ export function validConfig(
   for (const [key, gate] of Object.entries(gates)) {
     const value = (config as Record<string, unknown>)[key];
     if (value === undefined) {
-      throw new Error(`a ${type} connection's config needs ${key}`);
+      throw new InvalidInputError(`a ${type} connection's config needs ${key}`);
     }
     stored[key] = gate(key, value);
   }
@@ -193,7 +194,7 @@ export function validCredentials(
   const rule = descriptorOf(type).credentials;
 
   if (!rule.required) {
-    if (credentials !== undefined) throw new Error(rule.refusal);
+    if (credentials !== undefined) throw new InvalidInputError(rule.refusal);
     return null;
   }
 
@@ -204,12 +205,12 @@ export function validCredentials(
     credentials === null ||
     Array.isArray(credentials)
   ) {
-    throw new Error(`a ${type} connection needs credentials shaped ${shape}`);
+    throw new InvalidInputError(`a ${type} connection needs credentials shaped ${shape}`);
   }
 
   for (const key of Object.keys(credentials)) {
     if (!rule.fields.includes(key)) {
-      throw new Error(
+      throw new InvalidInputError(
         `a ${type} connection's credentials have no key "${key}"; they are ` +
           `shaped ${shape}`,
       );
@@ -224,7 +225,7 @@ export function validCredentials(
     // nothing to say the stored value was the problem.
     const trimmed = typeof value === "string" ? value.trim() : "";
     if (trimmed === "") {
-      throw new Error(
+      throw new InvalidInputError(
         `a ${type} connection's credentials need ${field} to be a non-empty string`,
       );
     }
@@ -232,7 +233,7 @@ export function validCredentials(
     // paste gone wrong — and the stored last-4 hint must stay a hint, never
     // most of the secret it hints at.
     if (trimmed.length < SHORTEST_CREDENTIAL) {
-      throw new Error(
+      throw new InvalidInputError(
         `a ${type} connection's credentials need ${field} to be at least ` +
           `${SHORTEST_CREDENTIAL} characters`,
       );

--- a/packages/db/src/access/errors.ts
+++ b/packages/db/src/access/errors.ts
@@ -2,6 +2,22 @@ import type { Role } from "../schema/columns.ts";
 import type { AuthContext } from "./context.ts";
 import type { Action, ActionScope } from "./permissions.ts";
 
+/** A caller supplied a value the resource contract cannot accept. */
+export class InvalidInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidInputError";
+  }
+}
+
+/** A valid create collided with a living resource that already owns its key. */
+export class ResourceConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ResourceConflictError";
+  }
+}
+
 /**
  * A write named a project belonging to another customer.
  *

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -56,10 +56,12 @@ export type { AuthContext, Role, Via } from "./context.ts";
 export { ROLES, VIA } from "./context.ts";
 export {
   AlreadyBelongsToAnOrganizationError,
+  InvalidInputError,
   LastAdminError,
   NotPermittedError,
   PersonaNamedByTestsError,
   ProjectOutsideOrganizationError,
+  ResourceConflictError,
   TraceStoreRefusedError,
   UnreadableTraceQueryError,
   type TestNamingPersona,
@@ -167,6 +169,7 @@ export {
   addConnection,
   createAgent,
   deleteAgent,
+  findRetellAgents,
   getAgent,
   getConnection,
   listAgents,
@@ -197,6 +200,7 @@ export {
   createPersona,
   deletePersona,
   editPersona,
+  getDefaultPersona,
   getPersona,
   getPersonaVersion,
   listPersonas,

--- a/packages/db/src/access/personas.ts
+++ b/packages/db/src/access/personas.ts
@@ -6,8 +6,10 @@ import {
   persona,
   personaVersion,
 } from "../schema/personas.ts";
+import { project } from "../schema/tenancy.ts";
 import type { AuthContext } from "./context.ts";
 import {
+  InvalidInputError,
   PersonaNamedByTestsError,
   ProjectOutsideOrganizationError,
 } from "./errors.ts";
@@ -320,6 +322,32 @@ export async function getPersona(
 
   if (row === undefined) return undefined;
   return { ...row, traits: traitsFromRow(row.traits, row.versionId) };
+}
+
+/** The living persona the acting project uses when a test names nobody. */
+export async function getDefaultPersona(
+  auth: AuthContext,
+): Promise<Persona | undefined> {
+  authorize(auth, "read", here(auth));
+  if (auth.projectId === undefined) {
+    throw new InvalidInputError(
+      "a default persona belongs to a project, and this credential is acting in none",
+    );
+  }
+  const [home] = await db()
+    .select({ personaId: project.defaultPersonaId })
+    .from(project)
+    .where(
+      within(
+        auth,
+        project,
+        and(eq(project.id, auth.projectId), isNull(project.deletedAt)),
+      ),
+    )
+    .limit(1);
+  return home?.personaId === null || home?.personaId === undefined
+    ? undefined
+    : getPersona(auth, home.personaId);
 }
 
 /**

--- a/packages/db/src/access/tests.ts
+++ b/packages/db/src/access/tests.ts
@@ -1,5 +1,5 @@
 import { isId, newId } from "@egma/ids";
-import { and, asc, desc, eq, inArray, isNull, lt, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, lt, sql, type SQL } from "drizzle-orm";
 
 import { db, type Queryable } from "../client.ts";
 import { persona } from "../schema/personas.ts";
@@ -7,6 +7,7 @@ import { project } from "../schema/tenancy.ts";
 import { test, testVersion, testVersionPersona } from "../schema/tests.ts";
 import type { AuthContext } from "./context.ts";
 import {
+  InvalidInputError,
   ProjectOutsideOrganizationError,
   type TestNamingPersona,
 } from "./errors.ts";
@@ -58,6 +59,8 @@ export type NewTest = {
    * on authoring a persona.
    */
   readonly personaIds?: readonly string[] | undefined;
+  /** Serialize a create-or-reuse flow without making ordinary test names unique. */
+  readonly idempotencyKey?: string | undefined;
 };
 
 /**
@@ -141,7 +144,7 @@ const COLUMNS = {
  */
 function validName(name: string): string {
   const trimmed = name.trim();
-  if (trimmed === "") throw new Error("a test needs a name");
+  if (trimmed === "") throw new InvalidInputError("a test needs a name");
   return trimmed;
 }
 
@@ -158,18 +161,20 @@ function validContent(input: {
 }): TestContent {
   const scenario = input.scenario.trim();
   if (scenario === "") {
-    throw new Error("a test needs a scenario: the situation the agent is put in");
+    throw new InvalidInputError(
+      "a test needs a scenario: the situation the agent is put in",
+    );
   }
 
   if (input.expectedBehaviors.length === 0) {
-    throw new Error(
+    throw new InvalidInputError(
       "a test needs at least one expected behavior, because a test that cannot fail is not a test",
     );
   }
   const expectedBehaviors = input.expectedBehaviors.map((behavior) => {
     const trimmed = behavior.trim();
     if (trimmed === "") {
-      throw new Error("an expected behavior needs to say something");
+      throw new InvalidInputError("an expected behavior needs to say something");
     }
     return trimmed;
   });
@@ -188,10 +193,10 @@ function validatePersonaIds(ids: readonly string[]): void {
   const seen = new Set<string>();
   for (const id of ids) {
     if (!isId("prs", id)) {
-      throw new Error(`"${id}" is not a persona id`);
+      throw new InvalidInputError(`"${id}" is not a persona id`);
     }
     if (seen.has(id)) {
-      throw new Error(`persona ${id} is named twice on one test`);
+      throw new InvalidInputError(`persona ${id} is named twice on one test`);
     }
     seen.add(id);
   }
@@ -322,10 +327,10 @@ async function validateNamedPersonas(
 
   for (const id of ids) {
     if (!found.has(id)) {
-      throw new Error(`there is no persona ${id} in this project`);
+      throw new InvalidInputError(`there is no persona ${id} in this project`);
     }
     if (found.get(id) !== null) {
-      throw new Error(
+      throw new InvalidInputError(
         `persona ${id} is deleted, and a test cannot name a deleted persona`,
       );
     }
@@ -359,7 +364,7 @@ async function projectDefaultPersona(
 
   const id = row?.defaultPersonaId ?? null;
   if (id === null) {
-    throw new Error(
+    throw new InvalidInputError(
       "this test names no persona and the project has no default persona; name one on the test, or set the project's default",
     );
   }
@@ -386,12 +391,12 @@ async function projectDefaultPersona(
     .for("share");
 
   if (pointed === undefined) {
-    throw new Error(
+    throw new InvalidInputError(
       `this test names no persona and the project's default points at ${id}, and there is no persona ${id} in this project; name one on the test, or point the project's default at a living persona of this project`,
     );
   }
   if (pointed.deletedAt !== null) {
-    throw new Error(
+    throw new InvalidInputError(
       `this test names no persona and the project's default persona ${id} is deleted; name one on the test, or point the project's default at a living persona`,
     );
   }
@@ -461,7 +466,7 @@ export async function createTest(
 
   const { projectId } = auth;
   if (projectId === undefined) {
-    throw new Error(
+    throw new InvalidInputError(
       "a test belongs to a project, and this credential is for the whole organization and acting in none",
     );
   }
@@ -471,16 +476,44 @@ export async function createTest(
   const name = validName(input.name);
   const content = validContent(input);
   const named = input.personaIds ?? [];
+  const idempotencyKey = input.idempotencyKey?.trim();
+  if (input.idempotencyKey !== undefined && idempotencyKey === "") {
+    throw new InvalidInputError("an idempotency key must not be empty");
+  }
   validatePersonaIds(named);
 
   if (!(await isProjectOfOrganization(auth, projectId))) {
     throw new ProjectOutsideOrganizationError(auth.organizationId, projectId);
   }
 
-  const id = newId("tst");
-  const versionId = newId("tstv");
+  return db().transaction(async (tx) => {
+    if (idempotencyKey !== undefined) {
+      const lock = `${auth.organizationId}:${projectId}:${idempotencyKey}`;
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${lock}, 0))`,
+      );
+      const [existing] = await selectWithCurrentVersion(tx)
+        .where(
+          within(
+            auth,
+            test,
+            and(notDeleted, inActingProject(auth), eq(test.name, name)),
+          ),
+        )
+        .orderBy(desc(test.id))
+        .limit(1);
+      if (existing !== undefined) {
+        const { content: stored, ...identity } = existing;
+        return {
+          ...identity,
+          ...contentFromRow(stored, identity.versionId),
+          personas: await personasOf(tx, identity.versionId),
+        };
+      }
+    }
 
-  const written = await db().transaction(async (tx) => {
+    const id = newId("tst");
+    const versionId = newId("tstv");
     const personaIds = await personaIdsFor(tx, auth, projectId, named);
 
     const [identity] = await tx
@@ -511,10 +544,14 @@ export async function createTest(
     // Read back inside the transaction, so what the create answers with is what
     // the transaction wrote and checked, rather than whatever the table holds
     // by the time it has committed.
-    return { ...identity, personas: await personasOf(tx, versionId) };
+    return {
+      ...identity,
+      version: 1,
+      versionId,
+      ...content,
+      personas: await personasOf(tx, versionId),
+    };
   });
-
-  return { ...written, version: 1, versionId, ...content };
 }
 
 /**
@@ -571,8 +608,8 @@ async function personasOf(
  * The identity row joined to its current version — the shape every read of a
  * whole test answers with, written once so two readers can never drift.
  */
-function selectWithCurrentVersion() {
-  return db()
+function selectWithCurrentVersion(on: Queryable = db()) {
+  return on
     .select({
       ...COLUMNS,
       version: testVersion.version,
@@ -813,9 +850,14 @@ export type TestPage = {
   readonly nextCursor: string | undefined;
 };
 
+type TestPageRequest = PageRequest & {
+  /** Exact identity-name filter used by repository-first setup. */
+  readonly name?: string | undefined;
+};
+
 export async function listTests(
   auth: AuthContext,
-  page?: PageRequest,
+  page?: TestPageRequest,
 ): Promise<TestPage> {
   authorize(auth, "read", here(auth));
 
@@ -825,13 +867,14 @@ export async function listTests(
     prefix: "tst",
   });
   const olderThanCursor = cursor === undefined ? undefined : lt(test.id, cursor);
+  const named = page?.name === undefined ? undefined : eq(test.name, page.name);
 
   const rows = await selectWithCurrentVersion()
     .where(
       within(
         auth,
         test,
-        and(notDeleted, inActingProject(auth), olderThanCursor),
+        and(notDeleted, inActingProject(auth), olderThanCursor, named),
       ),
     )
     .orderBy(desc(test.id))

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -100,8 +100,10 @@ const CONTEXT_REQUIRING = [
   "editPersona",
   "editTest",
   "failSimulation",
+  "findRetellAgents",
   "getAgent",
   "getConnection",
+  "getDefaultPersona",
   "getPersona",
   "getPersonaVersion",
   "getRun",
@@ -154,10 +156,12 @@ const PERMISSION = [
 /** Vocabulary: the table definitions, how a caller proved who they are, and the refusals. */
 const VALUES = [
   "AlreadyBelongsToAnOrganizationError",
+  "InvalidInputError",
   "LastAdminError",
   "NotPermittedError",
   "PersonaNamedByTestsError",
   "ProjectOutsideOrganizationError",
+  "ResourceConflictError",
   // The store's answer to a batch it will never take, told apart from a store
   // that is merely unreachable — a door has to answer those two differently,
   // and only the module that owns the client can tell them apart.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,12 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1
 
+  apps/cli:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.13.3
+
   apps/web:
     dependencies:
       next:

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -15,6 +15,7 @@
     "vitest.config.ts",
     "packages/*/src/**/*.test.ts",
     "packages/*/test/**/*.ts",
-    "apps/api/test/**/*.ts"
+    "apps/api/test/**/*.ts",
+    "apps/cli/test/**/*.ts"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       "packages/*/src/**/*.test.ts",
       "packages/*/test/**/*.test.ts",
       "apps/api/test/**/*.test.ts",
+      "apps/cli/test/**/*.test.ts",
       "apps/web/test/**/*.test.ts",
     ],
     // The API logs a line per request, and a test run is thousands of them.


### PR DESCRIPTION
## What this proves

A developer can run one repository-first command from `egma-receptionist` and get an Egma agent, a Retell connection, and a first test that uses the project default persona.

The CLI discovers the selected Retell agent from the repository, shows an exact plan, asks for approval, creates or reuses the three resources, writes a non-secret receipt, and installs an agent skill. It supports both humans and coding agents through text and JSON output.

## Safety boundary

- Reads local Retell and Supabase configuration.
- Stores the Retell credential only in Egma connection storage.
- Does not change Retell.
- Does not upload source code.
- Does not start a simulation.
- Requires explicit `--apply`; non-interactive apply also requires `--yes`.

## Live prototype proof

Tested against the Suncrest agent in a local `egma-receptionist` checkout. A second apply reused the same resources. `egma init status` read back the agent, connection, first test, and living default persona from the API.

The next boundary is intentionally visible but not implemented by this prototype: `egma run create --test <test> --agent <agent> --connection <connection>`.

## Checks

- `pnpm typecheck`
- `pnpm test` — 46 files, 822 tests passed
- Live plan, apply, repeat apply, and status proof
- Independent security, API contract, performance, maintainability, test, and adversarial reviews

This is a draft prototype PR. The purpose is to make the onboarding contract concrete before we turn it into a permanent product surface.