### PR TITLE
One more compose container that only dials out

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,10 @@ node_modules
 **/.next
 **/.turbo
 **/*.tsbuildinfo
+**/.venv
+**/__pycache__
+**/.pytest_cache
+**/.ruff_cache
 .env
 .env.*
 !.env.example

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ node_modules
 **/__pycache__
 **/.pytest_cache
 **/.ruff_cache
+**/.egma-simulator
 .env
 .env.*
 !.env.example

--- a/.env.example
+++ b/.env.example
@@ -124,5 +124,6 @@ EGMA_SIMULATOR_LOG_LEVEL=INFO
 
 # Which port the workbench publishes, for the dev-only overlay that starts one.
 # `docker compose up` starts no workbench, so this is unused until you ask for
-# it; see the README.
+# it; see the README. It is published to 127.0.0.1 and not to the network,
+# whatever port you pick: the workbench authenticates nobody.
 EGMA_WORKBENCH_PORT=8085

--- a/.env.example
+++ b/.env.example
@@ -62,12 +62,10 @@ EGMA_RATE_LIMIT_PER_MINUTE=600
 # application is built, not when it starts.
 EGMA_API_ORIGIN=http://api:3100
 
-# --- The simulator ----------------------------------------------------------
-#
-# The container that conducts simulations. It claims its work rather than being
-# sent it, so it publishes no port and needs no inbound networking. Everything
-# below has a working default; the simulator refuses to start on anything it
-# cannot use and names the variable when it does.
+# The simulator, the container that conducts simulations. It claims its work
+# rather than being sent it, so it publishes no port and needs no inbound
+# networking. Everything below has a working default, and the simulator
+# refuses to start on anything it cannot use, naming the variable when it does.
 
 # Where it claims, heartbeats and reports. Required — a simulator with no
 # control plane is nothing — and compose supplies the API's address on its own
@@ -110,11 +108,16 @@ EGMA_SIMULATOR_CLAIM_WAIT_SECONDS=30
 # becomes its only record. Seconds.
 EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS=120
 
-# Where recordings land and where reports are written before they are sent.
-# The compose file points both inside the `simulator-data` volume and there is
-# rarely a reason to move them; set them only if you mount something else.
-EGMA_SIMULATOR_BLOB_DIR=/var/lib/egma-simulator/blobs
-EGMA_SIMULATOR_WAL_DIR=/var/lib/egma-simulator/wal
+# Where recordings land, and where reports are written before they are sent.
+# These two are the exception to the line at the top of this file: under
+# compose they are fixed to paths inside the `simulator-data` volume and are
+# not read from here, because a value in .env that moved either of them off
+# that volume would quietly cost you every recording the next time a container
+# was replaced. To move them under compose, use a compose override. The values
+# below are what a bare `egma-simulator` process uses, relative to wherever it
+# was started.
+EGMA_SIMULATOR_BLOB_DIR=.egma-simulator/blobs
+EGMA_SIMULATOR_WAL_DIR=.egma-simulator/wal
 
 # The usual levels: CRITICAL, ERROR, WARNING, INFO, DEBUG.
 EGMA_SIMULATOR_LOG_LEVEL=INFO

--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,65 @@ EGMA_RATE_LIMIT_PER_MINUTE=600
 # Where the web application proxies the API's paths. Read when the web
 # application is built, not when it starts.
 EGMA_API_ORIGIN=http://api:3100
+
+# --- The simulator ----------------------------------------------------------
+#
+# The container that conducts simulations. It claims its work rather than being
+# sent it, so it publishes no port and needs no inbound networking. Everything
+# below has a working default; the simulator refuses to start on anything it
+# cannot use and names the variable when it does.
+
+# Where it claims, heartbeats and reports. Required — a simulator with no
+# control plane is nothing — and compose supplies the API's address on its own
+# network. Point it elsewhere to run a simulator beside somebody else's egma.
+EGMA_SIMULATOR_CONTROL_PLANE_URL=http://api:3100
+
+# What it shows the control plane to be allowed to claim, sent as
+# `Authorization: Bearer`. Optional, and empty by default: both halves meet on
+# one private network under compose. A simulator claiming across the internet
+# needs one.
+EGMA_SIMULATOR_SERVICE_TOKEN=
+
+# How many simulations this simulator conducts at once. It claims only what it
+# has room for, so more work than this queues instead of overloading.
+EGMA_SIMULATOR_CAPACITY=4
+
+# Where the persona's words come from: `scripted` or `openai`. `scripted` walks
+# the scenario deterministically and needs no account, which is why it is the
+# default. `openai` speaks the OpenAI chat-completions shape to any provider
+# using it, and makes the model name and key required.
+EGMA_SIMULATOR_MODEL_PROVIDER=scripted
+EGMA_SIMULATOR_MODEL_NAME=
+EGMA_SIMULATOR_MODEL_API_KEY=
+
+# Which endpoint the `openai` provider speaks to. Defaults to OpenAI's own.
+EGMA_SIMULATOR_MODEL_BASE_URL=https://api.openai.com/v1
+
+# How this simulator names itself when claiming; it is stamped on the row it
+# claims. Defaults to its host name and process id, which under compose is the
+# container — enough to tell two simulators apart.
+EGMA_SIMULATOR_CLAIMANT=
+
+# How often each running simulation beats, and how long one claim request may
+# hang while the queue is empty. Both in seconds, and both are for a slow link
+# rather than for tuning.
+EGMA_SIMULATOR_HEARTBEAT_SECONDS=5
+EGMA_SIMULATOR_CLAIM_WAIT_SECONDS=30
+
+# How long one report keeps being resent before the write-ahead log on disk
+# becomes its only record. Seconds.
+EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS=120
+
+# Where recordings land and where reports are written before they are sent.
+# The compose file points both inside the `simulator-data` volume and there is
+# rarely a reason to move them; set them only if you mount something else.
+EGMA_SIMULATOR_BLOB_DIR=/var/lib/egma-simulator/blobs
+EGMA_SIMULATOR_WAL_DIR=/var/lib/egma-simulator/wal
+
+# The usual levels: CRITICAL, ERROR, WARNING, INFO, DEBUG.
+EGMA_SIMULATOR_LOG_LEVEL=INFO
+
+# Which port the workbench publishes, for the dev-only overlay that starts one.
+# `docker compose up` starts no workbench, so this is unused until you ask for
+# it; see the README.
+EGMA_WORKBENCH_PORT=8085

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You need Docker with Compose. Nothing else.
 docker compose up
 ```
 
-That starts four services and applies both schemas. Nobody runs a migration
+That starts five services and applies both schemas. Nobody runs a migration
 step, because there isn't one — the API applies its migrations while it boots.
 
 | Service | URL |
@@ -20,6 +20,7 @@ step, because there isn't one — the API applies its migrations while it boots.
 | API | http://localhost:3100 |
 | Postgres | `postgres://egma:egma@localhost:5433/egma` |
 | ClickHouse | `http://egma:egma@localhost:8124/egma` |
+| Simulator | none — it only dials out |
 
 Open http://localhost:3101 and sign up. Your organization and your first project
 are created together, and you become their admin. On a fresh instance the first
@@ -48,6 +49,62 @@ bring the services back up — Compose reads it on top with no further arguments
 It is an override rather than the default because a container may not raise its
 limit past the daemon's own, so a host with a low hard `nofile` would not start
 at all.
+
+## The simulator, and why it publishes nothing
+
+The fifth service conducts simulations: it takes a persona and a scenario and
+holds a real conversation with the agent under test, then reports the
+transcript, the measurements and how it ended.
+
+**It claims its work rather than being sent it.** It asks the control plane for
+what it has room for, keeps a heartbeat going while it conducts, and posts what
+happened as it happens. Every arrow points out, so there is no `ports:` on that
+service and no inbound network surface to think about — adding a second
+simulator is copying the entry, and the two distribute work between themselves
+with nothing in front of them.
+
+**One volume, `simulator-data`, holds what a report can only point at.**
+Recordings of voice simulations land there, and so does the write-ahead log,
+which is the only record of a report that never got through. Both survive the
+container being restarted, replaced or rebuilt; only `docker compose down -v`
+removes them, and that is what it is for.
+
+Everything else is environment, and `.env.example` names each one with its
+default. Two are worth knowing about before anything else:
+
+- **`EGMA_SIMULATOR_MODEL_PROVIDER` decides where the persona's words come
+  from.** The default, `scripted`, walks the scenario deterministically and
+  needs no account at all. Set it to `openai` — with `EGMA_SIMULATOR_MODEL_NAME`
+  and `EGMA_SIMULATOR_MODEL_API_KEY`, and `EGMA_SIMULATOR_MODEL_BASE_URL` for
+  anything OpenAI-compatible — and the persona improvises instead.
+- **`EGMA_SIMULATOR_CAPACITY` is how many conversations happen at once.** The
+  simulator claims only what it can hold, so a big run degrades into a queue
+  rather than into overload.
+
+Anything set to something it cannot use stops the container on its first line,
+naming the variable. A wrongly mounted volume is caught the same way, rather
+than by losing the first recording.
+
+### Watching one without a control plane
+
+The endpoints the simulator dials are still being built, so there is nothing to
+trigger a run with yet. To see the machinery work anyway, start it against the
+**workbench** — a fake control plane that speaks the same contract from spec
+fixtures, with no database anywhere:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.workbench.yml \
+  up --build simulator workbench
+```
+
+The workbench prints one JSON line per observation — queued, the claim, each
+heartbeat, each reported event — which is a simulation going queued → claimed →
+running → completed in front of you. Chat exchanges finish in seconds; the
+voice fixture leaves a real `.wav` on the volume with one speaker per channel.
+`http://localhost:8085/workbench/records` is the same thing as JSON.
+
+`docker compose up` starts no workbench. This is a dev and demo affair, which
+is why it lives in a file you have to ask for by name.
 
 ## Working on it
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ The workbench prints one JSON line per observation — queued, the claim, each
 heartbeat, each reported event — which is a simulation going queued → claimed →
 running → completed in front of you. Chat exchanges finish in seconds; the
 voice fixture leaves a real `.wav` on the volume with one speaker per channel.
-`http://localhost:8085/workbench/records` is the same thing as JSON.
+`http://localhost:8085/workbench/records` is the same thing as JSON, and is
+published to this machine only — the workbench asks nobody who they are, so
+handing it to a network would hand over queueing and cancelling work too.
 
 `docker compose up` starts no workbench. This is a dev and demo affair, which
 is why it lives in a file you have to ask for by name.

--- a/apps/simulator/Dockerfile
+++ b/apps/simulator/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+
+# The one Python image in a TypeScript monorepo. Built from the repository
+# root like the other two, because the simulator needs one thing from
+# outside its own directory: the contract package, which is the whole of
+# what it shares with the rest of egma.
+#
+# Debian rather than Alpine, unlike the Node images beside it. The audio
+# stack underneath the voice legs ships compiled wheels for glibc and not
+# for musl, so Alpine would trade a smaller image for building numpy from
+# source on every self-hoster's machine.
+FROM python:3.13-slim-bookworm AS build
+
+# uv is the simulator's toolchain everywhere else, so it is the toolchain
+# here too — same lockfile, same resolution, no second way to install. It
+# comes from the package index rather than from its own published image so
+# that this build reaches exactly two hosts: the one the base image is on
+# and the one the dependencies are on. A self-hoster behind a proxy has
+# fewer things to allow, and a third registry cannot be what stops them.
+RUN --mount=type=cache,target=/root/.cache/pip pip install uv==0.11.17
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+WORKDIR /src/apps/simulator
+
+# Manifests first, so editing source does not reinstall the world.
+COPY apps/simulator/pyproject.toml apps/simulator/uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+# Then the simulator itself, copied into the environment rather than
+# linked into it: the runtime stage below carries the environment and
+# nothing else, and an editable install would point at a directory that
+# is not there.
+COPY apps/simulator/README.md ./
+COPY apps/simulator/src ./src
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable
+
+FROM python:3.13-slim-bookworm AS runtime
+
+WORKDIR /app
+ENV PATH=/app/.venv/bin:$PATH \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    EGMA_SIMULATION_CONTRACT_DIR=/app/packages/simulation-contract
+
+COPY --from=build /app/.venv /app/.venv
+
+# The contract, read at runtime rather than vendored: one shared artifact,
+# two readers. The walk that finds it inside a checkout would find it here
+# too, but a deployment should not depend on being shaped like a checkout,
+# so the variable that exists for exactly this points at it above.
+COPY packages/simulation-contract /app/packages/simulation-contract
+
+# No EXPOSE, and no `ports:` in the compose file either. The simulator
+# claims its work rather than being sent it, so nothing ever dials in and
+# there is no port to declare. This absence is the feature.
+
+CMD ["egma-simulator"]

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -143,6 +143,7 @@ Everything arrives as environment variables.
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `EGMA_SIMULATOR_CONTROL_PLANE_URL` | (required) | Where to claim, heartbeat, and report. |
+| `EGMA_SIMULATOR_SERVICE_TOKEN` | (none) | Sent as `Authorization: Bearer` on every outbound call. The workbench asks for none. |
 | `EGMA_SIMULATOR_CAPACITY` | `4` | Most simulations conducted at once. |
 | `EGMA_SIMULATOR_CLAIMANT` | `egma-simulator-<host>-<pid>` | The name stamped on claims. |
 | `EGMA_SIMULATOR_HEARTBEAT_SECONDS` | `5` | Beat interval per running simulation. |
@@ -154,8 +155,39 @@ Everything arrives as environment variables.
 | `EGMA_SIMULATOR_MODEL_API_KEY` | (required for `openai`) | The provider key. Never logged. |
 | `EGMA_SIMULATOR_WAL_DIR` | `.egma-simulator/wal` | Where report documents land before sending. |
 | `EGMA_SIMULATOR_BLOB_DIR` | `.egma-simulator/blobs` | Where recordings land, for the filesystem-backed blob store. |
-| `EGMA_SIMULATOR_LOG_LEVEL` | `INFO` | The usual levels. |
+| `EGMA_SIMULATOR_LOG_LEVEL` | `INFO` | The usual levels: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. |
 | `EGMA_SIMULATION_CONTRACT_DIR` | auto-located | The contract package, when the repo layout isn't around it. |
+
+One of these is required and the rest have working defaults, which is the
+whole rule. Anything set to something unusable stops the process on its
+first line in a sentence naming the variable — a capacity that is not a
+number, a level nobody defined, a URL with no scheme, a directory that
+cannot be written. The two directories are proved by writing to them at
+startup, and made if they are not there, because a volume mounted wrongly
+would otherwise stay quiet until it lost a recording. Blank counts as
+unset everywhere, so a compose entry can carry `${VAR:-}` for every
+optional one.
+
+## In a container
+
+`apps/simulator/Dockerfile` builds it, from the repository root like the
+other two apps — the contract package is the one thing it needs from
+outside this directory, and it is copied in and pointed at with
+`EGMA_SIMULATION_CONTRACT_DIR`. The image declares no port, because
+nothing ever dials in.
+
+The repository's `docker-compose.yml` runs it as one more service beside
+the API, with a named volume for the recordings and the write-ahead log,
+and `docker-compose.workbench.yml` is the dev overlay that stands a
+workbench up beside it and points the simulator there:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.workbench.yml \
+  up --build simulator workbench
+```
+
+That is the same story as the two terminals above, in containers, with
+the fixtures already inside the image. The root README tells the rest.
 
 ## Tests
 

--- a/apps/simulator/src/egma_simulator/__main__.py
+++ b/apps/simulator/src/egma_simulator/__main__.py
@@ -63,13 +63,14 @@ def _gather_loguru(level: str) -> None:
     loguru_logger.add(hand_over, level=level.upper())
 
 
-async def _run() -> None:
+async def _run(config: SimulatorConfig) -> None:
     registry = SecretRegistry()
-    config = SimulatorConfig.from_env()
-    # The model key is configuration rather than a spec's credential, but it
-    # is a secret all the same, and the same filter keeps it out of logs.
-    if config.model_api_key is not None:
-        registry.register(config.model_api_key)
+    # The model key and the service token are configuration rather than a
+    # spec's credentials, but they are secrets all the same, and the same
+    # filter keeps them out of logs.
+    for secret in (config.model_api_key, config.service_token):
+        if secret is not None:
+            registry.register(secret)
     _configure_logging(config.log_level, registry)
 
     service = SimulatorService(config, secrets=registry)
@@ -86,7 +87,18 @@ async def _run() -> None:
 
 
 def main() -> None:
-    asyncio.run(_run())
+    try:
+        config = SimulatorConfig.from_env()
+    except ValueError as misconfigured:
+        # A container that cannot start says one thing, and it is the
+        # sentence naming the variable to fix. A traceback down through
+        # the standard library would bury it under frames nobody deploying
+        # this can act on — and this is written before logging is
+        # configured, because configuring it is one of the things that
+        # could have gone wrong.
+        print(f"egma-simulator cannot start: {misconfigured}", file=sys.stderr)
+        raise SystemExit(1) from None
+    asyncio.run(_run(config))
 
 
 if __name__ == "__main__":

--- a/apps/simulator/src/egma_simulator/client.py
+++ b/apps/simulator/src/egma_simulator/client.py
@@ -61,16 +61,26 @@ class ControlPlaneClient:
         base_url: str,
         *,
         claim_wait_seconds: float,
+        service_token: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._claim_timeout = aiohttp.ClientTimeout(
             total=claim_wait_seconds + CLAIM_TIMEOUT_MARGIN_SECONDS
         )
         self._brisk_timeout = aiohttp.ClientTimeout(total=BRISK_TIMEOUT_SECONDS)
+        # The simulator is never dialled into, so its own requests are the
+        # only place it can show it is allowed to claim work. The token sits
+        # on the session rather than on each call, because "every arrow out
+        # carries it" is not a thing to remember three times. No token
+        # means no header at all — the workbench asks for nothing, and a
+        # bare `Bearer ` would be a worse answer than silence.
+        self._headers = (
+            {"Authorization": f"Bearer {service_token}"} if service_token else {}
+        )
         self._session: aiohttp.ClientSession | None = None
 
     async def __aenter__(self) -> ControlPlaneClient:
-        self._session = aiohttp.ClientSession()
+        self._session = aiohttp.ClientSession(headers=self._headers)
         return self
 
     async def __aexit__(self, *exc_info: object) -> None:

--- a/apps/simulator/src/egma_simulator/config.py
+++ b/apps/simulator/src/egma_simulator/config.py
@@ -32,11 +32,11 @@ def _text(name: str, fallback: str | None = None) -> str | None:
     """A variable's value, where blank means absent.
 
     Compose passes an unset optional through as an empty string rather
-    than leaving it out, which is what lets every entry in the compose
-    file carry its own ``${VAR:-}`` default. So "" and "never set" have to
-    mean the same thing here: otherwise a blank model base URL would
-    become a base URL of nothing, and the first request would go nowhere
-    with no idea why.
+    than leaving it out, which is what lets a compose entry carry a
+    ``${VAR:-}`` default at all. So "" and "never set" have to mean the
+    same thing here: otherwise a blank model base URL would become a base
+    URL of nothing, and the first request would go nowhere with no idea
+    why.
     """
     raw = os.environ.get(name)
     if raw is None or not raw.strip():

--- a/apps/simulator/src/egma_simulator/config.py
+++ b/apps/simulator/src/egma_simulator/config.py
@@ -16,6 +16,7 @@ simulation, and never guessed at.
 
 from __future__ import annotations
 
+import math
 import os
 import socket
 from dataclasses import dataclass, field
@@ -66,6 +67,19 @@ def _seconds(name: str, fallback: float, *, allow_zero: bool = False) -> float:
         raise ValueError(
             f"{name} must be a number of seconds, got {raw!r}"
         ) from None
+    if not math.isfinite(value):
+        # `float()` reads "nan", "inf" and "-inf", and the range check
+        # below cannot catch the first two: every comparison against nan
+        # is False, and +inf is greater than zero, so both would be taken
+        # as a duration. What they would then buy is silence — an
+        # infinite heartbeat interval never beats again, so the control
+        # plane sees an orphan while the simulation is conducting fine,
+        # and an infinite report deadline retries one report until the
+        # process ends, holding a capacity slot nothing will free. Both
+        # are worse than not starting.
+        raise ValueError(
+            f"{name} must be a finite number of seconds, got {raw!r}"
+        )
     if value < 0 or (value == 0 and not allow_zero):
         wanted = "zero or more" if allow_zero else "more than zero"
         raise ValueError(f"{name} must be {wanted}, got {raw}")

--- a/apps/simulator/src/egma_simulator/config.py
+++ b/apps/simulator/src/egma_simulator/config.py
@@ -4,6 +4,14 @@ The simulator is one more compose container that only dials out, so
 everything it needs to know arrives as ``EGMA_SIMULATOR_*`` environment
 variables — no flags, no config files, nothing that would make the hosted
 and self-hosted deployments differ.
+
+A container's whole conversation with whoever deployed it is its
+environment and its first log lines, which settles how everything below
+behaves. One variable is required, because a simulator with no control
+plane is nothing; everything else has a default that works. Anything set
+to something unusable is refused here, at startup, in a sentence naming
+the variable — never discovered halfway through somebody's first
+simulation, and never guessed at.
 """
 
 from __future__ import annotations
@@ -17,18 +25,93 @@ from .reporting import DELIVERY_DEADLINE_SECONDS
 
 MODEL_PROVIDERS = ("scripted", "openai")
 DEFAULT_MODEL_BASE_URL = "https://api.openai.com/v1"
+LOG_LEVELS = ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG")
+
+
+def _text(name: str, fallback: str | None = None) -> str | None:
+    """A variable's value, where blank means absent.
+
+    Compose passes an unset optional through as an empty string rather
+    than leaving it out, which is what lets every entry in the compose
+    file carry its own ``${VAR:-}`` default. So "" and "never set" have to
+    mean the same thing here: otherwise a blank model base URL would
+    become a base URL of nothing, and the first request would go nowhere
+    with no idea why.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return fallback
+    return raw.strip()
+
+
+def _whole(name: str, fallback: int) -> int:
+    """A count from the environment, refused by name rather than by Python's."""
+    raw = _text(name)
+    if raw is None:
+        return fallback
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be a whole number, got {raw!r}") from None
 
 
 def _seconds(name: str, fallback: float, *, allow_zero: bool = False) -> float:
     """A duration from the environment, refused rather than guessed at."""
-    raw = os.environ.get(name)
-    if raw is None or raw == "":
+    raw = _text(name)
+    if raw is None:
         return fallback
-    value = float(raw)
+    try:
+        value = float(raw)
+    except ValueError:
+        raise ValueError(
+            f"{name} must be a number of seconds, got {raw!r}"
+        ) from None
     if value < 0 or (value == 0 and not allow_zero):
         wanted = "zero or more" if allow_zero else "more than zero"
         raise ValueError(f"{name} must be {wanted}, got {raw}")
     return value
+
+
+def _level(name: str, fallback: str) -> str:
+    """A log level, checked here so the refusal can name the variable.
+
+    Handing an unknown level to the logging module raises too, but a
+    ``Unknown level: 'CHATTY'`` from inside logging setup tells a
+    self-hoster nothing about which of their variables to fix.
+    """
+    level = _text(name, fallback).upper()
+    if level not in LOG_LEVELS:
+        raise ValueError(
+            f"{name} must be one of {', '.join(LOG_LEVELS)}; got {level!r}"
+        )
+    return level
+
+
+def _writable_directory(name: str, path: Path) -> Path:
+    """A directory the simulator can really write to, proven at startup.
+
+    In a compose deployment both directories are a mounted volume, and a
+    volume that is read-only, or owned by somebody else, or shadowed by a
+    file, does not announce itself. It waits — for the recording at the
+    end of a voice exchange, or for the first report on its way out — and
+    then takes that simulation down with it. A container that cannot keep
+    what it is asked to keep should say so before it claims anything.
+
+    Proving it is also making it, which is the other half of the point: a
+    fresh volume arrives empty and nothing else would create the two
+    directories inside it.
+    """
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / f".egma-simulator-write-probe-{os.getpid()}"
+        probe.write_bytes(b"")
+        probe.unlink()
+    except OSError as refusal:
+        raise ValueError(
+            f"{name}={path} is not a directory the simulator can write to: "
+            f"{refusal}"
+        ) from refusal
+    return path
 
 
 @dataclass(frozen=True)
@@ -63,6 +146,15 @@ class SimulatorConfig:
 
     log_level: str
 
+    service_token: str | None = field(default=None, repr=False)
+    """What the simulator shows the control plane to be allowed to claim.
+
+    It rides every outbound call as a bearer, the same header an egma key
+    uses everywhere else. Optional, because the workbench asks for nothing
+    and a local run should need nothing; a control plane handing out real
+    work asks for it. Kept out of the dataclass repr — it is a credential
+    and travels like one."""
+
     model_provider: str = "scripted"
     """Where the persona's words come from: ``scripted`` (deterministic,
     what CI and the local workbench story run on) or ``openai`` (any
@@ -80,27 +172,35 @@ class SimulatorConfig:
 
     @classmethod
     def from_env(cls) -> SimulatorConfig:
-        url = os.environ.get("EGMA_SIMULATOR_CONTROL_PLANE_URL")
+        url = _text("EGMA_SIMULATOR_CONTROL_PLANE_URL")
         if not url:
             raise ValueError(
                 "EGMA_SIMULATOR_CONTROL_PLANE_URL is required: the simulator "
                 "is nothing without a control plane to claim from"
             )
+        if not url.startswith(("http://", "https://")):
+            # `api:3100` is the natural thing to write next to a compose
+            # service name, and it reaches nothing. Said now rather than
+            # by the first claim failing with an unreadable URL error.
+            raise ValueError(
+                "EGMA_SIMULATOR_CONTROL_PLANE_URL must start with http:// or "
+                f"https://, got {url!r}"
+            )
 
-        capacity = int(os.environ.get("EGMA_SIMULATOR_CAPACITY", "4"))
+        capacity = _whole("EGMA_SIMULATOR_CAPACITY", 4)
         if capacity < 1:
             raise ValueError(
                 f"EGMA_SIMULATOR_CAPACITY must be at least 1, got {capacity}"
             )
 
-        provider = os.environ.get("EGMA_SIMULATOR_MODEL_PROVIDER", "scripted")
+        provider = _text("EGMA_SIMULATOR_MODEL_PROVIDER", "scripted")
         if provider not in MODEL_PROVIDERS:
             raise ValueError(
                 "EGMA_SIMULATOR_MODEL_PROVIDER must be one of "
                 f"{', '.join(MODEL_PROVIDERS)}; got {provider!r}"
             )
-        model_name = os.environ.get("EGMA_SIMULATOR_MODEL_NAME") or None
-        model_api_key = os.environ.get("EGMA_SIMULATOR_MODEL_API_KEY") or None
+        model_name = _text("EGMA_SIMULATOR_MODEL_NAME")
+        model_api_key = _text("EGMA_SIMULATOR_MODEL_API_KEY")
         if provider == "openai":
             if model_name is None:
                 raise ValueError(
@@ -115,7 +215,7 @@ class SimulatorConfig:
 
         return cls(
             control_plane_url=url.rstrip("/"),
-            claimant=os.environ.get(
+            claimant=_text(
                 "EGMA_SIMULATOR_CLAIMANT",
                 f"egma-simulator-{socket.gethostname()}-{os.getpid()}",
             ),
@@ -125,15 +225,18 @@ class SimulatorConfig:
             report_deadline_seconds=_seconds(
                 "EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS", DELIVERY_DEADLINE_SECONDS
             ),
-            wal_dir=Path(
-                os.environ.get("EGMA_SIMULATOR_WAL_DIR", ".egma-simulator/wal")
+            wal_dir=_writable_directory(
+                "EGMA_SIMULATOR_WAL_DIR",
+                Path(_text("EGMA_SIMULATOR_WAL_DIR", ".egma-simulator/wal")),
             ),
-            blob_dir=Path(
-                os.environ.get("EGMA_SIMULATOR_BLOB_DIR", ".egma-simulator/blobs")
+            blob_dir=_writable_directory(
+                "EGMA_SIMULATOR_BLOB_DIR",
+                Path(_text("EGMA_SIMULATOR_BLOB_DIR", ".egma-simulator/blobs")),
             ),
-            log_level=os.environ.get("EGMA_SIMULATOR_LOG_LEVEL", "INFO"),
+            log_level=_level("EGMA_SIMULATOR_LOG_LEVEL", "INFO"),
+            service_token=_text("EGMA_SIMULATOR_SERVICE_TOKEN"),
             model_provider=provider,
-            model_base_url=os.environ.get(
+            model_base_url=_text(
                 "EGMA_SIMULATOR_MODEL_BASE_URL", DEFAULT_MODEL_BASE_URL
             ).rstrip("/"),
             model_name=model_name,

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -295,7 +295,13 @@ class SimulatorService:
         self._secrets = secrets
         self._blobs = FilesystemBlobStore(config.blob_dir)
         self._last_claim_failure: str | None = None
-        self._claim_failure_since = 0.0
+        # Two clocks, because they answer two questions. One is how long
+        # this failure has been going on, which is what the operator wants
+        # to hear; the other is when it was last said, which is only what
+        # paces the repeats. Sharing one made the count restart every time
+        # it spoke, while the sentence read as a total.
+        self._claim_failure_began = 0.0
+        self._claim_failure_said_at = 0.0
         self._claim_failure_count = 0
 
     async def run(self) -> None:
@@ -363,22 +369,27 @@ class SimulatorService:
         now = asyncio.get_running_loop().time()
         if failure != self._last_claim_failure:
             self._last_claim_failure = failure
-            self._claim_failure_since = now
+            self._claim_failure_began = now
+            self._claim_failure_said_at = now
             self._claim_failure_count = 1
             logger.warning("claim did not land: %s", failure)
             return
 
+        # The count is every attempt since this failure began, not since it
+        # was last mentioned: "after 300 attempts" has to mean what an
+        # operator reads it to mean, and the elapsed time is said beside it
+        # so neither number has to be inferred from the other.
         self._claim_failure_count += 1
-        if now - self._claim_failure_since < REPEATED_CLAIM_FAILURE_SECONDS:
+        if now - self._claim_failure_said_at < REPEATED_CLAIM_FAILURE_SECONDS:
             logger.debug("claim did not land: %s", failure)
             return
         logger.warning(
-            "claim still not landing after %d attempts: %s",
+            "claim still not landing after %d attempts over %.0fs: %s",
             self._claim_failure_count,
+            now - self._claim_failure_began,
             failure,
         )
-        self._claim_failure_since = now
-        self._claim_failure_count = 0
+        self._claim_failure_said_at = now
 
     def _accept(self, documents: list, executor: Executor) -> None:
         """Take what fits and can be understood; refuse the rest out loud.

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -41,6 +41,16 @@ logger = logging.getLogger(__name__)
 
 CLAIM_RETRY_SECONDS = 1.0
 
+REPEATED_CLAIM_FAILURE_SECONDS = 60.0
+"""How often a claim failure that has not changed says so again.
+
+A control plane that is down fails the same way every retry for as long as
+it lasts. Written out each time that is one sentence a second — megabytes
+a day of a log nobody can read, with the only thing that would be news, the
+failure changing, buried inside it. So a failure speaks up when it is new
+and once a minute while it persists; the repeats are still there at DEBUG
+for whoever wants to count them."""
+
 
 class Executor(Protocol):
     """The seam between claiming work and running it.
@@ -284,6 +294,9 @@ class SimulatorService:
         self._config = config
         self._secrets = secrets
         self._blobs = FilesystemBlobStore(config.blob_dir)
+        self._last_claim_failure: str | None = None
+        self._claim_failure_since = 0.0
+        self._claim_failure_count = 0
 
     async def run(self) -> None:
         """Claim and conduct until cancelled. Cancellation is the only exit."""
@@ -291,6 +304,7 @@ class SimulatorService:
         async with ControlPlaneClient(
             config.control_plane_url,
             claim_wait_seconds=config.claim_wait_seconds,
+            service_token=config.service_token,
         ) as client:
             executor = AsyncioExecutor(
                 config.capacity,
@@ -321,7 +335,7 @@ class SimulatorService:
                     self._config.claimant, executor.free_capacity
                 )
             except ClaimFailure as failure:
-                logger.warning("claim did not land: %s", failure)
+                self._note_claim_failure(str(failure))
                 await asyncio.sleep(CLAIM_RETRY_SECONDS)
                 continue
             except asyncio.CancelledError:
@@ -334,7 +348,37 @@ class SimulatorService:
                 await asyncio.sleep(CLAIM_RETRY_SECONDS)
                 continue
 
+            # Whatever was wrong is over; the next one to go wrong is news
+            # again, even if it is the same sentence as before.
+            self._last_claim_failure = None
             self._accept(specs, executor)
+
+    def _note_claim_failure(self, failure: str) -> None:
+        """Say a claim failure when it is new, and once a minute after that.
+
+        See :data:`REPEATED_CLAIM_FAILURE_SECONDS`. Nothing here decides
+        anything — the loop retries either way — so a quiet log costs no
+        behavior, only the repetition.
+        """
+        now = asyncio.get_running_loop().time()
+        if failure != self._last_claim_failure:
+            self._last_claim_failure = failure
+            self._claim_failure_since = now
+            self._claim_failure_count = 1
+            logger.warning("claim did not land: %s", failure)
+            return
+
+        self._claim_failure_count += 1
+        if now - self._claim_failure_since < REPEATED_CLAIM_FAILURE_SECONDS:
+            logger.debug("claim did not land: %s", failure)
+            return
+        logger.warning(
+            "claim still not landing after %d attempts: %s",
+            self._claim_failure_count,
+            failure,
+        )
+        self._claim_failure_since = now
+        self._claim_failure_count = 0
 
     def _accept(self, documents: list, executor: Executor) -> None:
         """Take what fits and can be understood; refuse the rest out loud.

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -164,6 +164,7 @@ def start_simulator(
         capacity: int = 2,
         log_level: str = "INFO",
         claimant: str = "sim-under-test",
+        extra_env: dict[str, str] | None = None,
     ) -> SimulatorProcess:
         stdout_path = tmp_path / f"simulator-{len(started)}.out"
         stderr_path = tmp_path / f"simulator-{len(started)}.err"
@@ -187,7 +188,7 @@ def start_simulator(
             "EGMA_SIMULATOR_WAL_DIR": str(wal_dir),
             "EGMA_SIMULATOR_BLOB_DIR": str(blob_dir),
             "EGMA_SIMULATOR_LOG_LEVEL": log_level,
-        }
+        } | (extra_env or {})
         with open(stdout_path, "wb") as stdout, open(stderr_path, "wb") as stderr:
             process = subprocess.Popen(
                 [sys.executable, "-m", "egma_simulator"],
@@ -201,6 +202,7 @@ def start_simulator(
             stderr_path=stderr_path,
             wal_dir=wal_dir,
             blob_dir=blob_dir,
+            extra_env=extra_env or {},
         )
         started.append(simulator)
         return simulator

--- a/apps/simulator/tests/test_client_auth.py
+++ b/apps/simulator/tests/test_client_auth.py
@@ -1,0 +1,79 @@
+"""How the simulator says who it is on the way out.
+
+The simulator dials out and is never dialled into, so the only place it
+can prove it is allowed to claim work is on its own requests. A configured
+service token rides every one of them as a bearer — the same header an
+egma key uses everywhere else — and no token means no header at all, which
+is what the workbench and every local run want.
+
+A real server on loopback reads the headers back, because what is under
+test is what actually goes on the wire.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from aiohttp import web
+
+from egma_simulator.client import ControlPlaneClient
+
+
+@pytest.fixture
+async def listening_control_plane() -> AsyncIterator[tuple[str, list[str | None]]]:
+    """Answers everything agreeably and keeps every ``Authorization`` it saw."""
+    offered: list[str | None] = []
+
+    async def claim(request: web.Request) -> web.Response:
+        offered.append(request.headers.get("Authorization"))
+        return web.json_response({"specs": []})
+
+    async def heartbeat(request: web.Request) -> web.Response:
+        offered.append(request.headers.get("Authorization"))
+        return web.json_response({"directive": None})
+
+    async def report(request: web.Request) -> web.Response:
+        offered.append(request.headers.get("Authorization"))
+        return web.Response(status=204)
+
+    app = web.Application()
+    app.router.add_post("/v1/claims", claim)
+    app.router.add_post("/v1/simulations/{simulation_id}/heartbeats", heartbeat)
+    app.router.add_post("/v1/simulations/{simulation_id}/reports", report)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        yield f"http://127.0.0.1:{runner.addresses[0][1]}", offered
+    finally:
+        await runner.cleanup()
+
+
+async def _make_all_three_calls(client: ControlPlaneClient) -> None:
+    await client.claim("sim-under-test", 1)
+    await client.heartbeat("sim-1", "sim-under-test")
+    await client.report("sim-1", b"{}")
+
+
+async def test_a_service_token_rides_every_outbound_call(listening_control_plane):
+    base_url, offered = listening_control_plane
+
+    async with ControlPlaneClient(
+        base_url, claim_wait_seconds=1, service_token="egma_service_token_under_test"
+    ) as client:
+        await _make_all_three_calls(client)
+
+    assert offered == ["Bearer egma_service_token_under_test"] * 3
+
+
+async def test_no_token_means_no_header(listening_control_plane):
+    """The workbench asks for nothing, and gets nothing, rather than "Bearer "."""
+    base_url, offered = listening_control_plane
+
+    async with ControlPlaneClient(base_url, claim_wait_seconds=1) as client:
+        await _make_all_three_calls(client)
+
+    assert offered == [None] * 3

--- a/apps/simulator/tests/test_client_auth.py
+++ b/apps/simulator/tests/test_client_auth.py
@@ -1,4 +1,4 @@
-"""How the simulator says who it is on the way out.
+"""How the simulator says who it is on the way out — and nowhere else.
 
 The simulator dials out and is never dialled into, so the only place it
 can prove it is allowed to claim work is on its own requests. A configured
@@ -7,12 +7,16 @@ egma key uses everywhere else — and no token means no header at all, which
 is what the workbench and every local run want.
 
 A real server on loopback reads the headers back, because what is under
-test is what actually goes on the wire.
+test is what actually goes on the wire. The last test runs a real
+simulator process against a control plane that quotes the request it
+refused, which is the one way a configured token could reach a log line.
 """
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 
 import pytest
 from aiohttp import web
@@ -77,3 +81,70 @@ async def test_no_token_means_no_header(listening_control_plane):
         await _make_all_three_calls(client)
 
     assert offered == [None] * 3
+
+
+# -- And nowhere else --------------------------------------------------------
+
+A_TOKEN = "egma_service_token_that_must_never_be_logged"
+
+
+@pytest.fixture
+async def quoting_control_plane() -> AsyncIterator[str]:
+    """Refuses every claim by quoting the request back — a plain 400 shape.
+
+    This is not a contrived leak. A control plane that says what it could
+    not parse is being helpful, and the claim loop logs the refusal's text
+    to say why work is not arriving. Between those two ordinary behaviors
+    the bearer ends up inside a log line, unless something put it in the
+    redacting filter first.
+    """
+
+    async def refuse(request: web.Request) -> web.Response:
+        return web.Response(
+            status=400,
+            text=f"cannot read this claim, sent with headers {dict(request.headers)}",
+        )
+
+    app = web.Application()
+    app.router.add_post("/v1/claims", refuse)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        yield f"http://127.0.0.1:{runner.addresses[0][1]}"
+    finally:
+        await runner.cleanup()
+
+
+async def test_a_configured_service_token_never_reaches_a_log_line(
+    quoting_control_plane, start_simulator
+):
+    """The token is registered at start-up, so no log line can carry it.
+
+    A spec's credentials are registered when the spec is claimed. A
+    service token arrives before any of that — it is configuration — so
+    only start-up can hand it over, and nothing else in the suite walks
+    that path. A real process, its real output, and a control plane doing
+    the one ordinary thing that would expose it.
+    """
+    simulator = start_simulator(
+        SimpleNamespace(base_url=quoting_control_plane),
+        extra_env={"EGMA_SIMULATOR_SERVICE_TOKEN": A_TOKEN},
+    )
+
+    output = ""
+    deadline = asyncio.get_running_loop().time() + 30.0
+    while "claim did not land" not in output:
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"the refusal was never logged; output was:\n{output}")
+        await asyncio.sleep(0.05)
+        output = simulator.output()
+    simulator.stop()
+    output = simulator.output()
+
+    # The line that would have carried it is there, and quotes the header
+    # it was sent with — so this is the leak happening, scrubbed.
+    assert "Authorization" in output, "the control plane's quote did not arrive"
+    assert A_TOKEN not in output, "a log line carried the service token"
+    assert "Bearer [redacted]" in output

--- a/apps/simulator/tests/test_config.py
+++ b/apps/simulator/tests/test_config.py
@@ -1,0 +1,237 @@
+"""What the simulator refuses to start with, and what it starts without.
+
+The simulator is one more container, and a container's whole conversation
+with whoever deployed it is its environment and its first log lines. So
+the rule these tests hold is one rule: anything the simulator cannot work
+without is refused at startup **by name**, and everything else has a
+working default. Nobody should discover a mistyped variable halfway
+through their first simulation, and nobody should have to set nine
+variables to see one.
+
+Every test here is hermetic — an environment, a temporary directory, and
+no network at all.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from egma_simulator.config import SimulatorConfig
+
+A_URL = "http://control-plane.internal:3100"
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """A clean environment, and somewhere harmless for the two directories.
+
+    Whatever this machine has set is cleared first, so a developer with
+    their own ``EGMA_SIMULATOR_*`` exported cannot make these pass or fail
+    differently from anybody else's.
+    """
+    for name in list(os.environ):
+        if name.startswith("EGMA_SIMULATOR_"):
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("EGMA_SIMULATOR_WAL_DIR", str(tmp_path / "wal"))
+    monkeypatch.setenv("EGMA_SIMULATOR_BLOB_DIR", str(tmp_path / "blobs"))
+    return monkeypatch
+
+
+def test_one_variable_is_enough(env, tmp_path):
+    """Everything but the control plane has a default that works."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+
+    config = SimulatorConfig.from_env()
+
+    assert config.control_plane_url == A_URL
+    assert config.capacity == 4
+    assert config.model_provider == "scripted"
+    assert config.service_token is None
+    assert config.claimant.startswith("egma-simulator-")
+    assert config.log_level == "INFO"
+    assert config.blob_dir == tmp_path / "blobs"
+
+
+def test_empty_means_unset(env):
+    """An optional variable left blank falls back rather than taking "".
+
+    Compose hands an unset optional through as an empty string instead of
+    leaving it out, so every entry in the compose file can carry a
+    ``${VAR:-}`` default. If "" were a value, a blank model base URL would
+    become a base URL of nothing and the first request would go nowhere.
+    """
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    for name in (
+        "EGMA_SIMULATOR_CAPACITY",
+        "EGMA_SIMULATOR_CLAIMANT",
+        "EGMA_SIMULATOR_HEARTBEAT_SECONDS",
+        "EGMA_SIMULATOR_LOG_LEVEL",
+        "EGMA_SIMULATOR_MODEL_BASE_URL",
+        "EGMA_SIMULATOR_MODEL_PROVIDER",
+        "EGMA_SIMULATOR_SERVICE_TOKEN",
+    ):
+        env.setenv(name, "")
+
+    config = SimulatorConfig.from_env()
+
+    assert config.capacity == 4
+    assert config.claimant.startswith("egma-simulator-")
+    assert config.heartbeat_seconds == 5.0
+    assert config.log_level == "INFO"
+    assert config.model_base_url == "https://api.openai.com/v1"
+    assert config.model_provider == "scripted"
+    assert config.service_token is None
+
+
+def test_a_missing_control_plane_url_is_refused_by_name(env):
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_CONTROL_PLANE_URL"):
+        SimulatorConfig.from_env()
+
+
+def test_a_control_plane_url_with_no_scheme_is_refused_by_name(env):
+    """``api:3100`` is a natural thing to write and reaches nothing."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", "api:3100")
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_CONTROL_PLANE_URL"):
+        SimulatorConfig.from_env()
+
+
+def test_a_capacity_that_is_not_a_number_is_refused_by_name(env):
+    """Not ``invalid literal for int()``, which names nothing."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_CAPACITY", "lots")
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_CAPACITY"):
+        SimulatorConfig.from_env()
+
+
+def test_a_capacity_below_one_is_refused_by_name(env):
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_CAPACITY", "0")
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_CAPACITY"):
+        SimulatorConfig.from_env()
+
+
+def test_a_duration_that_is_not_a_number_is_refused_by_name(env):
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_HEARTBEAT_SECONDS", "often")
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_HEARTBEAT_SECONDS"):
+        SimulatorConfig.from_env()
+
+
+def test_a_negative_duration_is_refused_by_name(env):
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_CLAIM_WAIT_SECONDS", "-1")
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_CLAIM_WAIT_SECONDS"):
+        SimulatorConfig.from_env()
+
+
+def test_an_unknown_log_level_is_refused_by_name(env):
+    """Caught here rather than in logging setup, which names no variable."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_LOG_LEVEL", "CHATTY")
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_LOG_LEVEL"):
+        SimulatorConfig.from_env()
+
+
+def test_a_log_level_is_taken_however_it_is_written(env):
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_LOG_LEVEL", "debug")
+
+    assert SimulatorConfig.from_env().log_level == "DEBUG"
+
+
+def test_an_unknown_model_provider_is_refused_by_name(env):
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_MODEL_PROVIDER", "telepathy")
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_MODEL_PROVIDER"):
+        SimulatorConfig.from_env()
+
+
+@pytest.mark.parametrize(
+    ("supplied", "missing"),
+    [
+        ({}, "EGMA_SIMULATOR_MODEL_NAME"),
+        ({"EGMA_SIMULATOR_MODEL_NAME": "gpt-4o-mini"}, "EGMA_SIMULATOR_MODEL_API_KEY"),
+    ],
+)
+def test_the_openai_provider_names_what_it_is_missing(env, supplied, missing):
+    """The provider is optional; choosing it makes two more required."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_MODEL_PROVIDER", "openai")
+    for name, value in supplied.items():
+        env.setenv(name, value)
+
+    with pytest.raises(ValueError, match=missing):
+        SimulatorConfig.from_env()
+
+
+@pytest.mark.parametrize(
+    "variable", ["EGMA_SIMULATOR_BLOB_DIR", "EGMA_SIMULATOR_WAL_DIR"]
+)
+def test_a_directory_that_cannot_be_written_is_refused_by_name(
+    env, tmp_path, variable
+):
+    """A volume mounted wrongly is found now, not by losing a recording.
+
+    Neither directory is written until a simulation is well under way — a
+    recording at the end of a voice exchange, a report on its way out — so
+    a bad mount would otherwise stay quiet until the first simulation, and
+    then take it down.
+    """
+    blocked = tmp_path / "occupied"
+    blocked.write_text("something that is not a directory")
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv(variable, str(blocked))
+
+    with pytest.raises(ValueError, match=variable):
+        SimulatorConfig.from_env()
+
+
+def test_both_directories_exist_once_the_config_does(env, tmp_path):
+    """Proving they are writable is also making them, which is the point."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+
+    config = SimulatorConfig.from_env()
+
+    assert config.blob_dir.is_dir()
+    assert config.wal_dir.is_dir()
+    assert list(tmp_path.glob("**/.egma-simulator-*")) == [], (
+        "the write probe cleaned up after itself"
+    )
+
+
+def test_starting_misconfigured_says_one_sentence_and_stops(env, capsys):
+    """The whole conversation a container has with whoever deployed it.
+
+    A traceback down through the standard library would bury the sentence
+    naming the variable under frames nobody deploying this can act on.
+    """
+    from egma_simulator.__main__ import main
+
+    with pytest.raises(SystemExit) as stopped:
+        main()
+
+    assert stopped.value.code == 1
+    said = capsys.readouterr().err
+    assert "EGMA_SIMULATOR_CONTROL_PLANE_URL" in said
+    assert "Traceback" not in said
+
+
+def test_the_service_token_is_read_and_kept_out_of_the_repr(env):
+    """It is a credential, so it travels like one: never in a printed config."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_SERVICE_TOKEN", "egma_service_token_under_test")
+
+    config = SimulatorConfig.from_env()
+
+    assert config.service_token == "egma_service_token_under_test"
+    assert "egma_service_token_under_test" not in repr(config)

--- a/apps/simulator/tests/test_config.py
+++ b/apps/simulator/tests/test_config.py
@@ -132,6 +132,45 @@ def test_a_negative_duration_is_refused_by_name(env):
         SimulatorConfig.from_env()
 
 
+DURATION_VARIABLES = [
+    "EGMA_SIMULATOR_HEARTBEAT_SECONDS",
+    "EGMA_SIMULATOR_CLAIM_WAIT_SECONDS",
+    "EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS",
+]
+"""Every variable read as a duration — all of them through one helper."""
+
+
+@pytest.mark.parametrize("variable", DURATION_VARIABLES)
+@pytest.mark.parametrize("written", ["nan", "inf", "-inf", "Infinity", "NaN"])
+def test_a_duration_that_is_not_finite_is_refused_by_name(env, variable, written):
+    """The numbers that read as numbers and behave as neither.
+
+    ``float()`` accepts every one of these, and the range check cannot
+    see two of them: every comparison against nan is False, and +inf is
+    greater than zero, so both would be taken for a duration. What they
+    would buy is silence rather than an error — an infinite heartbeat
+    interval never beats again, so a simulation going along fine looks
+    orphaned to the control plane, and an infinite report deadline
+    retries one report until the process ends, holding a capacity slot
+    nothing will ever free.
+    """
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv(variable, written)
+
+    with pytest.raises(ValueError, match=variable):
+        SimulatorConfig.from_env()
+
+
+@pytest.mark.parametrize("written", ["nan", "inf", "-inf"])
+def test_a_capacity_that_is_not_finite_is_refused_by_name(env, written):
+    """The other numeric variable, which `int()` turns down on its own."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_CAPACITY", written)
+
+    with pytest.raises(ValueError, match="EGMA_SIMULATOR_CAPACITY"):
+        SimulatorConfig.from_env()
+
+
 def test_an_unknown_log_level_is_refused_by_name(env):
     """Caught here rather than in logging setup, which names no variable."""
     env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)

--- a/apps/simulator/tests/test_service.py
+++ b/apps/simulator/tests/test_service.py
@@ -179,6 +179,38 @@ async def test_a_claim_failure_that_never_changes_is_said_once_not_forever(
     assert client.attempts >= 25, "the loop kept trying, quietly"
 
 
+async def test_an_outage_that_speaks_again_counts_from_when_it_began(
+    tmp_path, caplog, monkeypatch
+):
+    """"After N attempts" means since the failure started, not since it last spoke.
+
+    Nobody reads a number in a log line and mentally scopes it to the
+    window it was counted in. With the repeat interval collapsed to
+    nothing, every attempt after the first speaks up, and each one has to
+    have counted every attempt before it.
+    """
+    monkeypatch.setattr(service_module, "CLAIM_RETRY_SECONDS", 0.001)
+    monkeypatch.setattr(service_module, "REPEATED_CLAIM_FAILURE_SECONDS", 0.0)
+    caplog.set_level(logging.DEBUG, logger="egma_simulator.service")
+    service = a_service(tmp_path)
+    client = RefusingClient(attempts_wanted=6)
+
+    claiming = asyncio.create_task(
+        service._claim_forever(client, RecordingExecutor(capacity=2))
+    )
+    await client.enough.wait()
+    claiming.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await claiming
+
+    counted = [
+        int(record.args[0])
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "still not landing" in record.msg
+    ]
+    assert counted[:5] == [2, 3, 4, 5, 6], counted
+
+
 def test_the_typed_spec_reads_what_the_document_says():
     spec = SimulationSpec.from_document(
         scripted_spec("sim-typed", scenario="Hello there.", max_turns=7)

--- a/apps/simulator/tests/test_service.py
+++ b/apps/simulator/tests/test_service.py
@@ -14,10 +14,14 @@ exercise them.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import logging
 
 import pytest
 from conftest import scripted_spec
 
+from egma_simulator import service as service_module
+from egma_simulator.client import ClaimFailure
 from egma_simulator.config import SimulatorConfig
 from egma_simulator.redaction import SecretRegistry
 from egma_simulator.service import SimulatorService
@@ -121,6 +125,58 @@ def test_a_spec_naming_an_unplugged_connection_type_is_refused(tmp_path, caplog)
 
     assert [spec.simulation_id for spec in executor.accepted] == ["sim-plugged"]
     assert "no platform plug" in caplog.text
+
+
+class RefusingClient:
+    """A control plane that turns down every claim the same way.
+
+    Counts the attempts and raises ``enough`` once there have been the
+    asked-for number of them, so the test waits on the loop having really
+    gone round rather than on a clock.
+    """
+
+    def __init__(self, *, attempts_wanted: int) -> None:
+        self.attempts = 0
+        self.enough = asyncio.Event()
+        self._wanted = attempts_wanted
+
+    async def claim(self, claimant: str, capacity: int) -> list[dict]:
+        self.attempts += 1
+        if self.attempts >= self._wanted:
+            self.enough.set()
+        raise ClaimFailure("claim answered 404: Route POST:/v1/claims not found")
+
+
+async def test_a_claim_failure_that_never_changes_is_said_once_not_forever(
+    tmp_path, caplog, monkeypatch
+):
+    """An outage is one piece of news, however long it lasts.
+
+    A control plane that is down, or that does not answer this question
+    yet, fails the identical way on every retry. Written out each time,
+    that is one sentence a second for the length of the outage — megabytes
+    a day of a log nobody can read. The repeats stay at DEBUG for whoever
+    wants to count them.
+    """
+    monkeypatch.setattr(service_module, "CLAIM_RETRY_SECONDS", 0.001)
+    caplog.set_level(logging.DEBUG, logger="egma_simulator.service")
+    service = a_service(tmp_path)
+    client = RefusingClient(attempts_wanted=25)
+
+    claiming = asyncio.create_task(
+        service._claim_forever(client, RecordingExecutor(capacity=2))
+    )
+    await client.enough.wait()
+    claiming.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await claiming
+
+    shouted = [
+        record for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert len(shouted) == 1, [record.getMessage() for record in shouted]
+    assert "claim did not land" in shouted[0].getMessage()
+    assert client.attempts >= 25, "the loop kept trying, quietly"
 
 
 def test_the_typed_spec_reads_what_the_document_says():

--- a/docker-compose.workbench.yml
+++ b/docker-compose.workbench.yml
@@ -1,0 +1,49 @@
+# A whole simulation, with no database and no control plane.
+#
+# `docker compose up` starts no workbench, deliberately: a self-hoster's
+# simulator claims from the real control plane and from nothing else. This
+# file is for the other case — seeing the simulator conduct real
+# conversations before there is anything to trigger one, which is what its
+# own development runs on and what a first look should cost.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.workbench.yml \
+#     up --build simulator workbench
+#
+# It adds one container — the workbench, a fake control plane speaking the
+# same contract from the spec fixtures already inside the image — and
+# points the simulator at it instead of the API. Both are the same image,
+# so this builds nothing extra.
+#
+# Naming the two services is what keeps Postgres, ClickHouse, the API and
+# the web application out of it: the simulator's dependency on the API is
+# replaced below rather than added to, because a demo that needs two
+# databases running is not the demo the workbench exists to be. Replacing
+# it takes the `!override` tag, which Compose has had since 2.24 — this is
+# the one thing in this repository that asks for a version, and it asks
+# only of whoever wants the demo.
+#
+# Watch the workbench's log. Every claim, heartbeat, report and refusal
+# prints as one JSON line the moment it happens, which is a simulation
+# going queued → claimed → running → completed in front of you. The same
+# is readable at http://localhost:8085/workbench/records, where
+# `POST /workbench/specs` queues another spec and
+# `POST /workbench/simulations/<id>/cancel` stops one mid-exchange.
+
+services:
+  workbench:
+    build:
+      context: .
+      dockerfile: apps/simulator/Dockerfile
+    command: ["egma-workbench", "--host", "0.0.0.0", "--port", "8085"]
+    # Published, unlike the simulator, and for the opposite reason: this
+    # one is dialled into. It is the stand-in for the control plane, and a
+    # person watching wants to read its records from their own machine.
+    ports:
+      - "${EGMA_WORKBENCH_PORT:-8085}:8085"
+
+  simulator:
+    environment:
+      EGMA_SIMULATOR_CONTROL_PLANE_URL: http://workbench:8085
+    depends_on: !override
+      workbench:
+        condition: service_started

--- a/docker-compose.workbench.yml
+++ b/docker-compose.workbench.yml
@@ -36,12 +36,20 @@ services:
     build:
       context: .
       dockerfile: apps/simulator/Dockerfile
+    # `0.0.0.0` is inside the container, where it has to be: the simulator
+    # reaches the workbench across this network by its service name, and a
+    # server bound to the container's loopback would answer nobody.
     command: ["egma-workbench", "--host", "0.0.0.0", "--port", "8085"]
     # Published, unlike the simulator, and for the opposite reason: this
-    # one is dialled into. It is the stand-in for the control plane, and a
-    # person watching wants to read its records from their own machine.
+    # one is dialled into. But bound to the host's loopback, because the
+    # workbench asks nobody who they are — it hands out specs, takes
+    # reports, queues work and cancels it, all unauthenticated, which is
+    # exactly right for a fake control plane on somebody's own machine and
+    # exactly wrong to offer the network. The simulator does not come
+    # through here; it uses the compose network either way. This mapping
+    # exists only so a person at this machine can read the records.
     ports:
-      - "${EGMA_WORKBENCH_PORT:-8085}:8085"
+      - "127.0.0.1:${EGMA_WORKBENCH_PORT:-8085}:8085"
 
   simulator:
     environment:

--- a/docker-compose.workbench.yml
+++ b/docker-compose.workbench.yml
@@ -11,8 +11,10 @@
 #
 # It adds one container — the workbench, a fake control plane speaking the
 # same contract from the spec fixtures already inside the image — and
-# points the simulator at it instead of the API. Both are the same image,
-# so this builds nothing extra.
+# points the simulator at it instead of the API. The workbench names the
+# same Dockerfile as the simulator, so Compose builds it a second time and
+# tags a second image; every step of that second build is a cache hit on
+# the first, and nothing is installed or downloaded twice.
 #
 # Naming the two services is what keeps Postgres, ClickHouse, the API and
 # the web application out of it: the simulator's dependency on the API is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,20 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    # No `healthcheck` here, unlike every other service, and for the same
+    # reason there is no `ports`: nothing listens. The other four are
+    # probed by asking them something over a port they listen on, and this
+    # one listens on none — a check that only proved the process exists
+    # would prove nothing Docker does not already know, since the process
+    # is the container and its death is the container's exit.
+    #
+    # What could go wrong instead is already answered elsewhere. Bad
+    # configuration stops it before it claims anything, saying which
+    # variable. A control plane it cannot reach is in its log, once and
+    # then once a minute. And a simulator that dies holding claimed work
+    # is the control plane's to notice, by the heartbeats stopping — which
+    # is the one place that can act on it, because it is the only side
+    # that knows what was claimed.
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,61 @@ services:
       retries: 30
       start_period: 5s
 
+  # The simulator: the service that conducts simulations. It claims its
+  # work rather than being sent it, so there is no `ports:` here and there
+  # never will be — every arrow points out, and adding this container to a
+  # self-host costs no inbound networking at all. Everything it needs is
+  # below; there are no files to place and no flags to pass.
+  simulator:
+    build:
+      context: .
+      dockerfile: apps/simulator/Dockerfile
+    environment:
+      # Where it claims, heartbeats and reports. The API and the simulator
+      # meet inside this network, so this is the service name rather than
+      # the origin a browser uses. The endpoints it dials arrive with the
+      # trigger; until then it asks, is told there is nothing, and asks
+      # again, which is what a queue with nothing in it looks like.
+      EGMA_SIMULATOR_CONTROL_PLANE_URL: ${EGMA_SIMULATOR_CONTROL_PLANE_URL:-http://api:3100}
+      # What it shows the control plane to be allowed to claim, as a bearer
+      # — the same header an egma key uses everywhere else. Unset is fine
+      # while both halves are yours and meet on this network; a simulator
+      # claiming across the internet needs one.
+      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:-}
+      # How many simulations one simulator conducts at once. It claims only
+      # what it has room for, so a big run degrades to a queue rather than
+      # to overload — raise this, or start a second simulator, and they
+      # distribute between themselves with nothing in front of them.
+      EGMA_SIMULATOR_CAPACITY: ${EGMA_SIMULATOR_CAPACITY:-4}
+      # Where the persona's words come from. `scripted` walks the scenario
+      # deterministically and needs no account, which is why it is the
+      # default; `openai` speaks to any provider using that shape and makes
+      # the next two required.
+      EGMA_SIMULATOR_MODEL_PROVIDER: ${EGMA_SIMULATOR_MODEL_PROVIDER:-scripted}
+      EGMA_SIMULATOR_MODEL_NAME: ${EGMA_SIMULATOR_MODEL_NAME:-}
+      EGMA_SIMULATOR_MODEL_API_KEY: ${EGMA_SIMULATOR_MODEL_API_KEY:-}
+      EGMA_SIMULATOR_MODEL_BASE_URL: ${EGMA_SIMULATOR_MODEL_BASE_URL:-}
+      # The volume below, and the two things kept on it. Recordings are
+      # what a report can only point at, and the write-ahead log is the
+      # only record of a report that never got through — losing either to
+      # a container being replaced would lose a simulation's evidence, so
+      # both live on the volume rather than in the container.
+      EGMA_SIMULATOR_BLOB_DIR: /var/lib/egma-simulator/blobs
+      EGMA_SIMULATOR_WAL_DIR: /var/lib/egma-simulator/wal
+      # How the pull behaves. The defaults suit a control plane on the same
+      # network; a slow link is what these are for.
+      EGMA_SIMULATOR_CLAIMANT: ${EGMA_SIMULATOR_CLAIMANT:-}
+      EGMA_SIMULATOR_HEARTBEAT_SECONDS: ${EGMA_SIMULATOR_HEARTBEAT_SECONDS:-}
+      EGMA_SIMULATOR_CLAIM_WAIT_SECONDS: ${EGMA_SIMULATOR_CLAIM_WAIT_SECONDS:-}
+      EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS: ${EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS:-}
+      EGMA_SIMULATOR_LOG_LEVEL: ${EGMA_SIMULATOR_LOG_LEVEL:-INFO}
+    volumes:
+      - simulator-data:/var/lib/egma-simulator
+    depends_on:
+      api:
+        condition: service_healthy
+
 volumes:
   postgres-data:
   clickhouse-data:
+  simulator-data:


### PR DESCRIPTION
## What this adds

The simulator becomes one more entry in `docker compose up`: configured entirely by environment, publishing no ports, dialling out for everything — claims, heartbeats, reports — exactly as the pull-based dispatch design intends. Hosted and self-hosted are the same deployment.

- **`apps/simulator/Dockerfile`** — two-stage, uv-managed, built from the repo root like its siblings; the final image carries no build tooling and declares no `EXPOSE`.
- **One `simulator` service** in `docker-compose.yml` with a named `simulator-data` volume for recordings and the write-ahead log — both survive container restarts and recreation, which is the point of a volume. No healthcheck, and the file says why: nothing listens, so there is no port to probe, and each failure mode is answered where it actually lives.
- **`docker-compose.workbench.yml`** — an opt-in dev/demo overlay that runs the fixture-fed workbench from the same image and points the simulator at it, so a whole simulation lifecycle can be watched inside compose with no database. A plain `docker compose up` starts no workbench.
- **Loud configuration failures**: every unusable value is refused at startup naming its variable — non-numeric caps, unknown log levels, scheme-less URLs, unwritable directories. Blank means unset, so compose can carry `${VAR:-}` defaults for every optional. Optional providers degrade cleanly.
- **`EGMA_SIMULATOR_SERVICE_TOKEN`** — optional bearer on every outbound call, held out of reprs, registered for log redaction, and proven: a test runs a real simulator against a control plane that quotes request headers back into an error, and the log shows `Bearer [redacted]` where the token would be.
- **A quieted claim loop**: pointing a fresh install at an API with no claim endpoint yet logged one warning per second, forever (~86k lines a day). Failures now log when new, then once a minute with a cumulative count and elapsed time, repeats at DEBUG.
- **Docs**: all 15 `EGMA_SIMULATOR_*` variables documented in `.env.example` and both READMEs, with defaults that match the code exactly.

## Verified in real Docker (isolated compose project, cleaned up after)

- The default stack came up: postgres, clickhouse, api healthy, simulator claiming — with zero published simulator ports (`ExposedPorts: null`).
- Under the workbench overlay, from an empty volume: five fixtures queued → claimed under the capacity cap → three completed (chat, chat, voice with a real dual-channel `.wav` on the volume), the `retell` fixture genuinely dialled Retell and failed honestly on its placeholder key, the `phone` fixture was refused out loud and reported nothing.
- The recording's bytes were identical after `restart`, after `down` and recreation, and when read by a throwaway container mounting the volume.
- Six missing/broken-config cases each exited naming their variable.

## Test plan

- `uv run pytest` in `apps/simulator`: 203 passed, 1 skipped (env-gated live test), from 180 on the base branch.
- `uv run ruff check src tests` clean. Both compose files validate under `docker compose config -q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)