### PR TITLE
The whole walk is proved: once offline in CI, and once for real with nobody at the keyboard

### DIFF
--- a/apps/api/test/support/instance.ts
+++ b/apps/api/test/support/instance.ts
@@ -55,7 +55,10 @@ const WEB = path.join(import.meta.dirname, "../../../web");
 export const SETTLE = 120_000;
 
 export type Instance = {
-  /** Where a browser goes. The pages and the API both answer here. */
+  /**
+   * Where a browser goes. The pages and the API both answer here — or, when
+   * the pages were left out, the API alone does.
+   */
   readonly origin: string;
   readonly api: FastifyInstance;
   readonly database: MigratedDatabase;
@@ -70,6 +73,19 @@ export type InstanceOptions = {
    * the store to answer the health check the boot waits on.
    */
   readonly traces?: boolean;
+  /**
+   * Whether the pages are served beside the API. On by default, because that is
+   * what a browser needs and the browser tests are why this exists.
+   *
+   * Off is for a caller that speaks only the HTTP API and never opens a page —
+   * the CLI is the whole of that list. A development server costs a minute or
+   * two to compile the first page, and a caller that will never ask for one
+   * should not pay it. With the pages off, `origin` is the API's own address
+   * and the instance tells itself so, which keeps every address it hands out —
+   * a device-flow approval address most of all — pointing at something that
+   * answers.
+   */
+  readonly web?: boolean;
 };
 
 /** A port nothing is listening on, so two test files never collide. */
@@ -129,8 +145,9 @@ export async function startInstance(
   });
   connectClickHouse({ clickhouseUrl: traceStore.url, maxOpenConnections: 4 });
 
+  const withPages = options.web ?? true;
   const apiPort = await freePort();
-  const webPort = await freePort();
+  const webPort = withPages ? await freePort() : apiPort;
   const origin = `http://127.0.0.1:${webPort}`;
 
   const { app } = buildApi({
@@ -145,30 +162,39 @@ export async function startInstance(
   });
   await app.listen({ host: "127.0.0.1", port: apiPort });
 
-  const web = spawn(
-    path.join(WEB, "node_modules/.bin/next"),
-    ["dev", "--port", String(webPort), "--hostname", "127.0.0.1"],
-    {
-      cwd: WEB,
-      env: {
-        ...process.env,
-        EGMA_API_ORIGIN: `http://127.0.0.1:${apiPort}`,
-        NODE_ENV: "development",
-      },
-      stdio: "ignore",
-    },
-  ) as ChildProcess;
+  const web: ChildProcess | undefined = withPages
+    ? (spawn(
+        path.join(WEB, "node_modules/.bin/next"),
+        ["dev", "--port", String(webPort), "--hostname", "127.0.0.1"],
+        {
+          cwd: WEB,
+          env: {
+            ...process.env,
+            EGMA_API_ORIGIN: `http://127.0.0.1:${apiPort}`,
+            NODE_ENV: "development",
+          },
+          stdio: "ignore",
+        },
+      ) as ChildProcess)
+    : undefined;
 
   // Loudly and at once, rather than after two minutes of nothing answering.
   let failedToStart: Error | undefined;
-  web.on("error", (cause) => {
+  web?.on("error", (cause) => {
     failedToStart = cause;
   });
-  web.on("exit", (code) => {
+  web?.on("exit", (code) => {
     failedToStart ??= new Error(`the web application exited with ${code}`);
   });
 
-  await answers(`${origin}/api/health`, SETTLE, () => failedToStart);
+  // The pages forward `/api/…` to the API, and the API's own health check is
+  // at `/health` — so which address is waited on depends on which of the two
+  // is answering at the origin.
+  await answers(
+    withPages ? `${origin}/api/health` : `${origin}/health`,
+    SETTLE,
+    () => failedToStart,
+  );
 
   return {
     origin,
@@ -176,7 +202,7 @@ export async function startInstance(
     database,
     traceStore,
     async close() {
-      web.kill("SIGTERM");
+      web?.kill("SIGTERM");
       await app.close();
       await disconnect();
       await disconnectClickHouse();

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -213,12 +213,19 @@ provider is actually running and in what it found in your repository. They
 arrive one file at a time, with what is still to come beside them:
 
 ```
-◼ quoted-a-price          written
-▶ lost-the-order-number   writing…
-◻ open-on-sunday
-
-Progress: 2/12
+A test                            ◼ quoted-a-price          written
+                                  ▶ lost-the-order-number   writing…
+One situation to put your agent   ◻ open-on-sunday
+in: what the person on the other
+end wants, and the expected       Progress: 2/12
+behaviors that say what should
+happen.
 ```
+
+Beside them, egma's own words: what a test is, what a run and its simulations
+are, and the difference between a metric and a grader. The cards turn on their
+own and nothing waits on them — the suite is written at exactly the speed it
+would be with the pane closed.
 
 Twelve tests, each with at least one expected behavior. A test with none can
 never fail, so egma will not upload one — it says which file and why, and
@@ -378,7 +385,10 @@ Environment:
 ```
 
 `Ctrl-C` stops a run at any point. The agent, and anything the agent started,
-is shut down before egma exits.
+is shut down before egma exits, and the line left behind says where it stopped.
+If tests had already been written into `egma/tests/`, that line says how many
+are there — they are yours, and egma never removes them to tidy up its own
+report.
 
 ## Requirements
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -18,7 +18,8 @@
     "build": "tsc -b",
     "smoke": "node smoke/real-claude-code.ts && node smoke/real-claude-code-fence.ts && node smoke/real-claude-code-discovery.ts && node smoke/real-claude-code-generation.ts",
     "smoke:platform": "node smoke/real-platform-login.ts",
-    "smoke:retell": "node smoke/real-retell-connect.ts"
+    "smoke:retell": "node smoke/real-retell-connect.ts",
+    "smoke:e2e": "node smoke/real-wizard-e2e.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",

--- a/apps/cli/smoke/real-retell-connect.ts
+++ b/apps/cli/smoke/real-retell-connect.ts
@@ -7,10 +7,11 @@
  * field names, the two halves an agent is really in.
  *
  * **It is read-only, and the read-only-ness is enforced rather than promised.**
- * Retell is not reached directly: everything goes through a gate started here
- * that forwards the listing and the reads behind it and refuses everything
- * else, so a change that made the CLI write could not do it through this check. The account belongs to
- * somebody and the agents on it answer real telephone numbers.
+ * Retell is not reached directly: everything goes through the gate in
+ * `support/retell-gate.ts`, started here, which forwards the listing and the
+ * reads behind it and refuses everything else — so a change that made the CLI
+ * write could not do it through this check. The account belongs to somebody and
+ * the agents on it answer real telephone numbers.
  *
  * The platform side is the fixture, so nothing is written to a real egma
  * either. What lands there is asserted; the account is never named in what this
@@ -32,16 +33,14 @@
  */
 
 import { spawn } from "node:child_process";
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { RETELL_API } from "../src/retell/client.ts";
 import { startPlatform, type Platform } from "../test/support/fixture-platform/index.ts";
+import { openGate, type Gate } from "./support/retell-gate.ts";
 
 const CLI_ENTRY = fileURLToPath(new URL("../dist/bin.js", import.meta.url));
 
@@ -102,99 +101,6 @@ function nothingWasVerified(strict: boolean): void {
     say("  with a failure instead.");
   }
   say(RULE);
-}
-
-/* ── the read-only gate ──────────────────────────────────────────────── */
-
-/** Exactly what this check is allowed to ask Retell for. */
-const ALLOWED: readonly { method: string; path: RegExp }[] = [
-  { method: "POST", path: /^\/v2\/list-agents$/u },
-  { method: "GET", path: /^\/get-agent\/[^/]+$/u },
-  { method: "GET", path: /^\/get-chat-agent\/[^/]+$/u },
-  { method: "GET", path: /^\/get-retell-llm\/[^/]+$/u },
-  { method: "GET", path: /^\/get-conversation-flow\/[^/]+$/u },
-];
-
-type Gate = {
-  readonly url: string;
-  /** How many reads were forwarded, by path shape. */
-  readonly forwarded: string[];
-  /** Anything the gate turned away. One entry here fails the whole run. */
-  readonly refused: string[];
-  /** What Retell answered, exactly, keyed by path — for a byte-for-byte check. */
-  answered(path: string): string | undefined;
-  close(): Promise<void>;
-};
-
-/**
- * A gate in front of Retell that forwards reads and refuses everything else.
- *
- * It is what makes "read-only" a property of this run rather than a promise
- * about the code: a request to create, update or delete never leaves this
- * machine, whatever the CLI asks for.
- */
-async function openGate(): Promise<Gate> {
-  const forwarded: string[] = [];
-  const refused: string[] = [];
-  const answers = new Map<string, string>();
-
-  const server: Server = createServer(
-    (incoming: IncomingMessage, outgoing: ServerResponse) => {
-      void (async () => {
-        const chunks: Buffer[] = [];
-        for await (const chunk of incoming) chunks.push(chunk as Buffer);
-        const raw = Buffer.concat(chunks).toString("utf8");
-
-        const at = new URL(incoming.url ?? "/", "http://gate.invalid");
-        const method = incoming.method ?? "GET";
-        const allowed = ALLOWED.some(
-          (rule) => rule.method === method && rule.path.test(at.pathname),
-        );
-
-        if (!allowed) {
-          refused.push(`${method} ${at.pathname}`);
-          outgoing.writeHead(403, { "content-type": "application/json" });
-          outgoing.end(JSON.stringify({ error_message: "this check is read-only" }));
-          return;
-        }
-
-        const answer = await fetch(`${RETELL_API}${at.pathname}${at.search}`, {
-          method,
-          headers: {
-            authorization: incoming.headers.authorization ?? "",
-            ...(raw === "" ? {} : { "content-type": "application/json" }),
-          },
-          ...(raw === "" ? {} : { body: raw }),
-        });
-        const body = await answer.text();
-
-        // The shape, never the identifier: which reads were made is worth
-        // printing, and whose agents they were is not.
-        forwarded.push(`${method} ${at.pathname.replace(/^(\/get-[a-z-]+)\/.+$/u, "$1/…")}`);
-        if (answer.ok) answers.set(at.pathname, body);
-
-        outgoing.writeHead(answer.status, { "content-type": "application/json" });
-        outgoing.end(body);
-      })();
-    },
-  );
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address() as AddressInfo;
-
-  return {
-    url: `http://127.0.0.1:${address.port}`,
-    forwarded,
-    refused,
-    answered: (at) => answers.get(at),
-    async close() {
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      });
-    },
-  };
 }
 
 /* ── running the command ─────────────────────────────────────────────── */

--- a/apps/cli/smoke/real-wizard-e2e.ts
+++ b/apps/cli/smoke/real-wizard-e2e.ts
@@ -78,9 +78,9 @@ const NO_BROWSER = "/usr/bin/true";
  * How many tests have to land for this to be a pass.
  *
  * Fewer than the suite egma asks for, on purpose. How many a real coding agent
- * writes is the agent's business and generation quality is a different question
- * with a ticket of its own; what is being proved here is that what it wrote
- * reached the platform as frozen versions and reached the repository as files.
+ * writes is the agent's business, and how good the tests are is a different
+ * question altogether; what is being proved here is that what it wrote reached
+ * the platform as frozen versions and reached the repository as files.
  */
 const TESTS_ENOUGH = 6;
 
@@ -276,6 +276,32 @@ async function showing(
   return held;
 }
 
+/**
+ * Every name the walk has registered so far, held as a thing never to print.
+ *
+ * It reads the key this walk's own wizard just stored, in this walk's own home,
+ * and asks the platform what is under it. Nothing here is a check and a look
+ * that fails fails quietly: what it buys is that the screens printed after it
+ * are redacted by this script, which is where that decision belongs.
+ */
+async function rememberNames(platform: HalfRealPlatform, home: string): Promise<void> {
+  try {
+    const held = JSON.parse(await readFile(path.join(home, "credentials"), "utf8")) as {
+      key?: unknown;
+    };
+    if (typeof held.key !== "string") return;
+    const agents = await askThePlatform(platform.url, held.key, "/api/agents");
+    const items = Array.isArray(agents.body.items)
+      ? (agents.body.items as Record<string, unknown>[])
+      : [];
+    for (const agent of items) {
+      if (typeof agent.name === "string") secrets.push(agent.name);
+    }
+  } catch {
+    // Nothing to add, and nothing that depends on it.
+  }
+}
+
 async function walkOnce(options: {
   readonly label: string;
   readonly platform: HalfRealPlatform;
@@ -371,6 +397,13 @@ async function walkOnce(options: {
     /* [human 4] no, there are no test cases written down already */
     await showing(terminal, "the question about prior work", BUDGET.existing, "Do you already have");
     terminal.write("n");
+
+    // Everything registered so far becomes a secret before the first screen is
+    // printed. Whose agents these were is not worth printing and the line that
+    // names them is filtered out below anyway — but a screen that is clean
+    // because one filter happened to match is clean by luck, and this makes it
+    // clean by redaction, which is the only kind that survives a wording change.
+    await rememberNames(options.platform, home);
 
     /* [human 5] the keystroke at the gate */
     await showing(terminal, "the gate", BUDGET.gate, "[enter] run");
@@ -664,7 +697,17 @@ async function main(): Promise<void> {
   say(RULE);
 }
 
-await main();
+try {
+  await main();
+} catch (problem) {
+  // The last place a path could get out. A copy that fails throws with the
+  // folder it was copying in the message, and Node would print that whole
+  // stack — so the stack goes through the same redaction as everything else
+  // and the run ends as a failure rather than as an unhandled rejection.
+  say("");
+  say(redact(problem instanceof Error ? (problem.stack ?? problem.message) : String(problem)));
+  process.exitCode = 1;
+}
 
 // A pseudo-terminal and an adapter's own process tree can both outlive what
 // started them, and either keeps Node alive. This leaves on its own answer once

--- a/apps/cli/smoke/real-wizard-e2e.ts
+++ b/apps/cli/smoke/real-wizard-e2e.ts
@@ -1,0 +1,675 @@
+/**
+ * The smoke check: the whole wizard, everything real, nobody at the keyboard.
+ *
+ * One command drives `npx egma` from its first screen to its last against the
+ * real things it is meant to work against: the developer's own coding agent
+ * over the protocol, a whole egma running on this machine, the developer's own
+ * repository, and a real Retell account. No fixture agent, no fake provider, no
+ * stubbed adapter. What is not real is named in one place —
+ * `support/half-real-platform.ts` — and it is exactly the endpoints the public
+ * API has not shipped yet.
+ *
+ * **Nobody types anything.** The wizard's five human moments are answered by
+ * this check through a real pseudo-terminal: the keystroke at the intro, the
+ * approval in a browser (made against the instance's own API, which is what the
+ * page would have called), the provider key, the choice of agent when the
+ * account holds several, and the keystroke at the gate.
+ *
+ * **The Retell account is only ever read.** Every request goes through the
+ * allow-list gate in `support/retell-gate.ts`, which forwards the listing and
+ * the reads behind it and refuses everything else. The agents on that account
+ * answer real telephone numbers; a write would be unacceptable and this makes
+ * it impossible rather than unlikely.
+ *
+ * **The provider key is typed, never exported.** It is taken out of this
+ * check's own environment before the wizard is started, so the coding agent
+ * egma drives — which inherits that environment — never has it in reach.
+ *
+ * Run it with:
+ *
+ *   set -a; . ~/.egma-dev-secrets.env; set +a
+ *   node apps/cli/smoke/real-wizard-e2e.ts
+ *
+ * It needs the Postgres and ClickHouse this repository's compose file brings
+ * up, already running; a coding agent installed and logged in; `EGMA_E2E_TARGET_REPO`
+ * pointing at a repository with a voice agent in it; and `RETELL_API_KEY`.
+ *
+ * Useful arguments:
+ *
+ *   --coding-agent <id>   Which agent to drive, as the registry names it.
+ *   --again               Walk a second time against the same egma, which is
+ *                         what proves a second run lands beside the first.
+ *   --require-target      Turn a skip into a failure, for a machine that is
+ *                         supposed to have all of this. `EGMA_SMOKE_REQUIRE_TARGET=1`
+ *                         does the same.
+ */
+
+import { cp, mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { startInstance, type Instance } from "../../api/test/support/instance.ts";
+import { DEFAULT_DRIVEN_AGENT_ID, launchForId } from "../src/acp/registry.ts";
+import { parseTestFile } from "../src/folder/test-file.ts";
+import { runInTerminal, type TerminalRun } from "../test/support/pty.ts";
+import { startHalfRealPlatform, type HalfRealPlatform } from "./support/half-real-platform.ts";
+import { openGate, type Gate } from "./support/retell-gate.ts";
+
+const CLI_ENTRY = fileURLToPath(new URL("../dist/bin.js", import.meta.url));
+
+/** The repository this walks in. Never named in anything committed here. */
+const TARGET_VARIABLE = "EGMA_E2E_TARGET_REPO";
+
+/** The one committed name for the key this check runs against. */
+const KEY_VARIABLE = "RETELL_API_KEY";
+
+/** The other name the command reads a key from, kept out of its environment. */
+const OTHER_KEY_VARIABLES = ["EGMA_RETELL_API_KEY"] as const;
+
+const STRICT_VARIABLE = "EGMA_SMOKE_REQUIRE_TARGET";
+const STRICT_FLAG = "--require-target";
+
+/** A browser this check must not open: it approves through the API instead. */
+const NO_BROWSER = "/usr/bin/true";
+
+/**
+ * How many tests have to land for this to be a pass.
+ *
+ * Fewer than the suite egma asks for, on purpose. How many a real coding agent
+ * writes is the agent's business and generation quality is a different question
+ * with a ticket of its own; what is being proved here is that what it wrote
+ * reached the platform as frozen versions and reached the repository as files.
+ */
+const TESTS_ENOUGH = 6;
+
+/** What the walk is given for each phase, in milliseconds. */
+const BUDGET = {
+  intro: 3 * 60_000,
+  login: 3 * 60_000,
+  key: 15 * 60_000,
+  agent: 2 * 60_000,
+  existing: 2 * 60_000,
+  gate: 25 * 60_000,
+  exit: 5 * 60_000,
+};
+
+const RULE = "─".repeat(58);
+
+const problems: string[] = [];
+/** Everything that must never appear in what this prints. */
+const secrets: string[] = [];
+
+function say(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function check(condition: boolean, what: string): void {
+  say(`${condition ? "  ok  " : "FAILED"}  ${what}`);
+  if (!condition) problems.push(what);
+}
+
+/**
+ * The text with everything that names the account or the machine taken out.
+ *
+ * A passing run of this is pasted into reviews, so the account it read and the
+ * developer's own paths must not be readable from it. Counts and shapes are the
+ * point; contents never were.
+ */
+function redact(text: string): string {
+  return [...new Set(secrets)]
+    .filter((one) => one.length > 3)
+    .sort((left, right) => right.length - left.length)
+    .reduce((held, one) => held.split(one).join("<redacted>"), text);
+}
+
+function requiresTarget(): boolean {
+  if (process.argv.includes(STRICT_FLAG)) return true;
+  const set = (process.env[STRICT_VARIABLE] ?? "").trim().toLowerCase();
+  return set !== "" && set !== "0" && set !== "false" && set !== "no";
+}
+
+function nothingWasVerified(strict: boolean, missing: readonly string[]): void {
+  const headline = strict
+    ? "FAILED — nothing was verified, and this run required a target"
+    : "SKIPPED — nothing was verified";
+
+  say(RULE);
+  say(`  ${headline}`);
+  say(RULE);
+  say(`  ${missing.join(" and ")} ${missing.length === 1 ? "is" : "are"} not set, so no`);
+  say("  wizard was started, no request was made, and nothing at all was");
+  say("  checked.");
+  say("");
+  say(`  ${TARGET_VARIABLE} points at a repository with a voice agent in it. It`);
+  say("  is copied before anything runs, so the repository itself is never");
+  say("  written to.");
+  say(`  ${KEY_VARIABLE} is a key for a real Retell account. Nothing on that`);
+  say("  account is written to: this check lists agents and reads");
+  say("  configuration, and a gate it starts refuses anything else.");
+  if (!strict) {
+    say("");
+    say("  Where a skip must not look like a pass — CI, or a machine that is");
+    say(`  supposed to have both — run this with ${STRICT_FLAG}, or with`);
+    say(`  ${STRICT_VARIABLE}=1, and a missing one ends the run`);
+    say("  with a failure instead.");
+  }
+  say(RULE);
+}
+
+/** The value after a flag, or `null` when it was not given. */
+function argumentAfter(flag: string): string | null {
+  const at = process.argv.indexOf(flag);
+  if (at === -1) return null;
+  return process.argv[at + 1] ?? null;
+}
+
+/* ── the person in the browser ───────────────────────────────────────── */
+
+/** The cookie header a browser would send back, given what it was just set. */
+function cookiesFrom(setCookie: string | null): string {
+  return (setCookie ?? "")
+    .split(/,(?=[^;]+?=)/u)
+    .map((cookie) => cookie.split(";", 1)[0]?.trim() ?? "")
+    .filter((cookie) => cookie !== "")
+    .join("; ");
+}
+
+/**
+ * The account this run signs up as, once.
+ *
+ * Once and not twice: a second walk has to land in the same project as the
+ * first for the second registration to mean anything, and a second signup would
+ * be a different customer entirely.
+ */
+async function signUp(apiOrigin: string): Promise<string> {
+  const created = await fetch(`${apiOrigin}/api/signup`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email: `ada+${Date.now()}@acme.example`,
+      password: "a-long-enough-password",
+      organizationName: "Acme",
+      projectName: "Default",
+    }),
+  });
+  if (created.status !== 201) {
+    throw new Error(`the instance would not take a signup (${created.status})`);
+  }
+  return cookiesFrom(created.headers.get("set-cookie"));
+}
+
+/**
+ * What the person looking at the approval page would have clicked.
+ *
+ * It is the request that page makes, made directly. The page itself is a
+ * browser check's business and has one of its own; what this needs is for the
+ * terminal's code to be approved by a real signed-in account on the real
+ * instance, which is what this is.
+ */
+async function approve(apiOrigin: string, cookie: string, userCode: string): Promise<string> {
+  const answered = await fetch(`${apiOrigin}/api/device/approve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify({ user_code: userCode }),
+  });
+  const held = (await answered.json().catch(() => ({}))) as { status?: unknown };
+  return typeof held.status === "string" ? held.status : `http ${answered.status}`;
+}
+
+/* ── the repository the walk runs in ─────────────────────────────────── */
+
+/** What is never worth copying, and would make the copy enormous. */
+const NOT_COPIED = new Set([".git", "node_modules", "dist", ".next", ".turbo", "target"]);
+
+/**
+ * A copy of the developer's repository, so the walk writes into a copy.
+ *
+ * The wizard makes an `egma/` folder in the repository it runs in, and this
+ * check runs several times a day. Copying is what keeps somebody's real
+ * checkout out of it — and what is copied is their real code, which is the part
+ * that matters to a coding agent reading it.
+ */
+async function copyOfTheRepository(from: string, label: string): Promise<string> {
+  const into = await mkdtemp(path.join(tmpdir(), `egma-e2e-${label}-`));
+  await cp(from, into, {
+    recursive: true,
+    filter: (source) => !NOT_COPIED.has(path.basename(source)),
+  });
+  return into;
+}
+
+/* ── the walk ────────────────────────────────────────────────────────── */
+
+type Timing = { readonly phase: string; readonly seconds: string };
+
+type WalkOutcome = {
+  readonly exitCode: number;
+  readonly exitLine: string;
+  readonly timings: readonly Timing[];
+  readonly credentials: { readonly url: string; readonly key: string };
+  readonly repository: string;
+  /** Whether the account offered a choice of agents, and how many. */
+  readonly chosenFrom: number;
+};
+
+/** Waits for every one of these to be on screen, or says what was there. */
+async function showing(
+  terminal: TerminalRun,
+  what: string,
+  budgetMs: number,
+  ...parts: readonly string[]
+): Promise<string> {
+  let held = "";
+  const shown = await terminal.waitFor(() => {
+    const screen = terminal.screen();
+    if (!parts.every((part) => screen.includes(part))) return false;
+    held = screen;
+    return true;
+  }, budgetMs);
+  if (!shown) {
+    throw new Error(
+      `the wizard never got to ${what}\n\nlast screen:\n${redact(terminal.screen())}`,
+    );
+  }
+  return held;
+}
+
+async function walkOnce(options: {
+  readonly label: string;
+  readonly platform: HalfRealPlatform;
+  readonly gate: Gate;
+  readonly cookie: string;
+  readonly drivenAgentId: string;
+  readonly targetRepo: string;
+  readonly key: string;
+}): Promise<WalkOutcome> {
+  const repository = await copyOfTheRepository(options.targetRepo, options.label);
+  const home = await mkdtemp(path.join(tmpdir(), `egma-e2e-home-${options.label}-`));
+  secrets.push(repository, home);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    EGMA_HOME: home,
+    BROWSER: NO_BROWSER,
+    EGMA_RETELL_URL: options.gate.url,
+  };
+  // The key is typed at the screen that asks for it and is in nothing the
+  // wizard — or the coding agent it starts, which inherits this — can read.
+  delete env[KEY_VARIABLE];
+  for (const other of OTHER_KEY_VARIABLES) delete env[other];
+  delete env.EGMA_URL;
+  delete env.EGMA_RETELL_AGENT_ID;
+  delete env[TARGET_VARIABLE];
+
+  const timings: Timing[] = [];
+  let since = Date.now();
+  const took = (phase: string): void => {
+    timings.push({ phase, seconds: ((Date.now() - since) / 1000).toFixed(1) });
+    since = Date.now();
+  };
+
+  const terminal = runInTerminal({
+    command: process.execPath,
+    args: [
+      CLI_ENTRY,
+      "--cwd",
+      repository,
+      "--url",
+      options.platform.url,
+      "--coding-agent",
+      options.drivenAgentId,
+    ],
+    cwd: repository,
+    env,
+    cols: 110,
+    rows: 34,
+  });
+
+  let chosenFrom = 1;
+
+  try {
+    /* [human 1] the keystroke at the intro */
+    await showing(terminal, "the intro", BUDGET.intro, "[enter] begin");
+    terminal.write("\r");
+    took("intro");
+
+    /* [human 2] the approval in a browser */
+    const shown = await showing(terminal, "the login code", BUDGET.login, "Code:");
+    const userCode = /Code: (\S+)/u.exec(shown)?.[1] ?? "";
+    if (userCode === "") throw new Error("the wizard showed no code to approve");
+    const status = await approve(options.platform.apiOrigin, options.cookie, userCode);
+    check(status === "approved", `the instance approved the terminal (it said ${status})`);
+
+    /* [human 3] the provider key */
+    await showing(terminal, "the key box", BUDGET.key, "Paste your Retell API key");
+    took("login and finding the agent");
+    terminal.write(`${options.key}\r`);
+
+    /* [human 3b, only when the account holds several] which agent */
+    const nextScreen = await terminal.waitFor(
+      () =>
+        terminal.screen().includes("Which one do you want tested?") ||
+        terminal.screen().includes("Do you already have test cases"),
+      BUDGET.agent,
+    );
+    if (!nextScreen) {
+      throw new Error(
+        `the wizard never got past the key\n\nlast screen:\n${redact(terminal.screen())}`,
+      );
+    }
+    if (terminal.screen().includes("Which one do you want tested?")) {
+      const listed = /reaches (\d+) agents/u.exec(terminal.screen())?.[1] ?? "0";
+      chosenFrom = Number(listed);
+      // The first of them. Which agent is the developer's choice on a real
+      // account, and any of them proves the same thing about the walk.
+      terminal.write("\r");
+    }
+    took("connecting");
+
+    /* [human 4] no, there are no test cases written down already */
+    await showing(terminal, "the question about prior work", BUDGET.existing, "Do you already have");
+    terminal.write("n");
+
+    /* [human 5] the keystroke at the gate */
+    await showing(terminal, "the gate", BUDGET.gate, "[enter] run");
+    const listing = terminal.screen();
+    took("writing the tests");
+    say("");
+    say("── the gate, as it was drawn ─────────────────────────────");
+    // Every line but the one naming the account's own agent: what is worth
+    // printing is that a suite was written and what it covers.
+    say(
+      redact(
+        listing
+          .split("\n")
+          .filter((line) => !line.includes("Run these against"))
+          .join("\n"),
+      ),
+    );
+    terminal.write("\r");
+
+    const exitCode = await Promise.race([
+      terminal.exited,
+      new Promise<number>((_, reject) =>
+        setTimeout(() => reject(new Error("the wizard never finished")), BUDGET.exit),
+      ),
+    ]);
+    took("pushing");
+
+    const held = JSON.parse(await readFile(path.join(home, "credentials"), "utf8")) as {
+      url: string;
+      key: string;
+    };
+    secrets.push(held.key);
+
+    return {
+      exitCode,
+      exitLine: terminal.scrollback().trim(),
+      timings,
+      credentials: held,
+      repository,
+      chosenFrom,
+    };
+  } finally {
+    await terminal.kill();
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+/* ── what landed ─────────────────────────────────────────────────────── */
+
+type Asked = { readonly status: number; readonly body: Record<string, unknown> };
+
+async function askThePlatform(
+  url: string,
+  key: string,
+  at: string,
+): Promise<Asked> {
+  const answered = await fetch(`${url}${at}`, { headers: { authorization: `Bearer ${key}` } });
+  const body = (await answered.json().catch(() => ({}))) as Record<string, unknown>;
+  return { status: answered.status, body };
+}
+
+async function assertWhatLanded(options: {
+  readonly platform: HalfRealPlatform;
+  readonly outcome: WalkOutcome;
+  readonly key: string;
+  readonly walk: number;
+}): Promise<string> {
+  const { platform, outcome } = options;
+  const held = outcome.credentials;
+
+  say("");
+  say(`── what walk ${options.walk} left on the platform ─────────────────`);
+
+  check(outcome.exitCode === 0, `the wizard exited 0 (it exited ${outcome.exitCode})`);
+  check(held.url === platform.url, "the key is stored against the egma it signed in to");
+  check(held.key.startsWith("egma_sk_"), "the key is one the instance really minted");
+
+  // The real half: the key opens a real door on a real instance.
+  const opened = await fetch(`${platform.apiOrigin}/api/keys`, {
+    headers: { authorization: `Bearer ${held.key}` },
+  });
+  check(opened.status === 200, `the key works on the real instance (it answered ${opened.status})`);
+
+  const agents = await askThePlatform(platform.url, held.key, "/api/agents");
+  const items = Array.isArray(agents.body.items) ? (agents.body.items as Record<string, unknown>[]) : [];
+  check(items.length === options.walk, `the platform holds ${items.length} agent(s) after walk ${options.walk}`);
+
+  const agent = items.at(-1);
+  const agentId = typeof agent?.id === "string" ? agent.id : "";
+  const agentName = typeof agent?.name === "string" ? agent.name : "";
+  secrets.push(agentName);
+  check(agentId !== "", "the agent egma registered has an id");
+
+  const one = await askThePlatform(platform.url, held.key, `/api/agents/${agentId}`);
+  const connections = Array.isArray(one.body.connections)
+    ? (one.body.connections as Record<string, unknown>[])
+    : [];
+  const connection = connections.at(-1);
+  check(connections.length >= 1, `a connection is attached to it (${connections.length})`);
+  check(connection?.type === "retell", `the connection is a retell one (${String(connection?.type)})`);
+  check(
+    connection?.modality === "voice" || connection?.modality === "chat",
+    `the connection names a modality (${String(connection?.modality)})`,
+  );
+  check(
+    connection?.credentialsHint === options.key.slice(-4),
+    "the key was sealed on the platform, and only its last characters came back",
+  );
+
+  const tests = await askThePlatform(platform.url, held.key, "/api/tests");
+  const landed = Array.isArray(tests.body.tests)
+    ? (tests.body.tests as Record<string, unknown>[])
+    : [];
+  const pinned = landed.filter((test) => String(test.version_id).startsWith("tstv_"));
+  check(
+    pinned.length >= TESTS_ENOUGH * options.walk,
+    `${pinned.length} tests are on the platform as frozen versions (wanted at least ${TESTS_ENOUGH * options.walk})`,
+  );
+
+  // And the same tests are files in the repository, each pinned to the version
+  // the platform answered with.
+  const folder = path.join(outcome.repository, "egma", "tests");
+  const files = (await readdir(folder).catch(() => [] as string[])).filter((name) =>
+    name.endsWith(".md"),
+  );
+  const versions = new Set(landed.map((test) => String(test.version_id)));
+  let pinnedFiles = 0;
+  for (const name of files) {
+    const test = parseTestFile(
+      await readFile(path.join(folder, name), "utf8"),
+      name,
+      name.replace(/\.md$/u, ""),
+    );
+    if (test.version !== null && versions.has(test.version)) pinnedFiles += 1;
+  }
+  check(
+    pinnedFiles >= TESTS_ENOUGH,
+    `${pinnedFiles} of the ${files.length} files in the repository pin a version the platform answered with`,
+  );
+
+  return agentName;
+}
+
+/* ── the check itself ────────────────────────────────────────────────── */
+
+async function main(): Promise<void> {
+  const targetRepo = (process.env[TARGET_VARIABLE] ?? "").trim();
+  const key = (process.env[KEY_VARIABLE] ?? "").trim();
+
+  const missing = [
+    ...(targetRepo === "" ? [TARGET_VARIABLE] : []),
+    ...(key === "" ? [KEY_VARIABLE] : []),
+  ];
+  if (missing.length > 0) {
+    const strict = requiresTarget();
+    nothingWasVerified(strict, missing);
+    if (strict) process.exitCode = 1;
+    return;
+  }
+  secrets.push(key, targetRepo);
+
+  if (!(await stat(targetRepo).then((found) => found.isDirectory(), () => false))) {
+    say(`FAILED: ${TARGET_VARIABLE} does not point at a folder.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const drivenAgentId = argumentAfter("--coding-agent") ?? DEFAULT_DRIVEN_AGENT_ID;
+  const walks = process.argv.includes("--again") ? 2 : 1;
+
+  // A name and a launch this machine can really start, before anything else is
+  // brought up: a typo in the agent id should cost a second, not a boot.
+  const launch = launchForId(drivenAgentId);
+
+  const real = path.join(process.env.HOME ?? "", ".egma", "credentials");
+  const before = await stat(real).then((found) => `${found.mtimeMs}`, () => "absent");
+
+  // The API writes a line per request, and one walk makes a great many.
+  process.env.LOG_LEVEL ??= "silent";
+
+  say(RULE);
+  say("  The whole wizard, everything real, nobody at the keyboard");
+  say(RULE);
+  say(`  coding agent:  ${launch.name} (${launch.id})`);
+  say(`  starts with:   ${launch.command} ${launch.args.join(" ")}`);
+  say(
+    `  its own env:   ${Object.keys(launch.env).length === 0 ? "nothing added" : Object.entries(launch.env).map(([name, value]) => `${name}=${value}`).join(", ")}`,
+  );
+  say(`  walks:         ${walks}`);
+  say(`  Retell:        read-only, through a gate on this machine`);
+  say("");
+
+  let instance: Instance | undefined;
+  let platform: HalfRealPlatform | undefined;
+  let gate: Gate | undefined;
+  const walked: WalkOutcome[] = [];
+  const names: string[] = [];
+
+  try {
+    const bootedAt = Date.now();
+    // The pages are left out: the CLI speaks the HTTP API and opens no page,
+    // and a development server would put two minutes in front of every run.
+    instance = await startInstance("cli-e2e", { web: false });
+    gate = await openGate();
+    platform = await startHalfRealPlatform(instance.origin);
+    const cookie = await signUp(instance.origin);
+    say(`Instance up in ${((Date.now() - bootedAt) / 1000).toFixed(1)}s.`);
+
+    for (let walk = 1; walk <= walks; walk += 1) {
+      say("");
+      say(RULE);
+      say(`  walk ${walk} of ${walks}`);
+      say(RULE);
+
+      const outcome = await walkOnce({
+        label: `walk${walk}`,
+        platform,
+        gate,
+        cookie,
+        drivenAgentId,
+        targetRepo,
+        key,
+      });
+      walked.push(outcome);
+
+      say("");
+      say("── the line it left behind ───────────────────────────────");
+      say(redact(outcome.exitLine));
+      say("");
+      say("── how long each phase took ──────────────────────────────");
+      for (const timing of outcome.timings) {
+        say(`  ${timing.phase.padEnd(28)} ${timing.seconds.padStart(7)}s`);
+      }
+      if (outcome.chosenFrom > 1) {
+        say(`  (the account listed ${outcome.chosenFrom} agents, and the first was taken)`);
+      }
+
+      names.push(await assertWhatLanded({ platform, outcome, key, walk }));
+    }
+
+    say("");
+    say("── what was asked of Retell, and what was refused ────────");
+    for (const shape of [...new Set(gate.forwarded)]) {
+      say(`  ${shape}  ×${gate.forwarded.filter((one) => one === shape).length}`);
+    }
+    say(`  refused: ${gate.refused.length}`);
+
+    say("");
+    say("── check ────────────────────────────────────────────────");
+    check(gate.refused.length === 0, "nothing but reads was asked of Retell");
+    check(
+      platform.served.real > 0 && platform.served.fixture > 0,
+      `the walk spoke to the real instance ${platform.served.real} times and to the endpoints it does not serve yet ${platform.served.fixture} times`,
+    );
+
+    if (walks > 1) {
+      // A second walk against an egma that already holds the first one's
+      // registration lands beside it rather than refusing.
+      const [first, second] = names;
+      check(
+        second !== undefined && first !== undefined && second !== first,
+        `the second walk registered a second agent (${redact(String(first))} then ${redact(String(second))})`,
+      );
+      check(
+        second !== undefined && /-\d+$/u.test(second),
+        "the second agent took the next free name rather than the taken one",
+      );
+    }
+
+    const after = await stat(real).then((found) => `${found.mtimeMs}`, () => "absent");
+    check(before === after, "nothing touched the credentials of whoever ran this");
+  } finally {
+    for (const outcome of walked) {
+      await rm(outcome.repository, { recursive: true, force: true });
+    }
+    await gate?.close();
+    await platform?.close();
+    await instance?.close();
+  }
+
+  say("");
+  if (problems.length > 0) {
+    for (const problem of problems) say(`FAILED: ${redact(problem)}`);
+    process.exitCode = 1;
+    return;
+  }
+  say(RULE);
+  say("  PASSED — the whole wizard, driven end to end with nobody at the");
+  say("  keyboard, put an agent, a connection and a suite of tests on a real");
+  say("  egma and left the files in the repository.");
+  say(RULE);
+}
+
+await main();
+
+// A pseudo-terminal and an adapter's own process tree can both outlive what
+// started them, and either keeps Node alive. This leaves on its own answer once
+// what it printed has really gone out.
+await new Promise<void>((resolve) => {
+  process.stdout.write("", () => resolve());
+});
+process.exit(process.exitCode ?? 0);

--- a/apps/cli/smoke/support/half-real-platform.ts
+++ b/apps/cli/smoke/support/half-real-platform.ts
@@ -1,0 +1,147 @@
+/**
+ * One address the CLI can be pointed at, in front of a real egma.
+ *
+ * **What is real here is real, and what is not is named.** A whole egma runs
+ * behind this — a real Postgres, a real ClickHouse, the real API — and every
+ * request the CLI makes goes to it: the device flow, the key it mints, the door
+ * that key opens. That is the half of the platform that has shipped.
+ *
+ * The agent, connection and test endpoints have not. The public API is a ticket
+ * of its own and until it lands there is nothing at `/api/agents` or
+ * `/api/tests` on a real instance to answer — so those paths, and only those,
+ * are served by the same fixture the offline checks run against, standing at the
+ * same seam. The alternative was to stop the end-to-end check at login, which
+ * would leave the whole walk unproven against anything real at all.
+ *
+ * The seam between the two halves is one line of code and it is worth reading:
+ * the key the real instance mints is handed to the fixture as one of its own,
+ * caught on its way past. Nothing else crosses.
+ *
+ * When the public API serves agents and tests, this file is deleted and the
+ * check is pointed straight at the instance. Nothing else about it changes.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import {
+  startPlatform,
+  type AgentControls,
+  type Platform,
+  type TestControls,
+} from "../../test/support/fixture-platform/index.ts";
+
+/** The paths the real instance does not serve yet, and the fixture does. */
+const NOT_YET_ON_THE_REAL_API = ["/api/agents", "/api/tests", "/api/test-versions"];
+
+export type HalfRealPlatform = {
+  /** What the CLI is pointed at. */
+  readonly url: string;
+  /** The real egma behind it, for the harness's own requests. */
+  readonly apiOrigin: string;
+  /** What was registered, on the half that is a fixture. */
+  readonly registered: AgentControls;
+  /** What was pushed, on the half that is a fixture. */
+  readonly tests: TestControls;
+  /** Every key the real instance minted while this was up, in order. */
+  readonly mintedKeys: readonly string[];
+  /** Which requests went where, by path shape, for the run to print. */
+  readonly served: { readonly real: number; readonly fixture: number };
+  close(): Promise<void>;
+};
+
+function goesToTheFixture(pathname: string): boolean {
+  return NOT_YET_ON_THE_REAL_API.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/** The key the real instance has just minted, out of a token answer. */
+function keyIn(body: string): string | null {
+  try {
+    const held = JSON.parse(body) as { access_token?: unknown };
+    return typeof held.access_token === "string" && held.access_token !== ""
+      ? held.access_token
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function startHalfRealPlatform(apiOrigin: string): Promise<HalfRealPlatform> {
+  const fixture: Platform = await startPlatform();
+  const mintedKeys: string[] = [];
+  const served = { real: 0, fixture: 0 };
+
+  const server: Server = createServer((incoming: IncomingMessage, outgoing: ServerResponse) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of incoming) chunks.push(chunk as Buffer);
+      const raw = Buffer.concat(chunks);
+
+      const at = new URL(incoming.url ?? "/", "http://front.invalid");
+      const toFixture = goesToTheFixture(at.pathname);
+      if (toFixture) served.fixture += 1;
+      else served.real += 1;
+
+      const headers: Record<string, string> = {};
+      for (const [name, value] of Object.entries(incoming.headers)) {
+        if (typeof value !== "string") continue;
+        // The hop's own headers: forwarding them would describe a request that
+        // is not the one being made.
+        if (["host", "connection", "content-length"].includes(name)) continue;
+        headers[name] = value;
+      }
+
+      const answer = await fetch(
+        `${toFixture ? fixture.url : apiOrigin}${at.pathname}${at.search}`,
+        {
+          method: incoming.method ?? "GET",
+          headers,
+          ...(raw.length === 0 ? {} : { body: raw }),
+        },
+      );
+      const body = await answer.text();
+
+      // The one thing that crosses between the halves: a key the real instance
+      // has just minted is a key the fixture must accept, because the machine
+      // holding it is about to write with it.
+      if (at.pathname === "/api/device/token" && answer.ok) {
+        const key = keyIn(body);
+        if (key !== null) {
+          mintedKeys.push(key);
+          fixture.signedInWith(key);
+        }
+      }
+
+      outgoing.writeHead(answer.status, {
+        "content-type": answer.headers.get("content-type") ?? "application/json",
+        "cache-control": "no-store",
+      });
+      outgoing.end(body);
+    })().catch(() => {
+      outgoing.writeHead(502, { "content-type": "application/json" });
+      outgoing.end(JSON.stringify({ error: "unreachable", message: "the instance did not answer" }));
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    apiOrigin,
+    registered: fixture.registered,
+    tests: fixture.tests,
+    mintedKeys,
+    served,
+    async close() {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      await fixture.close();
+    },
+  };
+}

--- a/apps/cli/smoke/support/half-real-platform.ts
+++ b/apps/cli/smoke/support/half-real-platform.ts
@@ -6,12 +6,12 @@
  * request the CLI makes goes to it: the device flow, the key it mints, the door
  * that key opens. That is the half of the platform that has shipped.
  *
- * The agent, connection and test endpoints have not. The public API is a ticket
- * of its own and until it lands there is nothing at `/api/agents` or
- * `/api/tests` on a real instance to answer — so those paths, and only those,
- * are served by the same fixture the offline checks run against, standing at the
- * same seam. The alternative was to stop the end-to-end check at login, which
- * would leave the whole walk unproven against anything real at all.
+ * The agent, connection and test endpoints have not. Until they do there is
+ * nothing at `/api/agents` or `/api/tests` on a real instance to answer — so
+ * those paths, and only those, are served by the same fixture the offline
+ * checks run against, standing at the same seam. The alternative was to stop
+ * the end-to-end check at login, which would leave the whole walk unproven
+ * against anything real at all.
  *
  * The seam between the two halves is one line of code and it is worth reading:
  * the key the real instance mints is handed to the fixture as one of its own,
@@ -114,6 +114,11 @@ export async function startHalfRealPlatform(apiOrigin: string): Promise<HalfReal
         }
       }
 
+      // The status and the body come back whole; the headers do not. Both
+      // halves answer JSON to a bearer key and nothing the CLI reads is in a
+      // header, so what is forwarded is the one header that says how to read
+      // the body. A flow that ever needs another will fail loudly here rather
+      // than behave subtly differently through the hop than without it.
       outgoing.writeHead(answer.status, {
         "content-type": answer.headers.get("content-type") ?? "application/json",
         "cache-control": "no-store",

--- a/apps/cli/smoke/support/retell-gate.ts
+++ b/apps/cli/smoke/support/retell-gate.ts
@@ -1,0 +1,98 @@
+/**
+ * A gate in front of the real Retell that forwards reads and refuses the rest.
+ *
+ * It is what makes "read-only" a property of a run rather than a promise about
+ * the code: a request to create, update or delete never leaves this machine,
+ * whatever the CLI asks for. The account these checks run against belongs to
+ * somebody and the agents on it answer real telephone numbers, so this is the
+ * one piece of smoke-check machinery that is shared rather than copied — two
+ * allow-lists would eventually differ, and the day they differed is the day one
+ * of them would be wrong.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { RETELL_API } from "../../src/retell/client.ts";
+
+/** Exactly what a check is allowed to ask Retell for. */
+export const ALLOWED: readonly { method: string; path: RegExp }[] = [
+  { method: "POST", path: /^\/v2\/list-agents$/u },
+  { method: "GET", path: /^\/get-agent\/[^/]+$/u },
+  { method: "GET", path: /^\/get-chat-agent\/[^/]+$/u },
+  { method: "GET", path: /^\/get-retell-llm\/[^/]+$/u },
+  { method: "GET", path: /^\/get-conversation-flow\/[^/]+$/u },
+];
+
+export type Gate = {
+  readonly url: string;
+  /** How many reads were forwarded, by path shape. */
+  readonly forwarded: string[];
+  /** Anything the gate turned away. One entry here fails the whole run. */
+  readonly refused: string[];
+  /** What Retell answered, exactly, keyed by path — for a byte-for-byte check. */
+  answered(path: string): string | undefined;
+  close(): Promise<void>;
+};
+
+export async function openGate(): Promise<Gate> {
+  const forwarded: string[] = [];
+  const refused: string[] = [];
+  const answers = new Map<string, string>();
+
+  const server: Server = createServer((incoming: IncomingMessage, outgoing: ServerResponse) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of incoming) chunks.push(chunk as Buffer);
+      const raw = Buffer.concat(chunks).toString("utf8");
+
+      const at = new URL(incoming.url ?? "/", "http://gate.invalid");
+      const method = incoming.method ?? "GET";
+      const allowed = ALLOWED.some(
+        (rule) => rule.method === method && rule.path.test(at.pathname),
+      );
+
+      if (!allowed) {
+        refused.push(`${method} ${at.pathname}`);
+        outgoing.writeHead(403, { "content-type": "application/json" });
+        outgoing.end(JSON.stringify({ error_message: "this check is read-only" }));
+        return;
+      }
+
+      const answer = await fetch(`${RETELL_API}${at.pathname}${at.search}`, {
+        method,
+        headers: {
+          authorization: incoming.headers.authorization ?? "",
+          ...(raw === "" ? {} : { "content-type": "application/json" }),
+        },
+        ...(raw === "" ? {} : { body: raw }),
+      });
+      const body = await answer.text();
+
+      // The shape, never the identifier: which reads were made is worth
+      // printing, and whose agents they were is not.
+      forwarded.push(`${method} ${at.pathname.replace(/^(\/get-[a-z-]+)\/.+$/u, "$1/…")}`);
+      if (answer.ok) answers.set(at.pathname, body);
+
+      outgoing.writeHead(answer.status, { "content-type": "application/json" });
+      outgoing.end(body);
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    forwarded,
+    refused,
+    answered: (at) => answers.get(at),
+    async close() {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}

--- a/apps/cli/src/ui/headless-ui.ts
+++ b/apps/cli/src/ui/headless-ui.ts
@@ -17,6 +17,7 @@
 import { loginLines, type LoginPrompt } from "../platform/login.ts";
 import type { RetellAgent } from "../retell/client.ts";
 import { keyAskLines, type KeyAsk } from "../retell/connect.ts";
+import type { Detection } from "../wizard/detection.ts";
 import type { ExitReport } from "../wizard/exit-line.ts";
 import type { TestGate } from "../wizard/gate.ts";
 import type { GenerationProgress } from "../wizard/test-generation.ts";
@@ -25,6 +26,8 @@ import type { AskId, DrivenAgent, GateId, WizardUI } from "./wizard-ui.ts";
 export type HeadlessRecord = {
   drivenAgent: DrivenAgent | null;
   drivenAgentLog: string | null;
+  /** What egma worked out for itself before it asked anybody anything. */
+  detection: Detection | null;
   logins: LoginPrompt[];
   /** Every time a key was asked for, and what was said about it. */
   keyAsks: KeyAsk[];
@@ -52,6 +55,7 @@ export class HeadlessUI implements WizardUI {
   readonly record: HeadlessRecord = {
     drivenAgent: null,
     drivenAgentLog: null,
+    detection: null,
     logins: [],
     keyAsks: [],
     agentChoices: [],
@@ -86,6 +90,19 @@ export class HeadlessUI implements WizardUI {
 
   setDrivenAgentLog(file: string): void {
     this.record.drivenAgentLog = file;
+  }
+
+  /**
+   * Kept, and never printed.
+   *
+   * This exists to fill a screen while a developer is away in a browser, and a
+   * run with nobody watching has neither. It also lands whenever it lands —
+   * nothing waits on it — so printing it would put lines in a promptless run's
+   * output in an order that depends on how fast a disk answered, and one of
+   * those orders is after the exit line.
+   */
+  setDetection(detection: Detection | null): void {
+    this.record.detection = detection;
   }
 
   setLogin(prompt: LoginPrompt | null): void {

--- a/apps/cli/src/ui/tui/ink-ui.ts
+++ b/apps/cli/src/ui/tui/ink-ui.ts
@@ -8,6 +8,7 @@
 import type { LoginPrompt } from "../../platform/login.ts";
 import type { RetellAgent } from "../../retell/client.ts";
 import type { KeyAsk } from "../../retell/connect.ts";
+import type { Detection } from "../../wizard/detection.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { TestGate } from "../../wizard/gate.ts";
 import type { GenerationProgress } from "../../wizard/test-generation.ts";
@@ -34,6 +35,10 @@ export class InkUI implements WizardUI {
 
   setDrivenAgentLog(file: string): void {
     this.store.setDrivenAgentLog(file);
+  }
+
+  setDetection(detection: Detection | null): void {
+    this.store.setDetection(detection);
   }
 
   setLogin(prompt: LoginPrompt | null): void {

--- a/apps/cli/src/ui/tui/screens/GeneratingScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/GeneratingScreen.tsx
@@ -1,5 +1,6 @@
 /**
- * The files arriving, one at a time, while they arrive.
+ * The files arriving, one at a time, while they arrive — and the words egma
+ * uses, taught beside them.
  *
  * Writing a suite takes a coding agent a couple of minutes, which is a long
  * time to look at a spinner. So the wait is the work: every test is on screen
@@ -7,16 +8,38 @@
  * where the developer can see it. By the time the list stops moving they have
  * read every name in it, which is what makes the one keystroke after this a
  * decision rather than a shrug.
+ *
+ * The left pane turns the rest of that time into the one thing the developer
+ * still needs and nobody has told them: what egma means by a test, a run, a
+ * simulation, a metric and a grader. It is drawn from a deck of plain cards and
+ * it turns on a timer of its own. **Nothing waits on it.** The flow never reads
+ * it, never awaits it and never learns whether it turned, so a suite that is
+ * written before the first card changes is written exactly as it would have
+ * been with no pane at all.
  */
 
-import { Box, Text } from "ink";
+import { useEffect, useState } from "react";
+import { Box, Text, useStdout } from "ink";
 
+import { cardAt, CARD_WIDTH } from "../../../wizard/teaching.ts";
 import type { GenerationProgress, WritingState } from "../../../wizard/test-generation.ts";
 
 export type GeneratingScreenProps = { readonly progress: GenerationProgress };
 
 /** How many rows are on screen at once, newest work always among them. */
 const VISIBLE_ROWS = 14;
+
+/**
+ * How long one card stays up.
+ *
+ * Long enough to read twice without hurrying, and long enough that a fast run
+ * finishes on the first card — which is the shape this has to have, because the
+ * pane exists to fill a wait and must never be a reason for one.
+ */
+export const TEACHING_ROTATE_MS = 8_000;
+
+/** The narrowest terminal that holds both panes with either still readable. */
+const BOTH_PANES_NEED = 76;
 
 const MARK: Readonly<Record<WritingState, string>> = {
   written: "◼",
@@ -35,7 +58,39 @@ function columnWidth(names: readonly string[]): number {
   return names.reduce((widest, name) => Math.max(widest, name.length), 0);
 }
 
+/**
+ * The card that is up, and the timer that changes it.
+ *
+ * The timer lives here and reaches nothing outside this component. A screen
+ * that is never drawn never starts it, and a run that ends before it fires ends
+ * exactly as it would have without it.
+ */
+function LearnPane() {
+  const [turn, setTurn] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => setTurn((held) => held + 1), TEACHING_ROTATE_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const card = cardAt(turn);
+
+  return (
+    <Box flexDirection="column" width={CARD_WIDTH} marginRight={3}>
+      <Text bold>{card.heading}</Text>
+      <Box height={1} />
+      {card.lines.map((line, index) => (
+        <Text key={`${index}-${line}`} dimColor>
+          {line === "" ? " " : line}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
 export function GeneratingScreen({ progress }: GeneratingScreenProps) {
+  const { stdout } = useStdout();
+  const columns = stdout?.columns ?? 80;
   const written = progress.tests.filter((test) => test.state === "written").length;
   const width = columnWidth(progress.tests.map((test) => test.name));
 
@@ -57,19 +112,23 @@ export function GeneratingScreen({ progress }: GeneratingScreenProps) {
           : "Writing tests for your voice agent."}
       </Text>
       <Box height={1} />
-      <Box flexDirection="column">
-        {shown.length === 0 ? (
-          <Text dimColor>Waiting for the first file.</Text>
-        ) : (
-          shown.map((test) => (
-            <Text key={test.name} dimColor={test.state === "queued"}>
-              {`${MARK[test.state]} ${test.name.padEnd(width)}  ${SAID[test.state]}`.trimEnd()}
-            </Text>
-          ))
-        )}
+      <Box flexDirection="row">
+        {/* A terminal too narrow for both keeps the one that is the work. */}
+        {columns >= BOTH_PANES_NEED ? <LearnPane /> : null}
+        <Box flexDirection="column" flexGrow={1}>
+          {shown.length === 0 ? (
+            <Text dimColor>Waiting for the first file.</Text>
+          ) : (
+            shown.map((test) => (
+              <Text key={test.name} dimColor={test.state === "queued"}>
+                {`${MARK[test.state]} ${test.name.padEnd(width)}  ${SAID[test.state]}`.trimEnd()}
+              </Text>
+            ))
+          )}
+          <Box height={1} />
+          <Text dimColor>{`Progress: ${written}/${progress.total}`}</Text>
+        </Box>
       </Box>
-      <Box height={1} />
-      <Text dimColor>{`Progress: ${written}/${progress.total}`}</Text>
       <Box height={1} />
       <Text dimColor>[ctrl-c] stop</Text>
     </Box>

--- a/apps/cli/src/ui/tui/screens/LoginScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/LoginScreen.tsx
@@ -14,6 +14,7 @@
 
 import { Box, Text, useInput, useStdout } from "ink";
 
+import { detectionLines } from "../../../wizard/detection.ts";
 import { dispatchKey, hintBar, isEnter, type KeyBinding } from "../keybindings.ts";
 import type { WizardState } from "../state.ts";
 import { addressFits, columnsNeeded } from "../width.ts";
@@ -109,6 +110,22 @@ export function LoginScreen({
       {state.loginTyping === "" ? null : (
         <Box marginTop={1}>
           <Text>{`› ${state.loginTyping}`}</Text>
+        </Box>
+      )}
+      {/*
+        The wait is somebody else's — a browser on another screen — so the time
+        it takes is spent showing what egma has already worked out rather than
+        showing nothing. It is written before the developer left and read when
+        they come back.
+      */}
+      {state.detection === null ? null : (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>While you were away, egma looked around:</Text>
+          {detectionLines(state.detection).map((line) => (
+            <Text key={line} dimColor>
+              {`  ${line}`}
+            </Text>
+          ))}
         </Box>
       )}
       <Box flexDirection="column" marginTop={1}>

--- a/apps/cli/src/ui/tui/state.ts
+++ b/apps/cli/src/ui/tui/state.ts
@@ -9,6 +9,7 @@
 import type { LoginPrompt } from "../../platform/login.ts";
 import type { RetellAgent } from "../../retell/client.ts";
 import type { KeyAsk } from "../../retell/connect.ts";
+import type { Detection } from "../../wizard/detection.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { TestGate } from "../../wizard/gate.ts";
 import type { GenerationProgress } from "../../wizard/test-generation.ts";
@@ -18,6 +19,8 @@ export type WizardState = {
   readonly drivenAgent: DrivenAgent | null;
   /** Where the coding agent's own output is kept, for a screen that tails it. */
   readonly drivenAgentLog: string | null;
+  /** What egma worked out about this machine for itself, or `null` before it has. */
+  readonly detection: Detection | null;
   /** What has to be approved in a browser, while it still has to be. */
   readonly login: LoginPrompt | null;
   /** What the developer is typing back at the login screen, so far. */
@@ -59,6 +62,7 @@ export function emptyState(): WizardState {
   return {
     drivenAgent: null,
     drivenAgentLog: null,
+    detection: null,
     login: null,
     loginTyping: "",
     loginCopied: false,

--- a/apps/cli/src/ui/tui/store.ts
+++ b/apps/cli/src/ui/tui/store.ts
@@ -16,6 +16,7 @@ import { emptyState, type WizardState } from "./state.ts";
 import type { LoginPrompt } from "../../platform/login.ts";
 import type { RetellAgent } from "../../retell/client.ts";
 import type { KeyAsk } from "../../retell/connect.ts";
+import type { Detection } from "../../wizard/detection.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { TestGate } from "../../wizard/gate.ts";
 import type { GenerationProgress } from "../../wizard/test-generation.ts";
@@ -144,6 +145,10 @@ export class WizardStore {
 
   setDrivenAgentLog(drivenAgentLog: string): void {
     this.change({ drivenAgentLog });
+  }
+
+  setDetection(detection: Detection | null): void {
+    this.change({ detection });
   }
 
   setLogin(login: LoginPrompt | null): void {

--- a/apps/cli/src/ui/wizard-ui.ts
+++ b/apps/cli/src/ui/wizard-ui.ts
@@ -13,6 +13,7 @@
 import type { LoginPrompt } from "../platform/login.ts";
 import type { RetellAgent } from "../retell/client.ts";
 import type { KeyAsk } from "../retell/connect.ts";
+import type { Detection } from "../wizard/detection.ts";
 import type { ExitReport } from "../wizard/exit-line.ts";
 import type { TestGate } from "../wizard/gate.ts";
 import type { GenerationProgress } from "../wizard/test-generation.ts";
@@ -49,6 +50,16 @@ export interface WizardUI {
 
   /** Where the coding agent's own output is being kept for this run. */
   setDrivenAgentLog(file: string): void;
+
+  /**
+   * What egma worked out about this machine for itself, or `null` before it
+   * has.
+   *
+   * Nothing in the flow reads this back and nothing waits on it. It is written
+   * once, while the developer is reading, so that the screen they sit in front
+   * of during the browser wait has something true on it rather than a spinner.
+   */
+  setDetection(detection: Detection | null): void;
 
   /**
    * What login is waiting to be approved, or `null` once it no longer is.

--- a/apps/cli/src/wizard/detection.ts
+++ b/apps/cli/src/wizard/detection.ts
@@ -1,0 +1,92 @@
+/**
+ * What egma can work out about this machine without asking anybody.
+ *
+ * Three facts, all of them free: which coding agent egma is about to drive,
+ * whether this folder is a git repository, and whether somebody has already
+ * been here — an `egma/` folder with tests in it means a teammate onboarded
+ * this repository and this developer's path is the shorter one.
+ *
+ * It is worked out while the developer is reading the intro and shown while
+ * they are away in a browser, because that is the only dead time the wizard
+ * has. Nothing waits on it and no step reads it: it is for the screen.
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+import { FOLDER_NAME, TESTS_FOLDER_NAME } from "../folder/egma-folder.ts";
+
+export type Detection = {
+  /** The coding agent egma will drive, or `null` when there is none yet. */
+  readonly drivenAgentName: string | null;
+  /** Whether the folder is inside a git repository. */
+  readonly gitRepository: boolean;
+  /** How many test files an egma folder here already holds. */
+  readonly testsAlreadyHere: number;
+  /** Whether there is an egma folder here at all. */
+  readonly egmaFolder: boolean;
+};
+
+async function isFolder(candidate: string): Promise<boolean> {
+  try {
+    return (await stat(candidate)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Whether this folder, or one above it, is a git repository. */
+async function insideGit(from: string): Promise<boolean> {
+  let at = path.resolve(from);
+  for (;;) {
+    if (await isFolder(path.join(at, ".git"))) return true;
+    const above = path.dirname(at);
+    if (above === at) return false;
+    at = above;
+  }
+}
+
+/** Everything egma can see for itself, for the screen to draw. */
+export async function detect(options: {
+  readonly cwd: string;
+  readonly drivenAgentName: string | null;
+}): Promise<Detection> {
+  const folder = path.join(options.cwd, FOLDER_NAME);
+  const tests = path.join(folder, TESTS_FOLDER_NAME);
+
+  const [gitRepository, egmaFolder, names] = await Promise.all([
+    insideGit(options.cwd),
+    isFolder(folder),
+    readdir(tests).catch(() => [] as string[]),
+  ]);
+
+  return {
+    drivenAgentName: options.drivenAgentName,
+    gitRepository,
+    egmaFolder,
+    testsAlreadyHere: names.filter((name) => name.endsWith(".md")).length,
+  };
+}
+
+/**
+ * The facts as lines, said the same way wherever they are shown.
+ *
+ * A fact that is not true yet is still a line, because "no egma folder here"
+ * is what tells a developer this is the first time anybody has done this in
+ * their repository.
+ */
+export function detectionLines(detection: Detection): readonly string[] {
+  const lines: string[] = [];
+  if (detection.drivenAgentName !== null) {
+    lines.push(`Coding agent   ${detection.drivenAgentName}`);
+  }
+  lines.push(`Git            ${detection.gitRepository ? "this is a repository" : "not a repository"}`);
+  lines.push(
+    `egma folder    ${
+      detection.egmaFolder
+        ? `already here, ${detection.testsAlreadyHere} ${detection.testsAlreadyHere === 1 ? "test" : "tests"} in it`
+        : "none yet — egma will make one"
+    }`,
+  );
+  return lines;
+}

--- a/apps/cli/src/wizard/exit-line.ts
+++ b/apps/cli/src/wizard/exit-line.ts
@@ -54,7 +54,19 @@ export type ExitReport =
       readonly reason: string;
     }
   | { readonly kind: "quit" }
-  | { readonly kind: "interrupted"; readonly drivenAgentName: string | null }
+  /**
+   * The developer changed their mind while egma was working.
+   *
+   * `testsKept` is how many test files were really on disk when it stopped. A
+   * stop part way through writing a suite leaves files behind, and a line that
+   * only said egma had stopped would leave a developer with a folder they were
+   * never told about. Absent, or zero, means the folder holds nothing to say.
+   */
+  | {
+      readonly kind: "interrupted";
+      readonly drivenAgentName: string | null;
+      readonly testsKept?: number;
+    }
   | { readonly kind: "failed"; readonly reason: string };
 
 /** One line means one line, whatever shape the reason arrived in. */
@@ -97,10 +109,19 @@ export function buildExitLine(report: ExitReport): string {
         : `${report.drivenAgentName} stopped before it found your voice agent: ${oneLine(report.reason)}`;
     case "quit":
       return "egma closed. Nothing ran.";
-    case "interrupted":
-      return report.drivenAgentName === null
-        ? "egma stopped before the task finished."
-        : `egma stopped before the task finished, and shut ${report.drivenAgentName} down.`;
+    case "interrupted": {
+      const stopped =
+        report.drivenAgentName === null
+          ? "egma stopped before the task finished."
+          : `egma stopped before the task finished, and shut ${report.drivenAgentName} down.`;
+      const kept = report.testsKept ?? 0;
+      if (kept === 0) return stopped;
+      // The folder is not empty, so the line says so. A developer who finds
+      // files they were never told about has been told a half-truth.
+      return kept === 1
+        ? `${stopped} Your 1 test is in ${TESTS_FOLDER}.`
+        : `${stopped} Your ${kept} tests are in ${TESTS_FOLDER}.`;
+    }
     case "failed":
       return `egma could not finish: ${oneLine(report.reason)}`;
   }

--- a/apps/cli/src/wizard/generate-step.ts
+++ b/apps/cli/src/wizard/generate-step.ts
@@ -82,6 +82,25 @@ export type GenerateStepOptions = {
 };
 
 /**
+ * How this step stops, with the folder counted.
+ *
+ * Everywhere else in the walk a stop leaves nothing behind. Here it leaves
+ * files: the coding agent writes them as it goes, and they are the developer's
+ * the moment they land. So the count is read off the disk at the moment of
+ * stopping and travels with the report, and the exit line says where they are.
+ */
+async function stoppedHere(
+  signal: AbortSignal,
+  drivenAgentName: string,
+  paths: FolderPaths,
+): Promise<ExitReport> {
+  const report = stopReport(signal, drivenAgentName);
+  if (report.kind !== "interrupted") return report;
+  const kept = (await namesInFolder(paths)).length;
+  return kept === 0 ? report : { ...report, testsKept: kept };
+}
+
+/**
  * One dispatch that writes files, with the pane following what really lands.
  *
  * The result is deliberately thin: whether the agent could be driven at all,
@@ -204,7 +223,7 @@ async function writeFiles(
       );
       return null;
     case "interrupted":
-      return stopReport(signal, launch.name);
+      return stoppedHere(signal, launch.name, paths);
     case "unreachable":
       return { kind: "no-coding-agent" };
     case "needs-login":
@@ -332,7 +351,7 @@ export async function generateStep(options: GenerateStepOptions): Promise<ExitRe
   // closes the wizard instead of answering has answered too, so the wait ends
   // with the signal and not only with a keystroke.
   const said = await untilAborted(ui.waitForAnswer("existing-tests"), signal);
-  if (signal.aborted) return stopReport(signal, options.launch.name);
+  if (signal.aborted) return stoppedHere(signal, options.launch.name, paths);
 
   const existing = await readExistingTests(cwd, said ?? null);
   if (existing.kind === "unusable") {
@@ -415,7 +434,7 @@ export async function generateStep(options: GenerateStepOptions): Promise<ExitRe
     // written, they are the developer's, and the line has to say where.
     return stopReasonOf(signal) === "quit"
       ? { kind: "tests-kept", count: gate.rows.length }
-      : stopReport(signal, options.launch.name);
+      : stoppedHere(signal, options.launch.name, paths);
   }
 
   return pushGate(options, paths, gate);

--- a/apps/cli/src/wizard/teaching.ts
+++ b/apps/cli/src/wizard/teaching.ts
@@ -15,7 +15,9 @@
  *
  * The words are the glossary's own, deliberately. A card that taught a near
  * synonym would be teaching a developer to say something egma does not answer
- * to, which is worse than teaching nothing.
+ * to, which is worse than teaching nothing. So the deck is held to the same ban
+ * list as the text egma puts in front of a coding agent, and to no weaker one:
+ * a word egma will not say to a model is a word it will not put on a screen.
  *
  * The shape — a card beside a wait, turning on its own — is the PostHog
  * wizard's idea. None of its code is here and none of these words are theirs.
@@ -32,7 +34,7 @@ export const CARD_WIDTH = 32;
 
 /**
  * The deck, in the order a developer meets the ideas: what they are authoring,
- * who calls about it, what happens when it runs, and what comes back.
+ * who is on the other end of it, what happens when it runs, and what comes back.
  */
 export const LEARN_CARDS: readonly LearnCard[] = [
   {
@@ -52,14 +54,14 @@ export const LEARN_CARDS: readonly LearnCard[] = [
   {
     heading: "A persona",
     lines: [
-      "The synthetic person who calls",
-      "your agent: their manner, their",
+      "The synthetic person on the",
+      "other end: their manner, their",
       "patience, how they behave when",
       "things go wrong.",
       "",
-      "A test names the personas who",
-      "should call about it. Naming",
-      "none takes your default one.",
+      "A test names the personas it",
+      "should be run with. Naming none",
+      "takes your default one.",
     ],
   },
   {
@@ -78,8 +80,8 @@ export const LEARN_CARDS: readonly LearnCard[] = [
     heading: "A simulation",
     lines: [
       "One test executed once inside a",
-      "run — one conversation, start to",
-      "finish.",
+      "run: your agent and one persona,",
+      "start to finish.",
       "",
       "A run produces one simulation",
       "per test per persona. Each one",
@@ -107,8 +109,8 @@ export const LEARN_CARDS: readonly LearnCard[] = [
       "",
       "A test that could not run is not",
       "a test that failed, so egma",
-      "never calls skipped or errored",
-      "a failure.",
+      "never counts skipped or errored",
+      "as one.",
     ],
   },
 ];

--- a/apps/cli/src/wizard/teaching.ts
+++ b/apps/cli/src/wizard/teaching.ts
@@ -1,0 +1,127 @@
+/**
+ * The words egma uses, taught while a coding agent writes the first tests.
+ *
+ * Writing a suite takes a couple of minutes. In that time a developer either
+ * learns what egma is talking about or does not, and every screen after this one
+ * assumes they did: the gate says "suite", the exit line says "tests", the
+ * results say "passed" and "skipped" and mean different things by them. So the
+ * wait teaches the vocabulary, one card at a time, beside the files as they
+ * land.
+ *
+ * The deck is plain data and it is read by the screen alone. Nothing in the
+ * walk waits on it, reads it, or is delayed by it — a developer on a fast
+ * machine sees one card and a developer on a slow one sees six, and the tests
+ * that get written are the same either way.
+ *
+ * The words are the glossary's own, deliberately. A card that taught a near
+ * synonym would be teaching a developer to say something egma does not answer
+ * to, which is worse than teaching nothing.
+ *
+ * The shape — a card beside a wait, turning on its own — is the PostHog
+ * wizard's idea. None of its code is here and none of these words are theirs.
+ */
+
+/** One card: a short heading and lines already broken to the pane's width. */
+export type LearnCard = {
+  readonly heading: string;
+  readonly lines: readonly string[];
+};
+
+/** How wide a card's lines are written to be, so the pane never rewraps them. */
+export const CARD_WIDTH = 32;
+
+/**
+ * The deck, in the order a developer meets the ideas: what they are authoring,
+ * who calls about it, what happens when it runs, and what comes back.
+ */
+export const LEARN_CARDS: readonly LearnCard[] = [
+  {
+    heading: "A test",
+    lines: [
+      "One situation to put your agent",
+      "in: what the person on the other",
+      "end wants, and the expected",
+      "behaviors that say what should",
+      "happen.",
+      "",
+      "At least one behavior, always —",
+      "a test that cannot fail is not",
+      "a test.",
+    ],
+  },
+  {
+    heading: "A persona",
+    lines: [
+      "The synthetic person who calls",
+      "your agent: their manner, their",
+      "patience, how they behave when",
+      "things go wrong.",
+      "",
+      "A test names the personas who",
+      "should call about it. Naming",
+      "none takes your default one.",
+    ],
+  },
+  {
+    heading: "A run",
+    lines: [
+      "One execution of a selection of",
+      "tests, against one agent, over",
+      "one connection.",
+      "",
+      "A run pins the versions it used,",
+      "so what last week's results mean",
+      "can never change underneath you.",
+    ],
+  },
+  {
+    heading: "A simulation",
+    lines: [
+      "One test executed once inside a",
+      "run — one conversation, start to",
+      "finish.",
+      "",
+      "A run produces one simulation",
+      "per test per persona. Each one",
+      "leaves a transcript, an outcome",
+      "and metrics behind it.",
+    ],
+  },
+  {
+    heading: "Measured, or judged",
+    lines: [
+      "A metric measures: how long it",
+      "took, how many turns, how late",
+      "the replies were.",
+      "",
+      "A grader judges. It reads the",
+      "transcript, the outcome, or a",
+      "metric, and returns a verdict.",
+    ],
+  },
+  {
+    heading: "The four verdicts",
+    lines: [
+      "passed, failed, skipped,",
+      "errored.",
+      "",
+      "A test that could not run is not",
+      "a test that failed, so egma",
+      "never calls skipped or errored",
+      "a failure.",
+    ],
+  },
+];
+
+/**
+ * The card at this turn of the deck, whichever turn it is.
+ *
+ * Total rather than bounded: the screen counts up for as long as the writing
+ * lasts, and a deck that ran out would leave the pane empty exactly when the
+ * developer has been waiting longest.
+ */
+export function cardAt(turn: number): LearnCard {
+  const cards = LEARN_CARDS;
+  const at = ((turn % cards.length) + cards.length) % cards.length;
+  return cards[at] as LearnCard;
+}

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -41,23 +41,45 @@ export type WalkOptions = {
   readonly howManyTests?: number;
 };
 
-/** Runs the walk and returns the line the wizard will leave behind. */
+/**
+ * Runs the walk and returns the line the wizard will leave behind.
+ *
+ * The one thing started here rather than inside the walk is the look around
+ * this machine. It is started before the intro is dismissed and shown behind
+ * the browser wait, which is the only dead time the walk has: nothing awaits
+ * it, no step reads it back, and a look that fails costs nothing.
+ *
+ * What it does need is a way to stop mattering. A walk can end — quit,
+ * interrupted, or simply finished — while the look is still going, and by then
+ * the screen it was for is coming down and the exit line is being written under
+ * it. So the answer is dropped rather than pushed at a UI that has nothing left
+ * to draw on.
+ */
 export async function walk(options: WalkOptions): Promise<ExitReport> {
+  const { ui, cwd, launch } = options;
+
+  let walking = true;
+  void detect({ cwd, drivenAgentName: launch.name }).then(
+    (detection) => {
+      if (walking) ui.setDetection(detection);
+    },
+    () => undefined,
+  );
+
+  try {
+    return await walkThrough(options);
+  } finally {
+    walking = false;
+  }
+}
+
+async function walkThrough(options: WalkOptions): Promise<ExitReport> {
   const { ui, launch, cwd, signal } = options;
 
   ui.setDrivenAgent({ id: launch.id, name: launch.name });
 
   const log = options.log ?? openDrivenAgentLog();
   ui.setDrivenAgentLog(log.file);
-
-  // Started before the intro is dismissed and shown behind the browser wait,
-  // which is the only dead time the walk has. It is handed to the UI whenever
-  // it lands and no step ever reads it back, so nothing in the walk is paced by
-  // it and a look that fails costs nothing.
-  void detect({ cwd, drivenAgentName: launch.name }).then(
-    (detection) => ui.setDetection(detection),
-    () => undefined,
-  );
 
   await untilAborted(ui.waitForGate("begin"), signal);
   if (signal.aborted) {

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -14,6 +14,7 @@ import { signedInAt } from "../platform/signed-in.ts";
 import type { ConnectOptions } from "../retell/connect.ts";
 import type { WizardUI } from "../ui/wizard-ui.ts";
 import { connectStep } from "./connect-step.ts";
+import { detect } from "./detection.ts";
 import { findTheAgent } from "./discovery.ts";
 import { openDrivenAgentLog, type DrivenAgentLog } from "./driven-agent-log.ts";
 import type { ExitReport } from "./exit-line.ts";
@@ -48,6 +49,15 @@ export async function walk(options: WalkOptions): Promise<ExitReport> {
 
   const log = options.log ?? openDrivenAgentLog();
   ui.setDrivenAgentLog(log.file);
+
+  // Started before the intro is dismissed and shown behind the browser wait,
+  // which is the only dead time the walk has. It is handed to the UI whenever
+  // it lands and no step ever reads it back, so nothing in the walk is paced by
+  // it and a look that fails costs nothing.
+  void detect({ cwd, drivenAgentName: launch.name }).then(
+    (detection) => ui.setDetection(detection),
+    () => undefined,
+  );
 
   await untilAborted(ui.waitForGate("begin"), signal);
   if (signal.aborted) {

--- a/apps/cli/test/assembly.test.ts
+++ b/apps/cli/test/assembly.test.ts
@@ -1,0 +1,297 @@
+/**
+ * The whole walk, offline, with nobody at the keyboard.
+ *
+ * Intro, login, finding the voice agent, connecting it, the folder, generation,
+ * the gate and the push — one run, start to finish, against the fixture
+ * platform, the committed fixture repository, a scripted coding agent and a UI
+ * with no screen. No model, no browser, no terminal, no network beyond this
+ * machine, and nothing typed by a person.
+ *
+ * **What is asserted is what a developer could check afterwards** — which agent
+ * and which connection are on egma, which tests are there and at which frozen
+ * versions, which files are in the repository and what they pin, and the one
+ * line left in the terminal. Nothing here asserts the order egma did any of it
+ * in: that is egma's business, and a check that pinned it would have to be
+ * rewritten every time a step moved.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readConfig } from "../src/folder/egma-folder.ts";
+import { parseTestFile } from "../src/folder/test-file.ts";
+import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import { buildExitLine } from "../src/wizard/exit-line.ts";
+import { walk } from "../src/wizard/walk.ts";
+import type { FakeStep } from "./support/fake-agent.ts";
+import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import {
+  RETELL_FIXTURE_REPO,
+  filesUnder,
+  makeWorkspace,
+  type Workspace,
+} from "./support/workspace.ts";
+
+// Three subprocesses and two servers per walk, inside a run using every core:
+// the budget is generous so that only a broken walk can reach it.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const KEY = "key_5f1a9c73e28b46d0a7c4";
+
+/** Which agent the account holds, which is what the connection will point at. */
+const RETELL_AGENT_ID = "agent_quillfeather_order_line";
+
+/**
+ * One agent on the account, running the fixture repository's own prompt.
+ *
+ * The repository's words and the provider's words are the same here on purpose:
+ * drift has checks of its own, and a walk that is about everything else should
+ * not have a drift line in the middle of it.
+ */
+function account(prompt: string): FakeRetellScript {
+  return {
+    keys: [KEY],
+    agents: [
+      {
+        agent_id: RETELL_AGENT_ID,
+        agent_name: "order-line",
+        response_engine: { type: "retell-llm", llm_id: "llm_quillfeather" },
+      },
+    ],
+    llms: [
+      {
+        llm_id: "llm_quillfeather",
+        general_prompt: prompt,
+        general_tools: [{ type: "end_call" }, { type: "custom", name: "look_up_order" }],
+      },
+    ],
+  };
+}
+
+/** How many tests this walk asks for. The suite the gate lists. */
+const SUITE_SIZE = 12;
+
+/** The fragment that names the find-the-agent task, whatever folder it is for. */
+const DISCOVERY_TASK = "Find the voice agent in";
+
+/** The fragment that names the write-the-tests task, for a suite of this size. */
+const GENERATE_TASK = `Write ${SUITE_SIZE} tests`;
+
+let platform: Platform;
+let retell: FakeRetell;
+let workspace: Workspace;
+let prompt: string;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  // The committed fixture repository: an invented workshop with invented
+  // prompts and invented tools, so there is a real repository to be found.
+  workspace = await makeWorkspace({}, { from: RETELL_FIXTURE_REPO });
+  prompt = await readFile(path.join(workspace.dir, "prompts", "order-line.md"), "utf8");
+  retell = await startFakeRetell(account(prompt));
+});
+
+afterEach(async () => {
+  await retell.close();
+  await platform.close();
+  await workspace.remove();
+});
+
+/** The names of the suite the scripted agent writes. */
+function suiteNames(): string[] {
+  return [
+    "price-question-on-a-rebind",
+    "sunday-drop-off",
+    "lost-the-order-number",
+    "wants-it-by-friday",
+    "asks-for-a-human",
+    "changes-the-address",
+    "cancels-halfway-through",
+    "asks-what-leather-costs",
+    "two-books-one-order",
+    "collection-instead-of-delivery",
+    "damaged-on-arrival",
+    "will-not-say-their-name",
+  ];
+}
+
+/** One test file, as a coding agent that had read the notes would write it. */
+function fileFor(name: string): string {
+  return [
+    "---",
+    `name: ${name}`,
+    "---",
+    "## Scenario",
+    `Somebody rings the order line about ${name.replaceAll("-", " ")}.`,
+    "## Expected behaviors",
+    "1. The agent says the workshop's name.",
+    "2. The agent does not quote a price.",
+    "",
+  ].join("\n");
+}
+
+/** Writing one file, announced the way the notes tell a coding agent to. */
+function writes(name: string): FakeStep[] {
+  return [
+    { kind: "say", text: `egma:writing ${name}\n` },
+    { kind: "write-file", path: `egma/tests/${name}.md`, content: fileFor(name) },
+    { kind: "say", text: `egma:wrote ${name}\n` },
+  ];
+}
+
+describe("the whole walk, offline", () => {
+  it("signs in, finds the agent, connects it, writes the suite and pushes it", async () => {
+    const names = suiteNames();
+
+    const script = await workspace.script({
+      steps: [{ kind: "stop", reason: "end_turn" }],
+      stepsByTask: [
+        {
+          contains: DISCOVERY_TASK,
+          steps: [
+            {
+              kind: "tool-call",
+              id: "t1",
+              title: "Read",
+              toolKind: "read",
+              locations: [{ path: "package.json" }],
+            },
+            { kind: "read-file", path: "package.json", recordAs: "manifest" },
+            { kind: "tool-call-update", id: "t1", status: "completed" },
+            { kind: "say", text: "egma:found framework retell-sdk\n" },
+            { kind: "say", text: "egma:found prompts prompts/order-line.md\n" },
+            { kind: "say", text: "egma:found tools src/tools/*.ts (2 definitions)\n" },
+            { kind: "stop", reason: "end_turn" },
+          ],
+        },
+        {
+          contains: GENERATE_TASK,
+          steps: [
+            { kind: "say", text: `egma:plan ${names.join(", ")}\n` },
+            ...names.flatMap((name) => writes(name)),
+            { kind: "stop", reason: "end_turn" },
+          ],
+        },
+      ],
+    });
+
+    // Everything a person would have done, done by the check: the keystroke at
+    // the intro and the gate open themselves, the browser approves the code,
+    // and the one thing nobody can answer in advance is answered here.
+    const ui = new HeadlessUI({ answers: { "retell-key": KEY } });
+
+    const report = await walk({
+      ui,
+      launch: workspace.launch(script),
+      cwd: workspace.dir,
+      signal: new AbortController().signal,
+      platform: {
+        url: platform.url,
+        credentialsFile: workspace.credentialsFile,
+        openBrowser: async (url) => {
+          const code = new URL(url).searchParams.get("user_code") ?? "";
+          return platform.device.approve(code);
+        },
+      },
+      retell: { url: retell.url },
+      howManyTests: SUITE_SIZE,
+    });
+
+    /* what the developer is left holding */
+
+    expect(report).toEqual({ kind: "tests-pushed", count: SUITE_SIZE });
+    expect(buildExitLine(report)).toBe(
+      `egma put ${SUITE_SIZE} tests on egma and left them in egma/tests/ — commit them, edit them, then run egma push.`,
+    );
+
+    /* this machine is signed in, and to this egma */
+
+    const held = JSON.parse(await readFile(workspace.credentialsFile, "utf8")) as {
+      url: string;
+      key: string;
+    };
+    expect(held.url).toBe(platform.url);
+    expect(platform.device.keys).toContain(held.key);
+
+    /* the agent and the way to reach it are on egma */
+
+    expect(platform.registered.agents.map((agent) => agent.name)).toEqual(["order-line"]);
+    const connection = platform.registered.connections[0];
+    expect(platform.registered.connections).toHaveLength(1);
+    expect(connection).toMatchObject({
+      agentId: platform.registered.agents[0]?.id,
+      type: "retell",
+      modality: "voice",
+      name: "retell-1",
+      config: { retellAgentId: RETELL_AGENT_ID },
+    });
+    // The key reached egma, and only its last characters ever came back.
+    expect(connection?.credentialsHint).toBe(KEY.slice(-4));
+    expect(platform.registered.sealed).toContain(KEY);
+    // What Retell is running was kept whole beside what egma read out of it.
+    expect(platform.registered.agents[0]?.pulled?.prompt).toBe(prompt);
+
+    /* the tests are on egma, every one of them a frozen version */
+
+    expect(platform.tests.tests).toHaveLength(SUITE_SIZE);
+    expect(platform.tests.tests.map((test) => test.name).sort()).toEqual([...names].sort());
+    for (const test of platform.tests.tests) {
+      expect(test.versionId, test.name).toMatch(/^tstv_/u);
+      expect(platform.tests.versionsOf(test.name), test.name).toBe(1);
+    }
+
+    /* the files are in the repository, pinned to those versions */
+
+    const inFolder = await filesUnder(path.join(workspace.dir, "egma"));
+    expect(inFolder).toContain("config.yaml");
+    expect(inFolder.filter((name) => name.startsWith("tests/"))).toHaveLength(SUITE_SIZE);
+
+    const pinned = new Map(platform.tests.tests.map((test) => [test.name, test.versionId]));
+    for (const name of names) {
+      const file = path.join(workspace.dir, "egma", "tests", `${name}.md`);
+      const test = parseTestFile(await readFile(file, "utf8"), `${name}.md`, name);
+      expect(test.version, name).toBe(pinned.get(name));
+      expect(test.expectedBehaviors.length, name).toBeGreaterThan(0);
+    }
+
+    // The folder's config names what egma registered, so a second developer
+    // cloning this repository lands on the same agent.
+    const config = await readConfig(path.join(workspace.dir, "egma", "config.yaml"));
+    expect(config.agent).toMatchObject({
+      name: "order-line",
+      id: platform.registered.agents[0]?.id,
+    });
+    expect(config.connection).toMatchObject({
+      name: "retell-1",
+      id: connection?.id,
+    });
+    expect(config.suite?.name).toBe("first-suite");
+
+    /* nobody was asked anything they had not already answered */
+
+    // What egma worked out for itself before it asked anything, which is what
+    // fills the screen while the developer is away in a browser.
+    expect(ui.record.detection).toEqual({
+      drivenAgentName: "Fake Agent",
+      gitRepository: false,
+      egmaFolder: false,
+      testsAlreadyHere: 0,
+    });
+
+    expect(ui.record.gatesOpened).toEqual(["begin", "run-tests"]);
+    expect(ui.record.gate?.rows).toHaveLength(SUITE_SIZE);
+    // One agent on the account is not a choice, so the choice never opened.
+    expect(ui.record.agentChoices).toEqual([]);
+    // And the repository is otherwise exactly as it was: egma wrote its own
+    // folder and touched nothing else the fixture repository ships.
+    expect(await filesUnder(path.join(workspace.dir, "src"))).toEqual([
+      "config.ts",
+      "server.ts",
+      "tools/book-drop-off.ts",
+      "tools/look-up-order.ts",
+    ]);
+  });
+});

--- a/apps/cli/test/exit-line.test.ts
+++ b/apps/cli/test/exit-line.test.ts
@@ -22,6 +22,8 @@ const EVERY_ENDING: readonly ExitReport[] = [
   { kind: "quit" },
   { kind: "interrupted", drivenAgentName: "Claude Agent" },
   { kind: "interrupted", drivenAgentName: null },
+  { kind: "interrupted", drivenAgentName: "Claude Agent", testsKept: 12 },
+  { kind: "interrupted", drivenAgentName: "Claude Agent", testsKept: 1 },
   { kind: "failed", reason: "the agent stopped talking" },
 ];
 
@@ -52,6 +54,14 @@ describe("the exit line", () => {
 
     expect(buildExitLine({ kind: "interrupted", drivenAgentName: "Claude Agent" })).toContain(
       "stopped before the task finished",
+    );
+
+    // A stop that left files behind says so, in the same one line: a folder a
+    // developer was never told about is a half-truth.
+    expect(
+      buildExitLine({ kind: "interrupted", drivenAgentName: "Claude Agent", testsKept: 12 }),
+    ).toBe(
+      "egma stopped before the task finished, and shut Claude Agent down. Your 12 tests are in egma/tests/.",
     );
 
     expect(buildExitLine({ kind: "failed", reason: "no answer" })).toContain("no answer");

--- a/apps/cli/test/failure-branches.test.ts
+++ b/apps/cli/test/failure-branches.test.ts
@@ -1,10 +1,10 @@
 /**
  * The five ways the walk does not reach a suite, each one ending honestly.
  *
- * They are the branches the reviewed transcript names, and they are first-class
- * here rather than an afterthought: a wizard is judged on what it does when the
- * machine is cold, the key is wrong, the repository is the wrong one, or egma
- * cannot do the thing the developer is about to be charged for.
+ * They are first-class here rather than an afterthought, because a wizard is
+ * judged on what it does when the machine is cold, the key is wrong, the
+ * repository is the wrong one, or egma cannot do the thing the developer is
+ * about to be charged for.
  *
  * What is asserted is what the developer is left with — the line in their
  * scrollback, the number the shell gets, and whether they were asked the same

--- a/apps/cli/test/failure-branches.test.ts
+++ b/apps/cli/test/failure-branches.test.ts
@@ -1,0 +1,249 @@
+/**
+ * The five ways the walk does not reach a suite, each one ending honestly.
+ *
+ * They are the branches the reviewed transcript names, and they are first-class
+ * here rather than an afterthought: a wizard is judged on what it does when the
+ * machine is cold, the key is wrong, the repository is the wrong one, or egma
+ * cannot do the thing the developer is about to be charged for.
+ *
+ * What is asserted is what the developer is left with — the line in their
+ * scrollback, the number the shell gets, and whether they were asked the same
+ * question twice. Not the order egma tried things in.
+ */
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { INVALID_KEY_LINE } from "../src/retell/connect.ts";
+import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import { buildExitLine, buildExitNotice } from "../src/wizard/exit-line.ts";
+import { walk } from "../src/wizard/walk.ts";
+import type { FakeStep } from "./support/fake-agent.ts";
+import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
+import { noAdapterRefusal, startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import {
+  CLI_ENTRY,
+  RETELL_FIXTURE_REPO,
+  makeWorkspace,
+  type Workspace,
+} from "./support/workspace.ts";
+
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const KEY = "key_3d8e1f60ba725c94af13";
+const WRONG_KEY = "key_0000000000000000notthis";
+
+const ACCOUNT: FakeRetellScript = {
+  keys: [KEY],
+  agents: [
+    {
+      agent_id: "agent_quillfeather_order_line",
+      agent_name: "order-line",
+      response_engine: { type: "retell-llm", llm_id: "llm_quillfeather" },
+    },
+  ],
+  llms: [{ llm_id: "llm_quillfeather", general_prompt: "Answer the order line.\n" }],
+};
+
+/** What the find-the-agent step is answered with when it is meant to succeed. */
+const FOUND: FakeStep[] = [
+  { kind: "say", text: "egma:found framework retell-sdk\n" },
+  { kind: "stop", reason: "end_turn" },
+];
+
+let platform: Platform;
+let retell: FakeRetell;
+let workspace: Workspace;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  retell = await startFakeRetell(ACCOUNT);
+  workspace = await makeWorkspace({}, { from: RETELL_FIXTURE_REPO });
+  await workspace.signIn(platform.url, platform.device.mint());
+});
+
+afterEach(async () => {
+  await retell.close();
+  await platform.close();
+  await workspace.remove();
+});
+
+/** The walk, with whatever the developer would have answered written down. */
+async function walkWith(options: {
+  readonly script: string;
+  readonly answers?: Partial<Record<"prompts-pointer" | "retell-key", string>>;
+}) {
+  const ui = new HeadlessUI({ answers: options.answers ?? {} });
+  const report = await walk({
+    ui,
+    launch: workspace.launch(options.script),
+    cwd: workspace.dir,
+    signal: new AbortController().signal,
+    platform: { url: platform.url, credentialsFile: workspace.credentialsFile },
+    retell: { url: retell.url },
+    howManyTests: 1,
+  });
+  return { ui, report };
+}
+
+describe("no coding agent on this machine", () => {
+  it("prints what to paste into one, and leaves without a fault", async () => {
+    // A command that is not on this machine is the same thing to a developer as
+    // no coding agent at all, so it is the same ending.
+    const missing = path.join(workspace.dir, "no-such-coding-agent");
+
+    const result = await new Promise<{ stdout: string; code: number }>((resolve) => {
+      const child = spawn(
+        process.execPath,
+        [CLI_ENTRY, "--headless", "--cwd", workspace.dir, "--", missing],
+        {
+          cwd: workspace.dir,
+          env: workspace.env({ EGMA_URL: platform.url }),
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      let stdout = "";
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.on("close", (code) => resolve({ stdout, code: code ?? 1 }));
+    });
+
+    // egma did everything it could, so this is the run finishing rather than
+    // failing — and the developer has words that work without egma at all.
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Open the coding agent you use, and paste this into it:");
+    expect(result.stdout.trimEnd().split("\n").at(-1)).toBe(
+      "egma found no coding agent on this machine that it can drive, so it printed what to paste into yours instead.",
+    );
+  });
+
+  it("says the same thing in the same words wherever the walk noticed", async () => {
+    const report = { kind: "no-coding-agent" } as const;
+    expect(buildExitNotice(report)).toContain("paste this into it:");
+    expect(buildExitLine(report)).toContain("printed what to paste into yours instead");
+  });
+});
+
+describe("a coding agent that is not logged in", () => {
+  it("hands the developer to its own login and carries straight on", async () => {
+    const script = await workspace.script({
+      // A cold machine: the first session is refused until the client has
+      // authenticated, exactly as a real adapter refuses one.
+      authRequiredUntilLogin: {},
+      steps: FOUND,
+      stepsByTask: [
+        {
+          contains: "Write 1 test",
+          steps: [
+            { kind: "say", text: "egma:writing open-on-sunday\n" },
+            {
+              kind: "write-file",
+              path: "egma/tests/open-on-sunday.md",
+              content: [
+                "---",
+                "name: open-on-sunday",
+                "---",
+                "## Scenario",
+                "Somebody rings on a Sunday.",
+                "## Expected behaviors",
+                "1. The agent says which days the workshop opens.",
+                "",
+              ].join("\n"),
+            },
+            { kind: "say", text: "egma:wrote open-on-sunday\n" },
+            { kind: "stop", reason: "end_turn" },
+          ],
+        },
+      ],
+    });
+
+    const { ui, report } = await walkWith({ script, answers: { "retell-key": KEY } });
+
+    // The login was handed off and the walk resumed on the other side of it.
+    const observed = JSON.parse(
+      await readFile(path.join(workspace.dir, "fake-agent-report.json"), "utf8"),
+    ) as { loggedInWith: string | null };
+    expect(observed.loggedInWith).toBe("own-login");
+    expect(ui.record.statuses.join("\n")).toContain("needs you to log in");
+
+    expect(report).toEqual({ kind: "tests-pushed", count: 1 });
+    expect(platform.tests.tests).toHaveLength(1);
+  });
+});
+
+describe("no voice agent anywhere", () => {
+  it("asks once where the prompts are, then says plainly to run it elsewhere", async () => {
+    const script = await workspace.script({
+      steps: [
+        { kind: "say", text: "egma:none There is no voice agent in this folder.\n" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+
+    const { ui, report } = await walkWith({ script });
+
+    // Asked once, and only once: a second question would be egma hoping.
+    expect(ui.record.asked).toEqual(["prompts-pointer"]);
+    expect(report).toEqual({ kind: "no-agent-context" });
+    expect(buildExitLine(report)).toBe(
+      "egma found no voice agent to test. Run egma again where your agent is defined.",
+    );
+
+    // Nothing was registered and no folder was made, because egma never got as
+    // far as knowing what it would have been for.
+    expect(platform.registered.agents).toHaveLength(0);
+    await expect(readFile(path.join(workspace.dir, "egma", "config.yaml"), "utf8")).rejects.toThrow();
+  });
+});
+
+describe("a Retell key Retell will not take", () => {
+  it("names that failure, asks once more, and stops on the second refusal", async () => {
+    const script = await workspace.script({ steps: FOUND });
+
+    const { ui, report } = await walkWith({
+      script,
+      answers: { "retell-key": WRONG_KEY },
+    });
+
+    // Told exactly which failure it was — not "something went wrong" — and
+    // asked again with that sentence above the box.
+    expect(ui.record.keyAsks).toHaveLength(2);
+    expect(ui.record.keyAsks[0]?.problem).toBeNull();
+    expect(ui.record.keyAsks[1]?.problem).toBe(INVALID_KEY_LINE);
+    expect(ui.record.statuses.filter((line) => line === INVALID_KEY_LINE)).toHaveLength(1);
+
+    expect(report).toEqual({ kind: "failed", reason: "Retell would not take that key." });
+    expect(buildExitLine(report)).toBe("egma could not finish: Retell would not take that key.");
+
+    // Nothing was written anywhere on a key that never worked.
+    expect(platform.registered.agents).toHaveLength(0);
+    expect(platform.registered.sealed).toHaveLength(0);
+  });
+});
+
+describe("a connection egma has no adapter for", () => {
+  it("prints the platform's refusal in the platform's own words", async () => {
+    // The platform refuses a connection it could not run simulations over. The
+    // wizard's whole job here is to hand that sentence on untouched.
+    platform.registered.withoutAdapterFor("retell");
+
+    const script = await workspace.script({ steps: FOUND });
+    const { ui, report } = await walkWith({ script, answers: { "retell-key": KEY } });
+
+    const refusal = noAdapterRefusal("retell");
+    expect(report).toEqual({ kind: "failed", reason: refusal });
+    expect(buildExitLine(report)).toBe(`egma could not finish: ${refusal}`);
+    // Verbatim: not summarised, not softened, not swallowed.
+    expect(buildExitLine(report)).toContain("no adapter for it has shipped");
+
+    expect(platform.registered.agents).toHaveLength(0);
+    expect(platform.registered.connections).toHaveLength(0);
+    expect(ui.record.gate).toBeNull();
+  });
+});

--- a/apps/cli/test/interrupt.test.ts
+++ b/apps/cli/test/interrupt.test.ts
@@ -129,15 +129,20 @@ describe("Ctrl-C while the browser is being waited on", () => {
       // The login screen: a code to approve, an address it is already in, and
       // the wait filled with what egma worked out while the developer read the
       // intro. None of it was asked for and none of it is waited on.
-      const waiting = await showing(
+      //
+      // Every line is waited for rather than read off one screen and asserted
+      // afterwards. The pane arrives on its own and a terminal paints a line at
+      // a time, so a screen caught between two of them is a screen that is half
+      // drawn — and a check that reads one is a check that fails on a fast day.
+      await showing(
         terminal,
         "Code:",
         "Approve this code",
         "While you were away, egma looked around:",
+        "Coding agent   node",
+        "Git            not a repository",
+        "egma folder    none yet — egma will make one",
       );
-      expect(waiting).toContain("Coding agent   node");
-      expect(waiting).toContain("Git            not a repository");
-      expect(waiting).toContain("egma folder    none yet");
 
       terminal.write(CTRL_C);
 

--- a/apps/cli/test/interrupt.test.ts
+++ b/apps/cli/test/interrupt.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Ctrl-C, at three different moments, in a real terminal.
+ *
+ * A developer changes their mind at whatever point they are at, and the wizard
+ * is at a different kind of moment at each of them: waiting on a browser with
+ * nothing started, part way through a task with somebody else's process tree
+ * running, and looking at a list of files that are already on disk.
+ *
+ * Three things have to be true at every one of them, and they are what these
+ * check:
+ *
+ * - **Nothing is left running.** The coding agent starts a process tree of its
+ *   own, and ending only the process egma spawned would leave the rest behind.
+ * - **Nothing is left in the repository without being said.** Files that were
+ *   written are the developer's, and the line has to name where they are.
+ * - **The line tells the truth about where it stopped**, and it is the only
+ *   thing in scrollback.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runInTerminal, showing } from "./support/pty.ts";
+import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import type { FakeStep } from "./support/fake-agent.ts";
+import {
+  CLI_ENTRY,
+  FAKE_AGENT,
+  RETELL_FIXTURE_REPO,
+  isAlive,
+  makeWorkspace,
+  waitUntil,
+  type Workspace,
+} from "./support/workspace.ts";
+
+// A real terminal, real subprocesses and two servers, inside a run using every
+// core: the budget is generous so that only a broken wizard can reach it.
+vi.setConfig({ testTimeout: 90_000, hookTimeout: 60_000 });
+
+const CTRL_C = "";
+
+const KEY = "key_71bc0e4d938a25f6c0ab";
+
+const ACCOUNT: FakeRetellScript = {
+  keys: [KEY],
+  agents: [
+    {
+      agent_id: "agent_quillfeather_order_line",
+      agent_name: "order-line",
+      response_engine: { type: "retell-llm", llm_id: "llm_quillfeather" },
+    },
+  ],
+  llms: [{ llm_id: "llm_quillfeather", general_prompt: "Answer the order line.\n" }],
+};
+
+let platform: Platform;
+let retell: FakeRetell;
+let workspace: Workspace;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  retell = await startFakeRetell(ACCOUNT);
+  workspace = await makeWorkspace({}, { from: RETELL_FIXTURE_REPO });
+});
+
+afterEach(async () => {
+  await retell.close();
+  await platform.close();
+  await workspace.remove();
+});
+
+/** The wizard, in a terminal, driving the scripted agent at this script. */
+function startWizard(script: string) {
+  return runInTerminal({
+    command: process.execPath,
+    args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+    cwd: workspace.dir,
+    env: workspace.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+    cols: 100,
+  });
+}
+
+/** Every test file the folder holds, or none when there is no folder. */
+async function testsInFolder(): Promise<string[]> {
+  return readdir(path.join(workspace.dir, "egma", "tests")).catch(() => [] as string[]);
+}
+
+/** The fragment only the write-the-tests task has, whatever it asks for. */
+const GENERATE_TASK = "## The words the agent is running on";
+
+/** Writing one file, announced the way the notes tell a coding agent to. */
+function writes(name: string): FakeStep[] {
+  return [
+    { kind: "say", text: `egma:writing ${name}\n` },
+    {
+      kind: "write-file",
+      path: `egma/tests/${name}.md`,
+      content: [
+        "---",
+        `name: ${name}`,
+        "---",
+        "## Scenario",
+        `Somebody rings the order line about ${name.replaceAll("-", " ")}.`,
+        "## Expected behaviors",
+        "1. The agent says the workshop's name.",
+        "",
+      ].join("\n"),
+    },
+    { kind: "say", text: `egma:wrote ${name}\n` },
+  ];
+}
+
+describe("Ctrl-C while the browser is being waited on", () => {
+  it("stops without a task ever starting, and leaves nothing in the repository", async () => {
+    // Nobody will approve this, and nothing should be waiting for them to.
+    platform.device.pollEvery(1);
+
+    const script = await workspace.script({ steps: [{ kind: "stop", reason: "end_turn" }] });
+    const terminal = startWizard(script);
+
+    try {
+      await showing(terminal, "egma is about to find", "[enter] begin");
+      terminal.write("\r");
+
+      // The login screen: a code to approve, an address it is already in, and
+      // the wait filled with what egma worked out while the developer read the
+      // intro. None of it was asked for and none of it is waited on.
+      const waiting = await showing(
+        terminal,
+        "Code:",
+        "Approve this code",
+        "While you were away, egma looked around:",
+      );
+      expect(waiting).toContain("Coding agent   node");
+      expect(waiting).toContain("Git            not a repository");
+      expect(waiting).toContain("egma folder    none yet");
+
+      terminal.write(CTRL_C);
+
+      expect(await terminal.exited).toBe(130);
+      expect(terminal.scrollback().trim()).toBe("egma stopped before the task finished.");
+
+      // Nothing was driven, so nothing was written and nothing was registered.
+      expect(await testsInFolder()).toEqual([]);
+      expect(platform.registered.agents).toHaveLength(0);
+    } finally {
+      await terminal.kill();
+    }
+  });
+});
+
+describe("Ctrl-C while the coding agent is working", () => {
+  it("ends the agent's whole process tree and says it did", async () => {
+    await workspace.signIn(platform.url, platform.device.mint());
+
+    const script = await workspace.script({
+      // The agent starts a process of its own, exactly as a real adapter starts
+      // its engine. Ending only the process egma spawned would strand it.
+      spawnChild: true,
+      steps: [
+        { kind: "tool-call", id: "t1", title: "Reading the repository" },
+        { kind: "wait", ms: 120_000 },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+    const terminal = startWizard(script);
+
+    try {
+      await showing(terminal, "egma is about to find", "[enter] begin");
+      terminal.write("\r");
+      await showing(terminal, "Reading the repository");
+
+      const observed = JSON.parse(
+        await readFile(path.join(workspace.dir, "fake-agent-report.json"), "utf8"),
+      ) as { childPid: number | null };
+      const childPid = observed.childPid;
+      expect(childPid).not.toBeNull();
+      expect(isAlive(childPid as number)).toBe(true);
+
+      terminal.write(CTRL_C);
+
+      expect(await terminal.exited).toBe(130);
+      expect(terminal.scrollback().trim()).toBe(
+        "egma stopped before the task finished, and shut node down.",
+      );
+
+      // The agent's own process is gone, and so is the one it started.
+      expect(await waitUntil(() => !isAlive(childPid as number), 10_000)).toBe(true);
+      expect(await testsInFolder()).toEqual([]);
+    } finally {
+      await terminal.kill();
+    }
+  });
+});
+
+describe("Ctrl-C at the gate, with the files already written", () => {
+  it("says how many tests are in the repository and pushes none of them", async () => {
+    await workspace.signIn(platform.url, platform.device.mint());
+
+    const names = ["open-on-sunday", "lost-the-order-number", "wants-it-by-friday"];
+    const script = await workspace.script({
+      spawnChild: true,
+      steps: [
+        { kind: "say", text: "egma:found framework retell-sdk\n" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+      stepsByTask: [
+        {
+          // Whatever size of suite egma asked for, this agent writes three and
+          // stops. What reaches the gate is what is really on disk.
+          contains: GENERATE_TASK,
+          steps: [
+            { kind: "say", text: `egma:plan ${names.join(", ")}\n` },
+            ...names.flatMap((name) => writes(name)),
+            { kind: "stop", reason: "end_turn" },
+          ],
+        },
+      ],
+    });
+
+    const terminal = startWizard(script);
+
+    try {
+      await showing(terminal, "egma is about to find", "[enter] begin");
+      terminal.write("\r");
+
+      await showing(terminal, "Paste your Retell API key");
+      terminal.write(`${KEY}\r`);
+
+      await showing(terminal, "Do you already have test cases");
+      terminal.write("n");
+
+      // The list, with every file on it, waiting on one keystroke.
+      await showing(terminal, "3 tests generated", "[enter] run", ...names);
+
+      terminal.write(CTRL_C);
+
+      expect(await terminal.exited).toBe(130);
+      expect(terminal.scrollback().trim()).toBe(
+        "egma stopped before the task finished, and shut node down. Your 3 tests are in egma/tests/.",
+      );
+
+      // The agent that wrote them, and the process it started, are both gone —
+      // the task was over before the gate, and nothing was left holding on.
+      const observed = JSON.parse(
+        await readFile(path.join(workspace.dir, "fake-agent-report.json"), "utf8"),
+      ) as { childPid: number | null };
+      expect(observed.childPid).not.toBeNull();
+      expect(await waitUntil(() => !isAlive(observed.childPid as number), 10_000)).toBe(true);
+
+      // The files are exactly where the line says they are, and nothing was
+      // uploaded: the developer stopped before the one keystroke that would
+      // have put them on egma.
+      expect((await testsInFolder()).sort()).toEqual(names.map((name) => `${name}.md`).sort());
+      expect(platform.tests.tests).toHaveLength(0);
+    } finally {
+      await terminal.kill();
+    }
+  });
+});

--- a/apps/cli/test/skills.test.ts
+++ b/apps/cli/test/skills.test.ts
@@ -19,69 +19,11 @@ import { describe, expect, it } from "vitest";
 import { SKILL_NAMES, instructionsWith, skill, skillFile } from "../src/skills/index.ts";
 import { FACTS } from "../src/wizard/facts.ts";
 import { pasteFallbackMessage } from "../src/wizard/no-coding-agent.ts";
+import { BANNED, SCENARIO_HEADING } from "./support/glossary.ts";
 
 const run = promisify(execFile);
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
-
-/**
- * The words the glossary bans, in the shapes that would slip past a reader.
- *
- * This is the whole banned list, not a sample of it: a skill is text egma puts
- * in front of a coding agent, and a word egma will not say on a screen is a
- * word it will not say to a model either.
- *
- * Two kinds of entry are left out on purpose, and both are carve-outs the
- * glossary itself makes rather than gaps.
- *
- *   The bans the glossary qualifies — `result` as an entity, `metric` for
- *   scoring logic, `check` as a name for a grader — cannot be told apart from
- *   their ordinary English by a regular expression, and a guard that fires on
- *   "check the manifest" is a guard somebody turns off.
- *
- *   `session` is banned for an exchange and right for two seams: a signed-in
- *   browser session, and the protocol's own name for its connection to a
- *   driven coding agent. Neither belongs in a skill, so the word is banned
- *   here in full — the carve-out lives in the code that speaks the protocol.
- */
-const BANNED = [
-  /\beval\b/i,
-  /\bevaluations?\b/i,
-  /\bevaluators?\b/i,
-  /\bscorers?\b/i,
-  /\bassertions?\b/i,
-  /\bcalls?\b/i,
-  /\bcallers?\b/i,
-  /\bconversations?\b/i,
-  /\bdigital humans?\b/i,
-  /\bsimulants?\b/i,
-  /\bvirtual humans?\b/i,
-  /\bsynthetic users?\b/i,
-  /\bdigital twins?\b/i,
-  /\bscenarios?\b/i,
-  /\bsessions?\b/i,
-  /\btrials?\b/i,
-  /\battempts?\b/i,
-  /\biterations?\b/i,
-  /\bexperiments?\b/i,
-  /\bbatch(?:es)?\b/i,
-  /\bexpected outcomes?\b/i,
-];
-
-/**
- * The one banned word a skill legitimately writes, in the one shape it may.
- *
- * The glossary bans `scenario` **as an entity** and keeps it as the name of a
- * field on a test — and the test file format calls its first heading exactly
- * that. A skill that teaches the format has to write the heading, so the
- * heading is taken out before the bans are run and every other use of the word
- * still fails. Written as the heading it is, backticks and all, and no wider
- * than that: a hash and blank space on the same line, the word, and a boundary
- * after it. A sentence about "the scenario" has no hash in front of it and a
- * heading called `## Scenarios` is the entity the glossary bans — neither can
- * hide behind this, and both still fail.
- */
-const SCENARIO_HEADING = /`?#{1,6}[ \t]*scenario(?!\w)`?/gi;
 
 describe("egma's skills", () => {
   it("are markdown content, shaped the way a skill file is", () => {

--- a/apps/cli/test/support/fixture-platform/agents.ts
+++ b/apps/cli/test/support/fixture-platform/agents.ts
@@ -292,7 +292,30 @@ function connectionOut(connection: StoredConnection): Record<string, unknown> {
   return shown;
 }
 
+/**
+ * What the platform says about a connection type it cannot reach yet.
+ *
+ * The rule it stands for is the platform's: a connection whose adapter has not
+ * shipped is refused **loudly, at creation, in the platform's own words**, and
+ * the wizard prints those words rather than a summary of them. Where that
+ * refusal is served from is the platform's business and it will move to run
+ * creation the day the public API serves runs; what this pins is the only half
+ * the CLI owns — that it swallows nothing.
+ */
+export function noAdapterRefusal(type: string): string {
+  return (
+    `egma cannot run simulations over a ${type} connection yet: no adapter for it ` +
+    "has shipped. Nothing was registered, because a way of reaching your agent " +
+    "that egma cannot use is not one."
+  );
+}
+
 export type AgentControls = {
+  /**
+   * Make this connection type one egma has no adapter for, so registering one
+   * is refused the way the platform refuses it.
+   */
+  withoutAdapterFor(type: string): void;
   /** Every agent written, oldest first. */
   readonly agents: readonly StoredAgent[];
   /** Every connection written, oldest first. */
@@ -317,6 +340,8 @@ export function agentRoutes(knowsKey: (key: string) => boolean): {
   const connections: StoredConnection[] = [];
   const sealed: string[] = [];
   const projectsNamed: (string | null)[] = [];
+  /** Connection types this instance has no adapter for. Empty by default. */
+  const unreachableTypes = new Set<string>();
 
   /** The project everything lands in when a write names none. */
   const HOME_PROJECT = newId("prj");
@@ -359,6 +384,9 @@ export function agentRoutes(knowsKey: (key: string) => boolean): {
   ): StoredConnection => {
     const descriptor = descriptorOf(input["type"]);
     const type = input["type"] as string;
+    if (unreachableTypes.has(type)) {
+      throw new Refusal(noAdapterRefusal(type), { status: 422, code: "no_adapter" });
+    }
     const modality = validModality(type, input["modality"]);
     const config = validConfig(type, input["config"]);
     const credentials = validCredentials(type, input["credentials"]);
@@ -522,5 +550,16 @@ export function agentRoutes(knowsKey: (key: string) => boolean): {
     ],
   };
 
-  return { group, controls: { agents, connections, sealed, projectsNamed } };
+  return {
+    group,
+    controls: {
+      withoutAdapterFor(type) {
+        unreachableTypes.add(type);
+      },
+      agents,
+      connections,
+      sealed,
+      projectsNamed,
+    },
+  };
 }

--- a/apps/cli/test/support/fixture-platform/index.ts
+++ b/apps/cli/test/support/fixture-platform/index.ts
@@ -12,6 +12,7 @@ import { deviceRoutes, type DeviceControls } from "./device.ts";
 import { startFixturePlatform, type FixturePlatform } from "./server.ts";
 import { testRoutes, type TestControls } from "./tests.ts";
 
+export { noAdapterRefusal } from "./agents.ts";
 export type { AgentControls } from "./agents.ts";
 export type { DeviceControls } from "./device.ts";
 export type { FixturePlatform, Observation } from "./server.ts";

--- a/apps/cli/test/support/glossary.ts
+++ b/apps/cli/test/support/glossary.ts
@@ -1,0 +1,70 @@
+/**
+ * The words the glossary bans, in the shapes that would slip past a reader.
+ *
+ * This is the whole banned list, not a sample of it, and it lives here rather
+ * than beside any one check because there is more than one kind of text egma
+ * writes for a person to read: the skills it puts in front of a coding agent,
+ * and the cards it teaches a developer with while they wait. Two lists would
+ * eventually differ, and the day they differed is the day one of them would be
+ * wrong — and it would be the shorter one, quietly.
+ *
+ * Two kinds of entry are left out on purpose, and both are carve-outs the
+ * glossary itself makes rather than gaps.
+ *
+ *   The bans the glossary qualifies — `result` as an entity, `metric` for
+ *   scoring logic, `check` as a name for a grader — cannot be told apart from
+ *   their ordinary English by a regular expression, and a guard that fires on
+ *   "check the manifest" is a guard somebody turns off.
+ *
+ *   `session` is banned for an exchange and right for two seams: a signed-in
+ *   browser session, and the protocol's own name for its connection to a
+ *   driven coding agent. Neither belongs in text a developer reads, so the word
+ *   is banned here in full — the carve-out lives in the code that speaks the
+ *   protocol.
+ */
+export const BANNED = [
+  /\beval\b/i,
+  /\bevaluations?\b/i,
+  /\bevaluators?\b/i,
+  /\bscorers?\b/i,
+  /\bassertions?\b/i,
+  /\bcalls?\b/i,
+  /\bcallers?\b/i,
+  /\bconversations?\b/i,
+  /\bdigital humans?\b/i,
+  /\bsimulants?\b/i,
+  /\bvirtual humans?\b/i,
+  /\bsynthetic users?\b/i,
+  /\bdigital twins?\b/i,
+  /\bscenarios?\b/i,
+  /\bsessions?\b/i,
+  /\btrials?\b/i,
+  /\battempts?\b/i,
+  /\biterations?\b/i,
+  /\bexperiments?\b/i,
+  /\bbatch(?:es)?\b/i,
+  /\bexpected outcomes?\b/i,
+];
+
+/**
+ * The one banned word a skill legitimately writes, in the one shape it may.
+ *
+ * The glossary bans `scenario` **as an entity** and keeps it as the name of a
+ * field on a test — and the test file format calls its first heading exactly
+ * that. A skill that teaches the format has to write the heading, so the
+ * heading is taken out before the bans are run and every other use of the word
+ * still fails. Written as the heading it is, backticks and all, and no wider
+ * than that: a hash and blank space on the same line, the word, and a boundary
+ * after it. A sentence about "the scenario" has no hash in front of it and a
+ * heading called `## Scenarios` is the entity the glossary bans — neither can
+ * hide behind this, and both still fail.
+ *
+ * It is a carve-out for a file format, not for prose, so nothing that is only
+ * ever prose takes it: the teaching deck is checked against the bans whole.
+ */
+export const SCENARIO_HEADING = /`?#{1,6}[ \t]*scenario(?!\w)`?/gi;
+
+/** Every ban this text breaks, in the words it broke them with. */
+export function bannedWordsIn(text: string): readonly string[] {
+  return BANNED.flatMap((banned) => banned.exec(text)?.[0] ?? []);
+}

--- a/apps/cli/test/teaching.test.ts
+++ b/apps/cli/test/teaching.test.ts
@@ -22,6 +22,7 @@ import { walk } from "../src/wizard/walk.ts";
 import type { FakeStep } from "./support/fake-agent.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { bannedWordsIn } from "./support/glossary.ts";
 import { runInTerminal, showing } from "./support/pty.ts";
 import {
   CLI_ENTRY,
@@ -136,20 +137,13 @@ describe("the deck", () => {
     // And none of the words the glossary bans, which is the half that matters:
     // a card teaching a near synonym teaches a developer to ask for something
     // egma does not answer to.
-    for (const banned of [
-      "eval",
-      "evaluator",
-      "scorer",
-      "assertion",
-      "digital human",
-      "caller",
-      "experiment",
-      "batch",
-      "conversation with",
-      "caller's session",
-    ]) {
-      expect(said.toLowerCase(), banned).not.toContain(banned);
-    }
+    //
+    // It is the same list the skills are held to, and it is that list rather
+    // than a shorter one written to fit the cards — a guard shaped around the
+    // text it guards proves only that somebody read the text once. The deck
+    // takes no carve-out at all: the one the skills take is for a file format,
+    // and a card is prose from the first word to the last.
+    expect(bannedWordsIn(said)).toEqual([]);
   });
 
   it("is written to the width of the pane, so nothing rewraps it", () => {
@@ -208,7 +202,7 @@ describe("the pane, while the files land", () => {
 
       // The timer never fired: the second card was never on screen, so nothing
       // about this run waited on the deck turning.
-      expect(drawn).not.toContain("The synthetic person who calls");
+      expect(drawn).not.toContain("The synthetic person on the");
       expect(drawn).not.toContain("A persona");
 
       /* the same walk, with no screen at all */

--- a/apps/cli/test/teaching.test.ts
+++ b/apps/cli/test/teaching.test.ts
@@ -1,0 +1,284 @@
+/**
+ * The words egma uses, taught while the files land — and never in the way.
+ *
+ * Two things have to be true of the pane and the second is the harder one. It
+ * has to teach the glossary's own vocabulary, because a developer who leaves
+ * the wizard calling a run a batch will not find anything egma answers to. And
+ * it has to cost nothing: the flow must not wait on it, be paced by it, or end
+ * differently because it was drawn. So the same suite is written twice — once
+ * with the pane on a real terminal and once with no screen at all — and what
+ * comes out is compared.
+ */
+
+import path from "node:path";
+import process from "node:process";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LEARN_CARDS, CARD_WIDTH, cardAt } from "../src/wizard/teaching.ts";
+import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import { buildExitLine } from "../src/wizard/exit-line.ts";
+import { walk } from "../src/wizard/walk.ts";
+import type { FakeStep } from "./support/fake-agent.ts";
+import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { runInTerminal, showing } from "./support/pty.ts";
+import {
+  CLI_ENTRY,
+  FAKE_AGENT,
+  RETELL_FIXTURE_REPO,
+  makeWorkspace,
+  type Workspace,
+} from "./support/workspace.ts";
+
+vi.setConfig({ testTimeout: 90_000, hookTimeout: 60_000 });
+
+const KEY = "key_44a0d7c1e6b39f28510d";
+
+const ACCOUNT: FakeRetellScript = {
+  keys: [KEY],
+  agents: [
+    {
+      agent_id: "agent_quillfeather_order_line",
+      agent_name: "order-line",
+      response_engine: { type: "retell-llm", llm_id: "llm_quillfeather" },
+    },
+  ],
+  llms: [{ llm_id: "llm_quillfeather", general_prompt: "Answer the order line.\n" }],
+};
+
+/** The fragment only the write-the-tests task has, whatever it asks for. */
+const GENERATE_TASK = "## The words the agent is running on";
+
+const NAMES = ["open-on-sunday", "lost-the-order-number", "wants-it-by-friday"];
+
+function fileFor(name: string): string {
+  return [
+    "---",
+    `name: ${name}`,
+    "---",
+    "## Scenario",
+    `Somebody rings the order line about ${name.replaceAll("-", " ")}.`,
+    "## Expected behaviors",
+    "1. The agent says the workshop's name.",
+    "",
+  ].join("\n");
+}
+
+function writes(name: string): FakeStep[] {
+  return [
+    { kind: "say", text: `egma:writing ${name}\n` },
+    { kind: "write-file", path: `egma/tests/${name}.md`, content: fileFor(name) },
+    { kind: "say", text: `egma:wrote ${name}\n` },
+  ];
+}
+
+/**
+ * The one script both runs use.
+ *
+ * It waits between files so that the pane is on screen long enough to be read —
+ * and for well under the time one card stays up, which is what makes "the timer
+ * never fired" a fact about this run rather than a hope.
+ */
+function scriptFor(workspace: Workspace): Promise<string> {
+  return workspace.script({
+    steps: [
+      { kind: "say", text: "egma:found framework retell-sdk\n" },
+      { kind: "stop", reason: "end_turn" },
+    ],
+    stepsByTask: [
+      {
+        contains: GENERATE_TASK,
+        steps: [
+          { kind: "say", text: `egma:plan ${NAMES.join(", ")}\n` },
+          ...NAMES.flatMap((name) => [
+            { kind: "wait", ms: 500 } as FakeStep,
+            ...writes(name),
+          ]),
+          { kind: "stop", reason: "end_turn" },
+        ],
+      },
+    ],
+  });
+}
+
+let platform: Platform;
+let retell: FakeRetell;
+let workspace: Workspace;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  retell = await startFakeRetell(ACCOUNT);
+  workspace = await makeWorkspace({}, { from: RETELL_FIXTURE_REPO });
+  await workspace.signIn(platform.url, platform.device.mint());
+});
+
+afterEach(async () => {
+  await retell.close();
+  await platform.close();
+  await workspace.remove();
+});
+
+describe("the deck", () => {
+  it("says what egma means, in egma's own words", () => {
+    const said = LEARN_CARDS.flatMap((card) => [card.heading, ...card.lines]).join(" ");
+
+    // The glossary's spine: a test is executed as simulations inside a run, a
+    // metric measures, a grader judges, and a verdict is one of four.
+    expect(said).toContain("expected behaviors");
+    expect(said).toContain("One execution of a selection of");
+    expect(said).toContain("One test executed once inside a");
+    expect(said).toContain("A metric measures");
+    expect(said).toContain("A grader judges");
+    expect(said).toContain("passed, failed, skipped,");
+    expect(said).toContain("errored");
+
+    // And none of the words the glossary bans, which is the half that matters:
+    // a card teaching a near synonym teaches a developer to ask for something
+    // egma does not answer to.
+    for (const banned of [
+      "eval",
+      "evaluator",
+      "scorer",
+      "assertion",
+      "digital human",
+      "caller",
+      "experiment",
+      "batch",
+      "conversation with",
+      "caller's session",
+    ]) {
+      expect(said.toLowerCase(), banned).not.toContain(banned);
+    }
+  });
+
+  it("is written to the width of the pane, so nothing rewraps it", () => {
+    for (const card of LEARN_CARDS) {
+      expect(card.heading.length, card.heading).toBeLessThanOrEqual(CARD_WIDTH);
+      for (const line of card.lines) {
+        expect(line.length, line).toBeLessThanOrEqual(CARD_WIDTH);
+      }
+    }
+  });
+
+  it("never runs out, however long the writing takes", () => {
+    expect(cardAt(0)).toBe(LEARN_CARDS[0]);
+    expect(cardAt(LEARN_CARDS.length)).toBe(LEARN_CARDS[0]);
+    expect(cardAt(LEARN_CARDS.length * 4 + 2)).toBe(LEARN_CARDS[2]);
+  });
+});
+
+describe("the pane, while the files land", () => {
+  it("is drawn beside them, and the walk ends exactly as it does without it", async () => {
+    const script = await scriptFor(workspace);
+
+    const terminal = runInTerminal({
+      command: process.execPath,
+      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      cwd: workspace.dir,
+      env: workspace.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+      cols: 100,
+    });
+
+    try {
+      await showing(terminal, "egma is about to find", "[enter] begin");
+      terminal.write("\r");
+
+      await showing(terminal, "Paste your Retell API key");
+      terminal.write(`${KEY}\r`);
+
+      await showing(terminal, "Do you already have test cases");
+      terminal.write("n");
+
+      // The first card is up, beside the list it is meant to fill the wait of.
+      const pane = await showing(
+        terminal,
+        "Writing tests for your voice agent.",
+        "A test",
+        "One situation to put your agent",
+        "Progress:",
+      );
+      expect(pane).toContain("behaviors that say what should");
+
+      await showing(terminal, "3 tests generated", "[enter] run");
+      terminal.write("\r");
+
+      expect(await terminal.exited).toBe(0);
+      const drawn = terminal.raw();
+
+      // The timer never fired: the second card was never on screen, so nothing
+      // about this run waited on the deck turning.
+      expect(drawn).not.toContain("The synthetic person who calls");
+      expect(drawn).not.toContain("A persona");
+
+      /* the same walk, with no screen at all */
+
+      const elsewhere = await startPlatform();
+      const second = await makeWorkspace({}, { from: RETELL_FIXTURE_REPO });
+      try {
+        await second.signIn(elsewhere.url, elsewhere.device.mint());
+        const ui = new HeadlessUI({ answers: { "retell-key": KEY } });
+        const report = await walk({
+          ui,
+          launch: second.launch(await scriptFor(second)),
+          cwd: second.dir,
+          signal: new AbortController().signal,
+          platform: { url: elsewhere.url, credentialsFile: second.credentialsFile },
+          retell: { url: retell.url },
+        });
+
+        expect(buildExitLine(report)).toBe(
+          "egma put 3 tests on egma and left them in egma/tests/ — commit them, edit them, then run egma push.",
+        );
+        // Byte for byte the same ending, and the same tests on egma either way.
+        expect(terminal.scrollback().trim()).toBe(buildExitLine(report));
+        expect(elsewhere.tests.tests.map((test) => test.name).sort()).toEqual(
+          platform.tests.tests.map((test) => test.name).sort(),
+        );
+        expect(platform.tests.tests.map((test) => test.name).sort()).toEqual([...NAMES].sort());
+      } finally {
+        await elsewhere.close();
+        await second.remove();
+      }
+    } finally {
+      await terminal.kill();
+    }
+  });
+
+  it("gives the whole width to the files when the terminal is too narrow for both", async () => {
+    const script = await scriptFor(workspace);
+
+    const terminal = runInTerminal({
+      command: process.execPath,
+      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      cwd: workspace.dir,
+      env: workspace.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+      cols: 64,
+    });
+
+    try {
+      await showing(terminal, "[enter] begin");
+      terminal.write("\r");
+      await showing(terminal, "Paste your Retell API key");
+      terminal.write(`${KEY}\r`);
+      await showing(terminal, "Do you already have test cases");
+      terminal.write("n");
+
+      const narrow = await showing(
+        terminal,
+        "Writing tests for your voice agent.",
+        "open-on-sunday",
+        "Progress:",
+      );
+      // The work is on screen whole; the teaching is what gives way.
+      expect(narrow).not.toContain("One situation to put your agent");
+
+      await showing(terminal, "[enter] run");
+      terminal.write("\r");
+      expect(await terminal.exited).toBe(0);
+      expect(path.basename(workspace.dir).startsWith("egma-cli-")).toBe(true);
+    } finally {
+      await terminal.kill();
+    }
+  });
+});


### PR DESCRIPTION
The wizard's steps stop being steps and become one flow, proven twice over.

Offline, in CI: one test walks intro → login → discovery → connect → folder → generate → gate → push against the fixture platform, the invented fixture repository, the scripted coding agent and the headless UI — asserting only what landed: the key that works, the agent and its connection, twelve frozen versions, twelve pinned files, the exit line. Nothing about internal order.

For real, with nobody at the keyboard: one command drives the actual wizard through a real terminal — real Claude Code, a real platform instance booted in-process, a real provider account behind a read-only gate that forwards list-and-get and refuses everything else. Run twice against one instance to prove the second walk lands beside the first. The same command passes with Codex, in half the time.

The five failure branches are first-class tests: no coding agent, agent not signed in, no context anywhere, a refused key, a connection type without an adapter — that last one surfacing the platform's refusal word for word. Ctrl-C is honest at three phases, with the driven agent's process tree asserted dead and the exit line saying exactly what was kept.

Riding along: a teaching pane that plays during generation and provably never delays it, and the login wait now shows what egma already worked out — the coding agent found, the git repository, the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)