### PR TITLE
The first real platform: the simulator conducts a Retell chat

### DIFF
--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -25,9 +25,11 @@ touching the others:
   that alone knows how to reach and exchange turns with that platform.
   Everything else is plug-blind. The scripted counterpart — a fake
   platform whose agent answers from a script — is the first plug, and the
-  reason the whole loop runs with no account and no network. To write a
-  plug for a real platform, read the `plugs/__init__.py` docstring; it is
-  the entire brief.
+  reason the whole loop runs with no account and no network. `retell` is
+  the first real one: it speaks Retell's chat API, driven entirely by the
+  spec's connection block, and adding it changed nothing outside
+  `plugs/`. To write the next, read the `plugs/__init__.py` docstring; it
+  is the entire brief.
 
 The speech legs — STT, TTS, the dual-channel recording, the measured audio
 band — arrive with the voice plug work; a chat exchange needs none of
@@ -79,8 +81,10 @@ uv run egma-simulator
 The workbench prints one JSON line per observation — queued, the claim,
 each heartbeat, each reported event — which is a simulation going
 queued → claimed → running → completed, live. The two `scripted` fixtures
-conduct whole conversations; the `retell` and `phone` fixtures are refused
-with a clear log line, honestly, until their plugs land.
+conduct whole conversations; the `retell` fixture really does dial Retell
+and fails at the door, because the key in a fixture is a placeholder; the
+`phone` fixture is refused with a clear log line, honestly, until its plug
+lands.
 `GET /workbench/records` returns the same as JSON;
 `POST /workbench/simulations/<id>/cancel` flags a cancel directive for the
 next heartbeat; `POST /workbench/specs` queues another spec while
@@ -139,6 +143,23 @@ validates the golden fixtures in `packages/simulation-contract` from the
 Python side — the other half of the drift guarantee the TypeScript suite
 holds.
 
+The `retell` plug converses with `tests/retell_stub.py`: a real local HTTP
+server shaped like Retell's chat API, so proving the plug speaks the
+protocol needs no account, no key and no network — failure paths included,
+where a refused key and an endpoint nobody answers each end the simulation
+`failed` with an honest reason and no leaked secret.
+
+One real conversation with a real Retell chat agent is opt-in, and skips
+when the environment is silent, so nothing in CI waits on an account:
+
+```bash
+TEST_RETELL_API_KEY=key_... \
+TEST_RETELL_AGENT_ID=agent_... \
+uv run --frozen pytest tests/test_live_retell.py -v
+```
+
+`TEST_RETELL_BASE_URL` points that test somewhere other than Retell.
+
 ## Layout
 
 ```
@@ -152,7 +173,8 @@ src/egma_simulator/
                   deciding the exchange is concluded.
   model.py        The model-client seam: scripted (CI) and OpenAI-compatible.
   plugs/          The platform-plug seam. Its __init__ docstring is the
-                  plug author's whole brief; scripted.py is the first plug.
+                  plug author's whole brief; scripted.py is CI's platform
+                  and retell.py the first real one.
   walk.py         One simulation's exchange: the turn loop, limits, cancel
                   delivery, and how each walk names its ending.
   reporting.py    Event minting, the write-ahead log, ordered delivery.

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -138,8 +138,10 @@ def plug_for(connection_type: str) -> PlugFactory | None:
     The registry is deliberately a literal here: adding a platform is one
     import and one line, and the diff that adds it touches nothing else.
     """
+    from .retell import RetellChat
     from .scripted import ScriptedCounterpart
 
     return {
+        "retell": RetellChat,
         "scripted": ScriptedCounterpart,
     }.get(connection_type)

--- a/apps/simulator/src/egma_simulator/plugs/retell.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell.py
@@ -50,19 +50,18 @@ from . import AgentReply, PlugError
 DEFAULT_BASE_URL = "https://api.retellai.com"
 """Retell's own API, where a connection with no base URL is reached."""
 
-END_TOOL_NAMES = frozenset({"end_call", "end_chat"})
-"""What a Retell agent's ending tool invokes under. ``end_call`` is the
-built-in one, named for voice and kept as-is for chat; ``end_chat`` is what
-an agent whose tool was renamed after the thing it does invokes. An agent
-carrying neither never ends an exchange itself, and the simulation's limits
-are what end it — deliberately, and never as the agent failing."""
+END_TOOL_NAMES = frozenset({"end_call"})
+"""What a Retell agent's ending tool invokes under: the built-in one, named
+for voice and kept as-is for chat. An agent carrying no such tool never ends
+an exchange itself, and the simulation's limits end it instead —
+deliberately, and never as the agent failing."""
 
 TIMEOUT_SECONDS = 60.0
 """The most one Retell call may take. Generous because a completion waits
 on the agent's own model, and anything past it is a platform that has
 stopped answering rather than one thinking."""
 
-QUOTED_FROM_A_REFUSAL = 200
+QUOTED_REFUSAL_CHARS = 200
 """How much of a refusal's body is quoted into the reason: enough to carry
 the platform's own words about what was wrong, short of pasting a page."""
 
@@ -185,7 +184,7 @@ class RetellChat:
 
     def _quotable(self, told: str) -> str:
         """The platform's own words, minus the key, short enough to read."""
-        return told.replace(self._api_key, REDACTED)[:QUOTED_FROM_A_REFUSAL]
+        return told.replace(self._api_key, REDACTED)[:QUOTED_REFUSAL_CHARS]
 
     async def _call(self, method: str, path: str, payload: dict) -> dict:
         """One Retell call, or a refusal saying what happened without the key."""

--- a/apps/simulator/src/egma_simulator/plugs/retell.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell.py
@@ -1,0 +1,261 @@
+"""Retell chat: the first plug against a platform egma does not own.
+
+It speaks Retell's public chat API over outbound HTTPS — ``create-chat`` to
+open the exchange, ``create-chat-completion`` for each persona turn,
+``end-chat`` to tear it down — with the connection's own key as a bearer
+token. Everything it needs arrives in the claimed spec's connection block;
+nothing about a Retell account lives in this process.
+
+Its config keys, like every plug's, are its own:
+
+- ``retellAgentId`` (string, required) — the chat agent the exchange is
+  opened against, exactly as the control plane stores it.
+- ``baseUrl`` (string, optional) — where the API answers, defaulting to
+  Retell itself. What lets a test converse with a Retell-shaped server on
+  loopback, and a proxy stand in front of the platform for a deployment
+  that needs one.
+
+Credentials are shaped ``{"apiKey": ...}`` — the shape the control plane
+seals — and are read for the ``Authorization`` header and nothing else.
+They are never logged, never returned, and never put into an exception
+message: a refusal names the status the platform answered with and the URL
+it answered from, which is what a person needs, and neither is a secret.
+
+A refusal also quotes the platform's own words about what was wrong, and
+those are not this plug's to trust: a platform that echoes the key back in
+its error body would otherwise put it in a failure reason and in the
+traceback logged beneath it. Everything quoted from the platform is
+therefore scrubbed of the key first, here, where the key is known.
+
+**How the exchange ends.** A Retell chat agent ends its own exchange by
+invoking its end tool; the invocation comes back among the completion's
+messages, so the signal is in-band and free. The alternative — reading
+``chat_status`` after every completion — would add a round trip to every
+turn, inside the very call whose duration the simulator reports as the
+agent's response latency.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import Any
+
+import aiohttp
+
+from ..client import UNREACHABLE
+from ..redaction import REDACTED
+from . import AgentReply, PlugError
+
+DEFAULT_BASE_URL = "https://api.retellai.com"
+"""Retell's own API, where a connection with no base URL is reached."""
+
+END_TOOL_NAMES = frozenset({"end_call", "end_chat"})
+"""What a Retell agent's ending tool invokes under. ``end_call`` is the
+built-in one, named for voice and kept as-is for chat; ``end_chat`` is what
+an agent whose tool was renamed after the thing it does invokes. An agent
+carrying neither never ends an exchange itself, and the simulation's limits
+are what end it — deliberately, and never as the agent failing."""
+
+TIMEOUT_SECONDS = 60.0
+"""The most one Retell call may take. Generous because a completion waits
+on the agent's own model, and anything past it is a platform that has
+stopped answering rather than one thinking."""
+
+QUOTED_FROM_A_REFUSAL = 200
+"""How much of a refusal's body is quoted into the reason: enough to carry
+the platform's own words about what was wrong, short of pasting a page."""
+
+_KNOWN_KEYS = {"retellAgentId", "baseUrl"}
+
+_CREDENTIAL_KEYS = {"apiKey"}
+"""Exactly what the control plane seals for a retell connection. Refused
+strictly, and for the same reason it is refused there: a secret handed over
+that nothing reads was handed over by mistake."""
+
+
+class RetellChat:
+    """One Retell chat, opened and conducted and ended, per instance."""
+
+    def __init__(
+        self, *, modality: str, config: dict[str, Any], credentials: object
+    ) -> None:
+        if modality != "chat":
+            raise PlugError(
+                f"the retell chat plug speaks chat only; a {modality!r} "
+                "simulation over retell needs the plug carrying the speech legs"
+            )
+
+        unknown = set(config) - _KNOWN_KEYS
+        if unknown:
+            raise PlugError(
+                f"the retell plug does not know config key(s) {sorted(unknown)}; "
+                f"it knows {sorted(_KNOWN_KEYS)}"
+            )
+
+        agent_id = config.get("retellAgentId")
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            raise PlugError(
+                "retell config: retellAgentId must be a non-empty string"
+            )
+
+        base_url = config.get("baseUrl", DEFAULT_BASE_URL)
+        if not isinstance(base_url, str) or not base_url.strip():
+            raise PlugError("retell config: baseUrl must be a non-empty string")
+
+        if not isinstance(credentials, dict):
+            raise PlugError(
+                "a retell connection needs credentials shaped {apiKey}"
+            )
+        stray = set(credentials) - _CREDENTIAL_KEYS
+        if stray:
+            raise PlugError(
+                f"retell credentials hold no key(s) {sorted(stray)}; they are "
+                "shaped {apiKey}"
+            )
+        api_key = credentials.get("apiKey")
+        if not isinstance(api_key, str) or not api_key.strip():
+            raise PlugError("retell credentials: apiKey must be a non-empty string")
+
+        self._agent_id = agent_id.strip()
+        self._base_url = base_url.strip().rstrip("/")
+        self._api_key = api_key.strip()
+        self._timeout = aiohttp.ClientTimeout(total=TIMEOUT_SECONDS)
+        self._session: aiohttp.ClientSession | None = None
+        self._chat_id: str | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Where this exchange is conducted — the URL every refusal names."""
+        return self._base_url
+
+    @property
+    def provider_reference(self) -> str | None:
+        """Retell's own id for this chat, once there is one to hold it by."""
+        return self._chat_id
+
+    async def open(self) -> str | None:
+        self._session = aiohttp.ClientSession()
+        opened = await self._call(
+            "POST", "/create-chat", {"agent_id": self._agent_id}
+        )
+        chat_id = opened.get("chat_id")
+        if not isinstance(chat_id, str) or not chat_id:
+            raise PlugError("retell opened a chat with no chat_id to hold it by")
+        self._chat_id = chat_id
+        # Retell answers create-chat with the chat as it stands, so an agent
+        # configured to speak first has already spoken by then.
+        return _agent_words(opened.get("message_with_tool_calls"))
+
+    async def deliver(self, text: str) -> AgentReply:
+        if self._chat_id is None:
+            raise PlugError("a turn reached the retell plug before the chat opened")
+        completion = await self._call(
+            "POST",
+            "/create-chat-completion",
+            {"chat_id": self._chat_id, "content": text},
+        )
+        messages = completion.get("messages")
+        if not isinstance(messages, list):
+            raise PlugError("retell answered a completion with no messages list")
+        return AgentReply(text=_agent_words(messages), ended=_ended(messages))
+
+    async def close(self) -> None:
+        session, self._session = self._session, None
+        if session is None:
+            return
+        try:
+            if self._chat_id is not None:
+                # The exchange is over either way: a chat the agent already
+                # ended refuses this, and a platform that cannot be reached
+                # to be told has nothing left to be told. Neither is worth
+                # raising over teardown.
+                with contextlib.suppress(*UNREACHABLE):
+                    async with session.patch(
+                        f"{self._base_url}/end-chat/{self._chat_id}",
+                        headers=self._headers(),
+                        timeout=self._timeout,
+                    ):
+                        pass
+        finally:
+            await session.close()
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"}
+
+    def _quotable(self, told: str) -> str:
+        """The platform's own words, minus the key, short enough to read."""
+        return told.replace(self._api_key, REDACTED)[:QUOTED_FROM_A_REFUSAL]
+
+    async def _call(self, method: str, path: str, payload: dict) -> dict:
+        """One Retell call, or a refusal saying what happened without the key."""
+        session = self._session
+        if session is None:
+            raise PlugError("the retell plug was used outside its own lifecycle")
+
+        url = f"{self._base_url}{path}"
+        try:
+            async with session.request(
+                method,
+                url,
+                json=payload,
+                headers=self._headers(),
+                timeout=self._timeout,
+            ) as response:
+                status = response.status
+                body = await response.text()
+        except UNREACHABLE as unreachable:
+            raise PlugError(
+                f"retell was unreachable at {url}: "
+                f"{self._quotable(repr(unreachable))}"
+            ) from unreachable
+
+        if status // 100 != 2:
+            raise PlugError(
+                f"retell answered {status} to {path} at {self._base_url}: "
+                f"{self._quotable(body)}"
+            )
+        try:
+            document = json.loads(body)
+        except ValueError as unreadable:
+            raise PlugError(
+                f"retell answered {path} with something that is not JSON"
+            ) from unreadable
+        if not isinstance(document, dict):
+            raise PlugError(
+                f"retell answered {path} with {type(document).__name__}, "
+                "not an object"
+            )
+        return document
+
+
+def _agent_words(messages: object) -> str | None:
+    """What the agent said, out of everything one answer carried.
+
+    An answer holds the agent's messages and its tool traffic together, so
+    the words are the ``agent`` role's contents in order; two bubbles for
+    one turn stay one turn. ``None`` when the agent produced no words at
+    all, which the walk records as an answer without words rather than as
+    silence in the transcript.
+    """
+    if not isinstance(messages, list):
+        return None
+    spoken = [
+        message["content"].strip()
+        for message in messages
+        if isinstance(message, dict)
+        and message.get("role") == "agent"
+        and isinstance(message.get("content"), str)
+        and message["content"].strip()
+    ]
+    return "\n".join(spoken) or None
+
+
+def _ended(messages: list) -> bool:
+    """Whether the agent ended the exchange with this answer."""
+    return any(
+        isinstance(message, dict)
+        and message.get("role") == "tool_call_invocation"
+        and message.get("name") in END_TOOL_NAMES
+        for message in messages
+    )

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -10,18 +10,20 @@ process. The rig here is exactly that wiring.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import signal
 import subprocess
 import sys
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import aiohttp
 import pytest
 from aiohttp import web
+from retell_stub import RetellStub, RunningStub, serving
 
 from egma_simulator.contract import contract_dir
 from egma_simulator.workbench.app import WorkbenchState, build_app
@@ -193,6 +195,22 @@ def start_simulator(
 
 
 @pytest.fixture
+async def start_retell_stub() -> AsyncIterator[Callable[..., Awaitable[RunningStub]]]:
+    """Start Retell-shaped stubs on loopback; each stops when the test ends.
+
+    The keyword arguments are :class:`RetellStub`'s script — the key it
+    honors, the greeting, the replies, whether the agent ends the exchange
+    itself.
+    """
+    async with contextlib.AsyncExitStack() as stack:
+
+        async def start(**script: object) -> RunningStub:
+            return await stack.enter_async_context(serving(RetellStub(**script)))
+
+        yield start
+
+
+@pytest.fixture
 def quick_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
     """Collapse delivery backoff so retry behavior can be tested in milliseconds.
 
@@ -252,6 +270,42 @@ def scripted_spec(
         "persona": {
             "traits": {"personality": personality, "language": "en-US"}
         },
+        "scenario": {"instructions": scenario},
+        "limits": {
+            "max_duration_seconds": max_duration_seconds,
+            "max_turns": max_turns,
+        },
+    }
+
+
+def retell_spec(
+    simulation_id: str,
+    *,
+    base_url: str,
+    api_key: str,
+    agent_id: str = "agent_stubbed_0001",
+    scenario: str = "State the first point. State the second point.",
+    personality: str = "Terse test person; sticks to the script.",
+    max_turns: int = 60,
+    max_duration_seconds: int = 600,
+) -> dict:
+    """One spec against a Retell chat connection, pointed wherever asked.
+
+    The connection block is exactly what the control plane stores for a
+    ``retell`` connection — the agent id in the config, the key in the
+    credentials — plus the base URL, which is what lets the exchange land on
+    a Retell-shaped stub instead of the platform itself.
+    """
+    return {
+        "contract_version": 1,
+        "simulation_id": simulation_id,
+        "modality": "chat",
+        "connection": {
+            "type": "retell",
+            "config": {"retellAgentId": agent_id, "baseUrl": base_url},
+            "credentials": {"apiKey": api_key},
+        },
+        "persona": {"traits": {"personality": personality, "language": "en-US"}},
         "scenario": {"instructions": scenario},
         "limits": {
             "max_duration_seconds": max_duration_seconds,

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -230,11 +230,43 @@ def load_fixture_spec(name: str) -> dict:
         return json.load(handle)
 
 
+A_SCENARIO = "State the first point. State the second point."
+"""Two sentences, so the scripted persona speaks twice and then concludes."""
+
+A_PERSONALITY = "Terse test person; sticks to the script."
+
+
+def a_spec(
+    simulation_id: str,
+    *,
+    connection: dict,
+    scenario: str,
+    personality: str,
+    max_turns: int,
+    max_duration_seconds: int,
+) -> dict:
+    """The envelope every spec shares: one persona, one scenario, one set of
+    walls, one chat. What differs between two specs is the connection block,
+    which is exactly the difference the plug seam exists to absorb."""
+    return {
+        "contract_version": 1,
+        "simulation_id": simulation_id,
+        "modality": "chat",
+        "connection": connection,
+        "persona": {"traits": {"personality": personality, "language": "en-US"}},
+        "scenario": {"instructions": scenario},
+        "limits": {
+            "max_duration_seconds": max_duration_seconds,
+            "max_turns": max_turns,
+        },
+    }
+
+
 def scripted_spec(
     simulation_id: str,
     *,
-    scenario: str = "State the first point. State the second point.",
-    personality: str = "Terse test person; sticks to the script.",
+    scenario: str = A_SCENARIO,
+    personality: str = A_PERSONALITY,
     greeting: str | None = None,
     replies: list[str] | None = None,
     ends_after_replies: bool = False,
@@ -258,24 +290,18 @@ def scripted_spec(
         config["ends_after_replies"] = True
     if provider_reference is not None:
         config["provider_reference"] = provider_reference
-    return {
-        "contract_version": 1,
-        "simulation_id": simulation_id,
-        "modality": "chat",
-        "connection": {
+    return a_spec(
+        simulation_id,
+        connection={
             "type": "scripted",
             "config": config,
             "credentials": credentials,
         },
-        "persona": {
-            "traits": {"personality": personality, "language": "en-US"}
-        },
-        "scenario": {"instructions": scenario},
-        "limits": {
-            "max_duration_seconds": max_duration_seconds,
-            "max_turns": max_turns,
-        },
-    }
+        scenario=scenario,
+        personality=personality,
+        max_turns=max_turns,
+        max_duration_seconds=max_duration_seconds,
+    )
 
 
 def retell_spec(
@@ -284,8 +310,8 @@ def retell_spec(
     base_url: str,
     api_key: str,
     agent_id: str = "agent_stubbed_0001",
-    scenario: str = "State the first point. State the second point.",
-    personality: str = "Terse test person; sticks to the script.",
+    scenario: str = A_SCENARIO,
+    personality: str = A_PERSONALITY,
     max_turns: int = 60,
     max_duration_seconds: int = 600,
 ) -> dict:
@@ -296,22 +322,45 @@ def retell_spec(
     credentials — plus the base URL, which is what lets the exchange land on
     a Retell-shaped stub instead of the platform itself.
     """
-    return {
-        "contract_version": 1,
-        "simulation_id": simulation_id,
-        "modality": "chat",
-        "connection": {
+    return a_spec(
+        simulation_id,
+        connection={
             "type": "retell",
             "config": {"retellAgentId": agent_id, "baseUrl": base_url},
             "credentials": {"apiKey": api_key},
         },
-        "persona": {"traits": {"personality": personality, "language": "en-US"}},
-        "scenario": {"instructions": scenario},
-        "limits": {
-            "max_duration_seconds": max_duration_seconds,
-            "max_turns": max_turns,
-        },
-    }
+        scenario=scenario,
+        personality=personality,
+        max_turns=max_turns,
+        max_duration_seconds=max_duration_seconds,
+    )
+
+
+def assert_kept_secret(
+    secret: str, *, records: list[dict], simulator: SimulatorProcess
+) -> None:
+    """A planted credential is in none of the three places it could surface.
+
+    The reports the control plane holds, every byte the process wrote, and
+    the write-ahead log on disk — all three, every time, because a secret
+    kept out of two of them is still a leaked secret. Each place is checked
+    to be non-empty first: scanning nothing always passes.
+
+    Call it once the simulator has stopped, so its output is all there.
+    """
+    assert secret not in json.dumps(records), "a report carried the credential"
+
+    output = simulator.output()
+    assert output, "expected the simulator to have logged something"
+    assert secret not in output, "a log line carried the credential"
+
+    wal_bytes = b"".join(
+        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
+    )
+    assert wal_bytes, "expected write-ahead log entries"
+    assert secret.encode() not in wal_bytes, (
+        "the write-ahead log carried the credential"
+    )
 
 
 # -- Record readers: the acceptance suite's entire vocabulary -----------------

--- a/apps/simulator/tests/retell_stub.py
+++ b/apps/simulator/tests/retell_stub.py
@@ -1,0 +1,233 @@
+"""CI's Retell: a local HTTP server shaped like Retell's chat API.
+
+Three endpoints, the ones the plug speaks — ``create-chat``,
+``create-chat-completion``, ``end-chat`` — answering with Retell's own
+field names, status codes and bearer-key auth, from a script. Real HTTP on
+a loopback port, because the plug's whole job is speaking a platform's wire
+protocol and a mock of that protocol would prove the mock instead.
+
+The stub is deliberately strict where the real platform is: a request
+without the exact bearer key is refused 401, a completion for a chat that
+was never opened is refused 422, and a chat that has ended refuses further
+completions. Those refusals are what the plug's failure paths are tested
+against.
+
+It also records every call it served, so a test can assert the plug drove
+the whole session lifecycle — opened once, delivered in order, ended at the
+platform — rather than only that a transcript came out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+from aiohttp import web
+
+END_TOOL = "end_call"
+"""The tool a Retell chat agent invokes to end its own exchange."""
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@dataclass
+class RetellStub:
+    """One scripted Retell account: an agent, a key, and what it says."""
+
+    api_key: str = "stub-key-not-a-real-secret"
+    greeting: str | None = None
+    """Spoken on ``create-chat``, the way a chat agent with a begin message
+    has already spoken by the time the answer arrives."""
+
+    replies: Sequence[str | Sequence[str]] = ()
+    """The agent's answers, in order, one per delivered turn. An answer
+    written as a list of strings comes back as several messages in one
+    completion, the way an agent that sends two bubbles for one turn does."""
+
+    ends_after_replies: bool = False
+    """When true the last scripted reply carries the end-tool invocation,
+    the way an agent ending its own exchange does."""
+
+    turn_seconds: float = 0.0
+    """How long a completion takes, the way a real agent takes time."""
+
+    echo_key_in_refusal: bool = False
+    """When true, a refused request comes back quoting the key it was given.
+
+    Careless platforms do this, and a plug quoting a platform's own words
+    into a failure reason is how a secret reaches a log it was never meant
+    to reach. Nothing here can stop a platform doing it; the plug is what
+    has to survive it."""
+
+    calls: list[dict] = field(default_factory=list)
+    """Every request served, in order — the session lifecycle on the record."""
+
+    chats: dict[str, dict] = field(default_factory=dict)
+
+    def delivered(self) -> list[str]:
+        return [
+            call["content"]
+            for call in self.calls
+            if call["endpoint"] == "create-chat-completion"
+        ]
+
+    def ended(self) -> list[str]:
+        return [
+            call["chat_id"] for call in self.calls if call["endpoint"] == "end-chat"
+        ]
+
+    def chat_ids(self) -> list[str]:
+        return list(self.chats)
+
+    def _authorized(self, request: web.Request) -> None:
+        offered = request.headers.get("Authorization", "")
+        if offered != f"Bearer {self.api_key}":
+            told = offered if self.echo_key_in_refusal else ""
+            raise web.HTTPUnauthorized(
+                text=json.dumps({"error_message": f"invalid api key {told}".strip()}),
+                content_type="application/json",
+            )
+
+    def _message(self, role: str, content: str) -> dict:
+        return {
+            "message_id": f"msg_{len(self.calls)}_{role}",
+            "role": role,
+            "content": content,
+            "created_timestamp": _now_ms(),
+        }
+
+    async def _create_chat(self, request: web.Request) -> web.Response:
+        self._authorized(request)
+        body = await request.json()
+        agent_id = body.get("agent_id")
+        if not isinstance(agent_id, str) or not agent_id:
+            raise web.HTTPUnprocessableEntity(text="agent_id is required")
+
+        chat_id = f"chat_{len(self.chats) + 1:04d}"
+        self.chats[chat_id] = {"agent_id": agent_id, "delivered": 0, "ended": False}
+        self.calls.append(
+            {"endpoint": "create-chat", "agent_id": agent_id, "chat_id": chat_id}
+        )
+        opening = [self._message("agent", self.greeting)] if self.greeting else []
+        return web.json_response(
+            {
+                "chat_id": chat_id,
+                "agent_id": agent_id,
+                "chat_status": "ongoing",
+                "chat_type": "api_chat",
+                "start_timestamp": _now_ms(),
+                "transcript": self.greeting or "",
+                "message_with_tool_calls": opening,
+            },
+            status=201,
+        )
+
+    async def _create_chat_completion(self, request: web.Request) -> web.Response:
+        self._authorized(request)
+        body = await request.json()
+        chat_id = body.get("chat_id")
+        content = body.get("content")
+        chat = self.chats.get(chat_id) if isinstance(chat_id, str) else None
+        if chat is None:
+            raise web.HTTPUnprocessableEntity(text="chat not found")
+        if chat["ended"]:
+            raise web.HTTPUnprocessableEntity(text="chat is not ongoing")
+        if not isinstance(content, str) or not content:
+            raise web.HTTPUnprocessableEntity(text="content is required")
+
+        self.calls.append(
+            {
+                "endpoint": "create-chat-completion",
+                "chat_id": chat_id,
+                "content": content,
+            }
+        )
+        if self.turn_seconds:
+            await asyncio.sleep(self.turn_seconds)
+
+        position = chat["delivered"]
+        chat["delivered"] += 1
+        messages: list[dict] = []
+        if position < len(self.replies):
+            answer = self.replies[position]
+            bubbles = [answer] if isinstance(answer, str) else list(answer)
+            messages.extend(self._message("agent", bubble) for bubble in bubbles)
+            last = position == len(self.replies) - 1
+            if last and self.ends_after_replies:
+                messages.append(
+                    {
+                        "message_id": f"msg_{len(self.calls)}_tool",
+                        "role": "tool_call_invocation",
+                        "tool_call_id": f"tool_{position}",
+                        "name": END_TOOL,
+                        "arguments": "{}",
+                        "created_timestamp": _now_ms(),
+                    }
+                )
+                chat["ended"] = True
+        else:
+            messages.append(self._message("agent", "Still here."))
+        return web.json_response({"messages": messages}, status=201)
+
+    async def _get_chat(self, request: web.Request) -> web.Response:
+        """Not a path the plug takes — the plug reads endings in-band — but
+        the one the live test uses to ask the platform whether the chat was
+        really ended, so that test can be rehearsed against this stub before
+        it is pointed at a real account."""
+        self._authorized(request)
+        chat_id = request.match_info["chat_id"]
+        chat = self.chats.get(chat_id)
+        if chat is None:
+            raise web.HTTPUnprocessableEntity(text="chat not found")
+        return web.json_response(
+            {
+                "chat_id": chat_id,
+                "agent_id": chat["agent_id"],
+                "chat_status": "ended" if chat["ended"] else "ongoing",
+                "chat_type": "api_chat",
+            }
+        )
+
+    async def _end_chat(self, request: web.Request) -> web.Response:
+        self._authorized(request)
+        chat_id = request.match_info["chat_id"]
+        if chat_id not in self.chats:
+            raise web.HTTPUnprocessableEntity(text="chat not found")
+        self.chats[chat_id]["ended"] = True
+        self.calls.append({"endpoint": "end-chat", "chat_id": chat_id})
+        return web.Response(status=204)
+
+    def build_app(self) -> web.Application:
+        app = web.Application()
+        app.router.add_post("/create-chat", self._create_chat)
+        app.router.add_post("/create-chat-completion", self._create_chat_completion)
+        app.router.add_get("/get-chat/{chat_id}", self._get_chat)
+        app.router.add_patch("/end-chat/{chat_id}", self._end_chat)
+        return app
+
+
+@dataclass
+class RunningStub:
+    """A stub on a loopback port, and the base URL a spec points at."""
+
+    base_url: str
+    stub: RetellStub
+
+
+@asynccontextmanager
+async def serving(stub: RetellStub) -> AsyncIterator[RunningStub]:
+    """Serve one stub on an ephemeral loopback port for the test's life."""
+    runner = web.AppRunner(stub.build_app())
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        yield RunningStub(f"http://127.0.0.1:{runner.addresses[0][1]}", stub)
+    finally:
+        await runner.cleanup()

--- a/apps/simulator/tests/retell_stub.py
+++ b/apps/simulator/tests/retell_stub.py
@@ -13,8 +13,8 @@ completions. Those refusals are what the plug's failure paths are tested
 against.
 
 It also records every call it served, so a test can assert the plug drove
-the whole session lifecycle — opened once, delivered in order, ended at the
-platform — rather than only that a transcript came out.
+the whole exchange — opened once, delivered in order, ended at the platform
+— rather than only that a transcript came out.
 """
 
 from __future__ import annotations
@@ -66,7 +66,7 @@ class RetellStub:
     has to survive it."""
 
     calls: list[dict] = field(default_factory=list)
-    """Every request served, in order — the session lifecycle on the record."""
+    """Every request served, in order — the whole exchange on the record."""
 
     chats: dict[str, dict] = field(default_factory=dict)
 

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -1,9 +1,11 @@
 """What the simulator promises, proved black-box at the contract seam.
 
 The workbench offers specs; a real simulator process claims, conducts,
-heartbeats and reports; every assertion below reads only what the
-workbench recorded. Nothing inspects the simulator — that is the point:
-what the records show is all the control plane will ever know.
+heartbeats and reports; the assertions below read what the workbench
+recorded — and, where a platform stands on the other side of the exchange,
+what that platform saw on its own wire. Nothing reaches inside the
+simulator — that is the point: what the records show is all the control
+plane will ever know.
 
 Every exchange here is a real conversation: the persona on the scripted
 model client, the agent played by the scripted counterpart plug. Nothing
@@ -14,12 +16,12 @@ scripted one, which is why none of it can flake.
 from __future__ import annotations
 
 import asyncio
-import json
 from datetime import datetime
 
 from conftest import (
     HEARTBEAT_SECONDS,
     all_terminal,
+    assert_kept_secret,
     events_for,
     has_terminal,
     heartbeats_for,
@@ -548,12 +550,7 @@ async def test_a_retell_chat_spec_conducts_a_multi_turn_exchange(
     ]
 
     simulator.stop()
-    assert sentinel not in json.dumps(records), "a report carried the key"
-    assert sentinel not in simulator.output(), "a log line carried the key"
-    wal_bytes = b"".join(
-        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
-    )
-    assert sentinel.encode() not in wal_bytes, "the write-ahead log carried the key"
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
 
 
 async def test_a_retell_key_the_platform_refuses_fails_honestly_and_silently(
@@ -581,12 +578,7 @@ async def test_a_retell_key_the_platform_refuses_fails_honestly_and_silently(
     assert events_for(records, "sim-retell-badkey", "turn") == []
 
     simulator.stop()
-    assert sentinel not in json.dumps(records), "a failure report carried the key"
-    assert sentinel not in simulator.output(), "a failure log carried the key"
-    wal_bytes = b"".join(
-        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
-    )
-    assert sentinel.encode() not in wal_bytes, "the write-ahead log carried the key"
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
 
 
 async def test_a_platform_that_says_the_key_back_still_leaks_nothing(
@@ -611,12 +603,7 @@ async def test_a_platform_that_says_the_key_back_still_leaks_nothing(
     assert terminal_event_for(records, "sim-retell-echoed")["status"] == "failed"
 
     simulator.stop()
-    assert sentinel not in json.dumps(records), "a report repeated the key"
-    assert sentinel not in simulator.output(), "a log line repeated the key"
-    wal_bytes = b"".join(
-        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
-    )
-    assert sentinel.encode() not in wal_bytes, "the write-ahead log repeated the key"
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
 
 
 async def test_a_retell_endpoint_that_answers_nowhere_fails_honestly(
@@ -642,8 +629,7 @@ async def test_a_retell_endpoint_that_answers_nowhere_fails_honestly(
     assert "127.0.0.1:1" in terminal["reason"], terminal["reason"]
 
     simulator.stop()
-    assert sentinel not in json.dumps(records)
-    assert sentinel not in simulator.output()
+    assert_kept_secret(sentinel, records=records, simulator=simulator)
 
 
 async def test_credentials_never_appear_in_logs_or_reports(
@@ -665,16 +651,4 @@ async def test_credentials_never_appear_in_logs_or_reports(
     assert terminal["status"] == "completed"
 
     simulator.stop()
-
-    everything_recorded = json.dumps(records)
-    assert sentinel not in everything_recorded, "a report carried the credential"
-
-    output = simulator.output()
-    assert output, "expected the simulator to have logged something"
-    assert sentinel not in output, "a log line carried the credential"
-
-    wal_bytes = b"".join(
-        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
-    )
-    assert wal_bytes, "expected write-ahead log entries"
-    assert sentinel.encode() not in wal_bytes, "the WAL carried the credential"
+    assert_kept_secret(sentinel, records=records, simulator=simulator)

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -24,6 +24,7 @@ from conftest import (
     has_terminal,
     heartbeats_for,
     load_fixture_spec,
+    retell_spec,
     scripted_spec,
     status_events_for,
     terminal_event_for,
@@ -426,7 +427,7 @@ async def test_a_spec_naming_an_unknown_connection_type_is_refused_out_loud(
 ):
     """No plug, no exchange, no report — and the simulator carries on."""
     unplugged = scripted_spec("sim-unplugged-001")
-    unplugged["connection"]["type"] = "retell"
+    unplugged["connection"]["type"] = "a-platform-with-no-plug-yet"
     await workbench.offer(unplugged)
     simulator = start_simulator(workbench)
 
@@ -476,6 +477,173 @@ async def test_a_plug_refusal_is_an_honest_failure_on_the_record(
     # Nothing was conducted: no exchange happened off the record.
     assert events_for(records, "sim-misconfigured-001", "turn") == []
     assert [record for record in records if record["kind"] == "refusal"] == []
+
+
+async def test_a_retell_chat_spec_conducts_a_multi_turn_exchange(
+    workbench, start_simulator, start_retell_stub
+):
+    """The first real platform, black-box: a spec carrying a Retell chat
+    connection block goes in, and a multi-turn transcript against a
+    Retell-shaped platform comes back — with the credential used and never
+    written down anywhere.
+
+    Nothing outside the plug knows this exchange is any different from the
+    scripted one, which is the whole extensibility claim.
+    """
+    sentinel = "SENTINEL-retell-key-c1d4e7f0a3b6"
+    running = await start_retell_stub(
+        api_key=sentinel,
+        greeting="Lakeside Dental, how can I help?",
+        replies=[
+            "Of course — could I take your name?",
+            "Done: Thursday at half past two.",
+        ],
+    )
+    spec = retell_spec(
+        "sim-retell-001",
+        base_url=running.base_url,
+        api_key=sentinel,
+        agent_id="agent_lakeside_chat",
+        scenario=(
+            "I need to move my Tuesday cleaning to Thursday. "
+            "My name is Margaret Hale."
+        ),
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-retell-001"))
+
+    turns = events_for(records, "sim-retell-001", "turn")
+    assert [(turn["speaker"], turn["text"]) for turn in turns] == [
+        ("agent", "Lakeside Dental, how can I help?"),
+        ("human", "I need to move my Tuesday cleaning to Thursday."),
+        ("agent", "Of course — could I take your name?"),
+        ("human", "My name is Margaret Hale."),
+        ("agent", "Done: Thursday at half past two."),
+        ("human", GOODBYE),
+    ]
+
+    terminal = terminal_event_for(records, "sim-retell-001")
+    assert terminal["status"] == "completed"
+    assert terminal["facts"]["ending"] == "persona_concluded"
+    assert terminal["facts"]["turn_count"] == len(turns)
+    # The join to the platform's own telemetry is Retell's chat id.
+    assert terminal["facts"]["provider_reference"] == running.stub.chat_ids()[0]
+
+    # And the platform's side of the same story: one chat opened against the
+    # agent the connection block named, the persona's turns delivered in
+    # order, the chat ended rather than left ongoing.
+    stub = running.stub
+    assert [call["endpoint"] for call in stub.calls] == [
+        "create-chat",
+        "create-chat-completion",
+        "create-chat-completion",
+        "end-chat",
+    ]
+    assert stub.calls[0]["agent_id"] == "agent_lakeside_chat"
+    assert stub.delivered() == [
+        "I need to move my Tuesday cleaning to Thursday.",
+        "My name is Margaret Hale.",
+    ]
+
+    simulator.stop()
+    assert sentinel not in json.dumps(records), "a report carried the key"
+    assert sentinel not in simulator.output(), "a log line carried the key"
+    wal_bytes = b"".join(
+        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
+    )
+    assert sentinel.encode() not in wal_bytes, "the write-ahead log carried the key"
+
+
+async def test_a_retell_key_the_platform_refuses_fails_honestly_and_silently(
+    workbench, start_simulator, start_retell_stub
+):
+    """The failure path a wrong credential takes: the simulation ends failed
+    with a reason naming what the platform said, and the key appears
+    nowhere — not in the report, not in a log line, not in the log on disk."""
+    sentinel = "SENTINEL-retell-key-wrong-8e2a5c9f"
+    running = await start_retell_stub(api_key="the-only-key-this-stub-honors")
+    spec = retell_spec(
+        "sim-retell-badkey", base_url=running.base_url, api_key=sentinel
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-retell-badkey"))
+
+    assert status_events_for(records, "sim-retell-badkey") == ["running", "failed"]
+    terminal = terminal_event_for(records, "sim-retell-badkey")
+    assert terminal["facts"]["ending"] == "error"
+    assert terminal["facts"]["turn_count"] == 0
+    assert "401" in terminal["reason"], terminal["reason"]
+    # Nothing was conducted: no exchange happened off the record.
+    assert events_for(records, "sim-retell-badkey", "turn") == []
+
+    simulator.stop()
+    assert sentinel not in json.dumps(records), "a failure report carried the key"
+    assert sentinel not in simulator.output(), "a failure log carried the key"
+    wal_bytes = b"".join(
+        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
+    )
+    assert sentinel.encode() not in wal_bytes, "the write-ahead log carried the key"
+
+
+async def test_a_platform_that_says_the_key_back_still_leaks_nothing(
+    workbench, start_simulator, start_retell_stub
+):
+    """The reason a plug gives carries the platform's own words, and a
+    careless platform's own words can include the key it was just given.
+    The plug is what has to survive that: nothing downstream — not the
+    report, not the log line, not the traceback under it — may repeat a
+    secret because somebody else did first."""
+    sentinel = "SENTINEL-retell-key-echoed-3d6f0b21"
+    running = await start_retell_stub(
+        api_key="the-only-key-this-stub-honors", echo_key_in_refusal=True
+    )
+    spec = retell_spec(
+        "sim-retell-echoed", base_url=running.base_url, api_key=sentinel
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-retell-echoed"))
+    assert terminal_event_for(records, "sim-retell-echoed")["status"] == "failed"
+
+    simulator.stop()
+    assert sentinel not in json.dumps(records), "a report repeated the key"
+    assert sentinel not in simulator.output(), "a log line repeated the key"
+    wal_bytes = b"".join(
+        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
+    )
+    assert sentinel.encode() not in wal_bytes, "the write-ahead log repeated the key"
+
+
+async def test_a_retell_endpoint_that_answers_nowhere_fails_honestly(
+    workbench, start_simulator
+):
+    """The other absence: nothing listening at all. Same honesty, same
+    silence about the key."""
+    sentinel = "SENTINEL-retell-key-unreachable-77b1"
+    spec = retell_spec(
+        "sim-retell-nowhere",
+        base_url="http://127.0.0.1:1",
+        api_key=sentinel,
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, log_level="DEBUG")
+
+    records = await workbench.wait_for(has_terminal("sim-retell-nowhere"))
+
+    terminal = terminal_event_for(records, "sim-retell-nowhere")
+    assert terminal["status"] == "failed"
+    assert terminal["facts"]["ending"] == "error"
+    assert "unreachable" in terminal["reason"], terminal["reason"]
+    assert "127.0.0.1:1" in terminal["reason"], terminal["reason"]
+
+    simulator.stop()
+    assert sentinel not in json.dumps(records)
+    assert sentinel not in simulator.output()
 
 
 async def test_credentials_never_appear_in_logs_or_reports(

--- a/apps/simulator/tests/test_live_retell.py
+++ b/apps/simulator/tests/test_live_retell.py
@@ -1,0 +1,119 @@
+"""One real conversation with a real Retell chat agent — opt-in.
+
+Everything else in this suite converses with a Retell-shaped stub, which
+proves the plug speaks the documented protocol and nothing at all about the
+platform behind it. This file is the other half: the whole path end to end
+against a live agent, so the runtime is trusted against reality rather than
+against a fixture.
+
+It is opt-in because CI holds no Retell account. With no credentials in the
+environment it skips — visibly, never failing, never waiting on anybody:
+
+    TEST_RETELL_API_KEY=key_... \\
+    TEST_RETELL_AGENT_ID=agent_... \\
+    uv run pytest tests/test_live_retell.py -v
+
+The agent is the only live thing in the exchange: the persona still speaks
+through the scripted model client, so what varies between two runs is the
+agent's own answers and nothing of egma's. Assertions read the workbench's
+records, exactly as the offline acceptance suite does — plus one question
+put to Retell itself, because whether the chat was really ended at the
+platform is not visible from inside egma.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import aiohttp
+import pytest
+from conftest import (
+    events_for,
+    has_terminal,
+    retell_spec,
+    terminal_event_for,
+)
+
+from egma_simulator.plugs.retell import DEFAULT_BASE_URL
+
+API_KEY = os.environ.get("TEST_RETELL_API_KEY", "").strip()
+AGENT_ID = os.environ.get("TEST_RETELL_AGENT_ID", "").strip()
+BASE_URL = os.environ.get("TEST_RETELL_BASE_URL", "").strip() or DEFAULT_BASE_URL
+
+pytestmark = pytest.mark.skipif(
+    not (API_KEY and AGENT_ID),
+    reason=(
+        "no live Retell credentials: set TEST_RETELL_API_KEY and "
+        "TEST_RETELL_AGENT_ID to conduct a real conversation"
+    ),
+)
+
+# Short walls on purpose: a live exchange pays real seconds per turn, and
+# this test proves the path works, not that an agent can talk all day.
+MAX_TURNS = 8
+MAX_DURATION_SECONDS = 45
+
+
+async def test_the_persona_conducts_a_real_conversation_with_a_retell_agent(
+    workbench, start_simulator
+):
+    spec = retell_spec(
+        "sim-retell-live-001",
+        base_url=BASE_URL,
+        api_key=API_KEY,
+        agent_id=AGENT_ID,
+        scenario=(
+            "You are calling about an appointment. "
+            "Ask whether you can move it to Thursday."
+        ),
+        personality="Polite and brief; asks one thing at a time.",
+        max_turns=MAX_TURNS,
+        max_duration_seconds=MAX_DURATION_SECONDS,
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench)
+
+    records = await workbench.wait_for(
+        has_terminal("sim-retell-live-001"), within_seconds=90
+    )
+    terminal = terminal_event_for(records, "sim-retell-live-001")
+    assert terminal["status"] == "completed", terminal["reason"]
+
+    # A real agent said real words, and the transcript alternates the way a
+    # conversation does.
+    turns = events_for(records, "sim-retell-live-001", "turn")
+    spoken = [(turn["speaker"], turn["text"]) for turn in turns]
+    agent_turns = [text for speaker, text in spoken if speaker == "agent"]
+    human_turns = [text for speaker, text in spoken if speaker == "human"]
+    assert agent_turns, f"the agent never said anything: {spoken}"
+    assert human_turns, f"the persona never said anything: {spoken}"
+    assert all(text.strip() for text in agent_turns)
+
+    chat_id = terminal["facts"]["provider_reference"]
+    assert chat_id, "no Retell chat id came back to join the record to theirs"
+
+    simulator.stop()
+
+    # The credential conducted the whole exchange and appears nowhere.
+    assert API_KEY not in json.dumps(records), "a report carried the key"
+    assert API_KEY not in simulator.output(), "a log line carried the key"
+    wal_bytes = b"".join(
+        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
+    )
+    assert API_KEY.encode() not in wal_bytes, "the write-ahead log carried the key"
+
+    # And the session was really torn down at the platform, which only the
+    # platform can say.
+    assert await _chat_status(chat_id) == "ended"
+
+
+async def _chat_status(chat_id: str) -> str:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            f"{BASE_URL}/get-chat/{chat_id}",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as response:
+            assert response.status == 200, await response.text()
+            return (await response.json())["chat_status"]

--- a/apps/simulator/tests/test_live_retell.py
+++ b/apps/simulator/tests/test_live_retell.py
@@ -23,12 +23,12 @@ platform is not visible from inside egma.
 
 from __future__ import annotations
 
-import json
 import os
 
 import aiohttp
 import pytest
 from conftest import (
+    assert_kept_secret,
     events_for,
     has_terminal,
     retell_spec,
@@ -96,14 +96,9 @@ async def test_the_persona_conducts_a_real_conversation_with_a_retell_agent(
     simulator.stop()
 
     # The credential conducted the whole exchange and appears nowhere.
-    assert API_KEY not in json.dumps(records), "a report carried the key"
-    assert API_KEY not in simulator.output(), "a log line carried the key"
-    wal_bytes = b"".join(
-        path.read_bytes() for path in simulator.wal_dir.glob("*.jsonl")
-    )
-    assert API_KEY.encode() not in wal_bytes, "the write-ahead log carried the key"
+    assert_kept_secret(API_KEY, records=records, simulator=simulator)
 
-    # And the session was really torn down at the platform, which only the
+    # And the exchange was really ended at the platform, which only the
     # platform can say.
     assert await _chat_status(chat_id) == "ended"
 

--- a/apps/simulator/tests/test_plug_retell.py
+++ b/apps/simulator/tests/test_plug_retell.py
@@ -1,7 +1,7 @@
 """The Retell chat plug against a Retell-shaped server.
 
 The plug is the one component that speaks a platform's wire protocol, so
-what is pinned here is the wire: the session opened once, a turn delivered
+what is pinned here is the wire: the chat opened once, a turn delivered
 per persona turn with the agent's own words coming back, the agent's ending
 read from its end-tool invocation, and the chat ended at the platform
 afterwards. The counterpart is a real HTTP server shaped like Retell's chat
@@ -63,9 +63,9 @@ async def test_the_plug_opens_delivers_and_ends_one_chat(start_retell_stub):
     )
     await plug.close()
 
-    # The whole session lifecycle, from the platform's own side: one chat
-    # opened against the configured agent, both turns delivered in order,
-    # the chat ended rather than left ongoing.
+    # The whole exchange, from the platform's own side: one chat opened
+    # against the configured agent, both turns delivered in order, the chat
+    # ended rather than left ongoing.
     stub = running.stub
     assert [call["endpoint"] for call in stub.calls] == [
         "create-chat",

--- a/apps/simulator/tests/test_plug_retell.py
+++ b/apps/simulator/tests/test_plug_retell.py
@@ -1,0 +1,274 @@
+"""The Retell chat plug against a Retell-shaped server.
+
+The plug is the one component that speaks a platform's wire protocol, so
+what is pinned here is the wire: the session opened once, a turn delivered
+per persona turn with the agent's own words coming back, the agent's ending
+read from its end-tool invocation, and the chat ended at the platform
+afterwards. The counterpart is a real HTTP server shaped like Retell's chat
+API, on loopback — no account, no key, no network.
+
+The failure paths get the same treatment, because they are where a
+credential leaks if it ever does: a key the platform refuses and an
+endpoint nothing answers on both end in a refusal a person can act on, and
+neither says the key.
+"""
+
+from __future__ import annotations
+
+import pytest
+from retell_stub import END_TOOL
+
+from egma_simulator.plugs import AgentReply, PlugError, plug_for
+from egma_simulator.plugs.retell import DEFAULT_BASE_URL, END_TOOL_NAMES, RetellChat
+from egma_simulator.redaction import REDACTED
+
+SENTINEL_KEY = "SENTINEL-retell-key-9f2c4a7b1e8d"
+
+
+def retell(
+    config: dict, *, modality: str = "chat", key: str | None = SENTINEL_KEY
+) -> RetellChat:
+    credentials = None if key is None else {"apiKey": key}
+    return RetellChat(modality=modality, config=config, credentials=credentials)
+
+
+def test_the_registry_knows_the_retell_plug():
+    assert plug_for("retell") is RetellChat
+
+
+def test_a_connection_saying_nothing_about_where_reaches_retell_itself():
+    """The base URL is the plug's own optional key; absent, it is the
+    platform, which is what every real connection block will mean."""
+    plug = retell({"retellAgentId": "agent_1"})
+    assert plug.base_url == DEFAULT_BASE_URL == "https://api.retellai.com"
+
+
+async def test_the_plug_opens_delivers_and_ends_one_chat(start_retell_stub):
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY,
+        greeting="Lakeside Dental, how can I help?",
+        replies=["Of course — could I take your name?", "Booked for Thursday."],
+    )
+    plug = retell({"retellAgentId": "agent_lakeside", "baseUrl": running.base_url})
+
+    assert plug.provider_reference is None, "no chat exists before it is opened"
+    assert await plug.open() == "Lakeside Dental, how can I help?"
+    assert plug.provider_reference == running.stub.chat_ids()[0]
+
+    assert await plug.deliver("I need to move my cleaning.") == AgentReply(
+        text="Of course — could I take your name?", ended=False
+    )
+    assert await plug.deliver("Margaret Hale.") == AgentReply(
+        text="Booked for Thursday.", ended=False
+    )
+    await plug.close()
+
+    # The whole session lifecycle, from the platform's own side: one chat
+    # opened against the configured agent, both turns delivered in order,
+    # the chat ended rather than left ongoing.
+    stub = running.stub
+    assert [call["endpoint"] for call in stub.calls] == [
+        "create-chat",
+        "create-chat-completion",
+        "create-chat-completion",
+        "end-chat",
+    ]
+    assert stub.calls[0]["agent_id"] == "agent_lakeside"
+    assert stub.delivered() == ["I need to move my cleaning.", "Margaret Hale."]
+    assert stub.ended() == [plug.provider_reference]
+
+
+async def test_an_agent_with_nothing_to_say_first_lets_the_persona_open(
+    start_retell_stub,
+):
+    running = await start_retell_stub(api_key=SENTINEL_KEY, replies=["Go on."])
+    plug = retell({"retellAgentId": "agent_quiet", "baseUrl": running.base_url})
+    assert await plug.open() is None
+    await plug.close()
+
+
+async def test_the_agent_ending_the_exchange_is_read_from_its_end_tool(
+    start_retell_stub,
+):
+    """A Retell chat agent ends its own exchange by invoking its end tool;
+    the invocation comes back with the completion, and the plug says so."""
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY,
+        replies=["Anything else?", "All sorted, goodbye now."],
+        ends_after_replies=True,
+    )
+    plug = retell({"retellAgentId": "agent_brisk", "baseUrl": running.base_url})
+    await plug.open()
+
+    assert await plug.deliver("Just the one thing.") == AgentReply(
+        text="Anything else?", ended=False
+    )
+    # The last reply carries the end-tool invocation: the agent's final
+    # words are still recorded, and the exchange is over.
+    assert await plug.deliver("No, that is everything.") == AgentReply(
+        text="All sorted, goodbye now.", ended=True
+    )
+    await plug.close()
+
+
+async def test_several_bubbles_in_one_completion_stay_one_turn(start_retell_stub):
+    """Retell answers a turn with everything the agent produced for it, and
+    an agent that sends two bubbles has still taken one turn."""
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY,
+        replies=[["Let me look that up.", "Yes — Thursday at two."]],
+    )
+    plug = retell({"retellAgentId": "agent_chatty", "baseUrl": running.base_url})
+    await plug.open()
+
+    assert await plug.deliver("Is Thursday free?") == AgentReply(
+        text="Let me look that up.\nYes — Thursday at two.", ended=False
+    )
+    await plug.close()
+
+
+async def test_an_answer_that_carried_no_words_is_an_answer_without_words(
+    start_retell_stub,
+):
+    """A completion can come back with tool traffic and nothing said. The
+    walk records no turn for it rather than an empty one."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY, replies=[[]])
+    plug = retell({"retellAgentId": "agent_silent", "baseUrl": running.base_url})
+    await plug.open()
+
+    assert await plug.deliver("Hello?") == AgentReply(text=None, ended=False)
+    await plug.close()
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"retellAgentId": ""},
+        {"retellAgentId": 7},
+        {"retellAgentId": "agent_1", "baseUrl": 12},
+        {"retellAgentId": "agent_1", "baseUrl": ""},
+        {"retellAgentId": "agent_1", "retellAgentld": "a typo"},
+        {"retellAgentId": "agent_1", "apiKey": "a secret in the wrong block"},
+    ],
+)
+def test_config_the_plug_does_not_understand_is_refused(config: dict):
+    with pytest.raises(PlugError):
+        retell(config)
+
+
+def test_a_config_typo_is_named_in_the_refusal():
+    with pytest.raises(PlugError) as refusal:
+        retell({"retellAgentId": "agent_1", "retellAgentld": "a typo"})
+    assert "retellAgentld" in str(refusal.value)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [None, {}, {"apiKey": ""}, {"apiKey": 7}, {"api_key": "wrong-name-000000"}],
+)
+def test_credentials_of_the_wrong_shape_are_refused(credentials):
+    with pytest.raises(PlugError):
+        RetellChat(
+            modality="chat",
+            config={"retellAgentId": "agent_1"},
+            credentials=credentials,
+        )
+
+
+def test_a_credential_refusal_names_the_key_and_never_its_value():
+    with pytest.raises(PlugError) as refusal:
+        RetellChat(
+            modality="chat",
+            config={"retellAgentId": "agent_1"},
+            credentials={"apiKey": SENTINEL_KEY, "apiSecret": SENTINEL_KEY},
+        )
+    assert "apiSecret" in str(refusal.value)
+    assert SENTINEL_KEY not in str(refusal.value)
+
+
+def test_the_plug_speaks_chat_only_for_now():
+    with pytest.raises(PlugError) as refusal:
+        retell({"retellAgentId": "agent_1"}, modality="voice")
+    assert "voice" in str(refusal.value)
+
+
+async def test_a_key_the_platform_refuses_fails_without_saying_the_key(
+    start_retell_stub,
+):
+    running = await start_retell_stub(api_key="the-only-key-this-stub-honors")
+    plug = retell({"retellAgentId": "agent_1", "baseUrl": running.base_url})
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    told = str(refusal.value)
+    assert "401" in told, "the reason has to name what the platform said"
+    assert SENTINEL_KEY not in told, "the refusal carried the credential"
+
+
+async def test_a_platform_that_says_the_key_back_is_quoted_without_it(
+    start_retell_stub,
+):
+    """A refusal carries the platform's own words, and those are not the
+    plug's to trust: a platform careless enough to echo the key back must
+    not get it repeated into a reason, a log line, or the traceback under
+    one."""
+    running = await start_retell_stub(
+        api_key="the-only-key-this-stub-honors", echo_key_in_refusal=True
+    )
+    plug = retell({"retellAgentId": "agent_1", "baseUrl": running.base_url})
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    told = str(refusal.value)
+    assert "invalid api key" in told, "the platform's own words are still quoted"
+    assert SENTINEL_KEY not in told, "the refusal repeated the key back"
+    assert REDACTED in told
+
+
+async def test_a_platform_that_answers_nowhere_fails_without_saying_the_key():
+    """A closed port: the other way a platform is absent."""
+    plug = retell({"retellAgentId": "agent_1", "baseUrl": "http://127.0.0.1:1"})
+
+    with pytest.raises(PlugError) as refusal:
+        await plug.open()
+    await plug.close()
+
+    told = str(refusal.value)
+    assert "127.0.0.1:1" in told, "the reason has to name what could not be reached"
+    assert SENTINEL_KEY not in told, "the refusal carried the credential"
+
+
+async def test_a_refused_completion_is_a_named_failure(start_retell_stub):
+    """The platform refusing mid-exchange is the plug's to name, not to hide."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY, replies=["Certainly."])
+    plug = retell({"retellAgentId": "agent_1", "baseUrl": running.base_url})
+    await plug.open()
+    assert (await plug.deliver("Hello.")).text == "Certainly."
+
+    # The platform ends the chat from its side — an inactivity close, say —
+    # and the next delivery is refused.
+    running.stub.chats[plug.provider_reference]["ended"] = True
+    with pytest.raises(PlugError) as refusal:
+        await plug.deliver("Are you still there?")
+    await plug.close()
+
+    told = str(refusal.value)
+    assert "422" in told
+    assert SENTINEL_KEY not in told
+
+
+async def test_closing_a_chat_that_was_never_opened_is_safe():
+    """``close`` is called whatever happened, including before ``open``."""
+    plug = retell({"retellAgentId": "agent_1", "baseUrl": "http://127.0.0.1:1"})
+    await plug.close()
+    await plug.close()
+
+
+def test_the_plug_and_the_stub_agree_on_how_an_agent_ends_an_exchange():
+    """Otherwise the ending test above pins the stub's habits, not Retell's."""
+    assert END_TOOL in END_TOOL_NAMES

--- a/apps/simulator/tests/test_service.py
+++ b/apps/simulator/tests/test_service.py
@@ -113,7 +113,7 @@ def test_a_spec_naming_an_unplugged_connection_type_is_refused(tmp_path, caplog)
     executor = RecordingExecutor(capacity=4)
 
     unplugged = scripted_spec("sim-unplugged")
-    unplugged["connection"]["type"] = "retell"
+    unplugged["connection"]["type"] = "a-platform-with-no-plug-yet"
     good = scripted_spec("sim-plugged")
 
     service._accept([unplugged, good], executor)


### PR DESCRIPTION
## What this adds

The first real platform plug. A spec whose connection block names `retell` now conducts a genuine chat against Retell's chat API — opening the exchange, delivering the persona's turns, hearing the agent's answers, detecting the ending, tearing down — driven entirely by the connection block. The persona brain, the walk, the claim loop, and the reporting are untouched: the diff that adds a platform is the plug and its two-line registration, which is the extensibility promise this change exists to prove.

- `plugs/retell.py` speaks Retell's chat API over outbound HTTPS (`create-chat`, `create-chat-completion`, `end-chat`, bearer auth), refuses config keys it does not know, refuses a modality it cannot speak, and scrubs its own key out of anything it quotes from the platform — so even a platform that echoes credentials back cannot leak them through egma.
- CI converses with a Retell-shaped stub (`tests/retell_stub.py`): a real local HTTP server with bearer auth, refusals, scripted replies, multi-bubble answers, and the agent's end-tool invocation. No account, no network.
- Black-box acceptance at the contract seam: a Retell connection block yields a multi-turn reported transcript with the platform's chat id as the provider reference; a bad key and an unreachable endpoint end `failed` with honest reasons; sentinel credentials are planted and proven absent from reports, logs, and the write-ahead log on every path, happy and failing.
- An env-gated live test (`TEST_RETELL_API_KEY` / `TEST_RETELL_AGENT_ID`, optional `TEST_RETELL_BASE_URL`) conducts one real end-to-end conversation when credentials are present and skips visibly when they are absent.

## Test plan

- `uv run pytest` in `apps/simulator`: 124 passed, 1 skipped (the live test without credentials), up from 92 on main.
- `uv run ruff check src tests` clean.
- The live test's own path was rehearsed end to end against the stub via `TEST_RETELL_BASE_URL`, so the first run with real credentials will not be the first run of that code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)