### PR TITLE
egma signs a machine in with a code, a browser, and a key only you can read

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -39,19 +39,23 @@ signs a machine in.
 
 ```
 url: https://app.egma.ai
-code: WDJB-MJHT
-approve_url: https://app.egma.ai/device?user_code=WDJB-MJHT
+code: WDJBMJHT
+approve_url: https://app.egma.ai/device?user_code=WDJBMJHT
 browser: opened
 waiting: for this code to be approved in a browser
 status: stored
 credentials: /home/you/.egma/credentials
 
-0 signed in   2 denied   3 the code ran out   4 egma did not answer
-130 stopped part way
+0 signed in   2 denied   3 the code ran out
+4 egma did not answer, or refused   130 stopped part way
 ```
 
 The key is written to `~/.egma/credentials`, readable only by you, together with
-the address it belongs to.
+the address it belongs to. Set `EGMA_HOME` to keep it somewhere else — it names
+the folder itself, not a home to put `.egma` inside.
+
+Already signed in? `egma login` says so and does nothing. Pass `--force` to sign
+in again and replace the key this machine holds.
 
 ### On a machine with no browser
 
@@ -112,6 +116,11 @@ egma login [options]     Sign this machine in. No questions, plain lines.
                        and the task taken as already agreed to.
   -h, --help           Print this.
   -v, --version        Print the version.
+
+Environment:
+  EGMA_URL             The egma to talk to, for a whole shell. Same as --url.
+  EGMA_HOME            The folder egma keeps this machine's key in.
+                       Default: ~/.egma
 ```
 
 `Ctrl-C` stops a run at any point. The agent, and anything the agent started,

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -17,11 +17,60 @@ is how CI runs it.
 
 ## What it does today
 
-This is the first working slice. `npx egma` starts the coding agent you already
-have, gives it one small task — read a file in this folder and say what it is —
-and shows you every action it takes while it works. That proves the path the
-rest of the product runs on: egma drives your own agent, on your own machine,
-with your own login.
+This is the first working slice. `npx egma` signs this machine in to egma, then
+starts the coding agent you already have, gives it one small task — read a file
+in this folder and say what it is — and shows you every action it takes while it
+works. That proves the path the rest of the product runs on: egma drives your
+own agent, on your own machine, with your own login.
+
+## Signing in
+
+egma shows a short code and opens your browser on a page that already has it in
+the field. You approve it there — signing up first if you are new — and egma
+collects a key of its own. No secret is ever typed into the terminal.
+
+```
+egma login
+```
+
+is the same thing with nobody watching: it asks nothing, prints one fact per
+line, and exits with a number you can branch on. That is how a coding agent
+signs a machine in.
+
+```
+url: https://app.egma.ai
+code: WDJB-MJHT
+approve_url: https://app.egma.ai/device?user_code=WDJB-MJHT
+browser: opened
+waiting: for this code to be approved in a browser
+status: stored
+credentials: /home/you/.egma/credentials
+
+0 signed in   2 denied   3 the code ran out   4 egma did not answer
+130 stopped part way
+```
+
+The key is written to `~/.egma/credentials`, readable only by you, together with
+the address it belongs to.
+
+### On a machine with no browser
+
+Over SSH, on a devbox, in a container: press `[c]` and egma asks your terminal
+to put the address on the clipboard of the machine your keyboard is on. Approve
+it in a browser over there, then paste it back — the whole address, the
+`?user_code=…` part of it, or just the code. All three work.
+
+If your terminal is too narrow to show the address whole, egma says how much
+wider it needs to be instead of drawing an address that breaks across two lines.
+
+### Your own instance
+
+```
+EGMA_URL=http://localhost:3000 npx egma
+```
+
+or `--url`. It is kept beside the key after the first login, so later commands
+find it without being told again.
 
 ## How it reaches your coding agent
 
@@ -48,11 +97,17 @@ still needs.
 ## Options
 
 ```
-egma [options]
+egma [options]           The wizard.
+egma login [options]     Sign this machine in. No questions, plain lines.
 
   --coding-agent <id>  Which coding agent to drive, named as the agent
                        registry names it. Default: claude-acp
   --cwd <path>         The folder to work in. Default: this folder.
+  --url <address>      The egma to talk to, for a self-hosted one. Kept
+                       after the first login, so it is set once. EGMA_URL
+                       does the same for a whole shell.
+  --force              With login: sign in again even when this machine
+                       already holds a key.
   --headless           Run with no terminal and no keystroke: plain lines,
                        and the task taken as already agreed to.
   -h, --help           Print this.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "smoke": "node smoke/real-claude-code.ts && node smoke/real-claude-code-fence.ts"
+    "smoke": "node smoke/real-claude-code.ts && node smoke/real-claude-code-fence.ts",
+    "smoke:platform": "node smoke/real-platform-login.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",

--- a/apps/cli/smoke/real-platform-login.ts
+++ b/apps/cli/smoke/real-platform-login.ts
@@ -1,0 +1,350 @@
+/**
+ * The smoke check: login against a whole real egma, approved in a real browser.
+ *
+ * Nothing here is a fixture. A real Postgres, a real ClickHouse, the real API,
+ * the real web application with its real pages, a real Chrome, and the built
+ * `egma` command in a real terminal. What it proves is the one thing an offline
+ * check cannot: that the address egma shows leads to a page that exists, that a
+ * person can sign up and approve there, and that the key which lands on disk
+ * afterwards opens a door on that instance.
+ *
+ * It runs twice over, because there are two ways in and both have to work: the
+ * wizard, driven through a pseudo-terminal, and `egma login` with nobody
+ * watching.
+ *
+ * Every run uses a throwaway egma folder of its own. The credentials of whoever
+ * runs this are never read and never written, and the check says so at the end.
+ *
+ * Run it with: node apps/cli/smoke/real-platform-login.ts
+ * It needs the compose Postgres and ClickHouse already up, and a Chrome.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import type { Browser, Page } from "playwright-core";
+
+import { openBrowser } from "../../api/test/support/browser.ts";
+import { startInstance, type Instance } from "../../api/test/support/instance.ts";
+import { runInTerminal } from "../test/support/pty.ts";
+
+const run = promisify(execFile);
+
+const CLI_ENTRY = fileURLToPath(new URL("../dist/bin.js", import.meta.url));
+
+const MANIFEST = `${JSON.stringify(
+  { name: "egma-smoke-repo", version: "1.0.0" },
+  null,
+  2,
+)}\n`;
+
+const FAKE_AGENT = fileURLToPath(new URL("../test/support/fake-agent.ts", import.meta.url));
+
+/** A browser egma must not open: this check drives its own. */
+const NO_BROWSER = "/usr/bin/true";
+
+const PASSWORD = "a-long-enough-password";
+
+// The API writes a line per request, and this check makes a great many.
+process.env.LOG_LEVEL ??= "silent";
+
+const problems: string[] = [];
+
+function say(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function check(condition: boolean, what: string): void {
+  say(`${condition ? "  ok  " : "FAILED"}  ${what}`);
+  if (!condition) problems.push(what);
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs: number,
+  what: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (condition()) return;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+type Home = { readonly folder: string; readonly credentials: string };
+
+async function throwawayHome(label: string): Promise<Home> {
+  const folder = await mkdtemp(path.join(tmpdir(), `egma-smoke-${label}-`));
+  return { folder, credentials: path.join(folder, "credentials") };
+}
+
+function envFor(home: Home): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, EGMA_HOME: home.folder, BROWSER: NO_BROWSER };
+  delete env.EGMA_URL;
+  return env;
+}
+
+/** What is on disk after a login, and what the file is readable by. */
+async function heldIn(home: Home): Promise<{ url: string; key: string; mode: string }> {
+  const held = JSON.parse(await readFile(home.credentials, "utf8")) as {
+    url: string;
+    key: string;
+  };
+  const mode = ((await stat(home.credentials)).mode & 0o777).toString(8);
+  return { ...held, mode };
+}
+
+/** The signup that happens inside the approval page, for a brand-new account. */
+async function signUpAndApprove(page: Page, approveUrl: string): Promise<void> {
+  await page.goto(approveUrl);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/signup\?next=/u);
+
+  await page.fill("#email", "ada@acme.example");
+  await page.fill("#password", PASSWORD);
+  await page.fill("#organizationName", "Acme");
+  await page.fill("#projectName", "Default");
+  await page.click('button[type="submit"]');
+
+  await page.waitForURL(/\/device\/approve\?user_code=/u);
+  await page.getByRole("button", { name: "Approve" }).click();
+  await page.waitForURL(/\/device\/success/u);
+}
+
+/** The second time round, when the browser already holds the sign-in. */
+async function approveOnly(page: Page, approveUrl: string): Promise<void> {
+  await page.goto(approveUrl);
+  // The address lands on the page that claims the code; it is only after that
+  // that there is anything to approve.
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/device\/approve\?user_code=/u);
+  await page.getByRole("button", { name: "Approve" }).click();
+  await page.waitForURL(/\/device\/success/u);
+}
+
+/**
+ * The words a terminal never says.
+ *
+ * What egma sets up for a brand-new account is set up in the browser page and
+ * named nowhere out here. This is that rule, held against what really reached a
+ * screen.
+ */
+function saysNothingAboutTenancy(shown: string, where: string): void {
+  for (const banned of ["organization", "organisation", "project", "tenant"]) {
+    check(!new RegExp(`\\b${banned}`, "iu").test(shown), `${where} never says "${banned}"`);
+  }
+}
+
+/** Whether a key opens a door on this instance. */
+async function keyWorks(origin: string, key: string): Promise<boolean> {
+  const used = await fetch(`${origin}/api/keys`, {
+    headers: { authorization: `Bearer ${key}` },
+  });
+  return used.status === 200;
+}
+
+/* ── the wizard, in a real terminal ──────────────────────────────────── */
+
+async function theWizard(instance: Instance, page: Page): Promise<void> {
+  say("");
+  say("── the wizard, driven through a real terminal ────────────");
+
+  const home = await throwawayHome("wizard");
+  const repo = await mkdtemp(path.join(tmpdir(), "egma-smoke-repo-"));
+  await writeFile(path.join(repo, "package.json"), MANIFEST, "utf8");
+
+  // The coding agent here is the scripted one: what is being checked is login
+  // against a real instance, and a real agent would only add minutes to it.
+  const script = path.join(repo, "agent-script.json");
+  await writeFile(
+    script,
+    JSON.stringify({
+      steps: [
+        { kind: "say", text: "It is a package manifest." },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    }),
+    "utf8",
+  );
+
+  const terminal = runInTerminal({
+    command: process.execPath,
+    args: [
+      CLI_ENTRY,
+      "--cwd",
+      repo,
+      "--url",
+      instance.origin,
+      "--",
+      process.execPath,
+      FAKE_AGENT,
+      script,
+    ],
+    cwd: repo,
+    env: envFor(home),
+    cols: 120,
+  });
+
+  try {
+    await waitFor(() => terminal.screen().includes("[enter] begin"), 60_000, "the intro");
+    terminal.write("\r");
+
+    await waitFor(() => terminal.screen().includes("Code:"), 60_000, "the code");
+    const screen = terminal.screen();
+    say("");
+    say(screen);
+    say("");
+
+    const code = /Code: ([0-9A-Z-]+)/u.exec(screen)?.[1] ?? "";
+    const approveUrl =
+      screen
+        .split("\n")
+        .map((line) => line.replaceAll("│", "").trim())
+        .find((line) => line.startsWith(instance.origin)) ?? "";
+
+    check(code !== "", "the wizard showed a code");
+    saysNothingAboutTenancy(screen, "the login screen");
+    check(
+      approveUrl.startsWith(instance.origin) && approveUrl.includes("user_code="),
+      "the address is on a line of its own and points at this instance",
+    );
+
+    await signUpAndApprove(page, approveUrl);
+
+    const exited = await Promise.race([
+      terminal.exited,
+      new Promise<number>((_, reject) =>
+        setTimeout(() => reject(new Error("the wizard never finished")), 120_000),
+      ),
+    ]);
+
+    check(exited === 0, `the wizard exited 0 (it exited ${exited})`);
+    say("");
+    say(`scrollback: ${terminal.scrollback().trim()}`);
+
+    const held = await heldIn(home);
+    check(held.url === instance.origin, "the key is stored against this instance");
+    check(held.key.startsWith("egma_sk_"), "the key is a real minted key");
+    check(held.mode === "600", `the credentials file is 0600 (it is 0${held.mode})`);
+    check(await keyWorks(instance.origin, held.key), "the stored key works on a real request");
+  } finally {
+    terminal.kill();
+    await rm(home.folder, { recursive: true, force: true });
+    await rm(repo, { recursive: true, force: true });
+  }
+}
+
+/* ── egma login, with nobody watching ────────────────────────────────── */
+
+async function theVerb(instance: Instance, page: Page): Promise<void> {
+  say("");
+  say("── egma login, headless ──────────────────────────────────");
+
+  const home = await throwawayHome("verb");
+
+  try {
+    const child = execFile(process.execPath, [CLI_ENTRY, "login", "--url", instance.origin], {
+      env: envFor(home),
+    });
+    let stdout = "";
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    await waitFor(() => stdout.includes("approve_url: "), 60_000, "the address to approve at");
+    const approveUrl = /approve_url: (\S+)/u.exec(stdout)?.[1] ?? "";
+    check(approveUrl.startsWith(instance.origin), "egma login printed an address on this instance");
+
+    // Ada's browser still holds the sign-in from the wizard's approval, which
+    // is the whole reason the results page opens signed in later.
+    await approveOnly(page, approveUrl);
+
+    const exited = await new Promise<number>((resolve) => {
+      child.on("close", (value) => resolve(value ?? 0));
+    });
+
+    say("");
+    say(stdout.trimEnd());
+    say("");
+
+    check(exited === 0, `egma login exited 0 (it exited ${exited})`);
+    check(stdout.includes("status: stored"), "egma login said it stored a key");
+    saysNothingAboutTenancy(stdout, "egma login");
+
+    const held = await heldIn(home);
+    check(held.mode === "600", `the credentials file is 0600 (it is 0${held.mode})`);
+    check(await keyWorks(instance.origin, held.key), "the stored key works on a real request");
+
+    // The second run needs nothing said at all: the address rode along with the
+    // key, and a key already held is not minted twice.
+    const again = await run(process.execPath, [CLI_ENTRY, "login"], { env: envFor(home) });
+    check(
+      again.stdout.includes("status: already-stored") &&
+        again.stdout.includes(`url: ${instance.origin}`),
+      "a second run found the instance and the key with nothing said",
+    );
+  } finally {
+    await rm(home.folder, { recursive: true, force: true });
+  }
+}
+
+/* ── the check itself ────────────────────────────────────────────────── */
+
+async function main(): Promise<void> {
+  const real = path.join(process.env.HOME ?? "", ".egma", "credentials");
+  const before = await stat(real).then(
+    (found) => `${found.mtimeMs}`,
+    () => "absent",
+  );
+
+  say("Starting a whole egma: Postgres, ClickHouse, the API and the pages.");
+  let instance: Instance | undefined;
+  let browser: Browser | undefined;
+
+  try {
+    instance = await startInstance("cli-login");
+    say(`Instance: ${instance.origin}`);
+
+    browser = await openBrowser();
+    const page = await browser.newPage();
+    page.setDefaultTimeout(60_000);
+
+    await theWizard(instance, page);
+    await theVerb(instance, page);
+
+    const after = await stat(real).then(
+      (found) => `${found.mtimeMs}`,
+      () => "absent",
+    );
+    say("");
+    check(before === after, "nothing touched the credentials of whoever ran this");
+  } finally {
+    await browser?.close();
+    await instance?.close();
+  }
+
+  say("");
+  if (problems.length > 0) {
+    for (const problem of problems) say(`FAILED: ${problem}`);
+    process.exitCode = 1;
+    return;
+  }
+  say("PASSED: a real login, approved in a real browser, leaves a key that works.");
+}
+
+await main();
+
+// A pseudo-terminal can outlive the command that ran in it, and an open one
+// keeps Node running — so this leaves on its own answer once what it printed
+// has really gone out.
+await new Promise<void>((resolve) => {
+  process.stdout.write("", () => resolve());
+});
+process.exit(process.exitCode ?? 0);

--- a/apps/cli/smoke/real-platform-login.ts
+++ b/apps/cli/smoke/real-platform-login.ts
@@ -201,7 +201,7 @@ async function theWizard(instance: Instance, page: Page): Promise<void> {
     say(screen);
     say("");
 
-    const code = /Code: ([0-9A-Z-]+)/u.exec(screen)?.[1] ?? "";
+    const code = /Code: (\S+)/u.exec(screen)?.[1] ?? "";
     const approveUrl =
       screen
         .split("\n")

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,0 +1,118 @@
+/**
+ * `egma login`: the same flow the wizard runs, with nobody watching.
+ *
+ * It asks nothing. Nothing here reads standard input, so a coding agent can run
+ * it, read what it prints, and act on the answer without a person relaying
+ * anything. What it prints is one fact per line, `name: value`, in a shape that
+ * does not move: the code and the address while it waits, then what happened
+ * and where the key went.
+ *
+ * The exit code is the branch. A coding agent that reads nothing at all still
+ * knows whether it has a key, whether somebody said no, and whether the code
+ * simply ran out.
+ */
+
+import { openInBrowser } from "../platform/browser.ts";
+import {
+  credentialsFileIn,
+  readCredentials,
+  resolvePlatformUrl,
+} from "../platform/credentials.ts";
+import { logIn, type LoginOutcome } from "../platform/login.ts";
+
+/** What each ending means to whoever ran the command. */
+export const LOGIN_EXIT = {
+  /** A key is on disk for the egma that was asked for. */
+  stored: 0,
+  /** Somebody said no in the browser. */
+  denied: 2,
+  /** Nobody approved it before the code ran out. */
+  expired: 3,
+  /** egma did not answer, or refused. */
+  unreachable: 4,
+  /** Stopped part way through. */
+  interrupted: 130,
+} as const;
+
+export type LoginCommandOptions = {
+  /** `--url`, when one was given. */
+  readonly url: string | null;
+  /** Mint a key even when this machine already holds one. */
+  readonly force: boolean;
+  readonly env: NodeJS.ProcessEnv;
+  readonly signal: AbortSignal;
+  readonly out: (line: string) => void;
+  readonly fail: (line: string) => void;
+};
+
+function exitCodeFor(outcome: LoginOutcome): number {
+  switch (outcome.kind) {
+    case "stored":
+    case "already-stored":
+      return LOGIN_EXIT.stored;
+    case "denied":
+      return LOGIN_EXIT.denied;
+    case "expired":
+      return LOGIN_EXIT.expired;
+    case "interrupted":
+      return LOGIN_EXIT.interrupted;
+    case "unreachable":
+    case "refused":
+      return LOGIN_EXIT.unreachable;
+  }
+}
+
+export async function runLoginCommand(options: LoginCommandOptions): Promise<number> {
+  const credentialsFile = credentialsFileIn(options.env);
+  const stored = await readCredentials(credentialsFile);
+  const url = resolvePlatformUrl({
+    flag: options.url,
+    env: options.env.EGMA_URL,
+    stored: stored?.url ?? null,
+  });
+
+  options.out(`url: ${url}`);
+
+  const outcome = await logIn({
+    url,
+    credentialsFile,
+    force: options.force,
+    signal: options.signal,
+    onPrompt: (prompt) => {
+      options.out(`code: ${prompt.userCode}`);
+      options.out(`approve_url: ${prompt.url}`);
+      options.out(`browser: ${prompt.browserOpened ? "opened" : "not-opened"}`);
+      options.out("waiting: for this code to be approved in a browser");
+    },
+    say: (line) => options.out(`note: ${line}`),
+    openBrowser: (address) => openInBrowser(address, options.env),
+  });
+
+  switch (outcome.kind) {
+    case "stored":
+    case "already-stored":
+      options.out(`status: ${outcome.kind}`);
+      options.out(`credentials: ${credentialsFile}`);
+      break;
+    case "denied":
+      options.out("status: denied");
+      options.fail("The login was denied in the browser. Nothing was stored.");
+      break;
+    case "expired":
+      options.out("status: expired");
+      options.fail("Nobody approved the login before the code ran out. Run egma login again.");
+      break;
+    case "interrupted":
+      options.out("status: interrupted");
+      options.fail("The login was stopped before it finished. Nothing was stored.");
+      break;
+    case "unreachable":
+    case "refused":
+      options.out(`status: ${outcome.kind}`);
+      options.out(`reason: ${outcome.reason}`);
+      options.fail(outcome.reason);
+      break;
+  }
+
+  return exitCodeFor(outcome);
+}

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -13,12 +13,8 @@
  */
 
 import { openInBrowser } from "../platform/browser.ts";
-import {
-  credentialsFileIn,
-  readCredentials,
-  resolvePlatformUrl,
-} from "../platform/credentials.ts";
-import { logIn, type LoginOutcome } from "../platform/login.ts";
+import type { PlatformAccess } from "../platform/credentials.ts";
+import { logIn, loginLines, type LoginResult } from "../platform/login.ts";
 
 /** What each ending means to whoever ran the command. */
 export const LOGIN_EXIT = {
@@ -28,15 +24,22 @@ export const LOGIN_EXIT = {
   denied: 2,
   /** Nobody approved it before the code ran out. */
   expired: 3,
-  /** egma did not answer, or refused. */
+  /**
+   * egma did not answer, or answered and would not do it.
+   *
+   * One number for both, because both mean the same thing to whoever ran the
+   * command: nothing is going to come of asking this egma again the same way,
+   * and a person has to look. The `status:` line tells the two apart for
+   * anything that reads rather than branches.
+   */
   unreachable: 4,
   /** Stopped part way through. */
   interrupted: 130,
 } as const;
 
 export type LoginCommandOptions = {
-  /** `--url`, when one was given. */
-  readonly url: string | null;
+  /** Which egma, and where the key goes. Resolved once, by the caller. */
+  readonly access: PlatformAccess;
   /** Mint a key even when this machine already holds one. */
   readonly force: boolean;
   readonly env: NodeJS.ProcessEnv;
@@ -45,8 +48,8 @@ export type LoginCommandOptions = {
   readonly fail: (line: string) => void;
 };
 
-function exitCodeFor(outcome: LoginOutcome): number {
-  switch (outcome.kind) {
+function loginExitCode(result: LoginResult): number {
+  switch (result.kind) {
     case "stored":
     case "already-stored":
       return LOGIN_EXIT.stored;
@@ -63,35 +66,27 @@ function exitCodeFor(outcome: LoginOutcome): number {
 }
 
 export async function runLoginCommand(options: LoginCommandOptions): Promise<number> {
-  const credentialsFile = credentialsFileIn(options.env);
-  const stored = await readCredentials(credentialsFile);
-  const url = resolvePlatformUrl({
-    flag: options.url,
-    env: options.env.EGMA_URL,
-    stored: stored?.url ?? null,
-  });
+  const { url, credentialsFile } = options.access;
 
   options.out(`url: ${url}`);
 
-  const outcome = await logIn({
+  const result = await logIn({
     url,
     credentialsFile,
     force: options.force,
     signal: options.signal,
     onPrompt: (prompt) => {
-      options.out(`code: ${prompt.userCode}`);
-      options.out(`approve_url: ${prompt.url}`);
-      options.out(`browser: ${prompt.browserOpened ? "opened" : "not-opened"}`);
-      options.out("waiting: for this code to be approved in a browser");
+      for (const line of loginLines(prompt)) options.out(line);
     },
     say: (line) => options.out(`note: ${line}`),
-    openBrowser: (address) => openInBrowser(address, options.env),
+    openBrowser: (address) =>
+      openInBrowser(address, { instanceUrl: url, env: options.env }),
   });
 
-  switch (outcome.kind) {
+  switch (result.kind) {
     case "stored":
     case "already-stored":
-      options.out(`status: ${outcome.kind}`);
+      options.out(`status: ${result.kind}`);
       options.out(`credentials: ${credentialsFile}`);
       break;
     case "denied":
@@ -108,11 +103,11 @@ export async function runLoginCommand(options: LoginCommandOptions): Promise<num
       break;
     case "unreachable":
     case "refused":
-      options.out(`status: ${outcome.kind}`);
-      options.out(`reason: ${outcome.reason}`);
-      options.fail(outcome.reason);
+      options.out(`status: ${result.kind}`);
+      options.out(`reason: ${result.reason}`);
+      options.fail(result.reason);
       break;
   }
 
-  return exitCodeFor(outcome);
+  return loginExitCode(result);
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -17,19 +17,37 @@ import {
   launchForId,
   type DrivenAgentLaunch,
 } from "./acp/registry.ts";
+import { runLoginCommand } from "./commands/login.ts";
+import { credentialsFileIn, readCredentials, resolvePlatformUrl } from "./platform/credentials.ts";
 import { HeadlessUI } from "./ui/headless-ui.ts";
 import { startTui } from "./ui/tui/start-tui.ts";
 import { buildExitLine, type ExitReport } from "./wizard/exit-line.ts";
+import type { PlatformAccess } from "./wizard/login-step.ts";
 import type { StopReason } from "./wizard/stop.ts";
 import { walk } from "./wizard/walk.ts";
+
+/**
+ * The verbs. A bare `egma` runs the wizard; naming one runs it headlessly,
+ * because a verb is what a coding agent types and a coding agent has no
+ * keystroke to give.
+ */
+export const VERBS = ["login"] as const;
+
+export type Verb = (typeof VERBS)[number];
 
 export type Invocation = {
   readonly help: boolean;
   readonly version: boolean;
+  /** The verb that was named, or `null` for the wizard. */
+  readonly verb: Verb | null;
   /** The developer has said, in the command, to run with nobody watching. */
   readonly headless: boolean;
   readonly drivenAgentId: string;
   readonly cwd: string | null;
+  /** `--url`: which egma to talk to, when it is not egma's own. */
+  readonly url: string | null;
+  /** `--force`: do the work again even though it has been done. */
+  readonly force: boolean;
   /**
    * A test seam, not product surface: `--file` and `-- <command>` let a test
    * pin the file and start a scripted agent in place of a real one. Neither is
@@ -41,12 +59,19 @@ export type Invocation = {
   readonly unknown: readonly string[];
 };
 
+function isVerb(argument: string): argument is Verb {
+  return (VERBS as readonly string[]).includes(argument);
+}
+
 export function parseArgs(argv: readonly string[]): Invocation {
   let help = false;
   let version = false;
+  let verb: Verb | null = null;
   let headless = false;
   let drivenAgentId = DEFAULT_DRIVEN_AGENT_ID;
   let cwd: string | null = null;
+  let url: string | null = null;
+  let force = false;
   let file: string | null = null;
   let drivenAgentCommand: string[] = [];
   const unknown: string[] = [];
@@ -62,11 +87,26 @@ export function parseArgs(argv: readonly string[]): Invocation {
     else if (argument === "--headless") headless = true;
     else if (argument === "--coding-agent") drivenAgentId = argv[(index += 1)] ?? drivenAgentId;
     else if (argument === "--cwd") cwd = argv[(index += 1)] ?? null;
+    else if (argument === "--url") url = argv[(index += 1)] ?? null;
+    else if (argument === "--force") force = true;
     else if (argument === "--file") file = argv[(index += 1)] ?? null;
+    else if (verb === null && isVerb(argument)) verb = argument;
     else unknown.push(argument);
   }
 
-  return { help, version, headless, drivenAgentId, cwd, file, drivenAgentCommand, unknown };
+  return {
+    help,
+    version,
+    verb,
+    headless,
+    drivenAgentId,
+    cwd,
+    url,
+    force,
+    file,
+    drivenAgentCommand,
+    unknown,
+  };
 }
 
 export function helpText(): string {
@@ -74,16 +114,29 @@ export function helpText(): string {
     "egma — walk from a voice agent to graded results.",
     "",
     "Usage:",
-    "  egma [options]",
+    "  egma [options]           The wizard.",
+    "  egma login [options]     Sign this machine in. No questions, plain lines.",
     "",
     "Options:",
     "  --coding-agent <id>  Which coding agent to drive, named as the agent",
     `                       registry names it. Default: ${DEFAULT_DRIVEN_AGENT_ID}`,
     "  --cwd <path>         The folder to work in. Default: this folder.",
+    "  --url <address>      The egma to talk to, for a self-hosted one. Kept",
+    "                       after the first login, so it is set once. EGMA_URL",
+    "                       does the same for a whole shell.",
+    "  --force              With login: sign in again even when this machine",
+    "                       already holds a key.",
     "  --headless           Run with no terminal and no keystroke: plain lines,",
     "                       and the task taken as already agreed to.",
     "  -h, --help           Print this.",
     "  -v, --version        Print the version.",
+    "",
+    "What egma login prints, one fact per line:",
+    "  url, code, approve_url, browser, waiting, status, credentials",
+    "",
+    "What egma login answers with:",
+    "  0 signed in   2 denied   3 the code ran out   4 egma did not answer",
+    "  130 stopped part way",
     "",
     `The agent registry was mirrored on ${REGISTRY_SNAPSHOT_MIRRORED_ON}.`,
   ].join("\n");
@@ -127,10 +180,30 @@ function exitCodeFor(report: ExitReport): number {
   }
 }
 
+/**
+ * Which egma this run signs in to, and where the key it gets is kept.
+ *
+ * Resolved once, here, so the wizard and every verb read the same answer from
+ * the same three places in the same order.
+ */
+async function platformFor(invocation: Invocation): Promise<PlatformAccess> {
+  const credentialsFile = credentialsFileIn(process.env);
+  const stored = await readCredentials(credentialsFile);
+  return {
+    url: resolvePlatformUrl({
+      flag: invocation.url,
+      env: process.env.EGMA_URL,
+      stored: stored?.url ?? null,
+    }),
+    credentialsFile,
+  };
+}
+
 async function runHeadless(
   launch: DrivenAgentLaunch,
   cwd: string,
   file: string | null,
+  platform: PlatformAccess,
 ): Promise<number> {
   const controller = new AbortController();
   const stop = (reason: StopReason): void => controller.abort(reason);
@@ -145,6 +218,7 @@ async function runHeadless(
       launch,
       cwd,
       signal: controller.signal,
+      platform,
       ...(file === null ? {} : { file }),
     });
     process.stdout.write(`${buildExitLine(report)}\n`);
@@ -159,6 +233,7 @@ async function runWizard(
   launch: DrivenAgentLaunch,
   cwd: string,
   file: string | null,
+  platform: PlatformAccess,
 ): Promise<number> {
   const controller = new AbortController();
   const tui = startTui({ stop: (reason) => controller.abort(reason) });
@@ -175,6 +250,7 @@ async function runWizard(
       launch,
       cwd,
       signal: controller.signal,
+      platform,
       ...(file === null ? {} : { file }),
     });
     tui.close(report);
@@ -183,6 +259,28 @@ async function runWizard(
     const reason = error instanceof Error ? error.message : String(error);
     tui.close({ kind: "failed", reason });
     return 1;
+  } finally {
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+  }
+}
+
+/** The login verb: no terminal needed, no keystroke taken, no question asked. */
+async function runLogin(invocation: Invocation): Promise<number> {
+  const controller = new AbortController();
+  const onSignal = (): void => controller.abort("interrupt");
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  try {
+    return await runLoginCommand({
+      url: invocation.url,
+      force: invocation.force,
+      env: process.env,
+      signal: controller.signal,
+      out: (line) => process.stdout.write(`${line}\n`),
+      fail: (line) => process.stderr.write(`${line}\n`),
+    });
   } finally {
     process.off("SIGINT", onSignal);
     process.off("SIGTERM", onSignal);
@@ -205,6 +303,13 @@ export async function main(argv: readonly string[]): Promise<void> {
       `egma does not know the option ${invocation.unknown[0]}. Run egma --help to see the ones it does.\n`,
     );
     process.exitCode = 1;
+    return;
+  }
+
+  // A verb needs no terminal and takes no keystroke: it drives no coding agent,
+  // so there is nothing for a keystroke to agree to.
+  if (invocation.verb === "login") {
+    process.exitCode = await runLogin(invocation);
     return;
   }
 
@@ -233,7 +338,9 @@ export async function main(argv: readonly string[]): Promise<void> {
     throw error;
   }
 
+  const platform = await platformFor(invocation);
+
   process.exitCode = invocation.headless
-    ? await runHeadless(launch, cwd, invocation.file)
-    : await runWizard(launch, cwd, invocation.file);
+    ? await runHeadless(launch, cwd, invocation.file, platform)
+    : await runWizard(launch, cwd, invocation.file, platform);
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -18,7 +18,7 @@ import {
   type DrivenAgentLaunch,
 } from "./acp/registry.ts";
 import { runLoginCommand } from "./commands/login.ts";
-import { credentialsFileIn, readCredentials, resolvePlatformUrl } from "./platform/credentials.ts";
+import { resolvePlatformAccess, UnusableUrlError } from "./platform/credentials.ts";
 import { HeadlessUI } from "./ui/headless-ui.ts";
 import { startTui } from "./ui/tui/start-tui.ts";
 import { buildExitLine, type ExitReport } from "./wizard/exit-line.ts";
@@ -131,12 +131,17 @@ export function helpText(): string {
     "  -h, --help           Print this.",
     "  -v, --version        Print the version.",
     "",
+    "Environment:",
+    "  EGMA_URL             The egma to talk to, for a whole shell. Same as --url.",
+    "  EGMA_HOME            The folder egma keeps this machine's key in.",
+    "                       Default: ~/.egma",
+    "",
     "What egma login prints, one fact per line:",
     "  url, code, approve_url, browser, waiting, status, credentials",
     "",
     "What egma login answers with:",
-    "  0 signed in   2 denied   3 the code ran out   4 egma did not answer",
-    "  130 stopped part way",
+    "  0 signed in   2 denied   3 the code ran out",
+    "  4 egma did not answer, or refused   130 stopped part way",
     "",
     `The agent registry was mirrored on ${REGISTRY_SNAPSHOT_MIRRORED_ON}.`,
   ].join("\n");
@@ -168,7 +173,8 @@ function launchFrom(invocation: Invocation): DrivenAgentLaunch {
   return launchForId(invocation.drivenAgentId);
 }
 
-function exitCodeFor(report: ExitReport): number {
+/** What the whole walk answers with, which is not what `egma login` answers. */
+function walkExitCode(report: ExitReport): number {
   switch (report.kind) {
     case "task-done":
     case "quit":
@@ -178,25 +184,6 @@ function exitCodeFor(report: ExitReport): number {
     case "failed":
       return 1;
   }
-}
-
-/**
- * Which egma this run signs in to, and where the key it gets is kept.
- *
- * Resolved once, here, so the wizard and every verb read the same answer from
- * the same three places in the same order.
- */
-async function platformFor(invocation: Invocation): Promise<PlatformAccess> {
-  const credentialsFile = credentialsFileIn(process.env);
-  const stored = await readCredentials(credentialsFile);
-  return {
-    url: resolvePlatformUrl({
-      flag: invocation.url,
-      env: process.env.EGMA_URL,
-      stored: stored?.url ?? null,
-    }),
-    credentialsFile,
-  };
 }
 
 async function runHeadless(
@@ -222,7 +209,7 @@ async function runHeadless(
       ...(file === null ? {} : { file }),
     });
     process.stdout.write(`${buildExitLine(report)}\n`);
-    return exitCodeFor(report);
+    return walkExitCode(report);
   } finally {
     process.off("SIGINT", onSignal);
     process.off("SIGTERM", onSignal);
@@ -254,7 +241,7 @@ async function runWizard(
       ...(file === null ? {} : { file }),
     });
     tui.close(report);
-    return exitCodeFor(report);
+    return walkExitCode(report);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     tui.close({ kind: "failed", reason });
@@ -266,7 +253,7 @@ async function runWizard(
 }
 
 /** The login verb: no terminal needed, no keystroke taken, no question asked. */
-async function runLogin(invocation: Invocation): Promise<number> {
+async function runLogin(invocation: Invocation, access: PlatformAccess): Promise<number> {
   const controller = new AbortController();
   const onSignal = (): void => controller.abort("interrupt");
   process.on("SIGINT", onSignal);
@@ -274,7 +261,7 @@ async function runLogin(invocation: Invocation): Promise<number> {
 
   try {
     return await runLoginCommand({
-      url: invocation.url,
+      access,
       force: invocation.force,
       env: process.env,
       signal: controller.signal,
@@ -306,10 +293,25 @@ export async function main(argv: readonly string[]): Promise<void> {
     return;
   }
 
+  // Which egma, resolved once for every path below, and refused here when the
+  // address a developer named is not one. A bad address is turned away before
+  // anything is started on it rather than after.
+  let access: PlatformAccess;
+  try {
+    access = await resolvePlatformAccess({ env: process.env, flag: invocation.url });
+  } catch (error) {
+    if (error instanceof UnusableUrlError) {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+
   // A verb needs no terminal and takes no keystroke: it drives no coding agent,
   // so there is nothing for a keystroke to agree to.
   if (invocation.verb === "login") {
-    process.exitCode = await runLogin(invocation);
+    process.exitCode = await runLogin(invocation, access);
     return;
   }
 
@@ -338,9 +340,7 @@ export async function main(argv: readonly string[]): Promise<void> {
     throw error;
   }
 
-  const platform = await platformFor(invocation);
-
   process.exitCode = invocation.headless
-    ? await runHeadless(launch, cwd, invocation.file, platform)
-    : await runWizard(launch, cwd, invocation.file, platform);
+    ? await runHeadless(launch, cwd, invocation.file, access)
+    : await runWizard(launch, cwd, invocation.file, access);
 }

--- a/apps/cli/src/platform/address.ts
+++ b/apps/cli/src/platform/address.ts
@@ -1,0 +1,56 @@
+/**
+ * Which addresses egma will act on, and which it will only ever print.
+ *
+ * Two addresses arrive from outside and neither can be believed. The one a
+ * developer types (`--url`, `EGMA_URL`) decides what egma talks to. The one the
+ * instance sends back (`verification_uri_complete`) is handed to a browser, and
+ * handing a string to a browser opener is handing it to a program: on Windows
+ * the opener is `cmd /c start`, and a command interpreter reads `&` and `|` as
+ * syntax rather than as characters in an address.
+ *
+ * So an address is checked before it reaches anything that starts a program.
+ * What fails the check is not opened — it is still shown on the screen, because
+ * a developer who can read it can still approve it somewhere, and showing it is
+ * the one thing that cannot start anything.
+ */
+
+/** True when this is a whole address egma can talk to: http or https, no more. */
+export function isWebAddress(candidate: string): boolean {
+  const parsed = parse(candidate);
+  return parsed !== null;
+}
+
+/**
+ * Characters an address does not need and a command interpreter reads as
+ * syntax. Whitespace and control characters are in here for the same reason:
+ * one argument stops being one argument the moment it holds a space.
+ */
+const SYNTAX = /[\p{Cc}\p{Cf}\s"'`$&()<>^|;\\]/u;
+
+/**
+ * True when egma may start a browser on this address.
+ *
+ * Three questions, and all three have to answer yes. Is it an address at all,
+ * and an http one — because `open` and `xdg-open` will launch a `javascript:`
+ * or a `file:` as happily as a web page. Is every character in it a character —
+ * because of the Windows opener above. And is it on the egma this login is
+ * against — because an instance that answers with somebody else's address is
+ * sending the developer somewhere egma never chose.
+ */
+export function isOpenable(address: string, instanceUrl: string): boolean {
+  const parsed = parse(address);
+  const instance = parse(instanceUrl);
+  if (parsed === null || instance === null) return false;
+  if (SYNTAX.test(address)) return false;
+  return parsed.origin === instance.origin;
+}
+
+function parse(candidate: string): URL | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate.trim());
+  } catch {
+    return null;
+  }
+  return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed : null;
+}

--- a/apps/cli/src/platform/browser.ts
+++ b/apps/cli/src/platform/browser.ts
@@ -2,7 +2,11 @@
  * Opening the developer's browser on the address they have to approve at.
  *
  * The address is handed to the opener as one argument and never through a
- * shell, so nothing in it can be read as a command.
+ * shell — but on Windows the opener *is* a shell, because `start` is a builtin
+ * of one, and it reads what it is given a second time. So the address is
+ * checked before it is passed to anything: it has to be an http address, on the
+ * egma this login is against, made of characters no command interpreter reads
+ * as syntax. Anything else is not opened at all.
  *
  * `BROWSER` is honoured first. It is the variable a developer already sets when
  * the machine's idea of a browser is wrong — a devbox, a container, a desktop
@@ -16,6 +20,8 @@
 
 import { spawn } from "node:child_process";
 import process from "node:process";
+
+import { isOpenable } from "./address.ts";
 
 /** How a browser is started, per platform, when nothing has been set. */
 function opener(platform: string): { command: string; args: readonly string[] } {
@@ -31,17 +37,30 @@ function opener(platform: string): { command: string; args: readonly string[] } 
   }
 }
 
+export type BrowserOptions = {
+  /**
+   * The egma this login is against. An address on any other origin is shown
+   * and never opened, because egma chose the instance and the instance does
+   * not get to choose where the developer is sent.
+   */
+  readonly instanceUrl: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly platform?: string;
+};
+
 /** True when a browser was started. False when there was nothing to start. */
 export async function openInBrowser(
   url: string,
-  env: NodeJS.ProcessEnv = process.env,
-  platform: string = process.platform,
+  options: BrowserOptions,
 ): Promise<boolean> {
+  if (!isOpenable(url, options.instanceUrl)) return false;
+
+  const env = options.env ?? process.env;
   const chosen = env.BROWSER?.trim();
   const { command, args } =
     chosen !== undefined && chosen !== ""
       ? { command: chosen, args: [] as readonly string[] }
-      : opener(platform);
+      : opener(options.platform ?? process.platform);
 
   return new Promise<boolean>((resolve) => {
     let settled = false;

--- a/apps/cli/src/platform/browser.ts
+++ b/apps/cli/src/platform/browser.ts
@@ -1,0 +1,68 @@
+/**
+ * Opening the developer's browser on the address they have to approve at.
+ *
+ * The address is handed to the opener as one argument and never through a
+ * shell, so nothing in it can be read as a command.
+ *
+ * `BROWSER` is honoured first. It is the variable a developer already sets when
+ * the machine's idea of a browser is wrong — a devbox, a container, a desktop
+ * with two of them — and honouring it costs nothing and is the difference
+ * between a working login and a shrug.
+ *
+ * Failing to open a browser is not a failure of login. The address is on the
+ * screen either way, and the whole point of the copy key and the paste-back is
+ * that a machine with no browser still gets through.
+ */
+
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+/** How a browser is started, per platform, when nothing has been set. */
+function opener(platform: string): { command: string; args: readonly string[] } {
+  switch (platform) {
+    case "darwin":
+      return { command: "open", args: [] };
+    case "win32":
+      // `start` is a shell builtin, so the shell is the command; the empty
+      // string is the window title `start` takes before the address.
+      return { command: "cmd", args: ["/c", "start", ""] };
+    default:
+      return { command: "xdg-open", args: [] };
+  }
+}
+
+/** True when a browser was started. False when there was nothing to start. */
+export async function openInBrowser(
+  url: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: string = process.platform,
+): Promise<boolean> {
+  const chosen = env.BROWSER?.trim();
+  const { command, args } =
+    chosen !== undefined && chosen !== ""
+      ? { command: chosen, args: [] as readonly string[] }
+      : opener(platform);
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const settle = (opened: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve(opened);
+    };
+
+    try {
+      const child = spawn(command, [...args, url], {
+        stdio: "ignore",
+        detached: true,
+      });
+      child.on("error", () => settle(false));
+      child.on("spawn", () => settle(true));
+      // The browser outlives the wizard, and a browser still running must never
+      // be what keeps the terminal from closing.
+      child.unref();
+    } catch {
+      settle(false);
+    }
+  });
+}

--- a/apps/cli/src/platform/clipboard.ts
+++ b/apps/cli/src/platform/clipboard.ts
@@ -1,0 +1,61 @@
+/**
+ * Putting the approval address on the clipboard, including over SSH.
+ *
+ * The terminal is asked to do it, with the escape sequence terminals answer for
+ * exactly this — because the machine egma is running on is often not the
+ * machine the keyboard is on, and a clipboard tool on a devbox copies to a
+ * clipboard nobody can paste from. The sequence travels the SSH connection and
+ * lands on the laptop's own clipboard, which is where the browser is.
+ *
+ * The local clipboard tool is tried as well, best effort, for the terminals
+ * that answer nothing. Whichever works, the developer never sees the
+ * difference; and if neither does, the address is still on the screen.
+ */
+
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+/** What a terminal is asked with. `c` is the clipboard everybody pastes from. */
+export function copySequence(url: string): string {
+  return `\u001b]52;c;${Buffer.from(url, "utf8").toString("base64")}\u0007`;
+}
+
+function localTool(platform: string): { command: string; args: readonly string[] } | null {
+  switch (platform) {
+    case "darwin":
+      return { command: "pbcopy", args: [] };
+    case "win32":
+      return { command: "clip", args: [] };
+    case "linux":
+      return { command: "xclip", args: ["-selection", "clipboard"] };
+    default:
+      return null;
+  }
+}
+
+export type CopyOptions = {
+  /** Where the escape sequence goes. The terminal egma is drawing on. */
+  readonly write: (sequence: string) => void;
+  readonly platform?: string;
+};
+
+/** Copies the address, both ways at once. Neither way is waited on. */
+export function copyLink(url: string, options: CopyOptions): void {
+  options.write(copySequence(url));
+
+  const tool = localTool(options.platform ?? process.platform);
+  if (tool === null) return;
+
+  try {
+    const child = spawn(tool.command, [...tool.args], {
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    // Nothing here is worth interrupting a login for: the sequence above has
+    // already gone, and a machine without the tool is the ordinary case.
+    child.on("error", () => undefined);
+    child.stdin.on("error", () => undefined);
+    child.stdin.end(url, "utf8");
+  } catch {
+    // Same.
+  }
+}

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -1,0 +1,133 @@
+/**
+ * The key egma mints for this machine, and which egma it belongs to.
+ *
+ * One flat file in the developer's home folder, readable by nobody else. It
+ * holds two facts, and they are kept together because they always travel
+ * together: a key minted against one instance means nothing against another, so
+ * remembering the key without remembering the address would leave a developer
+ * re-typing the address on every command afterwards.
+ *
+ * The folder is resolved rather than assumed. That is what lets a test and a
+ * check against a real instance each run a whole login without ever reading or
+ * writing the credentials of the person running them.
+ */
+
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+/** The egma a command talks to when nothing says otherwise. */
+export const DEFAULT_PLATFORM_URL = "https://app.egma.ai";
+
+/** Owner only, on the file and on the folder that holds it. */
+const FILE_MODE = 0o600;
+const FOLDER_MODE = 0o700;
+
+export type Credentials = {
+  /** The egma that minted this key. */
+  readonly url: string;
+  /** The key itself, handed over once at the end of login and kept here. */
+  readonly key: string;
+};
+
+/**
+ * The folder egma keeps this machine's credentials in.
+ *
+ * `EGMA_HOME` names the folder outright rather than naming a home to put
+ * `.egma` inside, so a caller that has to be certain — a test, a check against a
+ * real instance — can say exactly one path and be sure nothing widens it.
+ */
+export function egmaFolderIn(env: NodeJS.ProcessEnv): string {
+  const named = env.EGMA_HOME?.trim();
+  if (named !== undefined && named !== "") return named;
+
+  const home = env.HOME?.trim() ?? env.USERPROFILE?.trim() ?? "";
+  return path.join(home === "" ? homedir() : home, ".egma");
+}
+
+export function credentialsFileIn(env: NodeJS.ProcessEnv): string {
+  return path.join(egmaFolderIn(env), "credentials");
+}
+
+/**
+ * An address in the one shape everything else compares against.
+ *
+ * A trailing slash and a stored address that differs from a typed one only by
+ * that slash are the same instance, and treating them as two would mint a
+ * second key for the same egma.
+ */
+export function tidyUrl(url: string): string {
+  return url.trim().replace(/\/+$/u, "");
+}
+
+/** What is on disk, or `null` when there is nothing usable there. */
+export async function readCredentials(file: string): Promise<Credentials | null> {
+  let raw: string;
+  try {
+    raw = await readFile(file, "utf8");
+  } catch {
+    return null;
+  }
+
+  try {
+    const held = JSON.parse(raw) as { url?: unknown; key?: unknown };
+    const url = typeof held.url === "string" ? tidyUrl(held.url) : "";
+    const key = typeof held.key === "string" ? held.key.trim() : "";
+    if (url === "" || key === "") return null;
+    return { url, key };
+  } catch {
+    // A file somebody edited by hand, or half a write. Either way there is
+    // nothing to log in with, and saying so sends the developer through login
+    // rather than through a parse error.
+    return null;
+  }
+}
+
+/**
+ * Write the key, owner-readable and no wider.
+ *
+ * The mode is set after the write as well as during it, because the mode a
+ * file is created with is narrowed by the process umask but never widened by
+ * it — and a file that already existed keeps whatever mode it had.
+ */
+export async function writeCredentials(
+  file: string,
+  credentials: Credentials,
+): Promise<void> {
+  const folder = path.dirname(file);
+  await mkdir(folder, { recursive: true, mode: FOLDER_MODE });
+  await chmod(folder, FOLDER_MODE).catch(() => undefined);
+
+  const document = `${JSON.stringify(
+    { url: tidyUrl(credentials.url), key: credentials.key },
+    null,
+    2,
+  )}\n`;
+  await writeFile(file, document, { encoding: "utf8", mode: FILE_MODE });
+  await chmod(file, FILE_MODE);
+}
+
+export type PlatformChoice = {
+  /** `--url`, which beats everything because it is the most deliberate. */
+  readonly flag?: string | null;
+  /** `EGMA_URL`, which is how a self-hoster sets it for a whole shell. */
+  readonly env?: string | undefined;
+  /** What the last successful login wrote, so it is set once and not again. */
+  readonly stored?: string | null;
+};
+
+/**
+ * Which egma this command talks to.
+ *
+ * Deliberate beats ambient beats remembered: a flag on the command, then the
+ * environment, then what login already stored, then egma's own address. The
+ * order is what makes "set it once" true — after a first login against a
+ * self-hosted instance, every later command finds it without being told again.
+ */
+export function resolvePlatformUrl(choice: PlatformChoice): string {
+  for (const candidate of [choice.flag, choice.env, choice.stored]) {
+    const tidy = typeof candidate === "string" ? tidyUrl(candidate) : "";
+    if (tidy !== "") return tidy;
+  }
+  return DEFAULT_PLATFORM_URL;
+}

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -12,9 +12,13 @@
  * writing the credentials of the person running them.
  */
 
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import process from "node:process";
+
+import { isWebAddress } from "./address.ts";
 
 /** The egma a command talks to when nothing says otherwise. */
 export const DEFAULT_PLATFORM_URL = "https://app.egma.ai";
@@ -83,28 +87,62 @@ export async function readCredentials(file: string): Promise<Credentials | null>
   }
 }
 
+export type WriteOptions = {
+  /** Where a folder egma could not lock down is said out loud. */
+  readonly warn?: (line: string) => void;
+};
+
 /**
  * Write the key, owner-readable and no wider.
  *
- * The mode is set after the write as well as during it, because the mode a
- * file is created with is narrowed by the process umask but never widened by
- * it — and a file that already existed keeps whatever mode it had.
+ * The key is written to a fresh file beside the target and renamed over it,
+ * which is the only way to be sure of the mode it lands with. `writeFile` with
+ * a mode applies that mode when it *creates* a file and never afterwards, so
+ * writing straight at the target would put the key inside whatever was already
+ * there, keeping whatever that was readable by — and if the target is a symlink
+ * it would put the key wherever the link points. A rename replaces the name
+ * itself, symlink and all, and it either happened or it did not, so no reader
+ * ever sees half a file.
+ *
+ * The new file is created with `wx`, so it is this run's file or nothing.
  */
 export async function writeCredentials(
   file: string,
   credentials: Credentials,
+  options: WriteOptions = {},
 ): Promise<void> {
+  const warn = options.warn ?? ((line: string) => void process.stderr.write(`${line}\n`));
+
   const folder = path.dirname(file);
   await mkdir(folder, { recursive: true, mode: FOLDER_MODE });
-  await chmod(folder, FOLDER_MODE).catch(() => undefined);
+  try {
+    await chmod(folder, FOLDER_MODE);
+  } catch {
+    // A folder egma cannot narrow is not a reason to fail a login that worked —
+    // but it is a reason to say so, because the developer is about to hold a
+    // key in a place other people on this machine can look into.
+    warn(
+      `egma could not make ${folder} readable by you alone. The key is written, and anybody who can read that folder can read it.`,
+    );
+  }
 
   const document = `${JSON.stringify(
     { url: tidyUrl(credentials.url), key: credentials.key },
     null,
     2,
   )}\n`;
-  await writeFile(file, document, { encoding: "utf8", mode: FILE_MODE });
-  await chmod(file, FILE_MODE);
+
+  const fresh = path.join(folder, `.credentials-${process.pid}-${randomBytes(6).toString("hex")}`);
+  await writeFile(fresh, document, { encoding: "utf8", mode: FILE_MODE, flag: "wx" });
+  try {
+    // The umask can only narrow what a file is created with, never widen it, so
+    // this is the one that makes 0600 true rather than 0600-or-less.
+    await chmod(fresh, FILE_MODE);
+    await rename(fresh, file);
+  } catch (cause) {
+    await rm(fresh, { force: true });
+    throw cause;
+  }
 }
 
 export type PlatformChoice = {
@@ -116,6 +154,16 @@ export type PlatformChoice = {
   readonly stored?: string | null;
 };
 
+/** What a developer is told when the address they named is not one. */
+export class UnusableUrlError extends Error {
+  constructor(where: string, given: string) {
+    super(
+      `${where} is ${given}, and egma cannot talk to that. Give a whole address that starts with http:// or https://.`,
+    );
+    this.name = "UnusableUrlError";
+  }
+}
+
 /**
  * Which egma this command talks to.
  *
@@ -123,11 +171,56 @@ export type PlatformChoice = {
  * environment, then what login already stored, then egma's own address. The
  * order is what makes "set it once" true — after a first login against a
  * self-hosted instance, every later command finds it without being told again.
+ *
+ * An address a person typed is checked here, at the edge that takes it, and a
+ * bad one is refused by name rather than carried into the flow — because the
+ * next thing that happens to it is that a browser is started on it. What login
+ * stored is only ever an address that already passed this, so a file somebody
+ * edited by hand is stepped over rather than made into a refusal on every
+ * command afterwards.
  */
 export function resolvePlatformUrl(choice: PlatformChoice): string {
-  for (const candidate of [choice.flag, choice.env, choice.stored]) {
+  const named: readonly [string, string | null | undefined][] = [
+    ["--url", choice.flag],
+    ["EGMA_URL", choice.env],
+  ];
+  for (const [where, candidate] of named) {
     const tidy = typeof candidate === "string" ? tidyUrl(candidate) : "";
-    if (tidy !== "") return tidy;
+    if (tidy === "") continue;
+    if (!isWebAddress(tidy)) throw new UnusableUrlError(where, tidy);
+    return tidy;
   }
+
+  const stored = typeof choice.stored === "string" ? tidyUrl(choice.stored) : "";
+  if (stored !== "" && isWebAddress(stored)) return stored;
   return DEFAULT_PLATFORM_URL;
+}
+
+/** Which egma a run signs in to, and where the key it gets is kept. */
+export type PlatformAccess = {
+  readonly url: string;
+  readonly credentialsFile: string;
+};
+
+/**
+ * Resolved once, in one place, so the wizard and every verb read the same
+ * answer from the same three places in the same order. Two copies of this would
+ * be two answers to "which egma is this", and the one that is wrong would be
+ * the one that wrote the key.
+ */
+export async function resolvePlatformAccess(choice: {
+  readonly env: NodeJS.ProcessEnv;
+  /** `--url`, when one was given. */
+  readonly flag: string | null;
+}): Promise<PlatformAccess> {
+  const credentialsFile = credentialsFileIn(choice.env);
+  const stored = await readCredentials(credentialsFile);
+  return {
+    url: resolvePlatformUrl({
+      flag: choice.flag,
+      env: choice.env.EGMA_URL,
+      stored: stored?.url ?? null,
+    }),
+    credentialsFile,
+  };
 }

--- a/apps/cli/src/platform/device-flow.ts
+++ b/apps/cli/src/platform/device-flow.ts
@@ -37,7 +37,32 @@ export type Collection =
   | { readonly kind: "refused"; readonly reason: string };
 
 /** The one thing this module needs from the world, so a test can stand in. */
-export type Caller = typeof fetch;
+export type Fetch = typeof fetch;
+
+/**
+ * What egma says about a refusal, in egma's own words.
+ *
+ * RFC 8628 carries an `error_description` beside the code, and none of it is
+ * ever repeated at a terminal. Two reasons, and either alone would be enough.
+ * It is written for whoever built the client rather than for whoever is sitting
+ * at it. And egma's own descriptions name what a terminal never names — what
+ * was set up for a new account is settled in the browser page and said nowhere
+ * out here — so relaying them would break that rule from the far end of an
+ * HTTP request, where no reading of this code could see it.
+ *
+ * So the code is switched on and the sentence is egma's. The instance's own
+ * words are read and dropped.
+ */
+export function refusalFor(code: string): string {
+  switch (code) {
+    case "invalid_grant":
+      return "egma would not mint a key for this login. Start again from the terminal.";
+    case "unsupported_grant_type":
+      return "egma did not understand this login request. Update egma, then try again.";
+    default:
+      return "egma refused this login. Start again from the terminal, and check the address if it happens again.";
+  }
+}
 
 /** A message a developer can act on, from a failure they cannot read. */
 export class PlatformUnreachableError extends Error {
@@ -54,8 +79,17 @@ async function bodyOf(response: Response): Promise<Record<string, unknown>> {
   return (await response.json().catch(() => ({}))) as Record<string, unknown>;
 }
 
+/**
+ * A string off the wire, with nothing in it a terminal would obey.
+ *
+ * Everything here ends up drawn on a screen, and a terminal reads a control
+ * character as an instruction rather than as text: an address carrying an
+ * escape sequence could move the cursor, clear the screen, or redraw what egma
+ * just said. They are taken out at the one edge that reads the wire, so nothing
+ * below here has to remember.
+ */
 function text(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
+  return typeof value === "string" ? value.replaceAll(/[\p{Cc}\p{Cf}]/gu, "").trim() : "";
 }
 
 function seconds(value: unknown, fallback: number): number {
@@ -72,11 +106,11 @@ function seconds(value: unknown, fallback: number): number {
  */
 export async function startDeviceAuthorization(
   url: string,
-  call: Caller = fetch,
+  fetchImpl: Fetch = fetch,
 ): Promise<DeviceGrant> {
   let response: Response;
   try {
-    response = await call(`${url}/api/device/code`, {
+    response = await fetchImpl(`${url}/api/device/code`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ client_id: DEVICE_CLIENT_ID }),
@@ -86,9 +120,10 @@ export async function startDeviceAuthorization(
   }
 
   if (!response.ok) {
-    const said = text((await bodyOf(response)).message);
+    // What the instance said about it is read and dropped, for the reason
+    // `refusalFor` gives: the words a terminal says are egma's own.
     throw new Error(
-      `egma at ${url} refused to start a login${said === "" ? "" : `: ${said}`}`,
+      `egma at ${url} would not start a login (${response.status}). Check the address, and that this egma is up to date.`,
     );
   }
 
@@ -118,16 +153,16 @@ export async function startDeviceAuthorization(
  *
  * The refusals are the protocol's own vocabulary, and each one means something
  * different to the person at the terminal: still waiting, polling too fast,
- * told no, and out of time are four outcomes and not one failure.
+ * told no, and out of time are four endings and not one failure.
  */
 export async function collectKey(
   url: string,
   deviceCode: string,
-  call: Caller = fetch,
+  fetchImpl: Fetch = fetch,
 ): Promise<Collection> {
   let response: Response;
   try {
-    response = await call(`${url}/api/device/token`, {
+    response = await fetchImpl(`${url}/api/device/token`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -145,7 +180,10 @@ export async function collectKey(
   if (response.ok) {
     const key = text(body.access_token);
     if (key === "") {
-      return { kind: "refused", reason: "egma minted no key for this login" };
+      return {
+        kind: "refused",
+        reason: "egma minted no key for this login. Start again from the terminal.",
+      };
     }
     return { kind: "key", key };
   }
@@ -159,13 +197,8 @@ export async function collectKey(
       return { kind: "denied" };
     case "expired_token":
       return { kind: "expired" };
-    default: {
-      const said = text(body.error_description) || text(body.message);
-      return {
-        kind: "refused",
-        reason: said === "" ? `egma refused this login (${response.status})` : said,
-      };
-    }
+    default:
+      return { kind: "refused", reason: refusalFor(text(body.error)) };
   }
 }
 

--- a/apps/cli/src/platform/device-flow.ts
+++ b/apps/cli/src/platform/device-flow.ts
@@ -1,0 +1,215 @@
+/**
+ * The terminal's half of the device flow: ask to be let in, then collect.
+ *
+ * A short code goes on the screen, a browser opens on it, somebody approves it
+ * where they can see who they are and what they are approving, and this end
+ * exchanges the code it was given for a key. No secret is ever typed into the
+ * terminal, and nothing rides on a URL.
+ *
+ * Everything here speaks the public HTTP API and nothing else, which is what
+ * lets the whole of login run against a fixture of that API in CI and against a
+ * real instance unchanged.
+ */
+
+/** The one client egma issues device codes to, and the name it says. */
+export const DEVICE_CLIENT_ID = "egma-cli";
+
+const DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+export type DeviceGrant = {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  /** The address to approve at, with the code already in it. */
+  readonly approveUrl: string;
+  /** How long the code is worth approving, in seconds. */
+  readonly expiresInSeconds: number;
+  /** How long to leave between two collections, in seconds. */
+  readonly intervalSeconds: number;
+};
+
+/** What one attempt to collect a key came back with. */
+export type Collection =
+  | { readonly kind: "key"; readonly key: string }
+  | { readonly kind: "waiting" }
+  | { readonly kind: "slow-down" }
+  | { readonly kind: "denied" }
+  | { readonly kind: "expired" }
+  | { readonly kind: "refused"; readonly reason: string };
+
+/** The one thing this module needs from the world, so a test can stand in. */
+export type Caller = typeof fetch;
+
+/** A message a developer can act on, from a failure they cannot read. */
+export class PlatformUnreachableError extends Error {
+  constructor(url: string, cause: unknown) {
+    super(
+      `egma at ${url} did not answer. Check the address, and that the instance is running.`,
+      { cause },
+    );
+    this.name = "PlatformUnreachableError";
+  }
+}
+
+async function bodyOf(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json().catch(() => ({}))) as Record<string, unknown>;
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function seconds(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : fallback;
+}
+
+/**
+ * Start. Asks for a pair of codes and the address to send somebody to.
+ *
+ * The address comes back from the instance rather than being built here, so a
+ * self-hosted egma sends people to itself and never to an address egma runs.
+ */
+export async function startDeviceAuthorization(
+  url: string,
+  call: Caller = fetch,
+): Promise<DeviceGrant> {
+  let response: Response;
+  try {
+    response = await call(`${url}/api/device/code`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ client_id: DEVICE_CLIENT_ID }),
+    });
+  } catch (cause) {
+    throw new PlatformUnreachableError(url, cause);
+  }
+
+  if (!response.ok) {
+    const said = text((await bodyOf(response)).message);
+    throw new Error(
+      `egma at ${url} refused to start a login${said === "" ? "" : `: ${said}`}`,
+    );
+  }
+
+  const body = await bodyOf(response);
+  const deviceCode = text(body.device_code);
+  const userCode = text(body.user_code);
+  const approveUrl =
+    text(body.verification_uri_complete) || text(body.verification_uri);
+
+  if (deviceCode === "" || userCode === "" || approveUrl === "") {
+    throw new Error(
+      `egma at ${url} answered a login request without a code to approve`,
+    );
+  }
+
+  return {
+    deviceCode,
+    userCode,
+    approveUrl,
+    expiresInSeconds: seconds(body.expires_in, 900),
+    intervalSeconds: seconds(body.interval, 5),
+  };
+}
+
+/**
+ * Collect. Exchanges the device code for a key, or says what it is waiting on.
+ *
+ * The refusals are the protocol's own vocabulary, and each one means something
+ * different to the person at the terminal: still waiting, polling too fast,
+ * told no, and out of time are four outcomes and not one failure.
+ */
+export async function collectKey(
+  url: string,
+  deviceCode: string,
+  call: Caller = fetch,
+): Promise<Collection> {
+  let response: Response;
+  try {
+    response = await call(`${url}/api/device/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: DEVICE_GRANT,
+        device_code: deviceCode,
+        client_id: DEVICE_CLIENT_ID,
+      }).toString(),
+    });
+  } catch (cause) {
+    throw new PlatformUnreachableError(url, cause);
+  }
+
+  const body = await bodyOf(response);
+
+  if (response.ok) {
+    const key = text(body.access_token);
+    if (key === "") {
+      return { kind: "refused", reason: "egma minted no key for this login" };
+    }
+    return { kind: "key", key };
+  }
+
+  switch (text(body.error)) {
+    case "authorization_pending":
+      return { kind: "waiting" };
+    case "slow_down":
+      return { kind: "slow-down" };
+    case "access_denied":
+      return { kind: "denied" };
+    case "expired_token":
+      return { kind: "expired" };
+    default: {
+      const said = text(body.error_description) || text(body.message);
+      return {
+        kind: "refused",
+        reason: said === "" ? `egma refused this login (${response.status})` : said,
+      };
+    }
+  }
+}
+
+/**
+ * A code as the instance stored it.
+ *
+ * People read these off one screen and type or paste them into another, so a
+ * hyphen, a space or a lower-case letter is a thing that happens rather than a
+ * thing to refuse. This is the edge that takes the typing, so this is where it
+ * is tidied up.
+ */
+export function normalizeUserCode(userCode: string): string {
+  return userCode.replaceAll(/[^0-9A-Za-z]/gu, "").toUpperCase();
+}
+
+/**
+ * The code inside whatever somebody pasted back, or `null` when there is none.
+ *
+ * On a machine with no browser of its own — a devbox, anything over SSH — the
+ * address goes to a browser elsewhere, and what comes back to the terminal is
+ * whatever was easiest to select over there. That is a whole address, or the
+ * query part of one, or the eight characters read off the screen. All three
+ * carry the same fact, so all three are accepted rather than one being called
+ * the right one.
+ */
+export function codeFromPaste(pasted: string): string | null {
+  const trimmed = pasted.trim();
+  if (trimmed === "") return null;
+
+  const query = trimmed.includes("?")
+    ? trimmed.slice(trimmed.indexOf("?") + 1)
+    : trimmed;
+  const named = new URLSearchParams(query).get("user_code");
+  if (named !== null) {
+    const code = normalizeUserCode(named);
+    return code === "" ? null : code;
+  }
+
+  // Nothing named a code, so what is left has to be the code itself: a few
+  // groups of letters and digits, split the way a code is written down or read
+  // out. An address that carried no code is not a code, and neither is a
+  // sentence — both reach here, and both have to be turned away.
+  if (!/^[0-9A-Za-z]{2,10}(?:[- ][0-9A-Za-z]{2,10}){0,3}$/u.test(trimmed)) return null;
+
+  const code = normalizeUserCode(trimmed);
+  return code.length < 4 || code.length > 32 ? null : code;
+}

--- a/apps/cli/src/platform/login.ts
+++ b/apps/cli/src/platform/login.ts
@@ -23,7 +23,7 @@ import {
   normalizeUserCode,
   startDeviceAuthorization,
   PlatformUnreachableError,
-  type Caller,
+  type Fetch,
 } from "./device-flow.ts";
 
 /** What the developer has to approve, and where. */
@@ -35,7 +35,24 @@ export type LoginPrompt = {
   readonly browserOpened: boolean;
 };
 
-export type LoginOutcome =
+/**
+ * The prompt as plain lines, one fact per line.
+ *
+ * Written once and read by both surfaces that print rather than draw — the
+ * headless wizard and `egma login`. Two copies of these four lines would drift,
+ * and a coding agent reading `browser:` from one of them and not the other is a
+ * bug nobody would think to look for.
+ */
+export function loginLines(prompt: LoginPrompt): readonly string[] {
+  return [
+    `code: ${prompt.userCode}`,
+    `approve_url: ${prompt.url}`,
+    `browser: ${prompt.browserOpened ? "opened" : "not-opened"}`,
+    "waiting: for this code to be approved in a browser",
+  ];
+}
+
+export type LoginResult =
   | { readonly kind: "stored"; readonly url: string; readonly key: string }
   | { readonly kind: "already-stored"; readonly url: string; readonly key: string }
   | { readonly kind: "denied" }
@@ -60,7 +77,7 @@ export type LogInOptions = {
   readonly paste?: () => string | null;
   /** Starts a browser on the address. Answers whether one started. */
   readonly openBrowser?: (url: string) => Promise<boolean>;
-  readonly call?: Caller;
+  readonly fetchImpl?: Fetch;
   readonly sleep?: (ms: number) => Promise<void>;
   readonly now?: () => number;
 };
@@ -73,9 +90,19 @@ const NOTHING = (): void => undefined;
  * The instance sets how often it may be asked for a key, and that is measured
  * in seconds. A developer who has just come back from a browser and pasted the
  * address should not sit through the rest of one, so the wait is slept in
- * slices and ends early the moment anything arrives.
+ * slices and ends early the moment the code on screen arrives.
  */
 const LOOK_UP_EVERY_MS = 100;
+
+/**
+ * What `slow_down` costs, in milliseconds.
+ *
+ * RFC 8628 sets both halves of this and neither is egma's to choose: five
+ * seconds, and for this request *and every one after it*. An interval that
+ * sprang back to what it was on the next answer would earn the same `slow_down`
+ * for as long as the login lasted.
+ */
+const SLOW_DOWN_MS = 5_000;
 
 function pause(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
@@ -95,23 +122,55 @@ function pause(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
-/** Waits out the interval, or ends early with whatever was pasted. */
-async function waitOrPaste(
-  waitMs: number,
-  sleep: (ms: number) => Promise<void>,
-  paste: (() => string | null) | undefined,
-  signal: AbortSignal,
-): Promise<string | null> {
-  let left = waitMs;
+type Wait = {
+  readonly waitMs: number;
+  readonly sleep: (ms: number) => Promise<void>;
+  readonly paste: (() => string | null) | undefined;
+  readonly say: (line: string) => void;
+  /** The code this terminal is waiting on, tidied for comparing. */
+  readonly waitingFor: string;
+  /** The same code as it is written on the screen, for saying back. */
+  readonly shownAs: string;
+  readonly signal: AbortSignal;
+};
+
+/**
+ * Waits out the interval, and ends early only for the code on this screen.
+ *
+ * Pasting is read here rather than by the caller because what a paste means is
+ * a question about the wait. The code on screen means "I have approved it, look
+ * now" and cuts the wait short. Anything else — a sentence, half an address,
+ * somebody else's code — is answered on screen and changes nothing: the pace
+ * belongs to the instance, and a keyboard must not be able to turn a wrong
+ * paste into a request. Otherwise a developer holding a paste key would make
+ * egma ask for a key as fast as they could type.
+ */
+async function waitForPace(wait: Wait): Promise<void> {
+  let left = wait.waitMs;
   for (;;) {
-    if (signal.aborted) return null;
+    if (wait.signal.aborted) return;
 
-    const typed = paste?.() ?? null;
-    if (typed !== null && typed.trim() !== "") return typed;
+    const typed = wait.paste?.() ?? null;
+    if (typed !== null && typed.trim() !== "") {
+      const code = codeFromPaste(typed);
+      if (code === null) {
+        wait.say("That is not an egma code or an approval address. Paste the whole line.");
+      } else if (code !== wait.waitingFor) {
+        wait.say(
+          `That code is ${code}, and this terminal is waiting on ${wait.shownAs}. Approve the one on this screen.`,
+        );
+      } else {
+        // The developer has been to a browser and come back, so the answer is
+        // asked for now rather than at the next tick. That is the whole point
+        // of pasting it back on a machine that could not open one itself.
+        wait.say("Checking that one now.");
+        return;
+      }
+    }
 
-    if (left <= 0) return null;
-    const slice = paste === undefined ? left : Math.min(left, LOOK_UP_EVERY_MS);
-    await sleep(slice);
+    if (left <= 0) return;
+    const slice = wait.paste === undefined ? left : Math.min(left, LOOK_UP_EVERY_MS);
+    await wait.sleep(slice);
     left -= slice;
   }
 }
@@ -123,11 +182,11 @@ async function waitOrPaste(
  * something different to whoever asked — a denial is not a fault, an expired
  * code is not a denial, and an instance that never answered is neither.
  */
-export async function logIn(options: LogInOptions): Promise<LoginOutcome> {
+export async function logIn(options: LogInOptions): Promise<LoginResult> {
   const say = options.say ?? NOTHING;
   const sleep = options.sleep ?? ((ms: number) => pause(ms, options.signal));
   const now = options.now ?? Date.now;
-  const call = options.call ?? fetch;
+  const fetchImpl = options.fetchImpl ?? fetch;
 
   const held = await readCredentials(options.credentialsFile);
   if (options.force !== true && held !== null && held.url === options.url) {
@@ -136,7 +195,7 @@ export async function logIn(options: LogInOptions): Promise<LoginOutcome> {
 
   let grant;
   try {
-    grant = await startDeviceAuthorization(options.url, call);
+    grant = await startDeviceAuthorization(options.url, fetchImpl);
   } catch (cause) {
     if (cause instanceof PlatformUnreachableError) {
       return { kind: "unreachable", reason: cause.message };
@@ -161,31 +220,13 @@ export async function logIn(options: LogInOptions): Promise<LoginOutcome> {
   const waitingFor = normalizeUserCode(grant.userCode);
   const givesUpAt = now() + grant.expiresInSeconds * 1000;
   let waitMs = grant.intervalSeconds * 1000;
-  let pasted: string | null = null;
 
   for (;;) {
     if (options.signal.aborted) return { kind: "interrupted" };
 
-    if (pasted !== null) {
-      const code = codeFromPaste(pasted);
-      if (code === null) {
-        say("That is not an egma code or an approval address. Paste the whole line.");
-      } else if (code !== waitingFor) {
-        say(
-          `That code is ${code}, and this terminal is waiting on ${grant.userCode}. Approve the one on this screen.`,
-        );
-      } else {
-        // The developer has been to a browser and come back, so the answer is
-        // asked for now rather than at the next tick. That is the whole point
-        // of pasting it back on a machine that could not open one itself.
-        say("Checking that one now.");
-      }
-      pasted = null;
-    }
-
     let collected;
     try {
-      collected = await collectKey(options.url, grant.deviceCode, call);
+      collected = await collectKey(options.url, grant.deviceCode, fetchImpl);
     } catch (cause) {
       if (cause instanceof PlatformUnreachableError) {
         return { kind: "unreachable", reason: cause.message };
@@ -207,16 +248,25 @@ export async function logIn(options: LogInOptions): Promise<LoginOutcome> {
         return { kind: "refused", reason: collected.reason };
       case "slow-down":
         // The instance sets the pace, and it has just said this one is too
-        // fast. Anything other than backing off gets the same answer forever.
-        waitMs = Math.max(waitMs, grant.intervalSeconds * 1000) + 1000;
+        // fast. The new pace is kept for the rest of the login: an interval
+        // that sprang back would earn the same answer at the next poll.
+        waitMs += SLOW_DOWN_MS;
         break;
       case "waiting":
-        waitMs = grant.intervalSeconds * 1000;
+        // Nobody has answered yet, and the pace is whatever it already was.
         break;
     }
 
     if (now() > givesUpAt) return { kind: "expired" };
-    pasted = await waitOrPaste(waitMs, sleep, options.paste, options.signal);
+    await waitForPace({
+      waitMs,
+      sleep,
+      paste: options.paste,
+      say,
+      waitingFor,
+      shownAs: grant.userCode,
+      signal: options.signal,
+    });
     if (options.signal.aborted) return { kind: "interrupted" };
   }
 }

--- a/apps/cli/src/platform/login.ts
+++ b/apps/cli/src/platform/login.ts
@@ -1,0 +1,222 @@
+/**
+ * Logging in, once, for both the wizard and the headless verb.
+ *
+ * There is one flow here and there is no second one. The wizard is a screen
+ * over it and `egma login` is plain lines over it, which is what makes the
+ * wizard passing its tests evidence that the agent-callable surface works.
+ *
+ * Nothing in here draws, and nothing in here reads a keystroke. What the
+ * developer has to see arrives through `onPrompt` and `say`; what they may have
+ * pasted back is read through `paste`, which the caller answers from wherever
+ * it collects typing. A flow that asked a question directly could not be both
+ * a wizard screen and a promptless command.
+ */
+
+import {
+  readCredentials,
+  writeCredentials,
+  type Credentials,
+} from "./credentials.ts";
+import {
+  codeFromPaste,
+  collectKey,
+  normalizeUserCode,
+  startDeviceAuthorization,
+  PlatformUnreachableError,
+  type Caller,
+} from "./device-flow.ts";
+
+/** What the developer has to approve, and where. */
+export type LoginPrompt = {
+  readonly userCode: string;
+  /** The address to approve at, with the code already in it. */
+  readonly url: string;
+  /** Whether a browser was started on it, or the address is all there is. */
+  readonly browserOpened: boolean;
+};
+
+export type LoginOutcome =
+  | { readonly kind: "stored"; readonly url: string; readonly key: string }
+  | { readonly kind: "already-stored"; readonly url: string; readonly key: string }
+  | { readonly kind: "denied" }
+  | { readonly kind: "expired" }
+  | { readonly kind: "interrupted" }
+  | { readonly kind: "refused"; readonly reason: string }
+  | { readonly kind: "unreachable"; readonly reason: string };
+
+export type LogInOptions = {
+  /** The egma being logged in to, already resolved. */
+  readonly url: string;
+  /** Where the key is kept if one is minted. */
+  readonly credentialsFile: string;
+  /** Log in again even when a key for this egma is already held. */
+  readonly force?: boolean;
+  readonly signal: AbortSignal;
+  /** The code and the address, as soon as egma has them. */
+  readonly onPrompt: (prompt: LoginPrompt) => void;
+  /** One line about what is happening, for whoever is watching. */
+  readonly say?: (line: string) => void;
+  /** What the developer has pasted back since the last look, if anything. */
+  readonly paste?: () => string | null;
+  /** Starts a browser on the address. Answers whether one started. */
+  readonly openBrowser?: (url: string) => Promise<boolean>;
+  readonly call?: Caller;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+};
+
+const NOTHING = (): void => undefined;
+
+/**
+ * How often a wait looks up to see whether something was pasted.
+ *
+ * The instance sets how often it may be asked for a key, and that is measured
+ * in seconds. A developer who has just come back from a browser and pasted the
+ * address should not sit through the rest of one, so the wait is slept in
+ * slices and ends early the moment anything arrives.
+ */
+const LOOK_UP_EVERY_MS = 100;
+
+function pause(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted || ms <= 0) {
+      setTimeout(resolve, 0);
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/** Waits out the interval, or ends early with whatever was pasted. */
+async function waitOrPaste(
+  waitMs: number,
+  sleep: (ms: number) => Promise<void>,
+  paste: (() => string | null) | undefined,
+  signal: AbortSignal,
+): Promise<string | null> {
+  let left = waitMs;
+  for (;;) {
+    if (signal.aborted) return null;
+
+    const typed = paste?.() ?? null;
+    if (typed !== null && typed.trim() !== "") return typed;
+
+    if (left <= 0) return null;
+    const slice = paste === undefined ? left : Math.min(left, LOOK_UP_EVERY_MS);
+    await sleep(slice);
+    left -= slice;
+  }
+}
+
+/**
+ * Runs the whole flow and answers what happened.
+ *
+ * Every ending is a value rather than an exception, because every ending means
+ * something different to whoever asked — a denial is not a fault, an expired
+ * code is not a denial, and an instance that never answered is neither.
+ */
+export async function logIn(options: LogInOptions): Promise<LoginOutcome> {
+  const say = options.say ?? NOTHING;
+  const sleep = options.sleep ?? ((ms: number) => pause(ms, options.signal));
+  const now = options.now ?? Date.now;
+  const call = options.call ?? fetch;
+
+  const held = await readCredentials(options.credentialsFile);
+  if (options.force !== true && held !== null && held.url === options.url) {
+    return { kind: "already-stored", url: held.url, key: held.key };
+  }
+
+  let grant;
+  try {
+    grant = await startDeviceAuthorization(options.url, call);
+  } catch (cause) {
+    if (cause instanceof PlatformUnreachableError) {
+      return { kind: "unreachable", reason: cause.message };
+    }
+    return {
+      kind: "refused",
+      reason: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+
+  const opened =
+    options.openBrowser === undefined
+      ? false
+      : await options.openBrowser(grant.approveUrl);
+
+  options.onPrompt({
+    userCode: grant.userCode,
+    url: grant.approveUrl,
+    browserOpened: opened,
+  });
+
+  const waitingFor = normalizeUserCode(grant.userCode);
+  const givesUpAt = now() + grant.expiresInSeconds * 1000;
+  let waitMs = grant.intervalSeconds * 1000;
+  let pasted: string | null = null;
+
+  for (;;) {
+    if (options.signal.aborted) return { kind: "interrupted" };
+
+    if (pasted !== null) {
+      const code = codeFromPaste(pasted);
+      if (code === null) {
+        say("That is not an egma code or an approval address. Paste the whole line.");
+      } else if (code !== waitingFor) {
+        say(
+          `That code is ${code}, and this terminal is waiting on ${grant.userCode}. Approve the one on this screen.`,
+        );
+      } else {
+        // The developer has been to a browser and come back, so the answer is
+        // asked for now rather than at the next tick. That is the whole point
+        // of pasting it back on a machine that could not open one itself.
+        say("Checking that one now.");
+      }
+      pasted = null;
+    }
+
+    let collected;
+    try {
+      collected = await collectKey(options.url, grant.deviceCode, call);
+    } catch (cause) {
+      if (cause instanceof PlatformUnreachableError) {
+        return { kind: "unreachable", reason: cause.message };
+      }
+      throw cause;
+    }
+
+    switch (collected.kind) {
+      case "key": {
+        const credentials: Credentials = { url: options.url, key: collected.key };
+        await writeCredentials(options.credentialsFile, credentials);
+        return { kind: "stored", url: credentials.url, key: credentials.key };
+      }
+      case "denied":
+        return { kind: "denied" };
+      case "expired":
+        return { kind: "expired" };
+      case "refused":
+        return { kind: "refused", reason: collected.reason };
+      case "slow-down":
+        // The instance sets the pace, and it has just said this one is too
+        // fast. Anything other than backing off gets the same answer forever.
+        waitMs = Math.max(waitMs, grant.intervalSeconds * 1000) + 1000;
+        break;
+      case "waiting":
+        waitMs = grant.intervalSeconds * 1000;
+        break;
+    }
+
+    if (now() > givesUpAt) return { kind: "expired" };
+    pasted = await waitOrPaste(waitMs, sleep, options.paste, options.signal);
+    if (options.signal.aborted) return { kind: "interrupted" };
+  }
+}

--- a/apps/cli/src/ui/headless-ui.ts
+++ b/apps/cli/src/ui/headless-ui.ts
@@ -10,6 +10,7 @@
  * and this UI answers it on their behalf.
  */
 
+import type { LoginPrompt } from "../platform/login.ts";
 import type { ExitReport } from "../wizard/exit-line.ts";
 import type { DrivenAgent, GateId, WizardUI } from "./wizard-ui.ts";
 
@@ -17,6 +18,7 @@ export type HeadlessRecord = {
   drivenAgent: DrivenAgent | null;
   drivenAgentLog: string | null;
   taskFile: string | null;
+  logins: LoginPrompt[];
   statuses: string[];
   summary: string;
   exit: ExitReport | null;
@@ -33,6 +35,7 @@ export class HeadlessUI implements WizardUI {
     drivenAgent: null,
     drivenAgentLog: null,
     taskFile: null,
+    logins: [],
     statuses: [],
     summary: "",
     exit: null,
@@ -64,6 +67,19 @@ export class HeadlessUI implements WizardUI {
   setTaskFile(file: string): void {
     this.record.taskFile = file;
     this.write(`Task: read ${file} and say what it is`);
+  }
+
+  setLogin(prompt: LoginPrompt | null): void {
+    if (prompt === null) return;
+    this.record.logins.push(prompt);
+    this.write(`code: ${prompt.userCode}`);
+    this.write(`approve_url: ${prompt.url}`);
+    this.write(`browser: ${prompt.browserOpened ? "opened" : "not-opened"}`);
+  }
+
+  /** Nobody is at this keyboard, so nothing is ever pasted at it. */
+  takeLoginPaste(): string | null {
+    return null;
   }
 
   waitForGate(gate: GateId): Promise<void> {

--- a/apps/cli/src/ui/headless-ui.ts
+++ b/apps/cli/src/ui/headless-ui.ts
@@ -10,7 +10,7 @@
  * and this UI answers it on their behalf.
  */
 
-import type { LoginPrompt } from "../platform/login.ts";
+import { loginLines, type LoginPrompt } from "../platform/login.ts";
 import type { ExitReport } from "../wizard/exit-line.ts";
 import type { DrivenAgent, GateId, WizardUI } from "./wizard-ui.ts";
 
@@ -72,9 +72,9 @@ export class HeadlessUI implements WizardUI {
   setLogin(prompt: LoginPrompt | null): void {
     if (prompt === null) return;
     this.record.logins.push(prompt);
-    this.write(`code: ${prompt.userCode}`);
-    this.write(`approve_url: ${prompt.url}`);
-    this.write(`browser: ${prompt.browserOpened ? "opened" : "not-opened"}`);
+    // The same lines `egma login` prints, from the same place, so the two
+    // promptless surfaces cannot drift apart.
+    for (const line of loginLines(prompt)) this.write(line);
   }
 
   /** Nobody is at this keyboard, so nothing is ever pasted at it. */

--- a/apps/cli/src/ui/tui/App.tsx
+++ b/apps/cli/src/ui/tui/App.tsx
@@ -6,9 +6,11 @@
  */
 
 import { useSyncExternalStore } from "react";
-import { useInput } from "ink";
+import { useInput, useStdout } from "ink";
 
+import { copyLink } from "../../platform/clipboard.ts";
 import { IntroScreen } from "./screens/IntroScreen.tsx";
+import { LoginScreen } from "./screens/LoginScreen.tsx";
 import { TaskScreen } from "./screens/TaskScreen.tsx";
 import type { WizardStore } from "./store.ts";
 
@@ -20,6 +22,7 @@ export type AppProps = {
 
 export function App({ store, onQuit, onInterrupt }: AppProps) {
   const state = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+  const { stdout } = useStdout();
 
   // Ctrl-C is handled here rather than by the renderer, because stopping means
   // shutting the driven agent down and leaving an honest line behind, not
@@ -32,6 +35,23 @@ export function App({ store, onQuit, onInterrupt }: AppProps) {
 
   if (screen === "intro") {
     return <IntroScreen state={state} onBegin={() => store.begin()} onQuit={onQuit} />;
+  }
+  if (screen === "login") {
+    return (
+      <LoginScreen
+        state={state}
+        onCopy={(url) => {
+          // The terminal is asked to copy, so the address lands on the
+          // clipboard of the machine the keyboard is on rather than the one
+          // egma happens to be running on.
+          copyLink(url, { write: (sequence) => stdout?.write(sequence) });
+          store.linkCopied();
+        }}
+        onType={(typed) => store.typeLogin(typed)}
+        onSubmit={() => store.submitLogin()}
+        onQuit={onQuit}
+      />
+    );
   }
   return <TaskScreen state={state} />;
 }

--- a/apps/cli/src/ui/tui/ink-ui.ts
+++ b/apps/cli/src/ui/tui/ink-ui.ts
@@ -5,6 +5,7 @@
  * asks — the screens read the store and own every keystroke.
  */
 
+import type { LoginPrompt } from "../../platform/login.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { DrivenAgent, GateId, WizardUI } from "../wizard-ui.ts";
 import type { WizardStore } from "./store.ts";
@@ -33,6 +34,14 @@ export class InkUI implements WizardUI {
 
   setTaskFile(file: string): void {
     this.store.setTaskFile(file);
+  }
+
+  setLogin(prompt: LoginPrompt | null): void {
+    this.store.setLogin(prompt);
+  }
+
+  takeLoginPaste(): string | null {
+    return this.store.takeLoginPaste();
   }
 
   waitForGate(gate: GateId): Promise<void> {

--- a/apps/cli/src/ui/tui/router.ts
+++ b/apps/cli/src/ui/tui/router.ts
@@ -15,7 +15,7 @@
 
 import type { WizardState } from "./state.ts";
 
-export type ScreenId = "intro" | "task";
+export type ScreenId = "intro" | "login" | "task";
 
 /** An interruption drawn over the flow. The stack is empty in the walk. */
 export type OverlayId = never;

--- a/apps/cli/src/ui/tui/screens/LoginScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/LoginScreen.tsx
@@ -1,0 +1,121 @@
+/**
+ * The browser step: a short code, the address it is already in, and a way back
+ * for a machine that has no browser of its own.
+ *
+ * Nothing secret is ever typed here. The code goes out, the approval happens
+ * where the developer can see who they are signing in as, and egma collects a
+ * key on its own.
+ *
+ * Three ways through, in the order they are reached for: the browser that
+ * opened by itself, the address copied to the clipboard for a browser on
+ * another machine, and the line pasted back when the developer wants to tell
+ * this terminal to look now.
+ */
+
+import { Box, Text, useInput, useStdout } from "ink";
+
+import { dispatchKey, hintBar, type KeyBinding } from "../keybindings.ts";
+import type { WizardState } from "../state.ts";
+import { addressFits, columnsNeeded } from "../width.ts";
+
+export type LoginScreenProps = {
+  readonly state: WizardState;
+  readonly onCopy: (url: string) => void;
+  readonly onType: (typed: string) => void;
+  readonly onSubmit: () => void;
+  readonly onQuit: () => void;
+};
+
+/** The newest lines only: what is happening now, not the whole history. */
+const VISIBLE_STATUS_LINES = 6;
+
+export function LoginScreen({
+  state,
+  onCopy,
+  onType,
+  onSubmit,
+  onQuit,
+}: LoginScreenProps) {
+  const { stdout } = useStdout();
+  const columns = stdout?.columns ?? 80;
+  const login = state.login;
+  const url = login?.url ?? "";
+
+  const bindings: KeyBinding[] = [
+    { match: "c", label: "c", action: "copy link", priority: 0, handler: () => onCopy(url) },
+    { match: "return", label: "enter", action: "paste a link back", priority: 1, handler: onSubmit },
+    { match: "q", label: "q", action: "quit", priority: 2, handler: onQuit },
+  ];
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onType("");
+      return;
+    }
+    if (key.backspace || key.delete) {
+      onType(state.loginTyping.slice(0, -1));
+      return;
+    }
+    // Anything longer than one character arrived as a paste rather than as a
+    // keystroke, and a pasted address or code may well begin with a letter that
+    // a key is bound to. Length is what tells the two apart, so a code starting
+    // with `c` is never read as the copy key.
+    if (input.length > 1) {
+      onType(state.loginTyping + input);
+      return;
+    }
+    // Once something is on the line, every character belongs to it. Enter sends
+    // it; escape clears it and gives the keys back.
+    if (state.loginTyping !== "" && !key.return) {
+      onType(state.loginTyping + input);
+      return;
+    }
+    dispatchKey(bindings, input, key);
+  });
+
+  const fits = addressFits(url, columns);
+  const shown = state.statuses.slice(-VISIBLE_STATUS_LINES);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={2} paddingY={1}>
+      <Text bold>egma</Text>
+      <Box height={1} />
+      <Text>
+        {login?.browserOpened === true
+          ? "Your browser is open on egma. Approve this code there."
+          : "Open this address in a browser and approve this code."}
+      </Text>
+      <Box height={1} />
+      <Text bold>{`Code: ${login?.userCode ?? ""}`}</Text>
+      <Box height={1} />
+      {fits ? (
+        <Text>{url}</Text>
+      ) : (
+        <Text>
+          {`The address needs ${columnsNeeded(url)} columns and this terminal has ${columns}. ` +
+            "Widen it to see the address, or press [c] to copy it."}
+        </Text>
+      )}
+      <Box height={1} />
+      <Text dimColor>
+        {state.loginCopied
+          ? "Copied. Open it on the machine your browser is on."
+          : "No browser on this machine? Copy the address, approve it elsewhere, then paste it back here."}
+      </Text>
+      {state.loginTyping === "" ? null : (
+        <Box marginTop={1}>
+          <Text>{`› ${state.loginTyping}`}</Text>
+        </Box>
+      )}
+      <Box flexDirection="column" marginTop={1}>
+        {shown.map((line, index) => (
+          <Text key={`${index}-${line}`} dimColor>
+            {line}
+          </Text>
+        ))}
+      </Box>
+      <Box height={1} />
+      <Text dimColor>{hintBar(bindings)}</Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/ui/tui/screens/LoginScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/LoginScreen.tsx
@@ -77,6 +77,8 @@ export function LoginScreen({
   const shown = state.statuses.slice(-VISIBLE_STATUS_LINES);
 
   return (
+    // The border and paddingX below are counted in `FRAMING_COLUMNS`, which is
+    // what decides whether the address fits. Changing either changes that.
     <Box flexDirection="column" borderStyle="round" paddingX={2} paddingY={1}>
       <Text bold>egma</Text>
       <Box height={1} />

--- a/apps/cli/src/ui/tui/state.ts
+++ b/apps/cli/src/ui/tui/state.ts
@@ -6,6 +6,7 @@
  * screens exist.
  */
 
+import type { LoginPrompt } from "../../platform/login.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { DrivenAgent } from "../wizard-ui.ts";
 
@@ -14,6 +15,12 @@ export type WizardState = {
   /** Where the coding agent's own output is kept, for a screen that tails it. */
   readonly drivenAgentLog: string | null;
   readonly taskFile: string | null;
+  /** What has to be approved in a browser, while it still has to be. */
+  readonly login: LoginPrompt | null;
+  /** What the developer is typing back at the login screen, so far. */
+  readonly loginTyping: string;
+  /** True for the moment after the address is copied, so the screen can say so. */
+  readonly loginCopied: boolean;
   /** The developer has read the intro and said go. */
   readonly begun: boolean;
   readonly running: boolean;
@@ -28,6 +35,9 @@ export function emptyState(): WizardState {
     drivenAgent: null,
     drivenAgentLog: null,
     taskFile: null,
+    login: null,
+    loginTyping: "",
+    loginCopied: false,
     begun: false,
     running: false,
     finished: false,

--- a/apps/cli/src/ui/tui/store.ts
+++ b/apps/cli/src/ui/tui/store.ts
@@ -13,12 +13,17 @@
 
 import { WizardRouter, type ScreenName, type Sequence } from "./router.ts";
 import { emptyState, type WizardState } from "./state.ts";
+import type { LoginPrompt } from "../../platform/login.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { DrivenAgent, GateId } from "../wizard-ui.ts";
 
 /** The screens of the walk, in order. */
 export const WALK_SCREENS: Sequence = [
   { id: "intro", isComplete: (state) => state.begun },
+  // Login shows only while there is something to approve, and stops showing the
+  // moment there is not — which is the router working the flow out from state
+  // rather than the flow navigating anywhere.
+  { id: "login", show: (state) => state.login !== null },
   { id: "task" },
 ];
 
@@ -41,6 +46,8 @@ export class WizardStore {
   private state: WizardState = emptyState();
   private readonly listeners = new Set<() => void>();
   private readonly gates = new Map<GateId, Gate>();
+  /** What the login screen has handed over and the flow has not taken yet. */
+  private pastedLogin: string | null = null;
 
   readonly router: WizardRouter;
 
@@ -91,6 +98,21 @@ export class WizardStore {
     this.change({ taskFile });
   }
 
+  setLogin(login: LoginPrompt | null): void {
+    this.change(
+      login === null
+        ? { login, loginTyping: "", loginCopied: false }
+        : { login },
+    );
+  }
+
+  /** Hands over what was typed back, and forgets it, so it is acted on once. */
+  takeLoginPaste(): string | null {
+    const typed = this.pastedLogin;
+    this.pastedLogin = null;
+    return typed;
+  }
+
   taskStarted(): void {
     this.change({ running: true });
   }
@@ -118,6 +140,24 @@ export class WizardStore {
   begin(): void {
     if (this.state.begun) return;
     this.change({ begun: true });
+  }
+
+  /** What the developer is typing back at the login screen, as they type it. */
+  typeLogin(loginTyping: string): void {
+    this.change({ loginTyping });
+  }
+
+  /** Hand what was typed to the flow, and clear the line it was typed on. */
+  submitLogin(): void {
+    const typed = this.state.loginTyping.trim();
+    if (typed === "") return;
+    this.pastedLogin = typed;
+    this.change({ loginTyping: "" });
+  }
+
+  /** The address has been put on the clipboard, and the screen may say so. */
+  linkCopied(): void {
+    this.change({ loginCopied: true });
   }
 
   private change(patch: Partial<WizardState>): void {

--- a/apps/cli/src/ui/tui/width.ts
+++ b/apps/cli/src/ui/tui/width.ts
@@ -11,8 +11,22 @@
  * that copies the address without drawing it.
  */
 
-/** What the box around a screen costs: a border and padding, each side. */
-export const FRAMING_COLUMNS = 6;
+/** A drawn border is one column wide, on the left and again on the right. */
+const BORDER_COLUMNS = 1;
+
+/** What `paddingX` is set to on the box the address is drawn in. */
+const PADDING_COLUMNS = 2;
+
+/**
+ * What the box around a screen costs, left and right together.
+ *
+ * Constraint, and the code cannot show it to you: this has to match the box
+ * `LoginScreen` draws — `borderStyle="round"` (one column each side) and
+ * `paddingX={2}` (two more each side). Change either of those there and this
+ * has to change with it, or the screen will promise an address fits and then
+ * wrap it.
+ */
+export const FRAMING_COLUMNS = (BORDER_COLUMNS + PADDING_COLUMNS) * 2;
 
 export function addressFits(url: string, columns: number, framing = FRAMING_COLUMNS): boolean {
   return url.length <= columns - framing;

--- a/apps/cli/src/ui/tui/width.ts
+++ b/apps/cli/src/ui/tui/width.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether an address fits on one line, and what to say when it does not.
+ *
+ * An address that wraps is worse than no address at all. Selecting it with a
+ * mouse copies the line break with it, and a line break pasted into a browser
+ * is an address that does not work — so the developer's first attempt fails for
+ * a reason nothing on screen explains.
+ *
+ * So it is never drawn wrapped. Either the whole address is on its own line, or
+ * the screen says how much wider the terminal has to be and points at the key
+ * that copies the address without drawing it.
+ */
+
+/** What the box around a screen costs: a border and padding, each side. */
+export const FRAMING_COLUMNS = 6;
+
+export function addressFits(url: string, columns: number, framing = FRAMING_COLUMNS): boolean {
+  return url.length <= columns - framing;
+}
+
+/** How wide the terminal has to be for the address to fit on one line. */
+export function columnsNeeded(url: string, framing = FRAMING_COLUMNS): number {
+  return url.length + framing;
+}

--- a/apps/cli/src/ui/wizard-ui.ts
+++ b/apps/cli/src/ui/wizard-ui.ts
@@ -10,6 +10,7 @@
  * depend on how a screen is drawn.
  */
 
+import type { LoginPrompt } from "../platform/login.ts";
 import type { ExitReport } from "../wizard/exit-line.ts";
 
 /** A point the flow waits at until the developer has moved past it. */
@@ -27,6 +28,25 @@ export interface WizardUI {
 
   /** Name the file the one task is about. */
   setTaskFile(file: string): void;
+
+  /**
+   * What login is waiting to be approved, or `null` once it no longer is.
+   *
+   * This is a write and not a question. The flow says what has to be approved
+   * and where; whether that is drawn in a box, printed as two plain lines, or
+   * drawn nowhere at all is the UI's business.
+   */
+  setLogin(prompt: LoginPrompt | null): void;
+
+  /**
+   * What the developer has pasted at the login screen since the last look, or
+   * `null`. Taken rather than read, so one paste is acted on once.
+   *
+   * This is still not a prompt: the flow never waits on it and never blocks
+   * for it. Typing lands in the UI, the flow looks up between polls, and a UI
+   * with nobody at the keyboard answers `null` forever.
+   */
+  takeLoginPaste(): string | null;
 
   /**
    * Park until the developer has let the flow past this point. A gate that the

--- a/apps/cli/src/wizard/login-step.ts
+++ b/apps/cli/src/wizard/login-step.ts
@@ -1,0 +1,76 @@
+/**
+ * The wizard's login step: the same flow the headless verb runs, on a screen.
+ *
+ * Everything the developer sees is pushed at the UI; everything they type is
+ * read back from it between polls. The step itself owns no drawing and no
+ * keystroke, which is what lets it be one step in the walk and one command at
+ * the same time.
+ *
+ * A new account signs up in the browser page this step opens, and comes back
+ * signed in. What egma provisions for them there is egma's business and is
+ * never named here — the terminal's job is a code, an address, and a key.
+ */
+
+import { openInBrowser } from "../platform/browser.ts";
+import { logIn, type LogInOptions } from "../platform/login.ts";
+import type { WizardUI } from "../ui/wizard-ui.ts";
+import type { ExitReport } from "./exit-line.ts";
+import { stopReport } from "./stop.ts";
+
+/** How the wizard reaches egma, and where the key it gets is kept. */
+export type PlatformAccess = {
+  /** The egma being logged in to, already resolved from flag, env or file. */
+  readonly url: string;
+  readonly credentialsFile: string;
+  /** Starts a browser. The developer's own opener when omitted. */
+  readonly openBrowser?: LogInOptions["openBrowser"];
+};
+
+/**
+ * Logs in, or answers with the line the wizard should close on.
+ *
+ * `null` means the developer is signed in and the walk carries on. Everything
+ * else is an ending, and each ending says which one it was: a denial is not a
+ * fault, a code that ran out is not a denial, and an instance that never
+ * answered is neither.
+ */
+export async function logInStep(
+  platform: PlatformAccess,
+  ui: WizardUI,
+  signal: AbortSignal,
+): Promise<ExitReport | null> {
+  const outcome = await logIn({
+    url: platform.url,
+    credentialsFile: platform.credentialsFile,
+    signal,
+    onPrompt: (prompt) => ui.setLogin(prompt),
+    say: (line) => ui.pushStatus(line),
+    paste: () => ui.takeLoginPaste(),
+    openBrowser: platform.openBrowser ?? ((url) => openInBrowser(url)),
+  });
+
+  ui.setLogin(null);
+
+  switch (outcome.kind) {
+    case "stored":
+      ui.pushStatus(`Signed in to ${outcome.url}.`);
+      return null;
+    case "already-stored":
+      // Nothing was approved and nothing needed to be: this machine already
+      // holds a key for this egma, so login is a step that costs no time.
+      ui.pushStatus(`Already signed in to ${outcome.url}.`);
+      return null;
+    case "denied":
+      return { kind: "failed", reason: "the login was denied in the browser." };
+    case "expired":
+      return {
+        kind: "failed",
+        reason: "nobody approved the login before the code ran out. Run egma again.",
+      };
+    case "interrupted":
+      return stopReport(signal, null);
+    case "unreachable":
+    case "refused":
+      return { kind: "failed", reason: outcome.reason };
+  }
+}

--- a/apps/cli/src/wizard/login-step.ts
+++ b/apps/cli/src/wizard/login-step.ts
@@ -12,16 +12,14 @@
  */
 
 import { openInBrowser } from "../platform/browser.ts";
+import type { PlatformAccess as ResolvedPlatform } from "../platform/credentials.ts";
 import { logIn, type LogInOptions } from "../platform/login.ts";
 import type { WizardUI } from "../ui/wizard-ui.ts";
 import type { ExitReport } from "./exit-line.ts";
 import { stopReport } from "./stop.ts";
 
 /** How the wizard reaches egma, and where the key it gets is kept. */
-export type PlatformAccess = {
-  /** The egma being logged in to, already resolved from flag, env or file. */
-  readonly url: string;
-  readonly credentialsFile: string;
+export type PlatformAccess = ResolvedPlatform & {
   /** Starts a browser. The developer's own opener when omitted. */
   readonly openBrowser?: LogInOptions["openBrowser"];
 };
@@ -39,26 +37,28 @@ export async function logInStep(
   ui: WizardUI,
   signal: AbortSignal,
 ): Promise<ExitReport | null> {
-  const outcome = await logIn({
+  const result = await logIn({
     url: platform.url,
     credentialsFile: platform.credentialsFile,
     signal,
     onPrompt: (prompt) => ui.setLogin(prompt),
     say: (line) => ui.pushStatus(line),
     paste: () => ui.takeLoginPaste(),
-    openBrowser: platform.openBrowser ?? ((url) => openInBrowser(url)),
+    openBrowser:
+      platform.openBrowser ??
+      ((url) => openInBrowser(url, { instanceUrl: platform.url })),
   });
 
   ui.setLogin(null);
 
-  switch (outcome.kind) {
+  switch (result.kind) {
     case "stored":
-      ui.pushStatus(`Signed in to ${outcome.url}.`);
+      ui.pushStatus(`Signed in to ${result.url}.`);
       return null;
     case "already-stored":
       // Nothing was approved and nothing needed to be: this machine already
       // holds a key for this egma, so login is a step that costs no time.
-      ui.pushStatus(`Already signed in to ${outcome.url}.`);
+      ui.pushStatus(`Already signed in to ${result.url}.`);
       return null;
     case "denied":
       return { kind: "failed", reason: "the login was denied in the browser." };
@@ -71,6 +71,6 @@ export async function logInStep(
       return stopReport(signal, null);
     case "unreachable":
     case "refused":
-      return { kind: "failed", reason: outcome.reason };
+      return { kind: "failed", reason: result.reason };
   }
 }

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -15,6 +15,7 @@ import type { DrivenAgentLaunch } from "../acp/registry.ts";
 import type { WizardUI } from "../ui/wizard-ui.ts";
 import { openDrivenAgentLog, type DrivenAgentLog } from "./driven-agent-log.ts";
 import type { ExitReport } from "./exit-line.ts";
+import { logInStep, type PlatformAccess } from "./login-step.ts";
 import { stopReport, untilAborted } from "./stop.ts";
 
 /**
@@ -38,6 +39,12 @@ export type WalkOptions = {
   readonly signal: AbortSignal;
   /** Where the agent's own output is kept. A fresh file per run by default. */
   readonly log?: DrivenAgentLog;
+  /**
+   * Which egma to sign in to, and where the key goes. Omit and the walk signs
+   * in to nothing — which is how the checks that are only about driving a
+   * coding agent stay about that.
+   */
+  readonly platform?: PlatformAccess;
 };
 
 async function isFile(candidate: string): Promise<boolean> {
@@ -114,6 +121,16 @@ export async function walk(options: WalkOptions): Promise<ExitReport> {
     const report = stopReport(signal, launch.name);
     ui.setExit(report);
     return report;
+  }
+
+  // Before anything is driven: who this is. Nothing else in the walk can name
+  // an agent, a connection or a test until egma knows whose they are.
+  if (options.platform !== undefined) {
+    const refusal = await logInStep(options.platform, ui, signal);
+    if (refusal !== null) {
+      ui.setExit(refusal);
+      return refusal;
+    }
   }
 
   ui.taskStarted();

--- a/apps/cli/test/cli.test.ts
+++ b/apps/cli/test/cli.test.ts
@@ -25,10 +25,13 @@ const run = promisify(execFile);
 
 async function egma(
   args: readonly string[],
-  cwd: string,
+  workspace: Workspace,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   try {
-    const { stdout, stderr } = await run(process.execPath, [CLI_ENTRY, ...args], { cwd });
+    const { stdout, stderr } = await run(process.execPath, [CLI_ENTRY, ...args], {
+      cwd: workspace.dir,
+      env: workspace.env(),
+    });
     return { stdout, stderr, code: 0 };
   } catch (error) {
     const failure = error as { stdout?: string; stderr?: string; code?: number };
@@ -41,6 +44,10 @@ describe("the egma command", () => {
 
   beforeEach(async () => {
     workspace = await makeWorkspace({ "package.json": MANIFEST });
+    // These checks are about driving a coding agent, so the machine they run on
+    // is already signed in and login costs them nothing. Login itself is proved
+    // in the checks that are about login.
+    await workspace.signIn("https://egma.invalid");
   });
 
   afterEach(async () => {
@@ -52,7 +59,7 @@ describe("the egma command", () => {
       const child = spawn(
         process.execPath,
         ["--import", PRETEND_OLD_NODE, CLI_ENTRY, "--help"],
-        { cwd: workspace.dir },
+        { cwd: workspace.dir, env: workspace.env() },
       );
       let stderr = "";
       child.stderr.setEncoding("utf8");
@@ -70,7 +77,7 @@ describe("the egma command", () => {
   });
 
   it("prints what it can do, and what version it is", async () => {
-    const help = await egma(["--help"], workspace.dir);
+    const help = await egma(["--help"], workspace);
     expect(help.code).toBe(0);
     expect(help.stdout).toContain("Usage:");
     expect(help.stdout).toContain("--coding-agent <id>");
@@ -79,12 +86,12 @@ describe("the egma command", () => {
     expect(help.stdout).not.toContain("--file");
     expect(help.stdout).not.toContain("-- <command>");
 
-    const version = await egma(["--version"], workspace.dir);
+    const version = await egma(["--version"], workspace);
     expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it("says so when handed an option it does not know", async () => {
-    const result = await egma(["--turbo"], workspace.dir);
+    const result = await egma(["--turbo"], workspace);
     expect(result.code).toBe(1);
     expect(result.stderr).toContain("--turbo");
   });
@@ -92,7 +99,7 @@ describe("the egma command", () => {
   it("refuses to run the wizard where there is no terminal to agree in", async () => {
     // Not a terminal: this is `npx egma | tee log`, where the keystroke that
     // means yes can never be pressed.
-    const result = await egma(["--cwd", workspace.dir], workspace.dir);
+    const result = await egma(["--cwd", workspace.dir], workspace);
 
     expect(result.code).toBe(1);
     expect(result.stderr).toContain("needs a terminal");
@@ -120,7 +127,7 @@ describe("the egma command", () => {
 
     const result = await egma(
       ["--headless", "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
-      workspace.dir,
+      workspace,
     );
 
     expect(result.code).toBe(0);
@@ -158,7 +165,7 @@ describe("the egma command", () => {
         FAKE_AGENT,
         script,
       ],
-      workspace.dir,
+      workspace,
     );
 
     expect(result.code).toBe(0);
@@ -182,7 +189,7 @@ describe("the egma command", () => {
     const child = spawn(
       process.execPath,
       [CLI_ENTRY, "--headless", "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
-      { cwd: workspace.dir },
+      { cwd: workspace.dir, env: workspace.env() },
     );
     let stdout = "";
     child.stdout.setEncoding("utf8");

--- a/apps/cli/test/login-command.test.ts
+++ b/apps/cli/test/login-command.test.ts
@@ -1,0 +1,214 @@
+/**
+ * `egma login` as a coding agent runs it: the built command, in a real
+ * subprocess, against a fixture of egma's public HTTP API.
+ *
+ * Nothing here is a terminal and nothing here answers a question, because the
+ * whole promise of the verb is that neither is needed. What is asserted is the
+ * two things something driving it can act on: the lines it prints and the
+ * number it exits with.
+ */
+
+import { execFile, spawn } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import process from "node:process";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { CLI_ENTRY, makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+const run = promisify(execFile);
+
+let platform: Platform;
+let workspace: Workspace;
+let browser: { command: string; opened: string };
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  workspace = await makeWorkspace();
+  browser = await workspace.browser();
+});
+
+afterEach(async () => {
+  await platform.close();
+  await workspace.remove();
+});
+
+type Result = { stdout: string; stderr: string; code: number };
+
+async function egma(args: readonly string[], env: NodeJS.ProcessEnv = {}): Promise<Result> {
+  try {
+    const { stdout, stderr } = await run(process.execPath, [CLI_ENTRY, ...args], {
+      cwd: workspace.dir,
+      env: workspace.env({
+        BROWSER: browser.command,
+        FIXTURE_BROWSER_WRITES_TO: browser.opened,
+        ...env,
+      }),
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (error) {
+    const failure = error as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: failure.stdout ?? "", stderr: failure.stderr ?? "", code: failure.code ?? 1 };
+  }
+}
+
+/** The printed lines, read the way something driving the command reads them. */
+function facts(stdout: string): Record<string, string> {
+  const read: Record<string, string> = {};
+  for (const line of stdout.trimEnd().split("\n")) {
+    const at = line.indexOf(": ");
+    if (at > 0) read[line.slice(0, at)] = line.slice(at + 2);
+  }
+  return read;
+}
+
+describe("egma login", () => {
+  it("signs the machine in with no terminal, no keystroke and no question", async () => {
+    const result = await egma(["login", "--url", platform.url]);
+
+    expect(result.code).toBe(0);
+    const said = facts(result.stdout);
+
+    // Everything something driving this needs, one fact per line.
+    expect(said.url).toBe(platform.url);
+    expect(said.code).toMatch(/^[A-Z]{4}-[A-Z]{4}$/u);
+    expect(said.approve_url).toContain(platform.url);
+    expect(said.approve_url).toContain(encodeURIComponent(said.code as string));
+    expect(said.browser).toBe("opened");
+    expect(said.status).toBe("stored");
+    expect(said.credentials).toBe(workspace.credentialsFile);
+
+    // The address egma handed the browser is the address it printed.
+    expect((await readFile(browser.opened, "utf8")).trim()).toBe(said.approve_url);
+
+    // The key is on disk, and nobody else on the machine can read it.
+    const held = JSON.parse(await readFile(workspace.credentialsFile, "utf8")) as {
+      url: string;
+      key: string;
+    };
+    expect(held.url).toBe(platform.url);
+    expect(held.key).toBe(platform.device.keys.at(-1));
+    expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
+
+    // And it works on a request that needs one.
+    const used = await fetch(`${platform.url}/api/keys`, {
+      headers: { authorization: `Bearer ${held.key}` },
+    });
+    expect(used.status).toBe(200);
+  });
+
+  it("finishes with no standard input at all, which is what promptless means", async () => {
+    // Not a terminal and not even a pipe: there is nothing here to read a
+    // keystroke from, so a command that asked anything could not finish.
+    const child = spawn(process.execPath, [CLI_ENTRY, "login", "--url", platform.url], {
+      cwd: workspace.dir,
+      env: workspace.env({
+        BROWSER: browser.command,
+        FIXTURE_BROWSER_WRITES_TO: browser.opened,
+      }),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    const code = await new Promise<number>((resolve) => {
+      child.on("close", (value) => resolve(value ?? 0));
+    });
+
+    expect(code).toBe(0);
+    expect(facts(stdout).status).toBe("stored");
+  });
+
+  it("keeps the address it was given, so later commands never repeat it", async () => {
+    // A self-hoster sets it once, for one shell.
+    const first = await egma(["login"], { EGMA_URL: platform.url });
+    expect(first.code).toBe(0);
+    expect(facts(first.stdout).status).toBe("stored");
+
+    // And the next command finds it with nothing said at all: no flag, and the
+    // variable gone from the environment.
+    const second = await egma(["login"]);
+    expect(second.code).toBe(0);
+    const said = facts(second.stdout);
+    expect(said.url).toBe(platform.url);
+    expect(said.status).toBe("already-stored");
+
+    // Nothing was approved the second time, because nothing needed to be.
+    expect(platform.records.filter((seen) => seen.path === "/api/device/code")).toHaveLength(1);
+    expect((await readFile(browser.opened, "utf8")).trimEnd().split("\n")).toHaveLength(1);
+  });
+
+  it("signs in again when told to, even though a key is already held", async () => {
+    await egma(["login", "--url", platform.url]);
+    const again = await egma(["login", "--force"]);
+
+    expect(again.code).toBe(0);
+    expect(facts(again.stdout).status).toBe("stored");
+    expect(platform.device.keys).toHaveLength(2);
+
+    const held = JSON.parse(await readFile(workspace.credentialsFile, "utf8")) as { key: string };
+    expect(held.key).toBe(platform.device.keys.at(-1));
+  });
+
+  it("answers 2 when the login is denied, and stores nothing", async () => {
+    const result = await egma(["login", "--url", platform.url], {
+      FIXTURE_BROWSER_DOES: "deny",
+    });
+
+    expect(result.code).toBe(2);
+    expect(facts(result.stdout).status).toBe("denied");
+    expect(result.stderr).toContain("denied");
+    await expect(readFile(workspace.credentialsFile, "utf8")).rejects.toThrow();
+  });
+
+  it("answers 3 when the code runs out, which is not being told no", async () => {
+    const result = await egma(["login", "--url", platform.url], {
+      FIXTURE_BROWSER_DOES: "expire",
+    });
+
+    expect(result.code).toBe(3);
+    expect(facts(result.stdout).status).toBe("expired");
+    await expect(readFile(workspace.credentialsFile, "utf8")).rejects.toThrow();
+  });
+
+  it("answers 4 and names the address when egma does not answer", async () => {
+    // Nothing listens here, and the address is in the message rather than in a
+    // stack trace.
+    const result = await egma(["login", "--url", "http://127.0.0.1:1"]);
+
+    expect(result.code).toBe(4);
+    const said = facts(result.stdout);
+    expect(said.status).toBe("unreachable");
+    expect(said.reason).toContain("127.0.0.1:1");
+    expect(result.stderr).toContain("127.0.0.1:1");
+  });
+
+  it("never says the words a terminal does not say", async () => {
+    const result = await egma(["login", "--url", platform.url]);
+
+    // A new account is signed up in the browser page and gets everything it
+    // needs there. What egma set up is never named out here — locked rule.
+    for (const banned of ["organization", "organisation", "project", "tenant"]) {
+      expect(
+        new RegExp(`\\b${banned}`, "iu").test(result.stdout + result.stderr),
+        `the command says "${banned}"`,
+      ).toBe(false);
+    }
+  });
+
+  it("is offered in the help, with what it prints and what it answers", async () => {
+    const help = await egma(["--help"]);
+
+    expect(help.code).toBe(0);
+    expect(help.stdout).toContain("egma login");
+    expect(help.stdout).toContain("--url <address>");
+    expect(help.stdout).toContain("approve_url");
+    expect(help.stdout).toContain("2 denied");
+  });
+});

--- a/apps/cli/test/login-command.test.ts
+++ b/apps/cli/test/login-command.test.ts
@@ -73,7 +73,7 @@ describe("egma login", () => {
 
     // Everything something driving this needs, one fact per line.
     expect(said.url).toBe(platform.url);
-    expect(said.code).toMatch(/^[A-Z]{4}-[A-Z]{4}$/u);
+    expect(said.code).toMatch(/^[A-Z0-9]{8}$/u);
     expect(said.approve_url).toContain(platform.url);
     expect(said.approve_url).toContain(encodeURIComponent(said.code as string));
     expect(said.browser).toBe("opened");
@@ -189,16 +189,102 @@ describe("egma login", () => {
     expect(result.stderr).toContain("127.0.0.1:1");
   });
 
-  it("never says the words a terminal does not say", async () => {
+  it("answers 4 and says so in egma's own words when egma refuses", async () => {
+    // A refusal is not a silence, and the help says so: 4 is both.
+    platform.device.answerTokenWith(
+      "invalid_grant",
+      "this authorization was approved without naming an organization and a project, so there is nothing to mint a key for. Start again from the terminal.",
+    );
+
     const result = await egma(["login", "--url", platform.url]);
 
-    // A new account is signed up in the browser page and gets everything it
-    // needs there. What egma set up is never named out here — locked rule.
-    for (const banned of ["organization", "organisation", "project", "tenant"]) {
-      expect(
-        new RegExp(`\\b${banned}`, "iu").test(result.stdout + result.stderr),
-        `the command says "${banned}"`,
-      ).toBe(false);
+    expect(result.code).toBe(4);
+    const said = facts(result.stdout);
+    expect(said.status).toBe("refused");
+    expect(said.reason).toBe(
+      "egma would not mint a key for this login. Start again from the terminal.",
+    );
+    await expect(readFile(workspace.credentialsFile, "utf8")).rejects.toThrow();
+  });
+
+  /**
+   * The words a terminal never says, held against every way a login can end.
+   *
+   * A new account is signed up in the browser page and gets everything it needs
+   * there. What egma set up is never named out here — locked rule. The real
+   * instance's own `error_description` says both words, so each refusal it can
+   * answer with is played back through the fixture in its own words, and none
+   * of them may reach a screen.
+   */
+  describe("never says the words a terminal does not say", () => {
+    const BANNED = ["organization", "organisation", "project", "tenant"];
+
+    /** What the real API answers, code and description, copied from it. */
+    const refusals = [
+      {
+        named: "access_denied",
+        error: "access_denied",
+        said: "this was denied in the browser",
+      },
+      {
+        named: "expired_token",
+        error: "expired_token",
+        said: "this authorization is over",
+      },
+      {
+        named: "invalid_grant, aimed at nothing",
+        error: "invalid_grant",
+        said: "this authorization was approved without naming an organization and a project, so there is nothing to mint a key for. Start again from the terminal.",
+      },
+      {
+        named: "invalid_grant, whoever approved it has gone",
+        error: "invalid_grant",
+        said: "the person who approved this is no longer in that organization",
+      },
+      {
+        named: "invalid_grant, what it was aimed at has gone",
+        error: "invalid_grant",
+        said: "the project this terminal was authorized for is gone. Start again from the terminal.",
+      },
+      {
+        named: "unsupported_grant_type",
+        error: "unsupported_grant_type",
+        said: "this endpoint understands urn:ietf:params:oauth:grant-type:device_code and nothing else",
+      },
+      {
+        named: "a refusal egma has never sent before",
+        error: "not_permitted",
+        said: "this role may not mint a key for that project in that organization",
+      },
+    ];
+
+    it("on the way through a login that works", async () => {
+      const result = await egma(["login", "--url", platform.url]);
+      for (const banned of BANNED) {
+        expect(
+          new RegExp(`\\b${banned}`, "iu").test(result.stdout + result.stderr),
+          `the command says "${banned}"`,
+        ).toBe(false);
+      }
+    });
+
+    for (const refusal of refusals) {
+      it(`when egma answers ${refusal.named}`, async () => {
+        platform.device.answerTokenWith(refusal.error, refusal.said);
+
+        const result = await egma(["login", "--url", platform.url]);
+
+        // It ended somehow, and nothing it printed came from the instance.
+        expect(result.code).not.toBe(0);
+        const shown = result.stdout + result.stderr;
+        expect(shown).not.toContain(refusal.said);
+        for (const banned of BANNED) {
+          expect(
+            new RegExp(`\\b${banned}`, "iu").test(shown),
+            `the command says "${banned}" on ${refusal.error}`,
+          ).toBe(false);
+        }
+      });
     }
   });
 
@@ -210,5 +296,26 @@ describe("egma login", () => {
     expect(help.stdout).toContain("--url <address>");
     expect(help.stdout).toContain("approve_url");
     expect(help.stdout).toContain("2 denied");
+    // 4 is both an egma that never answered and one that said no, and the help
+    // says both rather than only the one that reads better.
+    expect(help.stdout).toContain("4 egma did not answer, or refused");
+  });
+
+  it("names the two things a self-hoster sets, in the help", async () => {
+    const help = await egma(["--help"]);
+
+    expect(help.stdout).toContain("EGMA_URL");
+    expect(help.stdout).toContain("EGMA_HOME");
+    expect(help.stdout).toContain("--force");
+  });
+
+  it("refuses an address that is not one, before it starts anything", async () => {
+    const result = await egma(["login", "--url", "javascript:alert(1)"]);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("http:// or https://");
+    // Nothing was asked of anything: the address was turned away at the door.
+    expect(platform.records).toHaveLength(0);
+    expect((await readFile(browser.opened, "utf8").catch(() => ""))).toBe("");
   });
 });

--- a/apps/cli/test/login-screen.test.ts
+++ b/apps/cli/test/login-screen.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The login step as a developer meets it, on a real terminal.
+ *
+ * A pseudo-terminal runs the built command and a headless terminal emulator
+ * reads its screen and everything it wrote, so the promises about the address
+ * are checked as terminal facts: the address on its own line, the copy key
+ * really copying it, and a terminal too narrow for it getting a way out rather
+ * than an address broken across two lines.
+ */
+
+import process from "node:process";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { copySequence } from "../src/platform/clipboard.ts";
+import { columnsNeeded } from "../src/ui/tui/width.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { runInTerminal } from "./support/pty.ts";
+import {
+  CLI_ENTRY,
+  FAKE_AGENT,
+  MANIFEST,
+  makeWorkspace,
+  waitUntil,
+  type Workspace,
+} from "./support/workspace.ts";
+
+let platform: Platform;
+let workspace: Workspace;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  workspace = await makeWorkspace({ "package.json": MANIFEST });
+});
+
+afterEach(async () => {
+  await platform.close();
+  await workspace.remove();
+});
+
+type Opened = { readonly command: string; readonly opened: string };
+
+async function wizard(options: {
+  readonly browser: Opened;
+  readonly does?: string;
+  readonly cols?: number;
+  readonly rows?: number;
+}) {
+  const script = await workspace.script({
+    steps: [
+      { kind: "say", text: "It is a package manifest." },
+      { kind: "stop", reason: "end_turn" },
+    ],
+  });
+
+  return runInTerminal({
+    command: process.execPath,
+    args: [
+      CLI_ENTRY,
+      "--cwd",
+      workspace.dir,
+      "--url",
+      platform.url,
+      "--",
+      process.execPath,
+      FAKE_AGENT,
+      script,
+    ],
+    cwd: workspace.dir,
+    env: workspace.env({
+      BROWSER: options.browser.command,
+      FIXTURE_BROWSER_WRITES_TO: options.browser.opened,
+      FIXTURE_BROWSER_DOES: options.does ?? "nothing",
+    }),
+    ...(options.cols === undefined ? {} : { cols: options.cols }),
+    ...(options.rows === undefined ? {} : { rows: options.rows }),
+  });
+}
+
+/** The code the terminal is showing, read off its screen. */
+function codeOn(screen: string): string {
+  return /Code: ([A-Z]{4}-[A-Z]{4})/u.exec(screen)?.[1] ?? "";
+}
+
+/**
+ * Wait until the whole login screen is drawn, not merely the first line of it.
+ *
+ * The hint bar is the last thing on the screen, so a screen carrying both the
+ * code and the hints is a finished frame rather than half of one.
+ */
+async function drawn(terminal: { screen(): string }): Promise<boolean> {
+  return waitUntil(() => {
+    const screen = terminal.screen();
+    return screen.includes("Code:") && screen.includes("[q] quit");
+  });
+}
+
+/** What is written inside the box, one line per line, without the box. */
+function linesInside(screen: string): string[] {
+  return screen.split("\n").map((line) => line.replaceAll("│", "").trim());
+}
+
+/** Everything on screen as one run of words, for text that has been wrapped. */
+function asOneLine(screen: string): string {
+  return linesInside(screen).join(" ").replaceAll(/\s+/gu, " ");
+}
+
+describe("the login screen", () => {
+  it("shows the code, the address on its own line, and a way to copy it", async () => {
+    const browser = await workspace.browser();
+    const terminal = await wizard({ browser, cols: 120 });
+
+    try {
+      // The intro comes first, and the consent keystroke opens the walk.
+      expect(await waitUntil(() => terminal.screen().includes("[enter] begin"))).toBe(true);
+      terminal.write("\r");
+
+      expect(await drawn(terminal)).toBe(true);
+      const screen = terminal.screen();
+      const code = codeOn(screen);
+      expect(code).not.toBe("");
+
+      // The address is on a line of its own, whole, with nothing else on it —
+      // which is what makes a triple-click select an address that works.
+      const approveUrl = `${platform.url}/device/approve?user_code=${encodeURIComponent(code)}`;
+      const ownLine = linesInside(screen).find((line) => line.startsWith(platform.url));
+      expect(ownLine).toBe(approveUrl);
+
+      expect(screen).toContain("[c] copy link");
+      expect(screen).toContain("Approve this code");
+
+      // Pressing it asks the terminal itself to copy, which is what reaches the
+      // clipboard of a laptop with an SSH connection open to somewhere else.
+      terminal.write("c");
+      expect(await waitUntil(() => terminal.raw().includes(copySequence(approveUrl)))).toBe(
+        true,
+      );
+      expect(await waitUntil(() => terminal.screen().includes("Copied."))).toBe(true);
+    } finally {
+      terminal.kill();
+    }
+  });
+
+  it("asks for a wider terminal rather than drawing an address that wraps", async () => {
+    const browser = await workspace.browser();
+    // Narrower than the address, which on a fixture is already short. Tall
+    // enough that nothing is cut off the bottom, so what is missing from the
+    // screen is missing because the screen left it out.
+    const terminal = await wizard({ browser, cols: 40, rows: 40 });
+
+    try {
+      expect(await waitUntil(() => terminal.screen().includes("[enter] begin"))).toBe(true);
+      terminal.write("\r");
+      expect(await drawn(terminal)).toBe(true);
+
+      const screen = terminal.screen();
+      const approveUrl = `${platform.url}/device/approve?user_code=${codeOn(screen)}`;
+      expect(asOneLine(screen)).toContain(
+        `The address needs ${columnsNeeded(approveUrl)} columns and this terminal has 40`,
+      );
+      expect(asOneLine(screen)).toContain("[c] copy link");
+
+      // The address itself is nowhere on the screen, whole or broken up. An
+      // address selected across a line break is an address that does not work.
+      expect(screen).not.toContain(platform.url);
+      expect(screen.replaceAll(/\s+/gu, "")).not.toContain(
+        platform.url.replaceAll(/\s+/gu, ""),
+      );
+    } finally {
+      terminal.kill();
+    }
+  });
+
+  it("completes the login when a whole address is pasted back at it", async () => {
+    const browser = await workspace.browser();
+    // The browser opens nothing and approves nothing: this is the machine with
+    // no browser on it at all.
+    const terminal = await wizard({ browser, cols: 120 });
+
+    try {
+      expect(await waitUntil(() => terminal.screen().includes("[enter] begin"))).toBe(true);
+      terminal.write("\r");
+      expect(await drawn(terminal)).toBe(true);
+
+      const code = codeOn(terminal.screen());
+      // Approved in a browser on another machine, and then pasted back here.
+      expect(platform.device.approve(code)).toBe(true);
+      terminal.write(`${platform.url}/device/approve?user_code=${code}\r`);
+
+      // The walk carried on: login is behind, the coding agent is being driven,
+      // and the run ends on the one line the wizard leaves in scrollback.
+      expect(await terminal.exited).toBe(0);
+      expect(terminal.scrollback().trim()).toBe(
+        "node read package.json for egma. Nothing in this folder was changed.",
+      );
+      expect(platform.device.keys).toHaveLength(1);
+    } finally {
+      terminal.kill();
+    }
+  });
+
+  it("carries on to the task once the browser has approved, showing nothing to approve", async () => {
+    const browser = await workspace.browser();
+    const terminal = await wizard({ browser, does: "approve", cols: 120 });
+
+    try {
+      expect(await waitUntil(() => terminal.screen().includes("[enter] begin"))).toBe(true);
+      terminal.write("\r");
+
+      expect(await terminal.exited).toBe(0);
+      expect(terminal.scrollback().trim()).toBe(
+        "node read package.json for egma. Nothing in this folder was changed.",
+      );
+
+      // A key was minted and kept, and it is the one this egma issued.
+      expect(platform.device.keys).toHaveLength(1);
+    } finally {
+      terminal.kill();
+    }
+  });
+
+  it("never says the words a terminal does not say", async () => {
+    const browser = await workspace.browser();
+    const terminal = await wizard({ browser, cols: 120 });
+
+    try {
+      expect(await waitUntil(() => terminal.screen().includes("[enter] begin"))).toBe(true);
+      terminal.write("\r");
+      expect(await drawn(terminal)).toBe(true);
+
+      // A new account signs up in that browser page and gets everything it
+      // needs there. The terminal names none of it — locked rule.
+      const shown = terminal.screen();
+      for (const banned of ["organization", "organisation", "project", "tenant"]) {
+        expect(new RegExp(`\\b${banned}`, "iu").test(shown), `the screen says "${banned}"`).toBe(
+          false,
+        );
+      }
+    } finally {
+      terminal.kill();
+    }
+  });
+});

--- a/apps/cli/test/login-screen.test.ts
+++ b/apps/cli/test/login-screen.test.ts
@@ -77,9 +77,15 @@ async function wizard(options: {
   });
 }
 
-/** The code the terminal is showing, read off its screen. */
+/**
+ * The code the terminal is showing, read off its screen.
+ *
+ * Whatever is on that line is the code. What shape egma issues codes in is the
+ * instance's business and is asserted where the instance is — baking it in here
+ * would make this screen check fail the day the codes get a character longer.
+ */
 function codeOn(screen: string): string {
-  return /Code: ([A-Z]{4}-[A-Z]{4})/u.exec(screen)?.[1] ?? "";
+  return /Code: (\S+)/u.exec(screen)?.[1] ?? "";
 }
 
 /**
@@ -122,7 +128,7 @@ describe("the login screen", () => {
 
       // The address is on a line of its own, whole, with nothing else on it —
       // which is what makes a triple-click select an address that works.
-      const approveUrl = `${platform.url}/device/approve?user_code=${encodeURIComponent(code)}`;
+      const approveUrl = `${platform.url}/device?user_code=${encodeURIComponent(code)}`;
       const ownLine = linesInside(screen).find((line) => line.startsWith(platform.url));
       expect(ownLine).toBe(approveUrl);
 
@@ -154,7 +160,7 @@ describe("the login screen", () => {
       expect(await drawn(terminal)).toBe(true);
 
       const screen = terminal.screen();
-      const approveUrl = `${platform.url}/device/approve?user_code=${codeOn(screen)}`;
+      const approveUrl = `${platform.url}/device?user_code=${codeOn(screen)}`;
       expect(asOneLine(screen)).toContain(
         `The address needs ${columnsNeeded(approveUrl)} columns and this terminal has 40`,
       );
@@ -185,7 +191,7 @@ describe("the login screen", () => {
       const code = codeOn(terminal.screen());
       // Approved in a browser on another machine, and then pasted back here.
       expect(platform.device.approve(code)).toBe(true);
-      terminal.write(`${platform.url}/device/approve?user_code=${code}\r`);
+      terminal.write(`${platform.url}/device?user_code=${code}\r`);
 
       // The walk carried on: login is behind, the coding agent is being driven,
       // and the run ends on the one line the wizard leaves in scrollback.

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Login, end to end, against a fixture of egma's public HTTP API.
+ *
+ * No platform, no database and no browser: the CLI speaks the public API and
+ * the fixture answers it, including which refusal goes with which state. What
+ * is asserted is what a developer could check afterwards — what landed on
+ * screen, what landed on disk, and what the file it landed in is readable by.
+ */
+
+import { stat } from "node:fs/promises";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { codeFromPaste } from "../src/platform/device-flow.ts";
+import {
+  readCredentials,
+  resolvePlatformUrl,
+  DEFAULT_PLATFORM_URL,
+} from "../src/platform/credentials.ts";
+import { logIn, type LoginPrompt } from "../src/platform/login.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+let platform: Platform;
+let workspace: Workspace;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  workspace = await makeWorkspace();
+});
+
+afterEach(async () => {
+  await platform.close();
+  await workspace.remove();
+});
+
+/** Everything a run of `logIn` said and did, collected for the assertions. */
+type Watched = {
+  readonly prompts: LoginPrompt[];
+  readonly said: string[];
+  readonly opened: string[];
+};
+
+function watch(): Watched {
+  return { prompts: [], said: [], opened: [] };
+}
+
+type RunOptions = {
+  readonly watched: Watched;
+  readonly signal?: AbortSignal;
+  readonly force?: boolean;
+  /** Answers with whatever should be pasted back, once. */
+  readonly paste?: () => string | null;
+  /** Runs the moment the code is on screen: what a person in a browser does. */
+  readonly whenPrompted?: (prompt: LoginPrompt) => void;
+};
+
+async function login(options: RunOptions) {
+  return logIn({
+    url: platform.url,
+    credentialsFile: workspace.credentialsFile,
+    signal: options.signal ?? new AbortController().signal,
+    ...(options.force === undefined ? {} : { force: options.force }),
+    ...(options.paste === undefined ? {} : { paste: options.paste }),
+    onPrompt: (prompt) => {
+      options.watched.prompts.push(prompt);
+      options.whenPrompted?.(prompt);
+    },
+    say: (line) => options.watched.said.push(line),
+    openBrowser: async (url) => {
+      options.watched.opened.push(url);
+      return true;
+    },
+    // Nothing here waits on a person, so nothing here waits.
+    sleep: async () => undefined,
+  });
+}
+
+describe("signing a machine in", () => {
+  it("shows a code and an address, and leaves a key only a person can read", async () => {
+    const watched = watch();
+
+    const outcome = await login({
+      watched,
+      // The browser opened and somebody approved what was already in the field.
+      whenPrompted: (prompt) => {
+        expect(platform.device.approve(prompt.userCode)).toBe(true);
+      },
+    });
+
+    expect(outcome.kind).toBe("stored");
+
+    // What the developer saw: one code, one address, and the address carries
+    // the code so nobody retypes eight characters between two windows.
+    expect(watched.prompts).toHaveLength(1);
+    const shown = watched.prompts[0] as LoginPrompt;
+    expect(shown.userCode).toMatch(/^[A-Z]{4}-[A-Z]{4}$/u);
+    expect(shown.url).toContain(platform.url);
+    expect(shown.url).toContain(encodeURIComponent(shown.userCode));
+    expect(shown.browserOpened).toBe(true);
+    expect(watched.opened).toEqual([shown.url]);
+
+    // The key landed, against the egma that minted it.
+    const held = await readCredentials(workspace.credentialsFile);
+    expect(held?.url).toBe(platform.url);
+    expect(held?.key).toMatch(/^egma_sk_/u);
+    expect(held?.key).toBe(platform.device.keys.at(-1));
+
+    // And nobody else on the machine can read it.
+    const mode = (await stat(workspace.credentialsFile)).mode & 0o777;
+    expect(mode.toString(8)).toBe("600");
+  });
+
+  it("proves the key it stored works on a request that needs one", async () => {
+    const watched = watch();
+    await login({
+      watched,
+      whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
+    });
+
+    const held = await readCredentials(workspace.credentialsFile);
+    const used = await fetch(`${platform.url}/api/keys`, {
+      headers: { authorization: `Bearer ${held?.key ?? ""}` },
+    });
+    expect(used.status).toBe(200);
+
+    const refused = await fetch(`${platform.url}/api/keys`, {
+      headers: { authorization: "Bearer egma_sk_not-a-real-one" },
+    });
+    expect(refused.status).toBe(401);
+  });
+
+  it("says so and stores nothing when the browser says no", async () => {
+    const watched = watch();
+    const outcome = await login({
+      watched,
+      whenPrompted: (prompt) => void platform.device.deny(prompt.userCode),
+    });
+
+    expect(outcome.kind).toBe("denied");
+    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+  });
+
+  it("says the code ran out, which is not the same as being told no", async () => {
+    const watched = watch();
+    const outcome = await login({
+      watched,
+      whenPrompted: (prompt) => void platform.device.expire(prompt.userCode),
+    });
+
+    expect(outcome.kind).toBe("expired");
+    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+  });
+
+  it("backs off when told it is asking too fast, and still gets there", async () => {
+    const watched = watch();
+    platform.device.slowDownOnce();
+
+    const outcome = await login({
+      watched,
+      whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
+    });
+
+    expect(outcome.kind).toBe("stored");
+    expect(platform.records.filter((seen) => seen.path === "/api/device/token").length)
+      .toBeGreaterThan(1);
+  });
+
+  it("names an egma that never answered, rather than reporting a broken thing", async () => {
+    const outcome = await logIn({
+      // Nothing listens here: the port is reserved and the address is not routed.
+      url: "http://127.0.0.1:1",
+      credentialsFile: workspace.credentialsFile,
+      signal: new AbortController().signal,
+      onPrompt: () => undefined,
+      sleep: async () => undefined,
+    });
+
+    expect(outcome.kind).toBe("unreachable");
+    expect(outcome.kind === "unreachable" && outcome.reason).toContain("127.0.0.1:1");
+    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+  });
+
+  it("stops where it stands when the developer stops it", async () => {
+    const controller = new AbortController();
+    const watched = watch();
+
+    const outcome = await login({
+      watched,
+      signal: controller.signal,
+      whenPrompted: () => controller.abort("interrupt"),
+    });
+
+    expect(outcome.kind).toBe("interrupted");
+    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+  });
+});
+
+describe("a machine that is already signed in", () => {
+  it("asks for nothing and approves nothing", async () => {
+    await workspace.signIn(platform.url, "egma_sk_held-already");
+
+    const watched = watch();
+    const outcome = await login({ watched });
+
+    expect(outcome.kind).toBe("already-stored");
+    expect(watched.prompts).toHaveLength(0);
+    // Not one call was made: the whole step costs nothing on a second run.
+    expect(platform.records).toHaveLength(0);
+  });
+
+  it("signs in again when told to, and replaces the key it held", async () => {
+    await workspace.signIn(platform.url, "egma_sk_held-already");
+
+    const watched = watch();
+    const outcome = await login({
+      watched,
+      force: true,
+      whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
+    });
+
+    expect(outcome.kind).toBe("stored");
+    const held = await readCredentials(workspace.credentialsFile);
+    expect(held?.key).not.toBe("egma_sk_held-already");
+    expect(held?.key).toBe(platform.device.keys.at(-1));
+  });
+
+  it("signs in again for a different egma, because a key is only good at one", async () => {
+    await workspace.signIn("https://somewhere.else.example", "egma_sk_for-somewhere-else");
+
+    const watched = watch();
+    const outcome = await login({
+      watched,
+      whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
+    });
+
+    expect(outcome.kind).toBe("stored");
+    expect((await readCredentials(workspace.credentialsFile))?.url).toBe(platform.url);
+  });
+});
+
+/**
+ * The machine with no browser on it: a devbox, anything over SSH.
+ *
+ * The address goes to a browser somewhere else, and what comes back is whatever
+ * was easiest to select over there. All three shapes carry the same fact, so
+ * all three work — and a code from somebody else's terminal is refused by name
+ * rather than silently waited on.
+ */
+describe("coming back from a browser on another machine", () => {
+  const shapes = [
+    { called: "the whole address", of: (prompt: LoginPrompt) => prompt.url },
+    {
+      called: "the query part of it",
+      of: (prompt: LoginPrompt) => `?user_code=${prompt.userCode}`,
+    },
+    { called: "the bare code", of: (prompt: LoginPrompt) => prompt.userCode },
+    {
+      called: "the code as it was read out",
+      of: (prompt: LoginPrompt) => prompt.userCode.replace("-", " ").toLowerCase(),
+    },
+  ];
+
+  /**
+   * The developer walks away with the address, approves it over there, and
+   * comes back to paste something in. Approving therefore happens at the moment
+   * the paste is handed over, and not before — which is why the first ask comes
+   * back pending and the paste is what makes the second one land.
+   */
+  function pasteAfterApproving(
+    watched: Watched,
+    held: { text: string | null },
+  ): () => string | null {
+    return () => {
+      const typed = held.text;
+      if (typed === null) return null;
+      held.text = null;
+      platform.device.approve(watched.prompts[0]?.userCode ?? "");
+      return typed;
+    };
+  }
+
+  for (const shape of shapes) {
+    it(`completes the login when ${shape.called} is pasted back`, async () => {
+      const watched = watch();
+      const held: { text: string | null } = { text: null };
+
+      const outcome = await login({
+        watched,
+        // No browser opens here: this is the machine that has none.
+        whenPrompted: (prompt) => {
+          held.text = shape.of(prompt);
+        },
+        paste: pasteAfterApproving(watched, held),
+      });
+
+      expect(outcome.kind).toBe("stored");
+      expect(watched.said).toContain("Checking that one now.");
+      expect((await readCredentials(workspace.credentialsFile))?.key).toBe(
+        platform.device.keys.at(-1),
+      );
+    });
+  }
+
+  it("says which code it is waiting on when somebody pastes another one", async () => {
+    const watched = watch();
+    const held = { text: "ZZZZ-ZZZZ" as string | null };
+
+    const outcome = await login({ watched, paste: pasteAfterApproving(watched, held) });
+
+    // Somebody else's code changes nothing about this terminal's own login,
+    // which still finishes on the approval that did happen.
+    expect(outcome.kind).toBe("stored");
+    const complaint = watched.said.find((line) => line.includes("ZZZZZZZZ"));
+    expect(complaint).toBeDefined();
+    expect(complaint).toContain(watched.prompts[0]?.userCode);
+  });
+
+  it("says so when what was pasted is not a code at all", async () => {
+    const watched = watch();
+    const held = { text: "I approved it, thanks" as string | null };
+
+    await login({ watched, paste: pasteAfterApproving(watched, held) });
+
+    expect(watched.said.some((line) => line.includes("not an egma code"))).toBe(true);
+  });
+});
+
+describe("reading a code out of whatever was pasted", () => {
+  it("takes all three shapes and refuses what is not one", () => {
+    expect(codeFromPaste("http://egma.example/device/approve?user_code=WDJB-MJHT")).toBe(
+      "WDJBMJHT",
+    );
+    expect(codeFromPaste("?user_code=WDJB-MJHT")).toBe("WDJBMJHT");
+    expect(codeFromPaste("user_code=wdjb-mjht")).toBe("WDJBMJHT");
+    expect(codeFromPaste("  WDJB-MJHT  ")).toBe("WDJBMJHT");
+    expect(codeFromPaste("wdjb mjht")).toBe("WDJBMJHT");
+
+    expect(codeFromPaste("")).toBeNull();
+    expect(codeFromPaste("http://egma.example/device")).toBeNull();
+    expect(codeFromPaste("no idea what you mean")).toBeNull();
+  });
+});
+
+describe("which egma a command talks to", () => {
+  it("takes the flag first, then the environment, then what was stored", () => {
+    expect(
+      resolvePlatformUrl({
+        flag: "http://flag.example/",
+        env: "http://env.example",
+        stored: "http://stored.example",
+      }),
+    ).toBe("http://flag.example");
+
+    expect(
+      resolvePlatformUrl({ flag: null, env: "http://env.example", stored: "http://stored.example" }),
+    ).toBe("http://env.example");
+
+    // Which is what "set it once" means: after the first login, nothing has to
+    // say the address again.
+    expect(resolvePlatformUrl({ flag: null, stored: "http://stored.example/" })).toBe(
+      "http://stored.example",
+    );
+
+    expect(resolvePlatformUrl({ flag: null, env: "", stored: null })).toBe(DEFAULT_PLATFORM_URL);
+  });
+});

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -7,19 +7,23 @@
  * screen, what landed on disk, and what the file it landed in is readable by.
  */
 
-import { stat } from "node:fs/promises";
+import { chmod, lstat, mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { codeFromPaste } from "../src/platform/device-flow.ts";
+import { openInBrowser } from "../src/platform/browser.ts";
+import { codeFromPaste, startDeviceAuthorization } from "../src/platform/device-flow.ts";
 import {
   readCredentials,
   resolvePlatformUrl,
+  writeCredentials,
   DEFAULT_PLATFORM_URL,
+  UnusableUrlError,
 } from "../src/platform/credentials.ts";
 import { logIn, type LoginPrompt } from "../src/platform/login.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
-import { makeWorkspace, type Workspace } from "./support/workspace.ts";
+import { makeWorkspace, NO_BROWSER, type Workspace } from "./support/workspace.ts";
 
 let platform: Platform;
 let workspace: Workspace;
@@ -53,6 +57,10 @@ type RunOptions = {
   readonly paste?: () => string | null;
   /** Runs the moment the code is on screen: what a person in a browser does. */
   readonly whenPrompted?: (prompt: LoginPrompt) => void;
+  /** Every wait, in milliseconds, in the order it was asked for. */
+  readonly waits?: number[];
+  /** Runs at each wait, so a test can change the world between two polls. */
+  readonly whenWaiting?: (waits: readonly number[]) => void;
 };
 
 async function login(options: RunOptions) {
@@ -71,8 +79,12 @@ async function login(options: RunOptions) {
       options.watched.opened.push(url);
       return true;
     },
-    // Nothing here waits on a person, so nothing here waits.
-    sleep: async () => undefined,
+    // Nothing here waits on a person, so nothing here waits — but how long it
+    // was going to wait for is written down, because the pace is a promise.
+    sleep: async (ms) => {
+      options.waits?.push(ms);
+      options.whenWaiting?.(options.waits ?? []);
+    },
   });
 }
 
@@ -80,7 +92,7 @@ describe("signing a machine in", () => {
   it("shows a code and an address, and leaves a key only a person can read", async () => {
     const watched = watch();
 
-    const outcome = await login({
+    const result = await login({
       watched,
       // The browser opened and somebody approved what was already in the field.
       whenPrompted: (prompt) => {
@@ -88,13 +100,14 @@ describe("signing a machine in", () => {
       },
     });
 
-    expect(outcome.kind).toBe("stored");
+    expect(result.kind).toBe("stored");
 
     // What the developer saw: one code, one address, and the address carries
     // the code so nobody retypes eight characters between two windows.
     expect(watched.prompts).toHaveLength(1);
     const shown = watched.prompts[0] as LoginPrompt;
-    expect(shown.userCode).toMatch(/^[A-Z]{4}-[A-Z]{4}$/u);
+    // Eight characters, exactly as the real instance issues them.
+    expect(shown.userCode).toMatch(/^[A-Z0-9]{8}$/u);
     expect(shown.url).toContain(platform.url);
     expect(shown.url).toContain(encodeURIComponent(shown.userCode));
     expect(shown.browserOpened).toBe(true);
@@ -132,42 +145,81 @@ describe("signing a machine in", () => {
 
   it("says so and stores nothing when the browser says no", async () => {
     const watched = watch();
-    const outcome = await login({
+    const result = await login({
       watched,
       whenPrompted: (prompt) => void platform.device.deny(prompt.userCode),
     });
 
-    expect(outcome.kind).toBe("denied");
+    expect(result.kind).toBe("denied");
     expect(await readCredentials(workspace.credentialsFile)).toBeNull();
   });
 
   it("says the code ran out, which is not the same as being told no", async () => {
     const watched = watch();
-    const outcome = await login({
+    const result = await login({
       watched,
       whenPrompted: (prompt) => void platform.device.expire(prompt.userCode),
     });
 
-    expect(outcome.kind).toBe("expired");
+    expect(result.kind).toBe("expired");
     expect(await readCredentials(workspace.credentialsFile)).toBeNull();
   });
 
-  it("backs off when told it is asking too fast, and still gets there", async () => {
+  it("backs off by five seconds when told it is asking too fast, and stays there", async () => {
     const watched = watch();
     platform.device.slowDownOnce();
 
-    const outcome = await login({
+    // Nobody approves at first, so the poll after the back-off is an ordinary
+    // "still waiting" — which is the answer the pace used to spring back on.
+    const waits: number[] = [];
+    const result = await login({
       watched,
-      whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
+      waits,
+      whenWaiting: (asked) => {
+        if (asked.length === 2) platform.device.approve(watched.prompts[0]?.userCode ?? "");
+      },
     });
 
-    expect(outcome.kind).toBe("stored");
-    expect(platform.records.filter((seen) => seen.path === "/api/device/token").length)
-      .toBeGreaterThan(1);
+    expect(result.kind).toBe("stored");
+    // RFC 8628: five seconds on top, for this request and every one after it.
+    // The fixture issues an interval of zero, so both waits are the five.
+    expect(waits).toEqual([5_000, 5_000]);
+  });
+
+  it("does not ask for a key again because somebody pasted the wrong thing", async () => {
+    // A wrong paste must not be a way to make egma poll: a developer holding a
+    // paste key would otherwise ask for a key as fast as they could type.
+    platform.device.pollEvery(30);
+
+    const watched = watch();
+    const controller = new AbortController();
+    const flood = ["I approved it, thanks", "https://example.test/somewhere", "ZZZZZZZZ"];
+    let pasted = 0;
+
+    const result = await login({
+      watched,
+      signal: controller.signal,
+      paste: () => {
+        if (pasted < flood.length) {
+          pasted += 1;
+          return flood[pasted - 1] ?? null;
+        }
+        controller.abort("interrupt");
+        return null;
+      },
+    });
+
+    expect(result.kind).toBe("interrupted");
+    expect(pasted).toBe(flood.length);
+    // One request, and it is the one that was going to happen anyway. Not one
+    // of the three pastes added another.
+    expect(platform.records.filter((seen) => seen.path === "/api/device/token")).toHaveLength(1);
+    // And the developer was told about every one of them.
+    expect(watched.said).toHaveLength(flood.length);
   });
 
   it("names an egma that never answered, rather than reporting a broken thing", async () => {
-    const outcome = await logIn({
+    const result = await logIn({
       // Nothing listens here: the port is reserved and the address is not routed.
       url: "http://127.0.0.1:1",
       credentialsFile: workspace.credentialsFile,
@@ -176,8 +228,8 @@ describe("signing a machine in", () => {
       sleep: async () => undefined,
     });
 
-    expect(outcome.kind).toBe("unreachable");
-    expect(outcome.kind === "unreachable" && outcome.reason).toContain("127.0.0.1:1");
+    expect(result.kind).toBe("unreachable");
+    expect(result.kind === "unreachable" && result.reason).toContain("127.0.0.1:1");
     expect(await readCredentials(workspace.credentialsFile)).toBeNull();
   });
 
@@ -185,13 +237,13 @@ describe("signing a machine in", () => {
     const controller = new AbortController();
     const watched = watch();
 
-    const outcome = await login({
+    const result = await login({
       watched,
       signal: controller.signal,
       whenPrompted: () => controller.abort("interrupt"),
     });
 
-    expect(outcome.kind).toBe("interrupted");
+    expect(result.kind).toBe("interrupted");
     expect(await readCredentials(workspace.credentialsFile)).toBeNull();
   });
 });
@@ -201,9 +253,9 @@ describe("a machine that is already signed in", () => {
     await workspace.signIn(platform.url, "egma_sk_held-already");
 
     const watched = watch();
-    const outcome = await login({ watched });
+    const result = await login({ watched });
 
-    expect(outcome.kind).toBe("already-stored");
+    expect(result.kind).toBe("already-stored");
     expect(watched.prompts).toHaveLength(0);
     // Not one call was made: the whole step costs nothing on a second run.
     expect(platform.records).toHaveLength(0);
@@ -213,13 +265,13 @@ describe("a machine that is already signed in", () => {
     await workspace.signIn(platform.url, "egma_sk_held-already");
 
     const watched = watch();
-    const outcome = await login({
+    const result = await login({
       watched,
       force: true,
       whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
     });
 
-    expect(outcome.kind).toBe("stored");
+    expect(result.kind).toBe("stored");
     const held = await readCredentials(workspace.credentialsFile);
     expect(held?.key).not.toBe("egma_sk_held-already");
     expect(held?.key).toBe(platform.device.keys.at(-1));
@@ -229,12 +281,12 @@ describe("a machine that is already signed in", () => {
     await workspace.signIn("https://somewhere.else.example", "egma_sk_for-somewhere-else");
 
     const watched = watch();
-    const outcome = await login({
+    const result = await login({
       watched,
       whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
     });
 
-    expect(outcome.kind).toBe("stored");
+    expect(result.kind).toBe("stored");
     expect((await readCredentials(workspace.credentialsFile))?.url).toBe(platform.url);
   });
 });
@@ -256,8 +308,9 @@ describe("coming back from a browser on another machine", () => {
     },
     { called: "the bare code", of: (prompt: LoginPrompt) => prompt.userCode },
     {
-      called: "the code as it was read out",
-      of: (prompt: LoginPrompt) => prompt.userCode.replace("-", " ").toLowerCase(),
+      called: "the code as somebody read it out",
+      of: (prompt: LoginPrompt) =>
+        `${prompt.userCode.slice(0, 4)} ${prompt.userCode.slice(4)}`.toLowerCase(),
     },
   ];
 
@@ -285,7 +338,7 @@ describe("coming back from a browser on another machine", () => {
       const watched = watch();
       const held: { text: string | null } = { text: null };
 
-      const outcome = await login({
+      const result = await login({
         watched,
         // No browser opens here: this is the machine that has none.
         whenPrompted: (prompt) => {
@@ -294,7 +347,7 @@ describe("coming back from a browser on another machine", () => {
         paste: pasteAfterApproving(watched, held),
       });
 
-      expect(outcome.kind).toBe("stored");
+      expect(result.kind).toBe("stored");
       expect(watched.said).toContain("Checking that one now.");
       expect((await readCredentials(workspace.credentialsFile))?.key).toBe(
         platform.device.keys.at(-1),
@@ -306,11 +359,11 @@ describe("coming back from a browser on another machine", () => {
     const watched = watch();
     const held = { text: "ZZZZ-ZZZZ" as string | null };
 
-    const outcome = await login({ watched, paste: pasteAfterApproving(watched, held) });
+    const result = await login({ watched, paste: pasteAfterApproving(watched, held) });
 
     // Somebody else's code changes nothing about this terminal's own login,
     // which still finishes on the approval that did happen.
-    expect(outcome.kind).toBe("stored");
+    expect(result.kind).toBe("stored");
     const complaint = watched.said.find((line) => line.includes("ZZZZZZZZ"));
     expect(complaint).toBeDefined();
     expect(complaint).toContain(watched.prompts[0]?.userCode);
@@ -328,9 +381,7 @@ describe("coming back from a browser on another machine", () => {
 
 describe("reading a code out of whatever was pasted", () => {
   it("takes all three shapes and refuses what is not one", () => {
-    expect(codeFromPaste("http://egma.example/device/approve?user_code=WDJB-MJHT")).toBe(
-      "WDJBMJHT",
-    );
+    expect(codeFromPaste("http://egma.example/device?user_code=WDJB-MJHT")).toBe("WDJBMJHT");
     expect(codeFromPaste("?user_code=WDJB-MJHT")).toBe("WDJBMJHT");
     expect(codeFromPaste("user_code=wdjb-mjht")).toBe("WDJBMJHT");
     expect(codeFromPaste("  WDJB-MJHT  ")).toBe("WDJBMJHT");
@@ -363,5 +414,139 @@ describe("which egma a command talks to", () => {
     );
 
     expect(resolvePlatformUrl({ flag: null, env: "", stored: null })).toBe(DEFAULT_PLATFORM_URL);
+  });
+
+  it("refuses an address that is not one, and names where it came from", () => {
+    // The next thing that happens to this address is that a browser is started
+    // on it, so it is checked at the edge that takes it and not after.
+    for (const given of ["javascript:alert(1)", "file:///etc/passwd", "not an address at all"]) {
+      expect(() => resolvePlatformUrl({ flag: given })).toThrow(UnusableUrlError);
+      expect(() => resolvePlatformUrl({ flag: null, env: given })).toThrow(UnusableUrlError);
+    }
+
+    expect(() => resolvePlatformUrl({ flag: "ftp://egma.example" })).toThrow(/--url/u);
+    expect(() => resolvePlatformUrl({ flag: null, env: "ftp://egma.example" })).toThrow(/EGMA_URL/u);
+
+    // A credentials file somebody edited by hand is stepped over rather than
+    // made into a refusal on every command afterwards.
+    expect(resolvePlatformUrl({ flag: null, stored: "javascript:alert(1)" })).toBe(
+      DEFAULT_PLATFORM_URL,
+    );
+  });
+});
+
+/**
+ * What egma will start a browser on.
+ *
+ * The address comes back from the instance, and handing a string to a browser
+ * opener is handing it to a program. What fails here is not a failed login: the
+ * address is still on the screen, and the paste-back still finishes it.
+ */
+describe("what an instance can put on this terminal's screen", () => {
+  it("draws no instruction, whatever the instance sent", async () => {
+    // A terminal reads a control character as an instruction rather than as
+    // text. An address carrying one could clear the screen or redraw what egma
+    // just said, so they are taken out where the wire is read.
+    const ESCAPE = "\u001b";
+    const BELL = "\u0007";
+    const answered = new Response(
+      JSON.stringify({
+        device_code: "a-device-code",
+        // An escape and a clear-the-screen, and an address that rings the bell.
+        user_code: `ABCD${ESCAPE}[2J1234`,
+        verification_uri_complete: `https://app.egma.example/device?user_code=ABCD${BELL}1234`,
+        expires_in: 900,
+        interval: 5,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+    const grant = await startDeviceAuthorization(
+      "https://app.egma.example",
+      async () => answered,
+    );
+
+    expect(grant.userCode).not.toContain(ESCAPE);
+    expect(grant.userCode).toBe("ABCD[2J1234");
+    expect(grant.approveUrl).not.toContain(BELL);
+    expect(grant.approveUrl).toBe("https://app.egma.example/device?user_code=ABCD1234");
+  });
+});
+
+describe("the addresses egma hands to a browser", () => {
+  const instance = "https://app.egma.example";
+  const opens = (url: string): Promise<boolean> =>
+    // A browser that opens nothing, because a check that opened a real one on
+    // the machine running the suite would be intolerable.
+    openInBrowser(url, { instanceUrl: instance, env: { BROWSER: NO_BROWSER } });
+
+  it("opens the approval address on the egma this login is against", async () => {
+    expect(await opens(`${instance}/device?user_code=ABCD1234`)).toBe(true);
+  });
+
+  it("opens nothing for a scheme that is not the web", async () => {
+    // `open` and `xdg-open` will launch these as happily as a web page.
+    expect(await opens("javascript:alert(document.cookie)")).toBe(false);
+    expect(await opens("file:///etc/passwd")).toBe(false);
+  });
+
+  it("opens nothing on an origin this login is not against", async () => {
+    expect(await opens("https://not-egma.example/device?user_code=ABCD1234")).toBe(false);
+  });
+
+  it("opens nothing carrying a character a command interpreter reads", async () => {
+    // On Windows the opener is `cmd /c start`, which reads what it is given a
+    // second time: these end the address and begin a command.
+    expect(await opens(`${instance}/device?user_code=A&calc.exe`)).toBe(false);
+    expect(await opens(`${instance}/device?user_code=A|calc.exe`)).toBe(false);
+    expect(await opens(`${instance}/device?user_code=A calc.exe`)).toBe(false);
+  });
+});
+
+describe("writing the key down", () => {
+  const held = { url: "https://app.egma.example", key: "egma_sk_freshly-minted" };
+
+  it("narrows a file that was already there, whatever it was readable by", async () => {
+    await mkdir(path.dirname(workspace.credentialsFile), { recursive: true });
+    await writeFile(workspace.credentialsFile, "{}\n", "utf8");
+    await chmod(workspace.credentialsFile, 0o644);
+
+    await writeCredentials(workspace.credentialsFile, held);
+
+    // The key landed in a file nobody else can read — which is only true
+    // because a fresh file was renamed over this one rather than written into.
+    expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
+    expect(await readCredentials(workspace.credentialsFile)).toEqual(held);
+  });
+
+  it("does not follow a link standing where the key goes", async () => {
+    const elsewhere = path.join(workspace.dir, "somebody-elses-file");
+    await writeFile(elsewhere, "not the key\n", "utf8");
+    await mkdir(path.dirname(workspace.credentialsFile), { recursive: true });
+    await symlink(elsewhere, workspace.credentialsFile);
+
+    await writeCredentials(workspace.credentialsFile, held);
+
+    // The link itself was replaced. Nothing was written through it, so the file
+    // it pointed at is exactly as it was.
+    expect(await readFile(elsewhere, "utf8")).toBe("not the key\n");
+    expect((await lstat(workspace.credentialsFile)).isSymbolicLink()).toBe(false);
+    expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
+    expect(await readCredentials(workspace.credentialsFile)).toEqual(held);
+  });
+
+  it("locks the folder down too, and says nothing when it could", async () => {
+    // The other half of this — a folder egma cannot narrow — is a filesystem
+    // refusing its own owner, which no check can stage. What is proved here is
+    // that the ordinary run really does narrow it, and that the line about
+    // failing to is not said when nothing failed.
+    const said: string[] = [];
+    await writeCredentials(workspace.credentialsFile, held, {
+      warn: (line) => said.push(line),
+    });
+
+    expect(said).toEqual([]);
+    const folder = await stat(path.dirname(workspace.credentialsFile));
+    expect((folder.mode & 0o777).toString(8)).toBe("700");
   });
 });

--- a/apps/cli/test/support/approving-browser.ts
+++ b/apps/cli/test/support/approving-browser.ts
@@ -1,0 +1,34 @@
+/**
+ * A browser that never opens: the stand-in egma starts in place of a real one.
+ *
+ * egma starts whatever `BROWSER` names, handing it the address to open. A check
+ * points `BROWSER` at this, so the whole of login runs with no window on the
+ * screen of whoever is running the suite — and the address egma really passed
+ * is written down where the check can read it.
+ *
+ * What it then does is what a person would have done in the window: approve,
+ * deny, or nothing at all. `FIXTURE_BROWSER_DOES` says which.
+ *
+ * Run as: node approving-browser.ts <address>
+ */
+
+import { appendFile } from "node:fs/promises";
+import process from "node:process";
+
+const address = process.argv[2] ?? "";
+const does = process.env.FIXTURE_BROWSER_DOES ?? "approve";
+const writeTo = process.env.FIXTURE_BROWSER_WRITES_TO;
+
+if (writeTo !== undefined && writeTo !== "") {
+  await appendFile(writeTo, `${address}\n`, "utf8");
+}
+
+if (does !== "nothing" && address !== "") {
+  const at = new URL(address);
+  const code = at.searchParams.get("user_code") ?? "";
+  await fetch(`${at.origin}/fixture/${does}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ user_code: code }),
+  });
+}

--- a/apps/cli/test/support/fixture-platform/controls.ts
+++ b/apps/cli/test/support/fixture-platform/controls.ts
@@ -1,0 +1,56 @@
+/**
+ * The fixture's own controls, which are not part of the contract.
+ *
+ * On a real instance a person approves a terminal in a browser. A check has no
+ * person and no browser, so it says the same thing over HTTP instead. These
+ * paths are under `/fixture` and nothing the CLI does ever touches them — the
+ * separation is the point, and it is the shape the simulator's workbench uses
+ * for the same reason.
+ *
+ * They are reachable over HTTP rather than only in the process that started the
+ * server, because the thing being checked is usually a subprocess: the built
+ * `egma` command, with a stand-in browser beside it.
+ */
+
+import type { DeviceControls } from "./device.ts";
+import type { RouteGroup } from "./server.ts";
+
+export function controlRoutes(controls: () => DeviceControls): RouteGroup {
+  const act = (
+    request: { url: URL; body: Record<string, unknown> | null },
+    take: (code: string) => boolean,
+  ) => {
+    const code =
+      request.url.searchParams.get("user_code") ??
+      (typeof request.body?.user_code === "string" ? request.body.user_code : "");
+    return take(code)
+      ? { status: 200, body: { done: true } }
+      : { status: 404, body: { done: false, message: `nothing is waiting on ${code}` } };
+  };
+
+  return {
+    name: "fixture-controls",
+    routes: [
+      {
+        method: "POST",
+        path: "/fixture/approve",
+        handle: (request) => act(request, (code) => controls().approve(code)),
+      },
+      {
+        method: "POST",
+        path: "/fixture/deny",
+        handle: (request) => act(request, (code) => controls().deny(code)),
+      },
+      {
+        method: "POST",
+        path: "/fixture/expire",
+        handle: (request) => act(request, (code) => controls().expire(code)),
+      },
+      {
+        method: "GET",
+        path: "/fixture/keys",
+        handle: () => ({ status: 200, body: { keys: [...controls().keys] } }),
+      },
+    ],
+  };
+}

--- a/apps/cli/test/support/fixture-platform/device.ts
+++ b/apps/cli/test/support/fixture-platform/device.ts
@@ -2,10 +2,15 @@
  * The device-flow endpoints of the fixture platform.
  *
  * This is the contract the CLI is built against, written down as something that
- * runs: the three calls a terminal makes to sign a machine in, and the one call
+ * runs: the three requests a terminal makes to sign a machine in, and the one
  * it makes afterwards to prove the key works. It answers exactly what the real
  * instance answers, including which refusal goes with which state, because a
  * fixture that is kinder than the real thing is a fixture that hides bugs.
+ *
+ * Every answer here is pinned to `apps/api/test/device-flow.test.ts`, which is
+ * the same contract asserted against the real API: an eight-character code, an
+ * address of the shape `/device?user_code=…`, and `expired_token` — not
+ * `invalid_grant` — for a device code that was spent or never issued.
  *
  * Approving is a control, not a contract. On a real instance a person approves
  * in a browser; here a test says so directly, which is what lets the whole of
@@ -24,18 +29,31 @@ type Authorization = {
   collected: boolean;
 };
 
+/** An answer a test has asked the next token request to be given. */
+type TokenAnswer = { readonly error: string; readonly said: string };
+
 export type DeviceState = {
   /** Every key this fixture has minted, newest last. */
   readonly keys: string[];
   /** Set to make the next collection answer `slow_down` once. */
   slowDownOnce: boolean;
+  /** How long the terminal is told to leave between two collections. */
+  intervalSeconds: number;
+  /** What the next collection answers, whatever state the code is in. */
+  nextAnswer: TokenAnswer | null;
 };
 
-const ALPHABET = "BCDFGHJKLMNPQRSTVWXZ";
+/**
+ * The characters a code is made of. Eight of them, upper case, letters and
+ * digits — the shape `apps/api/test/device-flow.test.ts` pins on the real one.
+ */
+const ALPHABET = "BCDFGHJKLMNPQRSTVWXZ0123456789";
+const CODE_LENGTH = 8;
 
 function userCode(): string {
-  const letters = [...randomBytes(8)].map((byte) => ALPHABET[byte % ALPHABET.length]);
-  return `${letters.slice(0, 4).join("")}-${letters.slice(4).join("")}`;
+  return [...randomBytes(CODE_LENGTH)]
+    .map((byte) => ALPHABET[byte % ALPHABET.length])
+    .join("");
 }
 
 function normalize(code: string): string {
@@ -49,6 +67,18 @@ export type DeviceControls = {
   /** What time passing does. */
   expire(code: string): boolean;
   slowDownOnce(): void;
+  /** What the instance tells the terminal its pace is. Zero by default. */
+  pollEvery(seconds: number): void;
+  /**
+   * Make the next collection answer this, whatever state the code is in.
+   *
+   * The real instance answers `invalid_grant` for states a fixture cannot
+   * reach — an account switched off between approving and collecting, a
+   * project that went away — and each of those answers carries a description
+   * written for whoever built the client. A test that wants to see what the
+   * terminal does with one says so here, with the instance's own words.
+   */
+  answerTokenWith(error: string, said: string): void;
   readonly keys: readonly string[];
 };
 
@@ -59,7 +89,13 @@ export function deviceRoutes(origin: () => string): {
   const byDeviceCode = new Map<string, Authorization>();
   const byUserCode = new Map<string, Authorization>();
   const keys: string[] = [];
-  const state: DeviceState = { keys, slowDownOnce: false };
+  const state: DeviceState = {
+    keys,
+    slowDownOnce: false,
+    // Nothing here waits on a person, so by default nothing here waits at all.
+    intervalSeconds: 0,
+    nextAnswer: null,
+  };
 
   const find = (code: string): Authorization | undefined =>
     byUserCode.get(normalize(code));
@@ -82,7 +118,9 @@ export function deviceRoutes(origin: () => string): {
           byDeviceCode.set(deviceCode, authorization);
           byUserCode.set(normalize(code), authorization);
 
-          const approveUrl = `${origin()}/device/approve?user_code=${encodeURIComponent(code)}`;
+          // The address the real instance hands back: its own `/device` page,
+          // with the code already in the field.
+          const approveUrl = `${origin()}/device?user_code=${encodeURIComponent(code)}`;
           return {
             status: 200,
             body: {
@@ -91,8 +129,7 @@ export function deviceRoutes(origin: () => string): {
               verification_uri: `${origin()}/device`,
               verification_uri_complete: approveUrl,
               expires_in: 900,
-              // Nothing here waits on a person, so nothing here waits at all.
-              interval: 0,
+              interval: state.intervalSeconds,
             },
           };
         },
@@ -112,11 +149,19 @@ export function deviceRoutes(origin: () => string): {
             };
           }
 
+          if (state.nextAnswer !== null) {
+            const { error, said } = state.nextAnswer;
+            state.nextAnswer = null;
+            return { status: 400, body: { error, error_description: said } };
+          }
+
           const authorization = byDeviceCode.get(form.get("device_code") ?? "");
           if (authorization === undefined || authorization.collected) {
+            // A code that was spent and a code nobody was ever given are the
+            // same answer on the real instance, and it is `expired_token`.
             return {
               status: 400,
-              body: { error: "invalid_grant", error_description: "no such device code" },
+              body: { error: "expired_token", error_description: "this authorization is over" },
             };
           }
 
@@ -171,7 +216,7 @@ export function deviceRoutes(origin: () => string): {
         // terminal shows is an address that answers, exactly as it is on a real
         // instance — a link that 404s is not a link a check can trust.
         method: "GET",
-        path: "/device/approve",
+        path: "/device",
         handle: (request) => {
           const asked = request.url.searchParams.get("user_code") ?? "";
           const authorization = find(asked);
@@ -230,6 +275,12 @@ export function deviceRoutes(origin: () => string): {
       },
       slowDownOnce() {
         state.slowDownOnce = true;
+      },
+      pollEvery(seconds) {
+        state.intervalSeconds = seconds;
+      },
+      answerTokenWith(error, said) {
+        state.nextAnswer = { error, said };
       },
       keys,
     },

--- a/apps/cli/test/support/fixture-platform/device.ts
+++ b/apps/cli/test/support/fixture-platform/device.ts
@@ -1,0 +1,237 @@
+/**
+ * The device-flow endpoints of the fixture platform.
+ *
+ * This is the contract the CLI is built against, written down as something that
+ * runs: the three calls a terminal makes to sign a machine in, and the one call
+ * it makes afterwards to prove the key works. It answers exactly what the real
+ * instance answers, including which refusal goes with which state, because a
+ * fixture that is kinder than the real thing is a fixture that hides bugs.
+ *
+ * Approving is a control, not a contract. On a real instance a person approves
+ * in a browser; here a test says so directly, which is what lets the whole of
+ * login run in CI with no browser and no platform.
+ */
+
+import { randomBytes } from "node:crypto";
+
+import type { RouteGroup } from "./server.ts";
+
+type Authorization = {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  state: "pending" | "approved" | "denied" | "expired";
+  /** Set once, when the key is collected. */
+  collected: boolean;
+};
+
+export type DeviceState = {
+  /** Every key this fixture has minted, newest last. */
+  readonly keys: string[];
+  /** Set to make the next collection answer `slow_down` once. */
+  slowDownOnce: boolean;
+};
+
+const ALPHABET = "BCDFGHJKLMNPQRSTVWXZ";
+
+function userCode(): string {
+  const letters = [...randomBytes(8)].map((byte) => ALPHABET[byte % ALPHABET.length]);
+  return `${letters.slice(0, 4).join("")}-${letters.slice(4).join("")}`;
+}
+
+function normalize(code: string): string {
+  return code.replaceAll(/[^0-9A-Za-z]/gu, "").toUpperCase();
+}
+
+export type DeviceControls = {
+  /** What a person clicking Approve in a browser does. */
+  approve(code: string): boolean;
+  deny(code: string): boolean;
+  /** What time passing does. */
+  expire(code: string): boolean;
+  slowDownOnce(): void;
+  readonly keys: readonly string[];
+};
+
+export function deviceRoutes(origin: () => string): {
+  readonly group: RouteGroup;
+  readonly controls: DeviceControls;
+} {
+  const byDeviceCode = new Map<string, Authorization>();
+  const byUserCode = new Map<string, Authorization>();
+  const keys: string[] = [];
+  const state: DeviceState = { keys, slowDownOnce: false };
+
+  const find = (code: string): Authorization | undefined =>
+    byUserCode.get(normalize(code));
+
+  const group: RouteGroup = {
+    name: "device",
+    routes: [
+      {
+        method: "POST",
+        path: "/api/device/code",
+        handle: () => {
+          const deviceCode = randomBytes(24).toString("hex");
+          const code = userCode();
+          const authorization: Authorization = {
+            deviceCode,
+            userCode: code,
+            state: "pending",
+            collected: false,
+          };
+          byDeviceCode.set(deviceCode, authorization);
+          byUserCode.set(normalize(code), authorization);
+
+          const approveUrl = `${origin()}/device/approve?user_code=${encodeURIComponent(code)}`;
+          return {
+            status: 200,
+            body: {
+              device_code: deviceCode,
+              user_code: code,
+              verification_uri: `${origin()}/device`,
+              verification_uri_complete: approveUrl,
+              expires_in: 900,
+              // Nothing here waits on a person, so nothing here waits at all.
+              interval: 0,
+            },
+          };
+        },
+      },
+      {
+        method: "POST",
+        path: "/api/device/token",
+        handle: (request) => {
+          const form = request.form ?? new URLSearchParams();
+          if (form.get("grant_type") !== "urn:ietf:params:oauth:grant-type:device_code") {
+            return {
+              status: 400,
+              body: {
+                error: "unsupported_grant_type",
+                error_description: "this endpoint understands the device grant and nothing else",
+              },
+            };
+          }
+
+          const authorization = byDeviceCode.get(form.get("device_code") ?? "");
+          if (authorization === undefined || authorization.collected) {
+            return {
+              status: 400,
+              body: { error: "invalid_grant", error_description: "no such device code" },
+            };
+          }
+
+          if (state.slowDownOnce) {
+            state.slowDownOnce = false;
+            return {
+              status: 400,
+              body: {
+                error: "slow_down",
+                error_description: "polling faster than the interval this was issued with",
+              },
+            };
+          }
+
+          switch (authorization.state) {
+            case "pending":
+              return {
+                status: 400,
+                body: {
+                  error: "authorization_pending",
+                  error_description: "nobody has approved this yet",
+                },
+              };
+            case "denied":
+              return {
+                status: 400,
+                body: { error: "access_denied", error_description: "this was denied in the browser" },
+              };
+            case "expired":
+              return {
+                status: 400,
+                body: { error: "expired_token", error_description: "this authorization is over" },
+              };
+            case "approved": {
+              authorization.collected = true;
+              const key = `egma_sk_${randomBytes(24).toString("hex")}`;
+              keys.push(key);
+              return {
+                status: 200,
+                body: {
+                  access_token: key,
+                  token_type: "Bearer",
+                  api_key_id: `ak_${randomBytes(8).toString("hex")}`,
+                },
+              };
+            }
+          }
+        },
+      },
+      {
+        // What a person's browser lands on. It is here so that the address the
+        // terminal shows is an address that answers, exactly as it is on a real
+        // instance — a link that 404s is not a link a check can trust.
+        method: "GET",
+        path: "/device/approve",
+        handle: (request) => {
+          const asked = request.url.searchParams.get("user_code") ?? "";
+          const authorization = find(asked);
+          return {
+            status: authorization === undefined ? 404 : 200,
+            contentType: "text/html; charset=utf-8",
+            text:
+              authorization === undefined
+                ? "<main>No terminal is waiting on that code.</main>"
+                : `<main>Authorize this terminal? <input id="user_code" value="${authorization.userCode}"></main>`,
+          };
+        },
+      },
+      {
+        // The first door a minted key opens, which is how the end of login is
+        // proved rather than asserted.
+        method: "GET",
+        path: "/api/keys",
+        handle: (request) => {
+          const offered = (request.headers.authorization ?? "").replace(/^Bearer\s+/iu, "");
+          if (offered === "" || !keys.includes(offered)) {
+            return {
+              status: 401,
+              body: { error: "not_authenticated", message: "no key, or not one of ours" },
+            };
+          }
+          return {
+            status: 200,
+            body: { keys: keys.map((key, index) => ({ id: `ak_${index}`, name: "egma-cli login" })) },
+          };
+        },
+      },
+    ],
+  };
+
+  return {
+    group,
+    controls: {
+      approve(code) {
+        const authorization = find(code);
+        if (authorization === undefined || authorization.state !== "pending") return false;
+        authorization.state = "approved";
+        return true;
+      },
+      deny(code) {
+        const authorization = find(code);
+        if (authorization === undefined) return false;
+        authorization.state = "denied";
+        return true;
+      },
+      expire(code) {
+        const authorization = find(code);
+        if (authorization === undefined) return false;
+        authorization.state = "expired";
+        return true;
+      },
+      slowDownOnce() {
+        state.slowDownOnce = true;
+      },
+      keys,
+    },
+  };
+}

--- a/apps/cli/test/support/fixture-platform/index.ts
+++ b/apps/cli/test/support/fixture-platform/index.ts
@@ -1,7 +1,7 @@
 /**
  * A whole fixture platform, ready to point a CLI at.
  *
- * One call starts an HTTP server speaking egma's public API, hands back the
+ * One function starts an HTTP server speaking egma's public API, hands back the
  * address to point at and the controls a test drives it with. Adding the next
  * part of the API is adding a group beside `deviceRoutes` here.
  */

--- a/apps/cli/test/support/fixture-platform/index.ts
+++ b/apps/cli/test/support/fixture-platform/index.ts
@@ -1,0 +1,31 @@
+/**
+ * A whole fixture platform, ready to point a CLI at.
+ *
+ * One call starts an HTTP server speaking egma's public API, hands back the
+ * address to point at and the controls a test drives it with. Adding the next
+ * part of the API is adding a group beside `deviceRoutes` here.
+ */
+
+import { controlRoutes } from "./controls.ts";
+import { deviceRoutes, type DeviceControls } from "./device.ts";
+import { startFixturePlatform, type FixturePlatform } from "./server.ts";
+
+export type { DeviceControls } from "./device.ts";
+export type { FixturePlatform, Observation } from "./server.ts";
+
+export type Platform = FixturePlatform & {
+  /** What a person in a browser would do, done directly. */
+  readonly device: DeviceControls;
+};
+
+export async function startPlatform(): Promise<Platform> {
+  let controls!: DeviceControls;
+
+  const platform = await startFixturePlatform((origin) => {
+    const device = deviceRoutes(origin);
+    controls = device.controls;
+    return [device.group, controlRoutes(() => controls)];
+  });
+
+  return { ...platform, device: controls };
+}

--- a/apps/cli/test/support/fixture-platform/server.ts
+++ b/apps/cli/test/support/fixture-platform/server.ts
@@ -25,7 +25,7 @@ export type FixtureRequest = {
   readonly headers: Record<string, string | undefined>;
   /** The body, when it arrived as JSON. */
   readonly body: Record<string, unknown> | null;
-  /** The body, when it arrived form-encoded, as RFC 8628's token call does. */
+  /** The body, when it arrived form-encoded, as RFC 8628's token request does. */
   readonly form: URLSearchParams | null;
 };
 

--- a/apps/cli/test/support/fixture-platform/server.ts
+++ b/apps/cli/test/support/fixture-platform/server.ts
@@ -1,0 +1,138 @@
+/**
+ * The fixture platform: egma's public HTTP API, faked, for tests to run against.
+ *
+ * The CLI speaks the public API and nothing else. That is the seam this stands
+ * in at — so the whole of a flow runs in CI with no database, no browser and no
+ * platform, and the same CLI binary runs unchanged against a real instance.
+ *
+ * It is built as a list of route groups because it is going to grow: login is
+ * the first group, and agents, connections and tests are groups beside it. Each
+ * group owns its own state and its own controls, and the server here owns only
+ * the plumbing — matching a request, reading a body, and recording what was
+ * asked.
+ *
+ * Every request is recorded in order. The records are what a test asserts on
+ * when it wants to know what the CLI actually said, rather than inferring it
+ * from what came back.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export type FixtureRequest = {
+  readonly method: string;
+  readonly url: URL;
+  readonly headers: Record<string, string | undefined>;
+  /** The body, when it arrived as JSON. */
+  readonly body: Record<string, unknown> | null;
+  /** The body, when it arrived form-encoded, as RFC 8628's token call does. */
+  readonly form: URLSearchParams | null;
+};
+
+export type FixtureAnswer = {
+  readonly status: number;
+  readonly body?: unknown;
+  readonly text?: string;
+  readonly contentType?: string;
+};
+
+export type Route = {
+  readonly method: string;
+  readonly path: string;
+  handle(request: FixtureRequest): FixtureAnswer;
+};
+
+export type RouteGroup = {
+  readonly name: string;
+  readonly routes: readonly Route[];
+};
+
+/** One request, as the fixture saw it. */
+export type Observation = {
+  readonly seq: number;
+  readonly method: string;
+  readonly path: string;
+  readonly status: number;
+};
+
+export type FixturePlatform = {
+  /** The address the CLI is pointed at. */
+  readonly url: string;
+  readonly records: readonly Observation[];
+  close(): Promise<void>;
+};
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function startFixturePlatform(
+  groupsFor: (origin: () => string) => readonly RouteGroup[],
+): Promise<FixturePlatform & { readonly server: Server }> {
+  let url = "";
+  const groups = groupsFor(() => url);
+  const routes = groups.flatMap((group) => group.routes);
+  const records: Observation[] = [];
+
+  const server = createServer((incoming: IncomingMessage, outgoing: ServerResponse) => {
+    void (async () => {
+      const at = new URL(incoming.url ?? "/", url === "" ? "http://fixture" : url);
+      const raw = await readBody(incoming);
+      const type = incoming.headers["content-type"] ?? "";
+
+      const route = routes.find(
+        (candidate) => candidate.method === incoming.method && candidate.path === at.pathname,
+      );
+
+      const answer: FixtureAnswer =
+        route === undefined
+          ? { status: 404, body: { error: "not_found", message: `nothing serves ${at.pathname}` } }
+          : route.handle({
+              method: incoming.method ?? "GET",
+              url: at,
+              headers: incoming.headers as Record<string, string | undefined>,
+              body:
+                type.includes("application/json") && raw !== ""
+                  ? (JSON.parse(raw) as Record<string, unknown>)
+                  : null,
+              form: type.includes("application/x-www-form-urlencoded")
+                ? new URLSearchParams(raw)
+                : null,
+            });
+
+      records.push({
+        seq: records.length,
+        method: incoming.method ?? "GET",
+        path: at.pathname,
+        status: answer.status,
+      });
+
+      const payload =
+        answer.text ?? JSON.stringify(answer.body ?? {});
+      outgoing.writeHead(answer.status, {
+        "content-type": answer.contentType ?? "application/json",
+        "cache-control": "no-store",
+      });
+      outgoing.end(payload);
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  url = `http://127.0.0.1:${address.port}`;
+
+  return {
+    url,
+    records,
+    server,
+    async close() {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}

--- a/apps/cli/test/support/workspace.ts
+++ b/apps/cli/test/support/workspace.ts
@@ -3,7 +3,7 @@
  * gets driven in it.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -13,6 +13,11 @@ import type { DrivenAgentLaunch } from "../../src/acp/registry.ts";
 import type { FakeScript } from "./fake-agent.ts";
 
 export const FAKE_AGENT = fileURLToPath(new URL("./fake-agent.ts", import.meta.url));
+
+/** The stand-in browser a workspace wraps in a command of its own. */
+export const APPROVING_BROWSER = fileURLToPath(
+  new URL("./approving-browser.ts", import.meta.url),
+);
 
 /** The file a workspace is given so the walk has something to read. */
 export const MANIFEST = JSON.stringify({ name: "customer-repo", version: "1.0.0" }, null, 2);
@@ -25,12 +30,39 @@ export const PRETEND_OLD_NODE = fileURLToPath(
 
 export type Workspace = {
   readonly dir: string;
+  /**
+   * The egma folder this workspace's runs use, inside the throwaway directory.
+   *
+   * Every check that starts the command hands this over, so no check anywhere
+   * can read or write the credentials of the person running the suite.
+   */
+  readonly egmaFolder: string;
+  /** The credentials file inside it. */
+  readonly credentialsFile: string;
+  /** What the command is given so it looks there and nowhere else. */
+  env(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+  /** Puts a key in that folder, as a login would have. */
+  signIn(url: string, key?: string): Promise<void>;
+  /**
+   * A stand-in browser to point `BROWSER` at, and the file it writes every
+   * address egma hands it into.
+   */
+  browser(): Promise<{ readonly command: string; readonly opened: string }>;
   /** Writes a script and answers the path to it. */
   script(script: FakeScript): Promise<string>;
   /** How egma would be told to start the fake agent with that script. */
   launch(scriptPath: string): DrivenAgentLaunch;
   remove(): Promise<void>;
 };
+
+/**
+ * A browser that opens nothing.
+ *
+ * The command is handed one, rather than none, because the code that starts a
+ * browser is part of what is being checked — and a check that started a real
+ * browser on the machine running it would be intolerable.
+ */
+export const NO_BROWSER = "/usr/bin/true";
 
 export async function makeWorkspace(
   files: Readonly<Record<string, string>> = {},
@@ -40,9 +72,48 @@ export async function makeWorkspace(
     await writeFile(path.join(dir, name), content, "utf8");
   }
 
+  const egmaFolder = path.join(dir, "egma-home");
+  const credentialsFile = path.join(egmaFolder, "credentials");
+
   let scripts = 0;
   return {
     dir,
+    egmaFolder,
+    credentialsFile,
+    env(extra = {}) {
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        EGMA_HOME: egmaFolder,
+        BROWSER: NO_BROWSER,
+        ...extra,
+      };
+      // Whatever the person running the suite has set, a check talks to the
+      // egma it is checking against and to nothing else. Removed rather than
+      // set to nothing: a pseudo-terminal turns an unset value into the word.
+      if (extra.EGMA_URL === undefined) delete env.EGMA_URL;
+      return env;
+    },
+    async signIn(url, key = "egma_sk_already-held") {
+      await mkdir(egmaFolder, { recursive: true, mode: 0o700 });
+      await writeFile(credentialsFile, `${JSON.stringify({ url, key })}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+    },
+    async browser() {
+      // `BROWSER` names one command, exactly as it does for every other tool
+      // that honours it, so the stand-in is a command rather than a command
+      // line.
+      const command = path.join(dir, "stand-in-browser");
+      const opened = path.join(dir, "addresses-opened.txt");
+      await writeFile(
+        command,
+        `#!/bin/sh\nexec '${process.execPath}' '${APPROVING_BROWSER}' "$@"\n`,
+        { encoding: "utf8", mode: 0o755 },
+      );
+      await chmod(command, 0o755);
+      return { command, opened };
+    },
     async script(script) {
       scripts += 1;
       const file = path.join(dir, `.fake-agent-${scripts}.json`);

--- a/apps/cli/test/tui.test.ts
+++ b/apps/cli/test/tui.test.ts
@@ -26,6 +26,8 @@ describe("the wizard on a real terminal", () => {
 
   beforeEach(async () => {
     workspace = await makeWorkspace({ "package.json": MANIFEST });
+    // Login has its own checks; these are about what a real terminal draws.
+    await workspace.signIn("https://egma.invalid");
   });
 
   afterEach(async () => {
@@ -48,6 +50,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
+      env: workspace.env(),
     });
 
     try {
@@ -88,6 +91,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
+      env: workspace.env(),
     });
 
     try {
@@ -118,6 +122,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
+      env: workspace.env(),
     });
 
     try {


### PR DESCRIPTION
The wizard's login step and the first headless verb. The device flow starts against the platform, the browser opens on a pre-filled code, and the developer comes back holding a minted API key in a credentials file only they can read (0600, written atomically, symlinks not followed). The SSH path works three ways: copy the link, paste the callback, or paste the bare code. \`EGMA_URL\` targets a self-hosted instance and is remembered beside the key.

\`egma login\` runs the same flow promptlessly with machine-readable lines and exit codes a coding agent can branch on.

The terminal never repeats what the platform says on a refusal — every failure has egma's own plain sentence, and the words the login page owns never appear in the terminal. Addresses are validated before any browser opener sees them: http(s) only, same origin as the instance, nothing a command interpreter reads as syntax.

The fixture platform gains the device-flow endpoints, pinned to the real API's own shapes and error answers. CI walks the whole flow against it; a live smoke walks it against the real platform, real browser, twice — the second run finding everything already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)