### PR TITLE
Heartbeats steer every conversation, and the sweep tells the truth

### DIFF
--- a/apps/api/src/routes/heartbeats.ts
+++ b/apps/api/src/routes/heartbeats.ts
@@ -1,0 +1,102 @@
+import { recordSimulationHeartbeat } from "@egma/db";
+import type { FastifyInstance } from "fastify";
+
+import { acceptsServiceToken } from "../auth/service-token.ts";
+import { invalid, notTheService } from "../http/refusals.ts";
+
+/**
+ * The heartbeat door: `POST /v1/simulations/:id/heartbeats`, where a
+ * conducting simulator says it is still here — and hears the one directive
+ * that ever travels back.
+ *
+ * The gate and the budget arrangements are the claim door's, for the claim
+ * door's reasons (`claims.ts` carries them in full): the service token is the
+ * whole gate and resolves to no customer, and the group sits outside the
+ * per-organization rate limit because a busy run beats every few seconds per
+ * conversation from inside egma itself, and must never eat any customer's
+ * request budget. Unlike the claim, nothing here watches the socket: a beat
+ * is one guarded update, answered briskly, with no hold for a client to
+ * abandon.
+ *
+ * **The answer steers, and `cancel` is its only word.** A beat lands on the
+ * claimant's own live row and answers `null` — or `"cancel"` when
+ * cancellation was requested, and equally for every row beyond help: an id
+ * this egma never issued, another claimant's row, one already terminal. The
+ * shipped simulator obeys exactly one directive, and steering it to stop
+ * within one beat beats letting it conduct a closed conversation to its
+ * duration limit against a customer's real agent. Which is also why there is
+ * deliberately no 404 here: "that conversation is not yours to conduct" and
+ * "stop conducting it" are the same instruction, and only one of them is a
+ * directive the simulator acts on.
+ */
+
+export type HeartbeatRoutesOptions = {
+  /** The deployment's service token, from configuration. */
+  readonly serviceToken: string;
+};
+
+export const HEARTBEATS_PATH = "/v1/simulations/:simulationId/heartbeats";
+
+type Body = Record<string, unknown>;
+
+/**
+ * The claimant as this door reads it, or the sentence refusing the body. The
+ * reader is the simulator's log and whoever is tailing it, so the refusal
+ * says what to send instead — and a malformed body is the one thing here
+ * that is never answered with a directive, because it is the caller's wiring
+ * that is broken, not the conversation.
+ */
+function claimantOf(body: Body): string | { readonly refusal: string } {
+  const claimant = body.claimant;
+  if (typeof claimant !== "string" || claimant.trim() === "") {
+    return {
+      refusal:
+        "a heartbeat names its claimant — the same name this simulator " +
+        "claimed the simulation under. Send claimant as non-empty text, " +
+        'like "egma-simulator-1".',
+    };
+  }
+  if (claimant.trim().length > 200) {
+    return {
+      refusal:
+        "a claimant's name fits in 200 characters; it is a label for telling " +
+        "two simulators apart, not a place for anything longer.",
+    };
+  }
+  return claimant.trim();
+}
+
+export async function heartbeatRoutes(
+  app: FastifyInstance,
+  options: HeartbeatRoutesOptions,
+): Promise<void> {
+  // The gate, as a hook on this scope rather than a line in the route, for
+  // the reason the claim door's is one: a route inside this group cannot run
+  // unguarded, and a header is all it reads — an unauthenticated request
+  // never has its body parsed at all.
+  app.addHook("onRequest", async (request, reply) => {
+    if (!acceptsServiceToken(request.headers.authorization, options.serviceToken)) {
+      return notTheService(reply);
+    }
+    return undefined;
+  });
+
+  /**
+   * One beat for one simulation, answering `{ directive: "cancel" | null }`.
+   */
+  app.post(HEARTBEATS_PATH, async (request, reply) => {
+    const claimant = claimantOf((request.body ?? {}) as Body);
+    if (typeof claimant !== "string") return invalid(reply, claimant.refusal);
+
+    const { simulationId } = request.params as { simulationId: string };
+    const held = await recordSimulationHeartbeat({ simulationId, claimant });
+
+    // A beat with nothing under it — unknown, someone else's, already ended
+    // — steers exactly as a requested cancellation does. The seam already
+    // answered "there is nothing here for you"; this door's job is to say it
+    // in the one word the simulator acts on.
+    const directive =
+      held === undefined || held.cancelRequested ? "cancel" : null;
+    return reply.send({ directive });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -24,6 +24,7 @@ import { traceReadRoutes } from "./routes/trace-reads.ts";
 import { traceRoutes } from "./routes/traces.ts";
 import { fixedWindowRateLimit, type RateLimit } from "./http/rate-limit.ts";
 import { webHandler } from "./http/web-handler.ts";
+import { startOrphanSweep, type OrphanSweep } from "./simulation-sweep.ts";
 import type { Config } from "./config.ts";
 
 /** Where the auth provider's own endpoints live, under the shared origin. */
@@ -43,6 +44,11 @@ export type ServerOptions = {
    * suite wait out a window.
    */
   readonly rateLimit?: RateLimit;
+  /**
+   * How often the standing orphan sweep runs. Defaults to the ~30s cadence; a
+   * test hands in a shorter one rather than watching a real clock.
+   */
+  readonly orphanSweepIntervalMilliseconds?: number;
 };
 
 export type Api = {
@@ -225,6 +231,22 @@ export function buildApi(options: ServerOptions): Api {
   // invitation has no membership, so there is no context to resolve them into
   // and no organization to key a budget on. The token is the credential there.
   void app.register(invitationRoutes, { provider: identity.provider });
+
+  // The standing orphan sweep, started with the server and stopped with it.
+  // Its timer is unref'd, so a shutdown never waits on a sweep that has not
+  // happened; every replica runs one, which the seam makes harmless.
+  let orphanSweep: OrphanSweep | undefined;
+  app.addHook("onReady", async () => {
+    orphanSweep = startOrphanSweep({
+      log: app.log,
+      ...(options.orphanSweepIntervalMilliseconds === undefined
+        ? {}
+        : { intervalMilliseconds: options.orphanSweepIntervalMilliseconds }),
+    });
+  });
+  app.addHook("onClose", async () => {
+    orphanSweep?.stop();
+  });
 
   return { app, identity };
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -245,7 +245,9 @@ export function buildApi(options: ServerOptions): Api {
     });
   });
   app.addHook("onClose", async () => {
-    orphanSweep?.stop();
+    // Awaited, so closing drains any tick in flight: whoever closes the app
+    // and then the stores knows the sweep holds no connection to them.
+    await orphanSweep?.stop();
   });
 
   return { app, identity };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -12,6 +12,7 @@ import { agentRoutes } from "./routes/agents.ts";
 import { apiKeyRoutes } from "./routes/api-keys.ts";
 import { claimRoutes } from "./routes/claims.ts";
 import { deviceRoutes } from "./routes/device.ts";
+import { heartbeatRoutes } from "./routes/heartbeats.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { meRoutes } from "./routes/me.ts";
 import { memberRoutes } from "./routes/members.ts";
@@ -195,6 +196,13 @@ export function buildApi(options: ServerOptions): Api {
   // customer — so there is no organization to key a budget on, and a busy
   // run can never eat a customer's request budget from the inside.
   void app.register(claimRoutes, {
+    serviceToken: config.simulatorServiceToken,
+  });
+
+  // The heartbeat door, beside the claim door on the same terms — and all
+  // the more so, because a busy run beats every few seconds per conversation,
+  // which is exactly the traffic a per-organization budget must never see.
+  void app.register(heartbeatRoutes, {
     serviceToken: config.simulatorServiceToken,
   });
 

--- a/apps/api/src/simulation-sweep.ts
+++ b/apps/api/src/simulation-sweep.ts
@@ -1,0 +1,107 @@
+import { sweepOrphanedSimulations } from "@egma/db";
+
+/**
+ * The standing orphan sweep: what notices a dead simulator.
+ *
+ * Everything else about a simulation's lifecycle is written by somebody's
+ * request — a claim, a beat, a report. A simulator that died mid-conversation
+ * sends none of those, so the one honest record it leaves is silence, and
+ * silence has to be read on a clock. This loop reads it: every interval, one
+ * call to the seam that marks every simulation silent past the staleness
+ * window `failed` with reason `orphaned` and finalizes the runs that were
+ * waiting on them.
+ *
+ * **Every replica runs one, and nothing elects a leader.** That is safe
+ * because the seam itself makes racing sweeps collide harmlessly — the
+ * guarded update ends each row exactly once and whoever arrives second finds
+ * nothing to do — so a second API replica costs duplicate reads, never
+ * duplicate records.
+ *
+ * **The first sweep waits a whole interval on purpose.** An API that was
+ * unreachable for longer than the staleness window comes back to rows whose
+ * heartbeats all look ancient — not because their simulators died, but
+ * because every beat they sent hit a closed door. Those simulators are still
+ * conducting and still beating every few seconds, so one interval of
+ * accepting requests is what lets every living row be stamped fresh before
+ * the first sweep reads its silence.
+ */
+
+/**
+ * How often the sweep runs. Near thirty seconds: fast enough that an orphan
+ * is named within about three minutes of its simulator dying (the staleness
+ * window plus one cadence), slow enough that the queue query is nothing
+ * against real traffic.
+ */
+export const SWEEP_INTERVAL_MILLISECONDS = 30_000;
+
+/** The two things the loop ever says, shaped so a test can hand in its own. */
+type SweepLog = {
+  info(details: object, message: string): void;
+  error(details: object, message: string): void;
+};
+
+export type OrphanSweepOptions = {
+  readonly log: SweepLog;
+  /** The cadence, for a test that cannot watch a real clock. */
+  readonly intervalMilliseconds?: number;
+};
+
+export type OrphanSweep = {
+  /** The only thing to do with the handle: the server is closing. */
+  stop(): void;
+};
+
+export function startOrphanSweep(options: OrphanSweepOptions): OrphanSweep {
+  const interval = options.intervalMilliseconds ?? SWEEP_INTERVAL_MILLISECONDS;
+  if (!Number.isInteger(interval) || interval < 1) {
+    throw new Error("a sweep cadence is a positive whole number of milliseconds");
+  }
+
+  let sweeping = false;
+  const tick = async (): Promise<void> => {
+    // A sweep that outlives the cadence — a stalled store, mostly — must not
+    // have a second one piled on top of it; the next tick after it returns
+    // will see everything this one would have.
+    if (sweeping) return;
+    sweeping = true;
+    try {
+      const swept = await sweepOrphanedSimulations();
+      // A quiet queue is the ordinary case and is not news; what was swept
+      // is, by name, because each of these rows is a conversation somebody
+      // is waiting on and this line is where its ending is first visible.
+      if (swept.length > 0) {
+        options.log.info(
+          {
+            simulationIds: swept.map((simulation) => simulation.id),
+            runIds: [...new Set(swept.map((simulation) => simulation.runId))],
+          },
+          `swept ${swept.length} orphaned simulation(s) whose simulator went silent`,
+        );
+      }
+    } catch (fault) {
+      // A store this loop cannot reach is an ordinary Tuesday, and the rows
+      // it would have swept keep waiting for the next tick. Ending the loop
+      // is the one cost nothing here is worth.
+      options.log.error(
+        { err: fault },
+        "the orphan sweep failed; silent simulations stay put until a sweep reaches them",
+      );
+    } finally {
+      sweeping = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, interval);
+  // A shutdown must never wait on a sweep that has not happened yet: the
+  // timer holds nothing open, and the rows it would have swept are exactly
+  // as swept by the next replica, or by this one when it returns.
+  timer.unref();
+
+  return {
+    stop() {
+      clearInterval(timer);
+    },
+  };
+}

--- a/apps/api/src/simulation-sweep.ts
+++ b/apps/api/src/simulation-sweep.ts
@@ -1,4 +1,7 @@
-import { sweepOrphanedSimulations } from "@egma/db";
+import {
+  sweepOrphanedSimulations,
+  type SweptSimulation,
+} from "@egma/db";
 
 /**
  * The standing orphan sweep: what notices a dead simulator.
@@ -44,6 +47,12 @@ export type OrphanSweepOptions = {
   readonly log: SweepLog;
   /** The cadence, for a test that cannot watch a real clock. */
   readonly intervalMilliseconds?: number;
+  /**
+   * The seam under the loop — what one tick runs. The default is the real
+   * sweep, and the product never passes anything else; a test hands in its
+   * own to hold a tick open or fail one on cue, which no real store does.
+   */
+  readonly sweep?: () => Promise<readonly SweptSimulation[]>;
 };
 
 export type OrphanSweep = {
@@ -61,15 +70,16 @@ export function startOrphanSweep(options: OrphanSweepOptions): OrphanSweep {
     throw new Error("a sweep cadence is a positive whole number of milliseconds");
   }
 
+  const sweep = options.sweep ?? sweepOrphanedSimulations;
+
+  // True from the moment a tick is called — synchronously, before its first
+  // await — until it settles, so the timer callback's read of it can never
+  // interleave with the write.
   let sweeping = false;
   const tick = async (): Promise<void> => {
-    // A sweep that outlives the cadence — a stalled store, mostly — must not
-    // have a second one piled on top of it; the next tick after it returns
-    // will see everything this one would have.
-    if (sweeping) return;
     sweeping = true;
     try {
-      const swept = await sweepOrphanedSimulations();
+      const swept = await sweep();
       // A quiet queue is the ordinary case and is not news; what was swept
       // is, by name, because each of these rows is a conversation somebody
       // is waiting on and this line is where its ending is first visible.
@@ -100,6 +110,14 @@ export function startOrphanSweep(options: OrphanSweepOptions): OrphanSweep {
   // latest promise is holding a completion, never an error to re-raise.
   let inFlight: Promise<void> = Promise.resolve();
   const timer = setInterval(() => {
+    // A sweep that outlives the cadence — a stalled store, mostly — is
+    // skipped over, not piled on: the next tick after it returns will see
+    // everything this one would have. The skip has to happen *here*, before
+    // the assignment, because it is the assignment that must not run — a
+    // skipped tick's already-settled promise would overwrite the running
+    // sweep's, and `stop` would resolve while the store was still being
+    // swept.
+    if (sweeping) return;
     inFlight = tick();
   }, interval);
   // A shutdown must never wait on a sweep that has not happened yet: the

--- a/apps/api/src/simulation-sweep.ts
+++ b/apps/api/src/simulation-sweep.ts
@@ -47,8 +47,12 @@ export type OrphanSweepOptions = {
 };
 
 export type OrphanSweep = {
-  /** The only thing to do with the handle: the server is closing. */
-  stop(): void;
+  /**
+   * The only thing to do with the handle: the server is closing. Settles when
+   * any tick already in flight has finished, so a caller that awaits it can
+   * tear the store down knowing the sweep holds no connection to it.
+   */
+  stop(): Promise<void>;
 };
 
 export function startOrphanSweep(options: OrphanSweepOptions): OrphanSweep {
@@ -91,8 +95,12 @@ export function startOrphanSweep(options: OrphanSweepOptions): OrphanSweep {
     }
   };
 
+  // Kept so `stop` can wait a started tick out. `tick` settles rather than
+  // throwing — every fault is caught and logged inside it — so holding the
+  // latest promise is holding a completion, never an error to re-raise.
+  let inFlight: Promise<void> = Promise.resolve();
   const timer = setInterval(() => {
-    void tick();
+    inFlight = tick();
   }, interval);
   // A shutdown must never wait on a sweep that has not happened yet: the
   // timer holds nothing open, and the rows it would have swept are exactly
@@ -100,8 +108,9 @@ export function startOrphanSweep(options: OrphanSweepOptions): OrphanSweep {
   timer.unref();
 
   return {
-    stop() {
+    async stop() {
       clearInterval(timer);
+      await inFlight;
     },
   };
 }

--- a/apps/api/test/heartbeats-routes.test.ts
+++ b/apps/api/test/heartbeats-routes.test.ts
@@ -1,0 +1,352 @@
+import {
+  claimSimulations,
+  completeSimulation,
+  createPersona,
+  getSimulation,
+  startSimulation,
+} from "@egma/db";
+import { newId } from "@egma/ids";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { HEARTBEATS_PATH } from "../src/routes/heartbeats.ts";
+import { fixedWindowRateLimit } from "../src/http/rate-limit.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The simulator's heartbeat door, over real HTTP against real Postgres.
+ *
+ * What is asserted here is what the shipped simulator observes: the token
+ * gate's one sentence, a `directive` that is `null` while the conversation is
+ * the claimant's to conduct and `"cancel"` the moment it is not — requested
+ * cancellation and every row beyond help answering alike, because the
+ * simulator obeys exactly one directive and must stop conducting closed
+ * conversations. There is deliberately no 404 anywhere in the matrix, and no
+ * organization's request budget moves.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const SIMULATOR = "sim-under-test";
+
+const RESCHEDULING = {
+  name: "Reschedules a booked appointment",
+  scenario:
+    "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+  expected_behaviors: ["confirms the new time back before finishing"],
+} as const;
+
+const RETELL = {
+  type: "retell",
+  modality: "chat",
+  config: { retellAgentId: "agent_in_retell_1" },
+  credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+} as const;
+
+/** One beat as the simulator sends it, with whatever token the test says. */
+async function beat(
+  token: string | undefined,
+  simulationId: string,
+  body: Record<string, unknown>,
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  const response = await api.app.inject({
+    method: "POST",
+    url: HEARTBEATS_PATH.replace(":simulationId", simulationId),
+    ...(token === undefined
+      ? {}
+      : { headers: { authorization: `Bearer ${token}` } }),
+    payload: body,
+  });
+  return {
+    statusCode: response.statusCode,
+    body: response.json() as Record<string, unknown>,
+  };
+}
+
+/** A customer with an agent, a persona, and a test — everything a run needs. */
+async function aCustomerReadyToRun(label: string): Promise<{
+  ada: Customer;
+  key: string;
+  connectionId: string;
+  versionId: string;
+}> {
+  api = await createApi(label);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await ask(api.app, "POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: RETELL,
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+  const connectionId = (registered.body.connection as { id: string }).id;
+
+  await createPersona(contextFor(ada, "member"), {
+    name: "Impatient Rita",
+    traits: NEUTRAL_TRAITS,
+  });
+  const pushed = await ask(api.app, "POST", "/api/tests", key, {
+    ...RESCHEDULING,
+    personas: ["Impatient Rita"],
+  });
+  expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
+
+  return {
+    ada,
+    key,
+    connectionId,
+    versionId: String(pushed.body.version_id),
+  };
+}
+
+/** A run whose one simulation lands queued, ready to be claimed. */
+async function aQueuedRun(
+  key: string,
+  connectionId: string,
+  versionId: string,
+): Promise<{ runId: string; simulationId: string }> {
+  const started = await ask(api.app, "POST", "/api/runs", key, {
+    connection: connectionId,
+    test_versions: [versionId],
+  });
+  expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+  const simulations = started.body.simulations as { id: string }[];
+  const first = simulations[0];
+  if (first === undefined) throw new Error("the run has no simulation");
+  return { runId: String(started.body.id), simulationId: first.id };
+}
+
+/** A queued run claimed by the simulator under test, as the claim door would. */
+async function aClaimedRun(
+  key: string,
+  connectionId: string,
+  versionId: string,
+): Promise<{ runId: string; simulationId: string }> {
+  const queued = await aQueuedRun(key, connectionId, versionId);
+  const claims = await claimSimulations({ claimant: SIMULATOR, capacity: 50 });
+  expect(claims.map((claim) => claim.id)).toContain(queued.simulationId);
+  return queued;
+}
+
+describe("the token gate", () => {
+  it("refuses a missing, wrong, unprefixed or customer token with one actionable sentence", async () => {
+    const { ada, key, connectionId, versionId } =
+      await aCustomerReadyToRun("beats_gate");
+    const { simulationId } = await aClaimedRun(key, connectionId, versionId);
+
+    // An old stamp first, so "the refused request wrote nothing" is a fact
+    // about the row rather than an assumption.
+    await api.database.sql(
+      "update simulation set heartbeat_at = now() - interval '60 seconds' where id = $1",
+      [simulationId],
+    );
+    const before = await getSimulation(contextFor(ada, "member"), simulationId);
+
+    const refusals = await Promise.all([
+      beat(undefined, simulationId, { claimant: SIMULATOR }),
+      beat("egma_st_not-the-configured-one", simulationId, {
+        claimant: SIMULATOR,
+      }),
+      beat("unprefixed-token", simulationId, { claimant: SIMULATOR }),
+      // A customer's own real key: a credential for reading their data, and
+      // exactly the thing this door must never answer a directive to.
+      beat(key, simulationId, { claimant: SIMULATOR }),
+    ]);
+
+    for (const refused of refusals) {
+      expect(refused.statusCode).toBe(401);
+      expect(refused.body.error).toBe("not_authenticated");
+      expect(String(refused.body.message)).toContain(
+        "EGMA_SIMULATOR_SERVICE_TOKEN",
+      );
+    }
+
+    // And none of them stamped the row.
+    const after = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(after?.heartbeatAt).toEqual(before?.heartbeatAt);
+  });
+});
+
+describe("a malformed beat", () => {
+  it("is a 400 saying what to send, and never a directive", async () => {
+    api = await createApi("beats_body");
+    const token = api.config.simulatorServiceToken;
+    const anywhere = newId("sim");
+
+    const missing = await beat(token, anywhere, {});
+    expect(missing.statusCode).toBe(400);
+    expect(missing.body.error).toBe("invalid_request");
+    expect(String(missing.body.message)).toContain("claimant");
+
+    const empty = await beat(token, anywhere, { claimant: "   " });
+    expect(empty.statusCode).toBe(400);
+    expect(empty.body.error).toBe("invalid_request");
+
+    const endless = await beat(token, anywhere, {
+      claimant: "x".repeat(201),
+    });
+    expect(endless.statusCode).toBe(400);
+    expect(String(endless.body.message)).toContain("200");
+  });
+});
+
+describe("the steering matrix", () => {
+  it("answers null to the claimant of a live conversation, and stamps the row", async () => {
+    const { ada, key, connectionId, versionId } =
+      await aCustomerReadyToRun("beats_alive");
+    const { simulationId } = await aClaimedRun(key, connectionId, versionId);
+
+    // An old stamp first, so the beat's advance is observable.
+    await api.database.sql(
+      "update simulation set heartbeat_at = now() - interval '60 seconds' where id = $1",
+      [simulationId],
+    );
+
+    const claimed = await beat(api.config.simulatorServiceToken, simulationId, {
+      claimant: SIMULATOR,
+    });
+    expect(claimed.statusCode).toBe(200);
+    expect(claimed.body).toEqual({ directive: null });
+
+    const stamped = await getSimulation(
+      contextFor(ada, "member"),
+      simulationId,
+    );
+    expect(Date.now() - (stamped?.heartbeatAt?.getTime() ?? 0)).toBeLessThan(
+      10_000,
+    );
+
+    // And the same once the conversation is underway.
+    await startSimulation(contextFor(ada, "member"), simulationId, SIMULATOR);
+    const running = await beat(api.config.simulatorServiceToken, simulationId, {
+      claimant: SIMULATOR,
+    });
+    expect(running.body).toEqual({ directive: null });
+  });
+
+  it("carries a requested cancellation on the next beat", async () => {
+    const { key, connectionId, versionId } =
+      await aCustomerReadyToRun("beats_cancel");
+    const { runId, simulationId } = await aClaimedRun(
+      key,
+      connectionId,
+      versionId,
+    );
+
+    // The cancel arrives the way a person sends one: through the run's own
+    // cancel route, while the simulator holds the conversation.
+    const canceled = await ask(
+      api.app,
+      "POST",
+      `/api/runs/${runId}/cancel`,
+      key,
+    );
+    expect(canceled.statusCode, JSON.stringify(canceled.body)).toBe(200);
+
+    const answered = await beat(
+      api.config.simulatorServiceToken,
+      simulationId,
+      { claimant: SIMULATOR },
+    );
+    expect(answered.statusCode).toBe(200);
+    expect(answered.body).toEqual({ directive: "cancel" });
+  });
+
+  it("answers cancel for every simulation beyond help, and 404 to nobody", async () => {
+    const { ada, key, connectionId, versionId } =
+      await aCustomerReadyToRun("beats_beyond_help");
+    const token = api.config.simulatorServiceToken;
+
+    // Unknown: an id this egma never issued.
+    const unknown = await beat(token, newId("sim"), { claimant: SIMULATOR });
+    expect(unknown.statusCode).toBe(200);
+    expect(unknown.body).toEqual({ directive: "cancel" });
+
+    // Queued: nobody's to conduct yet, so nobody's to beat for.
+    const queued = await aQueuedRun(key, connectionId, versionId);
+    const unclaimed = await beat(token, queued.simulationId, {
+      claimant: SIMULATOR,
+    });
+    expect(unclaimed.body).toEqual({ directive: "cancel" });
+
+    // Another claimant's row: told to stop, and the row left unstamped so
+    // the real claimant's silence still counts.
+    const held = await aClaimedRun(key, connectionId, versionId);
+    await api.database.sql(
+      "update simulation set heartbeat_at = now() - interval '60 seconds' where id = $1",
+      [held.simulationId],
+    );
+    const before = await getSimulation(
+      contextFor(ada, "member"),
+      held.simulationId,
+    );
+    const foreign = await beat(token, held.simulationId, {
+      claimant: "some-other-simulator",
+    });
+    expect(foreign.statusCode).toBe(200);
+    expect(foreign.body).toEqual({ directive: "cancel" });
+    const after = await getSimulation(
+      contextFor(ada, "member"),
+      held.simulationId,
+    );
+    expect(after?.heartbeatAt).toEqual(before?.heartbeatAt);
+
+    // Terminal: the record already closed this conversation, so even its own
+    // claimant is steered to stop.
+    await startSimulation(contextFor(ada, "member"), held.simulationId, SIMULATOR);
+    await completeSimulation(
+      contextFor(ada, "member"),
+      held.simulationId,
+      SIMULATOR,
+      { endingReason: "persona_concluded", transcript: [] },
+    );
+    const late = await beat(token, held.simulationId, { claimant: SIMULATOR });
+    expect(late.statusCode).toBe(200);
+    expect(late.body).toEqual({ directive: "cancel" });
+  });
+});
+
+describe("what the heartbeat door never touches", () => {
+  it("spends no organization's request budget, and no budget stops a beat", async () => {
+    // A budget of three, so the ceiling is reachable by hand.
+    api = await createApi("beats_budget", {
+      rateLimit: fixedWindowRateLimit({ limit: 3, windowMilliseconds: 60_000 }),
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const token = api.config.simulatorServiceToken;
+
+    // Beats beyond any organization's budget, every one answered. The row
+    // does not exist, which is the cheapest beat there is — and still a 200.
+    for (let i = 0; i < 6; i += 1) {
+      const answered = await beat(token, newId("sim"), { claimant: SIMULATOR });
+      expect(answered.statusCode).toBe(200);
+    }
+
+    // The organization's own budget is untouched by all of that…
+    const read = await ask(api.app, "GET", "/api/agents", key);
+    expect(read.statusCode).toBe(200);
+
+    // …and once the organization does spend it, the heartbeat door is unmoved.
+    let refused = 0;
+    for (let i = 0; i < 6; i += 1) {
+      const answer = await ask(api.app, "GET", "/api/agents", key);
+      if (answer.statusCode === 429) refused += 1;
+    }
+    expect(refused).toBeGreaterThan(0);
+
+    const stillBeats = await beat(token, newId("sim"), { claimant: SIMULATOR });
+    expect(stillBeats.statusCode).toBe(200);
+  });
+});

--- a/apps/api/test/heartbeats-routes.test.ts
+++ b/apps/api/test/heartbeats-routes.test.ts
@@ -2,8 +2,10 @@ import {
   claimSimulations,
   completeSimulation,
   createPersona,
+  failSimulationDispatch,
   getSimulation,
   startSimulation,
+  type SimulationClaim,
 } from "@egma/db";
 import { newId } from "@egma/ids";
 import { afterEach, describe, expect, it } from "vitest";
@@ -132,11 +134,12 @@ async function aClaimedRun(
   key: string,
   connectionId: string,
   versionId: string,
-): Promise<{ runId: string; simulationId: string }> {
+): Promise<{ runId: string; simulationId: string; claim: SimulationClaim }> {
   const queued = await aQueuedRun(key, connectionId, versionId);
   const claims = await claimSimulations({ claimant: SIMULATOR, capacity: 50 });
-  expect(claims.map((claim) => claim.id)).toContain(queued.simulationId);
-  return queued;
+  const claim = claims.find((one) => one.id === queued.simulationId);
+  if (claim === undefined) throw new Error("the claim missed the run under test");
+  return { ...queued, claim };
 }
 
 describe("the token gate", () => {
@@ -314,6 +317,21 @@ describe("the steering matrix", () => {
     const late = await beat(token, held.simulationId, { claimant: SIMULATOR });
     expect(late.statusCode).toBe(200);
     expect(late.body).toEqual({ directive: "cancel" });
+
+    // And the platform's own landing is terminal like any other: a claimed
+    // simulation that could not be handed over reads dispatch_failed on the
+    // row, and its claimant's next beat is steered to stop the same way.
+    const doomed = await aClaimedRun(key, connectionId, versionId);
+    await failSimulationDispatch(
+      doomed.claim.auth,
+      doomed.claim.id,
+      doomed.claim.claimedBy,
+    );
+    const undispatched = await beat(token, doomed.simulationId, {
+      claimant: SIMULATOR,
+    });
+    expect(undispatched.statusCode).toBe(200);
+    expect(undispatched.body).toEqual({ directive: "cancel" });
   });
 });
 

--- a/apps/api/test/simulation-sweep.test.ts
+++ b/apps/api/test/simulation-sweep.test.ts
@@ -170,6 +170,51 @@ describe("the standing sweep", () => {
     }
   });
 
+  it("holds stop for a sweep that outlives the cadence, starting nothing beside it", async () => {
+    // A sweep held open from the seam, the way a stalled store would hold
+    // one — the one condition a real store cannot produce on cue.
+    const log = capturingLog();
+    let release: (() => void) | undefined;
+    let started = 0;
+    const sweep = startOrphanSweep({
+      log,
+      intervalMilliseconds: 25,
+      sweep: () => {
+        started += 1;
+        return new Promise((resolve) => {
+          release = () => resolve([]);
+        });
+      },
+    });
+    try {
+      // The first tick starts and holds; the cadence keeps firing meanwhile
+      // and must start no second sweep beside the stalled one.
+      await vi.waitFor(() => expect(started).toBe(1), {
+        timeout: 5_000,
+        interval: 10,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(started).toBe(1);
+
+      // stop() during the held sweep settles only once the sweep does: the
+      // skipped ticks in between must not have handed stop an
+      // already-settled promise to await instead of the running one.
+      let stopped = false;
+      const stopping = sweep.stop().then(() => {
+        stopped = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(stopped).toBe(false);
+
+      release?.();
+      await stopping;
+      expect(stopped).toBe(true);
+    } finally {
+      release?.();
+      await sweep.stop();
+    }
+  });
+
   it("outlives a sweep that fails, saying so instead of dying", async () => {
     // No store at all — the sharpest form of the one Tuesday this loop will
     // actually meet. Every tick fails, and every failure must cost that tick

--- a/apps/api/test/simulation-sweep.test.ts
+++ b/apps/api/test/simulation-sweep.test.ts
@@ -1,0 +1,190 @@
+import { claimSimulations, createPersona, getSimulation } from "@egma/db";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  startOrphanSweep,
+  SWEEP_INTERVAL_MILLISECONDS,
+} from "../src/simulation-sweep.ts";
+import { createApi, type TestApi, type TestApiOptions } from "./support/api.ts";
+import {
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The standing orphan sweep: the loop the API runs so a dead simulator's
+ * rows land `failed` without anybody asking. What is pinned here is the
+ * loop's own conduct — it starts with the server, it says what it swept and
+ * only when it swept something, and a sweep that fails leaves the loop
+ * standing — because the sweeping itself is the db seam's, proven where it
+ * lives.
+ */
+
+let api: TestApi | undefined;
+
+afterEach(async () => {
+  await api?.close();
+  api = undefined;
+});
+
+/** What one test's loop said, in order, without a real logger in the way. */
+function capturingLog(): {
+  infos: { details: Record<string, unknown>; message: string }[];
+  errors: { details: Record<string, unknown>; message: string }[];
+  info(details: object, message: string): void;
+  error(details: object, message: string): void;
+} {
+  const infos: { details: Record<string, unknown>; message: string }[] = [];
+  const errors: { details: Record<string, unknown>; message: string }[] = [];
+  return {
+    infos,
+    errors,
+    info(details, message) {
+      infos.push({ details: details as Record<string, unknown>, message });
+    },
+    error(details, message) {
+      errors.push({ details: details as Record<string, unknown>, message });
+    },
+  };
+}
+
+/** A customer, a claimed simulation, and a heartbeat far in the past. */
+async function anOrphan(
+  label: string,
+  options: TestApiOptions = {},
+): Promise<{
+  ada: Customer;
+  key: string;
+  runId: string;
+  simulationId: string;
+  api: TestApi;
+}> {
+  api = await createApi(label, options);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await ask(api.app, "POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: {
+      type: "retell",
+      modality: "chat",
+      config: { retellAgentId: "agent_in_retell_1" },
+      credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    },
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+  const connectionId = (registered.body.connection as { id: string }).id;
+
+  await createPersona(contextFor(ada, "member"), {
+    name: "Impatient Rita",
+    traits: NEUTRAL_TRAITS,
+  });
+  const pushed = await ask(api.app, "POST", "/api/tests", key, {
+    name: "Reschedules a booked appointment",
+    scenario: "Their cleaning is booked for Thursday and has to move.",
+    expected_behaviors: ["confirms the new time back before finishing"],
+    personas: ["Impatient Rita"],
+  });
+  expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
+
+  const started = await ask(api.app, "POST", "/api/runs", key, {
+    connection: connectionId,
+    test_versions: [String(pushed.body.version_id)],
+  });
+  expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+  const simulations = started.body.simulations as { id: string }[];
+  const simulationId = simulations[0]?.id ?? "";
+
+  const claims = await claimSimulations({
+    claimant: "simulator-that-died",
+    capacity: 50,
+  });
+  expect(claims.map((claim) => claim.id)).toContain(simulationId);
+
+  // The one write no seam should offer: the silence a dead simulator
+  // actually leaves behind.
+  await api.database.sql(
+    "update simulation set heartbeat_at = now() - interval '10 minutes' where id = $1",
+    [simulationId],
+  );
+
+  return { ada, key, runId: String(started.body.id), simulationId, api };
+}
+
+describe("the standing sweep", () => {
+  it("runs with the server, so an orphan lands without anybody asking", async () => {
+    const { ada, key, runId, simulationId, api: running } = await anOrphan(
+      "sweep_wired",
+      { orphanSweepIntervalMilliseconds: 100 },
+    );
+
+    // Nothing calls anything from here: the loop the server started is the
+    // only mover, on the shortened cadence the test asked the server for.
+    await vi.waitFor(
+      async () => {
+        const row = await getSimulation(contextFor(ada, "member"), simulationId);
+        expect(row?.status).toBe("failed");
+        expect(row?.endingReason).toBe("orphaned");
+      },
+      { timeout: 5_000, interval: 100 },
+    );
+
+    const header = await ask(running.app, "GET", `/api/runs/${runId}`, key);
+    expect(header.body.status).toBe("completed");
+  });
+
+  it("ships with a cadence near thirty seconds, inside the staleness window", () => {
+    // The window is 150s of silence; a sweep every ~30s means an orphan is
+    // named within about three minutes of its simulator dying, and a live
+    // simulator restarting after an API outage has a whole interval of
+    // landing heartbeats before the first sweep reads its silence.
+    expect(SWEEP_INTERVAL_MILLISECONDS).toBe(30_000);
+  });
+
+  it("says what it swept when it swept something, and nothing otherwise", async () => {
+    const { simulationId, runId } = await anOrphan("sweep_speaks");
+
+    const log = capturingLog();
+    const sweep = startOrphanSweep({ log, intervalMilliseconds: 50 });
+    try {
+      await vi.waitFor(() => expect(log.infos.length).toBeGreaterThan(0), {
+        timeout: 5_000,
+        interval: 25,
+      });
+
+      const said = log.infos[0];
+      expect(said?.message).toContain("orphaned");
+      expect(said?.details.simulationIds).toContain(simulationId);
+      expect(said?.details.runIds).toContain(runId);
+
+      // Later ticks find nothing, and a quiet queue is not news.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(log.infos).toHaveLength(1);
+      expect(log.errors).toHaveLength(0);
+    } finally {
+      sweep.stop();
+    }
+  });
+
+  it("outlives a sweep that fails, saying so instead of dying", async () => {
+    // No store at all — the sharpest form of the one Tuesday this loop will
+    // actually meet. Every tick fails, and every failure must cost that tick
+    // and nothing after it.
+    const log = capturingLog();
+    const sweep = startOrphanSweep({ log, intervalMilliseconds: 50 });
+    try {
+      await vi.waitFor(() => expect(log.errors.length).toBeGreaterThan(1), {
+        timeout: 5_000,
+        interval: 25,
+      });
+      expect(log.errors[0]?.message).toContain("sweep");
+      expect(log.infos).toHaveLength(0);
+    } finally {
+      sweep.stop();
+    }
+  });
+});

--- a/apps/api/test/simulation-sweep.test.ts
+++ b/apps/api/test/simulation-sweep.test.ts
@@ -166,7 +166,7 @@ describe("the standing sweep", () => {
       expect(log.infos).toHaveLength(1);
       expect(log.errors).toHaveLength(0);
     } finally {
-      sweep.stop();
+      await sweep.stop();
     }
   });
 
@@ -184,7 +184,7 @@ describe("the standing sweep", () => {
       expect(log.errors[0]?.message).toContain("sweep");
       expect(log.infos).toHaveLength(0);
     } finally {
-      sweep.stop();
+      await sweep.stop();
     }
   });
 });

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -55,6 +55,8 @@ export type TestApiOptions = {
   readonly emailDelivers?: boolean;
   /** A budget small enough to reach, for the tests about reaching it. */
   readonly rateLimit?: RateLimit;
+  /** A sweep cadence short enough to observe, for the tests about the sweep. */
+  readonly orphanSweepIntervalMilliseconds?: number;
   /**
    * Whether this API needs a trace store of its own. Off by default: creating
    * and migrating a ClickHouse database costs a second, and only the files
@@ -115,6 +117,12 @@ export async function createApi(
     config,
     emailSender,
     ...(options.rateLimit === undefined ? {} : { rateLimit: options.rateLimit }),
+    ...(options.orphanSweepIntervalMilliseconds === undefined
+      ? {}
+      : {
+          orphanSweepIntervalMilliseconds:
+            options.orphanSweepIntervalMilliseconds,
+        }),
   });
   await app.ready();
 

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -394,8 +394,10 @@ export {
   type SimulationClaimRequest,
   type SimulationConnection,
   type SimulationFailure,
+  type SimulationHeartbeat,
   type SimulationReport,
   type StartedRun,
+  type SweptSimulation,
 } from "./runs.ts";
 export type {
   RunEventKind,

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -60,18 +60,23 @@ import { within } from "./within.ts";
  * machinery is gated by `start_and_cancel_runs` throughout, because claiming
  * and reporting a simulation *is* conducting the run somebody started.
  *
- * One exception, drawn on the grading queue's precedent and as narrowly:
- * `claimSimulations` takes no context and cannot be given one, because the
- * simulator stands behind every organization on the deployment at once and
- * there is no honest credential to give it. It reaches only the queue of
- * simulations egma itself wrote, carries out identifiers and no content, and
- * hands back with every claim the context the conducting is then done under —
- * built from the claimed row's own tenancy and from nothing the service said.
+ * Three exceptions, drawn on the grading queue's precedent and as narrowly:
+ * `claimSimulations`, `recordSimulationHeartbeat` and
+ * `sweepOrphanedSimulations` take no context and cannot be given one, because
+ * each stands where the simulator does — behind every organization on the
+ * deployment at once, with no honest credential to give it. The claim hands
+ * work out; the heartbeat keeps one dispatch alive and steers it; the sweep
+ * accounts for dispatches whose simulator died. All three reach only rows
+ * egma's own machinery wrote — the queue, and the claims made from it — and
+ * carry out identifiers and no content. The claim hands back with every row
+ * the context the conducting is then done under, built from the row's own
+ * tenancy and from nothing the service said; the other two derive their
+ * narrowness the same way, from the row rather than from any caller.
  * `resolveSimulationConnection` and `failSimulationDispatch` are the two
- * doors only such a context may open — the secret the dispatch needs, and
- * the honest landing when the dispatch cannot happen — and each refuses
- * every other kind. The whole argument is written out on the three
- * functions.
+ * doors only such a claim-minted context may open — the secret the dispatch
+ * needs, and the honest landing when the dispatch cannot happen — and each
+ * refuses every other kind. The whole argument is written out on the
+ * functions themselves.
  *
  * Writers keep to one lock order — simulation rows first, the run header last
  * — so the claim path, the cancel path and the report path do not deadlock
@@ -326,8 +331,22 @@ const MOST_SIMULATIONS_PER_RUN = 200;
 /** How many queued simulations one claim may take, however large the fleet. */
 const LARGEST_CLAIM_CAPACITY = 50;
 
-/** How long a claimed simulation may go silent before the sweep calls it. */
-const DEFAULT_STALE_AFTER_SECONDS = 60;
+/**
+ * How long a claimed or running simulation may go silent before the sweep
+ * calls it orphaned.
+ *
+ * The window is set against the report, not the heartbeat. The simulator's
+ * report sender retries a terminal document for up to two minutes before it
+ * abandons delivery, so a partition can swallow every heartbeat and still end
+ * in time for the report to land — and a window shorter than that deadline
+ * would let the sweep write `orphaned` over a conversation that genuinely
+ * finished, minutes before its own record arrived to say so. 150 seconds
+ * outlasts the retrying with room to spare, and against a beat every few
+ * seconds it is dozens of missed beats — never a simulator that is merely
+ * slow. The cost, accepted: a truly crashed simulator's rows stay `running`
+ * for up to about three minutes before the honest `failed`.
+ */
+const DEFAULT_STALE_AFTER_SECONDS = 150;
 
 /**
  * The failure reasons a simulator may give — everything but the platform's
@@ -584,22 +603,26 @@ function isGradable(status: SimulationStatus): boolean {
  * for a sweep of forgotten simulations to exist in. The notification the
  * enqueue raises travels on the same transaction and so reaches a listening
  * grader the moment the transition is visible to it.
+ *
+ * The tenancy the work is filed under comes in with the row rather than from
+ * any context, because not every caller has one: a landing reached its row
+ * through `within` and passes the context's organization, which is the row's
+ * by construction; the sweep holds no context at all and passes what the row
+ * itself says — either way, the job lands inside the customer the simulation
+ * belongs to.
  */
 async function makeGradable(
   tx: Transaction,
-  auth: AuthContext,
   row: {
     readonly id: string;
     readonly status: string;
+    readonly organizationId: string;
     readonly projectId: string;
   },
 ): Promise<void> {
   if (!isGradable(row.status as SimulationStatus)) return;
-  // The organization comes off the context rather than off the row: the row was
-  // reached through `within`, so its organization is this one by construction,
-  // and the answer's columns stay the tenant-free view they are everywhere else.
   await enqueueGradingJob(tx, {
-    organizationId: auth.organizationId,
+    organizationId: row.organizationId,
     projectId: row.projectId,
     source: "simulation",
     simulationId: row.id,
@@ -1756,33 +1779,40 @@ export async function resolveSimulationConnection(
   };
 }
 
+/** One beat, as the wire carries it: which simulation, and who is conducting. */
+export type SimulationHeartbeat = {
+  readonly simulationId: string;
+  /** This simulator's own name for itself — the name the claim stamped. */
+  readonly claimant: string;
+};
+
 /**
  * Still alive, still holding this conversation — and the answer carries the
  * one directive that travels back on a heartbeat: whether cancellation has
- * been requested. `undefined` is a heartbeat with nothing under it: a
- * simulation out of reach, not this claimant's, or no longer moving — the
- * signal to stop, not to retry.
+ * been requested. `undefined` is a heartbeat with nothing under it: an id
+ * this egma never issued, another claimant's row, or one no longer moving —
+ * the signal to stop, not to retry.
+ *
+ * **It takes no `AuthContext` and cannot be given one**, on the claim's exact
+ * terms (see the note at the top of this file): the beat comes from egma's
+ * own simulator, which stands behind every organization at once and holds no
+ * credential to build a context from. What keeps it narrow is the guarded
+ * update itself — the only row it can touch is one the caller's own name is
+ * already stamped on, in a state only egma's claim machinery writes — and the
+ * answer is a single boolean egma itself stamped. Nothing a customer authored
+ * goes in or comes out.
  */
 export async function recordSimulationHeartbeat(
-  auth: AuthContext,
-  id: string,
-  claimant: string,
+  beat: SimulationHeartbeat,
 ): Promise<{ readonly cancelRequested: boolean } | undefined> {
-  authorize(auth, "start_and_cancel_runs", here(auth));
-
   const [row] = await db()
     .update(simulation)
     .set({ heartbeatAt: new Date() })
     .where(
-      within(
-        auth,
-        simulation,
-        and(
-          eq(simulation.id, id),
-          eq(simulation.claimedBy, validClaimant(claimant)),
-          inArray(simulation.status, ["claimed", "running"]),
-          inActingProject(auth, simulation),
-        ),
+      and(
+        eq(simulation.id, beat.simulationId),
+        eq(simulation.claimedBy, validClaimant(beat.claimant)),
+        inArray(simulation.status, ["claimed", "running"]),
       ),
     )
     .returning({ cancelRequestedAt: simulation.cancelRequestedAt });
@@ -1882,7 +1912,10 @@ async function landSimulation(
 
     // The judgement is queued in the same transaction as the landing, so a
     // conversation that ended is never recorded without the work to judge it.
-    await makeGradable(tx, auth, row);
+    // The organization comes off the context: the row was reached through
+    // `within`, so its organization is this one by construction, and the
+    // answer's columns stay the tenant-free view they are everywhere else.
+    await makeGradable(tx, { ...row, organizationId: auth.organizationId });
     const settled = await finalizeRunIfDone(tx, row.runId, now);
     await appendRunEvents(tx, row.runId, now, [
       {
@@ -2032,22 +2065,48 @@ export async function markSimulationCanceled(
 }
 
 /**
+ * What the sweep answers with: which rows it ended, named and nothing more.
+ * The caller's whole use for the answer is to say what happened — anything
+ * fuller would carry customers' content out of a call that has no context
+ * to hold it to one customer.
+ */
+export type SweptSimulation = {
+  readonly id: string;
+  readonly runId: string;
+};
+
+/**
  * The orphan sweep: every claimed or running simulation whose simulator has
  * been silent past the staleness window is marked `failed` with reason
  * `orphaned` — an honest "started, never finished" instead of a row stuck
  * running forever — and any run that was waiting only on orphans is
  * finalized. Returns what it swept, so the caller can say what it did.
  *
+ * **It takes no `AuthContext` and cannot be given one**, on the claim's exact
+ * terms (see the note at the top of this file): silence is noticed by egma
+ * standing behind every organization at once, because the simulator whose
+ * silence this is stood there too. The only rows it moves are ones egma's own
+ * claim machinery stamped, each orphan's grading work is filed under the
+ * tenancy the row itself carries, and the answer is identifiers and no
+ * content.
+ *
+ * **Racing sweeps collide harmlessly**, which is what makes it safe to run on
+ * an interval in every replica with nothing elected to go first. The guarded
+ * update is the whole arbiter: of two sweeps reaching one row, whichever
+ * arrives second re-reads it after the first commits, finds it no longer
+ * `claimed` or `running`, and leaves it alone — so a row is ended once, its
+ * grading work enqueued once, its run finalized once. And the after-work
+ * walks rows and runs in id order, so two sweeps over one set cannot
+ * deadlock over the order they took things in.
+ *
  * The staleness window is measured in whole seconds against the last
- * heartbeat. The default is generous next to the heartbeat interval, because
- * the sweep's one sin would be calling a slow simulator dead.
+ * heartbeat. The default is `DEFAULT_STALE_AFTER_SECONDS`, set where it is so
+ * a partition cannot out-wait a report that is still coming; the sweep's one
+ * sin would be calling a simulator dead that isn't.
  */
 export async function sweepOrphanedSimulations(
-  auth: AuthContext,
   options?: { readonly staleAfterSeconds?: number | undefined },
-): Promise<readonly Simulation[]> {
-  authorize(auth, "start_and_cancel_runs", here(auth));
-
+): Promise<readonly SweptSimulation[]> {
   const staleAfterSeconds =
     options?.staleAfterSeconds ?? DEFAULT_STALE_AFTER_SECONDS;
   if (!Number.isInteger(staleAfterSeconds) || staleAfterSeconds < 1) {
@@ -2062,25 +2121,27 @@ export async function sweepOrphanedSimulations(
       .update(simulation)
       .set({ status: "failed", endingReason: "orphaned", endedAt: now })
       .where(
-        within(
-          auth,
-          simulation,
-          and(
-            inArray(simulation.status, ["claimed", "running"]),
-            lt(simulation.heartbeatAt, silentSince),
-            inActingProject(auth, simulation),
-          ),
+        and(
+          inArray(simulation.status, ["claimed", "running"]),
+          lt(simulation.heartbeatAt, silentSince),
         ),
       )
-      .returning(SIMULATION_COLUMNS);
+      .returning({
+        id: simulation.id,
+        runId: simulation.runId,
+        organizationId: simulation.organizationId,
+        projectId: simulation.projectId,
+        status: simulation.status,
+      });
 
     // An orphan is a terminal transition like any other, so it becomes work
     // like any other: a simulator that died mid-conversation produces a `failed`
     // simulation, and a `failed` simulation is judged `errored` rather than left
     // unjudged. In id order, so two sweeps racing over one set take the rows in
-    // one order and cannot deadlock over them.
+    // one order and cannot deadlock over them. The tenancy each job is filed
+    // under is the row's own — the one thing here `within` would otherwise say.
     for (const row of [...rows].sort((a, b) => (a.id < b.id ? -1 : 1))) {
-      await makeGradable(tx, auth, row);
+      await makeGradable(tx, row);
     }
 
     // Each affected run at most once, in one order, as everywhere else — and
@@ -2109,7 +2170,7 @@ export async function sweepOrphanedSimulations(
     return rows;
   });
 
-  return swept.map(simulationFromRow);
+  return swept.map((row) => ({ id: row.id, runId: row.runId }));
 }
 
 /**

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -69,22 +69,30 @@ const CONTEXT_ESTABLISHING = [
 const INSTANCE_SCOPED = ["instanceIsClaimed"];
 
 /**
- * What hands egma's own services their work. The grader and the simulator each
- * stand behind every organization on the deployment at once and hold no
- * credential, because there is no honest one to give them — so each is handed
- * work rather than asked for one.
+ * What hands egma's own services their work, and what keeps a dispatch honest
+ * afterwards. The grader and the simulator each stand behind every
+ * organization on the deployment at once and hold no credential, because
+ * there is no honest one to give them — so each is handed work rather than
+ * asked for one, and the simulator's heartbeat and orphan sweep stand on the
+ * same ground: a beat arrives bearing a token that resolves to nobody, and
+ * silence is noticed by nobody in particular.
  *
- * Three names, and a fourth is a decision somebody makes on purpose. None takes
+ * Five names, and a sixth is a decision somebody makes on purpose. None takes
  * an argument by which a caller could name a customer, and a build rule refuses
  * one that grows one; the only rows any of them reaches are egma's own queues —
- * grading jobs, and the simulations egma itself wrote as queued; and every
- * claim arrives carrying the `AuthContext` narrowed to that row's own
- * organization and project, which is what all of the work afterwards goes
- * through.
+ * grading jobs, and the simulations egma itself wrote and claimed. A claim
+ * arrives carrying the `AuthContext` narrowed to that row's own organization
+ * and project, which is what all of the work afterwards goes through; the
+ * heartbeat can stamp only a row already claimed under the caller's own name
+ * and answers one boolean egma wrote; the sweep files each orphan's grading
+ * work under the tenancy the row itself carries and answers identifiers and
+ * no content.
  */
 const WORK_DISPATCHING = [
   "claimGradingJobs",
   "claimSimulations",
+  "recordSimulationHeartbeat",
+  "sweepOrphanedSimulations",
   "watchGradingWork",
 ];
 
@@ -195,7 +203,6 @@ const CONTEXT_REQUIRING = [
   "recordDeviceAuthorization",
   "recordGradingHeartbeat",
   "recordProductionTraces",
-  "recordSimulationHeartbeat",
   "registerAgent",
   "regrade",
   "releaseGradingJob",
@@ -217,7 +224,6 @@ const CONTEXT_REQUIRING = [
   "setJudgeConfiguration",
   "startRun",
   "startSimulation",
-  "sweepOrphanedSimulations",
   "updateAgent",
   "updateConnection",
   "updateOrganizationSettings",

--- a/packages/db/test/grading-jobs.test.ts
+++ b/packages/db/test/grading-jobs.test.ts
@@ -283,7 +283,7 @@ describe("a terminal transition", () => {
       [simulationId],
     );
 
-    const swept = await sweepOrphanedSimulations(auth, { staleAfterSeconds: 1 });
+    const swept = await sweepOrphanedSimulations({ staleAfterSeconds: 1 });
     expect(swept.map((simulation) => simulation.id)).toContain(simulationId);
 
     const [job] = await listGradingJobsForSimulation(auth, simulationId);

--- a/packages/db/test/run-events.test.ts
+++ b/packages/db/test/run-events.test.ts
@@ -268,7 +268,7 @@ describe("every lifecycle change", () => {
       "update simulation set heartbeat_at = now() - interval '1 hour' where id = $1",
       [only.id],
     );
-    await sweepOrphanedSimulations(actingAsAcme(), { staleAfterSeconds: 30 });
+    await sweepOrphanedSimulations({ staleAfterSeconds: 30 });
 
     const feed = await feedOf(started.id);
     expect(feed.events.map(said)).toEqual([

--- a/packages/db/test/runs.test.ts
+++ b/packages/db/test/runs.test.ts
@@ -659,11 +659,10 @@ describe("the lifecycle, conducted by a claimant", () => {
     expect(running?.status).toBe("running");
     expect(running?.startedAt).toBeInstanceOf(Date);
 
-    const beat = await recordSimulationHeartbeat(
-      actingAsAcme(),
+    const beat = await recordSimulationHeartbeat({
       simulationId,
-      simulator,
-    );
+      claimant: simulator,
+    });
     expect(beat).toEqual({ cancelRequested: false });
 
     // A chat simulation reports no audio facts — the row would refuse them.
@@ -722,21 +721,23 @@ describe("the lifecycle, conducted by a claimant", () => {
 
   it("answers a stranger's report with undefined and moves nothing", async () => {
     const { simulationId } = await claimedOne();
+    const before = await getSimulation(actingAsAcme(), simulationId);
 
     expect(
       await startSimulation(actingAsAcme(), simulationId, "simulator-green-2"),
     ).toBeUndefined();
     expect(
-      await recordSimulationHeartbeat(
-        actingAsAcme(),
+      await recordSimulationHeartbeat({
         simulationId,
-        "simulator-green-2",
-      ),
+        claimant: "simulator-green-2",
+      }),
     ).toBeUndefined();
 
-    expect(
-      (await getSimulation(actingAsAcme(), simulationId))?.status,
-    ).toBe("claimed");
+    // Not moved, and not stamped either: a stranger's beat must not keep a
+    // row alive that its own claimant has gone silent on.
+    const after = await getSimulation(actingAsAcme(), simulationId);
+    expect(after?.status).toBe("claimed");
+    expect(after?.heartbeatAt).toEqual(before?.heartbeatAt);
   });
 
   it("narrows the claimant's writes to the acting project, like every other verb", async () => {
@@ -745,9 +746,6 @@ describe("the lifecycle, conducted by a claimant", () => {
     // The right claimant, the wrong project: a credential acting in the
     // sibling reaches nothing, even inside its own organization.
     const actingInSibling = { ...actingAsAcme(), projectId: acme.outbound };
-    expect(
-      await recordSimulationHeartbeat(actingInSibling, simulationId, simulator),
-    ).toBeUndefined();
     expect(
       await startSimulation(actingInSibling, simulationId, simulator),
     ).toBeUndefined();
@@ -760,6 +758,71 @@ describe("the lifecycle, conducted by a claimant", () => {
     expect(
       (await getSimulation(actingAsAcme(), simulationId))?.status,
     ).toBe("claimed");
+  });
+
+  it("stamps the row on a healthy beat, which is what keeps the sweep away", async () => {
+    const { simulationId } = await claimedOne();
+
+    // An old stamp, then a beat: the row's heartbeat has to move forward,
+    // because the stamp is the one fact the orphan sweep reads.
+    await database.sql(
+      "update simulation set heartbeat_at = now() - interval '120 seconds' where id = $1",
+      [simulationId],
+    );
+    const before = await getSimulation(actingAsAcme(), simulationId);
+
+    const beat = await recordSimulationHeartbeat({
+      simulationId,
+      claimant: simulator,
+    });
+    expect(beat).toEqual({ cancelRequested: false });
+
+    const after = await getSimulation(actingAsAcme(), simulationId);
+    expect(after?.heartbeatAt?.getTime() ?? 0).toBeGreaterThan(
+      before?.heartbeatAt?.getTime() ?? 0,
+    );
+
+    // Leave nothing claimed behind for the claim-shaped tests that follow.
+    await failSimulation(actingAsAcme(), simulationId, simulator, {
+      reason: "simulator_error",
+    });
+  });
+
+  it("answers a heartbeat for a simulation beyond help with nothing under it", async () => {
+    // Unknown: an id this egma never issued a row for.
+    expect(
+      await recordSimulationHeartbeat({
+        simulationId: newId("sim"),
+        claimant: simulator,
+      }),
+    ).toBeUndefined();
+
+    // Queued: a row nobody holds, so there is no claimant to stamp for.
+    const queued = await startRun(actingAsAcme(), aRun());
+    const queuedId = queued.simulations[0]?.id ?? "";
+    expect(
+      await recordSimulationHeartbeat({
+        simulationId: queuedId,
+        claimant: simulator,
+      }),
+    ).toBeUndefined();
+    await cancelRun(actingAsAcme(), queued.id);
+
+    // Terminal: the conversation is over, even for the claimant that
+    // conducted it — a late beat after landing is a signal to stop, not a
+    // row to revive.
+    const { simulationId } = await claimedOne();
+    await startSimulation(actingAsAcme(), simulationId, simulator);
+    await completeSimulation(actingAsAcme(), simulationId, simulator, {
+      endingReason: "persona_concluded",
+      transcript: [],
+    });
+    expect(
+      await recordSimulationHeartbeat({
+        simulationId,
+        claimant: simulator,
+      }),
+    ).toBeUndefined();
   });
 
   it("keeps a completed simulation's report readable exactly as reported", async () => {
@@ -815,11 +878,10 @@ describe("canceling a run", () => {
     // counts wait for the straggler.
     expect(canceled?.finishedAt).toBeNull();
 
-    const beat = await recordSimulationHeartbeat(
-      actingAsAcme(),
-      claimed.id,
-      simulator,
-    );
+    const beat = await recordSimulationHeartbeat({
+      simulationId: claimed.id,
+      claimant: simulator,
+    });
     expect(beat).toEqual({ cancelRequested: true });
 
     const landed = await markSimulationCanceled(
@@ -887,16 +949,14 @@ describe("the orphan sweep", () => {
     const claimed = await claimOwn(started.id);
     await startSimulation(actingAsAcme(), claimed.id, simulator);
 
-    // The one write no seam should offer: a heartbeat two minutes into the
+    // The one write no seam should offer: a heartbeat three minutes into the
     // past, which is what a dead simulator leaves behind.
     await database.sql(
-      "update simulation set heartbeat_at = now() - interval '120 seconds' where id = $1",
+      "update simulation set heartbeat_at = now() - interval '180 seconds' where id = $1",
       [claimed.id],
     );
 
-    const swept = await sweepOrphanedSimulations(actingAsAcme(), {
-      staleAfterSeconds: 60,
-    });
+    const swept = await sweepOrphanedSimulations({ staleAfterSeconds: 60 });
     expect(swept.map((simulation) => simulation.id)).toContain(claimed.id);
 
     const orphaned = await getSimulation(actingAsAcme(), claimed.id);
@@ -908,13 +968,58 @@ describe("the orphan sweep", () => {
     expect(header?.failedCount).toBe(1);
   });
 
+  it("answers what it swept as identifiers, and nothing a customer wrote", async () => {
+    const started = await startRun(actingAsAcme(), aRun());
+    const claimed = await claimOwn(started.id);
+    await database.sql(
+      "update simulation set heartbeat_at = now() - interval '180 seconds' where id = $1",
+      [claimed.id],
+    );
+
+    const swept = await sweepOrphanedSimulations({ staleAfterSeconds: 60 });
+    const ours = swept.find((simulation) => simulation.id === claimed.id);
+    expect(ours).toEqual({ id: claimed.id, runId: started.id });
+  });
+
+  it("calls nothing dead inside 150 seconds of silence, and everything past it", async () => {
+    // The window under test is the default one, so neither sweep names a
+    // window here — what this pins is the shipped number itself, one second
+    // each side of it.
+    const slow = await claimOwn((await startRun(actingAsAcme(), aRun())).id);
+    const dead = await claimOwn((await startRun(actingAsAcme(), aRun())).id);
+    await database.sql(
+      "update simulation set heartbeat_at = now() - interval '149 seconds' where id = $1",
+      [slow.id],
+    );
+    await database.sql(
+      "update simulation set heartbeat_at = now() - interval '151 seconds' where id = $1",
+      [dead.id],
+    );
+
+    const swept = await sweepOrphanedSimulations();
+    const ids = swept.map((simulation) => simulation.id);
+    expect(ids).toContain(dead.id);
+    expect(ids).not.toContain(slow.id);
+
+    // The slow-but-alive one is untouched, not merely unreported.
+    expect((await getSimulation(actingAsAcme(), slow.id))?.status).toBe(
+      "claimed",
+    );
+    expect((await getSimulation(actingAsAcme(), dead.id))?.endingReason).toBe(
+      "orphaned",
+    );
+
+    // Leave nothing claimed behind for the claim-shaped tests that follow.
+    await failSimulation(actingAsAcme(), slow.id, simulator, {
+      reason: "simulator_error",
+    });
+  });
+
   it("leaves a simulator that is still talking alone", async () => {
     const started = await startRun(actingAsAcme(), aRun());
     const claimed = await claimOwn(started.id);
 
-    const swept = await sweepOrphanedSimulations(actingAsAcme(), {
-      staleAfterSeconds: 60,
-    });
+    const swept = await sweepOrphanedSimulations({ staleAfterSeconds: 60 });
     expect(swept.map((simulation) => simulation.id)).not.toContain(claimed.id);
     expect((await getSimulation(actingAsAcme(), claimed.id))?.status).toBe(
       "claimed",

--- a/packages/db/test/simulation-claims.test.ts
+++ b/packages/db/test/simulation-claims.test.ts
@@ -14,10 +14,12 @@ import {
   getSimulationTestVersion,
   listGradingJobsForSimulation,
   listRunEvents,
+  recordSimulationHeartbeat,
   removeConnection,
   resolveSimulationConnection,
   startRun,
   startSimulation,
+  sweepOrphanedSimulations,
   updateConnection,
   type AuthContext,
   type SimulationClaim,
@@ -284,6 +286,52 @@ describe("the instance-wide claim", () => {
     await expect(
       claimSimulations({ claimant: "   ", capacity: 1 }),
     ).rejects.toThrow(/needs a name/);
+  });
+});
+
+describe("the instance-wide heartbeat and sweep", () => {
+  it("reach every customer's held rows with no context at all, and answer no content", async () => {
+    const acmeRun = await oneQueuedSimulation(actingAsAcme(), acmeSeed);
+    const globexRun = await oneQueuedSimulation(actingAsGlobex(), globexSeed);
+    await claimSimulations({ claimant: "simulator-blue-1", capacity: 50 });
+
+    // A beat for each customer's row, made from nothing but the row's own id
+    // and the claimant's name — the two things the wire actually carries.
+    for (const simulationId of [acmeRun.simulationId, globexRun.simulationId]) {
+      expect(
+        await recordSimulationHeartbeat({
+          simulationId,
+          claimant: "simulator-blue-1",
+        }),
+      ).toEqual({ cancelRequested: false });
+    }
+
+    // Silence both, and one ask accounts for both customers — the sweep
+    // stands where the simulator does, behind every organization at once.
+    await database.sql(
+      "update simulation set heartbeat_at = now() - interval '10 minutes' where id = any($1)",
+      [[acmeRun.simulationId, globexRun.simulationId]],
+    );
+    const swept = await sweepOrphanedSimulations();
+    const ids = swept.map((simulation) => simulation.id);
+    expect(ids).toContain(acmeRun.simulationId);
+    expect(ids).toContain(globexRun.simulationId);
+
+    // Identifiers and no content: the answer names the row and its run so a
+    // caller can say what it did, and carries nothing a customer wrote.
+    for (const simulation of swept) {
+      expect(Object.keys(simulation).sort()).toEqual(["id", "runId"]);
+    }
+
+    // And each customer's record landed inside that customer, as their own
+    // reads tell it.
+    expect(
+      (await getSimulation(actingAsAcme(), acmeRun.simulationId))?.endingReason,
+    ).toBe("orphaned");
+    expect(
+      (await getSimulation(actingAsGlobex(), globexRun.simulationId))
+        ?.endingReason,
+    ).toBe("orphaned");
   });
 });
 

--- a/packages/db/test/sweep-concurrency.test.ts
+++ b/packages/db/test/sweep-concurrency.test.ts
@@ -1,0 +1,166 @@
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  claimSimulations,
+  createAgent,
+  createPersona,
+  createTest,
+  getRun,
+  getSimulation,
+  listGradingJobsForSimulation,
+  startRun,
+  sweepOrphanedSimulations,
+  type AuthContext,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * Two sweeps, one set of orphans — racing on a real Postgres, because replica
+ * safety is the point. The API runs the sweep on an interval in every replica
+ * and nothing elects a leader, so two copies will land on the same silence at
+ * the same moment as a matter of course. What makes that harmless is the
+ * guarded update — whichever transaction gets a row second re-reads it,
+ * finds it already failed, and matches nothing — and the ordered after-work,
+ * which takes rows and runs in one order so racing sweeps cannot deadlock.
+ * These tests race real transactions rather than mocking, because the
+ * guarantee under test is Postgres's, not egma's code.
+ */
+
+let database: MigratedDatabase;
+
+const organizationId = newId("org");
+const projectId = newId("prj");
+const ada = newId("usr");
+
+const auth: AuthContext = {
+  userId: ada,
+  organizationId,
+  projectId,
+  role: "member",
+  via: "session",
+};
+
+let agentId: string;
+let connectionId: string;
+let testVersionId: string;
+
+async function oneQueuedSimulation(): Promise<{
+  runId: string;
+  simulationId: string;
+}> {
+  const started = await startRun(auth, {
+    agentId,
+    connectionId,
+    testVersionIds: [testVersionId],
+  });
+  const simulation = started.simulations[0];
+  if (simulation === undefined) throw new Error("the run has no simulation");
+  return { runId: started.id, simulationId: simulation.id };
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("sweep_race");
+
+  await seedOrganization(database, organizationId, [
+    { id: projectId, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+
+  const created = await createAgent(auth, {
+    name: "Front desk",
+    connection: {
+      type: "retell",
+      modality: "chat",
+      config: { retellAgentId: "agent_in_retell_1" },
+      credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    },
+  });
+  agentId = created.id;
+  connectionId = created.connection?.id ?? "";
+
+  const personaId = (
+    await createPersona(auth, {
+      name: "Impatient Rita",
+      traits: {
+        personality: "Speaks plainly.",
+        language: "en-US",
+        voice: {
+          provider: "elevenlabs",
+          voiceId: "EXAVITQu4vr4xnSDxMaL",
+          speed: 1,
+        },
+      },
+    })
+  ).id;
+
+  testVersionId = (
+    await createTest(auth, {
+      name: "Reschedules",
+      scenario: "Their cleaning is booked for Thursday and has to move.",
+      expectedBehaviors: ["confirms the new time back before finishing"],
+      personaIds: [personaId],
+    })
+  ).versionId;
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("two sweepers racing over one set of orphans", () => {
+  it("end every orphan exactly once between them, and neither breaks", async () => {
+    const orphans = [
+      await oneQueuedSimulation(),
+      await oneQueuedSimulation(),
+      await oneQueuedSimulation(),
+    ];
+    await claimSimulations({ claimant: "simulator-that-died", capacity: 50 });
+    await database.sql(
+      "update simulation set heartbeat_at = now() - interval '10 minutes' where id = any($1)",
+      [orphans.map((orphan) => orphan.simulationId)],
+    );
+
+    const [first, second] = await Promise.all([
+      sweepOrphanedSimulations(),
+      sweepOrphanedSimulations(),
+    ]);
+
+    // Between the two answers, each orphan appears exactly once: whichever
+    // sweep reached a row second re-read it as already failed and left it
+    // alone, so nothing was ended twice and nothing was missed.
+    const taken = [...first, ...second]
+      .map((simulation) => simulation.id)
+      .filter((id) => orphans.some((orphan) => orphan.simulationId === id));
+    expect(new Set(taken).size).toBe(taken.length);
+    expect(taken).toHaveLength(orphans.length);
+
+    for (const orphan of orphans) {
+      const row = await getSimulation(auth, orphan.simulationId);
+      expect(row?.status).toBe("failed");
+      expect(row?.endingReason).toBe("orphaned");
+
+      // One landing means one piece of grading work: had both sweeps ended a
+      // row, the enqueue's unique would have thrown one of them out of this
+      // very test.
+      const jobs = await listGradingJobsForSimulation(
+        auth,
+        orphan.simulationId,
+      );
+      expect(jobs).toHaveLength(1);
+
+      // And each run finalized once, its counts written by whichever sweep
+      // ended its last conversation — the header's trigger refuses a second
+      // write, so a double finalization would also have broken a sweep.
+      const header = await getRun(auth, orphan.runId);
+      expect(header?.status).toBe("completed");
+      expect(header?.failedCount).toBe(1);
+      expect(header?.finishedAt).toBeInstanceOf(Date);
+    }
+  });
+});

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -95,38 +95,51 @@ const CONTEXT_ESTABLISHING = [
 const INSTANCE_SCOPED = ["instanceIsClaimed"];
 
 /**
- * The exports that dispatch egma's own work across the whole deployment.
+ * The exports that dispatch egma's own work across the whole deployment, and
+ * the ones that keep a dispatch honest afterwards.
  *
  * The grader and the simulator each stand behind every organization at once
  * and hold no credential, because there is no honest one to give them: an API
  * key minted inside one customer would either see too little to do the job or
  * be shared between customers to do it. So each is handed work instead of
- * asked for a credential — and the three calls that hand it out are these.
+ * asked for a credential — the claims hand it out, and the simulator's
+ * heartbeat and orphan sweep stand on the same ground for the same reason:
+ * a beat arrives bearing the service token, which resolves to nobody, and
+ * silence is noticed by nobody in particular.
  *
  * `claimSimulations` was added on 2026-08-08 with the simulator's claim door,
  * deliberately and after the rule stopped the build: the tenancy-scoped claim
  * it replaced had no production caller, and the real one reaches every
  * customer's queue on the grading claim's exact terms.
+ * `recordSimulationHeartbeat` and `sweepOrphanedSimulations` followed the
+ * same day on the same replaced-function terms: a heartbeat can only stamp a
+ * row already claimed under the caller's own name and answers one boolean
+ * egma itself wrote, and the sweep moves only rows the claim machinery
+ * stamped, filing each orphan's grading work under the tenancy the row
+ * itself carries.
  *
  * This category is narrower than it looks, and the rule enforces the property
  * that makes it safe: **nothing here may take an argument by which a caller
- * could name a customer.** A claimant's name and a capacity say who is asking
- * and how much they can hold; neither says whose work to bring back. A function
- * here that grew an `organizationId` or a `projectId` would be an ordinary
- * cross-tenant read wearing an exemption, and the rule refuses it.
+ * could name a customer.** A claimant's name, a capacity, a simulation id, a
+ * staleness window — each says which piece of egma's own bookkeeping is
+ * meant; none says whose data to bring back. A function here that grew an
+ * `organizationId` or a `projectId` would be an ordinary cross-tenant read
+ * wearing an exemption, and the rule refuses it.
  *
  * The rest of what makes it safe is not mechanical and is written out where
  * the functions live: the only rows any of them reaches are egma's own queues
- * — grading jobs, and the simulations egma itself wrote as queued — a claim
+ * — grading jobs, and the simulations egma itself wrote and claimed — a claim
  * carries identifiers and tenancy rather than anything a customer wrote, and
  * every claim arrives with the `AuthContext` narrowed to that row's own
  * organization and project — which is what the work itself goes through.
  *
- * A fourth name here is a decision somebody has to make on purpose.
+ * A sixth name here is a decision somebody has to make on purpose.
  */
 const WORK_DISPATCHING = [
   "claimGradingJobs",
   "claimSimulations",
+  "recordSimulationHeartbeat",
+  "sweepOrphanedSimulations",
   "watchGradingWork",
 ];
 
@@ -439,9 +452,10 @@ function asWritten(tree: ts.SourceFile, parameter: ts.ParameterDeclaration): str
 /**
  * Every function the module exports either takes an `AuthContext` first, or is
  * one of the named exceptions: the seven that produce a context, the one that
- * asks about the deployment, and the two that dispatch egma's own work. Nothing
- * exported takes a predicate, so there is no call shape that lets a caller
- * supply their own tenancy filter — or none.
+ * asks about the deployment, and the five that dispatch egma's own work and
+ * keep those dispatches honest. Nothing exported takes a predicate, so there
+ * is no call shape that lets a caller supply their own tenancy filter — or
+ * none.
  */
 async function checkExportedCallShapes(root: string): Promise<Violation[]> {
   const surface = path.join(root, ACCESS_SURFACE);


### PR DESCRIPTION
The second and third of the simulator's three doors: the heartbeat, and the standing sweep that notices a simulator gone quiet.

- `POST /v1/simulations/:id/heartbeats` — service-token gated, outside the per-organization budget. A beat stamps the row and answers the one directive the simulator obeys: `cancel` when cancellation was requested, and equally for every conversation beyond help — unknown, another claimant's, unclaimed, already terminal. Deliberately no 404: the shipped simulator treats any non-200 as retryable and would keep conducting a closed conversation against a customer's real agent; `cancel` stops it within one beat. The shipped simulator itself is untouched.
- The heartbeat and the orphan sweep join the claim as instance-wide, no-context calls — narrowness derived from the row (the claimant's own name, the states the claim machinery writes), identifiers only outward. The sweep's return narrowed to ids for exactly that reason.
- The staleness window rises 60s → 150s: it must outlast the report sender's two-minute retry deadline, or a network partition records a genuinely completed conversation as orphaned. Cost accepted and stated: a crashed simulator's rows stay `running` ~3 minutes before the honest `failed`.
- The sweep runs inside the API every 30s — first tick deliberately deferred one interval so an API returning from an outage doesn't call every living simulator dead before their 5s-cadence beats land; overlap-guarded, unref'd, drained on close so a shutting-down API can't race its own sweep; replica-safe by the same guarded updates and database triggers that make racing sweeps collide harmlessly (proven with real concurrent transactions).
- `makeGradable` now takes the organization with the row instead of from a context — the sweep has no context to offer — and every caller provably passes the row's own tenancy.

Tests: the steering matrix at both seams (including no-stamp proofs for refused beats), the fake-clock 149s/151s window, racing sweeps over real concurrency, the cancel round-trip through the run's own cancel door, and the composition a dispatch-failed row's claimant hearing `cancel` on its next beat. Full suite 1843 passed / 2 skipped on the rebased tree; typecheck and lint gates green.

Independently reviewed before opening: verdict mergeable as-is; the `makeGradable` re-signing security-checked (no path files grading work under a foreign customer), the window arithmetic verified against the shipped simulator's cadences, and the removed context-shaped test judged genuinely superseded by sharper claimant-guard proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds authenticated simulator heartbeats and a periodic orphan sweep, while adapting grading finalization to work without request context.
- Adds heartbeat steering that refreshes claimant-owned live simulations and returns cancellation directives for unavailable work.
- Adds an overlap-guarded orphan-sweep lifecycle that starts with the API and drains during shutdown.
- Extends database access for heartbeat recording, orphan detection, and context-free grading finalization.
- Raises the heartbeat staleness window and adds route, timing, concurrency, and shutdown coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/heartbeats.ts | Adds the service-token-protected heartbeat endpoint and claimant-aware cancellation steering. |
| apps/api/src/simulation-sweep.ts | Adds the periodic orphan sweep and correctly preserves the active sweep promise when overlapping ticks are skipped. |
| apps/api/src/server.ts | Registers the heartbeat route and ties the sweep handle to Fastify startup and shutdown. |
| packages/db/src/access/runs.ts | Adds heartbeat and orphan-sweep data-access operations and passes row-derived tenancy into grading finalization. |
| apps/api/test/simulation-sweep.test.ts | Covers sweep startup, logging, failure recovery, overlap prevention, and shutdown draining. |
| apps/api/test/heartbeats-routes.test.ts | Covers authentication, validation, heartbeat stamping, cancellation steering, and rate-limit isolation. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Simulator
    participant API
    participant DB
    participant Sweep as Orphan Sweep

    Simulator->>API: POST /v1/simulations/:id/heartbeats
    API->>DB: Record heartbeat for claimant-owned live row
    DB-->>API: Simulation state or no match
    API-->>Simulator: directive: null or cancel

    loop Every sweep interval
        Sweep->>DB: Sweep stale claimed/running simulations
        DB-->>Sweep: Swept simulation and run IDs
    end

    Note over API,Sweep: API shutdown stops the timer and awaits the active sweep
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Guard the tick where its promise is take..."](https://github.com/egma-ai/egma/commit/a329380ade4611290ebdf08b6039f3f15b5a88a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51413202)</sub>

<!-- /greptile_comment -->