### PR TITLE
egma finds the voice agent, by handing its own skills to the agent it drives

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -17,15 +17,22 @@ is how CI runs it.
 
 ## What it does today
 
+<!-- The facts are FACTS in src/wizard/facts.ts, which is the source of truth; keep this sentence in step. -->
+
 `npx egma` finds your voice agent. It starts the coding agent you already have,
 hands it egma's own notes on how voice agents are built, and has it read this
-folder and report four things: which framework runs your voice agent, where its
-prompts live, where its tools are defined, and how it reaches production. Every
-action it takes appears on screen while it works, and the facts it finds arrive
-one line at a time.
+folder and report which framework runs it, where its prompts live, where its
+tools are defined, how it reaches production, and where its identifier is
+written down. Every action it takes appears on screen while it works, and the
+facts it finds arrive one line at a time.
 
-Nothing is changed and nothing is written. Your code and your prompts never
-leave this machine.
+The task tells your coding agent to change nothing, and any file whose name
+starts with `.env` is refused when the agent goes through egma for it. Both are
+real, and neither is a lock: your coding agent runs its own commands, and a
+command that writes is one egma shows you rather than one egma stops. That is
+the trade — you see everything, as it happens.
+
+Your code and your prompts never leave this machine.
 
 If this folder holds no voice agent, egma asks once for the folder your prompts
 are in — teams often keep them apart — looks there, and otherwise says plainly

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -17,11 +17,28 @@ is how CI runs it.
 
 ## What it does today
 
-This is the first working slice. `npx egma` starts the coding agent you already
-have, gives it one small task — read a file in this folder and say what it is —
-and shows you every action it takes while it works. That proves the path the
-rest of the product runs on: egma drives your own agent, on your own machine,
-with your own login.
+`npx egma` finds your voice agent. It starts the coding agent you already have,
+hands it egma's own notes on how voice agents are built, and has it read this
+folder and report four things: which framework runs your voice agent, where its
+prompts live, where its tools are defined, and how it reaches production. Every
+action it takes appears on screen while it works, and the facts it finds arrive
+one line at a time.
+
+Nothing is changed and nothing is written. Your code and your prompts never
+leave this machine.
+
+If this folder holds no voice agent, egma asks once for the folder your prompts
+are in — teams often keep them apart — looks there, and otherwise says plainly
+that you should run it where your agent is defined.
+
+## The notes egma hands your coding agent
+
+They are markdown files inside this package, under `skills/`. They are sent as
+part of the task, at the moment the task is sent. Nothing is installed on your
+machine, nothing is downloaded, and nothing is written to your repository.
+
+Today there are two: one on finding a voice agent in a repository nobody has
+described, and one on what a Retell voice agent looks like from the inside.
 
 ## How it reaches your coding agent
 
@@ -64,9 +81,13 @@ is shut down before egma exits.
 
 ## Requirements
 
-Node 22 or newer. A coding agent installed and logged in — Claude Code and
-Codex both work, as does any agent in the protocol registry that ships as a
-package.
+Node 22 or newer. A coding agent installed — Claude Code and Codex both work,
+as does any agent in the protocol registry that ships as a package.
+
+You do not have to be logged in to it first. If it asks egma to log in, egma
+hands you to that agent's own login and carries on where it left off. And if
+there is no coding agent here for egma to drive at all, it prints the words to
+paste into whichever one you do use, and stops.
 
 ## Licence
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "egma": "./dist/bin.js"
   },
-  "files": ["dist", "NOTICE", "README.md"],
+  "files": ["dist", "skills", "NOTICE", "README.md"],
   "engines": {
     "node": ">=22"
   },
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "smoke": "node smoke/real-claude-code.ts && node smoke/real-claude-code-fence.ts"
+    "smoke": "node smoke/real-claude-code.ts && node smoke/real-claude-code-fence.ts && node smoke/real-claude-code-discovery.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",

--- a/apps/cli/skills/context-finding.md
+++ b/apps/cli/skills/context-finding.md
@@ -13,6 +13,8 @@ Read the repository. Report facts. Change nothing.
 
 ## The facts egma needs
 
+<!-- The names in this table are FACTS in src/wizard/facts.ts, which is the source of truth; keep the two in step. -->
+
 | Fact | What it means |
 |---|---|
 | `framework` | The library or platform that runs the voice agent |

--- a/apps/cli/skills/context-finding.md
+++ b/apps/cli/skills/context-finding.md
@@ -1,0 +1,105 @@
+---
+name: finding-the-voice-agent
+description: Find the voice agent in a repository nobody has described to you — its framework, its prompts, its tools and how it reaches production — and report the facts as egma marker lines.
+---
+
+# Find the voice agent in this repository
+
+egma is driving you. Somewhere in the folder you were started in there is a
+**voice agent**: a program that speaks with a person and does something for
+them. egma needs a few facts about it before it can test it.
+
+Read the repository. Report facts. Change nothing.
+
+## The facts egma needs
+
+| Fact | What it means |
+|---|---|
+| `framework` | The library or platform that runs the voice agent |
+| `prompts` | Where the words that steer the voice agent live |
+| `tools` | Where the actions the voice agent can take are defined |
+| `deploy` | How the voice agent reaches production |
+| `agent-id` | Where an identifier for the voice agent is written down, if there is one |
+
+## How to report: marker lines
+
+Put each fact on a line of its own, at the very start of the line, with no
+bullet, no number and no code fence around it:
+
+```
+egma:found framework retell-sdk
+egma:found prompts prompts/greeter.md
+egma:found tools src/tools/ (2 definitions)
+egma:found deploy Retell-hosted, updated by scripts/deploy.ts
+egma:found agent-id src/config.ts
+```
+
+Three more markers exist:
+
+```
+egma:note Reading package.json
+egma:none There is no voice agent in this folder.
+egma:abort I cannot read this repository.
+```
+
+`egma:note` is one short line about what you are doing right now. Use
+`egma:none` when you have looked properly and there is no voice agent here —
+never guess one into existence. Use `egma:abort` only when something stops you
+outright; egma itself ends the work when it reads that line.
+
+Everything else you write goes to a log file the developer can open. Only
+marker lines reach the screen, so a fact that is not in a marker line is a fact
+egma does not have.
+
+**End every marker line with a line break, and never put ordinary words on the
+same line as a marker.** Write the `egma:found` lines as one block, last, with
+nothing after them.
+
+## Where to look, in this order
+
+1. **The manifest.** `package.json`, `pyproject.toml`, `requirements.txt`,
+   `go.mod`, `Cargo.toml`. Its dependency list names the framework faster than
+   any amount of reading.
+2. **The entry point the manifest names** — `main`, `scripts.start`, a
+   `Dockerfile` command, a `Procfile`.
+3. **Prompt-shaped files.** A `prompts/` folder, `prompt.*`, `*.prompt.*`,
+   `instructions.*`, `system*.md`, a `.txt` full of prose — or a long string
+   constant in the source itself.
+4. **Tool-shaped files.** A `tools/` or `functions/` folder, a list of tool
+   definitions handed to the framework, a declared MCP server, HTTP routes the
+   platform posts to.
+5. **Deploy-shaped files.** `Dockerfile`, `fly.toml`, `render.yaml`,
+   `serverless.yml`, `.github/workflows/`, `scripts/deploy.*`, a `Makefile`.
+
+## Frameworks to recognise
+
+| In the manifest | Report as `framework` | Where the prompt usually sits |
+|---|---|---|
+| `retell-sdk` | `retell-sdk` | Often in the Retell dashboard rather than the repository — read the Retell skill |
+| `@vapi-ai/server-sdk`, `@vapi-ai/web`, `vapi_python` | `vapi` | An assistant object in the source, or in the Vapi dashboard |
+| `livekit-agents`, `@livekit/agents` | `livekit-agents` | The instructions given to the agent in the worker file |
+| `pipecat-ai` | `pipecat` | The first system message of the context handed to the pipeline |
+
+If the manifest names none of these, the voice agent may sit straight on a
+model provider's realtime API or on a telephony library. Report the library you
+actually see rather than forcing it into this table.
+
+## Rules
+
+- **Read only.** Do not write, move or delete anything. Do not run a command
+  that changes the repository, installs a package, or reaches the network.
+- **Report paths as the repository holds them**, relative to the folder you
+  were started in. A glob such as `src/tools/*.ts` is a good value when several
+  files share a job.
+- **One fact per marker line.** The first word after `egma:found` is the fact's
+  name; the rest of the line is its value.
+- **Never invent.** If the prompts are not in the repository, say where they are
+  instead — `managed in the Retell dashboard` is a good `prompts` value — or
+  leave the fact out entirely.
+- Any file whose name starts with `.env` is fenced off. Asking for one is
+  refused; work from the code, and report what the code says the file holds.
+
+## When you are done
+
+Stop once the marker lines are written. Do not offer to make changes and do not
+ask a question. egma reads your marker lines, not your prose.

--- a/apps/cli/skills/retell.md
+++ b/apps/cli/skills/retell.md
@@ -1,0 +1,101 @@
+---
+name: retell-voice-agents
+description: What a Retell voice agent looks like from inside a repository — the SDK, dashboard-managed against repository-managed prompts, and where the identifiers are written down.
+---
+
+# Retell voice agents, as a repository shows them
+
+Retell hosts voice agents and puts them behind a phone number or a web widget.
+The fact that matters most when you read a repository: **much of what steers a
+Retell voice agent lives on Retell's side, not in the files in front of you.**
+A repository can look nearly empty and still have a complete voice agent behind
+it. Report where the steering lives, whatever the answer is.
+
+## The signs
+
+**In the manifest.** `retell-sdk` in `package.json`; `retell-sdk` in
+`pyproject.toml` or `requirements.txt` — Retell publishes both under that one
+name.
+
+**In the source.**
+
+```ts
+import Retell from "retell-sdk";
+const retell = new Retell({ apiKey: process.env.RETELL_API_KEY });
+```
+
+```python
+from retell import Retell
+client = Retell(api_key=os.environ["RETELL_API_KEY"])
+```
+
+**Around the edges.** `RETELL_API_KEY` named in a Dockerfile, a workflow file or
+the README. A webhook route that Retell posts events to. A `wss://` endpoint the
+repository serves. (Files named `.env…` are fenced off from you, so read the
+names out of the code and the committed configuration instead.)
+
+## Two halves, and why it matters
+
+Retell splits a voice agent in two:
+
+- **the agent** — voice, language, telephony, webhook endpoints. Its identifier
+  starts with `agent_`.
+- **the response engine** — the words and the tools. Its shape is the fork you
+  are looking for:
+
+| `response_engine` | What it means | What to report as `prompts` |
+|---|---|---|
+| `{ type: "retell-llm", llm_id: "llm_…" }` | The prompt is a Retell LLM object, normally edited in the Retell dashboard | `managed in the Retell dashboard (llm_…)`, plus the file the id sits in |
+| `{ type: "custom-llm", llm_websocket_url: "wss://…" }` | The repository runs the model itself and Retell streams to it | the file in the repository that builds the system prompt |
+
+There is a third, and it is the one worth looking hardest for: a repository
+that keeps its prompt in a file **and pushes it to Retell**. It shows up as a
+deploy script reading a prompt file and handing it to the SDK:
+
+```ts
+await retell.llm.update(LLM_ID, {
+  general_prompt: await readFile("prompts/greeter.md", "utf8"),
+});
+```
+
+When you see that, both answers are true: report the repository file as
+`prompts`, and name the script under `deploy`.
+
+## Where the identifiers live
+
+`agent_` and `llm_` identifiers are long hexadecimal strings. Look in
+`src/config.*`, `config.json`, `retell.json`, a constant beside the SDK client,
+or a workflow file's environment block. Report the **file** in `agent-id`, not
+the identifier itself.
+
+## Where the tools live
+
+On a Retell LLM the tools sit in `general_tools`, and in a multi-state agent
+each state carries its own set beside a `state_prompt`. Retell ships some tools
+of its own; the ones a repository defines are custom tools that name a `url`,
+and that url points at a route this repository serves. Those routes — often
+under `src/tools/`, `api/`, or a router file — are the tool definitions to
+report.
+
+## How it reaches production
+
+Common shapes, in the order you will meet them:
+
+1. A script (`scripts/deploy.*`, an npm script, a CI workflow) that creates or
+   updates the agent and the LLM through the SDK.
+2. A web service the repository deploys — the tool routes, the webhook
+   endpoint, or a custom-LLM websocket server — with the agent itself created
+   once by hand in the dashboard.
+3. Nothing at all in the repository, because everything was done in the
+   dashboard. That is a real answer: report `deploy` as
+   `Retell-hosted, configured in the Retell dashboard`.
+
+## What a good report looks like
+
+```
+egma:found framework retell-sdk
+egma:found prompts prompts/greeter.md (pushed to Retell by scripts/deploy.ts)
+egma:found tools src/tools/*.ts (2 definitions, registered as Retell custom tools)
+egma:found deploy Retell-hosted; scripts/deploy.ts updates the agent
+egma:found agent-id src/config.ts
+```

--- a/apps/cli/smoke/real-claude-code-discovery.ts
+++ b/apps/cli/smoke/real-claude-code-discovery.ts
@@ -10,6 +10,17 @@
  * is never written down here. Its path is redacted from everything printed, so
  * the output of a passing run can be pasted anywhere.
  *
+ * With that variable unset there is nothing to look in, so the check verifies
+ * nothing and says so loudly rather than exiting quietly on a zero — a skip
+ * that reads like a pass is worse than no check at all. Where a skip must be a
+ * failure instead, run it strictly:
+ *
+ *   node apps/cli/smoke/real-claude-code-discovery.ts --require-target
+ *   EGMA_SMOKE_REQUIRE_TARGET=1 node apps/cli/smoke/real-claude-code-discovery.ts
+ *
+ * Either one turns an unset target into a non-zero exit. That is what CI, and
+ * `pnpm smoke` on a machine that is supposed to have a target, should use.
+ *
  * Run it with: node apps/cli/smoke/real-claude-code-discovery.ts
  * It needs Claude Code logged in, and the network the first time.
  */
@@ -19,36 +30,96 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { FACTS } from "../src/wizard/facts.ts";
+import { DETAIL_MARK } from "../src/wizard/status.ts";
+
 const CLI_ENTRY = fileURLToPath(new URL("../dist/bin.js", import.meta.url));
 
 /** The one committed name for the repository this check runs against. */
 const TARGET_VARIABLE = "EGMA_E2E_TARGET_REPO";
 
+/** The switch that turns a skip into a failure. */
+const STRICT_VARIABLE = "EGMA_SMOKE_REQUIRE_TARGET";
+const STRICT_FLAG = "--require-target";
+
 /** npx may have to fetch the adapter the first time, so this is generous. */
 const TIMEOUT_MS = 6 * 60_000;
+
+const RULE = "─".repeat(58);
 
 function say(message: string): void {
   process.stdout.write(`${message}\n`);
 }
 
-/** What the target repository is called, replaced everywhere by what it is. */
+/** Whether an unset target must end this run with a failure. */
+function requiresTarget(): boolean {
+  if (process.argv.includes(STRICT_FLAG)) return true;
+  const set = (process.env[STRICT_VARIABLE] ?? "").trim().toLowerCase();
+  return set !== "" && set !== "0" && set !== "false" && set !== "no";
+}
+
+/**
+ * What is printed when there is no repository to look in.
+ *
+ * It is loud on purpose. This check sits inside `pnpm smoke`, and a line of
+ * polite prose between two passing checks is read as a third passing check.
+ */
+function nothingWasVerified(strict: boolean): void {
+  const headline = strict
+    ? "FAILED — nothing was verified, and this run required a target"
+    : "SKIPPED — nothing was verified";
+
+  say(RULE);
+  say(`  ${headline}`);
+  say(RULE);
+  say(`  ${TARGET_VARIABLE} is not set, so no repository was read, no coding`);
+  say("  agent was started, and nothing at all was checked.");
+  say("");
+  say(`  Set ${TARGET_VARIABLE} to the folder a real voice agent is`);
+  say("  checked out in, then run this again.");
+  if (!strict) {
+    say("");
+    say("  Where a skip must not look like a pass — CI, or a machine that is");
+    say(`  supposed to have a target — run this with ${STRICT_FLAG}, or with`);
+    say(`  ${STRICT_VARIABLE}=1, and an unset target ends the run`);
+    say("  with a failure instead.");
+  }
+  say(RULE);
+}
+
+/** The shortest piece of a path still worth hiding. */
+const TELLING = 8;
+
+/**
+ * What the target repository is called, replaced everywhere by what it is.
+ *
+ * Every cut-short form of the path counts too. egma trims a long command to
+ * fit one status line, and half a path is still the path. It hides more than
+ * it strictly has to, which is the right way round: a redaction that takes an
+ * unrelated folder with it costs a reader nothing, and one that stops a
+ * character short costs the name this check exists not to print.
+ */
 function redactor(target: string): (text: string) => string {
-  const parts = [target, path.resolve(target), path.basename(target)].filter(
-    (part) => part.length > 2,
+  const names = [target, path.resolve(target), path.basename(target)].filter(
+    (name) => name.length > 2,
   );
-  const ordered = [...new Set(parts)].sort((left, right) => right.length - left.length);
-  return (text) =>
-    ordered.reduce((held, part) => held.split(part).join("<target repo>"), text);
+
+  const parts = new Set<string>();
+  for (const name of names) {
+    parts.add(name);
+    for (let end = name.length - 1; end >= TELLING; end -= 1) parts.add(name.slice(0, end));
+  }
+
+  const ordered = [...parts].sort((left, right) => right.length - left.length);
+  return (text) => ordered.reduce((held, part) => held.split(part).join("<target repo>"), text);
 }
 
 async function main(): Promise<void> {
   const target = process.env[TARGET_VARIABLE];
   if (target === undefined || target.trim() === "") {
-    say(`${TARGET_VARIABLE} is not set, so there is no repository to look in.`);
-    say("");
-    say("This check drives real Claude Code over a real voice agent's repository.");
-    say(`Set ${TARGET_VARIABLE} to the folder that repository is checked out in,`);
-    say("then run this again. Nothing was started.");
+    const strict = requiresTarget();
+    nothingWasVerified(strict);
+    if (strict) process.exitCode = 1;
     return;
   }
 
@@ -92,9 +163,13 @@ async function main(): Promise<void> {
     say(redact(stderr).trimEnd());
   }
 
-  const facts = lines.filter((line) => line.startsWith("┊ "));
-  const prompts = facts.find((line) => line.startsWith("┊ Prompts"));
-  const framework = facts.find((line) => line.startsWith("┊ Framework"));
+  // A detail line is not a fact — a command egma showed under a terminal
+  // action starts the same way — so the facts are counted by their own names.
+  const facts = lines.filter((line) =>
+    FACTS.some((fact) => line.startsWith(`${DETAIL_MARK} ${fact.label}`)),
+  );
+  const prompts = facts.find((line) => line.startsWith(`${DETAIL_MARK} Prompts`));
+  const framework = facts.find((line) => line.startsWith(`${DETAIL_MARK} Framework`));
 
   say("");
   say("── check ─────────────────────────────────────────────────");

--- a/apps/cli/smoke/real-claude-code-discovery.ts
+++ b/apps/cli/smoke/real-claude-code-discovery.ts
@@ -1,0 +1,128 @@
+/**
+ * The smoke check: real Claude Code, finding a real voice agent's prompts.
+ *
+ * Nothing here is scripted. egma starts the adapter the agent registry names,
+ * hands it the two skills as the task's instructions, and the check passes only
+ * if the coding agent comes back with marker lines naming the framework and the
+ * prompts — read out of a repository this file has never seen and does not name.
+ *
+ * The repository is supplied by the developer through EGMA_E2E_TARGET_REPO and
+ * is never written down here. Its path is redacted from everything printed, so
+ * the output of a passing run can be pasted anywhere.
+ *
+ * Run it with: node apps/cli/smoke/real-claude-code-discovery.ts
+ * It needs Claude Code logged in, and the network the first time.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const CLI_ENTRY = fileURLToPath(new URL("../dist/bin.js", import.meta.url));
+
+/** The one committed name for the repository this check runs against. */
+const TARGET_VARIABLE = "EGMA_E2E_TARGET_REPO";
+
+/** npx may have to fetch the adapter the first time, so this is generous. */
+const TIMEOUT_MS = 6 * 60_000;
+
+function say(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+/** What the target repository is called, replaced everywhere by what it is. */
+function redactor(target: string): (text: string) => string {
+  const parts = [target, path.resolve(target), path.basename(target)].filter(
+    (part) => part.length > 2,
+  );
+  const ordered = [...new Set(parts)].sort((left, right) => right.length - left.length);
+  return (text) =>
+    ordered.reduce((held, part) => held.split(part).join("<target repo>"), text);
+}
+
+async function main(): Promise<void> {
+  const target = process.env[TARGET_VARIABLE];
+  if (target === undefined || target.trim() === "") {
+    say(`${TARGET_VARIABLE} is not set, so there is no repository to look in.`);
+    say("");
+    say("This check drives real Claude Code over a real voice agent's repository.");
+    say(`Set ${TARGET_VARIABLE} to the folder that repository is checked out in,`);
+    say("then run this again. Nothing was started.");
+    return;
+  }
+
+  const redact = redactor(target.trim());
+
+  say("Starting: egma, driving the coding agent the registry calls claude-acp.");
+  say("Folder:   <target repo>");
+  say("");
+
+  const started = Date.now();
+  const child = spawn(process.execPath, [CLI_ENTRY, "--headless", "--cwd", target.trim()], {
+    cwd: target.trim(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const giveUp = setTimeout(() => child.kill("SIGKILL"), TIMEOUT_MS);
+  const code = await new Promise<number>((resolve) => {
+    child.on("close", (value) => resolve(value ?? 1));
+  });
+  clearTimeout(giveUp);
+
+  const lines = redact(stdout).trimEnd().split("\n");
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+
+  say("── what egma showed ──────────────────────────────────────");
+  for (const line of lines) say(line);
+  if (stderr.trim() !== "") {
+    say("");
+    say("── standard error ────────────────────────────────────────");
+    say(redact(stderr).trimEnd());
+  }
+
+  const facts = lines.filter((line) => line.startsWith("┊ "));
+  const prompts = facts.find((line) => line.startsWith("┊ Prompts"));
+  const framework = facts.find((line) => line.startsWith("┊ Framework"));
+
+  say("");
+  say("── check ─────────────────────────────────────────────────");
+  say(`exit code:      ${code}`);
+  say(`facts reported: ${facts.length}`);
+  say(`elapsed:        ${seconds}s`);
+
+  const problems: string[] = [];
+  if (code !== 0) problems.push(`exit code was ${code}, expected 0`);
+  if (framework === undefined) problems.push("no framework was reported");
+  if (prompts === undefined) problems.push("no prompts were reported");
+  else if (prompts.replace("┊ Prompts", "").trim() === "") {
+    problems.push("the prompts fact came back empty");
+  }
+  if (!lines.some((line) => line.includes("egma found your voice agent"))) {
+    problems.push("the exit line does not say a voice agent was found");
+  }
+
+  if (problems.length > 0) {
+    say("");
+    for (const problem of problems) say(`FAILED: ${problem}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  say("");
+  say("PASSED: real Claude Code read the repository and reported its prompts.");
+}
+
+await main();
+process.exit(process.exitCode ?? 0);

--- a/apps/cli/smoke/real-claude-code.ts
+++ b/apps/cli/smoke/real-claude-code.ts
@@ -11,25 +11,16 @@
  * It needs Claude Code logged in, and it needs the network the first time.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { runInTerminal } from "../test/support/pty.ts";
+import { RETELL_FIXTURE_REPO } from "../test/support/workspace.ts";
 
 const CLI_ENTRY = fileURLToPath(new URL("../dist/bin.js", import.meta.url));
-
-const MANIFEST = `${JSON.stringify(
-  {
-    name: "egma-smoke-repo",
-    version: "1.0.0",
-    description: "A tiny repository that exists so an agent has something to read.",
-  },
-  null,
-  2,
-)}\n`;
 
 /** npx may have to fetch the adapter the first time, so this is generous. */
 const OVERALL_TIMEOUT_MS = 6 * 60_000;
@@ -53,7 +44,8 @@ async function waitFor(
 
 async function main(): Promise<void> {
   const dir = await mkdtemp(path.join(tmpdir(), "egma-smoke-"));
-  await writeFile(path.join(dir, "package.json"), MANIFEST, "utf8");
+  // The committed fixture repository, so there is a real voice agent to find.
+  await cp(RETELL_FIXTURE_REPO, dir, { recursive: true });
   // A secret in the folder, so the fence has something real to stand in front of.
   await writeFile(path.join(dir, ".env"), "SMOKE_SECRET=never-read-this\n", "utf8");
 
@@ -90,9 +82,9 @@ async function main(): Promise<void> {
       OVERALL_TIMEOUT_MS,
       "the first action to stream",
     );
-    // Give the agent a moment to say which file it means, so the captured
-    // frame shows the whole action rather than only its first line.
-    await waitFor(() => terminal.screen().includes("┊"), 15_000, "the file").catch(
+    // Give the agent a moment to report its first fact, so the captured frame
+    // shows the step working rather than only starting.
+    await waitFor(() => terminal.screen().includes("┊"), 120_000, "the first fact").catch(
       () => undefined,
     );
     working = terminal.screen();
@@ -129,9 +121,8 @@ async function main(): Promise<void> {
     const problems: string[] = [];
     if (code !== 0) problems.push(`exit code was ${code}, expected 0`);
     if (keystrokes !== 1) problems.push(`${keystrokes} keystrokes were needed, expected 1`);
-    if (scrollback.split("\n").length !== 1) problems.push("scrollback is not one line");
-    if (!scrollback.includes("read package.json for egma")) {
-      problems.push("the exit line does not say the task was done");
+    if (!scrollback.includes("egma found your voice agent")) {
+      problems.push("the exit line does not say a voice agent was found");
     }
     if (!working.includes("◆")) problems.push("no action streamed while the agent worked");
 

--- a/apps/cli/src/acp/drive.ts
+++ b/apps/cli/src/acp/drive.ts
@@ -25,7 +25,11 @@ import type { DrivenAgentLaunch } from "./registry.ts";
 /** How the one task ended. */
 export type DriveResult =
   | { readonly kind: "done"; readonly summary: string }
+  /** The agent said it could not go on, and egma ended the task on that word. */
+  | { readonly kind: "aborted"; readonly reason: string }
   | { readonly kind: "interrupted" }
+  /** egma could not start this coding agent, or it does not speak the protocol. */
+  | { readonly kind: "unreachable"; readonly reason: string }
   | { readonly kind: "needs-login"; readonly drivenAgentName: string }
   | { readonly kind: "failed"; readonly reason: string };
 
@@ -38,6 +42,15 @@ export type DriveOptions = {
   readonly signal: AbortSignal;
   /** Where the agent's own noise goes. Omit to drop it. */
   readonly logStderr?: (chunk: string) => void;
+  /**
+   * Sees the coding agent's own words as they arrive, in order. Answer a reason
+   * to end the task now, or `null` to let it carry on. This is where a step
+   * enforces its own abort: egma stops on the word, rather than waiting for the
+   * agent to agree that it has finished.
+   */
+  readonly watch?: (text: string) => string | null;
+  /** Told when the coding agent has to log in before egma can drive it. */
+  readonly onLogin?: (drivenAgentName: string) => void;
 };
 
 /** JSON-RPC code the protocol reserves for "this agent is not logged in". */
@@ -83,6 +96,16 @@ class DrivenAgentProcess {
   }
 }
 
+/**
+ * Why the agent never got as far as speaking the protocol.
+ *
+ * A command that is not on this machine, and a command that is but exits
+ * immediately, look the same from here and mean the same thing: there is no
+ * coding agent at the other end of this. It is held rather than thrown because
+ * it happens off to one side of the request egma is waiting on.
+ */
+type Startup = { failure: string | null };
+
 function start(launch: DrivenAgentLaunch, cwd: string, logStderr?: (chunk: string) => void) {
   const child = spawn(launch.command, [...launch.args], {
     cwd,
@@ -96,7 +119,15 @@ function start(launch: DrivenAgentLaunch, cwd: string, logStderr?: (chunk: strin
   child.stderr?.setEncoding("utf8");
   child.stderr?.on("data", (chunk: string) => logStderr?.(chunk));
 
-  return { child, handle: new DrivenAgentProcess(child) };
+  const startup: Startup = { failure: null };
+  child.once("error", (error: Error) => {
+    startup.failure ??= error.message;
+  });
+  child.once("exit", (code) => {
+    startup.failure ??= `it stopped straight away${code === null ? "" : ` (exit ${code})`}`;
+  });
+
+  return { child, handle: new DrivenAgentProcess(child), startup };
 }
 
 /**
@@ -170,6 +201,29 @@ function isAuthRequired(error: unknown): boolean {
   return error instanceof acp.RequestError && error.code === AUTH_REQUIRED;
 }
 
+/**
+ * The login egma can hand the developer to.
+ *
+ * A coding agent advertises how it wants to be logged in. Some of those ways
+ * are the agent's own — it opens its own browser page, or runs its own
+ * command — and those are the ones egma can hand off to and then carry on from.
+ * A method that asks for an environment variable is not a handoff: egma would
+ * have to collect a secret it has no business holding, so it is left alone and
+ * the developer is told to log in themselves.
+ */
+function ownLoginMethod(response: acp.InitializeResponse): string | null {
+  for (const method of response.authMethods ?? []) {
+    const kind = (method as { type?: string }).type;
+    if (kind === undefined || kind === "terminal") return method.id;
+  }
+  return null;
+}
+
+/** What one prompt turn came to. */
+type TurnOutcome =
+  | { readonly kind: "spoken"; readonly text: string }
+  | { readonly kind: "aborted"; readonly reason: string };
+
 function reasonFrom(error: unknown): string {
   if (error instanceof Error && error.message !== "") return error.message;
   return String(error);
@@ -181,8 +235,11 @@ export async function driveOneTask(options: DriveOptions): Promise<DriveResult> 
 
   if (signal.aborted) return { kind: "interrupted" };
 
-  const { child, handle } = start(launch, cwd, options.logStderr);
+  const { child, handle, startup } = start(launch, cwd, options.logStderr);
 
+  // Once the agent has answered `initialize` it is reachable, whatever happens
+  // afterwards. Before that, every failure means the same thing to a developer.
+  let reached = false;
   let interrupted = false;
   const onAbort = (): void => {
     interrupted = true;
@@ -202,7 +259,7 @@ export async function driveOneTask(options: DriveOptions): Promise<DriveResult> 
       Readable.toWeb(stdout) as ReadableStream<Uint8Array>,
     );
 
-    const summary = await acp
+    const outcome = await acp
       .client({ name: "egma" })
       .onRequest(acp.methods.client.session.requestPermission, (ctx) =>
         permissionHandler(ui)(ctx.params),
@@ -214,7 +271,7 @@ export async function driveOneTask(options: DriveOptions): Promise<DriveResult> 
         writeTextFileHandler(cwd, ui)(ctx.params),
       )
       .connectWith(stream, async (ctx) => {
-        await ctx.request(acp.methods.agent.initialize, {
+        const greeting = await ctx.request(acp.methods.agent.initialize, {
           protocolVersion: acp.PROTOCOL_VERSION,
           clientCapabilities: {
             // Reading and writing through egma is what puts the fence in the
@@ -222,6 +279,7 @@ export async function driveOneTask(options: DriveOptions): Promise<DriveResult> 
             fs: { readTextFile: true, writeTextFile: true },
           },
         });
+        reached = true;
 
         const meta = sessionMetaFor(launch.id);
         const request: acp.NewSessionRequest = {
@@ -230,35 +288,71 @@ export async function driveOneTask(options: DriveOptions): Promise<DriveResult> 
           ...(meta === null ? {} : { _meta: meta }),
         };
 
-        return ctx.buildSession(request).withSession(async (session) => {
-          // The first belt: start in the most permissive mode the agent offers,
-          // so most requests are never raised at all.
-          const mode = zeroPromptMode(session.modes);
-          if (mode !== null) {
-            await ctx.request(acp.methods.agent.session.setMode, {
-              sessionId: session.sessionId,
-              modeId: mode,
-            });
-          }
+        const runTask = async (): Promise<TurnOutcome> =>
+          ctx.buildSession(request).withSession(async (session) => {
+            // The first belt: start in the most permissive mode the agent
+            // offers, so most requests are never raised at all.
+            const mode = zeroPromptMode(session.modes);
+            if (mode !== null) {
+              await ctx.request(acp.methods.agent.session.setMode, {
+                sessionId: session.sessionId,
+                modeId: mode,
+              });
+            }
 
-          const turn = session.prompt(instructions);
-          turn.catch(() => undefined);
+            const turn = session.prompt(instructions);
+            turn.catch(() => undefined);
 
-          const actions = new ActionStream(cwd);
-          let spoken = "";
-          for (;;) {
-            const message = await session.nextUpdate();
-            if (message.kind === "stop") return spoken.trim();
-            for (const line of actions.lines(message.update)) ui.pushStatus(line);
-            spoken += drivenAgentTextIn(message.update);
-          }
-        });
+            const actions = new ActionStream(cwd);
+            let spoken = "";
+            for (;;) {
+              const message = await session.nextUpdate();
+              if (message.kind === "stop") return { kind: "spoken", text: spoken.trim() };
+
+              for (const line of actions.lines(message.update)) ui.pushStatus(line);
+
+              const said = drivenAgentTextIn(message.update);
+              if (said === "") continue;
+              spoken += said;
+
+              const reason = options.watch?.(said) ?? null;
+              if (reason === null) continue;
+              // egma ends the turn itself rather than asking the agent to stop
+              // and hoping. The cancel is a courtesy to the agent; the task is
+              // over either way.
+              await ctx
+                .notify(acp.methods.agent.session.cancel, { sessionId: session.sessionId })
+                .catch(() => undefined);
+              return { kind: "aborted", reason };
+            }
+          });
+
+        try {
+          return await runTask();
+        } catch (error) {
+          // A cold machine answers the first session with "log in first". That
+          // is the agent's own login to run, not egma's, so egma asks it to run
+          // it and then carries straight on with the same task.
+          if (!isAuthRequired(error)) throw error;
+          const method = ownLoginMethod(greeting);
+          if (method === null) throw error;
+          options.onLogin?.(launch.name);
+          await ctx.request(acp.methods.agent.authenticate, { methodId: method });
+          return await runTask();
+        }
       });
 
     if (interrupted) return { kind: "interrupted" };
-    return { kind: "done", summary };
+    if (outcome.kind === "aborted") return { kind: "aborted", reason: outcome.reason };
+    return { kind: "done", summary: outcome.text };
   } catch (error) {
     if (interrupted) return { kind: "interrupted" };
+    if (!reached) {
+      return {
+        kind: "unreachable",
+        reason: startup.failure ?? reasonFrom(error),
+      };
+    }
     if (isAuthRequired(error)) return { kind: "needs-login", drivenAgentName: launch.name };
     return { kind: "failed", reason: reasonFrom(error) };
   } finally {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -19,7 +19,8 @@ import {
 } from "./acp/registry.ts";
 import { HeadlessUI } from "./ui/headless-ui.ts";
 import { startTui } from "./ui/tui/start-tui.ts";
-import { buildExitLine, type ExitReport } from "./wizard/exit-line.ts";
+import { buildExitLine, buildExitNotice, type ExitReport } from "./wizard/exit-line.ts";
+import { pasteFallbackMessage } from "./wizard/no-coding-agent.ts";
 import type { StopReason } from "./wizard/stop.ts";
 import { walk } from "./wizard/walk.ts";
 
@@ -31,12 +32,9 @@ export type Invocation = {
   readonly drivenAgentId: string;
   readonly cwd: string | null;
   /**
-   * A test seam, not product surface: `--file` and `-- <command>` let a test
-   * pin the file and start a scripted agent in place of a real one. Neither is
-   * documented, and neither is stable.
+   * A test seam, not product surface: `-- <command>` starts a scripted agent in
+   * place of a real one. It is not documented and it is not stable.
    */
-  readonly file: string | null;
-  /** A command to start as the coding agent, in place of a registry lookup. */
   readonly drivenAgentCommand: readonly string[];
   readonly unknown: readonly string[];
 };
@@ -47,7 +45,6 @@ export function parseArgs(argv: readonly string[]): Invocation {
   let headless = false;
   let drivenAgentId = DEFAULT_DRIVEN_AGENT_ID;
   let cwd: string | null = null;
-  let file: string | null = null;
   let drivenAgentCommand: string[] = [];
   const unknown: string[] = [];
 
@@ -62,11 +59,10 @@ export function parseArgs(argv: readonly string[]): Invocation {
     else if (argument === "--headless") headless = true;
     else if (argument === "--coding-agent") drivenAgentId = argv[(index += 1)] ?? drivenAgentId;
     else if (argument === "--cwd") cwd = argv[(index += 1)] ?? null;
-    else if (argument === "--file") file = argv[(index += 1)] ?? null;
     else unknown.push(argument);
   }
 
-  return { help, version, headless, drivenAgentId, cwd, file, drivenAgentCommand, unknown };
+  return { help, version, headless, drivenAgentId, cwd, drivenAgentCommand, unknown };
 }
 
 export function helpText(): string {
@@ -117,21 +113,21 @@ function launchFrom(invocation: Invocation): DrivenAgentLaunch {
 
 function exitCodeFor(report: ExitReport): number {
   switch (report.kind) {
-    case "task-done":
+    case "found-agent":
     case "quit":
+    // egma did everything it could here: it named what is missing and handed
+    // over words that work without it. That is the run finishing, not failing.
+    case "no-coding-agent":
       return 0;
     case "interrupted":
       return 130;
+    case "no-agent-context":
     case "failed":
       return 1;
   }
 }
 
-async function runHeadless(
-  launch: DrivenAgentLaunch,
-  cwd: string,
-  file: string | null,
-): Promise<number> {
+async function runHeadless(launch: DrivenAgentLaunch, cwd: string): Promise<number> {
   const controller = new AbortController();
   const stop = (reason: StopReason): void => controller.abort(reason);
   const onSignal = (): void => stop("interrupt");
@@ -140,13 +136,9 @@ async function runHeadless(
 
   const ui = new HeadlessUI({ write: (line) => process.stdout.write(`${line}\n`) });
   try {
-    const report = await walk({
-      ui,
-      launch,
-      cwd,
-      signal: controller.signal,
-      ...(file === null ? {} : { file }),
-    });
+    const report = await walk({ ui, launch, cwd, signal: controller.signal });
+    const notice = buildExitNotice(report);
+    if (notice !== null) process.stdout.write(`${notice}\n\n`);
     process.stdout.write(`${buildExitLine(report)}\n`);
     return exitCodeFor(report);
   } finally {
@@ -155,11 +147,7 @@ async function runHeadless(
   }
 }
 
-async function runWizard(
-  launch: DrivenAgentLaunch,
-  cwd: string,
-  file: string | null,
-): Promise<number> {
+async function runWizard(launch: DrivenAgentLaunch, cwd: string): Promise<number> {
   const controller = new AbortController();
   const tui = startTui({ stop: (reason) => controller.abort(reason) });
 
@@ -170,13 +158,7 @@ async function runWizard(
   process.on("SIGTERM", onSignal);
 
   try {
-    const report = await walk({
-      ui: tui.ui,
-      launch,
-      cwd,
-      signal: controller.signal,
-      ...(file === null ? {} : { file }),
-    });
+    const report = await walk({ ui: tui.ui, launch, cwd, signal: controller.signal });
     tui.close(report);
     return exitCodeFor(report);
   } catch (error) {
@@ -226,14 +208,15 @@ export async function main(argv: readonly string[]): Promise<void> {
     launch = launchFrom(invocation);
   } catch (error) {
     if (error instanceof UnlaunchableDrivenAgentError) {
-      process.stderr.write(`${error.message}\n`);
-      process.exitCode = 1;
+      // There is no coding agent here for egma to drive, so there is nothing to
+      // open a wizard for. The developer gets the words that work anyway.
+      process.stdout.write(`${error.message}\n\n${pasteFallbackMessage()}\n`);
       return;
     }
     throw error;
   }
 
   process.exitCode = invocation.headless
-    ? await runHeadless(launch, cwd, invocation.file)
-    : await runWizard(launch, cwd, invocation.file);
+    ? await runHeadless(launch, cwd)
+    : await runWizard(launch, cwd);
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -122,6 +122,9 @@ function exitCodeFor(report: ExitReport): number {
     case "interrupted":
       return 130;
     case "no-agent-context":
+    // The coding agent stopped the work itself. Nothing was found, and the run
+    // did not do what it set out to do.
+    case "coding-agent-stopped":
     case "failed":
       return 1;
   }

--- a/apps/cli/src/skills/index.ts
+++ b/apps/cli/src/skills/index.ts
@@ -1,0 +1,52 @@
+/**
+ * egma's skills: content, not code.
+ *
+ * A skill is a markdown file that teaches a coding agent one concern. It ships
+ * inside this package and it is read out of the package at dispatch time and
+ * put at the top of the task's instructions. Nothing is installed, nothing is
+ * copied, and nothing is written to the developer's disk while the wizard runs
+ * — a skill reaches the coding agent the same way a sentence does.
+ *
+ * The files sit beside `dist` rather than inside it, at the same depth from
+ * this module either way, so the one relative path works in the source tree, in
+ * the built output, and in the published package.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/** One skill, named by its file. */
+export type SkillName = "context-finding" | "retell";
+
+export const SKILL_NAMES: readonly SkillName[] = ["context-finding", "retell"];
+
+/** Where the packaged skill files live, relative to the package root. */
+export const SKILLS_DIRECTORY = "skills";
+
+const cache = new Map<SkillName, string>();
+
+/** The absolute path of a skill's file, wherever this package is running from. */
+export function skillFile(name: SkillName): string {
+  return fileURLToPath(new URL(`../../${SKILLS_DIRECTORY}/${name}.md`, import.meta.url));
+}
+
+/** A skill's content, read from the package. */
+export function skill(name: SkillName): string {
+  const held = cache.get(name);
+  if (held !== undefined) return held;
+  const content = readFileSync(skillFile(name), "utf8").trimEnd();
+  cache.set(name, content);
+  return content;
+}
+
+/**
+ * The instructions for one dispatched task: the skills it needs, then the task
+ * itself. The skills come first because they are what the coding agent has to
+ * know before the task makes sense, and last place in a long prompt is where
+ * the thing to actually do belongs.
+ */
+export function instructionsWith(skills: readonly SkillName[], task: string): string {
+  const parts = skills.map((name) => skill(name));
+  parts.push(task.trim());
+  return parts.join("\n\n---\n\n");
+}

--- a/apps/cli/src/ui/headless-ui.ts
+++ b/apps/cli/src/ui/headless-ui.ts
@@ -8,41 +8,49 @@
  * path. Because every gate opens itself, nothing here may ever be reached
  * without that word from the developer: the gate is where consent is given,
  * and this UI answers it on their behalf.
+ *
+ * A gate carrying a value is different. Consent can be given in advance;
+ * knowledge cannot. So an answer nobody supplied is `null`, and the flow takes
+ * the branch it takes when a developer has nothing to add.
  */
 
 import type { ExitReport } from "../wizard/exit-line.ts";
-import type { DrivenAgent, GateId, WizardUI } from "./wizard-ui.ts";
+import type { AskId, DrivenAgent, GateId, WizardUI } from "./wizard-ui.ts";
 
 export type HeadlessRecord = {
   drivenAgent: DrivenAgent | null;
   drivenAgentLog: string | null;
-  taskFile: string | null;
   statuses: string[];
   summary: string;
   exit: ExitReport | null;
   gatesOpened: GateId[];
+  asked: AskId[];
 };
 
 export type HeadlessOptions = {
   /** Where plain lines go. Omit to keep the run silent. */
   readonly write?: (line: string) => void;
+  /** What the developer would have said, for a run where nobody is asked. */
+  readonly answers?: Partial<Readonly<Record<AskId, string>>>;
 };
 
 export class HeadlessUI implements WizardUI {
   readonly record: HeadlessRecord = {
     drivenAgent: null,
     drivenAgentLog: null,
-    taskFile: null,
     statuses: [],
     summary: "",
     exit: null,
     gatesOpened: [],
+    asked: [],
   };
 
   private readonly write: (line: string) => void;
+  private readonly answers: Partial<Readonly<Record<AskId, string>>>;
 
   constructor(options: HeadlessOptions = {}) {
     this.write = options.write ?? (() => undefined);
+    this.answers = options.answers ?? {};
   }
 
   readonly log = {
@@ -61,14 +69,14 @@ export class HeadlessUI implements WizardUI {
     this.record.drivenAgentLog = file;
   }
 
-  setTaskFile(file: string): void {
-    this.record.taskFile = file;
-    this.write(`Task: read ${file} and say what it is`);
-  }
-
   waitForGate(gate: GateId): Promise<void> {
     this.record.gatesOpened.push(gate);
     return Promise.resolve();
+  }
+
+  waitForAnswer(ask: AskId): Promise<string | null> {
+    this.record.asked.push(ask);
+    return Promise.resolve(this.answers[ask] ?? null);
   }
 
   taskStarted(): void {

--- a/apps/cli/src/ui/tui/App.tsx
+++ b/apps/cli/src/ui/tui/App.tsx
@@ -9,6 +9,7 @@ import { useSyncExternalStore } from "react";
 import { useInput } from "ink";
 
 import { IntroScreen } from "./screens/IntroScreen.tsx";
+import { PromptsPointerScreen } from "./screens/PromptsPointerScreen.tsx";
 import { TaskScreen } from "./screens/TaskScreen.tsx";
 import type { WizardStore } from "./store.ts";
 
@@ -32,6 +33,13 @@ export function App({ store, onQuit, onInterrupt }: AppProps) {
 
   if (screen === "intro") {
     return <IntroScreen state={state} onBegin={() => store.begin()} onQuit={onQuit} />;
+  }
+  if (screen === "prompts-pointer") {
+    return (
+      <PromptsPointerScreen
+        onAnswer={(pointer) => store.answer("prompts-pointer", pointer)}
+      />
+    );
   }
   return <TaskScreen state={state} />;
 }

--- a/apps/cli/src/ui/tui/ink-ui.ts
+++ b/apps/cli/src/ui/tui/ink-ui.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ExitReport } from "../../wizard/exit-line.ts";
-import type { DrivenAgent, GateId, WizardUI } from "../wizard-ui.ts";
+import type { AskId, DrivenAgent, GateId, WizardUI } from "../wizard-ui.ts";
 import type { WizardStore } from "./store.ts";
 
 export class InkUI implements WizardUI {
@@ -31,12 +31,12 @@ export class InkUI implements WizardUI {
     this.store.setDrivenAgentLog(file);
   }
 
-  setTaskFile(file: string): void {
-    this.store.setTaskFile(file);
-  }
-
   waitForGate(gate: GateId): Promise<void> {
     return this.store.getGate(gate);
+  }
+
+  waitForAnswer(ask: AskId): Promise<string | null> {
+    return this.store.ask(ask);
   }
 
   taskStarted(): void {

--- a/apps/cli/src/ui/tui/keybindings.ts
+++ b/apps/cli/src/ui/tui/keybindings.ts
@@ -63,10 +63,25 @@ export function defaultPriority(match: KeyMatch | readonly KeyMatch[]): number {
   return DEFAULT_PRIORITY[first as string] ?? 15;
 }
 
+/**
+ * Enter, whichever byte the terminal sent for it.
+ *
+ * A terminal in its ordinary line-by-line mode turns the carriage return that
+ * Enter sends into a line feed, and the renderer only calls a carriage return
+ * `return`. The two are the same key, and the moment they differ is exactly the
+ * moment a developer presses Enter: the first frame is on screen a beat before
+ * the renderer takes the terminal into raw mode, and a keystroke in that beat
+ * arrives as a line feed. Reading only `key.return` drops it, and the wizard
+ * sits there looking as though it did not hear.
+ */
+function isEnter(input: string, key: KeyState): boolean {
+  return key.return === true || input === "\r" || input === "\n";
+}
+
 export function matchesKey(match: KeyMatch, input: string, key: KeyState): boolean {
   switch (match) {
     case "return":
-      return key.return === true;
+      return isEnter(input, key);
     case "escape":
       return key.escape === true;
     case "space":

--- a/apps/cli/src/ui/tui/router.ts
+++ b/apps/cli/src/ui/tui/router.ts
@@ -15,7 +15,7 @@
 
 import type { WizardState } from "./state.ts";
 
-export type ScreenId = "intro" | "task";
+export type ScreenId = "intro" | "prompts-pointer" | "task";
 
 /** An interruption drawn over the flow. The stack is empty in the walk. */
 export type OverlayId = never;

--- a/apps/cli/src/ui/tui/screens/IntroScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/IntroScreen.tsx
@@ -9,6 +9,7 @@
 
 import { Box, Text, useInput } from "ink";
 
+import { FACTS } from "../../../wizard/facts.ts";
 import { dispatchKey, hintBar, type KeyBinding } from "../keybindings.ts";
 import type { WizardState } from "../state.ts";
 
@@ -38,12 +39,13 @@ export function IntroScreen({ state, onBegin, onQuit }: IntroScreenProps) {
       <Box height={1} />
       <Text>{`It reads this folder with ${drivenAgentName}, here on this machine, and reports:`}</Text>
       <Box height={1} />
-      <Text> which framework runs your voice agent</Text>
-      <Text> where its prompts live</Text>
-      <Text> where its tools are defined</Text>
-      <Text> how it reaches production</Text>
+      {/* The facts themselves are FACTS in wizard/facts.ts, so this promise
+          cannot fall behind what the step actually brings back. */}
+      {FACTS.map((fact) => (
+        <Text key={fact.name}> {fact.phrase}</Text>
+      ))}
       <Box height={1} />
-      <Text>Nothing here is changed. Your code stays on this machine.</Text>
+      <Text>egma tells it to change nothing. Your code stays on this machine.</Text>
       <Box height={1} />
       <Text>Every action your coding agent takes appears below as it happens.</Text>
       <Box height={1} />

--- a/apps/cli/src/ui/tui/screens/IntroScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/IntroScreen.tsx
@@ -28,18 +28,21 @@ export function IntroScreen({ state, onBegin, onQuit }: IntroScreenProps) {
     dispatchKey(bindings, input, key);
   });
 
-  const drivenAgentName = state.drivenAgent?.name ?? "your coding agent";
-  const file = state.taskFile ?? "one file";
+  const drivenAgentName = state.drivenAgent?.name ?? "your own coding agent";
 
   return (
     <Box flexDirection="column" borderStyle="round" paddingX={2} paddingY={1}>
       <Text bold>egma</Text>
       <Box height={1} />
-      <Text>This is the first check that egma can drive your own coding agent.</Text>
+      <Text>egma is about to find your voice agent.</Text>
       <Box height={1} />
-      <Text>
-        {`egma will ask ${drivenAgentName} to read ${file} in this folder and say what it is.`}
-      </Text>
+      <Text>{`It reads this folder with ${drivenAgentName}, here on this machine, and reports:`}</Text>
+      <Box height={1} />
+      <Text> which framework runs your voice agent</Text>
+      <Text> where its prompts live</Text>
+      <Text> where its tools are defined</Text>
+      <Text> how it reaches production</Text>
+      <Box height={1} />
       <Text>Nothing here is changed. Your code stays on this machine.</Text>
       <Box height={1} />
       <Text>Every action your coding agent takes appears below as it happens.</Text>

--- a/apps/cli/src/ui/tui/screens/PromptsPointerScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/PromptsPointerScreen.tsx
@@ -1,0 +1,68 @@
+/**
+ * The one question the find-the-agent step asks.
+ *
+ * Plenty of teams keep the words their voice agent runs on in a folder or a
+ * repository of their own, so a folder with nothing in it is not proof that the
+ * team has nothing. egma asks once, looks where it is pointed, and does not ask
+ * again — a wizard that keeps asking the same question is a wizard that has
+ * stopped believing the answer.
+ */
+
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+import { dispatchKey, hintBar, type KeyBinding } from "../keybindings.ts";
+
+export type PromptsPointerScreenProps = {
+  /** The path the developer typed, or `null` when they have none to give. */
+  readonly onAnswer: (pointer: string | null) => void;
+};
+
+export function PromptsPointerScreen({ onAnswer }: PromptsPointerScreenProps) {
+  const [typed, setTyped] = useState("");
+
+  const bindings: KeyBinding[] = [
+    {
+      match: "return",
+      label: "enter",
+      action: "look there",
+      priority: 0,
+      handler: () => onAnswer(typed.trim() === "" ? null : typed.trim()),
+    },
+    {
+      match: "escape",
+      label: "esc",
+      action: "nowhere else",
+      priority: 1,
+      handler: () => onAnswer(null),
+    },
+  ];
+
+  useInput((input, key) => {
+    if (dispatchKey(bindings, input, key)) return;
+    if (key.backspace || key.delete) {
+      setTyped((held) => held.slice(0, -1));
+      return;
+    }
+    // Control keys are not path characters, and a paste arrives as plain text.
+    if (key.ctrl || key.meta || input === "") return;
+    setTyped((held) => held + input);
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={2} paddingY={1}>
+      <Text bold>egma</Text>
+      <Box height={1} />
+      <Text>Nothing in this folder looks like a voice agent.</Text>
+      <Box height={1} />
+      <Text>
+        Teams often keep their prompts somewhere else. If yours are in another
+        folder, type the path to it and egma will look there.
+      </Text>
+      <Box height={1} />
+      <Text>{`  › ${typed}`}</Text>
+      <Box height={1} />
+      <Text dimColor>{hintBar(bindings)}</Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/ui/tui/start-tui.ts
+++ b/apps/cli/src/ui/tui/start-tui.ts
@@ -13,7 +13,7 @@ import { createElement } from "react";
 
 import { render } from "ink";
 
-import { buildExitLine, type ExitReport } from "../../wizard/exit-line.ts";
+import { buildExitLine, buildExitNotice, type ExitReport } from "../../wizard/exit-line.ts";
 import type { StopReason } from "../../wizard/stop.ts";
 import type { WizardUI } from "../wizard-ui.ts";
 import { App } from "./App.tsx";
@@ -57,6 +57,8 @@ export function startTui(options: StartTuiOptions): TuiHandle {
     closed = true;
     instance.unmount();
     leaveAlternateScreen(stdout);
+    const notice = buildExitNotice(report);
+    if (notice !== null) stdout.write(`${notice}\n\n`);
     stdout.write(`${buildExitLine(report)}\n`);
   };
 

--- a/apps/cli/src/ui/tui/state.ts
+++ b/apps/cli/src/ui/tui/state.ts
@@ -7,17 +7,18 @@
  */
 
 import type { ExitReport } from "../../wizard/exit-line.ts";
-import type { DrivenAgent } from "../wizard-ui.ts";
+import type { AskId, DrivenAgent } from "../wizard-ui.ts";
 
 export type WizardState = {
   readonly drivenAgent: DrivenAgent | null;
   /** Where the coding agent's own output is kept, for a screen that tails it. */
   readonly drivenAgentLog: string | null;
-  readonly taskFile: string | null;
   /** The developer has read the intro and said go. */
   readonly begun: boolean;
   readonly running: boolean;
   readonly finished: boolean;
+  /** The question the flow is parked on, or `null` when it is not parked. */
+  readonly asking: AskId | null;
   readonly statuses: readonly string[];
   readonly summary: string;
   readonly exit: ExitReport | null;
@@ -27,10 +28,10 @@ export function emptyState(): WizardState {
   return {
     drivenAgent: null,
     drivenAgentLog: null,
-    taskFile: null,
     begun: false,
     running: false,
     finished: false,
+    asking: null,
     statuses: [],
     summary: "",
     exit: null,

--- a/apps/cli/src/ui/tui/store.ts
+++ b/apps/cli/src/ui/tui/store.ts
@@ -14,11 +14,14 @@
 import { WizardRouter, type ScreenName, type Sequence } from "./router.ts";
 import { emptyState, type WizardState } from "./state.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
-import type { DrivenAgent, GateId } from "../wizard-ui.ts";
+import type { AskId, DrivenAgent, GateId } from "../wizard-ui.ts";
 
 /** The screens of the walk, in order. */
 export const WALK_SCREENS: Sequence = [
   { id: "intro", isComplete: (state) => state.begun },
+  // Only ever on while the flow is parked on that one question, and gone the
+  // moment it is answered — which is the router working the way it should.
+  { id: "prompts-pointer", show: (state) => state.asking === "prompts-pointer" },
   { id: "task" },
 ];
 
@@ -34,6 +37,12 @@ type Gate = {
   opened: boolean;
 };
 
+/** A question the flow is parked on, and the promise waiting for its answer. */
+type OpenQuestion = {
+  readonly promise: Promise<string | null>;
+  readonly settle: (answer: string | null) => void;
+};
+
 /** The most recent status lines kept in memory, oldest dropped first. */
 const MAX_STATUS_LINES = 200;
 
@@ -41,6 +50,7 @@ export class WizardStore {
   private state: WizardState = emptyState();
   private readonly listeners = new Set<() => void>();
   private readonly gates = new Map<GateId, Gate>();
+  private readonly answers = new Map<AskId, OpenQuestion>();
 
   readonly router: WizardRouter;
 
@@ -77,6 +87,34 @@ export class WizardStore {
     return this.gates.get(gate)?.promise ?? Promise.resolve();
   }
 
+  /**
+   * Park on a question until a screen answers it.
+   *
+   * The same pattern as a gate, carrying a value. It is the flow that says a
+   * question is open and the screen that closes it, so no screen can be reached
+   * for a question nobody asked.
+   */
+  ask(ask: AskId): Promise<string | null> {
+    const held = this.answers.get(ask);
+    if (held !== undefined) return held.promise;
+
+    let settle!: (answer: string | null) => void;
+    const promise = new Promise<string | null>((resolve) => {
+      settle = resolve;
+    });
+    this.answers.set(ask, { promise, settle });
+    this.change({ asking: ask });
+    return promise;
+  }
+
+  /** A screen's answer to the open question. `null` means "I have none". */
+  answer(ask: AskId, value: string | null): void {
+    const open = this.answers.get(ask);
+    if (open === undefined) return;
+    this.change({ asking: this.state.asking === ask ? null : this.state.asking });
+    open.settle(value);
+  }
+
   // ── The flow's writes ────────────────────────────────────────────────
 
   setDrivenAgent(drivenAgent: DrivenAgent | null): void {
@@ -85,10 +123,6 @@ export class WizardStore {
 
   setDrivenAgentLog(drivenAgentLog: string): void {
     this.change({ drivenAgentLog });
-  }
-
-  setTaskFile(taskFile: string): void {
-    this.change({ taskFile });
   }
 
   taskStarted(): void {

--- a/apps/cli/src/ui/wizard-ui.ts
+++ b/apps/cli/src/ui/wizard-ui.ts
@@ -15,6 +15,16 @@ import type { ExitReport } from "../wizard/exit-line.ts";
 /** A point the flow waits at until the developer has moved past it. */
 export type GateId = "begin";
 
+/**
+ * A point the flow waits at for something only the developer knows.
+ *
+ * It is the same gate pattern, carrying a value: the flow parks, a screen
+ * collects the answer, the gate opens. Nothing here draws and nothing here
+ * reads a keystroke, so this is still not a prompt method — the screen owns
+ * every key, and a developer who answers nothing answers `null`.
+ */
+export type AskId = "prompts-pointer";
+
 /** The coding agent egma is driving. */
 export type DrivenAgent = { readonly id: string; readonly name: string };
 
@@ -25,15 +35,18 @@ export interface WizardUI {
   /** Where the coding agent's own output is being kept for this run. */
   setDrivenAgentLog(file: string): void;
 
-  /** Name the file the one task is about. */
-  setTaskFile(file: string): void;
-
   /**
    * Park until the developer has let the flow past this point. A gate that the
    * developer never opens never resolves — closing the wizard is how they say
    * no, and there is no answer for this method to return.
    */
   waitForGate(gate: GateId): Promise<void>;
+
+  /**
+   * Park until the developer has answered, or said they have no answer. `null`
+   * is a real answer and the flow must handle it.
+   */
+  waitForAnswer(ask: AskId): Promise<string | null>;
 
   /** The coding agent has been started and the task is under way. */
   taskStarted(): void;

--- a/apps/cli/src/wizard/discovery.ts
+++ b/apps/cli/src/wizard/discovery.ts
@@ -1,0 +1,279 @@
+/**
+ * Find the agent: the wizard's first intelligent step.
+ *
+ * Nothing about a repository tells egma where a voice agent is. A person would
+ * read the code to work it out, so egma has a coding agent read it — the
+ * developer's own, on the developer's own machine, with two egma skills at the
+ * top of the task saying what to look for and what to report. The repository
+ * never leaves the machine and no skill is ever installed on it.
+ *
+ * What comes back is marker lines. They become the status lines the developer
+ * watches and the card they read at the end; the agent's prose goes to the log.
+ *
+ * Teams split repositories, so a folder with no voice agent in it is not the end
+ * of the walk. egma asks once for a pointer to the prompts, looks there, and
+ * only then says plainly that this is the wrong folder to have started in.
+ */
+
+import { stat } from "node:fs/promises";
+import path from "node:path";
+
+import { driveOneTask } from "../acp/drive.ts";
+import type { DrivenAgentLaunch } from "../acp/registry.ts";
+import { instructionsWith } from "../skills/index.ts";
+import type { WizardUI } from "../ui/wizard-ui.ts";
+import type { DrivenAgentLog } from "./driven-agent-log.ts";
+import type { ExitReport } from "./exit-line.ts";
+import { MarkerStream, type Marker, type ParsedLine } from "./markers.ts";
+import { ACTION_MARK, DETAIL_MARK } from "./status.ts";
+import { stopReport, untilAborted } from "./stop.ts";
+
+/** The facts the step exists to bring back, and what they are called on screen. */
+const FIELDS = [
+  ["framework", "Framework"],
+  ["prompts", "Prompts"],
+  ["tools", "Tools"],
+  ["deploy", "Deploy"],
+  ["agent-id", "Agent id"],
+] as const;
+
+const LABEL_WIDTH = Math.max(...FIELDS.map(([, label]) => label.length));
+
+/** What the coding agent reported, keyed by field name. */
+export type Facts = ReadonlyMap<string, string>;
+
+export type DiscoveryOutcome =
+  | { readonly kind: "found"; readonly facts: Facts }
+  /** The agent looked and there is no voice agent in this folder. */
+  | { readonly kind: "nothing-found" }
+  | { readonly kind: "interrupted" }
+  | { readonly kind: "unreachable" }
+  | { readonly kind: "needs-login"; readonly drivenAgentName: string }
+  | { readonly kind: "failed"; readonly reason: string };
+
+export type DiscoveryOptions = {
+  readonly ui: WizardUI;
+  readonly launch: DrivenAgentLaunch;
+  /** The folder to look in. */
+  readonly cwd: string;
+  readonly signal: AbortSignal;
+  readonly log: DrivenAgentLog;
+};
+
+/** What egma asks the coding agent to do, under the two skills. */
+export function discoveryTask(where: string): string {
+  return [
+    "# Your task",
+    "",
+    `Find the voice agent in ${where} and report what you find.`,
+    "",
+    "Work only in that folder. Read the files. Change nothing, install nothing,",
+    "and run no command that reaches the network.",
+    "",
+    "Report with the marker lines the skill above describes, and stop when you",
+    "have written them.",
+  ].join("\n");
+}
+
+/** The instructions dispatched for this step: both skills, then the task. */
+export function discoveryInstructions(where: string): string {
+  return instructionsWith(["context-finding", "retell"], discoveryTask(where));
+}
+
+function labelFor(field: string): string | null {
+  return FIELDS.find(([name]) => name === field)?.[1] ?? null;
+}
+
+/** The status line one marker is worth, or `null` when it is not for the screen. */
+export function statusLineFor(marker: Marker): string | null {
+  switch (marker.kind) {
+    case "note":
+      return `${ACTION_MARK} ${marker.text}`;
+    case "found": {
+      const label = labelFor(marker.field);
+      if (label === null) return null;
+      return `${DETAIL_MARK} ${label.padEnd(LABEL_WIDTH)}  ${marker.value}`;
+    }
+    case "none":
+    case "abort":
+      return null;
+  }
+}
+
+/**
+ * The card at the end of the step: every fact, one per line, aligned.
+ *
+ * It exists to be read in five seconds, so it says nothing the facts do not.
+ */
+export function summaryCard(facts: Facts): string {
+  const lines = ["Your voice agent"];
+  for (const [field, label] of FIELDS) {
+    const value = facts.get(field);
+    if (value === undefined) continue;
+    lines.push(`  ${label.padEnd(LABEL_WIDTH)}  ${value}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Whether what came back is worth calling a find.
+ *
+ * A framework name or a prompt location is enough to carry on from. Anything
+ * less and egma does not know where the agent is, however much prose arrived
+ * alongside it.
+ */
+function isAFind(facts: Facts): boolean {
+  return facts.has("framework") || facts.has("prompts");
+}
+
+/** Runs the step once, in one folder. */
+export async function discoverIn(options: DiscoveryOptions): Promise<DiscoveryOutcome> {
+  const { ui, launch, cwd, signal, log } = options;
+
+  const facts = new Map<string, string>();
+  const markers = new MarkerStream();
+  let reportedNothing = false;
+
+  /** Reads whole lines: facts are kept, markers are shown, prose is logged. */
+  const take = (lines: readonly ParsedLine[]): string | null => {
+    let abort: string | null = null;
+    for (const line of lines) {
+      if (line.kind === "prose") {
+        log.write(`${line.text}\n`);
+        continue;
+      }
+      const marker = line.marker;
+      if (marker.kind === "found") facts.set(marker.field, marker.value);
+      if (marker.kind === "none") reportedNothing = true;
+      if (marker.kind === "abort") abort = marker.reason;
+      const status = statusLineFor(marker);
+      // A fact this step never asked for is still something the agent said, so
+      // it is kept where the developer can find it rather than dropped.
+      if (status === null) log.write(`${JSON.stringify(marker)}\n`);
+      else ui.pushStatus(status);
+    }
+    return abort;
+  };
+
+  const result = await driveOneTask({
+    launch,
+    cwd,
+    instructions: discoveryInstructions(cwd),
+    ui,
+    signal,
+    logStderr: (chunk) => log.write(chunk),
+    watch: (chunk) => take(markers.push(chunk)),
+    onLogin: (name) =>
+      ui.pushStatus(`${ACTION_MARK} ${name} needs you to log in. Handing you to its own login.`),
+  });
+
+  // An agent's last line often arrives without an ending, so it is read here
+  // rather than lost.
+  take(markers.flush());
+
+  switch (result.kind) {
+    case "interrupted":
+      return { kind: "interrupted" };
+    case "unreachable":
+      return { kind: "unreachable" };
+    case "needs-login":
+      return { kind: "needs-login", drivenAgentName: result.drivenAgentName };
+    case "failed":
+      return { kind: "failed", reason: result.reason };
+    case "aborted":
+      // The agent stopping itself is not the same as finding nothing, but if it
+      // reported facts before it stopped they are still facts.
+      return isAFind(facts) ? { kind: "found", facts } : { kind: "nothing-found" };
+    case "done":
+      if (reportedNothing && !isAFind(facts)) return { kind: "nothing-found" };
+      return isAFind(facts) ? { kind: "found", facts } : { kind: "nothing-found" };
+  }
+}
+
+export type FindOptions = DiscoveryOptions;
+
+async function isFolder(candidate: string): Promise<boolean> {
+  try {
+    return (await stat(candidate)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function reportFor(facts: Facts): ExitReport {
+  return {
+    kind: "found-agent",
+    framework: facts.get("framework") ?? null,
+    prompts: facts.get("prompts") ?? null,
+  };
+}
+
+function endFor(
+  outcome: Exclude<DiscoveryOutcome, { kind: "found" } | { kind: "nothing-found" }>,
+  options: FindOptions,
+): ExitReport {
+  switch (outcome.kind) {
+    case "interrupted":
+      return stopReport(options.signal, options.launch.name);
+    case "unreachable":
+      return { kind: "no-coding-agent" };
+    case "needs-login":
+      return {
+        kind: "failed",
+        reason: `${outcome.drivenAgentName} is not logged in, and egma could not hand you to its login. Log in to it, then run egma again.`,
+      };
+    case "failed":
+      return { kind: "failed", reason: outcome.reason };
+  }
+}
+
+/**
+ * The whole step: look here, ask once if there is nothing, look there, or say
+ * plainly that this is the wrong folder.
+ */
+export async function findTheAgent(options: FindOptions): Promise<ExitReport> {
+  const { ui, log } = options;
+
+  ui.taskStarted();
+  const here = await discoverIn(options);
+  ui.taskFinished();
+
+  if (here.kind === "found") {
+    ui.setSummary(summaryCard(here.facts));
+    return reportFor(here.facts);
+  }
+  if (here.kind !== "nothing-found") {
+    // A failure is the one time the agent's own output is worth reading, so it
+    // is the one time the developer is told where it is.
+    if (here.kind === "failed") ui.pushStatus(`What ${options.launch.name} printed is in ${log.file}`);
+    return endFor(here, options);
+  }
+
+  // Teams keep prompts in a repository of their own, so one folder saying no is
+  // not an answer about the team. This is the only question the step asks, and
+  // it is asked once. A developer who closes the wizard instead of answering has
+  // answered too, so the wait ends with the signal and not only with a keystroke.
+  const pointer = await untilAborted(ui.waitForAnswer("prompts-pointer"), options.signal);
+  if (options.signal.aborted) return stopReport(options.signal, options.launch.name);
+  if (pointer === undefined || pointer === null || pointer.trim() === "") {
+    return { kind: "no-agent-context" };
+  }
+
+  const where = path.resolve(options.cwd, pointer.trim());
+  if (!(await isFolder(where))) {
+    ui.pushStatus(`${ACTION_MARK} There is no folder at ${pointer.trim()}.`);
+    return { kind: "no-agent-context" };
+  }
+
+  ui.taskStarted();
+  const there = await discoverIn({ ...options, cwd: where });
+  ui.taskFinished();
+
+  if (there.kind === "found") {
+    ui.setSummary(summaryCard(there.facts));
+    return reportFor(there.facts);
+  }
+  if (there.kind === "nothing-found") return { kind: "no-agent-context" };
+  if (there.kind === "failed") ui.pushStatus(`What ${options.launch.name} printed is in ${log.file}`);
+  return endFor(there, options);
+}

--- a/apps/cli/src/wizard/discovery.ts
+++ b/apps/cli/src/wizard/discovery.ts
@@ -24,28 +24,25 @@ import { instructionsWith } from "../skills/index.ts";
 import type { WizardUI } from "../ui/wizard-ui.ts";
 import type { DrivenAgentLog } from "./driven-agent-log.ts";
 import type { ExitReport } from "./exit-line.ts";
+import { FACTS, LABEL_WIDTH, labelFor } from "./facts.ts";
 import { MarkerStream, type Marker, type ParsedLine } from "./markers.ts";
-import { ACTION_MARK, DETAIL_MARK } from "./status.ts";
+import { ACTION_MARK, DETAIL_MARK, FAILURE_MARK } from "./status.ts";
 import { stopReport, untilAborted } from "./stop.ts";
-
-/** The facts the step exists to bring back, and what they are called on screen. */
-const FIELDS = [
-  ["framework", "Framework"],
-  ["prompts", "Prompts"],
-  ["tools", "Tools"],
-  ["deploy", "Deploy"],
-  ["agent-id", "Agent id"],
-] as const;
-
-const LABEL_WIDTH = Math.max(...FIELDS.map(([, label]) => label.length));
 
 /** What the coding agent reported, keyed by field name. */
 export type Facts = ReadonlyMap<string, string>;
 
 export type DiscoveryOutcome =
   | { readonly kind: "found"; readonly facts: Facts }
-  /** The agent looked and there is no voice agent in this folder. */
+  /**
+   * The agent looked and there is no voice agent in this folder. Whether it
+   * said so with `egma:none` or simply reported no facts makes no difference
+   * to what happens next, so the two are one outcome. What the agent said is
+   * on the screen and in the log either way.
+   */
   | { readonly kind: "nothing-found" }
+  /** The agent stopped the work itself, and said why. */
+  | { readonly kind: "aborted"; readonly reason: string }
   | { readonly kind: "interrupted" }
   | { readonly kind: "unreachable" }
   | { readonly kind: "needs-login"; readonly drivenAgentName: string }
@@ -80,11 +77,14 @@ export function discoveryInstructions(where: string): string {
   return instructionsWith(["context-finding", "retell"], discoveryTask(where));
 }
 
-function labelFor(field: string): string | null {
-  return FIELDS.find(([name]) => name === field)?.[1] ?? null;
-}
-
-/** The status line one marker is worth, or `null` when it is not for the screen. */
+/**
+ * The status line one marker is worth, or `null` when it is not for the screen.
+ *
+ * Every action egma takes is shown, and an agent saying it found nothing or
+ * cannot go on is the most important thing it will say all run. Both therefore
+ * reach the screen in the agent's own words: a stop is marked as the failure it
+ * is, an empty answer as the quiet note it is.
+ */
 export function statusLineFor(marker: Marker): string | null {
   switch (marker.kind) {
     case "note":
@@ -95,8 +95,11 @@ export function statusLineFor(marker: Marker): string | null {
       return `${DETAIL_MARK} ${label.padEnd(LABEL_WIDTH)}  ${marker.value}`;
     }
     case "none":
+      return marker.reason === "" ? null : `${DETAIL_MARK} ${marker.reason}`;
     case "abort":
-      return null;
+      return marker.reason === ""
+        ? `${FAILURE_MARK} Your coding agent stopped, and did not say why.`
+        : `${FAILURE_MARK} ${marker.reason}`;
   }
 }
 
@@ -107,10 +110,10 @@ export function statusLineFor(marker: Marker): string | null {
  */
 export function summaryCard(facts: Facts): string {
   const lines = ["Your voice agent"];
-  for (const [field, label] of FIELDS) {
-    const value = facts.get(field);
+  for (const fact of FACTS) {
+    const value = facts.get(fact.name);
     if (value === undefined) continue;
-    lines.push(`  ${label.padEnd(LABEL_WIDTH)}  ${value}`);
+    lines.push(`  ${fact.label.padEnd(LABEL_WIDTH)}  ${value}`);
   }
   return lines.join("\n");
 }
@@ -132,7 +135,6 @@ export async function discoverIn(options: DiscoveryOptions): Promise<DiscoveryOu
 
   const facts = new Map<string, string>();
   const markers = new MarkerStream();
-  let reportedNothing = false;
 
   /** Reads whole lines: facts are kept, markers are shown, prose is logged. */
   const take = (lines: readonly ParsedLine[]): string | null => {
@@ -144,13 +146,13 @@ export async function discoverIn(options: DiscoveryOptions): Promise<DiscoveryOu
       }
       const marker = line.marker;
       if (marker.kind === "found") facts.set(marker.field, marker.value);
-      if (marker.kind === "none") reportedNothing = true;
       if (marker.kind === "abort") abort = marker.reason;
+      // Every marker is kept where the developer can find it afterwards —
+      // including a fact this step never asked for, which is still something
+      // the agent said. The screen gets the ones that are worth a line.
+      log.write(`${JSON.stringify(marker)}\n`);
       const status = statusLineFor(marker);
-      // A fact this step never asked for is still something the agent said, so
-      // it is kept where the developer can find it rather than dropped.
-      if (status === null) log.write(`${JSON.stringify(marker)}\n`);
-      else ui.pushStatus(status);
+      if (status !== null) ui.pushStatus(status);
     }
     return abort;
   };
@@ -181,16 +183,15 @@ export async function discoverIn(options: DiscoveryOptions): Promise<DiscoveryOu
     case "failed":
       return { kind: "failed", reason: result.reason };
     case "aborted":
-      // The agent stopping itself is not the same as finding nothing, but if it
-      // reported facts before it stopped they are still facts.
-      return isAFind(facts) ? { kind: "found", facts } : { kind: "nothing-found" };
+      // The agent stopping itself is not the same as finding nothing, and must
+      // never be told as if it were. If it reported facts before it stopped,
+      // those are still facts.
+      if (isAFind(facts)) return { kind: "found", facts };
+      return { kind: "aborted", reason: result.reason };
     case "done":
-      if (reportedNothing && !isAFind(facts)) return { kind: "nothing-found" };
       return isAFind(facts) ? { kind: "found", facts } : { kind: "nothing-found" };
   }
 }
-
-export type FindOptions = DiscoveryOptions;
 
 async function isFolder(candidate: string): Promise<boolean> {
   try {
@@ -208,13 +209,36 @@ function reportFor(facts: Facts): ExitReport {
   };
 }
 
-function endFor(
-  outcome: Exclude<DiscoveryOutcome, { kind: "found" } | { kind: "nothing-found" }>,
-  options: FindOptions,
-): ExitReport {
+/**
+ * One look in one folder, and the ending it forces.
+ *
+ * `null` is the one answer that is not an ending: the agent looked, there is
+ * nothing here, and the walk has somewhere else to try. Both looks the step
+ * makes are this same shape, so neither can grow an ending the other does not
+ * have.
+ */
+async function lookIn(options: DiscoveryOptions): Promise<ExitReport | null> {
+  const { ui, launch, log, signal } = options;
+
+  ui.taskStarted();
+  const outcome = await discoverIn(options);
+  ui.taskFinished();
+
   switch (outcome.kind) {
+    case "found":
+      ui.setSummary(summaryCard(outcome.facts));
+      return reportFor(outcome.facts);
+    case "nothing-found":
+      return null;
+    case "aborted":
+      return { kind: "coding-agent-stopped", drivenAgentName: launch.name, reason: outcome.reason };
+    case "failed":
+      // A failure is the one time the agent's own output is worth reading, so
+      // it is the one time the developer is told where it is.
+      ui.pushStatus(`What ${launch.name} printed is in ${log.file}`);
+      return { kind: "failed", reason: outcome.reason };
     case "interrupted":
-      return stopReport(options.signal, options.launch.name);
+      return stopReport(signal, launch.name);
     case "unreachable":
       return { kind: "no-coding-agent" };
     case "needs-login":
@@ -222,8 +246,6 @@ function endFor(
         kind: "failed",
         reason: `${outcome.drivenAgentName} is not logged in, and egma could not hand you to its login. Log in to it, then run egma again.`,
       };
-    case "failed":
-      return { kind: "failed", reason: outcome.reason };
   }
 }
 
@@ -231,29 +253,15 @@ function endFor(
  * The whole step: look here, ask once if there is nothing, look there, or say
  * plainly that this is the wrong folder.
  */
-export async function findTheAgent(options: FindOptions): Promise<ExitReport> {
-  const { ui, log } = options;
-
-  ui.taskStarted();
-  const here = await discoverIn(options);
-  ui.taskFinished();
-
-  if (here.kind === "found") {
-    ui.setSummary(summaryCard(here.facts));
-    return reportFor(here.facts);
-  }
-  if (here.kind !== "nothing-found") {
-    // A failure is the one time the agent's own output is worth reading, so it
-    // is the one time the developer is told where it is.
-    if (here.kind === "failed") ui.pushStatus(`What ${options.launch.name} printed is in ${log.file}`);
-    return endFor(here, options);
-  }
+export async function findTheAgent(options: DiscoveryOptions): Promise<ExitReport> {
+  const here = await lookIn(options);
+  if (here !== null) return here;
 
   // Teams keep prompts in a repository of their own, so one folder saying no is
   // not an answer about the team. This is the only question the step asks, and
   // it is asked once. A developer who closes the wizard instead of answering has
   // answered too, so the wait ends with the signal and not only with a keystroke.
-  const pointer = await untilAborted(ui.waitForAnswer("prompts-pointer"), options.signal);
+  const pointer = await untilAborted(options.ui.waitForAnswer("prompts-pointer"), options.signal);
   if (options.signal.aborted) return stopReport(options.signal, options.launch.name);
   if (pointer === undefined || pointer === null || pointer.trim() === "") {
     return { kind: "no-agent-context" };
@@ -261,19 +269,9 @@ export async function findTheAgent(options: FindOptions): Promise<ExitReport> {
 
   const where = path.resolve(options.cwd, pointer.trim());
   if (!(await isFolder(where))) {
-    ui.pushStatus(`${ACTION_MARK} There is no folder at ${pointer.trim()}.`);
+    options.ui.pushStatus(`${ACTION_MARK} There is no folder at ${pointer.trim()}.`);
     return { kind: "no-agent-context" };
   }
 
-  ui.taskStarted();
-  const there = await discoverIn({ ...options, cwd: where });
-  ui.taskFinished();
-
-  if (there.kind === "found") {
-    ui.setSummary(summaryCard(there.facts));
-    return reportFor(there.facts);
-  }
-  if (there.kind === "nothing-found") return { kind: "no-agent-context" };
-  if (there.kind === "failed") ui.pushStatus(`What ${options.launch.name} printed is in ${log.file}`);
-  return endFor(there, options);
+  return (await lookIn({ ...options, cwd: where })) ?? { kind: "no-agent-context" };
 }

--- a/apps/cli/src/wizard/exit-line.ts
+++ b/apps/cli/src/wizard/exit-line.ts
@@ -8,19 +8,45 @@
  * printed after that screen is released, into the buffer they can scroll back
  * through. It is one line, with no border and no colour, so a terminal
  * triple-click selects it whole.
+ *
+ * One ending needs more than a line: the developer has to copy something. That
+ * arrives as a notice printed above the line, never instead of it, so the line
+ * is still the last thing in scrollback and still selects whole.
  */
+
+import { pasteFallbackMessage } from "./no-coding-agent.ts";
 
 /** Why the wizard stopped, and what it can honestly say about it. */
 export type ExitReport =
-  | { readonly kind: "task-done"; readonly drivenAgentName: string; readonly file: string }
+  | {
+      readonly kind: "found-agent";
+      readonly framework: string | null;
+      readonly prompts: string | null;
+    }
+  /** Nothing here looks like a voice agent, and the pointer did not help. */
+  | { readonly kind: "no-agent-context" }
+  /** There is no coding agent on this machine for egma to drive. */
+  | { readonly kind: "no-coding-agent" }
   | { readonly kind: "quit" }
   | { readonly kind: "interrupted"; readonly drivenAgentName: string | null }
   | { readonly kind: "failed"; readonly reason: string };
 
+function foundLine(framework: string | null, prompts: string | null): string {
+  const facts: string[] = [];
+  if (framework !== null) facts.push(framework);
+  if (prompts !== null) facts.push(`prompts in ${prompts}`);
+  if (facts.length === 0) return "egma found your voice agent.";
+  return `egma found your voice agent: ${facts.join(", ")}.`;
+}
+
 export function buildExitLine(report: ExitReport): string {
   switch (report.kind) {
-    case "task-done":
-      return `${report.drivenAgentName} read ${report.file} for egma. Nothing in this folder was changed.`;
+    case "found-agent":
+      return foundLine(report.framework, report.prompts);
+    case "no-agent-context":
+      return "egma found no voice agent to test. Run egma again where your agent is defined.";
+    case "no-coding-agent":
+      return "egma found no coding agent on this machine that it can drive, so it printed what to paste into yours instead.";
     case "quit":
       return "egma closed. Nothing ran.";
     case "interrupted":
@@ -30,4 +56,15 @@ export function buildExitLine(report: ExitReport): string {
     case "failed":
       return `egma could not finish: ${report.reason}`;
   }
+}
+
+/**
+ * What is printed above the exit line, or `null` when the line says it all.
+ *
+ * The only ending that needs one is the machine with no coding agent on it: a
+ * message is the whole answer there, and a message the developer cannot copy is
+ * not one.
+ */
+export function buildExitNotice(report: ExitReport): string | null {
+  return report.kind === "no-coding-agent" ? pasteFallbackMessage() : null;
 }

--- a/apps/cli/src/wizard/exit-line.ts
+++ b/apps/cli/src/wizard/exit-line.ts
@@ -27,9 +27,23 @@ export type ExitReport =
   | { readonly kind: "no-agent-context" }
   /** There is no coding agent on this machine for egma to drive. */
   | { readonly kind: "no-coding-agent" }
+  /**
+   * The coding agent stopped the work itself and said why. It is not the same
+   * as finding nothing, and saying it was would put words in the agent's mouth.
+   */
+  | {
+      readonly kind: "coding-agent-stopped";
+      readonly drivenAgentName: string;
+      readonly reason: string;
+    }
   | { readonly kind: "quit" }
   | { readonly kind: "interrupted"; readonly drivenAgentName: string | null }
   | { readonly kind: "failed"; readonly reason: string };
+
+/** One line means one line, whatever shape the reason arrived in. */
+function oneLine(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
 
 function foundLine(framework: string | null, prompts: string | null): string {
   const facts: string[] = [];
@@ -47,6 +61,10 @@ export function buildExitLine(report: ExitReport): string {
       return "egma found no voice agent to test. Run egma again where your agent is defined.";
     case "no-coding-agent":
       return "egma found no coding agent on this machine that it can drive, so it printed what to paste into yours instead.";
+    case "coding-agent-stopped":
+      return oneLine(report.reason) === ""
+        ? `${report.drivenAgentName} stopped before it found your voice agent, and did not say why.`
+        : `${report.drivenAgentName} stopped before it found your voice agent: ${oneLine(report.reason)}`;
     case "quit":
       return "egma closed. Nothing ran.";
     case "interrupted":
@@ -54,7 +72,7 @@ export function buildExitLine(report: ExitReport): string {
         ? "egma stopped before the task finished."
         : `egma stopped before the task finished, and shut ${report.drivenAgentName} down.`;
     case "failed":
-      return `egma could not finish: ${report.reason}`;
+      return `egma could not finish: ${oneLine(report.reason)}`;
   }
 }
 

--- a/apps/cli/src/wizard/facts.ts
+++ b/apps/cli/src/wizard/facts.ts
@@ -1,0 +1,45 @@
+/**
+ * The facts the find-the-agent step brings back, in one place.
+ *
+ * The same list is said four ways: the name a marker line reports it under,
+ * the label the card and the status line write, and the words a sentence asks
+ * for it in. Keeping the three beside each other is what stops the screen, the
+ * card and the message a developer pastes into a coding agent egma cannot
+ * drive from drifting apart.
+ *
+ * This module is the source of truth. Prose that has to stay prose — the skill
+ * that teaches the marker lines, and the README — repeats the list and carries
+ * a comment pointing here.
+ */
+
+export type Fact = {
+  /** The name the agent reports it under: `egma:found <name> <value>`. */
+  readonly name: string;
+  /** How the card and the status line label it. */
+  readonly label: string;
+  /** How a sentence asks for it. */
+  readonly phrase: string;
+};
+
+export const FACTS: readonly Fact[] = [
+  { name: "framework", label: "Framework", phrase: "which framework runs it" },
+  { name: "prompts", label: "Prompts", phrase: "where its prompts live" },
+  { name: "tools", label: "Tools", phrase: "where its tools are defined" },
+  { name: "deploy", label: "Deploy", phrase: "how it reaches production" },
+  { name: "agent-id", label: "Agent id", phrase: "where its identifier is written down" },
+] as const;
+
+/** Every label padded to this, so the values line up under each other. */
+export const LABEL_WIDTH = Math.max(...FACTS.map((fact) => fact.label.length));
+
+/** What this fact is called on screen, or `null` when it is not one egma asked for. */
+export function labelFor(name: string): string | null {
+  return FACTS.find((fact) => fact.name === name)?.label ?? null;
+}
+
+/** The facts as one English list, for a sentence that asks for all of them. */
+export function factsAsked(): string {
+  const phrases = FACTS.map((fact) => fact.phrase);
+  const last = phrases[phrases.length - 1] as string;
+  return phrases.length === 1 ? last : `${phrases.slice(0, -1).join(", ")}, and ${last}`;
+}

--- a/apps/cli/src/wizard/markers.ts
+++ b/apps/cli/src/wizard/markers.ts
@@ -41,8 +41,22 @@ export type ParsedLine =
 /** Leading decoration a model adds when it thinks it is formatting a list. */
 const DECORATION = /^(?:[-*+>]\s+|\d+[.)]\s+)*/;
 
+/** The whole line in bold: `**egma:found framework retell-sdk**`. */
+const WHOLE_BOLD = /^(\*\*|__)([\s\S]+)\1$/;
+
+/** Only the marker's own name in bold: `**egma:found** framework retell-sdk`. */
+const LEADING_BOLD = /^(\*\*|__)([\s\S]+?)\1/;
+
 function undecorate(line: string): string {
   let text = line.trim().replace(DECORATION, "").trim();
+
+  // Bold is what a model reaches for when it is told to write a bare line and
+  // cannot help itself. The whole line is tried first, so a value holding an
+  // asterisk — `src/**/*.ts` is a good value — is not cut short by its own
+  // glob.
+  const bold = WHOLE_BOLD.exec(text) ?? LEADING_BOLD.exec(text);
+  if (bold !== null) text = `${bold[2] as string}${text.slice(bold[0].length)}`.trim();
+
   // A model that has been told "no code fence" often reaches for inline code.
   if (text.startsWith("`") && text.endsWith("`") && text.length > 1) {
     text = text.slice(1, -1).trim();
@@ -86,12 +100,22 @@ export function markerIn(line: string): Marker | null {
  * An agent's words arrive in pieces, and the piece before a marker sometimes
  * ends without the line ending that was meant to follow it — so a line of prose
  * and the marker after it become one line, and the marker is lost. A marker
- * pressed straight against a word with no space is never how anyone writes a
- * sentence, so it is read as the line break that went missing. A marker with a
- * space in front of it is left alone: that is somebody talking about markers,
- * and talking about one does not make one.
+ * pressed straight against the end of a sentence is never how anyone writes
+ * one, so it is read as the line break that went missing.
+ *
+ * The split fires only where a lost line ending is the plausible explanation:
+ * after a word character, a full stop or a comma. It never fires after a
+ * backtick, a bracket, a quote or an asterisk, because those are how a person
+ * writes *about* a marker — `` `egma:found framework retell-sdk` `` in a
+ * sentence is somebody explaining the format, and splitting there turns the
+ * rest of their sentence into a fact egma never found. A marker with a space
+ * in front of it is left alone for the same reason.
+ *
+ * What may sit between the two is the decoration the next line would have
+ * carried anyway: a model that writes `**egma:found** …` writes it that way
+ * whether or not the line ending survived.
  */
-const WELDED_MARKER = /(?<=\S)(?=egma:)/gi;
+const WELDED_MARKER = /(?<=[\w.,])(?=(?:\*\*|__|`)?egma:)/gi;
 
 /**
  * The agent's words as they arrive, split into markers and everything else.

--- a/apps/cli/src/wizard/markers.ts
+++ b/apps/cli/src/wizard/markers.ts
@@ -1,0 +1,129 @@
+/**
+ * The marker lines a driven coding agent reports through.
+ *
+ * A coding agent writes prose, and prose is not a report. So every step that
+ * egma dispatches asks for its answers on marker lines: one fact per line, at
+ * the start of the line, beginning `egma:`. Those become status lines and the
+ * step's result. Everything else the agent says is kept in the log and never
+ * put on screen, because a wall of text is not visibility.
+ *
+ * Four markers, and they mean the same thing in every step:
+ *
+ *   egma:note   <text>          something the developer should see happening
+ *   egma:found  <field> <value> one fact this step was sent to find
+ *   egma:none   <reason>        the agent looked and there is nothing to report
+ *   egma:abort  <reason>        the agent cannot go on
+ *
+ * `abort` is enforced here rather than trusted to the agent: egma reads the
+ * line, ends the task itself, and does not wait for the agent to agree that it
+ * has finished.
+ *
+ * The parser is forgiving about the shapes a model reaches for when it is
+ * trying to be helpful — a bullet in front, backticks around, a stray capital —
+ * and forgiving about nothing else. A line that is not a marker is not a fact.
+ */
+
+/** What every marker line starts with. */
+export const MARKER_PREFIX = "egma:";
+
+export type Marker =
+  | { readonly kind: "note"; readonly text: string }
+  | { readonly kind: "found"; readonly field: string; readonly value: string }
+  | { readonly kind: "none"; readonly reason: string }
+  | { readonly kind: "abort"; readonly reason: string };
+
+/** What one line of the agent's output turned out to be. */
+export type ParsedLine =
+  | { readonly kind: "marker"; readonly marker: Marker }
+  /** Not a marker: the log's, not the screen's. */
+  | { readonly kind: "prose"; readonly text: string };
+
+/** Leading decoration a model adds when it thinks it is formatting a list. */
+const DECORATION = /^(?:[-*+>]\s+|\d+[.)]\s+)*/;
+
+function undecorate(line: string): string {
+  let text = line.trim().replace(DECORATION, "").trim();
+  // A model that has been told "no code fence" often reaches for inline code.
+  if (text.startsWith("`") && text.endsWith("`") && text.length > 1) {
+    text = text.slice(1, -1).trim();
+  }
+  return text;
+}
+
+/** The marker on this line, or `null` when the line is not one. */
+export function markerIn(line: string): Marker | null {
+  const text = undecorate(line);
+  if (!text.toLowerCase().startsWith(MARKER_PREFIX)) return null;
+
+  const body = text.slice(MARKER_PREFIX.length).trim();
+  const space = body.search(/\s/);
+  const name = (space === -1 ? body : body.slice(0, space)).toLowerCase();
+  const rest = space === -1 ? "" : body.slice(space).trim();
+
+  switch (name) {
+    case "note":
+      return rest === "" ? null : { kind: "note", text: rest };
+    case "none":
+      return { kind: "none", reason: rest };
+    case "abort":
+      return { kind: "abort", reason: rest };
+    case "found": {
+      const gap = rest.search(/\s/);
+      if (gap === -1) return null;
+      const field = rest.slice(0, gap).replace(/:$/, "").toLowerCase();
+      const value = rest.slice(gap).trim();
+      if (field === "" || value === "") return null;
+      return { kind: "found", field, value };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * A marker welded onto the end of the line before it.
+ *
+ * An agent's words arrive in pieces, and the piece before a marker sometimes
+ * ends without the line ending that was meant to follow it — so a line of prose
+ * and the marker after it become one line, and the marker is lost. A marker
+ * pressed straight against a word with no space is never how anyone writes a
+ * sentence, so it is read as the line break that went missing. A marker with a
+ * space in front of it is left alone: that is somebody talking about markers,
+ * and talking about one does not make one.
+ */
+const WELDED_MARKER = /(?<=\S)(?=egma:)/gi;
+
+/**
+ * The agent's words as they arrive, split into markers and everything else.
+ *
+ * Text arrives in pieces that do not respect line endings, so a line is only
+ * read once it is whole. Whatever is left over when the turn ends is read by
+ * `flush` — an agent's last line often arrives without one.
+ */
+export class MarkerStream {
+  private pending = "";
+
+  /** Everything that has become whole since the last call. */
+  push(chunk: string): ParsedLine[] {
+    this.pending = (this.pending + chunk).replace(WELDED_MARKER, "\n");
+    const parts = this.pending.split("\n");
+    this.pending = parts.pop() ?? "";
+    return parts.map(read);
+  }
+
+  /** The last line, if the agent stopped without ending it. */
+  flush(): ParsedLine[] {
+    if (this.pending.trim() === "") {
+      this.pending = "";
+      return [];
+    }
+    const last = read(this.pending);
+    this.pending = "";
+    return [last];
+  }
+}
+
+function read(line: string): ParsedLine {
+  const marker = markerIn(line);
+  return marker === null ? { kind: "prose", text: line } : { kind: "marker", marker };
+}

--- a/apps/cli/src/wizard/no-coding-agent.ts
+++ b/apps/cli/src/wizard/no-coding-agent.ts
@@ -6,7 +6,42 @@
  * wait for, so egma stops and hands over the one thing that still works: the
  * words to paste into whatever coding agent the developer does use. A message,
  * not a second product.
+ *
+ * The words ask for the same facts the step itself asks for, because they are
+ * built from the same list. A message that drifted from the step would send a
+ * developer back with an answer egma cannot read.
  */
+
+import { factsAsked } from "./facts.ts";
+
+/** Wide enough to read, narrow enough that no terminal folds it itself. */
+const WIDTH = 70;
+
+/** The text as lines no wider than `WIDTH`, broken between words. */
+function wrap(text: string, width: number): string[] {
+  const lines: string[] = [];
+  let line = "";
+  for (const word of text.split(/\s+/).filter((part) => part !== "")) {
+    if (line === "") line = word;
+    else if (`${line} ${word}`.length > width) {
+      lines.push(line);
+      line = word;
+    } else line = `${line} ${word}`;
+  }
+  if (line !== "") lines.push(line);
+  return lines;
+}
+
+/** The block a developer copies: indented, so it reads as one thing to take. */
+function toPaste(): string[] {
+  const asked = [
+    `Find the voice agent in this repository and tell me ${factsAsked()}.`,
+    "Look at the dependency list first — retell-sdk, vapi, livekit-agents and",
+    "pipecat are the ones to expect. Give me the file paths as this repository",
+    "holds them, and change nothing.",
+  ].join(" ");
+  return wrap(asked, WIDTH - 2).map((line) => `  ${line}`);
+}
 
 /** What a developer with no drivable coding agent is given instead. */
 export function pasteFallbackMessage(): string {
@@ -15,11 +50,7 @@ export function pasteFallbackMessage(): string {
     "",
     "Open the coding agent you use, and paste this into it:",
     "",
-    "  Find the voice agent in this repository and tell me four things: which",
-    "  framework runs it, where its prompts live, where its tools are defined,",
-    "  and how it reaches production. Look at the dependency list first —",
-    "  retell-sdk, vapi, livekit-agents and pipecat are the ones to expect.",
-    "  Give me the file paths as this repository holds them, and change nothing.",
+    ...toPaste(),
     "",
     "Then run egma again from a machine with a coding agent it can start. egma",
     "drives Claude Code and Codex today, and every agent the protocol registry",

--- a/apps/cli/src/wizard/no-coding-agent.ts
+++ b/apps/cli/src/wizard/no-coding-agent.ts
@@ -1,0 +1,28 @@
+/**
+ * The machine with no coding agent on it.
+ *
+ * egma drives the coding agent the developer already has. On a machine that has
+ * none — or one egma cannot start — there is nothing to drive and nothing to
+ * wait for, so egma stops and hands over the one thing that still works: the
+ * words to paste into whatever coding agent the developer does use. A message,
+ * not a second product.
+ */
+
+/** What a developer with no drivable coding agent is given instead. */
+export function pasteFallbackMessage(): string {
+  return [
+    "egma could not reach a coding agent on this machine that it can drive.",
+    "",
+    "Open the coding agent you use, and paste this into it:",
+    "",
+    "  Find the voice agent in this repository and tell me four things: which",
+    "  framework runs it, where its prompts live, where its tools are defined,",
+    "  and how it reaches production. Look at the dependency list first —",
+    "  retell-sdk, vapi, livekit-agents and pipecat are the ones to expect.",
+    "  Give me the file paths as this repository holds them, and change nothing.",
+    "",
+    "Then run egma again from a machine with a coding agent it can start. egma",
+    "drives Claude Code and Codex today, and every agent the protocol registry",
+    "publishes as a package.",
+  ].join("\n");
+}

--- a/apps/cli/src/wizard/status.ts
+++ b/apps/cli/src/wizard/status.ts
@@ -11,6 +11,11 @@
  * which file it means. Nothing is held back waiting for that: the action is
  * shown the moment it starts, and the file follows on its own line as soon as
  * the agent says which one it is.
+ *
+ * Not every action has a file. A terminal call has a command line instead, and
+ * `◆ Terminal` on its own says nothing a developer can check — seven of them in
+ * one run says nothing seven times. So the command is read out of the raw
+ * arguments the same way the fence reads them, and shown beside the title.
  */
 
 import path from "node:path";
@@ -28,6 +33,15 @@ export const FAILURE_MARK = "✗";
 
 /** Keys an agent names a file with in a tool call's raw arguments. */
 const PATH_KEYS = ["file_path", "filePath", "path", "notebook_path", "abs_path"];
+
+/** Keys an agent names a command with in a tool call's raw arguments. */
+const COMMAND_KEYS = ["command", "cmd", "commandLine", "command_line", "script"];
+
+/** How deep into nested raw arguments a command is looked for. */
+const MAX_DEPTH = 8;
+
+/** How much of a command line one status line carries. */
+const COMMAND_WIDTH = 72;
 
 type Located = {
   readonly locations?: readonly { readonly path?: string }[] | null;
@@ -55,13 +69,57 @@ export function fileNamedBy(update: Located): string | null {
   return null;
 }
 
-function describe(title: string, file: string | null, cwd: string): string {
-  if (file === null) return title;
-  const shortened = shorten(file, cwd);
-  return title.includes(shortened) ? title : `${title} ${shortened}`;
+/** One command, on one line, short enough to sit beside a title. */
+function oneLine(command: string): string {
+  const collapsed = command.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= COMMAND_WIDTH) return collapsed;
+  return `${collapsed.slice(0, COMMAND_WIDTH - 1).trimEnd()}…`;
 }
 
-type Action = { title: string; file: string | null; failureShown: boolean };
+function commandIn(value: unknown, depth: number): string | null {
+  if (value === null || typeof value !== "object" || depth >= MAX_DEPTH) return null;
+  const held = value as Record<string, unknown>;
+
+  for (const key of COMMAND_KEYS) {
+    const named = held[key];
+    if (typeof named === "string" && named.trim() !== "") return named;
+    if (Array.isArray(named)) {
+      // Some agents send the command already split into its words.
+      const words = named.filter((word): word is string => typeof word === "string");
+      if (words.length > 0) return words.join(" ");
+    }
+  }
+
+  // An adapter can bury the call one or two objects down, so the search goes
+  // as deep as the fence's does rather than only reading the top level.
+  for (const nested of Object.values(held)) {
+    const found = commandIn(nested, depth + 1);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+/** The command a tool call is about to run, or `null` when it runs none. */
+export function commandNamedBy(update: Located): string | null {
+  const found = commandIn(update.rawInput, 0);
+  return found === null ? null : oneLine(found);
+}
+
+type Action = {
+  title: string;
+  file: string | null;
+  command: string | null;
+  failureShown: boolean;
+};
+
+function describe(action: Action, cwd: string): string {
+  if (action.file !== null) {
+    const shortened = shorten(action.file, cwd);
+    return action.title.includes(shortened) ? action.title : `${action.title} ${shortened}`;
+  }
+  if (action.command !== null) return `${action.title} ${DETAIL_MARK} ${action.command}`;
+  return action.title;
+}
 
 /** One task's worth of actions, turned into lines as the agent takes them. */
 export class ActionStream {
@@ -78,10 +136,11 @@ export class ActionStream {
       const action: Action = {
         title: update.title,
         file: fileNamedBy(update),
+        command: commandNamedBy(update),
         failureShown: false,
       };
       this.actions.set(update.toolCallId, action);
-      return [`${ACTION_MARK} ${describe(action.title, action.file, this.cwd)}`];
+      return [`${ACTION_MARK} ${describe(action, this.cwd)}`];
     }
 
     if (update.sessionUpdate !== "tool_call_update") return [];
@@ -89,20 +148,31 @@ export class ActionStream {
     const lines: string[] = [];
     let action = this.actions.get(update.toolCallId) ?? null;
     if (action === null) {
-      action = { title: update.title ?? "Working", file: fileNamedBy(update), failureShown: false };
+      action = {
+        title: update.title ?? "Working",
+        file: fileNamedBy(update),
+        command: commandNamedBy(update),
+        failureShown: false,
+      };
       this.actions.set(update.toolCallId, action);
-      lines.push(`${ACTION_MARK} ${describe(action.title, action.file, this.cwd)}`);
+      lines.push(`${ACTION_MARK} ${describe(action, this.cwd)}`);
     } else if (action.file === null) {
       const named = fileNamedBy(update);
       if (named !== null) {
         action.file = named;
         lines.push(`${DETAIL_MARK} ${shorten(named, this.cwd)}`);
+      } else if (action.command === null) {
+        const command = commandNamedBy(update);
+        if (command !== null) {
+          action.command = command;
+          lines.push(`${DETAIL_MARK} ${command}`);
+        }
       }
     }
 
     if (update.status === "failed" && !action.failureShown) {
       action.failureShown = true;
-      lines.push(`${FAILURE_MARK} ${describe(action.title, action.file, this.cwd)} did not work`);
+      lines.push(`${FAILURE_MARK} ${describe(action, this.cwd)} did not work`);
     }
 
     return lines;

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -1,92 +1,28 @@
 /**
  * The walk: what the wizard actually does, once, from start to exit line.
  *
- * Today it is one task, which is the point — it proves the whole path (start
- * the developer's coding agent, drive it, show every action, leave one line
- * behind) before any product flow rides on it. The flow never draws anything
- * and never reads a keystroke: it pushes state at the UI and parks on a gate.
+ * The flow never draws anything and never reads a keystroke: it pushes state at
+ * the UI and parks on a gate. One step so far — find the voice agent — and the
+ * shape is deliberate, because every intelligent step after it is the same
+ * shape: skills plus a task, dispatched to the developer's own coding agent,
+ * with every action it takes shown as it happens.
  */
 
-import { readdir, stat } from "node:fs/promises";
-import path from "node:path";
-
-import { driveOneTask, type DriveResult } from "../acp/drive.ts";
 import type { DrivenAgentLaunch } from "../acp/registry.ts";
 import type { WizardUI } from "../ui/wizard-ui.ts";
+import { findTheAgent } from "./discovery.ts";
 import { openDrivenAgentLog, type DrivenAgentLog } from "./driven-agent-log.ts";
 import type { ExitReport } from "./exit-line.ts";
 import { stopReport, untilAborted } from "./stop.ts";
-
-/**
- * Files a repository is likely to have that say what it is in a few lines. The
- * task is trivial on purpose; the point is the path, not the answer.
- */
-const PREFERRED_FILES = [
-  "package.json",
-  "pyproject.toml",
-  "go.mod",
-  "Cargo.toml",
-  "README.md",
-];
 
 export type WalkOptions = {
   readonly ui: WizardUI;
   readonly launch: DrivenAgentLaunch;
   readonly cwd: string;
-  /** The file the agent is asked about. Chosen from the folder when omitted. */
-  readonly file?: string;
   readonly signal: AbortSignal;
   /** Where the agent's own output is kept. A fresh file per run by default. */
   readonly log?: DrivenAgentLog;
 };
-
-async function isFile(candidate: string): Promise<boolean> {
-  try {
-    return (await stat(candidate)).isFile();
-  } catch {
-    return false;
-  }
-}
-
-/** A file in this folder for the agent to read, or `null` when there is none. */
-export async function chooseFile(cwd: string): Promise<string | null> {
-  for (const name of PREFERRED_FILES) {
-    if (await isFile(path.join(cwd, name))) return name;
-  }
-  const entries = await readdir(cwd, { withFileTypes: true });
-  const plain = entries.find((entry) => entry.isFile() && !entry.name.startsWith("."));
-  return plain?.name ?? null;
-}
-
-/** What egma asks the agent to do. One file, one sentence, no changes. */
-export function instructionsFor(file: string): string {
-  return [
-    `Read the file ${file} in the current folder.`,
-    "Then reply with one short sentence saying what it is.",
-    "Do not change any file, and do not run any command.",
-  ].join(" ");
-}
-
-function reportFor(
-  result: DriveResult,
-  drivenAgentName: string,
-  file: string,
-  signal: AbortSignal,
-): ExitReport {
-  switch (result.kind) {
-    case "done":
-      return { kind: "task-done", drivenAgentName, file };
-    case "interrupted":
-      return stopReport(signal, drivenAgentName);
-    case "needs-login":
-      return {
-        kind: "failed",
-        reason: `${result.drivenAgentName} is not logged in. Log in to it, then run egma again.`,
-      };
-    case "failed":
-      return { kind: "failed", reason: result.reason };
-  }
-}
 
 /** Runs the walk and returns the line the wizard will leave behind. */
 export async function walk(options: WalkOptions): Promise<ExitReport> {
@@ -97,18 +33,6 @@ export async function walk(options: WalkOptions): Promise<ExitReport> {
   const log = options.log ?? openDrivenAgentLog();
   ui.setDrivenAgentLog(log.file);
 
-  const file = options.file ?? (await chooseFile(cwd));
-  if (file === null) {
-    const report: ExitReport = {
-      kind: "failed",
-      reason:
-        "there is no file in this folder for your coding agent to read. Run egma inside your repository.",
-    };
-    ui.setExit(report);
-    return report;
-  }
-  ui.setTaskFile(file);
-
   await untilAborted(ui.waitForGate("begin"), signal);
   if (signal.aborted) {
     const report = stopReport(signal, launch.name);
@@ -116,25 +40,7 @@ export async function walk(options: WalkOptions): Promise<ExitReport> {
     return report;
   }
 
-  ui.taskStarted();
-  const result = await driveOneTask({
-    launch,
-    cwd,
-    instructions: instructionsFor(file),
-    ui,
-    signal,
-    logStderr: (chunk) => log.write(chunk),
-  });
-  ui.taskFinished();
-
-  if (result.kind === "done") ui.setSummary(result.summary);
-  // A failure is the one time the agent's own output is worth reading, so it is
-  // the one time the developer is told where it is.
-  if (result.kind === "failed" || result.kind === "needs-login") {
-    ui.pushStatus(`What ${launch.name} itself printed is in ${log.file}`);
-  }
-
-  const report = reportFor(result, launch.name, file, signal);
+  const report = await findTheAgent({ ui, launch, cwd, signal, log });
   ui.setExit(report);
   return report;
 }

--- a/apps/cli/test/cli.test.ts
+++ b/apps/cli/test/cli.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { execFile, spawn } from "node:child_process";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
@@ -75,8 +75,7 @@ describe("the egma command", () => {
     expect(help.stdout).toContain("Usage:");
     expect(help.stdout).toContain("--coding-agent <id>");
 
-    // The two test seams are not product surface, so they are not offered.
-    expect(help.stdout).not.toContain("--file");
+    // The test seam is not product surface, so it is not offered.
     expect(help.stdout).not.toContain("-- <command>");
 
     const version = await egma(["--version"], workspace.dir);
@@ -102,7 +101,7 @@ describe("the egma command", () => {
     expect(result.stdout).toBe("");
   });
 
-  it("drives the whole task and ends with the one exit line", async () => {
+  it("drives the whole step and ends with the one exit line", async () => {
     const script = await workspace.script({
       steps: [
         {
@@ -112,8 +111,14 @@ describe("the egma command", () => {
           locations: [{ path: "package.json" }],
         },
         { kind: "read-file", path: "package.json", recordAs: "manifest" },
-        { kind: "write-file", path: "notes.txt", content: "a package manifest\n" },
-        { kind: "say", text: "It is a package manifest." },
+        {
+          kind: "say",
+          text: [
+            "egma:found framework retell-sdk",
+            "egma:found prompts prompts/order-line.md",
+            "",
+          ].join("\n"),
+        },
         { kind: "stop", reason: "end_turn" },
       ],
     });
@@ -126,46 +131,64 @@ describe("the egma command", () => {
     expect(result.code).toBe(0);
     const lines = result.stdout.trimEnd().split("\n");
     expect(lines).toContain("◆ Read package.json");
+    expect(lines).toContain("┊ Framework  retell-sdk");
     expect(lines.at(-1)).toBe(
-      `${path.basename(process.execPath)} read package.json for egma. Nothing in this folder was changed.`,
-    );
-    expect(await readFile(path.join(workspace.dir, "notes.txt"), "utf8")).toBe(
-      "a package manifest\n",
+      "egma found your voice agent: retell-sdk, prompts in prompts/order-line.md.",
     );
   });
 
-  it("keeps the two seams working that the tests themselves are driven by", async () => {
-    // `--file` and `-- <command>` are how a test pins the file and starts a
-    // scripted agent. They are not offered in the help text, and they are not
-    // stable, but everything offline rides on them — so they are checked.
-    await writeFile(path.join(workspace.dir, "NOTES.md"), "just some notes\n", "utf8");
-    const script = await workspace.script({
-      steps: [
-        { kind: "say", text: "It is a notes file." },
-        { kind: "stop", reason: "end_turn" },
-      ],
-    });
-
+  it("prints what to paste, and exits cleanly, with no coding agent to drive", async () => {
     const result = await egma(
       [
         "--headless",
         "--cwd",
         workspace.dir,
-        "--file",
-        "NOTES.md",
         "--",
-        process.execPath,
-        FAKE_AGENT,
-        script,
+        path.join(workspace.dir, "no-such-coding-agent"),
       ],
       workspace.dir,
     );
 
     expect(result.code).toBe(0);
-    // The named file won over the one the folder would have chosen.
-    expect(result.stdout).toContain("Task: read NOTES.md and say what it is");
+    expect(result.stdout).toContain("Open the coding agent you use, and paste this into it:");
+    expect(result.stdout).toContain("Find the voice agent in this repository");
+    expect(result.stdout.trimEnd().split("\n").at(-1)).toContain(
+      "no coding agent on this machine",
+    );
+    // A message, not a crash.
+    expect(result.stderr).toBe("");
+  });
+
+  it("prints the same message when the registry names an agent it cannot start", async () => {
+    const result = await egma(
+      ["--headless", "--cwd", workspace.dir, "--coding-agent", "not-a-real-agent"],
+      workspace.dir,
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("not-a-real-agent");
+    expect(result.stdout).toContain("Open the coding agent you use, and paste this into it:");
+  });
+
+  it("keeps the seam working that the tests themselves are driven by", async () => {
+    // `-- <command>` is how a test starts a scripted agent in place of a real
+    // one. It is not offered in the help text and it is not stable, but
+    // everything offline rides on it — so it is checked.
+    const script = await workspace.script({
+      steps: [
+        { kind: "say", text: "egma:none There is no voice agent here.\n" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+
+    const result = await egma(
+      ["--headless", "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      workspace.dir,
+    );
+
+    expect(result.code).toBe(1);
     expect(result.stdout.trimEnd().split("\n").at(-1)).toBe(
-      `${path.basename(process.execPath)} read NOTES.md for egma. Nothing in this folder was changed.`,
+      "egma found no voice agent to test. Run egma again where your agent is defined.",
     );
   });
 

--- a/apps/cli/test/discovery.test.ts
+++ b/apps/cli/test/discovery.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Finding the voice agent, against a committed repository and a scripted agent.
+ *
+ * No model, no network, no human. What is checked is what a developer could
+ * check afterwards: what the wizard said on screen, what the summary card holds,
+ * what the coding agent was handed, what landed on disk, and the one line left
+ * behind. Never the order egma did things in.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import { buildExitLine, buildExitNotice } from "../src/wizard/exit-line.ts";
+import { walk } from "../src/wizard/walk.ts";
+import type { FakeStep } from "./support/fake-agent.ts";
+import {
+  RETELL_FIXTURE_REPO,
+  filesUnder,
+  makeWorkspace,
+  type Workspace,
+} from "./support/workspace.ts";
+
+type Report = {
+  observations: Record<string, unknown>;
+  instructions: string[];
+  folders: string[];
+  loggedInWith: string | null;
+};
+
+/** One turn of the agent's own words, ended the way a real one ends a line. */
+function says(...lines: string[]): FakeStep {
+  return { kind: "say", text: `${lines.join("\n")}\n` };
+}
+
+/** What a coding agent that read the fixture repository properly would report. */
+const REPORTS_THE_FIXTURE: FakeStep[] = [
+  says("egma:note Reading package.json"),
+  {
+    kind: "tool-call",
+    id: "t1",
+    title: "Read",
+    toolKind: "read",
+    locations: [{ path: "package.json" }],
+  },
+  { kind: "read-file", path: "package.json", recordAs: "manifest" },
+  { kind: "tool-call-update", id: "t1", status: "completed" },
+  says(
+    "I can see a Retell agent here.",
+    "egma:found framework retell-sdk",
+    "egma:found prompts prompts/order-line.md (pushed to Retell by scripts/deploy.ts)",
+    "egma:found tools src/tools/*.ts (2 definitions, registered as Retell custom tools)",
+    "egma:found deploy Retell-hosted; scripts/deploy.ts updates the agent",
+    "egma:found agent-id src/config.ts",
+  ),
+  { kind: "stop", reason: "end_turn" },
+];
+
+/** A folder with nothing in it that egma could test. */
+const REPORTS_NOTHING: FakeStep[] = [
+  says("egma:note Reading the folder"),
+  says("egma:none There is no voice agent in this folder."),
+  { kind: "stop", reason: "end_turn" },
+];
+
+describe("finding the voice agent", () => {
+  /** The repository under test: the committed fixture, copied so it can be watched. */
+  let repo: Workspace;
+  /** Everything the test itself needs on disk, kept out of the repository. */
+  let scratch: Workspace;
+
+  beforeEach(async () => {
+    repo = await makeWorkspace({}, { from: RETELL_FIXTURE_REPO });
+    scratch = await makeWorkspace();
+  });
+
+  afterEach(async () => {
+    await repo.remove();
+    await scratch.remove();
+  });
+
+  const reportFile = (): string => path.join(scratch.dir, "agent-report.json");
+
+  const observed = async (): Promise<Report> =>
+    JSON.parse(await readFile(reportFile(), "utf8")) as Report;
+
+  /** The record a dispatch left in the folder it was sent to work in. */
+  const recordIn = async (dir: string): Promise<Report> =>
+    JSON.parse(await readFile(path.join(dir, "fake-agent-report.json"), "utf8")) as Report;
+
+  it("reports the framework, the prompts, the tools and how it reaches production", async () => {
+    const script = await scratch.script({
+      reportFile: reportFile(),
+      steps: REPORTS_THE_FIXTURE,
+    });
+
+    const ui = new HeadlessUI();
+    const report = await walk({
+      ui,
+      launch: scratch.launch(script),
+      cwd: repo.dir,
+      signal: new AbortController().signal,
+    });
+
+    // Every fact reached the screen while the agent worked.
+    expect(ui.record.statuses).toContain("◆ Reading package.json");
+    expect(ui.record.statuses).toContain("┊ Framework  retell-sdk");
+    expect(ui.record.statuses).toContain(
+      "┊ Prompts    prompts/order-line.md (pushed to Retell by scripts/deploy.ts)",
+    );
+
+    // And the card at the end holds all of them, in one place, aligned.
+    expect(ui.record.summary.split("\n")).toEqual([
+      "Your voice agent",
+      "  Framework  retell-sdk",
+      "  Prompts    prompts/order-line.md (pushed to Retell by scripts/deploy.ts)",
+      "  Tools      src/tools/*.ts (2 definitions, registered as Retell custom tools)",
+      "  Deploy     Retell-hosted; scripts/deploy.ts updates the agent",
+      "  Agent id   src/config.ts",
+    ]);
+
+    expect(report).toEqual({
+      kind: "found-agent",
+      framework: "retell-sdk",
+      prompts: "prompts/order-line.md (pushed to Retell by scripts/deploy.ts)",
+    });
+    expect(buildExitLine(report)).toBe(
+      "egma found your voice agent: retell-sdk, prompts in prompts/order-line.md (pushed to Retell by scripts/deploy.ts).",
+    );
+  });
+
+  it("hands the coding agent both skills, and leaves the repository as it found it", async () => {
+    const before = await filesUnder(repo.dir);
+
+    const script = await scratch.script({
+      reportFile: reportFile(),
+      steps: REPORTS_THE_FIXTURE,
+    });
+
+    await walk({
+      ui: new HeadlessUI(),
+      launch: scratch.launch(script),
+      cwd: repo.dir,
+      signal: new AbortController().signal,
+    });
+
+    // The skills arrived as the task's own instructions — not installed, not
+    // written down, not fetched: sent.
+    const instructions = (await observed()).instructions;
+    expect(instructions).toHaveLength(1);
+    const sent = instructions[0] as string;
+    expect(sent).toContain("name: finding-the-voice-agent");
+    expect(sent).toContain("name: retell-voice-agents");
+    expect(sent).toContain("egma:found framework retell-sdk");
+    expect(sent).toContain("# Your task");
+    expect(sent).toContain(repo.dir);
+
+    // And nothing at all landed on the developer's disk.
+    expect(await filesUnder(repo.dir)).toEqual(before);
+    expect(before).toContain("prompts/order-line.md");
+  });
+
+  it("asks once for a pointer when the folder holds nothing, and looks there", async () => {
+    const elsewhere = await makeWorkspace({}, { from: RETELL_FIXTURE_REPO });
+    const empty = await makeWorkspace({ "README.md": "# nothing here yet\n" });
+
+    try {
+      // Each dispatch is its own agent, so each leaves its own record where it
+      // was pointed — which is how both folders can be checked.
+      const script = await scratch.script({
+        steps: REPORTS_NOTHING,
+        stepsByFolder: [{ contains: path.basename(elsewhere.dir), steps: REPORTS_THE_FIXTURE }],
+      });
+
+      const ui = new HeadlessUI({ answers: { "prompts-pointer": elsewhere.dir } });
+      const report = await walk({
+        ui,
+        launch: scratch.launch(script),
+        cwd: empty.dir,
+        signal: new AbortController().signal,
+      });
+
+      // Asked once, and only once.
+      expect(ui.record.asked).toEqual(["prompts-pointer"]);
+      // Looked here first, then where it was pointed — two folders, two tasks.
+      expect((await recordIn(empty.dir)).folders).toEqual([empty.dir]);
+      expect((await recordIn(elsewhere.dir)).folders).toEqual([elsewhere.dir]);
+      expect((await recordIn(elsewhere.dir)).instructions[0]).toContain(
+        `Find the voice agent in ${elsewhere.dir}`,
+      );
+      expect(report).toEqual({
+        kind: "found-agent",
+        framework: "retell-sdk",
+        prompts: "prompts/order-line.md (pushed to Retell by scripts/deploy.ts)",
+      });
+      expect(ui.record.summary).toContain("src/config.ts");
+    } finally {
+      await elsewhere.remove();
+      await empty.remove();
+    }
+  });
+
+  it("says in plain words where to run again when there is nothing to point at", async () => {
+    const empty = await makeWorkspace({ "README.md": "# nothing here yet\n" });
+
+    try {
+      const script = await scratch.script({
+        reportFile: reportFile(),
+        steps: REPORTS_NOTHING,
+      });
+
+      // Nobody supplied a pointer, which is a real answer and not a hang.
+      const ui = new HeadlessUI();
+      const report = await walk({
+        ui,
+        launch: scratch.launch(script),
+        cwd: empty.dir,
+        signal: new AbortController().signal,
+      });
+
+      expect(ui.record.asked).toEqual(["prompts-pointer"]);
+      expect(report).toEqual({ kind: "no-agent-context" });
+      expect(buildExitLine(report)).toBe(
+        "egma found no voice agent to test. Run egma again where your agent is defined.",
+      );
+      expect(buildExitNotice(report)).toBeNull();
+    } finally {
+      await empty.remove();
+    }
+  });
+
+  it("stops asking after the pointer, even when the pointer leads nowhere either", async () => {
+    const alsoEmpty = await makeWorkspace({ "notes.txt": "nothing\n" });
+    const empty = await makeWorkspace({ "README.md": "# nothing here yet\n" });
+
+    try {
+      const script = await scratch.script({
+        reportFile: reportFile(),
+        steps: REPORTS_NOTHING,
+      });
+
+      const ui = new HeadlessUI({ answers: { "prompts-pointer": alsoEmpty.dir } });
+      const report = await walk({
+        ui,
+        launch: scratch.launch(script),
+        cwd: empty.dir,
+        signal: new AbortController().signal,
+      });
+
+      expect(ui.record.asked).toEqual(["prompts-pointer"]);
+      expect(report).toEqual({ kind: "no-agent-context" });
+    } finally {
+      await alsoEmpty.remove();
+      await empty.remove();
+    }
+  });
+
+  it("hands the developer to the coding agent's own login, then finishes the step", async () => {
+    const script = await scratch.script({
+      reportFile: reportFile(),
+      authRequiredUntilLogin: {},
+      steps: REPORTS_THE_FIXTURE,
+    });
+
+    const ui = new HeadlessUI();
+    const report = await walk({
+      ui,
+      launch: scratch.launch(script),
+      cwd: repo.dir,
+      signal: new AbortController().signal,
+    });
+
+    // It was the agent's own login that ran, and egma carried straight on.
+    expect((await observed()).loggedInWith).toBe("own-login");
+    expect(ui.record.statuses).toContain(
+      "◆ Fake Agent needs you to log in. Handing you to its own login.",
+    );
+    expect(report.kind).toBe("found-agent");
+    expect(ui.record.summary).toContain("retell-sdk");
+  });
+
+  it("ends the task itself when the agent says it cannot go on", async () => {
+    const script = await scratch.script({
+      reportFile: reportFile(),
+      steps: [
+        says("egma:abort This repository is not one I can read."),
+        { kind: "wait", ms: 60_000 },
+        { kind: "write-file", path: "never-written.txt", content: "x\n", recordAs: "afterAbort" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+
+    const ui = new HeadlessUI();
+    const report = await walk({
+      ui,
+      launch: scratch.launch(script),
+      cwd: repo.dir,
+      signal: new AbortController().signal,
+    });
+
+    // egma did not wait out the minute, and the step after the abort never ran.
+    expect(report).toEqual({ kind: "no-agent-context" });
+    expect(await filesUnder(repo.dir)).not.toContain("never-written.txt");
+    expect((await observed()).observations["afterAbort"]).toBeUndefined();
+  });
+
+  it("keeps the agent's prose in the log and off the screen", async () => {
+    const script = await scratch.script({
+      reportFile: reportFile(),
+      steps: REPORTS_THE_FIXTURE,
+    });
+
+    const kept: string[] = [];
+    const ui = new HeadlessUI();
+    await walk({
+      ui,
+      launch: scratch.launch(script),
+      cwd: repo.dir,
+      signal: new AbortController().signal,
+      log: { file: path.join(scratch.dir, "agent.log"), write: (chunk) => kept.push(chunk) },
+    });
+
+    expect(kept.join("")).toContain("I can see a Retell agent here.");
+    expect(ui.record.statuses.join("\n")).not.toContain("I can see a Retell agent here.");
+  });
+
+  it("prints what to paste when there is no coding agent on the machine", async () => {
+    const ui = new HeadlessUI();
+    const report = await walk({
+      ui,
+      launch: {
+        id: "not-here",
+        name: "Nothing",
+        command: path.join(scratch.dir, "no-such-coding-agent"),
+        args: [],
+        env: {},
+      },
+      cwd: repo.dir,
+      signal: new AbortController().signal,
+    });
+
+    expect(report).toEqual({ kind: "no-coding-agent" });
+
+    const notice = buildExitNotice(report) as string;
+    expect(notice).toContain("Open the coding agent you use, and paste this into it:");
+    expect(notice).toContain("Find the voice agent in this repository");
+    expect(buildExitLine(report)).toContain("no coding agent on this machine");
+  });
+
+});

--- a/apps/cli/test/discovery.test.ts
+++ b/apps/cli/test/discovery.test.ts
@@ -301,9 +301,75 @@ describe("finding the voice agent", () => {
     });
 
     // egma did not wait out the minute, and the step after the abort never ran.
-    expect(report).toEqual({ kind: "no-agent-context" });
     expect(await filesUnder(repo.dir)).not.toContain("never-written.txt");
     expect((await observed()).observations["afterAbort"]).toBeUndefined();
+
+    // A stop is a stop. It is never told as an empty folder, so nobody is
+    // asked to point egma somewhere else and nobody is told there is no voice
+    // agent here — neither of which the agent said.
+    expect(report).toEqual({
+      kind: "coding-agent-stopped",
+      drivenAgentName: "Fake Agent",
+      reason: "This repository is not one I can read.",
+    });
+    expect(ui.record.asked).toEqual([]);
+    expect(buildExitLine(report)).toBe(
+      "Fake Agent stopped before it found your voice agent: This repository is not one I can read.",
+    );
+
+    // And the reason was on screen while it happened, not only at the end.
+    expect(ui.record.statuses).toContain("✗ This repository is not one I can read.");
+  });
+
+  it("shows the agent's own words when it looked and found nothing", async () => {
+    const empty = await makeWorkspace({ "README.md": "# nothing here yet\n" });
+
+    try {
+      const script = await scratch.script({ reportFile: reportFile(), steps: REPORTS_NOTHING });
+
+      const ui = new HeadlessUI();
+      await walk({
+        ui,
+        launch: scratch.launch(script),
+        cwd: empty.dir,
+        signal: new AbortController().signal,
+      });
+
+      // Every action is streamed, and "I found nothing" is the most important
+      // thing this agent said all run.
+      expect(ui.record.statuses).toContain("┊ There is no voice agent in this folder.");
+    } finally {
+      await empty.remove();
+    }
+  });
+
+  it("names the command in a terminal line, which says nothing without one", async () => {
+    const script = await scratch.script({
+      reportFile: reportFile(),
+      steps: [
+        {
+          kind: "tool-call",
+          id: "t1",
+          title: "Terminal",
+          toolKind: "execute",
+          rawInput: { command: "rg -l retell-sdk src", description: "Look for the SDK" },
+        },
+        { kind: "tool-call-update", id: "t1", status: "completed" },
+        says("egma:found framework retell-sdk"),
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+
+    const ui = new HeadlessUI();
+    await walk({
+      ui,
+      launch: scratch.launch(script),
+      cwd: repo.dir,
+      signal: new AbortController().signal,
+    });
+
+    expect(ui.record.statuses).toContain("◆ Terminal ┊ rg -l retell-sdk src");
+    expect(ui.record.statuses).not.toContain("◆ Terminal");
   });
 
   it("keeps the agent's prose in the log and off the screen", async () => {

--- a/apps/cli/test/exit-line.test.ts
+++ b/apps/cli/test/exit-line.test.ts
@@ -1,18 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { buildExitLine } from "../src/wizard/exit-line.ts";
+import { buildExitLine, buildExitNotice, type ExitReport } from "../src/wizard/exit-line.ts";
+
+const EVERY_ENDING: readonly ExitReport[] = [
+  { kind: "found-agent", framework: "retell-sdk", prompts: "prompts/order-line.md" },
+  { kind: "found-agent", framework: "retell-sdk", prompts: null },
+  { kind: "found-agent", framework: null, prompts: null },
+  { kind: "no-agent-context" },
+  { kind: "no-coding-agent" },
+  { kind: "quit" },
+  { kind: "interrupted", drivenAgentName: "Claude Agent" },
+  { kind: "interrupted", drivenAgentName: null },
+  { kind: "failed", reason: "the agent stopped talking" },
+];
 
 describe("the exit line", () => {
   it("is always exactly one line, with nothing to select around", () => {
-    const reports = [
-      { kind: "task-done", drivenAgentName: "Claude Agent", file: "package.json" },
-      { kind: "quit" },
-      { kind: "interrupted", drivenAgentName: "Claude Agent" },
-      { kind: "interrupted", drivenAgentName: null },
-      { kind: "failed", reason: "the agent stopped talking" },
-    ] as const;
-
-    for (const report of reports) {
+    for (const report of EVERY_ENDING) {
       const line = buildExitLine(report);
       expect(line).not.toContain("\n");
       // Nothing painted: a terminal selects a plain line cleanly.
@@ -24,13 +28,32 @@ describe("the exit line", () => {
 
   it("says what happened, in words", () => {
     expect(
-      buildExitLine({ kind: "task-done", drivenAgentName: "Claude Agent", file: "package.json" }),
-    ).toBe("Claude Agent read package.json for egma. Nothing in this folder was changed.");
+      buildExitLine({
+        kind: "found-agent",
+        framework: "retell-sdk",
+        prompts: "prompts/order-line.md",
+      }),
+    ).toBe("egma found your voice agent: retell-sdk, prompts in prompts/order-line.md.");
+
+    expect(buildExitLine({ kind: "no-agent-context" })).toContain(
+      "Run egma again where your agent is defined",
+    );
 
     expect(buildExitLine({ kind: "interrupted", drivenAgentName: "Claude Agent" })).toContain(
       "stopped before the task finished",
     );
 
     expect(buildExitLine({ kind: "failed", reason: "no answer" })).toContain("no answer");
+  });
+
+  it("prints something to copy only when the developer has to copy something", () => {
+    for (const report of EVERY_ENDING) {
+      const notice = buildExitNotice(report);
+      if (report.kind === "no-coding-agent") {
+        expect(notice).toContain("paste this into it");
+      } else {
+        expect(notice).toBeNull();
+      }
+    }
   });
 });

--- a/apps/cli/test/exit-line.test.ts
+++ b/apps/cli/test/exit-line.test.ts
@@ -8,6 +8,12 @@ const EVERY_ENDING: readonly ExitReport[] = [
   { kind: "found-agent", framework: null, prompts: null },
   { kind: "no-agent-context" },
   { kind: "no-coding-agent" },
+  {
+    kind: "coding-agent-stopped",
+    drivenAgentName: "Claude Agent",
+    reason: "I cannot read this repository.",
+  },
+  { kind: "coding-agent-stopped", drivenAgentName: "Claude Agent", reason: "" },
   { kind: "quit" },
   { kind: "interrupted", drivenAgentName: "Claude Agent" },
   { kind: "interrupted", drivenAgentName: null },
@@ -44,6 +50,27 @@ describe("the exit line", () => {
     );
 
     expect(buildExitLine({ kind: "failed", reason: "no answer" })).toContain("no answer");
+  });
+
+  /**
+   * A coding agent that stopped is not a folder that held nothing. Telling the
+   * second story for the first says egma looked and found no voice agent, when
+   * what happened is that nobody ever looked.
+   */
+  it("says a stop was a stop, and whose it was", () => {
+    expect(
+      buildExitLine({
+        kind: "coding-agent-stopped",
+        drivenAgentName: "Claude Agent",
+        reason: "I cannot read this repository.",
+      }),
+    ).toBe(
+      "Claude Agent stopped before it found your voice agent: I cannot read this repository.",
+    );
+
+    expect(
+      buildExitLine({ kind: "coding-agent-stopped", drivenAgentName: "Claude Agent", reason: "" }),
+    ).toBe("Claude Agent stopped before it found your voice agent, and did not say why.");
   });
 
   it("prints something to copy only when the developer has to copy something", () => {

--- a/apps/cli/test/fixtures/retell-agent/README.md
+++ b/apps/cli/test/fixtures/retell-agent/README.md
@@ -1,0 +1,13 @@
+# Quillfeather Bindery — order line
+
+The voice agent that answers the order line for Quillfeather Bindery, an
+invented bookbinding workshop. Retell runs the voice agent; this repository
+holds the prompt, the two tools it can use, and the service Retell reaches for
+them.
+
+- `prompts/order-line.md` — the prompt, reviewed here and pushed to Retell.
+- `src/tools/` — the tool definitions and the code behind them.
+- `src/config.ts` — the Retell agent and LLM identifiers.
+- `scripts/deploy.ts` — pushes the prompt and the tools to Retell.
+
+Set `RETELL_API_KEY` before running the deploy script.

--- a/apps/cli/test/fixtures/retell-agent/package.json
+++ b/apps/cli/test/fixtures/retell-agent/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "quillfeather-bindery-line",
+  "version": "1.4.0",
+  "private": true,
+  "description": "The voice agent that answers the order line for Quillfeather Bindery, a made-up bookbinding workshop.",
+  "type": "module",
+  "main": "src/server.ts",
+  "scripts": {
+    "start": "node src/server.ts",
+    "deploy": "node scripts/deploy.ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "retell-sdk": "^4.14.0"
+  }
+}

--- a/apps/cli/test/fixtures/retell-agent/prompts/order-line.md
+++ b/apps/cli/test/fixtures/retell-agent/prompts/order-line.md
@@ -1,0 +1,30 @@
+# Quillfeather Bindery — order line
+
+You answer the order line for Quillfeather Bindery, a small workshop that
+rebinds books and makes notebooks to order. You are warm, unhurried, and you
+never promise a date the workshop has not confirmed.
+
+## What you do
+
+- Take new orders for rebinding and for made-to-order notebooks.
+- Tell people where an order they already placed has got to.
+- Book a drop-off slot at the workshop, which is open Tuesday to Saturday,
+  ten in the morning until five in the afternoon.
+
+## What you never do
+
+- Never quote a price for a rebinding job. Every book is different, so the
+  binder quotes after seeing it. Say that plainly.
+- Never say an order is finished unless the tool told you it is.
+- Never take payment details. Payment happens at collection.
+
+## How to open
+
+Greet the person, say the workshop's name, and ask what you can help with.
+Keep it to one sentence.
+
+## Getting the details right
+
+Read a quoted date back before you book it. Spell an unusual surname back
+letter by letter. If someone gives an order number, repeat it once so they can
+correct you.

--- a/apps/cli/test/fixtures/retell-agent/scripts/deploy.ts
+++ b/apps/cli/test/fixtures/retell-agent/scripts/deploy.ts
@@ -1,0 +1,38 @@
+/**
+ * Pushes the repository's prompt and tools up to Retell.
+ *
+ * The prompt in `prompts/` is the one this workshop reviews in pull requests,
+ * so it is the one Retell has to be running. This script is what makes that
+ * true, and it runs from the release workflow.
+ */
+
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+import Retell from "retell-sdk";
+
+import { RETELL_AGENT_ID, RETELL_LLM_ID } from "../src/config.ts";
+import { bookDropOffTool } from "../src/tools/book-drop-off.ts";
+import { lookUpOrderTool } from "../src/tools/look-up-order.ts";
+
+const retell = new Retell({ apiKey: process.env.RETELL_API_KEY ?? "" });
+
+const generalPrompt = await readFile(
+  new URL("../prompts/order-line.md", import.meta.url),
+  "utf8",
+);
+
+await retell.llm.update(RETELL_LLM_ID, {
+  general_prompt: generalPrompt,
+  begin_message: "Quillfeather Bindery, how can I help?",
+  general_tools: [lookUpOrderTool, bookDropOffTool],
+});
+
+await retell.agent.update(RETELL_AGENT_ID, {
+  agent_name: "order-line",
+  voice_id: "11labs-Chloe",
+  language: "en-GB",
+  webhook_url: "https://orders.quillfeather.example/retell/events",
+});
+
+process.stdout.write("Quillfeather's order line is up to date on Retell.\n");

--- a/apps/cli/test/fixtures/retell-agent/src/config.ts
+++ b/apps/cli/test/fixtures/retell-agent/src/config.ts
@@ -1,0 +1,8 @@
+/** Where Quillfeather's voice agent is registered on Retell. */
+export const RETELL_AGENT_ID = "agent_5f2c9a1b7d4e08c3a6b1d92e40";
+
+/** The Retell LLM object the agent's prompt and tools are written to. */
+export const RETELL_LLM_ID = "llm_1a7b4c9d2e6f80351c8b2a4d7e";
+
+/** Where Retell reaches this service for the custom tools below. */
+export const TOOLS_BASE_URL = "https://orders.quillfeather.example/retell";

--- a/apps/cli/test/fixtures/retell-agent/src/server.ts
+++ b/apps/cli/test/fixtures/retell-agent/src/server.ts
@@ -1,0 +1,30 @@
+/**
+ * The web service Retell reaches for the two custom tools, and for events.
+ *
+ * Retell hosts the voice agent itself; this is only the part of it that has to
+ * run where the workshop's own data is.
+ */
+
+import express from "express";
+
+import { bookDropOff } from "./tools/book-drop-off.ts";
+import { lookUpOrder } from "./tools/look-up-order.ts";
+
+const app = express();
+app.use(express.json());
+
+app.post("/retell/look-up-order", (request, response) => {
+  const { order_number: orderNumber } = request.body as { order_number: string };
+  response.json(lookUpOrder(orderNumber));
+});
+
+app.post("/retell/book-drop-off", (request, response) => {
+  const { name, day, time } = request.body as { name: string; day: string; time: string };
+  response.json(bookDropOff(name, day, time));
+});
+
+app.post("/retell/events", (_request, response) => {
+  response.sendStatus(204);
+});
+
+app.listen(Number(process.env.PORT ?? 8080));

--- a/apps/cli/test/fixtures/retell-agent/src/tools/book-drop-off.ts
+++ b/apps/cli/test/fixtures/retell-agent/src/tools/book-drop-off.ts
@@ -1,0 +1,26 @@
+import { TOOLS_BASE_URL } from "../config.ts";
+
+/** Told to Retell so the voice agent knows when and how to use this tool. */
+export const bookDropOffTool = {
+  type: "custom",
+  name: "book_drop_off",
+  description:
+    "Hold a drop-off slot at the workshop. Only for slots the workshop is open for: Tuesday to Saturday, 10:00 to 17:00.",
+  url: `${TOOLS_BASE_URL}/book-drop-off`,
+  speak_during_execution: true,
+  speak_after_execution: true,
+  parameters: {
+    type: "object",
+    properties: {
+      name: { type: "string", description: "Who is bringing the book in." },
+      day: { type: "string", description: "The day, as an ISO date." },
+      time: { type: "string", description: "The time, as 24-hour HH:MM." },
+    },
+    required: ["name", "day", "time"],
+  },
+};
+
+export function bookDropOff(name: string, day: string, time: string): { held: boolean } {
+  const hour = Number(time.slice(0, 2));
+  return { held: name !== "" && day !== "" && hour >= 10 && hour < 17 };
+}

--- a/apps/cli/test/fixtures/retell-agent/src/tools/look-up-order.ts
+++ b/apps/cli/test/fixtures/retell-agent/src/tools/look-up-order.ts
@@ -1,0 +1,31 @@
+import { TOOLS_BASE_URL } from "../config.ts";
+
+/** Told to Retell so the voice agent knows when and how to use this tool. */
+export const lookUpOrderTool = {
+  type: "custom",
+  name: "look_up_order",
+  description:
+    "Find an order by its number and answer where it has got to. Use it whenever someone asks about an order they already placed.",
+  url: `${TOOLS_BASE_URL}/look-up-order`,
+  speak_during_execution: true,
+  speak_after_execution: true,
+  parameters: {
+    type: "object",
+    properties: {
+      order_number: {
+        type: "string",
+        description: "The order number, in the shape QB-00000.",
+      },
+    },
+    required: ["order_number"],
+  },
+};
+
+export type OrderState = "received" | "with the binder" | "ready to collect";
+
+export function lookUpOrder(orderNumber: string): { state: OrderState; due: string } {
+  // The real workshop system sits behind this; the fixture answers a fixed row.
+  return orderNumber === "QB-00042"
+    ? { state: "with the binder", due: "next Thursday" }
+    : { state: "received", due: "not yet set" };
+}

--- a/apps/cli/test/markers.test.ts
+++ b/apps/cli/test/markers.test.ts
@@ -48,6 +48,28 @@ describe("a marker line", () => {
     expect(markerIn("EGMA:FOUND framework retell-sdk")).toEqual(wanted);
   });
 
+  it("survives bold, which is the decoration a model reaches for most", () => {
+    const wanted = { kind: "found", field: "framework", value: "retell-sdk" };
+    // Only the marker's own name in bold: the commonest shape of all.
+    expect(markerIn("**egma:found** framework retell-sdk")).toEqual(wanted);
+    expect(markerIn("__egma:found__ framework retell-sdk")).toEqual(wanted);
+    // The whole line in bold.
+    expect(markerIn("**egma:found framework retell-sdk**")).toEqual(wanted);
+    expect(markerIn("- **egma:found framework retell-sdk**")).toEqual(wanted);
+    expect(markerIn("**`egma:found framework retell-sdk`**")).toEqual(wanted);
+    expect(markerIn("**egma:note** Reading package.json")).toEqual({
+      kind: "note",
+      text: "Reading package.json",
+    });
+
+    // And a value made of asterisks is not cut short by its own glob.
+    expect(markerIn("**egma:found tools src/**/*.ts (2 definitions)**")).toEqual({
+      kind: "found",
+      field: "tools",
+      value: "src/**/*.ts (2 definitions)",
+    });
+  });
+
   it("is not a marker just because the word appears", () => {
     expect(markerIn("I will report this with egma:found when I know.")).toBeNull();
     expect(markerIn("egma:invented framework retell-sdk")).toBeNull();
@@ -80,11 +102,52 @@ describe("markers arriving in pieces", () => {
     ]);
   });
 
+  it("reads a marker welded to a word, which is where a line ending belongs", () => {
+    const stream = new MarkerStream();
+
+    // No punctuation between them, and still the only reading that makes sense.
+    expect(stream.push("Reading the manifestegma:found framework retell-sdk\n")).toEqual([
+      { kind: "prose", text: "Reading the manifest" },
+      { kind: "marker", marker: { kind: "found", field: "framework", value: "retell-sdk" } },
+    ]);
+  });
+
   it("leaves a marker alone when somebody is only talking about one", () => {
     const stream = new MarkerStream();
 
     expect(stream.push("I will report this with egma:found when I know.\n")).toEqual([
       { kind: "prose", text: "I will report this with egma:found when I know." },
+    ]);
+  });
+
+  /**
+   * The shapes a model writes when it is explaining the format rather than
+   * using it. Each one is a sentence with a marker inside it, and reading any
+   * of them as a fact invents the rest of the sentence as its value.
+   */
+  it("leaves a marker inside a sentence alone, whatever is wrapped around it", () => {
+    const prose = [
+      "I will use the format (egma:found framework retell-sdk) for each fact.",
+      "Use `egma:found framework retell-sdk` when you know it.",
+      'The line reads "egma:found framework retell-sdk" and nothing else.',
+      "Write it as [egma:found framework retell-sdk] on its own line.",
+      "The marker is *egma:found framework retell-sdk* in this example.",
+      "One line each: 'egma:found framework retell-sdk' is the shape.",
+    ];
+
+    for (const line of prose) {
+      const stream = new MarkerStream();
+      expect(stream.push(`${line}\n`), line).toEqual([{ kind: "prose", text: line }]);
+    }
+  });
+
+  it("reads a bold marker welded to the line before it", () => {
+    const stream = new MarkerStream();
+
+    expect(stream.push("egma:note Reading the manifest.")).toEqual([]);
+    expect(stream.push("**egma:found** framework retell-sdk\n")).toEqual([
+      { kind: "marker", marker: { kind: "note", text: "Reading the manifest." } },
+      { kind: "marker", marker: { kind: "found", field: "framework", value: "retell-sdk" } },
     ]);
   });
 

--- a/apps/cli/test/markers.test.ts
+++ b/apps/cli/test/markers.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The marker lines, read the way a coding agent really writes them.
+ *
+ * A model told to write a bare line writes a bullet, or wraps it in backticks,
+ * or breaks it across two pieces of a stream. None of that changes what it
+ * meant, so none of it may change what egma reads — and nothing that is not a
+ * marker may ever become one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { MarkerStream, markerIn } from "../src/wizard/markers.ts";
+
+describe("a marker line", () => {
+  it("carries a fact, its name and its value", () => {
+    expect(markerIn("egma:found prompts prompts/order-line.md")).toEqual({
+      kind: "found",
+      field: "prompts",
+      value: "prompts/order-line.md",
+    });
+    expect(markerIn("egma:found tools src/tools/*.ts (2 definitions)")).toEqual({
+      kind: "found",
+      field: "tools",
+      value: "src/tools/*.ts (2 definitions)",
+    });
+  });
+
+  it("carries the three other things a step can say", () => {
+    expect(markerIn("egma:note Reading package.json")).toEqual({
+      kind: "note",
+      text: "Reading package.json",
+    });
+    expect(markerIn("egma:none Nothing here looks like a voice agent.")).toEqual({
+      kind: "none",
+      reason: "Nothing here looks like a voice agent.",
+    });
+    expect(markerIn("egma:abort I cannot read this folder.")).toEqual({
+      kind: "abort",
+      reason: "I cannot read this folder.",
+    });
+  });
+
+  it("survives the decoration a model adds when it is being helpful", () => {
+    const wanted = { kind: "found", field: "framework", value: "retell-sdk" };
+    expect(markerIn("- egma:found framework retell-sdk")).toEqual(wanted);
+    expect(markerIn("  * `egma:found framework retell-sdk`  ")).toEqual(wanted);
+    expect(markerIn("2. egma:found framework: retell-sdk")).toEqual(wanted);
+    expect(markerIn("EGMA:FOUND framework retell-sdk")).toEqual(wanted);
+  });
+
+  it("is not a marker just because the word appears", () => {
+    expect(markerIn("I will report this with egma:found when I know.")).toBeNull();
+    expect(markerIn("egma:invented framework retell-sdk")).toBeNull();
+    expect(markerIn("egma:found framework")).toBeNull();
+    expect(markerIn("egma:note")).toBeNull();
+    expect(markerIn("Reading package.json")).toBeNull();
+    expect(markerIn("")).toBeNull();
+  });
+});
+
+describe("markers arriving in pieces", () => {
+  it("waits for a line to be whole before reading it", () => {
+    const stream = new MarkerStream();
+
+    expect(stream.push("egma:found frame")).toEqual([]);
+    expect(stream.push("work retell-sdk\nLet me look at the tools now.\n")).toEqual([
+      { kind: "marker", marker: { kind: "found", field: "framework", value: "retell-sdk" } },
+      { kind: "prose", text: "Let me look at the tools now." },
+    ]);
+  });
+
+  it("reads a marker welded to the line before it, when a line ending went missing", () => {
+    const stream = new MarkerStream();
+
+    // Two messages, and the line ending between them never arrived.
+    expect(stream.push("egma:note Reading the manifest.")).toEqual([]);
+    expect(stream.push("egma:found framework retell-sdk\n")).toEqual([
+      { kind: "marker", marker: { kind: "note", text: "Reading the manifest." } },
+      { kind: "marker", marker: { kind: "found", field: "framework", value: "retell-sdk" } },
+    ]);
+  });
+
+  it("leaves a marker alone when somebody is only talking about one", () => {
+    const stream = new MarkerStream();
+
+    expect(stream.push("I will report this with egma:found when I know.\n")).toEqual([
+      { kind: "prose", text: "I will report this with egma:found when I know." },
+    ]);
+  });
+
+  it("reads the last line even when the agent never ended it", () => {
+    const stream = new MarkerStream();
+
+    expect(stream.push("egma:none nothing here")).toEqual([]);
+    expect(stream.flush()).toEqual([
+      { kind: "marker", marker: { kind: "none", reason: "nothing here" } },
+    ]);
+    // And nothing twice.
+    expect(stream.flush()).toEqual([]);
+  });
+});

--- a/apps/cli/test/router.test.ts
+++ b/apps/cli/test/router.test.ts
@@ -43,6 +43,19 @@ describe("keys as data", () => {
     expect(pressed).toEqual(["begin", "quit"]);
   });
 
+  /**
+   * A terminal that has not been taken into raw mode yet turns the carriage
+   * return Enter sends into a line feed, and the renderer calls only the first
+   * of those `return`. The developer pressed one key. So did the test.
+   */
+  it("takes Enter whichever byte the terminal sent for it", () => {
+    pressed.length = 0;
+    expect(dispatchKey(bindings, "\r", {})).toBe(true);
+    expect(dispatchKey(bindings, "\n", {})).toBe(true);
+    expect(dispatchKey(bindings, "", { return: true })).toBe(true);
+    expect(pressed).toEqual(["begin", "begin", "begin"]);
+  });
+
   it("builds the hint bar from the same list, so the two cannot drift", () => {
     const ordered: KeyBinding[] = [
       { ...(bindings[0] as KeyBinding), priority: 0 },

--- a/apps/cli/test/skills.test.ts
+++ b/apps/cli/test/skills.test.ts
@@ -1,0 +1,112 @@
+/**
+ * egma's skills as a shipped artifact.
+ *
+ * A skill nobody can read is not a skill, and a skill that falls out of the
+ * package on the way to npm is worse than none — it works on the machine it was
+ * written on and nowhere else. So this checks the two things a developer could
+ * check for themselves: the files are in the package that `npm pack` would
+ * build, and their content is what the wizard puts in front of a coding agent.
+ */
+
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { SKILL_NAMES, instructionsWith, skill, skillFile } from "../src/skills/index.ts";
+
+const run = promisify(execFile);
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+/** The words the glossary bans, in the shapes that would slip past a reader. */
+const BANNED = [
+  /\beval\b/i,
+  /\bevaluations?\b/i,
+  /\bevaluators?\b/i,
+  /\bcalls?\b/i,
+  /\bcallers?\b/i,
+  /\bconversations?\b/i,
+  /\bdigital humans?\b/i,
+  /\bscenarios?\b/i,
+  /\bsessions?\b/i,
+  /\btrials?\b/i,
+  /\bexperiments?\b/i,
+];
+
+describe("egma's skills", () => {
+  it("are markdown content, shaped the way a skill file is", () => {
+    for (const name of SKILL_NAMES) {
+      const content = skill(name);
+      expect(content.startsWith("---\n")).toBe(true);
+      expect(content).toMatch(/^name: \S+$/m);
+      expect(content).toMatch(/^description: \S.+$/m);
+      // Long enough to teach something, short enough to sit in a prompt.
+      expect(content.length).toBeGreaterThan(1_000);
+      expect(content.length).toBeLessThan(20_000);
+    }
+  });
+
+  it("teach the marker lines egma reads answers from", () => {
+    const finding = skill("context-finding");
+    expect(finding).toContain("egma:found framework");
+    expect(finding).toContain("egma:note");
+    expect(finding).toContain("egma:none");
+    expect(finding).toContain("egma:abort");
+  });
+
+  it("say what a Retell voice agent looks like, both ways round", () => {
+    const retell = skill("retell");
+    expect(retell).toContain("retell-sdk");
+    expect(retell).toContain("Retell dashboard");
+    expect(retell).toContain("agent_");
+    expect(retell).toContain("llm_");
+  });
+
+  it("use the words egma uses, because a skill is user-facing text", () => {
+    for (const name of SKILL_NAMES) {
+      const content = skill(name);
+      for (const banned of BANNED) {
+        expect({ name, banned: String(banned), hit: banned.exec(content)?.[0] ?? null }).toEqual({
+          name,
+          banned: String(banned),
+          hit: null,
+        });
+      }
+      // The bare word is the voice agent; the driven one is always named.
+      expect(content).toContain("voice agent");
+    }
+  });
+
+  it("survive npm packing, which is the only reason they are outside dist", async () => {
+    const { stdout } = await run("npm", ["pack", "--dry-run", "--json"], { cwd: PACKAGE_ROOT });
+    const packed = (JSON.parse(stdout) as { files: { path: string }[] }[])[0];
+    const paths = (packed?.files ?? []).map((file) => file.path);
+
+    for (const name of SKILL_NAMES) {
+      expect(paths).toContain(`skills/${name}.md`);
+    }
+  });
+
+  it("are read out of the package, wherever the package is", () => {
+    for (const name of SKILL_NAMES) {
+      const file = skillFile(name);
+      expect(path.relative(PACKAGE_ROOT, file)).toBe(path.join("skills", `${name}.md`));
+      expect(readFileSync(file, "utf8")).toContain(skill(name));
+    }
+  });
+
+  it("go in front of the task, in the order they were asked for", () => {
+    const instructions = instructionsWith(["context-finding", "retell"], "# Your task\nLook.");
+
+    expect(instructions.indexOf(skill("context-finding"))).toBe(0);
+    expect(instructions.indexOf(skill("retell"))).toBeGreaterThan(0);
+    expect(instructions.indexOf(skill("retell"))).toBeLessThan(
+      instructions.indexOf("# Your task"),
+    );
+    expect(instructions.endsWith("# Your task\nLook.")).toBe(true);
+  });
+});

--- a/apps/cli/test/skills.test.ts
+++ b/apps/cli/test/skills.test.ts
@@ -17,24 +17,55 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 import { SKILL_NAMES, instructionsWith, skill, skillFile } from "../src/skills/index.ts";
+import { FACTS } from "../src/wizard/facts.ts";
+import { pasteFallbackMessage } from "../src/wizard/no-coding-agent.ts";
 
 const run = promisify(execFile);
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
-/** The words the glossary bans, in the shapes that would slip past a reader. */
+/**
+ * The words the glossary bans, in the shapes that would slip past a reader.
+ *
+ * This is the whole banned list, not a sample of it: a skill is text egma puts
+ * in front of a coding agent, and a word egma will not say on a screen is a
+ * word it will not say to a model either.
+ *
+ * Two kinds of entry are left out on purpose, and both are carve-outs the
+ * glossary itself makes rather than gaps.
+ *
+ *   The bans the glossary qualifies — `result` as an entity, `metric` for
+ *   scoring logic, `check` as a name for a grader — cannot be told apart from
+ *   their ordinary English by a regular expression, and a guard that fires on
+ *   "check the manifest" is a guard somebody turns off.
+ *
+ *   `session` is banned for an exchange and right for two seams: a signed-in
+ *   browser session, and the protocol's own name for its connection to a
+ *   driven coding agent. Neither belongs in a skill, so the word is banned
+ *   here in full — the carve-out lives in the code that speaks the protocol.
+ */
 const BANNED = [
   /\beval\b/i,
   /\bevaluations?\b/i,
   /\bevaluators?\b/i,
+  /\bscorers?\b/i,
+  /\bassertions?\b/i,
   /\bcalls?\b/i,
   /\bcallers?\b/i,
   /\bconversations?\b/i,
   /\bdigital humans?\b/i,
+  /\bsimulants?\b/i,
+  /\bvirtual humans?\b/i,
+  /\bsynthetic users?\b/i,
+  /\bdigital twins?\b/i,
   /\bscenarios?\b/i,
   /\bsessions?\b/i,
   /\btrials?\b/i,
+  /\battempts?\b/i,
+  /\biterations?\b/i,
   /\bexperiments?\b/i,
+  /\bbatch(?:es)?\b/i,
+  /\bexpected outcomes?\b/i,
 ];
 
 describe("egma's skills", () => {
@@ -56,6 +87,28 @@ describe("egma's skills", () => {
     expect(finding).toContain("egma:note");
     expect(finding).toContain("egma:none");
     expect(finding).toContain("egma:abort");
+  });
+
+  /**
+   * The facts are prose in three places — this skill, the README, and the
+   * message for a machine with no coding agent on it — and code in one. The
+   * code is the source of truth; this is what keeps the prose from drifting
+   * away from it without anybody noticing.
+   */
+  it("ask for the facts egma reads back, in the words egma reads them", () => {
+    // Prose is wrapped to a width, and a phrase does not stop meaning what it
+    // means because a line ending landed in the middle of it.
+    const unwrapped = (text: string): string => text.replace(/\s+/g, " ");
+
+    const finding = skill("context-finding");
+    const readme = unwrapped(readFileSync(path.join(PACKAGE_ROOT, "README.md"), "utf8"));
+    const pasted = unwrapped(pasteFallbackMessage());
+
+    for (const fact of FACTS) {
+      expect(finding, fact.name).toContain(`\`${fact.name}\``);
+      expect(readme, fact.name).toContain(fact.phrase);
+      expect(pasted, fact.name).toContain(fact.phrase);
+    }
   });
 
   it("say what a Retell voice agent looks like, both ways round", () => {

--- a/apps/cli/test/status.test.ts
+++ b/apps/cli/test/status.test.ts
@@ -55,6 +55,76 @@ describe("what the developer is shown while the agent works", () => {
     ).toEqual([]);
   });
 
+  /**
+   * `◆ Terminal` is a line nobody can check. The command is the whole content
+   * of a terminal action, and a run that shows seven of these shows nothing
+   * seven times.
+   */
+  it("names the command a terminal action runs", () => {
+    const actions = new ActionStream(CWD);
+
+    expect(
+      actions.lines({
+        sessionUpdate: "tool_call",
+        toolCallId: "t1",
+        title: "Terminal",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: "rg -l retell-sdk src", description: "Look for the SDK" },
+      }),
+    ).toEqual(["◆ Terminal ┊ rg -l retell-sdk src"]);
+  });
+
+  it("finds the command wherever the adapter buried it, and keeps it to one line", () => {
+    const actions = new ActionStream(CWD);
+
+    // Split into words by one agent, nested by another, and wrapped by a third.
+    expect(
+      actions.lines({
+        sessionUpdate: "tool_call",
+        toolCallId: "t1",
+        title: "Terminal",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { tool: { input: { terminal: { command: ["cat", "package.json"] } } } },
+      }),
+    ).toEqual(["◆ Terminal ┊ cat package.json"]);
+
+    expect(
+      actions.lines({
+        sessionUpdate: "tool_call",
+        toolCallId: "t2",
+        title: "Terminal",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: `grep -rn "retell"\n  --include=*.ts\n  ${"src/".repeat(30)}` },
+      })[0]?.split("\n"),
+    ).toHaveLength(1);
+  });
+
+  it("says the command as soon as the agent names it, when it comes later", () => {
+    const actions = new ActionStream(CWD);
+
+    expect(
+      actions.lines({
+        sessionUpdate: "tool_call",
+        toolCallId: "t1",
+        title: "Terminal",
+        kind: "execute",
+        status: "pending",
+        rawInput: {},
+      }),
+    ).toEqual(["◆ Terminal"]);
+
+    expect(
+      actions.lines({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "t1",
+        rawInput: { command: "ls prompts" },
+      }),
+    ).toEqual(["┊ ls prompts"]);
+  });
+
   it("shows an action that never names a file rather than swallowing it", () => {
     const actions = new ActionStream(CWD);
 

--- a/apps/cli/test/support/fake-agent.ts
+++ b/apps/cli/test/support/fake-agent.ts
@@ -28,6 +28,8 @@ export type FakeStep =
       title: string;
       toolKind?: acp.ToolKind;
       locations?: Location[];
+      /** The arguments the call carries — a terminal call's command lives here. */
+      rawInput?: Record<string, unknown>;
     }
   | { kind: "tool-call-update"; id: string; status: acp.ToolCallStatus; title?: string }
   | {
@@ -158,6 +160,7 @@ async function run(): Promise<void> {
               kind: step.toolKind ?? "read",
               status: "in_progress",
               locations: step.locations ?? [],
+              ...(step.rawInput === undefined ? {} : { rawInput: step.rawInput }),
             },
           });
           break;

--- a/apps/cli/test/support/fake-agent.ts
+++ b/apps/cli/test/support/fake-agent.ts
@@ -53,7 +53,19 @@ export type FakeScript = {
   spawnChild?: boolean;
   /** Where the record of what happened is written, relative to the folder. */
   reportFile?: string;
+  /**
+   * Refuse the first session with "log in first", the way a cold machine does,
+   * and work normally once the client has authenticated. The login methods the
+   * agent advertises; omit for the ordinary one it runs itself.
+   */
+  authRequiredUntilLogin?: { methods?: acp.AuthMethod[] };
   steps: FakeStep[];
+  /**
+   * Steps to play instead when the session's folder contains this fragment.
+   * A repository whose prompts live somewhere else is two folders and two
+   * answers, and one scripted agent has to give both.
+   */
+  stepsByFolder?: { contains: string; steps: FakeStep[] }[];
 };
 
 const DEFAULT_REPORT_FILE = "fake-agent-report.json";
@@ -70,6 +82,12 @@ type Report = {
   modeSetTo: string | null;
   observations: Record<string, unknown>;
   childPid: number | null;
+  /** Every set of instructions the client sent, in order. */
+  instructions: string[];
+  /** The folder of each session the client opened, in order. */
+  folders: string[];
+  /** Which login method the client picked, if it had to log in at all. */
+  loggedInWith: string | null;
 };
 
 async function run(): Promise<void> {
@@ -80,6 +98,9 @@ async function run(): Promise<void> {
     modeSetTo: null,
     observations: {},
     childPid: null,
+    instructions: [],
+    folders: [],
+    loggedInWith: null,
   };
 
   let cwd = process.cwd();
@@ -104,9 +125,16 @@ async function run(): Promise<void> {
   };
 
   let sessionId = "";
+  let loggedIn = script.authRequiredUntilLogin === undefined;
+
+  /** The steps for the folder the session was opened in. */
+  function stepsFor(folder: string): FakeStep[] {
+    const matched = (script.stepsByFolder ?? []).find((entry) => folder.includes(entry.contains));
+    return matched?.steps ?? script.steps;
+  }
 
   async function play(client: acp.AgentContext, signal: AbortSignal): Promise<acp.StopReason> {
-    for (const step of script.steps) {
+    for (const step of stepsFor(cwd)) {
       if (signal.aborted) return "cancelled";
 
       switch (step.kind) {
@@ -233,14 +261,28 @@ async function run(): Promise<void> {
     .onRequest(acp.methods.agent.initialize, (ctx) => {
       report.protocolVersion = Math.min(ctx.params.protocolVersion, acp.PROTOCOL_VERSION);
       report.clientCapabilities = ctx.params.clientCapabilities ?? null;
+      const login = script.authRequiredUntilLogin;
       return {
         protocolVersion: report.protocolVersion,
         agentCapabilities: { loadSession: false },
+        ...(login === undefined
+          ? {}
+          : { authMethods: login.methods ?? [{ id: "own-login", name: "Log in to Fake Agent" }] }),
       };
     })
+    .onRequest(acp.methods.agent.authenticate, (ctx) => {
+      report.loggedInWith = ctx.params.methodId;
+      loggedIn = true;
+      flush();
+      return {};
+    })
     .onRequest(acp.methods.agent.session.new, (ctx) => {
+      // A cold machine says this before it says anything else, and says it
+      // once: after its own login has run, the same request works.
+      if (!loggedIn) throw new acp.RequestError(-32000, "Authentication required");
       cwd = ctx.params.cwd;
       sessionId = "fake-1";
+      report.folders.push(cwd);
       flush();
       return { sessionId, modes };
     })
@@ -250,6 +292,10 @@ async function run(): Promise<void> {
       return {};
     })
     .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+      for (const block of ctx.params.prompt) {
+        if (block.type === "text") report.instructions.push(block.text);
+      }
+      flush();
       const controller = new AbortController();
       running.set(sessionId, controller);
       const stopReason = await play(ctx.client, controller.signal);

--- a/apps/cli/test/support/pty.ts
+++ b/apps/cli/test/support/pty.ts
@@ -8,6 +8,18 @@
  * output to a headless terminal emulator, and lets a test read either screen:
  * the alternate one the wizard draws on, or the ordinary one whose contents are
  * what a developer scrolls back through.
+ *
+ * A frame does not arrive whole. A pseudo-terminal hands its output over in
+ * chunks of about a kilobyte, and one drawn screen is several of those, so a
+ * test that polls the screen on a timer can read a frame that is half painted:
+ * the first line of the wizard is there and the rest of it is still in flight.
+ * The emulator parses each chunk asynchronously as well, so even a chunk that
+ * has arrived may not be on the screen yet.
+ *
+ * `waitFor` closes both gaps. It is told when a chunk has been *parsed* rather
+ * than when it arrived, and it checks the condition then — so a test waits for
+ * everything it is about to assert, in one condition, and reads the screen that
+ * satisfied it.
  */
 
 import { chmodSync, existsSync } from "node:fs";
@@ -51,9 +63,25 @@ export type TerminalRun = {
   write(input: string): void;
   /** Everything the command has written, escape codes and all. */
   raw(): string;
+  /**
+   * Settles as soon as the condition holds, checked every time a chunk has been
+   * parsed onto the screen. `false` means the budget ran out first.
+   */
+  waitFor(condition: () => boolean, timeoutMs?: number): Promise<boolean>;
   kill(): void;
+  /** The exit code, once everything the command wrote is on the screen. */
   exited: Promise<number>;
 };
+
+/**
+ * How long a condition is given.
+ *
+ * Generous on purpose: this is a real subprocess starting a real Node runtime
+ * inside a test run that is using every core, so the honest budget is one that
+ * cannot be reached by a machine merely being busy. A test that is going to
+ * fail still fails at once, because the condition is checked on every chunk.
+ */
+const WAIT_BUDGET_MS = 20_000;
 
 export function runInTerminal(options: {
   readonly command: string;
@@ -83,16 +111,62 @@ export function runInTerminal(options: {
     env: env as Record<string, string>,
   });
 
+  /** Told every time the screen has changed, not every time bytes arrived. */
+  const watchers = new Set<() => void>();
+  const tell = (): void => {
+    for (const watcher of [...watchers]) watcher();
+  };
+
+  /** Chunks the emulator has been handed and has not parsed yet. */
+  let unparsed = 0;
+
   child.onData((chunk) => {
     raw += chunk;
-    terminal.write(chunk);
+    unparsed += 1;
+    terminal.write(chunk, () => {
+      unparsed -= 1;
+      tell();
+    });
   });
 
+  const waitFor = (condition: () => boolean, timeoutMs = WAIT_BUDGET_MS): Promise<boolean> =>
+    new Promise<boolean>((resolve) => {
+      let done = false;
+      const finish = (held: boolean): void => {
+        if (done) return;
+        done = true;
+        watchers.delete(check);
+        clearInterval(tick);
+        clearTimeout(budget);
+        resolve(held);
+      };
+      function check(): void {
+        if (condition()) finish(true);
+      }
+      // A backstop for a condition that does not depend on the screen at all;
+      // the chunk callbacks are what make this prompt.
+      const tick = setInterval(check, 100);
+      const budget = setTimeout(() => finish(false), timeoutMs);
+      watchers.add(check);
+      check();
+    });
+
   let settle!: (code: number) => void;
-  const exited = new Promise<number>((resolve) => {
+  const finished = new Promise<number>((resolve) => {
     settle = resolve;
   });
-  child.onExit(({ exitCode }) => settle(exitCode));
+  child.onExit(({ exitCode }) => {
+    settle(exitCode);
+    tell();
+  });
+
+  // A command's last words can still be inside the emulator when it exits, and
+  // scrollback is the thing tests read afterwards. So the code arrives once the
+  // screen is caught up with it.
+  const exited = finished.then(async (code) => {
+    await waitFor(() => unparsed === 0, 5_000);
+    return code;
+  });
 
   const readBuffer = (buffer: IBuffer): string => {
     const lines: string[] = [];
@@ -109,6 +183,7 @@ export function runInTerminal(options: {
     screen: () => readBuffer(terminal.buffer.active),
     scrollback: () => readBuffer(terminal.buffer.normal),
     raw: () => raw,
+    waitFor,
     write: (input) => child.write(input),
     kill: () => {
       try {

--- a/apps/cli/test/support/workspace.ts
+++ b/apps/cli/test/support/workspace.ts
@@ -3,7 +3,7 @@
  * gets driven in it.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -13,6 +13,16 @@ import type { DrivenAgentLaunch } from "../../src/acp/registry.ts";
 import type { FakeScript } from "./fake-agent.ts";
 
 export const FAKE_AGENT = fileURLToPath(new URL("./fake-agent.ts", import.meta.url));
+
+/**
+ * A small repository shaped like a Retell voice agent, committed so CI has one.
+ *
+ * Every word of it is invented: a bookbinding workshop that does not exist,
+ * with prompts and tools written for this test and nowhere else.
+ */
+export const RETELL_FIXTURE_REPO = fileURLToPath(
+  new URL("../fixtures/retell-agent", import.meta.url),
+);
 
 /** The file a workspace is given so the walk has something to read. */
 export const MANIFEST = JSON.stringify({ name: "customer-repo", version: "1.0.0" }, null, 2);
@@ -32,10 +42,17 @@ export type Workspace = {
   remove(): Promise<void>;
 };
 
+export type WorkspaceOptions = {
+  /** A folder copied in whole before anything else, e.g. a fixture repository. */
+  readonly from?: string;
+};
+
 export async function makeWorkspace(
   files: Readonly<Record<string, string>> = {},
+  options: WorkspaceOptions = {},
 ): Promise<Workspace> {
   const dir = await mkdtemp(path.join(tmpdir(), "egma-cli-"));
+  if (options.from !== undefined) await cp(options.from, dir, { recursive: true });
   for (const [name, content] of Object.entries(files)) {
     await writeFile(path.join(dir, name), content, "utf8");
   }
@@ -62,6 +79,20 @@ export async function makeWorkspace(
       await rm(dir, { recursive: true, force: true });
     },
   };
+}
+
+/**
+ * Every file in a folder, relative and sorted — the way to check that a step
+ * which promised to leave a repository alone left it alone.
+ */
+export async function filesUnder(dir: string, prefix = ""): Promise<string[]> {
+  const found: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const name = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+    if (entry.isDirectory()) found.push(...(await filesUnder(path.join(dir, entry.name), name)));
+    else found.push(name);
+  }
+  return found.sort();
 }
 
 /** True while the process is alive. */

--- a/apps/cli/test/tui.test.ts
+++ b/apps/cli/test/tui.test.ts
@@ -37,9 +37,9 @@ describe("the wizard on a real terminal", () => {
       steps: [
         { kind: "tool-call", id: "t1", title: "Read", locations: [{ path: "package.json" }] },
         { kind: "read-file", path: "package.json", recordAs: "manifest" },
+        { kind: "say", text: "egma:found framework retell-sdk\n" },
         // A real agent takes seconds; this is long enough to watch it work.
         { kind: "wait", ms: 750 },
-        { kind: "say", text: "It is a package manifest." },
         { kind: "stop", reason: "end_turn" },
       ],
     });
@@ -51,11 +51,13 @@ describe("the wizard on a real terminal", () => {
     });
 
     try {
-      expect(await waitUntil(() => terminal.screen().includes("read package.json"))).toBe(true);
+      expect(
+        await waitUntil(() => terminal.screen().includes("egma is about to find your voice agent")),
+      ).toBe(true);
 
       // The intro says what is about to happen and what the keystroke means.
       const intro = terminal.screen();
-      expect(intro).toContain("This is the first check that egma can drive your own coding agent");
+      expect(intro).toContain("where its prompts live");
       expect(intro).toContain("[enter] begin");
       expect(intro).toContain("[q] quit");
       expect(intro.indexOf("[enter] begin")).toBeLessThan(intro.indexOf("[q] quit"));
@@ -66,16 +68,92 @@ describe("the wizard on a real terminal", () => {
       terminal.write("\r");
 
       expect(await waitUntil(() => terminal.screen().includes("Read package.json"))).toBe(true);
+      // Every fact the agent reports lands on screen as it reports it.
+      expect(
+        await waitUntil(() => terminal.screen().includes("┊ Framework  retell-sdk")),
+      ).toBe(true);
 
       const code = await terminal.exited;
       expect(code).toBe(0);
 
       // Everything the wizard drew is gone. One line is left, and it is plain.
       const left = terminal.scrollback().trim();
-      expect(left).toBe(
-        "node read package.json for egma. Nothing in this folder was changed.",
-      );
+      expect(left).toBe("egma found your voice agent: retell-sdk.");
       expect(left.split("\n")).toHaveLength(1);
+    } finally {
+      terminal.kill();
+    }
+  });
+
+  it("asks once for the prompts when the folder holds no voice agent", async () => {
+    const script = await workspace.script({
+      steps: [
+        { kind: "say", text: "egma:none There is no voice agent in this folder.\n" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+
+    const terminal = runInTerminal({
+      command: process.execPath,
+      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      cwd: workspace.dir,
+    });
+
+    try {
+      expect(
+        await waitUntil(() => terminal.screen().includes("egma is about to find your voice agent")),
+      ).toBe(true);
+      terminal.write("\r");
+
+      expect(
+        await waitUntil(() =>
+          terminal.screen().includes("Nothing in this folder looks like a voice agent"),
+        ),
+      ).toBe(true);
+      expect(terminal.screen()).toContain("[enter] look there");
+      expect(terminal.screen()).toContain("[esc] nowhere else");
+
+      // The developer has nowhere to point egma at, and says so.
+      terminal.write("");
+
+      expect(await terminal.exited).toBe(1);
+      expect(terminal.scrollback().trim()).toBe(
+        "egma found no voice agent to test. Run egma again where your agent is defined.",
+      );
+    } finally {
+      terminal.kill();
+    }
+  });
+
+  it("stops rather than hangs when Ctrl-C lands on that question", async () => {
+    const script = await workspace.script({
+      steps: [
+        { kind: "say", text: "egma:none There is no voice agent in this folder.\n" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+
+    const terminal = runInTerminal({
+      command: process.execPath,
+      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      cwd: workspace.dir,
+    });
+
+    try {
+      expect(
+        await waitUntil(() => terminal.screen().includes("egma is about to find")),
+      ).toBe(true);
+      terminal.write("\r");
+      expect(
+        await waitUntil(() =>
+          terminal.screen().includes("Nothing in this folder looks like a voice agent"),
+        ),
+      ).toBe(true);
+
+      terminal.write("");
+
+      expect(await terminal.exited).toBe(130);
+      expect(terminal.scrollback().trim()).toContain("stopped before the task finished");
     } finally {
       terminal.kill();
     }
@@ -92,7 +170,7 @@ describe("the wizard on a real terminal", () => {
 
     try {
       expect(
-        await waitUntil(() => terminal.screen().includes("This is the first check")),
+        await waitUntil(() => terminal.screen().includes("egma is about to find")),
       ).toBe(true);
 
       terminal.write("q");
@@ -122,7 +200,7 @@ describe("the wizard on a real terminal", () => {
 
     try {
       expect(
-        await waitUntil(() => terminal.screen().includes("This is the first check")),
+        await waitUntil(() => terminal.screen().includes("egma is about to find")),
       ).toBe(true);
       terminal.write("\r");
       expect(await waitUntil(() => terminal.screen().includes("Thinking about it"))).toBe(true);

--- a/apps/cli/test/tui.test.ts
+++ b/apps/cli/test/tui.test.ts
@@ -5,21 +5,46 @@
  * reads both of its screens, so the promise about scrollback is checked as a
  * terminal fact rather than as an intention. Still no model and still no human:
  * the agent is the scripted one and the keystrokes are written by the test.
+ *
+ * Every wait here asks for **everything** the assertions after it will read,
+ * and reads the screen that satisfied the wait. A frame arrives in chunks, so
+ * waiting for its first line and then asserting on its last is a race that
+ * the machine wins whenever it is busy — which is what made this file flaky.
  */
 
 import process from "node:process";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { runInTerminal } from "./support/pty.ts";
-import {
-  CLI_ENTRY,
-  FAKE_AGENT,
-  MANIFEST,
-  makeWorkspace,
-  waitUntil,
-  type Workspace,
-} from "./support/workspace.ts";
+import { runInTerminal, type TerminalRun } from "./support/pty.ts";
+import { CLI_ENTRY, FAKE_AGENT, MANIFEST, makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+// A real subprocess, a real terminal and a test run using every core: the
+// budget is generous so that only a broken wizard can reach it.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+/**
+ * Waits until the screen holds every one of these, and answers that screen.
+ *
+ * The screen is captured at the moment the condition held, so a redraw that
+ * starts immediately afterwards cannot take a line back out from under the
+ * assertions.
+ */
+async function showing(terminal: TerminalRun, ...parts: readonly string[]): Promise<string> {
+  let held = "";
+  const shown = await terminal.waitFor(() => {
+    const screen = terminal.screen();
+    if (!parts.every((part) => screen.includes(part))) return false;
+    held = screen;
+    return true;
+  });
+  if (!shown) {
+    throw new Error(
+      `the terminal never showed all of: ${parts.join(" | ")}\n\nlast screen:\n${terminal.screen()}`,
+    );
+  }
+  return held;
+}
 
 describe("the wizard on a real terminal", () => {
   let workspace: Workspace;
@@ -51,15 +76,14 @@ describe("the wizard on a real terminal", () => {
     });
 
     try {
-      expect(
-        await waitUntil(() => terminal.screen().includes("egma is about to find your voice agent")),
-      ).toBe(true);
-
       // The intro says what is about to happen and what the keystroke means.
-      const intro = terminal.screen();
-      expect(intro).toContain("where its prompts live");
-      expect(intro).toContain("[enter] begin");
-      expect(intro).toContain("[q] quit");
+      const intro = await showing(
+        terminal,
+        "egma is about to find your voice agent",
+        "where its prompts live",
+        "[enter] begin",
+        "[q] quit",
+      );
       expect(intro.indexOf("[enter] begin")).toBeLessThan(intro.indexOf("[q] quit"));
 
       // It is drawn on the alternate screen, so scrollback is still untouched.
@@ -67,11 +91,9 @@ describe("the wizard on a real terminal", () => {
 
       terminal.write("\r");
 
-      expect(await waitUntil(() => terminal.screen().includes("Read package.json"))).toBe(true);
-      // Every fact the agent reports lands on screen as it reports it.
-      expect(
-        await waitUntil(() => terminal.screen().includes("┊ Framework  retell-sdk")),
-      ).toBe(true);
+      // Every action the agent takes, and every fact it reports, lands on
+      // screen while it works.
+      await showing(terminal, "Read package.json", "┊ Framework  retell-sdk");
 
       const code = await terminal.exited;
       expect(code).toBe(0);
@@ -100,18 +122,15 @@ describe("the wizard on a real terminal", () => {
     });
 
     try {
-      expect(
-        await waitUntil(() => terminal.screen().includes("egma is about to find your voice agent")),
-      ).toBe(true);
+      await showing(terminal, "egma is about to find your voice agent", "[enter] begin");
       terminal.write("\r");
 
-      expect(
-        await waitUntil(() =>
-          terminal.screen().includes("Nothing in this folder looks like a voice agent"),
-        ),
-      ).toBe(true);
-      expect(terminal.screen()).toContain("[enter] look there");
-      expect(terminal.screen()).toContain("[esc] nowhere else");
+      await showing(
+        terminal,
+        "Nothing in this folder looks like a voice agent",
+        "[enter] look there",
+        "[esc] nowhere else",
+      );
 
       // The developer has nowhere to point egma at, and says so.
       terminal.write("");
@@ -140,15 +159,9 @@ describe("the wizard on a real terminal", () => {
     });
 
     try {
-      expect(
-        await waitUntil(() => terminal.screen().includes("egma is about to find")),
-      ).toBe(true);
+      await showing(terminal, "egma is about to find", "[enter] begin");
       terminal.write("\r");
-      expect(
-        await waitUntil(() =>
-          terminal.screen().includes("Nothing in this folder looks like a voice agent"),
-        ),
-      ).toBe(true);
+      await showing(terminal, "Nothing in this folder looks like a voice agent", "[esc] nowhere else");
 
       terminal.write("");
 
@@ -169,9 +182,7 @@ describe("the wizard on a real terminal", () => {
     });
 
     try {
-      expect(
-        await waitUntil(() => terminal.screen().includes("egma is about to find")),
-      ).toBe(true);
+      await showing(terminal, "egma is about to find", "[q] quit");
 
       terminal.write("q");
 
@@ -199,11 +210,9 @@ describe("the wizard on a real terminal", () => {
     });
 
     try {
-      expect(
-        await waitUntil(() => terminal.screen().includes("egma is about to find")),
-      ).toBe(true);
+      await showing(terminal, "egma is about to find", "[enter] begin");
       terminal.write("\r");
-      expect(await waitUntil(() => terminal.screen().includes("Thinking about it"))).toBe(true);
+      await showing(terminal, "Thinking about it");
 
       terminal.write("");
 

--- a/apps/cli/test/walk.test.ts
+++ b/apps/cli/test/walk.test.ts
@@ -59,7 +59,7 @@ describe("one task, driven on a scripted agent", () => {
   it("negotiates, sets the mode that stops questions, works, and leaves one line", async () => {
     const script = await workspace.script({
       steps: [
-        { kind: "say", text: "Let me look at that file." },
+        { kind: "say", text: "Let me look at that file.\n" },
         {
           kind: "tool-call",
           id: "t1",
@@ -69,8 +69,7 @@ describe("one task, driven on a scripted agent", () => {
         },
         { kind: "read-file", path: "package.json", recordAs: "manifest" },
         { kind: "tool-call-update", id: "t1", status: "completed" },
-        { kind: "write-file", path: "notes.txt", content: "a package manifest\n" },
-        { kind: "say", text: "It is a package manifest." },
+        { kind: "say", text: "egma:found framework retell-sdk\n" },
         { kind: "stop", reason: "end_turn" },
       ],
     });
@@ -83,19 +82,8 @@ describe("one task, driven on a scripted agent", () => {
       signal: new AbortController().signal,
     });
 
-    expect(report).toEqual({
-      kind: "task-done",
-      drivenAgentName: "Fake Agent",
-      file: "package.json",
-    });
-    expect(buildExitLine(report)).toBe(
-      "Fake Agent read package.json for egma. Nothing in this folder was changed.",
-    );
-
-    // The file the agent was told to write is the one that landed.
-    expect(await readFile(path.join(workspace.dir, "notes.txt"), "utf8")).toBe(
-      "a package manifest\n",
-    );
+    expect(report).toEqual({ kind: "found-agent", framework: "retell-sdk", prompts: null });
+    expect(buildExitLine(report)).toBe("egma found your voice agent: retell-sdk.");
 
     const observed = await reportIn(workspace);
     expect(observed.protocolVersion).toBeGreaterThan(0);
@@ -103,9 +91,11 @@ describe("one task, driven on a scripted agent", () => {
     expect(observed.clientCapabilities?.fs).toEqual({ readTextFile: true, writeTextFile: true });
     expect(observed.observations["manifest"]).toEqual({ read: MANIFEST.length });
 
-    // Every action the agent took was shown, and its own words were kept.
+    // Every action the agent took was shown, and the fact it reported is on the
+    // card, while the words around it are not.
     expect(ui.record.statuses).toContain("◆ Read package.json");
-    expect(ui.record.summary).toContain("It is a package manifest.");
+    expect(ui.record.summary).toContain("Framework  retell-sdk");
+    expect(ui.record.summary).not.toContain("Let me look at that file.");
   });
 
   it("approves what the agent asks for, so the developer is never interrupted", async () => {
@@ -252,7 +242,7 @@ describe("one task, driven on a scripted agent", () => {
     const script = await workspace.script({
       steps: [
         { kind: "grumble", text: "warning: the adapter is talking to itself" },
-        { kind: "say", text: "It is a package manifest." },
+        { kind: "say", text: "egma:found framework retell-sdk\n" },
         { kind: "grumble", text: "warning: and again on the way out" },
         { kind: "stop", reason: "end_turn" },
       ],

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -18,5 +18,10 @@
     "apps/api/test/**/*.ts",
     "apps/cli/test/**/*.ts",
     "apps/cli/smoke/**/*.ts"
+  ],
+  "exclude": [
+    // A committed fixture repository is another project's source, kept as it
+    // would really be written. It is read by tests, never compiled with them.
+    "apps/cli/test/fixtures/**"
   ]
 }


### PR DESCRIPTION
The wizard's first intelligent step. egma ships its know-how as content — a context-finding note and a Retell note, markdown inside the package — and hands them to the developer's own coding agent as the instructions of one task: identify the voice agent in this repository. Nothing is installed on the developer's machine; nothing of the repository transits egma.

The driven agent reports through a small marker grammar (\`egma:note\`, \`egma:found\`, \`egma:none\`, \`egma:abort\`), parsed forgivingly where models decorate and strictly where prose merely mentions a marker. Facts stream as status lines and end in a summary card; terminal actions name the command they run; every marker also lands in the run's log file.

The honest ends all exist: nothing found asks once for a pointer and then says plainly where to run again; no coding agent on the machine prints a complete paste-into-your-agent fallback and exits clean; an agent that stops is reported as stopped, with its reason; an agent that isn't signed in is handed to its own login and the step resumes.

A committed synthetic fixture repo (an invented bindery) carries CI; a smoke drives real Claude Code over a real repository, with a strict switch so a skipped run can never look like a passing one. Along the way a real input bug fell out: Enter pressed in the first beat after render arrived as \`\n\` and was dropped — egma now takes Enter whichever byte the terminal sends.

Merged here with the login work: the wizard now signs in, then finds the agent, in one walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)