### PR TITLE
Serve the simulator's claim door, instance-wide, behind the service token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,10 +72,14 @@ EGMA_API_ORIGIN=http://api:3100
 # network. Point it elsewhere to run a simulator beside somebody else's egma.
 EGMA_SIMULATOR_CONTROL_PLANE_URL=http://api:3100
 
-# What it shows the control plane to be allowed to claim, sent as
-# `Authorization: Bearer`. Optional, and empty by default: both halves meet on
-# one private network under compose. A simulator claiming across the internet
-# needs one.
+# What the simulator shows the API to be allowed to claim work, sent as
+# `Authorization: Bearer`. One value, read by both containers, and the API
+# checks it on every claim — the answers carry your customers' live provider
+# credentials, so this door is never open. The compose file has a development
+# default; CHANGE IT before anybody else can reach your instance, because
+# port 3100 is published on the host and whoever holds this token is handed
+# those credentials. It must start with egma_st_ so scanners recognise a leak;
+# `echo "egma_st_$(openssl rand -hex 32)"` makes one.
 EGMA_SIMULATOR_SERVICE_TOKEN=
 
 # How many simulations this simulator conducts at once. It claims only what it

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ environment; see `.env.example` for the names and their defaults.
 one.** Compose supplies a development default so that `docker compose up` works
 out of the box. Change it before anybody else can reach your instance.
 
+**`EGMA_SIMULATOR_SERVICE_TOKEN` is what the simulator shows the API to claim
+work, and the API refuses to start without one.** The answers to a claim carry
+your live provider credentials, and port 3100 is published on the host, so the
+check is always on. Compose supplies one development default to both
+containers so they match out of the box. Change it — one line in `.env` covers
+both — before anybody else can reach your instance:
+`echo "egma_st_$(openssl rand -hex 32)"` makes one.
+
 Email is optional, and this is load-bearing rather than a convenience. See
 [Adding a second person](#adding-a-second-person).
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@egma/db": "workspace:*",
     "@egma/ids": "workspace:*",
+    "@egma/simulation-contract": "workspace:*",
     "better-auth": "^1.6.25",
     "fastify": "^5.6.1",
     "nodemailer": "^9.0.3",

--- a/apps/api/src/auth/service-token.ts
+++ b/apps/api/src/auth/service-token.ts
@@ -1,0 +1,63 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+/**
+ * The secret the simulator holds, and how a request carrying one is let in.
+ *
+ * This is the sibling of `api-key.ts`, and the whole of the difference is
+ * what the secret resolves to: nothing. An egma key becomes a customer
+ * `AuthContext`; the service token opens the work-claiming door and becomes
+ * no context at all, which is what makes it structurally unable to widen
+ * into anybody's data — the claim it guards hands back per-simulation
+ * contexts built from the claimed rows, never from the caller. One
+ * deployment-level value, read from the environment on both sides, on the
+ * pattern every self-host-first pull worker ships.
+ */
+
+/**
+ * The static prefix every egma service token starts with.
+ *
+ * It exists for the same two reasons `egma_sk_` does — a secret-scanning
+ * service can recognise a leaked token, and the two resolvers can never
+ * mistake each other's credential: the customer-key path demands `egma_sk_`,
+ * this one demands `egma_st_`, and a token is one or the other by its first
+ * bytes.
+ */
+export const SERVICE_TOKEN_PREFIX = "egma_st_";
+
+/**
+ * The service token on a request, if it carries one.
+ *
+ * `Authorization: Bearer <token>`, and the prefix has to be the service
+ * one — anything else is a customer key, a session token or a header meant
+ * for the provider, and none of those is this door's business.
+ */
+function serviceTokenOn(header: string | undefined): string | null {
+  if (header === undefined) return null;
+
+  const [scheme, ...rest] = header.trim().split(/\s+/u);
+  if (scheme?.toLowerCase() !== "bearer") return null;
+
+  const token = rest.join("");
+  return token.startsWith(SERVICE_TOKEN_PREFIX) ? token : null;
+}
+
+/**
+ * Whether this request holds the deployment's service token.
+ *
+ * Both sides are hashed before the compare, the house habit from
+ * `api-key.ts`: `timingSafeEqual` demands equal-length inputs, and hashing
+ * is what makes the lengths equal without an early return that would leak
+ * how much of the token matched. The presented token is never echoed, never
+ * logged, and never stored — there is nothing to resolve it into.
+ */
+export function acceptsServiceToken(
+  header: string | undefined,
+  configured: string,
+): boolean {
+  const presented = serviceTokenOn(header);
+  if (presented === null) return false;
+
+  const digest = (value: string): Buffer =>
+    createHash("sha256").update(value, "utf8").digest();
+  return timingSafeEqual(digest(presented), digest(configured));
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,3 +1,4 @@
+import { SERVICE_TOKEN_PREFIX } from "./auth/service-token.ts";
 import type { SmtpSettings } from "./auth/email.ts";
 
 export type Config = {
@@ -204,18 +205,19 @@ export function loadConfig(
         "the simulator shows this API to claim simulation work, and claim " +
         "answers carry customers' live connection credentials — so the door " +
         "refuses to exist unguarded. Set the same value on the api and " +
-        "simulator containers: egma_st_ followed by `openssl rand -hex 32`.",
+        `simulator containers: ${SERVICE_TOKEN_PREFIX} followed by ` +
+        "`openssl rand -hex 32`.",
     );
   }
   // The prefix is checked at startup rather than discovered as a mystery
   // 401: the claim door only reads bearers that start with it, so a token
   // without it would be configured and yet never match anything.
-  if (!simulatorServiceToken.startsWith("egma_st_")) {
+  if (!simulatorServiceToken.startsWith(SERVICE_TOKEN_PREFIX)) {
     throw new Error(
-      "EGMA_SIMULATOR_SERVICE_TOKEN must start with egma_st_, so a leaked " +
-        "service token is recognisable to secret scanners and can never be " +
-        "mistaken for a customer key. Use egma_st_ followed by " +
-        "`openssl rand -hex 32`.",
+      `EGMA_SIMULATOR_SERVICE_TOKEN must start with ${SERVICE_TOKEN_PREFIX}, ` +
+        "so a leaked service token is recognisable to secret scanners and " +
+        "can never be mistaken for a customer key. Use " +
+        `${SERVICE_TOKEN_PREFIX} followed by \`openssl rand -hex 32\`.`,
     );
   }
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -59,6 +59,16 @@ export type Config = {
    */
   readonly rateLimitPerMinute: number;
   /**
+   * What the simulator shows this API to claim simulation work — `egma_st_`
+   * and then a secret, the same value both containers read. Absent means the
+   * service will not start: the claim answers carry customers' live provider
+   * credentials, port 3100 is published on the host, and a claim door that
+   * quietly served whoever asked would hand those credentials to the LAN.
+   * The compose file has a development default on the `EGMA_AUTH_SECRET`
+   * pattern, so `docker compose up` still works with zero setup.
+   */
+  readonly simulatorServiceToken: string;
+  /**
    * Where to post mail, if anywhere. **Absent is the ordinary case and is never
    * an error**: with no transport configured, signup asks for no verification
    * and an invitation hands its link back to the person who created it. Setting
@@ -186,6 +196,29 @@ export function loadConfig(
     );
   }
 
+  const simulatorServiceToken =
+    environment.EGMA_SIMULATOR_SERVICE_TOKEN?.trim();
+  if (!simulatorServiceToken) {
+    throw new Error(
+      "EGMA_SIMULATOR_SERVICE_TOKEN is required and was not set. It is what " +
+        "the simulator shows this API to claim simulation work, and claim " +
+        "answers carry customers' live connection credentials — so the door " +
+        "refuses to exist unguarded. Set the same value on the api and " +
+        "simulator containers: egma_st_ followed by `openssl rand -hex 32`.",
+    );
+  }
+  // The prefix is checked at startup rather than discovered as a mystery
+  // 401: the claim door only reads bearers that start with it, so a token
+  // without it would be configured and yet never match anything.
+  if (!simulatorServiceToken.startsWith("egma_st_")) {
+    throw new Error(
+      "EGMA_SIMULATOR_SERVICE_TOKEN must start with egma_st_, so a leaked " +
+        "service token is recognisable to secret scanners and can never be " +
+        "mistaken for a customer key. Use egma_st_ followed by " +
+        "`openssl rand -hex 32`.",
+    );
+  }
+
   const baseUrl = environment.EGMA_BASE_URL?.trim() || "http://localhost:3101";
   try {
     new URL(baseUrl);
@@ -205,5 +238,6 @@ export function loadConfig(
     singleOrganization: flag(environment, "EGMA_SINGLE_ORGANIZATION", true),
     trustProxy: flag(environment, "EGMA_TRUST_PROXY", false),
     rateLimitPerMinute,
+    simulatorServiceToken,
   };
 }

--- a/apps/api/src/http/refusals.ts
+++ b/apps/api/src/http/refusals.ts
@@ -104,6 +104,23 @@ export function notAuthenticated(reply: FastifyReply): FastifyReply {
   );
 }
 
+/**
+ * No usable service token, on the routes egma's own simulator claims work
+ * through. The same code as the door above and a different sentence, because
+ * the caller's next move is different in kind: no sign-in and no customer key
+ * can ever open this one — the deployment's own secret is the whole gate.
+ */
+export function notTheService(reply: FastifyReply): FastifyReply {
+  return refuse(
+    reply,
+    "not_authenticated",
+    "this route hands out simulation work and answers only to egma's own " +
+      "simulator. Send Authorization: Bearer with the deployment's " +
+      "EGMA_SIMULATOR_SERVICE_TOKEN — the same value the api and simulator " +
+      "containers were started with. A customer API key can never open it.",
+  );
+}
+
 /** The organization's request budget is spent; the header says when to retry. */
 export function tooManyRequests(
   reply: FastifyReply,

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -275,7 +275,17 @@ export async function claimRoutes(
 
     const specs: Record<string, unknown>[] = [];
     for (const claim of claims) {
-      const spec = await assembledSpec(claim);
+      // A row whose stored shapes will not open — a sealed envelope that no
+      // longer decrypts, a column holding something egma never writes —
+      // throws from the reads rather than answering empty. Caught here,
+      // because that too is one row's fault and never the batch's: an
+      // escape would abort the whole response and withhold every valid
+      // claim beside it from a simulator standing ready to conduct them.
+      const spec = await assembledSpec(claim).catch(
+        (fault: unknown): { readonly unbuildable: string } => ({
+          unbuildable: fault instanceof Error ? fault.message : String(fault),
+        }),
+      );
       if ("unbuildable" in spec) {
         // Fail loudly on this side and keep dispatching the rest: one
         // corrupt row must not hold up the batch, and the simulator is

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -252,56 +252,70 @@ export async function claimRoutes(
 
     // A client that hangs up mid-hold should stop being worked for: rows
     // claimed for nobody would sit claimed until the sweep called them
-    // orphaned, so the hold checks the connection is still there before
-    // every re-ask.
-    let gone = false;
-    request.raw.once("close", () => {
+    // orphaned, so the hold checks the client is still there before every
+    // re-ask. The signal has to come from the **socket**, not the request:
+    // a request message emits `close` the moment its body has been read —
+    // which happened before this handler ran — so a listener there would
+    // read every hold as abandoned at once and answer each empty-queue
+    // claim immediately. The socket closes only when the client actually
+    // goes.
+    const socket = request.raw.socket;
+    let gone = socket.destroyed;
+    const clientLeft = (): void => {
       gone = true;
-    });
+    };
+    socket.once("close", clientLeft);
 
-    const deadline = Date.now() + ask.holdSeconds * 1_000;
-    let claims = await claimSimulations({
-      claimant: ask.claimant,
-      capacity: ask.capacity,
-    });
-    while (claims.length === 0 && !gone && Date.now() < deadline) {
-      await sleep(Math.min(RECHECK_MILLISECONDS, deadline - Date.now()));
-      if (gone) break;
-      claims = await claimSimulations({
+    try {
+      const deadline = Date.now() + ask.holdSeconds * 1_000;
+      let claims = await claimSimulations({
         claimant: ask.claimant,
         capacity: ask.capacity,
       });
-    }
-
-    const specs: Record<string, unknown>[] = [];
-    for (const claim of claims) {
-      // A row whose stored shapes will not open — a sealed envelope that no
-      // longer decrypts, a column holding something egma never writes —
-      // throws from the reads rather than answering empty. Caught here,
-      // because that too is one row's fault and never the batch's: an
-      // escape would abort the whole response and withhold every valid
-      // claim beside it from a simulator standing ready to conduct them.
-      const spec = await assembledSpec(claim).catch(
-        (fault: unknown): { readonly unbuildable: string } => ({
-          unbuildable: fault instanceof Error ? fault.message : String(fault),
-        }),
-      );
-      if ("unbuildable" in spec) {
-        // Fail loudly on this side and keep dispatching the rest: one
-        // corrupt row must not hold up the batch, and the simulator is
-        // never handed a document it would have to refuse. The row stays
-        // claimed for now — the orphan sweep is what eventually ends it —
-        // until the dispatch-failure landing gives a simulation the
-        // platform could not hand over its own honest terminal state.
-        request.log.error(
-          { simulationId: claim.id, runId: claim.runId },
-          `simulation ${claim.id} was claimed and could not be dispatched: ${spec.unbuildable}`,
-        );
-        continue;
+      while (claims.length === 0 && !gone && Date.now() < deadline) {
+        await sleep(Math.min(RECHECK_MILLISECONDS, deadline - Date.now()));
+        if (gone) break;
+        claims = await claimSimulations({
+          claimant: ask.claimant,
+          capacity: ask.capacity,
+        });
       }
-      specs.push(spec);
-    }
 
-    return reply.send({ specs });
+      const specs: Record<string, unknown>[] = [];
+      for (const claim of claims) {
+        // A row whose stored shapes will not open — a sealed envelope that no
+        // longer decrypts, a column holding something egma never writes —
+        // throws from the reads rather than answering empty. Caught here,
+        // because that too is one row's fault and never the batch's: an
+        // escape would abort the whole response and withhold every valid
+        // claim beside it from a simulator standing ready to conduct them.
+        const spec = await assembledSpec(claim).catch(
+          (fault: unknown): { readonly unbuildable: string } => ({
+            unbuildable: fault instanceof Error ? fault.message : String(fault),
+          }),
+        );
+        if ("unbuildable" in spec) {
+          // Fail loudly on this side and keep dispatching the rest: one
+          // corrupt row must not hold up the batch, and the simulator is
+          // never handed a document it would have to refuse. The row stays
+          // claimed for now — the orphan sweep is what eventually ends it —
+          // until the dispatch-failure landing gives a simulation the
+          // platform could not hand over its own honest terminal state.
+          request.log.error(
+            { simulationId: claim.id, runId: claim.runId },
+            `simulation ${claim.id} was claimed and could not be dispatched: ${spec.unbuildable}`,
+          );
+          continue;
+        }
+        specs.push(spec);
+      }
+
+      return await reply.send({ specs });
+    } finally {
+      // Taken back off rather than left behind: a keep-alive socket outlives
+      // this request, and a listener per claim would pile up for as long as
+      // the simulator keeps its connection — which is its whole life.
+      socket.removeListener("close", clientLeft);
+    }
   });
 }

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -1,0 +1,297 @@
+import { setTimeout as sleep } from "node:timers/promises";
+
+import {
+  claimSimulations,
+  getPersonaVersion,
+  getSimulationTestVersion,
+  resolveSimulationConnection,
+  type SimulationClaim,
+} from "@egma/db";
+import { specComplaints } from "@egma/simulation-contract";
+import type { FastifyInstance } from "fastify";
+
+import { acceptsServiceToken } from "../auth/service-token.ts";
+import { invalid, notTheService } from "../http/refusals.ts";
+
+/**
+ * The claim door: `POST /v1/claims`, where the simulator asks for work.
+ *
+ * This group is deliberately unlike every other on the API, in three ways
+ * that are each contract rather than convenience.
+ *
+ * **The service token is the whole gate, and it resolves to nothing.** These
+ * routes never accept a customer key or a session — the deployment's own
+ * `EGMA_SIMULATOR_SERVICE_TOKEN`, compared in constant time, opens the door
+ * and becomes no context at all. Every claimed simulation instead arrives
+ * from the module with a context narrowed to that row's own organization and
+ * project, so the credential a simulator holds cannot widen into anybody's
+ * data even in principle: there is no context to widen.
+ *
+ * **The group sits outside the per-organization rate limit.** The budget
+ * exists so one customer's runaway loop is not everybody's problem, and it
+ * is keyed on the organization a credential resolves to; the simulator is
+ * egma's own service standing behind every organization at once, so a busy
+ * run must never eat any customer's budget from the inside — and there is no
+ * organization to key its own on. The token is the gate here, not a budget.
+ *
+ * **The claim is held open rather than answered empty.** Dispatch is pull,
+ * and the promise a developer actually feels is "a queued simulation is
+ * claimed within about a second". So an empty queue holds the request and
+ * re-asks every second until work arrives or the hold runs out — the long
+ * poll every pull-dispatch product ships. The client says how long it is
+ * willing to hang (`wait_seconds`), the server holds at most `min` of that
+ * and its own cap, and a client that said nothing gets a middling default —
+ * so a short-waiting client can never see its own request time out. A
+ * notification may one day replace the re-ask behind this same route;
+ * nothing the simulator sees would change.
+ *
+ * What goes back is the whole work order: for each claimed simulation, a
+ * fully assembled spec — persona traits as the pinned version saved them,
+ * the pinned test version's scenario, the connection's config with its
+ * credentials unsealed, and the platform's limits — validated against the
+ * contract schema before a byte of it is sent. This is the only place
+ * credential material ever travels; the report direction structurally has
+ * nowhere to put it.
+ */
+
+export type ClaimRoutesOptions = {
+  /** The deployment's service token, from configuration. */
+  readonly serviceToken: string;
+};
+
+export const CLAIMS_PATH = "/v1/claims";
+
+/**
+ * How long a claim may be held open, however patient the client says it is.
+ * Under the common 30s+ client timeouts and proxy idle windows, so a held
+ * claim always answers as a response rather than dying as a timeout.
+ */
+const LONGEST_HOLD_SECONDS = 25;
+
+/** The hold for a client that did not say how long it would wait. */
+const DEFAULT_HOLD_SECONDS = 15;
+
+/** How often a held claim re-asks the queue. The "about a second" promise. */
+const RECHECK_MILLISECONDS = 1_000;
+
+/**
+ * The most simulations one claim may take, mirrored from the module's own
+ * cap. A larger ask is clamped rather than refused: a simulator declaring a
+ * huge capacity is a configuration to serve at the platform's pace, not a
+ * request that deserves to fail.
+ */
+const LARGEST_CLAIM_CAPACITY = 50;
+
+/**
+ * The walls around one simulation, by modality — named constants matching
+ * the contract's golden fixtures, so what the platform hands out and what
+ * the fixtures teach cannot drift apart. A limit tripping ends a simulation
+ * deliberately (`limit_reached`), which is never the agent failing; the
+ * numbers bound egma's spend on a conversation going nowhere. Voice is
+ * shorter than chat because every voice minute costs real speech synthesis
+ * and transcription. Per-test limits are a future column on the test; these
+ * are the platform's own.
+ */
+const SIMULATION_LIMITS = {
+  chat: { max_duration_seconds: 600, max_turns: 60 },
+  voice: { max_duration_seconds: 300, max_turns: 40 },
+} as const;
+
+/** The one contract version this control plane speaks. */
+const CONTRACT_VERSION = 1;
+
+type Body = Record<string, unknown>;
+
+/** What a claim request said, once every field has been read and refused for itself. */
+type ClaimAsk = {
+  readonly claimant: string;
+  readonly capacity: number;
+  /** Seconds this request may be held; already bounded by the cap. */
+  readonly holdSeconds: number;
+};
+
+/**
+ * The body as this door reads it, or the sentence refusing it. Each field
+ * refuses for itself in words that say what to send instead, because the
+ * reader is the simulator's log and whoever is tailing it.
+ */
+function claimAsk(body: Body): ClaimAsk | { readonly refusal: string } {
+  const claimant = body.claimant;
+  if (typeof claimant !== "string" || claimant.trim() === "") {
+    return {
+      refusal:
+        "a claim names its claimant — this simulator's own name for itself, " +
+        'stamped on every row it takes. Send claimant as non-empty text, like ' +
+        '"egma-simulator-1".',
+    };
+  }
+  if (claimant.trim().length > 200) {
+    return {
+      refusal:
+        "a claimant's name fits in 200 characters; it is a label for telling " +
+        "two simulators apart, not a place for anything longer.",
+    };
+  }
+
+  const capacity = body.capacity;
+  if (typeof capacity !== "number" || !Number.isInteger(capacity) || capacity < 1) {
+    return {
+      refusal:
+        "a claim declares capacity — how many simulations this simulator has " +
+        "room to conduct at once — as a whole number of at least 1.",
+    };
+  }
+
+  const wait = body.wait_seconds;
+  if (
+    wait !== undefined &&
+    (typeof wait !== "number" || !Number.isFinite(wait) || wait < 0)
+  ) {
+    return {
+      refusal:
+        "wait_seconds is how long this request may be held open while the " +
+        "queue is empty, as a number of seconds of at least 0. Leave it out " +
+        `and egma holds for ${DEFAULT_HOLD_SECONDS}.`,
+    };
+  }
+
+  return {
+    claimant: claimant.trim(),
+    capacity: Math.min(capacity, LARGEST_CLAIM_CAPACITY),
+    holdSeconds: Math.min(
+      wait === undefined ? DEFAULT_HOLD_SECONDS : wait,
+      LONGEST_HOLD_SECONDS,
+    ),
+  };
+}
+
+/**
+ * One claimed simulation as the wire carries it — the flattened work order
+ * the contract's spec schema describes — or the reason it could not become
+ * one.
+ *
+ * Everything is read through the claim's own narrowed context, so the
+ * assembly of one customer's spec happens inside that customer exactly as a
+ * person's read would. The reads can each come back empty — a connection
+ * deleted mid-flight, a row from before tests were pinned — and the schema
+ * check at the end holds whatever was assembled to the same standard the
+ * simulator's own check will apply on receipt.
+ */
+async function assembledSpec(
+  claim: SimulationClaim,
+): Promise<Record<string, unknown> | { readonly unbuildable: string }> {
+  const personaVersion = await getPersonaVersion(
+    claim.auth,
+    claim.personaVersionId,
+  );
+  if (personaVersion === undefined) {
+    return { unbuildable: "its pinned persona version could not be read" };
+  }
+
+  const testVersion = await getSimulationTestVersion(claim.auth, claim.id);
+  if (testVersion === undefined) {
+    return { unbuildable: "its pinned test version could not be read" };
+  }
+
+  const connection = await resolveSimulationConnection(claim.auth, claim.id);
+  if (connection === undefined) {
+    return {
+      unbuildable: "its connection is gone or its credentials would not unseal",
+    };
+  }
+
+  const spec = {
+    contract_version: CONTRACT_VERSION,
+    simulation_id: claim.id,
+    modality: claim.modality,
+    connection: {
+      type: connection.type,
+      config: connection.config,
+      credentials: connection.credentials,
+    },
+    persona: { traits: personaVersion.traits },
+    scenario: { instructions: testVersion.scenario },
+    limits: SIMULATION_LIMITS[claim.modality],
+  };
+
+  // Validated on the way out, against the same schema the simulator compiles
+  // on the way in — so a document that does not speak the contract is this
+  // side's fault, caught here, rather than a refusal the simulator has to
+  // explain back over the wire.
+  const complaints = specComplaints(spec);
+  if (complaints.length > 0) {
+    return { unbuildable: `its spec violates the contract: ${complaints.join("; ")}` };
+  }
+
+  return spec;
+}
+
+export async function claimRoutes(
+  app: FastifyInstance,
+  options: ClaimRoutesOptions,
+): Promise<void> {
+  // The gate, as a hook on this scope rather than a line in the route, for
+  // the reason `credentialed` is one: a route inside this group cannot run
+  // unguarded, and a header is all it reads — an unauthenticated request
+  // never has its body parsed at all.
+  app.addHook("onRequest", async (request, reply) => {
+    if (!acceptsServiceToken(request.headers.authorization, options.serviceToken)) {
+      return notTheService(reply);
+    }
+    return undefined;
+  });
+
+  /**
+   * Claim up to `capacity` queued simulations, held open while the queue is
+   * empty, answering `{ specs: [...] }` — possibly empty, which is what a
+   * quiet queue looks like and what the client asks again after.
+   */
+  app.post(CLAIMS_PATH, async (request, reply) => {
+    const ask = claimAsk((request.body ?? {}) as Body);
+    if ("refusal" in ask) return invalid(reply, ask.refusal);
+
+    // A client that hangs up mid-hold should stop being worked for: rows
+    // claimed for nobody would sit claimed until the sweep called them
+    // orphaned, so the hold checks the connection is still there before
+    // every re-ask.
+    let gone = false;
+    request.raw.once("close", () => {
+      gone = true;
+    });
+
+    const deadline = Date.now() + ask.holdSeconds * 1_000;
+    let claims = await claimSimulations({
+      claimant: ask.claimant,
+      capacity: ask.capacity,
+    });
+    while (claims.length === 0 && !gone && Date.now() < deadline) {
+      await sleep(Math.min(RECHECK_MILLISECONDS, deadline - Date.now()));
+      if (gone) break;
+      claims = await claimSimulations({
+        claimant: ask.claimant,
+        capacity: ask.capacity,
+      });
+    }
+
+    const specs: Record<string, unknown>[] = [];
+    for (const claim of claims) {
+      const spec = await assembledSpec(claim);
+      if ("unbuildable" in spec) {
+        // Fail loudly on this side and keep dispatching the rest: one
+        // corrupt row must not hold up the batch, and the simulator is
+        // never handed a document it would have to refuse. The row stays
+        // claimed for now — the orphan sweep is what eventually ends it —
+        // until the dispatch-failure landing gives a simulation the
+        // platform could not hand over its own honest terminal state.
+        request.log.error(
+          { simulationId: claim.id, runId: claim.runId },
+          `simulation ${claim.id} was claimed and could not be dispatched: ${spec.unbuildable}`,
+        );
+        continue;
+      }
+      specs.push(spec);
+    }
+
+    return reply.send({ specs });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -10,6 +10,7 @@ import {
 import { admitIdentity, onIdentityCreated } from "./auth/provisioning.ts";
 import { agentRoutes } from "./routes/agents.ts";
 import { apiKeyRoutes } from "./routes/api-keys.ts";
+import { claimRoutes } from "./routes/claims.ts";
 import { deviceRoutes } from "./routes/device.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { meRoutes } from "./routes/me.ts";
@@ -186,6 +187,15 @@ export function buildApi(options: ServerOptions): Api {
     provider: identity.provider,
     rateLimit,
     baseUrl: config.baseUrl,
+  });
+
+  // The simulator's claim door. Outside the credentialed scope and the
+  // per-organization rate limit on purpose: the caller is egma's own
+  // simulator, whose service token is the whole gate and resolves to no
+  // customer — so there is no organization to key a budget on, and a busy
+  // run can never eat a customer's request budget from the inside.
+  void app.register(claimRoutes, {
+    serviceToken: config.simulatorServiceToken,
   });
 
   // The OTLP door, registered without `fastify-plugin` for the same reason the

--- a/apps/api/test/claims-hold.test.ts
+++ b/apps/api/test/claims-hold.test.ts
@@ -1,0 +1,195 @@
+import { createPersona, type AuthContext } from "@egma/db";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { NEUTRAL_TRAITS } from "./support/traces.ts";
+import { startInstance, type Instance } from "./support/instance.ts";
+
+/**
+ * The held claim, over a real socket.
+ *
+ * The rest of the claim door's suite drives the API in process, and that is
+ * the right altitude for everything except the hold — because the hold's one
+ * moving part is the connection itself. The route watches the socket to stop
+ * claiming for a client that hung up, and a socket is exactly what an
+ * injected request does not have: the in-process harness never emits the
+ * lifecycle events a real connection does, so only a listening server can
+ * prove the hold survives them. A request's own `close` fires when its body
+ * has been read — milliseconds in, client still there — and a hold that
+ * mistook that for the client leaving would answer every empty-queue claim
+ * at once, turning the simulator's patient long poll into a busy loop.
+ *
+ * So: a real port, a real HTTP client, and the two promises measured on a
+ * clock — a short `wait_seconds` really holds, and work arriving mid-hold
+ * really answers.
+ */
+
+/** The value `startInstance` configures the API with. */
+const SERVICE_TOKEN = "egma_st_held-by-this-test-suite-alone";
+
+let instance: Instance;
+
+/** Somebody with a key, an agent, and a test — everything a run needs. */
+let key: string;
+let connectionId: string;
+let versionId: string;
+
+async function api(
+  method: "GET" | "POST",
+  path: string,
+  headers: Record<string, string>,
+  payload?: unknown,
+): Promise<{ status: number; body: Record<string, unknown>; setCookie: string }> {
+  const response = await fetch(`${instance.origin}${path}`, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    ...(payload === undefined ? {} : { body: JSON.stringify(payload) }),
+  });
+  return {
+    status: response.status,
+    body: (await response.json()) as Record<string, unknown>,
+    setCookie: response.headers.get("set-cookie") ?? "",
+  };
+}
+
+/** One claim as the simulator makes it: a real request over a real socket. */
+async function claim(
+  body: Record<string, unknown>,
+): Promise<{ elapsed: number; status: number; specs: unknown[] }> {
+  const asked = Date.now();
+  const response = await fetch(`${instance.origin}/v1/claims`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${SERVICE_TOKEN}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const answered = (await response.json()) as { specs: unknown[] };
+  return {
+    elapsed: Date.now() - asked,
+    status: response.status,
+    specs: answered.specs,
+  };
+}
+
+async function aQueuedRun(): Promise<void> {
+  const started = await api(
+    "POST",
+    "/api/runs",
+    { authorization: `Bearer ${key}` },
+    { connection: connectionId, test_versions: [versionId] },
+  );
+  expect(started.status, JSON.stringify(started.body)).toBe(201);
+}
+
+beforeAll(async () => {
+  instance = await startInstance("claims_hold", { web: false });
+
+  const signedUp = await api("POST", "/api/signup", {}, {
+    email: "ada@acme.example",
+    password: "a-long-enough-password",
+    organizationName: "Acme",
+  });
+  expect(signedUp.status, JSON.stringify(signedUp.body)).toBe(201);
+  const cookie = signedUp.setCookie.split(";", 1)[0] ?? "";
+  const landed = signedUp.body as unknown as {
+    userId: string;
+    organization: { id: string };
+    project: { id: string };
+  };
+
+  const minted = await api(
+    "POST",
+    "/api/keys",
+    { cookie },
+    { name: "a terminal", project_id: landed.project.id },
+  );
+  expect(minted.status, JSON.stringify(minted.body)).toBe(201);
+  key = String(minted.body.secret);
+
+  const registered = await api(
+    "POST",
+    "/api/agents",
+    { authorization: `Bearer ${key}` },
+    {
+      name: "Front desk",
+      connection: {
+        type: "retell",
+        modality: "chat",
+        config: { retellAgentId: "agent_in_retell_1" },
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+      },
+    },
+  );
+  expect(registered.status, JSON.stringify(registered.body)).toBe(201);
+  connectionId = (registered.body.connection as { id: string }).id;
+
+  // The persona is authored at the seam — no route ships for one — which the
+  // in-process half of this instance makes reachable.
+  const author: AuthContext = {
+    userId: landed.userId,
+    organizationId: landed.organization.id,
+    projectId: landed.project.id,
+    role: "member",
+    via: "session",
+  };
+  await createPersona(author, { name: "Impatient Rita", traits: NEUTRAL_TRAITS });
+
+  const pushed = await api(
+    "POST",
+    "/api/tests",
+    { authorization: `Bearer ${key}` },
+    {
+      name: "Reschedules a booked appointment",
+      scenario:
+        "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+      expected_behaviors: ["confirms the new time back before finishing"],
+      personas: ["Impatient Rita"],
+    },
+  );
+  expect(pushed.status, JSON.stringify(pushed.body)).toBe(201);
+  versionId = String(pushed.body.version_id);
+});
+
+afterAll(async () => {
+  await instance?.close();
+});
+
+describe("the held claim, over a real socket", () => {
+  it("holds an empty-queue claim for the client's own wait, and no less", async () => {
+    const answered = await claim({
+      claimant: "sim-under-test",
+      capacity: 1,
+      wait_seconds: 2,
+    });
+
+    expect(answered.status).toBe(200);
+    expect(answered.specs).toEqual([]);
+    // The whole point of asking over a real connection: a hold that mistook
+    // the request finishing for the client leaving answers in milliseconds,
+    // and this is where that reads as a failure rather than as speed.
+    expect(answered.elapsed).toBeGreaterThanOrEqual(1_900);
+    expect(answered.elapsed).toBeLessThan(8_000);
+  });
+
+  it("answers a patient client within about a second of work arriving", async () => {
+    const holding = claim({
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 20,
+    });
+
+    // Work arrives while the claim is being held open.
+    await new Promise((resume) => setTimeout(resume, 400));
+    await aQueuedRun();
+
+    const answered = await holding;
+    expect(answered.status).toBe(200);
+    expect(answered.specs).toHaveLength(1);
+    // Held until the queue filled — never answered empty before it did —
+    // and answered on the ~1s re-check rather than sitting out the twenty
+    // seconds asked for.
+    expect(answered.elapsed).toBeGreaterThanOrEqual(400);
+    expect(answered.elapsed).toBeLessThan(8_000);
+  });
+});

--- a/apps/api/test/claims-routes.test.ts
+++ b/apps/api/test/claims-routes.test.ts
@@ -1,0 +1,432 @@
+import {
+  createPersona,
+  getSimulation,
+  removeConnection,
+} from "@egma/db";
+import { specComplaints } from "@egma/simulation-contract";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  acceptsServiceToken,
+  SERVICE_TOKEN_PREFIX,
+} from "../src/auth/service-token.ts";
+import { CLAIMS_PATH } from "../src/routes/claims.ts";
+import { fixedWindowRateLimit } from "../src/http/rate-limit.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The simulator's claim door, over real HTTP against real Postgres.
+ *
+ * This is the one route a customer credential can never open: the service
+ * token is the whole gate, the claim reaches every customer's queue at once,
+ * and what comes back is the fully assembled spec — credentials included —
+ * that the shipped simulator conducts from. So what is asserted here is what
+ * that simulator observes: the token gate's one sentence, the held claim
+ * answering the moment work arrives, every outgoing spec speaking the
+ * contract, and a budget that belongs to no organization being spent by none.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const RESCHEDULING = {
+  name: "Reschedules a booked appointment",
+  scenario:
+    "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+  expected_behaviors: ["confirms the new time back before finishing"],
+} as const;
+
+const RETELL = {
+  type: "retell",
+  modality: "chat",
+  config: { retellAgentId: "agent_in_retell_1" },
+  credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+} as const;
+
+/** One claim as the simulator makes it, with whatever token the test says. */
+async function claim(
+  token: string | undefined,
+  body: Record<string, unknown>,
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  const response = await api.app.inject({
+    method: "POST",
+    url: CLAIMS_PATH,
+    ...(token === undefined
+      ? {}
+      : { headers: { authorization: `Bearer ${token}` } }),
+    payload: body,
+  });
+  return {
+    statusCode: response.statusCode,
+    body: response.json() as Record<string, unknown>,
+  };
+}
+
+/** A customer with an agent, a persona, and a test — everything a run needs. */
+async function aCustomerReadyToRun(label: string): Promise<{
+  ada: Customer;
+  key: string;
+  agentId: string;
+  connectionId: string;
+  versionId: string;
+}> {
+  api = await createApi(label);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await ask(api.app, "POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: RETELL,
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+  const agentId = (registered.body.agent as { id: string }).id;
+  const connectionId = (registered.body.connection as { id: string }).id;
+
+  // The persona is authored at the seam — no route ships for one — and the
+  // test then names her, which is what the claimed spec's traits come from.
+  await createPersona(contextFor(ada, "member"), {
+    name: "Impatient Rita",
+    traits: NEUTRAL_TRAITS,
+  });
+  const pushed = await ask(api.app, "POST", "/api/tests", key, {
+    ...RESCHEDULING,
+    personas: ["Impatient Rita"],
+  });
+  expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
+
+  return {
+    ada,
+    key,
+    agentId,
+    connectionId,
+    versionId: String(pushed.body.version_id),
+  };
+}
+
+/** A run over the customer's connection, whose simulation lands queued. */
+async function aQueuedRun(
+  key: string,
+  connectionId: string,
+  versionId: string,
+): Promise<{ runId: string; simulationId: string }> {
+  const started = await ask(api.app, "POST", "/api/runs", key, {
+    connection: connectionId,
+    test_versions: [versionId],
+  });
+  expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+  const simulations = started.body.simulations as { id: string }[];
+  const first = simulations[0];
+  if (first === undefined) throw new Error("the run has no simulation");
+  return { runId: String(started.body.id), simulationId: first.id };
+}
+
+describe("the token gate", () => {
+  it("refuses a missing, wrong, unprefixed or customer token with one actionable sentence", async () => {
+    const { key } = await aCustomerReadyToRun("claims_gate");
+
+    const refusals = await Promise.all([
+      claim(undefined, { claimant: "sim-1", capacity: 1, wait_seconds: 0 }),
+      claim("egma_st_not-the-configured-one", {
+        claimant: "sim-1",
+        capacity: 1,
+        wait_seconds: 0,
+      }),
+      claim("unprefixed-token", { claimant: "sim-1", capacity: 1, wait_seconds: 0 }),
+      // A customer's own real key: a credential for reading their data,
+      // and exactly the thing this door must never widen into claiming.
+      claim(key, { claimant: "sim-1", capacity: 1, wait_seconds: 0 }),
+    ]);
+
+    for (const refused of refusals) {
+      expect(refused.statusCode).toBe(401);
+      expect(refused.body.error).toBe("not_authenticated");
+      expect(String(refused.body.message)).toContain(
+        "EGMA_SIMULATOR_SERVICE_TOKEN",
+      );
+    }
+  });
+
+  it("compares tokens in constant time, hashing both sides first", () => {
+    const configured = `${SERVICE_TOKEN_PREFIX}the-configured-secret`;
+    expect(
+      acceptsServiceToken(`Bearer ${configured}`, configured),
+    ).toBe(true);
+    expect(
+      acceptsServiceToken(`Bearer ${SERVICE_TOKEN_PREFIX}wrong`, configured),
+    ).toBe(false);
+    // Different lengths must answer false rather than throw: the hash is
+    // what equalises them before the constant-time compare.
+    expect(
+      acceptsServiceToken(
+        `Bearer ${SERVICE_TOKEN_PREFIX}${"x".repeat(200)}`,
+        configured,
+      ),
+    ).toBe(false);
+    expect(acceptsServiceToken("Bearer unprefixed", configured)).toBe(false);
+    expect(acceptsServiceToken(undefined, configured)).toBe(false);
+  });
+});
+
+describe("claiming work", () => {
+  it("answers a queued simulation as a schema-valid spec, credentials included", async () => {
+    const { ada, key, connectionId, versionId } =
+      await aCustomerReadyToRun("claims_spec");
+    const { runId, simulationId } = await aQueuedRun(key, connectionId, versionId);
+
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 0,
+    });
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+
+    const specs = answered.body.specs as Record<string, unknown>[];
+    expect(specs).toHaveLength(1);
+    const spec = specs[0];
+    if (spec === undefined) throw new Error("no spec came back");
+
+    // The whole point of validating on the way out: what leaves this door is
+    // exactly what the simulator's own check will accept.
+    expect(specComplaints(spec)).toEqual([]);
+
+    expect(spec.contract_version).toBe(1);
+    expect(spec.simulation_id).toBe(simulationId);
+    expect(spec.modality).toBe("chat");
+    expect(spec.connection).toEqual({
+      type: "retell",
+      config: { retellAgentId: "agent_in_retell_1" },
+      credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    });
+    expect(spec.persona).toEqual({ traits: NEUTRAL_TRAITS });
+    expect(spec.scenario).toEqual({ instructions: RESCHEDULING.scenario });
+    expect(spec.limits).toEqual({ max_duration_seconds: 600, max_turns: 60 });
+
+    // The row carries the claim, and the run has started.
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("claimed");
+    expect(row?.claimedBy).toBe("sim-under-test");
+    expect(row?.heartbeatAt).toBeInstanceOf(Date);
+
+    const header = await ask(api.app, "GET", `/api/runs/${runId}`, key);
+    expect(header.body.status).toBe("running");
+  });
+
+  it("splits one queue between two claimants without handing anything out twice", async () => {
+    const { key, connectionId, versionId } =
+      await aCustomerReadyToRun("claims_race");
+    await aQueuedRun(key, connectionId, versionId);
+    await aQueuedRun(key, connectionId, versionId);
+
+    const [blue, green] = await Promise.all([
+      claim(api.config.simulatorServiceToken, {
+        claimant: "simulator-blue-1",
+        capacity: 2,
+        wait_seconds: 0,
+      }),
+      claim(api.config.simulatorServiceToken, {
+        claimant: "simulator-green-2",
+        capacity: 2,
+        wait_seconds: 0,
+      }),
+    ]);
+
+    const taken = [
+      ...(blue.body.specs as { simulation_id: string }[]),
+      ...(green.body.specs as { simulation_id: string }[]),
+    ].map((spec) => spec.simulation_id);
+    expect(taken).toHaveLength(2);
+    expect(new Set(taken).size).toBe(2);
+  });
+
+  it("clamps capacity at fifty rather than refusing a large fleet", async () => {
+    api = await createApi("claims_clamp");
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-1",
+      capacity: 500,
+      wait_seconds: 0,
+    });
+    expect(answered.statusCode).toBe(200);
+    expect(answered.body.specs).toEqual([]);
+  });
+
+  it("refuses a body it cannot read, saying what to send instead", async () => {
+    api = await createApi("claims_body");
+    const token = api.config.simulatorServiceToken;
+
+    const noClaimant = await claim(token, { capacity: 1, wait_seconds: 0 });
+    expect(noClaimant.statusCode).toBe(400);
+    expect(noClaimant.body.error).toBe("invalid_request");
+    expect(String(noClaimant.body.message)).toContain("claimant");
+
+    const badCapacity = await claim(token, {
+      claimant: "sim-1",
+      capacity: 0,
+      wait_seconds: 0,
+    });
+    expect(badCapacity.statusCode).toBe(400);
+    expect(String(badCapacity.body.message)).toContain("capacity");
+
+    const badWait = await claim(token, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: "soon",
+    });
+    expect(badWait.statusCode).toBe(400);
+    expect(String(badWait.body.message)).toContain("wait_seconds");
+  });
+});
+
+describe("the held claim", () => {
+  it("answers within about a second of a simulation being queued", async () => {
+    const { key, connectionId, versionId } =
+      await aCustomerReadyToRun("claims_hold");
+
+    const asked = Date.now();
+    const holding = claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 20,
+    });
+
+    // Work arrives while the claim is being held open.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await aQueuedRun(key, connectionId, versionId);
+
+    const answered = await holding;
+    const waited = Date.now() - asked;
+
+    expect(answered.statusCode).toBe(200);
+    expect(answered.body.specs as unknown[]).toHaveLength(1);
+    // Well before the twenty seconds asked for: the hold noticed the queue
+    // fill on its ~1s re-check rather than sitting out the request.
+    expect(waited).toBeLessThan(8_000);
+  });
+
+  it("bounds the hold by the client's own wait_seconds", async () => {
+    api = await createApi("claims_bounded");
+
+    const asked = Date.now();
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 1,
+      wait_seconds: 1,
+    });
+    const waited = Date.now() - asked;
+
+    expect(answered.statusCode).toBe(200);
+    expect(answered.body.specs).toEqual([]);
+    // Held about the one second asked for — never the 15s default, never
+    // the 25s cap — so a short-waiting client cannot see a timeout.
+    expect(waited).toBeGreaterThanOrEqual(900);
+    expect(waited).toBeLessThan(6_000);
+  });
+
+  it("answers an empty queue at once when the client will not wait", async () => {
+    api = await createApi("claims_no_wait");
+
+    const asked = Date.now();
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 1,
+      wait_seconds: 0,
+    });
+
+    expect(answered.statusCode).toBe(200);
+    expect(answered.body.specs).toEqual([]);
+    expect(Date.now() - asked).toBeLessThan(2_000);
+  });
+});
+
+describe("what the claim door never touches", () => {
+  it("spends no organization's request budget, and no budget stops a claim", async () => {
+    // A budget of three, so the ceiling is reachable by hand.
+    api = await createApi("claims_budget", {
+      rateLimit: fixedWindowRateLimit({ limit: 3, windowMilliseconds: 60_000 }),
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    // Claims beyond any organization's budget, every one answered.
+    for (let i = 0; i < 6; i += 1) {
+      const answered = await claim(api.config.simulatorServiceToken, {
+        claimant: "sim-1",
+        capacity: 1,
+        wait_seconds: 0,
+      });
+      expect(answered.statusCode).toBe(200);
+    }
+
+    // The organization's own budget is untouched by all of that…
+    const read = await ask(api.app, "GET", "/api/agents", key);
+    expect(read.statusCode).toBe(200);
+
+    // …and once the organization does spend it, the claim door is unmoved.
+    let refused = 0;
+    for (let i = 0; i < 6; i += 1) {
+      const answer = await ask(api.app, "GET", "/api/agents", key);
+      if (answer.statusCode === 429) refused += 1;
+    }
+    expect(refused).toBeGreaterThan(0);
+
+    const stillClaims = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+    });
+    expect(stillClaims.statusCode).toBe(200);
+  });
+});
+
+describe("a simulation the platform cannot hand over", () => {
+  it("is skipped out loud while the rest of the batch still dispatches", async () => {
+    const { ada, key, agentId, connectionId, versionId } =
+      await aCustomerReadyToRun("claims_skip");
+
+    // Two runs over two connections; one connection disappears before the
+    // claim, so one spec can be assembled and one cannot.
+    const doomed = await aQueuedRun(key, connectionId, versionId);
+    const registered = await ask(api.app, "POST", "/api/agents", key, {
+      name: "Second desk",
+      connection: { ...RETELL, config: { retellAgentId: "agent_in_retell_2" } },
+    });
+    const secondConnection = (registered.body.connection as { id: string }).id;
+    const healthy = await aQueuedRun(key, secondConnection, versionId);
+
+    await removeConnection(contextFor(ada, "member"), agentId, connectionId);
+
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 0,
+    });
+    expect(answered.statusCode).toBe(200);
+
+    const specs = answered.body.specs as { simulation_id: string }[];
+    expect(specs.map((spec) => spec.simulation_id)).toEqual([
+      healthy.simulationId,
+    ]);
+
+    // The unbuildable row was claimed and stays claimed rather than looping
+    // through the queue: a second ask does not see it again.
+    const again = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 0,
+    });
+    expect(again.body.specs).toEqual([]);
+
+    const row = await getSimulation(contextFor(ada, "member"), doomed.simulationId);
+    expect(row?.status).toBe("claimed");
+  });
+});

--- a/apps/api/test/claims-routes.test.ts
+++ b/apps/api/test/claims-routes.test.ts
@@ -429,4 +429,46 @@ describe("a simulation the platform cannot hand over", () => {
     const row = await getSimulation(contextFor(ada, "member"), doomed.simulationId);
     expect(row?.status).toBe("claimed");
   });
+
+  it("skips a credential that will not unseal, and the batch still dispatches", async () => {
+    const { ada, key, connectionId, versionId } =
+      await aCustomerReadyToRun("claims_corrupt");
+
+    const doomed = await aQueuedRun(key, connectionId, versionId);
+    const registered = await ask(api.app, "POST", "/api/agents", key, {
+      name: "Second desk",
+      connection: { ...RETELL, config: { retellAgentId: "agent_in_retell_2" } },
+    });
+    const secondConnection = (registered.body.connection as { id: string }).id;
+    const healthy = await aQueuedRun(key, secondConnection, versionId);
+
+    // The one write no seam should offer: a sealed envelope replaced with
+    // bytes that will never decrypt, which is what a lost encryption key or
+    // a hand-edited row leaves behind. Unsealing it throws rather than
+    // answering empty, and that throw must cost one row, not the batch.
+    await api.database.sql(
+      "update connection set credentials = 'not-an-envelope-at-all' where id = $1",
+      [connectionId],
+    );
+
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 0,
+    });
+    expect(answered.statusCode).toBe(200);
+
+    const specs = answered.body.specs as { simulation_id: string }[];
+    expect(specs.map((spec) => spec.simulation_id)).toEqual([
+      healthy.simulationId,
+    ]);
+
+    // The unopenable row was claimed and stays that way for the sweep; the
+    // batch around it went out whole.
+    const row = await getSimulation(
+      contextFor(ada, "member"),
+      doomed.simulationId,
+    );
+    expect(row?.status).toBe("claimed");
+  });
 });

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -30,6 +30,7 @@ const enough = {
   CLICKHOUSE_URL: "http://x:8123/y",
   EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
   EGMA_ENCRYPTION_KEY: "0123456789abcdef".repeat(4),
+  EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
 };
 
 describe("configuration", () => {
@@ -83,6 +84,24 @@ describe("configuration", () => {
         EGMA_ENCRYPTION_KEY: "not-hex-but-sixty-four-characters-long-oh-dear!!".padEnd(64, "x"),
       }),
     ).toThrow(/64 hex characters/);
+  });
+
+  /**
+   * On the auth secret's terms exactly: the claim door hands out customers'
+   * live provider credentials, so an instance may not start with that door
+   * unguarded — and a token the door could never match (the claim path only
+   * reads bearers with the service prefix) is refused as loudly as none.
+   */
+  it("refuses to start without a usable simulator service token", () => {
+    expect(() =>
+      loadConfig({ ...enough, EGMA_SIMULATOR_SERVICE_TOKEN: "" }),
+    ).toThrow(/EGMA_SIMULATOR_SERVICE_TOKEN is required/);
+    expect(() =>
+      loadConfig({
+        ...enough,
+        EGMA_SIMULATOR_SERVICE_TOKEN: "prefixless-token",
+      }),
+    ).toThrow(/must start with egma_st_/);
   });
 
   it("refuses a port that is not a port", () => {

--- a/apps/api/test/runs-cli-verbs.test.ts
+++ b/apps/api/test/runs-cli-verbs.test.ts
@@ -273,7 +273,7 @@ describe("following a run from the terminal's own code", () => {
     expect((await follow()).done).toBe(false);
 
     const claimed = (
-      await claimSimulations(auth, { claimant: CLAIMANT, capacity: 50 })
+      await claimSimulations({ claimant: CLAIMANT, capacity: 50 })
     ).filter((one) => one.runId === runId);
     const [first, second] = claimed;
     if (first === undefined || second === undefined) {

--- a/apps/api/test/runs-routes.test.ts
+++ b/apps/api/test/runs-routes.test.ts
@@ -10,7 +10,7 @@ import {
   markSimulationCanceled,
   startSimulation,
   type AuthContext,
-  type Simulation,
+  type SimulationClaim,
 } from "@egma/db";
 import { newId } from "@egma/ids";
 import { afterEach, describe, expect, it } from "vitest";
@@ -155,14 +155,13 @@ async function aCustomerReadyToRun(label: string): Promise<{
 const CLAIMANT = "simulator-blue-1";
 
 async function claimOwn(
-  auth: AuthContext,
   runId: string,
-): Promise<readonly Simulation[]> {
-  const claimed = await claimSimulations(auth, {
+): Promise<readonly SimulationClaim[]> {
+  const claimed = await claimSimulations({
     claimant: CLAIMANT,
     capacity: 50,
   });
-  return claimed.filter((simulation) => simulation.runId === runId);
+  return claimed.filter((claim) => claim.runId === runId);
 }
 
 describe("starting a run", () => {
@@ -725,7 +724,7 @@ describe("following a run", () => {
 
     expect((await follow()).events).toEqual([]);
 
-    const [first, second, third] = await claimOwn(auth, runId);
+    const [first, second, third] = await claimOwn(runId);
     if (first === undefined || second === undefined || third === undefined) {
       throw new Error("the claim missed the run under test");
     }
@@ -781,7 +780,7 @@ describe("following a run", () => {
     });
     const runId = String(started.body.id);
 
-    const [only] = await claimOwn(auth, runId);
+    const [only] = await claimOwn(runId);
     if (only === undefined) throw new Error("the claim missed the run");
     await failSimulation(auth, only.id, CLAIMANT, { reason: "not_answered" });
 
@@ -966,7 +965,7 @@ describe("stopping a run", () => {
       test_versions: [oneCaller],
     });
     const runId = String(started.body.id);
-    const [only] = await claimOwn(auth, runId);
+    const [only] = await claimOwn(runId);
     if (only === undefined) throw new Error("the claim missed the run");
 
     const canceled = await request("POST", `/api/runs/${runId}/cancel`, key);
@@ -1017,7 +1016,7 @@ describe("stopping a run", () => {
       test_versions: [twoCallers],
     });
     const ranId = String(ran.body.id);
-    for (const one of await claimOwn(auth, ranId)) {
+    for (const one of await claimOwn(ranId)) {
       await startSimulation(auth, one.id, CLAIMANT);
       await completeSimulation(auth, one.id, CLAIMANT, {
         endingReason: "agent_ended",

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -70,6 +70,7 @@ export function testConfig(overrides: Partial<Config> = {}): Config {
       CLICKHOUSE_URL: "http://unused/unused",
       EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
       EGMA_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
+      EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
       EGMA_BASE_URL: "http://localhost:3101",
     }),
     ...overrides,

--- a/apps/api/test/support/instance.ts
+++ b/apps/api/test/support/instance.ts
@@ -156,6 +156,7 @@ export async function startInstance(
       CLICKHOUSE_URL: traceStore.url,
       EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
       EGMA_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
+      EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
       EGMA_BASE_URL: origin,
       EGMA_SINGLE_ORGANIZATION: "false",
     }),

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -6,5 +6,9 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../../packages/ids" }, { "path": "../../packages/db" }]
+  "references": [
+    { "path": "../../packages/ids" },
+    { "path": "../../packages/db" },
+    { "path": "../../packages/simulation-contract" }
+  ]
 }

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -302,7 +302,7 @@ export async function conductSimulation(
   // itself reliable. A real simulator has the same shape and does not care,
   // because it conducts whatever it claimed rather than one row it named.
   await eventually(`simulation ${only.id} to be claimed`, async () => {
-    await claimSimulations(world.auth, { claimant, capacity: 50 });
+    await claimSimulations({ claimant, capacity: 50 });
     const now = await getSimulation(world.auth, only.id);
     return now?.status === "claimed" ? now : undefined;
   });

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -250,11 +250,11 @@ Everything arrives as environment variables.
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `EGMA_SIMULATOR_CONTROL_PLANE_URL` | (required) | Where to claim, heartbeat, and report. |
-| `EGMA_SIMULATOR_SERVICE_TOKEN` | (none) | Sent as `Authorization: Bearer` on every outbound call. The workbench asks for none. |
+| `EGMA_SIMULATOR_SERVICE_TOKEN` | (none) | Sent as `Authorization: Bearer` on every outbound call. The real control plane requires it and checks it against its own `EGMA_SIMULATOR_SERVICE_TOKEN` — under compose one development default reaches both sides, and changing it (once, in `.env`) before anybody else can reach the machine is part of deploying; the claim answers carry live provider credentials. The workbench asks for none. |
 | `EGMA_SIMULATOR_CAPACITY` | `4` | Most simulations conducted at once. |
 | `EGMA_SIMULATOR_CLAIMANT` | `egma-simulator-<host>-<pid>` | The name stamped on claims. |
 | `EGMA_SIMULATOR_HEARTBEAT_SECONDS` | `5` | Beat interval per running simulation. |
-| `EGMA_SIMULATOR_CLAIM_WAIT_SECONDS` | `30` | How long one claim request may hang. |
+| `EGMA_SIMULATOR_CLAIM_WAIT_SECONDS` | `30` | How long one claim request is willing to hang, sent as the claim's `wait_seconds` so the control plane holds no longer than the client will wait. The control plane caps its own hold below this default. |
 | `EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS` | `120` | How long one report is resent before the log on disk becomes its only record. |
 | `EGMA_SIMULATOR_MODEL_PROVIDER` | `scripted` | Where the persona's words come from: `scripted` or `openai`. |
 | `EGMA_SIMULATOR_MODEL_BASE_URL` | `https://api.openai.com/v1` | The provider, for `openai` — any OpenAI-compatible endpoint. |

--- a/apps/simulator/src/egma_simulator/client.py
+++ b/apps/simulator/src/egma_simulator/client.py
@@ -64,6 +64,11 @@ class ControlPlaneClient:
         service_token: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        # Sent on every claim as ``wait_seconds`` and enforced locally as the
+        # timeout below: the control plane holds an empty-queue claim open no
+        # longer than the client says it will wait, so the two ends agree and
+        # a quiet queue can never read as a client-side timeout.
+        self._claim_wait_seconds = claim_wait_seconds
         self._claim_timeout = aiohttp.ClientTimeout(
             total=claim_wait_seconds + CLAIM_TIMEOUT_MARGIN_SECONDS
         )
@@ -98,7 +103,11 @@ class ControlPlaneClient:
         try:
             async with self._live_session().post(
                 f"{self._base_url}/v1/claims",
-                json={"claimant": claimant, "capacity": capacity},
+                json={
+                    "claimant": claimant,
+                    "capacity": capacity,
+                    "wait_seconds": self._claim_wait_seconds,
+                },
                 timeout=self._claim_timeout,
             ) as response:
                 if response.status != 200:

--- a/apps/simulator/tests/test_client_claims.py
+++ b/apps/simulator/tests/test_client_claims.py
@@ -1,0 +1,54 @@
+"""What a claim request says on the wire.
+
+The claim is the one call whose body the control plane's hold depends on:
+``wait_seconds`` says how long this simulator is willing to hang, so the
+other end can hold the request open no longer than the client will wait.
+A claim that kept that number to itself would make the control plane
+guess — and a guess longer than the client's patience turns a quiet queue
+into a spurious client-side timeout.
+
+A real server on loopback reads the body back, because what is under test
+is what actually goes on the wire.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from aiohttp import web
+
+from egma_simulator.client import ControlPlaneClient
+
+
+@pytest.fixture
+async def recording_control_plane() -> AsyncIterator[tuple[str, list[dict]]]:
+    """Answers every claim with an empty queue and keeps every body it saw."""
+    bodies: list[dict] = []
+
+    async def claim(request: web.Request) -> web.Response:
+        bodies.append(await request.json())
+        return web.json_response({"specs": []})
+
+    app = web.Application()
+    app.router.add_post("/v1/claims", claim)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        yield f"http://127.0.0.1:{runner.addresses[0][1]}", bodies
+    finally:
+        await runner.cleanup()
+
+
+async def test_a_claim_declares_how_long_it_will_wait(recording_control_plane):
+    base_url, bodies = recording_control_plane
+
+    async with ControlPlaneClient(base_url, claim_wait_seconds=7.0) as client:
+        await client.claim("sim-under-test", 3)
+
+    assert bodies == [
+        {"claimant": "sim-under-test", "capacity": 3, "wait_seconds": 7.0}
+    ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,13 @@ services:
       # reach needs its own — `openssl rand -hex 32` makes one. Back it up
       # alongside the database; losing it loses every stored credential.
       EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
+      # What the simulator must show to claim work. Claim answers carry
+      # customers' live connection credentials and port 3100 is published on
+      # this machine, so the check is always on: the default is a development
+      # one, interpolated identically into the simulator below so the two
+      # halves always match, and every instance that anybody else can reach
+      # needs its own — egma_st_ then `openssl rand -hex 32`.
+      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:-egma_st_development-only-change-this-before-anybody-else-can-reach-it}
       # Where a browser reaches this instance. The pages and the API answer on
       # one origin, and that origin is the self-hoster's own.
       EGMA_BASE_URL: ${EGMA_BASE_URL:-http://localhost:3101}
@@ -140,10 +147,11 @@ services:
       # again, which is what a queue with nothing in it looks like.
       EGMA_SIMULATOR_CONTROL_PLANE_URL: ${EGMA_SIMULATOR_CONTROL_PLANE_URL:-http://api:3100}
       # What it shows the control plane to be allowed to claim, as a bearer
-      # — the same header an egma key uses everywhere else. Unset is fine
-      # while both halves are yours and meet on this network; a simulator
-      # claiming across the internet needs one.
-      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:-}
+      # — the same header an egma key uses everywhere else. The API checks it
+      # on every claim, so this interpolates the same development default as
+      # the api service above and the two halves always match. Change it —
+      # once, in .env, for both — before anybody else can reach the machine.
+      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:-egma_st_development-only-change-this-before-anybody-else-can-reach-it}
       # How many simulations one simulator conducts at once. It claims only
       # what it has room for, so a big run degrades to a queue rather than
       # to overload — raise this, or start a second simulator, and they

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -9,7 +9,7 @@ import {
   type Modality,
   type Topology,
 } from "../schema/agents.ts";
-import { openCredentials, sealCredentials } from "../sealing.ts";
+import { sealCredentials } from "../sealing.ts";
 import {
   descriptorOf,
   validConfig,
@@ -43,11 +43,16 @@ import { within } from "./within.ts";
  * it may use, because a connection lands in the project its agent already
  * names.
  *
- * Credentials pass through here exactly twice: sealed on the way in (create
- * and whole-object rotation), and unsealed in `resolveConnectionCredentials`,
- * the one door to the plaintext. Every read shape omits the field entirely,
- * so leaking a secret through a serializer is a compile error rather than a
- * review catch.
+ * Credentials pass through here once, sealed on the way in (create and
+ * whole-object rotation) and never opened on the way out: every read shape
+ * omits the field entirely, so leaking a secret through a serializer is a
+ * compile error rather than a review catch. The one door to the plaintext is
+ * the dispatch path's `resolveSimulationConnection`, beside the claim that
+ * mints the only kind of context it opens for. (This file's own role-gated
+ * resolver was retired on 2026-08-08 without ever gaining a production
+ * caller: the caller it imagined — something resolving credentials as a run
+ * starts — is exactly what the claim's door replaced, refusing by how a
+ * context came to exist rather than by what a role permits.)
  */
 
 export type NewConnection = {
@@ -1081,39 +1086,3 @@ export async function removeConnection(
   return { ...row, deletedAt };
 }
 
-/**
- * The one door to the plaintext, and the simulation runtime is who knocks:
- * handed `(agent_id, connection_id)` when a run starts, it answers the
- * decrypted credentials object — or `null` for a type where the customer
- * supplies no secret, or `undefined` for a connection out of the caller's
- * reach. Nothing else in the codebase can decrypt, and the gate is the
- * run-starter's permission rather than the reader's, because resolving a
- * credential *is* starting to act with it.
- */
-export async function resolveConnectionCredentials(
-  auth: AuthContext,
-  agentId: string,
-  connectionId: string,
-): Promise<Readonly<Record<string, string>> | null | undefined> {
-  authorize(auth, "start_and_cancel_runs", here(auth));
-
-  if ((await visibleAgent(auth, agentId)) === undefined) return undefined;
-
-  const [row] = await db()
-    .select({ id: connection.id, credentials: connection.credentials })
-    .from(connection)
-    .where(theConnection(auth, agentId, connectionId))
-    .limit(1);
-
-  if (row === undefined) return undefined;
-  if (row.credentials === null) return null;
-
-  return stringRecordFromRow(
-    openCredentials(row.credentials),
-    () =>
-      new Error(
-        `connection ${row.id} holds credentials in a shape egma never ` +
-          `writes; the row needs repairing before anybody can use it`,
-      ),
-  );
-}

--- a/packages/db/src/access/agents.ts
+++ b/packages/db/src/access/agents.ts
@@ -276,8 +276,13 @@ async function visibleAgent(
  * fail here, loudly and naming itself, rather than leak into a caller as a
  * shape it isn't. Shape only, deliberately: the registry's demands may
  * tighten later, and an old row must stay readable exactly as it was written.
+ *
+ * Exported for the one sibling that also reads a connection's stored shapes —
+ * the simulator's connection door in `runs.ts` — so the two files cannot
+ * drift into two ideas of what a well-formed row is. It is not on the
+ * package's surface.
  */
-function stringRecordFromRow(
+export function stringRecordFromRow(
   value: unknown,
   malformed: () => Error,
 ): Record<string, string> {

--- a/packages/db/src/access/context.ts
+++ b/packages/db/src/access/context.ts
@@ -43,15 +43,23 @@ export type AuthContext = {
 /**
  * How the caller proved who they are.
  *
- * `engine` is egma's own grading service, and it is the one value that names no
- * person. It proved nothing, because there is nobody for it to be: it holds a
- * grading claim — a work order egma issued to itself, naming the organization
- * and the project of one finished conversation — and `claimGradingJobs` builds
- * the context from that claim and from nothing the service said. The word exists
- * so that a context which came from a claim rather than from a credential says
- * so on its face, wherever it is read.
+ * `engine` is egma's own grading service, and it is one of the two values that
+ * name no person. It proved nothing, because there is nobody for it to be: it
+ * holds a grading claim — a work order egma issued to itself, naming the
+ * organization and the project of one finished conversation — and
+ * `claimGradingJobs` builds the context from that claim and from nothing the
+ * service said. The word exists so that a context which came from a claim
+ * rather than from a credential says so on its face, wherever it is read.
+ *
+ * `simulator` is its sibling for egma's own conductor of simulations, on
+ * exactly the same terms: `claimSimulations` builds one per claimed row, from
+ * the row's own tenancy and from nothing the service said. It exists as its
+ * own word rather than reusing `engine` because the two services are answered
+ * different secrets — a connection's credentials open only to `simulator`, a
+ * judge key only to `engine` — and a door that gated on one word for both
+ * would hand each service the other's.
  */
-export const VIA = ["session", "api_key", "engine"] as const;
+export const VIA = ["session", "api_key", "engine", "simulator"] as const;
 export type Via = (typeof VIA)[number];
 
 /**

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -246,7 +246,6 @@ export {
   listConnections,
   registerAgent,
   removeConnection,
-  resolveConnectionCredentials,
   updateAgent,
   updateConnection,
   type Agent,

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -35,18 +35,21 @@
  * is asked by the one caller with no credential at all — somebody looking at a
  * signup form — and the same test names it.
  *
- * **Work-dispatching.** `claimGradingJobs` and `watchGradingWork`, and only
- * those two. They are asked by the grader service, which stands behind every
- * organization on the deployment at once and holds no credential, because there
- * is no honest one to give it. The exemption is narrow and each half of it is
- * enforced: neither takes an argument by which a caller could name a customer,
- * and a build rule refuses one that grows one; the only table either reaches is
- * egma's own grading queue; a claim carries out identifiers and tenancy and
+ * **Work-dispatching.** `claimGradingJobs`, `watchGradingWork` and
+ * `claimSimulations`, and only those three. They are asked by egma's own two
+ * services — the grader and the simulator — each of which stands behind every
+ * organization on the deployment at once and holds no credential, because
+ * there is no honest one to give it. The exemption is narrow and each half of
+ * it is enforced: none takes an argument by which a caller could name a
+ * customer, and a build rule refuses one that grows one; the only rows any of
+ * them reaches are egma's own queues — grading jobs, and the simulations egma
+ * itself wrote as queued; a claim carries out identifiers and tenancy and
  * never anything a customer wrote; and every claim arrives with the
- * `AuthContext` narrowed to that job's own organization and project, which is
- * what all of the grading afterwards goes through. `grading.ts` writes the
- * reasoning out in full. A third name in this category is a deliberate act: a
- * test names both and fails when one appears.
+ * `AuthContext` narrowed to that row's own organization and project, which is
+ * what all of the work afterwards goes through. `grading.ts` writes the
+ * reasoning out in full and `runs.ts` inherits it whole. A fourth name in this
+ * category is a deliberate act: a test names all three and fails when another
+ * appears.
  *
  * **Deciding.** The role list, the action list, and the one function every
  * action in the product passes through. They take an `AuthContext` like
@@ -373,6 +376,7 @@ export {
   listSimulations,
   markSimulationCanceled,
   recordSimulationHeartbeat,
+  resolveSimulationConnection,
   startRun,
   startSimulation,
   sweepOrphanedSimulations,
@@ -386,6 +390,9 @@ export {
   type RunEventPage,
   type RunPage,
   type Simulation,
+  type SimulationClaim,
+  type SimulationClaimRequest,
+  type SimulationConnection,
   type SimulationFailure,
   type SimulationReport,
   type StartedRun,

--- a/packages/db/src/access/judges.ts
+++ b/packages/db/src/access/judges.ts
@@ -245,16 +245,17 @@ export async function getJudgeConfiguration(
  * The one door to the judge key's plaintext, and **egma's own grading engine is
  * the only thing that may knock.**
  *
- * The gate is narrower than a role, on purpose. `resolveConnectionCredentials`
- * asks for the run-starter's permission because resolving a connection's
- * credential *is* starting to act with it; the same reasoning lands somewhere
- * else here, because the only thing egma ever does with a judge key is judge,
- * and the only thing that judges is the grading service. So the check is on how
- * the caller came to exist rather than on what their role permits: a context
- * built from a grading claim says `engine` on its face, and every other context
- * in the product — a person's session, an API key, a `viewer` and an `admin`
- * alike — is refused. There is no product surface that hands a customer their
- * own key back, and this is what keeps it that way while roles move around.
+ * The gate is narrower than a role, on purpose: the only thing egma ever does
+ * with a judge key is judge, and the only thing that judges is the grading
+ * service. So the check is on how the caller came to exist rather than on what
+ * their role permits: a context built from a grading claim says `engine` on its
+ * face, and every other context in the product — a person's session, an API
+ * key, a `viewer` and an `admin` alike — is refused. There is no product
+ * surface that hands a customer their own key back, and this is what keeps it
+ * that way while roles move around. The other secret egma replays — a
+ * connection's credentials, on the dispatch path — sits behind
+ * `resolveSimulationConnection`, the same shape of door demanding `simulator`
+ * for the same reason.
  *
  * The reference is checked against the project the context is already narrowed
  * to, so a claim for one project cannot resolve another's key even if something

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -23,6 +23,7 @@ import {
   type Topology,
 } from "../schema/agents.ts";
 import { persona } from "../schema/personas.ts";
+import { openCredentials } from "../sealing.ts";
 import { test, testVersion, testPersona } from "../schema/tests.ts";
 import {
   COMPLETED_ENDING_REASONS,
@@ -37,6 +38,7 @@ import {
   type SimulationStatus,
   type Verdict,
 } from "../schema/runs.ts";
+import { stringRecordFromRow } from "./agents.ts";
 import { validClaimant } from "./claimants.ts";
 import { descriptorOf, noSimulatorAdapterMessage } from "./connection-registry.ts";
 import type { AuthContext } from "./context.ts";
@@ -57,6 +59,17 @@ import { within } from "./within.ts";
  * same seam on the same terms: every function takes the context, and the run
  * machinery is gated by `start_and_cancel_runs` throughout, because claiming
  * and reporting a simulation *is* conducting the run somebody started.
+ *
+ * One exception, drawn on the grading queue's precedent and as narrowly:
+ * `claimSimulations` takes no context and cannot be given one, because the
+ * simulator stands behind every organization on the deployment at once and
+ * there is no honest credential to give it. It reaches only the queue of
+ * simulations egma itself wrote, carries out identifiers and no content, and
+ * hands back with every claim the context the conducting is then done under —
+ * built from the claimed row's own tenancy and from nothing the service said.
+ * `resolveSimulationConnection` is the one door such a context is for, and it
+ * refuses every other kind. The whole argument is written out on the two
+ * functions.
  *
  * Writers keep to one lock order — simulation rows first, the run header last
  * — so the claim path, the cancel path and the report path do not deadlock
@@ -1413,25 +1426,134 @@ export async function cancelRun(
 }
 
 /**
- * The atomic claim. Up to `capacity` of the oldest queued simulations the
- * caller can reach move to `claimed` in one transaction, stamped with the
- * claimant and their first heartbeat; whatever another claimant holds locked
- * is skipped rather than waited on, so two simulators drain one queue without
- * ever taking the same conversation. The capacity is the simulator's own
- * declaration of what it can hold — a big run degrades to a queue, never to
- * overload.
+ * What a claim answers with, and no more — identifiers, tenancy, the two
+ * stamps the claim itself wrote, and the pins a spec is assembled from.
+ *
+ * Deliberately not the `Simulation` shape: a claim crosses every customer on
+ * the deployment, so what it carries out is held to what the assembly needs
+ * to *ask for* — never the asked-for things themselves. No transcript, no
+ * configuration, no credentials, nothing a customer wrote. Each of those is
+ * read afterwards through the ordinary scoped surface, under `auth`.
+ */
+export type SimulationClaim = {
+  readonly id: string;
+  readonly runId: string;
+  readonly organizationId: string;
+  readonly projectId: string;
+  readonly agentId: string;
+  readonly connectionId: string;
+  /** Who calls, by identity, and the pin the traits are read from. */
+  readonly personaId: string;
+  readonly personaVersionId: string;
+  /** What is being checked; both absent only on an upgraded instance's history. */
+  readonly testId: string | null;
+  readonly testVersionId: string | null;
+  readonly connectionType: ConnectionType;
+  readonly modality: Modality;
+  readonly claimedBy: string;
+  readonly claimedAt: Date;
+  /**
+   * Narrowed to this simulation's own organization and project, built here
+   * from the claimed row and from nothing the claimant said. It is what every
+   * read the spec assembly makes goes through, so the conducting happens
+   * inside one customer even though the claim that found the work was not.
+   */
+  readonly auth: AuthContext;
+};
+
+const SIMULATION_CLAIM_COLUMNS = {
+  id: simulation.id,
+  runId: simulation.runId,
+  organizationId: simulation.organizationId,
+  projectId: simulation.projectId,
+  agentId: simulation.agentId,
+  connectionId: simulation.connectionId,
+  personaId: simulation.personaId,
+  personaVersionId: simulation.personaVersionId,
+  testId: simulation.testId,
+  testVersionId: simulation.testVersionId,
+  connectionType: simulation.connectionType,
+  modality: simulation.modality,
+  claimedBy: simulation.claimedBy,
+  claimedAt: simulation.claimedAt,
+} as const;
+
+/**
+ * The name the simulator's context wears where a person's id would be.
+ *
+ * The same shape as the grading queue's `engine`, for the same reason: the
+ * simulator is a process, and the conversations it conducts were asked for by
+ * whoever started the run rather than by it. Deliberately not shaped like an
+ * identifier, so anything that ever tried to write it as one is refused out
+ * loud by the foreign key to `user` rather than quietly attributing a
+ * machine's act to a person.
+ */
+const THE_SIMULATOR = "simulator";
+
+/**
+ * The context one claimed simulation is conducted under.
+ *
+ * `member`, where the grading engine's is `viewer`, and the difference is the
+ * work: the engine only reads and writes egma's own records, while conducting
+ * moves the simulation row itself through the machinery this file gates with
+ * `start_and_cancel_runs` — because claiming and reporting a simulation *is*
+ * conducting the run somebody started. What keeps the context narrower than a
+ * person holding the same role is not the role at all: every write requires
+ * the claimant's own name on the row, and the one secret it can ask for sits
+ * behind a door that checks how the context came to exist, not what its role
+ * permits.
+ */
+function conductingContext(
+  organizationId: string,
+  projectId: string,
+): AuthContext {
+  return {
+    userId: THE_SIMULATOR,
+    organizationId,
+    projectId,
+    role: "member",
+    via: "simulator",
+  };
+}
+
+export type SimulationClaimRequest = {
+  /** This simulator's own name for itself. */
+  readonly claimant: string;
+  /** How many conversations it has room to conduct at once. */
+  readonly capacity: number;
+};
+
+/**
+ * The atomic claim, across every organization on this deployment.
+ *
+ * Up to `capacity` of the oldest queued simulations move to `claimed` in one
+ * transaction, stamped with the claimant and their first heartbeat; whatever
+ * another claimant holds locked is skipped rather than waited on, so two
+ * simulators drain one queue without ever taking the same conversation.
+ * `SKIP LOCKED`, exactly as `claimGradingJobs` does it, because it is exactly
+ * the same problem. The capacity is the simulator's own declaration of what
+ * it can hold — a big run degrades to a queue, never to overload.
  *
  * Every claimed simulation's run leaves `pending` here, because a run has
  * started when its first conversation is someone's to conduct.
+ *
+ * **It takes no `AuthContext` and cannot be given one.** See the note at the
+ * top of this file, and the grading queue's, whose reasoning this claim
+ * inherits whole: it is the one call in this file that reaches across
+ * customers; the only rows it moves are egma's own queue of simulations; it
+ * takes a claimant's name and a capacity, and there is no argument by which a
+ * caller could name whose work they want — a build rule holds it to that; it
+ * carries out identifiers and no content; and every claim arrives with the
+ * narrowed context the conducting is actually done under. There is no
+ * tenancy-scoped claim beside it, deliberately — a claim a customer's
+ * credential could make would be a claim that has to answer which customers
+ * it serves, and the honest answer is all of them.
  */
 export async function claimSimulations(
-  auth: AuthContext,
-  input: { readonly claimant: string; readonly capacity: number },
-): Promise<readonly Simulation[]> {
-  authorize(auth, "start_and_cancel_runs", here(auth));
-
-  const claimant = validClaimant(input.claimant);
-  const { capacity } = input;
+  request: SimulationClaimRequest,
+): Promise<readonly SimulationClaim[]> {
+  const claimant = validClaimant(request.claimant);
+  const { capacity } = request;
   if (
     !Number.isInteger(capacity) ||
     capacity < 1 ||
@@ -1448,22 +1570,16 @@ export async function claimSimulations(
     const candidates = await tx
       .select({ id: simulation.id })
       .from(simulation)
-      .where(
-        within(
-          auth,
-          simulation,
-          and(
-            eq(simulation.status, "queued"),
-            inActingProject(auth, simulation),
-          ),
-        ),
-      )
+      .where(eq(simulation.status, "queued"))
       .orderBy(asc(simulation.id))
       .limit(capacity)
       .for("update", { skipLocked: true });
 
     if (candidates.length === 0) return [];
 
+    // Bare `eq`s and `inArray`s from here down: every id came off the rows
+    // locked just above, in this same transaction, so nothing below reaches
+    // further than that select already did.
     const rows = await tx
       .update(simulation)
       .set({
@@ -1478,11 +1594,10 @@ export async function claimSimulations(
           candidates.map((candidate) => candidate.id),
         ),
       )
-      .returning(SIMULATION_COLUMNS);
+      .returning(SIMULATION_CLAIM_COLUMNS);
 
     // The runs these came from, each flipped at most once, one at a time in
     // one order — so two claimants touching the same runs cannot deadlock.
-    // Bare `eq`s: every id came off the tenancy-checked rows just claimed.
     // Each run's events go in beside its own flip, in the same order: the
     // conversations that were picked up, and then the run that started
     // because they were.
@@ -1515,8 +1630,122 @@ export async function claimSimulations(
   });
 
   return claimed
-    .map(simulationFromRow)
+    .map((row) => ({
+      id: row.id,
+      runId: row.runId,
+      organizationId: row.organizationId,
+      projectId: row.projectId,
+      agentId: row.agentId,
+      connectionId: row.connectionId,
+      personaId: row.personaId,
+      personaVersionId: row.personaVersionId,
+      testId: row.testId,
+      testVersionId: row.testVersionId,
+      connectionType: row.connectionType as ConnectionType,
+      modality: row.modality as Modality,
+      claimedBy: row.claimedBy ?? claimant,
+      claimedAt: row.claimedAt ?? now,
+      auth: conductingContext(row.organizationId, row.projectId),
+    }))
     .sort((a, b) => (a.id < b.id ? -1 : 1));
+}
+
+/**
+ * How the simulator reaches the agent of one claimed simulation: the
+ * connection's type, its non-secret config, and the credentials unsealed — or
+ * null where the customer supplies no secret for the type.
+ */
+export type SimulationConnection = {
+  readonly connectionId: string;
+  readonly type: ConnectionType;
+  readonly config: Readonly<Record<string, string>>;
+  readonly credentials: Readonly<Record<string, string>> | null;
+};
+
+/**
+ * The one door to a connection's plaintext on the dispatch path, and **egma's
+ * own simulator is the only thing that may knock.**
+ *
+ * The gate is narrower than a role, on the terms `resolveJudgeKey` drew for
+ * the other secret egma holds: the only thing egma ever does with a
+ * connection's credentials at this seam is conduct a simulation over them,
+ * and the only thing that conducts is the simulator. So the check is on how
+ * the caller came to exist rather than on what their role permits — a context
+ * built from a claim says `simulator` on its face, and every other context in
+ * the product, a person's session and an API key and the grading engine
+ * alike, is refused out loud.
+ *
+ * It is asked with a simulation, never with a connection, and that is the
+ * second half of the door: the row names the connection it was pinned to when
+ * the run started, so there is no argument by which a caller could point the
+ * unsealing at a connection the claimed row does not name. And it answers
+ * only while the row stands `claimed` — the one moment a spec is assembled.
+ * Before the claim there is nobody to hand a secret to, and after the
+ * conversation starts nothing asks again.
+ *
+ * `undefined` answers three absences alike — a simulation out of the
+ * context's tenancy, one not standing claimed, and a connection since deleted
+ * — because telling them apart at this seam would confirm rows the context
+ * cannot see. A caller who needs the difference is holding the claim, which
+ * already says what was claimed; a connection gone mid-flight is the one case
+ * left, and it is exactly the "could not be handed over" the dispatch path
+ * answers for out loud.
+ */
+export async function resolveSimulationConnection(
+  auth: AuthContext,
+  simulationId: string,
+): Promise<SimulationConnection | undefined> {
+  authorize(auth, "read", here(auth));
+
+  if (auth.via !== "simulator") {
+    throw new Error(
+      "a connection's credentials are unsealed for egma's own simulator and for nothing else, because conducting is the only thing egma does with them",
+    );
+  }
+
+  const [row] = await db()
+    .select({
+      connectionId: connection.id,
+      type: connection.type,
+      config: connection.config,
+      credentials: connection.credentials,
+    })
+    .from(simulation)
+    .innerJoin(connection, eq(simulation.connectionId, connection.id))
+    .where(
+      within(
+        auth,
+        simulation,
+        and(
+          eq(simulation.id, simulationId),
+          eq(simulation.status, "claimed"),
+          isNull(connection.deletedAt),
+          inActingProject(auth, simulation),
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (row === undefined) return undefined;
+
+  const malformed = (held: string) => () =>
+    new Error(
+      `connection ${row.connectionId} holds ${held} in a shape egma never ` +
+        `writes; the row needs repairing before anybody can conduct over it`,
+    );
+
+  return {
+    connectionId: row.connectionId,
+    type: row.type as ConnectionType,
+    config: stringRecordFromRow(row.config, malformed("config")),
+    credentials:
+      row.credentials === null
+        ? null
+        : stringRecordFromRow(
+            openCredentials(row.credentials),
+            malformed("credentials"),
+          ),
+  };
 }
 
 /**

--- a/packages/db/test/agents-list-update-delete.test.ts
+++ b/packages/db/test/agents-list-update-delete.test.ts
@@ -11,7 +11,6 @@ import {
   listConnections,
   NotPermittedError,
   removeConnection,
-  resolveConnectionCredentials,
   updateAgent,
   updateConnection,
   type Agent,
@@ -406,13 +405,6 @@ describe("deleting an agent", () => {
     ).toBeUndefined();
     expect(
       await removeConnection(actingIn(acme.deleting), wired.id, attached.id),
-    ).toBeUndefined();
-    expect(
-      await resolveConnectionCredentials(
-        actingIn(acme.deleting),
-        wired.id,
-        attached.id,
-      ),
     ).toBeUndefined();
     expect(
       await addConnection(actingIn(acme.deleting), wired.id, retellConnection()),

--- a/packages/db/test/connections.test.ts
+++ b/packages/db/test/connections.test.ts
@@ -9,7 +9,6 @@ import {
   listConnections,
   NotPermittedError,
   removeConnection,
-  resolveConnectionCredentials,
   updateConnection,
   type AuthContext,
   type NewConnection,
@@ -289,47 +288,10 @@ describe("the sealed credential", () => {
     expect(rows[0]?.credentials_hint).toBe("WXYZ");
   });
 
-  it("round-trips through the resolver, the one door to the plaintext", async () => {
-    const agentId = await agentNamed("Resolved");
-    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
-
-    const resolved = await resolveConnectionCredentials(
-      actingAsAcme(),
-      agentId,
-      added?.id ?? "",
-    );
-    expect(resolved).toEqual({ apiKey: "retell-secret-A1B2C3D4WXYZ" });
-  });
-
-  it("resolves to null for a type that holds no secret", async () => {
-    const agentId = await agentNamed("Resolved Phone");
-    const added = await addConnection(actingAsAcme(), agentId, {
-      name: "hotline",
-      type: "phone",
-      modality: "voice",
-      config: { phoneNumber: "+15559876543" },
-    });
-
-    const resolved = await resolveConnectionCredentials(
-      actingAsAcme(),
-      agentId,
-      added?.id ?? "",
-    );
-    expect(resolved).toBeNull();
-  });
-
-  it("refuses the resolver to a viewer, who cannot start a run", async () => {
-    const agentId = await agentNamed("Resolver Gate");
-    const added = await addConnection(actingAsAcme(), agentId, retellConnection());
-
-    await expect(
-      resolveConnectionCredentials(
-        actingAsAcme("viewer"),
-        agentId,
-        added?.id ?? "",
-      ),
-    ).rejects.toThrow(NotPermittedError);
-  });
+  // What the plaintext opens back into — a fresh seal, a rotation, a padded
+  // paste — is proven where the one door to it now lives: the dispatch path's
+  // resolver, in `simulation-claims.test.ts`, which walks seal → store →
+  // claim → unseal through the same rows these tests write.
 
   it("stores the key trimmed, so a padded paste still authenticates", async () => {
     const agentId = await agentNamed("Padded Key");
@@ -339,13 +301,9 @@ describe("the sealed credential", () => {
       retellConnection({ credentials: { apiKey: "  retell-secret-padded-1234  " } }),
     );
 
+    // The hint is the stored value's own tail, so a hint without the pasted
+    // whitespace is the trim having happened before the seal.
     expect(added?.credentialsHint).toBe("1234");
-    const resolved = await resolveConnectionCredentials(
-      actingAsAcme(),
-      agentId,
-      added?.id ?? "",
-    );
-    expect(resolved).toEqual({ apiKey: "retell-secret-padded-1234" });
   });
 
   it("rotates by replacing the object whole, resealing envelope and hint", async () => {
@@ -367,13 +325,6 @@ describe("the sealed credential", () => {
       [added?.id],
     );
     expect(after.rows[0]?.credentials).not.toBe(before.rows[0]?.credentials);
-
-    const resolved = await resolveConnectionCredentials(
-      actingAsAcme(),
-      agentId,
-      added?.id ?? "",
-    );
-    expect(resolved).toEqual({ apiKey: "retell-secret-rotated-9999ABCD" });
   });
 });
 
@@ -524,9 +475,6 @@ describe("reaching a connection through the wrong door", () => {
     expect(
       await removeConnection(actingAsAcme(), neighbour, added?.id ?? ""),
     ).toBeUndefined();
-    expect(
-      await resolveConnectionCredentials(actingAsAcme(), neighbour, added?.id ?? ""),
-    ).toBeUndefined();
   });
 
   it("is unreachable under another organization's auth context, every verb", async () => {
@@ -547,9 +495,6 @@ describe("reaching a connection through the wrong door", () => {
     ).toBeUndefined();
     expect(
       await removeConnection(actingAsGlobex(), agentId, added?.id ?? ""),
-    ).toBeUndefined();
-    expect(
-      await resolveConnectionCredentials(actingAsGlobex(), agentId, added?.id ?? ""),
     ).toBeUndefined();
   });
 

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -69,18 +69,24 @@ const CONTEXT_ESTABLISHING = [
 const INSTANCE_SCOPED = ["instanceIsClaimed"];
 
 /**
- * What hands egma's own engine its work. The grader service stands behind every
- * organization on the deployment at once and holds no credential, because there
- * is no honest one to give it — so it is handed work rather than asked for one.
+ * What hands egma's own services their work. The grader and the simulator each
+ * stand behind every organization on the deployment at once and hold no
+ * credential, because there is no honest one to give them — so each is handed
+ * work rather than asked for one.
  *
- * Two names, and a third is a decision somebody makes on purpose. Neither takes
+ * Three names, and a fourth is a decision somebody makes on purpose. None takes
  * an argument by which a caller could name a customer, and a build rule refuses
- * one that grows one; the only table either reaches is egma's own grading queue;
- * and every claim arrives carrying the `AuthContext` narrowed to that job's own
- * organization and project, which is what all of the grading afterwards goes
+ * one that grows one; the only rows any of them reaches are egma's own queues —
+ * grading jobs, and the simulations egma itself wrote as queued; and every
+ * claim arrives carrying the `AuthContext` narrowed to that row's own
+ * organization and project, which is what all of the work afterwards goes
  * through.
  */
-const WORK_DISPATCHING = ["claimGradingJobs", "watchGradingWork"];
+const WORK_DISPATCHING = [
+  "claimGradingJobs",
+  "claimSimulations",
+  "watchGradingWork",
+];
 
 /**
  * Everything that touches a customer's data. All of it needs the context.
@@ -120,7 +126,6 @@ const CONTEXT_REQUIRING = [
   "appendVerdicts",
   "cancelRun",
   "changeRole",
-  "claimSimulations",
   "clonePersona",
   "cloneTest",
   "completeSimulation",
@@ -197,6 +202,11 @@ const CONTEXT_REQUIRING = [
   // Names off a reviewed file turned into the identity a version names. It
   // reads personas and nothing else, and only ones the context already reaches.
   "resolvePersonaNames",
+  // The dispatch path's door to a connection's plaintext. It takes the context
+  // like everything else — and then refuses every one that did not come from a
+  // simulation claim, because conducting is the only thing egma does with a
+  // connection's credentials at this seam.
+  "resolveSimulationConnection",
   "revokeApiKey",
   "setJudgeConfiguration",
   "startRun",

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -195,7 +195,6 @@ const CONTEXT_REQUIRING = [
   "removeConnection",
   "reopenGradingJob",
   "removeMember",
-  "resolveConnectionCredentials",
   // The second secret egma holds, on the first one's terms: the read answers a
   // reference and a hint, and this is the one door to the plaintext behind it.
   "resolveJudgeKey",

--- a/packages/db/test/grading-jobs.test.ts
+++ b/packages/db/test/grading-jobs.test.ts
@@ -96,7 +96,10 @@ async function aSimulation(): Promise<string> {
 
 async function aRunningSimulation(claimant = "simulator-1"): Promise<string> {
   const id = await aSimulation();
-  await claimSimulations(auth, { claimant, capacity: 1 });
+  // The claim is instance-wide and oldest-first, so it takes everything
+  // outstanding rather than one — anything less could hand back somebody
+  // else's leftovers and leave this test's own row queued.
+  await claimSimulations({ claimant, capacity: 50 });
   await startSimulation(auth, id, claimant);
   return id;
 }
@@ -629,7 +632,7 @@ describe("the claim", () => {
     });
     const [conversation] = started.simulations;
     if (conversation === undefined) throw new Error("no simulation");
-    await claimSimulations(globexAuth, { claimant: "sim", capacity: 1 });
+    await claimSimulations({ claimant: "sim", capacity: 50 });
     await startSimulation(globexAuth, conversation.id, "sim");
     await completeSimulation(globexAuth, conversation.id, "sim", {
       endingReason: "agent_ended",

--- a/packages/db/test/regrade.test.ts
+++ b/packages/db/test/regrade.test.ts
@@ -118,7 +118,7 @@ async function aFinishedSimulation(): Promise<Conducted> {
   const [only] = started.simulations;
   if (only === undefined) throw new Error("the run has no simulation");
 
-  await claimSimulations(auth, { claimant, capacity: 50 });
+  await claimSimulations({ claimant, capacity: 50 });
   await startSimulation(auth, only.id, claimant);
   await completeSimulation(auth, only.id, claimant, {
     endingReason: "persona_concluded",

--- a/packages/db/test/run-events.test.ts
+++ b/packages/db/test/run-events.test.ts
@@ -18,7 +18,7 @@ import {
   sweepOrphanedSimulations,
   type AuthContext,
   type RunEvent,
-  type Simulation,
+  type SimulationClaim,
 } from "@egma/db";
 
 import {
@@ -90,13 +90,13 @@ async function aRun(testVersionIds: readonly string[] = [oneCaller]) {
   return startRun(actingAsAcme(), { agentId, connectionId, testVersionIds });
 }
 
-/** Claim for one run under test; the queue is the whole customer's. */
-async function claimOwn(runId: string): Promise<readonly Simulation[]> {
-  const claimed = await claimSimulations(actingAsAcme(), {
+/** Claim for one run under test; the queue is the whole deployment's. */
+async function claimOwn(runId: string): Promise<readonly SimulationClaim[]> {
+  const claimed = await claimSimulations({
     claimant: CLAIMANT,
     capacity: 50,
   });
-  return claimed.filter((simulation) => simulation.runId === runId);
+  return claimed.filter((claim) => claim.runId === runId);
 }
 
 async function feedOf(runId: string, after = 0) {

--- a/packages/db/test/runs-claim-concurrency.test.ts
+++ b/packages/db/test/runs-claim-concurrency.test.ts
@@ -6,6 +6,7 @@ import {
   createAgent,
   createPersona,
   createTest,
+  getSimulation,
   startRun,
   type AuthContext,
 } from "@egma/db";
@@ -17,10 +18,11 @@ import {
 import { seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
- * Two simulators, one queue. The claim is atomic — `SKIP LOCKED` underneath —
- * so racing claimants split the queue between them and never take the same
- * conversation twice. These tests race real transactions on a real Postgres,
- * because the guarantee under test is Postgres's locking, not egma's code.
+ * Two simulators, one queue — the deployment's whole queue, because the claim
+ * is instance-wide. The claim is atomic — `SKIP LOCKED` underneath — so racing
+ * claimants split it between them and never take the same conversation twice.
+ * These tests race real transactions on a real Postgres, because the guarantee
+ * under test is Postgres's locking, not egma's code.
  */
 
 let database: MigratedDatabase;
@@ -107,12 +109,12 @@ describe("two claimants on one queued simulation", () => {
     const simulationId = await oneQueuedSimulation();
 
     const [blue, green] = await Promise.all([
-      claimSimulations(auth, { claimant: "simulator-blue-1", capacity: 1 }),
-      claimSimulations(auth, { claimant: "simulator-green-2", capacity: 1 }),
+      claimSimulations({ claimant: "simulator-blue-1", capacity: 1 }),
+      claimSimulations({ claimant: "simulator-green-2", capacity: 1 }),
     ]);
 
     const claims = [...blue, ...green].filter(
-      (simulation) => simulation.id === simulationId,
+      (claim) => claim.id === simulationId,
     );
     expect(claims).toHaveLength(1);
     expect([blue.length, green.length].sort()).toEqual([0, 1]);
@@ -128,11 +130,11 @@ describe("a fleet draining a queue", () => {
 
     const fleet = await Promise.all(
       ["simulator-a", "simulator-b", "simulator-c"].map((claimant) =>
-        claimSimulations(auth, { claimant, capacity: 2 }),
+        claimSimulations({ claimant, capacity: 2 }),
       ),
     );
 
-    const taken = fleet.flat().map((simulation) => simulation.id);
+    const taken = fleet.flat().map((claim) => claim.id);
     // No conversation twice, and every claimed one was really queued.
     expect(new Set(taken).size).toBe(taken.length);
     for (const id of taken) {
@@ -141,12 +143,12 @@ describe("a fleet draining a queue", () => {
     // Three claimants of capacity two drain all six between them.
     expect(taken.length).toBe(6);
 
-    // And each claimed row says who holds it.
+    // And each claim says who holds it, on the answer and on the row.
     for (const [index, claims] of fleet.entries()) {
       const claimant = ["simulator-a", "simulator-b", "simulator-c"][index];
-      for (const simulation of claims) {
-        expect(simulation.claimedBy).toBe(claimant);
-        expect(simulation.status).toBe("claimed");
+      for (const claim of claims) {
+        expect(claim.claimedBy).toBe(claimant);
+        expect((await getSimulation(auth, claim.id))?.status).toBe("claimed");
       }
     }
   });

--- a/packages/db/test/runs.test.ts
+++ b/packages/db/test/runs.test.ts
@@ -31,7 +31,7 @@ import {
   type AuthContext,
   type NewRun,
   type Role,
-  type Simulation,
+  type SimulationClaim,
   type StartedRun,
 } from "@egma/db";
 
@@ -141,18 +141,15 @@ function aRun(overrides: Partial<NewRun> = {}): NewRun {
 
 /**
  * Claim for one run under test. A claim takes the oldest queued simulations
- * of the whole customer, and earlier tests leave some behind on purpose, so
+ * of the whole deployment, and earlier tests leave some behind on purpose, so
  * every test names its own run and fishes its own simulation out.
  */
 async function claimOwn(
   runId: string,
   claimant = "simulator-blue-1",
-): Promise<Simulation> {
-  const claimed = await claimSimulations(actingAsAcme(), {
-    claimant,
-    capacity: 50,
-  });
-  const ours = claimed.find((simulation) => simulation.runId === runId);
+): Promise<SimulationClaim> {
+  const claimed = await claimSimulations({ claimant, capacity: 50 });
+  const ours = claimed.find((claim) => claim.runId === runId);
   if (ours === undefined) throw new Error("the claim missed the run under test");
   return ours;
 }
@@ -797,13 +794,11 @@ describe("canceling a run", () => {
       expect(simulation.cancelRequestedAt).toBeInstanceOf(Date);
     }
 
-    const claimed = await claimSimulations(actingAsAcme(), {
+    const claimed = await claimSimulations({
       claimant: simulator,
       capacity: 50,
     });
-    expect(
-      claimed.filter((simulation) => simulation.runId === started.id),
-    ).toEqual([]);
+    expect(claimed.filter((claim) => claim.runId === started.id)).toEqual([]);
   });
 
   it("stamps the intent on a claimed simulation, and the next heartbeat carries it", async () => {

--- a/packages/db/test/simulation-claims.test.ts
+++ b/packages/db/test/simulation-claims.test.ts
@@ -13,6 +13,7 @@ import {
   removeConnection,
   resolveSimulationConnection,
   startRun,
+  updateConnection,
   type AuthContext,
   type SimulationClaim,
 } from "@egma/db";
@@ -381,5 +382,23 @@ describe("the connection door", () => {
       agentId: restored.id,
       connectionId: restored.connection?.id ?? "",
     };
+  });
+
+  it("unseals what a rotation resealed, trimmed as it was stored", async () => {
+    const { simulationId } = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+
+    // Rotated between the queueing and the claim — with a padded paste, the
+    // way a rotation actually arrives — because credentials are the one thing
+    // a claim reads live: connections are deliberately unversioned, and a
+    // key rotated mid-run must be the key the next conversation dials with.
+    await updateConnection(actingAsAcme(), acmeSeed.agentId, acmeSeed.connectionId, {
+      credentials: { apiKey: "  retell-secret-rotated-9999ABCD  " },
+    });
+
+    const claim = await claimOne(simulationId);
+    const reached = await resolveSimulationConnection(claim.auth, claim.id);
+    expect(reached?.credentials).toEqual({
+      apiKey: "retell-secret-rotated-9999ABCD",
+    });
   });
 });

--- a/packages/db/test/simulation-claims.test.ts
+++ b/packages/db/test/simulation-claims.test.ts
@@ -1,0 +1,385 @@
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  claimSimulations,
+  createAgent,
+  createPersona,
+  createTest,
+  getPersonaVersion,
+  getRun,
+  getSimulation,
+  getSimulationTestVersion,
+  removeConnection,
+  resolveSimulationConnection,
+  startRun,
+  type AuthContext,
+  type SimulationClaim,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * The simulator's claim, instance-wide, and the door its credentials come
+ * through.
+ *
+ * The simulator stands behind every organization on the deployment at once
+ * and holds no credential, so its claim takes no context and reaches every
+ * customer's queue — and what makes that safe is what these tests pin down:
+ * a claim carries out identifiers and no content, every claimed simulation
+ * arrives with a context narrowed to its own tenancy, and the one door to a
+ * connection's plaintext refuses every caller whose context did not come
+ * from a claim.
+ */
+
+let database: MigratedDatabase;
+
+/** Two customers on one deployment, so "instance-wide" is observable. */
+const acme = { organization: newId("org"), project: newId("prj") };
+const globex = { organization: newId("org"), project: newId("prj") };
+
+const ada = newId("usr");
+const grace = newId("usr");
+
+function actingAsAcme(): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role: "member",
+    via: "session",
+  };
+}
+
+function actingAsGlobex(): AuthContext {
+  return {
+    userId: grace,
+    organizationId: globex.organization,
+    projectId: globex.project,
+    role: "member",
+    via: "session",
+  };
+}
+
+const NEUTRAL_TRAITS = {
+  personality: "Speaks plainly, stays patient, asks one question at a time.",
+  language: "en-US",
+  voice: {
+    provider: "elevenlabs",
+    voiceId: "EXAVITQu4vr4xnSDxMaL",
+    speed: 1,
+  },
+} as const;
+
+const SCENARIO =
+  "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.";
+
+type Seeded = {
+  readonly agentId: string;
+  readonly connectionId: string;
+  readonly personaId: string;
+  readonly testVersionId: string;
+};
+
+/** An agent, somebody to call, and a test — everything one run needs. */
+async function seedCustomer(
+  auth: AuthContext,
+  apiKey: string,
+): Promise<Seeded> {
+  const created = await createAgent(auth, {
+    name: "Front desk",
+    connection: {
+      type: "retell",
+      modality: "chat",
+      config: { retellAgentId: `agent_${apiKey}` },
+      credentials: { apiKey },
+    },
+  });
+
+  const personaId = (
+    await createPersona(auth, { name: "Impatient Rita", traits: NEUTRAL_TRAITS })
+  ).id;
+
+  const testVersionId = (
+    await createTest(auth, {
+      name: "Reschedules",
+      scenario: SCENARIO,
+      expectedBehaviors: ["confirms the new time back before finishing"],
+      personaIds: [personaId],
+    })
+  ).versionId;
+
+  return {
+    agentId: created.id,
+    connectionId: created.connection?.id ?? "",
+    personaId,
+    testVersionId,
+  };
+}
+
+let acmeSeed: Seeded;
+let globexSeed: Seeded;
+
+async function oneQueuedSimulation(
+  auth: AuthContext,
+  seed: Seeded,
+): Promise<{ runId: string; simulationId: string }> {
+  const started = await startRun(auth, {
+    agentId: seed.agentId,
+    connectionId: seed.connectionId,
+    testVersionIds: [seed.testVersionId],
+  });
+  const simulation = started.simulations[0];
+  if (simulation === undefined) throw new Error("the run has no simulation");
+  return { runId: started.id, simulationId: simulation.id };
+}
+
+/** Claim everything outstanding and hand back the one claim asked about. */
+async function claimOne(
+  simulationId: string,
+  claimant = "simulator-blue-1",
+): Promise<SimulationClaim> {
+  const claims = await claimSimulations({ claimant, capacity: 50 });
+  const ours = claims.find((claim) => claim.id === simulationId);
+  if (ours === undefined) throw new Error("the claim missed the simulation under test");
+  return ours;
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("simulation_claims");
+
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedUser(database, grace, "grace@globex.example");
+
+  acmeSeed = await seedCustomer(actingAsAcme(), "retell-secret-A1B2C3D4WXYZ");
+  globexSeed = await seedCustomer(actingAsGlobex(), "retell-secret-E5F6G7H8UVWX");
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("the instance-wide claim", () => {
+  it("reaches every customer's queue in one ask, and narrows each claim to its own", async () => {
+    const acmeRun = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+    const globexRun = await oneQueuedSimulation(actingAsGlobex(), globexSeed);
+
+    const claims = await claimSimulations({
+      claimant: "simulator-blue-1",
+      capacity: 50,
+    });
+
+    const ours = claims.filter((claim) =>
+      [acmeRun.simulationId, globexRun.simulationId].includes(claim.id),
+    );
+    expect(ours).toHaveLength(2);
+
+    const byId = new Map(ours.map((claim) => [claim.id, claim]));
+    const acmeClaim = byId.get(acmeRun.simulationId);
+    const globexClaim = byId.get(globexRun.simulationId);
+
+    // Each claim carries the context the work is done under, built from the
+    // claimed row and from nothing the claimant said.
+    expect(acmeClaim?.organizationId).toBe(acme.organization);
+    expect(acmeClaim?.auth).toEqual({
+      userId: "simulator",
+      organizationId: acme.organization,
+      projectId: acme.project,
+      role: "member",
+      via: "simulator",
+    });
+    expect(globexClaim?.organizationId).toBe(globex.organization);
+    expect(globexClaim?.auth).toEqual({
+      userId: "simulator",
+      organizationId: globex.organization,
+      projectId: globex.project,
+      role: "member",
+      via: "simulator",
+    });
+  });
+
+  it("carries out identifiers and claim stamps, and no content", async () => {
+    const { runId, simulationId } = await oneQueuedSimulation(
+      actingAsAcme(),
+      acmeSeed,
+    );
+    const claim = await claimOne(simulationId);
+
+    expect(claim.runId).toBe(runId);
+    expect(claim.agentId).toBe(acmeSeed.agentId);
+    expect(claim.connectionId).toBe(acmeSeed.connectionId);
+    expect(claim.personaId).toBe(acmeSeed.personaId);
+    expect(claim.personaVersionId).toMatch(/^prsv_/);
+    expect(claim.testVersionId).toBe(acmeSeed.testVersionId);
+    expect(claim.connectionType).toBe("retell");
+    expect(claim.modality).toBe("chat");
+    expect(claim.claimedBy).toBe("simulator-blue-1");
+    expect(claim.claimedAt).toBeInstanceOf(Date);
+
+    // No transcript, no configuration, nothing a customer wrote. The spec is
+    // assembled afterwards, through the scoped reads, under the claim's own
+    // context — the claim itself hands over nothing to leak.
+    expect(claim).not.toHaveProperty("transcript");
+    expect(claim).not.toHaveProperty("events");
+    expect(claim).not.toHaveProperty("metrics");
+  });
+
+  it("stamps the row and starts the run, exactly as the scoped claim did", async () => {
+    const { runId, simulationId } = await oneQueuedSimulation(
+      actingAsAcme(),
+      acmeSeed,
+    );
+    const claim = await claimOne(simulationId, "simulator-green-2");
+
+    const row = await getSimulation(actingAsAcme(), simulationId);
+    expect(row?.status).toBe("claimed");
+    expect(row?.claimedBy).toBe("simulator-green-2");
+    expect(row?.claimedAt).toBeInstanceOf(Date);
+    expect(row?.heartbeatAt).toBeInstanceOf(Date);
+
+    const started = await getRun(actingAsAcme(), runId);
+    expect(started?.status).toBe("running");
+    expect(started?.startedAt).toBeInstanceOf(Date);
+
+    expect(claim.claimedBy).toBe("simulator-green-2");
+  });
+
+  it("hands back a context the whole spec assembly can read through", async () => {
+    const { simulationId } = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+    const claim = await claimOne(simulationId);
+
+    const personaVersion = await getPersonaVersion(
+      claim.auth,
+      claim.personaVersionId,
+    );
+    expect(personaVersion?.traits.personality).toBe(NEUTRAL_TRAITS.personality);
+
+    const testVersion = await getSimulationTestVersion(claim.auth, claim.id);
+    expect(testVersion?.scenario).toBe(SCENARIO);
+  });
+
+  it("takes a capacity between one and fifty, and a named claimant", async () => {
+    await expect(
+      claimSimulations({ claimant: "simulator-blue-1", capacity: 0 }),
+    ).rejects.toThrow(/between 1 and 50/);
+    await expect(
+      claimSimulations({ claimant: "simulator-blue-1", capacity: 51 }),
+    ).rejects.toThrow(/between 1 and 50/);
+    await expect(
+      claimSimulations({ claimant: "   ", capacity: 1 }),
+    ).rejects.toThrow(/needs a name/);
+  });
+});
+
+describe("the connection door", () => {
+  it("answers the claimed row's own connection, credentials unsealed", async () => {
+    const { simulationId } = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+    const claim = await claimOne(simulationId);
+
+    const reached = await resolveSimulationConnection(claim.auth, claim.id);
+    expect(reached?.connectionId).toBe(acmeSeed.connectionId);
+    expect(reached?.type).toBe("retell");
+    expect(reached?.config).toEqual({
+      retellAgentId: "agent_retell-secret-A1B2C3D4WXYZ",
+    });
+    expect(reached?.credentials).toEqual({ apiKey: "retell-secret-A1B2C3D4WXYZ" });
+  });
+
+  it("refuses every context that is not the simulator's own", async () => {
+    const { simulationId } = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+    const claim = await claimOne(simulationId);
+
+    // A person's session, a key, and the grading engine — each holds a
+    // context that can read plenty, and none of them conducts a simulation,
+    // so none of them is answered a live provider secret.
+    const session = actingAsAcme();
+    const apiKey: AuthContext = { ...session, via: "api_key" };
+    const engine: AuthContext = {
+      userId: "engine",
+      organizationId: acme.organization,
+      projectId: acme.project,
+      role: "viewer",
+      via: "engine",
+    };
+
+    for (const auth of [session, apiKey, engine]) {
+      await expect(resolveSimulationConnection(auth, claim.id)).rejects.toThrow(
+        /simulator/,
+      );
+    }
+  });
+
+  it("cannot be walked out of the claim's own tenancy", async () => {
+    const acmeRun = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+    const globexRun = await oneQueuedSimulation(actingAsGlobex(), globexSeed);
+
+    const claims = await claimSimulations({
+      claimant: "simulator-blue-1",
+      capacity: 50,
+    });
+    const acmeClaim = claims.find((claim) => claim.id === acmeRun.simulationId);
+    if (acmeClaim === undefined) throw new Error("the claim missed acme's row");
+
+    // Acme's context, Globex's simulation: as absent as one that never was.
+    expect(
+      await resolveSimulationConnection(acmeClaim.auth, globexRun.simulationId),
+    ).toBeUndefined();
+  });
+
+  it("answers nothing for a simulation nobody has claimed", async () => {
+    const { simulationId } = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+
+    // A context shaped like the claim's, for a row still queued: the door
+    // opens during spec assembly, and before the claim there is nobody to
+    // hand a secret to.
+    const conductor: AuthContext = {
+      userId: "simulator",
+      organizationId: acme.organization,
+      projectId: acme.project,
+      role: "member",
+      via: "simulator",
+    };
+    expect(
+      await resolveSimulationConnection(conductor, simulationId),
+    ).toBeUndefined();
+
+    // Leave nothing queued behind for the claims that follow.
+    await claimOne(simulationId);
+  });
+
+  it("answers nothing once the connection is gone", async () => {
+    const { simulationId } = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+    const claim = await claimOne(simulationId);
+
+    await removeConnection(actingAsAcme(), acmeSeed.agentId, acmeSeed.connectionId);
+    expect(
+      await resolveSimulationConnection(claim.auth, claim.id),
+    ).toBeUndefined();
+
+    // Put the connection back for whatever runs after this file's tests.
+    const restored = await createAgent(actingAsAcme(), {
+      name: "Front desk restored",
+      connection: {
+        type: "retell",
+        modality: "chat",
+        config: { retellAgentId: "agent_restored_1" },
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+      },
+    });
+    acmeSeed = {
+      ...acmeSeed,
+      agentId: restored.id,
+      connectionId: restored.connection?.id ?? "",
+    };
+  });
+});

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -97,11 +97,16 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
 /**
  * The exports that dispatch egma's own work across the whole deployment.
  *
- * The grader service stands behind every organization at once and holds no
- * credential, because there is no honest one to give it: an API key minted
- * inside one customer would either see too little to do the job or be shared
- * between customers to do it. So it is handed work instead of asked for a
- * credential — and the two calls that hand it out are these.
+ * The grader and the simulator each stand behind every organization at once
+ * and hold no credential, because there is no honest one to give them: an API
+ * key minted inside one customer would either see too little to do the job or
+ * be shared between customers to do it. So each is handed work instead of
+ * asked for a credential — and the three calls that hand it out are these.
+ *
+ * `claimSimulations` was added on 2026-08-08 with the simulator's claim door,
+ * deliberately and after the rule stopped the build: the tenancy-scoped claim
+ * it replaced had no production caller, and the real one reaches every
+ * customer's queue on the grading claim's exact terms.
  *
  * This category is narrower than it looks, and the rule enforces the property
  * that makes it safe: **nothing here may take an argument by which a caller
@@ -110,15 +115,20 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * here that grew an `organizationId` or a `projectId` would be an ordinary
  * cross-tenant read wearing an exemption, and the rule refuses it.
  *
- * The rest of what makes it safe is not mechanical and is written out where the
- * functions live: the only table either reaches is egma's own grading queue, a
- * claim carries identifiers and tenancy rather than anything a customer wrote,
- * and every claim arrives with the `AuthContext` narrowed to that job's own
- * organization and project — which is what the grading itself goes through.
+ * The rest of what makes it safe is not mechanical and is written out where
+ * the functions live: the only rows any of them reaches are egma's own queues
+ * — grading jobs, and the simulations egma itself wrote as queued — a claim
+ * carries identifiers and tenancy rather than anything a customer wrote, and
+ * every claim arrives with the `AuthContext` narrowed to that row's own
+ * organization and project — which is what the work itself goes through.
  *
- * A third name here is a decision somebody has to make on purpose.
+ * A fourth name here is a decision somebody has to make on purpose.
  */
-const WORK_DISPATCHING = ["claimGradingJobs", "watchGradingWork"];
+const WORK_DISPATCHING = [
+  "claimGradingJobs",
+  "watchGradingWork",
+  "claimSimulations",
+];
 
 /**
  * What a work-dispatching export may not be handed, in any position: an

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -126,8 +126,8 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  */
 const WORK_DISPATCHING = [
   "claimGradingJobs",
-  "watchGradingWork",
   "claimSimulations",
+  "watchGradingWork",
 ];
 
 /**

--- a/packages/simulation-contract/package.json
+++ b/packages/simulation-contract/package.json
@@ -10,11 +10,15 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist", "schemas", "measure-catalog.md"],
+  "files": [
+    "dist",
+    "schemas",
+    "measure-catalog.md"
+  ],
   "scripts": {
     "build": "tsc -b"
   },
-  "devDependencies": {
+  "dependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1"
   }

--- a/packages/simulation-contract/src/documents.ts
+++ b/packages/simulation-contract/src/documents.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+
+import { Ajv2020, type ValidateFunction } from "ajv/dist/2020.js";
+import ajvFormats from "ajv-formats";
+import type { FormatsPlugin } from "ajv-formats";
+
+// ajv-formats ships CommonJS whose module.exports is the plugin function
+// itself; under NodeNext TypeScript types the default import as a namespace,
+// so the callable gets its name here.
+const addFormats = ajvFormats as unknown as FormatsPlugin;
+
+/**
+ * The contract's documents, as TypeScript can check them.
+ *
+ * The schemas under `schemas/` are the authority, read from disk because the
+ * other reader of those bytes is not TypeScript — the simulator compiles the
+ * same files (`contract.py`) and holds every claimed spec to the spec schema.
+ * This is the control plane's half of the same guarantee, pointed the other
+ * way: a spec is checked *before it is sent*, so a document that does not
+ * speak the contract is a fault caught on the sending side rather than a
+ * refusal the simulator has to explain back.
+ *
+ * The answer is a list of complaints rather than a thrown violation, because
+ * the caller's next move is not an exception's: one unbuildable spec is
+ * skipped and said out loud, and the rest of the batch still goes. Each
+ * complaint names the place and the problem — `/modality: must be equal to
+ * one of the allowed values` — in the same shape the simulator's own check
+ * logs, so the two sides of the wire read alike in two languages.
+ *
+ * Only the spec direction is checked from here today, because only specs are
+ * composed on this side; the report direction's TypeScript half arrives with
+ * the route that consumes reports.
+ */
+
+/**
+ * Compiled once, on first use rather than at import, so loading the package
+ * for its measure catalog never pays for — or fails on — schema compilation.
+ * Compiling is itself part of the check: a schema that is not valid 2020-12
+ * fails loudly here, rather than quietly accepting everything.
+ */
+let compiledSpec: ValidateFunction | undefined;
+
+function specValidator(): ValidateFunction {
+  if (compiledSpec === undefined) {
+    const ajv = new Ajv2020({ strict: true, allErrors: true });
+    addFormats(ajv);
+    const schema: unknown = JSON.parse(
+      readFileSync(
+        new URL("../schemas/simulation-spec.v1.schema.json", import.meta.url),
+        "utf8",
+      ),
+    );
+    compiledSpec = ajv.compile(schema as Record<string, unknown>);
+  }
+  return compiledSpec;
+}
+
+/**
+ * Everything wrong with one would-be spec document, or nothing.
+ *
+ * An empty answer is the green light: the document speaks the spec direction
+ * of the contract and a simulator holding this contract version will accept
+ * it. Anything else is the full list — `allErrors`, deliberately, so a log
+ * line about a skipped simulation says everything wrong with it at once
+ * rather than one complaint per attempt that will never be retried.
+ */
+export function specComplaints(document: unknown): readonly string[] {
+  const validate = specValidator();
+  if (validate(document)) return [];
+  return (validate.errors ?? []).map(
+    (error) => `${error.instancePath}: ${error.message ?? "does not validate"}`,
+  );
+}

--- a/packages/simulation-contract/src/index.ts
+++ b/packages/simulation-contract/src/index.ts
@@ -3,10 +3,13 @@
  *
  * Almost all of this contract is JSON — two schemas under `schemas/`, read by
  * both sides from disk, because the other reader of those bytes is not
- * TypeScript. What is here is the part the control plane checks *before* a
- * simulation exists: the measure catalog, which a grader's write door refuses
- * an unknown measure against.
+ * TypeScript. What is here is what the control plane checks on its own side
+ * of the wire: the measure catalog, which a grader's write door refuses an
+ * unknown measure against, and the spec check every outgoing claim answer
+ * passes through before a byte of it is sent.
  */
+
+export { specComplaints } from "./documents.ts";
 
 export {
   catalogedMeasure,

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -7,6 +7,8 @@ import ajvFormats from "ajv-formats";
 import type { FormatsPlugin } from "ajv-formats";
 import { describe, expect, it } from "vitest";
 
+import { specComplaints } from "@egma/simulation-contract";
+
 // ajv-formats ships CommonJS whose module.exports is the plugin function
 // itself; under NodeNext TypeScript types the default import as a namespace,
 // so the callable gets its name here.
@@ -387,5 +389,41 @@ describe("the report schema structurally forbids credential material", () => {
         "must NOT have additional properties",
       );
     }
+  });
+});
+
+describe("the exported spec check, which the control plane sends through", () => {
+  it("has no complaints about any valid golden fixture", async () => {
+    for (const fixture of await fixturesUnder("spec", "valid")) {
+      expect(specComplaints(fixture.document), fixture.name).toEqual([]);
+    }
+  });
+
+  it("complains about every deliberately invalid fixture", async () => {
+    for (const fixture of await fixturesUnder("spec", "invalid")) {
+      expect(
+        specComplaints(fixture.document).length,
+        `${fixture.name} raised no complaint`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("names the place a document is wrong, the way the simulator's check does", async () => {
+    const [valid] = await fixturesUnder("spec", "valid");
+    if (valid === undefined) throw new Error("no valid spec fixture");
+
+    const { limits: _limits, ...missingLimits } = valid.document;
+    expect(specComplaints(missingLimits)).toEqual([
+      ": must have required property 'limits'",
+    ]);
+
+    expect(
+      specComplaints({ ...valid.document, modality: "carrier-pigeon" }),
+    ).toEqual(["/modality: must be equal to one of the allowed values"]);
+  });
+
+  it("complains about a document that is not an object at all", () => {
+    expect(specComplaints(null).length).toBeGreaterThan(0);
+    expect(specComplaints("a string").length).toBeGreaterThan(0);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@egma/ids':
         specifier: workspace:*
         version: link:../../packages/ids
+      '@egma/simulation-contract':
+        specifier: workspace:*
+        version: link:../../packages/simulation-contract
       better-auth:
         specifier: ^1.6.25
         version: 1.6.25(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.20.3)(kysely@0.29.4)(pg@8.22.0))(next@15.5.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@3.2.7(@types/node@24.13.3)(tsx@4.23.1))
@@ -138,7 +141,7 @@ importers:
         version: 5.9.3
 
   packages/simulation-contract:
-    devDependencies:
+    dependencies:
       ajv:
         specifier: ^8.17.1
         version: 8.20.0


### PR DESCRIPTION
## What

`POST /v1/claims` is real. The shipped simulator asks the API for work and receives fully assembled, schema-valid simulation specs — persona-version traits, the pinned test version's scenario, the connection's config with its credentials unsealed, and the platform's limit constants (chat 600s/60 turns, voice 300s/40) — while everyone else is refused. Until now only the workbench, a dev fake, answered this call.

**The claim goes instance-wide.** The tenancy-scoped `claimSimulations` had no production caller and is replaced, on the grading claim's exact precedent: the claim takes no `AuthContext` and cannot be given one, moves only rows egma itself wrote as queued, carries out identifiers and no content, and hands back with every claimed row a context narrowed to that row's own organization and project, wearing the new `via: "simulator"`. The build rule and the golden surface list both name it deliberately. Spec assembly then happens through the ordinary scoped reads under that per-row context, and the one door to a connection's plaintext on this path — `resolveSimulationConnection`, mirroring `resolveJudgeKey` — refuses every context that did not come from a claim, and is asked with a simulation rather than a connection so it can never be pointed at a connection the claimed row does not name.

**The service token guards the door.** `EGMA_SIMULATOR_SERVICE_TOKEN`, `egma_st_` prefix (so scanners recognise a leak and the customer-key resolver can never mistake it), compared in constant time by hashing both sides, resolving to no customer context at all. On by default with a development default interpolated into both compose containers — the `EGMA_AUTH_SECRET` house pattern — because port 3100 is published on the host and an unchecked claim door would hand live provider credentials to the LAN. `.env.example` and both READMEs say loudly to change it. The API refuses to start without one. The claim route sits outside the per-organization rate limit; budgets belong to customers and the token is the gate here.

**The claim is held open.** An empty queue holds the request up to 25 seconds, re-asking every second, so a queued simulation is claimed within about a second of appearing despite dispatch being pull. The client now sends its configured wait as `wait_seconds`; the server holds `min(wait_seconds, 25)`, or 15s when absent, so a short-waiting client can never see its own request time out. A client that hangs up mid-hold stops being claimed for.

**Every outgoing spec validates against the contract schema** before a byte is sent — `@egma/simulation-contract` now exports `specComplaints`, compiling the same schema the simulator's own check compiles, complaints in the same `/place: message` shape. A claimed row that cannot become a valid spec — connection deleted, credentials unopenable, schema refusal — is skipped out loud server-side while the rest of the batch dispatches; its honest terminal state arrives with the dispatch-failure landing (the seam is marked in the route), and until then the orphan sweep is what ends it.

Refusals are written for coding agents: a stable code and a sentence saying what happened and what to send instead, including which environment variable opens the door.

## Why

Dispatch is pull, and until now nothing real answered the pull: the run and simulation tables, the claim machinery and the compose wiring all existed, and the simulator's three outbound calls hit a wall. This lands the first of the three routes — the one that hands out work and the only direction credential material ever travels — with the auth model the rest (heartbeats, reports) will derive their contexts from.

## Test evidence

- `pnpm exec vitest run` — **111 files, 1821 passed, 2 skipped** (full TypeScript suite: db seam, routes, contract fixtures, grader, CLI, browser)
- `apps/simulator`: `uv run --frozen pytest` — **331 passed, 5 skipped** (the skips are live-provider tests), re-run after the compose changes so the deployment tests saw them
- `uv run --frozen ruff check src tests` — clean
- `pnpm typecheck` (build + lint rules + tests project + web) — clean
- New coverage: instance-wide claim narrowing and concurrency, the credentials door refusing every non-simulator context at the access seam, the token gate (missing/wrong/unprefixed/customer key, constant-time helper), long-poll hold and `wait_seconds` bounding, claims spending no organization's budget, unbuildable rows skipped while the batch dispatches, the exported spec check against the golden fixtures, and the claim body carrying `wait_seconds` on the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the production simulator claim endpoint, protected by a deployment-wide service token, and assembles schema-validated simulation specifications under per-row scoped contexts.
- Adds instance-wide, concurrency-safe simulation claiming and credential resolution restricted to simulator-originated contexts.
- Implements authenticated long polling with bounded client wait times and disconnect handling.
- Exports simulation-contract validation for outgoing specifications and wires matching API/simulator configuration through Compose.
- Adds route, database, contract, deployment, and simulator-client coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/claims.ts | Adds the service-token-protected long-poll claim route, per-row scoped specification assembly, contract validation, and isolation of unbuildable claims. |
| packages/db/src/access/runs.ts | Replaces tenant-scoped simulation claiming with an instance-wide claim operation that returns a narrowed simulator context for each claimed row. |
| packages/db/src/access/context.ts | Extends access context provenance with the simulator claim origin used to constrain privileged credential resolution. |
| apps/api/src/auth/service-token.ts | Implements prefixed bearer-token parsing and constant-time digest comparison for the simulator service boundary. |
| packages/simulation-contract/src/documents.ts | Exposes contract-schema complaint generation so the API can validate each outgoing simulation specification. |
| apps/simulator/src/egma_simulator/client.py | Updates simulator claims to authenticate with the service token and send the configured wait duration. |
| docker-compose.yml | Supplies matching simulator service-token configuration to the API and simulator containers. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Simulator
    participant A as API claim route
    participant D as Database
    participant C as Contract validator
    S->>A: POST /v1/claims + service token
    A->>A: Verify deployment token
    loop Until work or bounded deadline
        A->>D: Claim queued simulations instance-wide
        D-->>A: Claims with per-row scoped contexts
    end
    loop Each claimed simulation
        A->>D: Read pinned persona, test, and connection
        D-->>A: Scoped data and unsealed credentials
        A->>C: Validate assembled specification
        C-->>A: Valid specification or complaints
    end
    A-->>S: "200 { specs: [...] }"
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Retire the role-gated credentials resolv..."](https://github.com/egma-ai/egma/commit/74bac2e43a649d53ab5ecec6073a50e8f8078264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51383293)</sub>

<!-- /greptile_comment -->