### PR TITLE
Serve the report door: the lifecycle lands, idempotent without a ledger

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -227,7 +227,7 @@ export async function reportRoutes(
       // getting a real home — as spans through the trace store's own ingest,
       // where a simulation reads like a production trace — so this door
       // keeps the shipped reporter working end to end without building a
-      // second storage path those tickets would immediately retire.
+      // second storage path that the spans work immediately retires.
       if (event.kind !== "status") continue;
 
       const applied = await applyStatusEvent(

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -100,6 +100,30 @@ const FAILED_ENDING_OF: Record<
   error: "simulator_error",
 };
 
+/**
+ * The reported moments, trusted exactly when they can be true.
+ *
+ * A landing given the conduction's own moments writes them over its server
+ * stamps, so a retried report cannot stretch the record — but a document
+ * whose `ended_at` precedes its `started_at` describes an interval that
+ * never existed on any clock, and writing it verbatim would put an
+ * impossible duration on the row forever. Refusing the document would be
+ * worse: the reporter treats a final refusal as final, and punishing
+ * delivery for a skewed clock would turn a truthful conversation into a
+ * sweep's false orphan. So an incoherent pair is answered with `undefined`,
+ * the landing falls back to its own server stamps for both moments, and the
+ * caller logs the pair it declined to believe.
+ */
+function reportedMoments(facts: {
+  readonly started_at: string;
+  readonly ended_at: string;
+}): { readonly startedAt: Date; readonly endedAt: Date } | undefined {
+  const startedAt = new Date(facts.started_at);
+  const endedAt = new Date(facts.ended_at);
+  if (endedAt.getTime() < startedAt.getTime()) return undefined;
+  return { startedAt, endedAt };
+}
+
 /** The terminal facts, as the landings take them. */
 function summaryFactsOf(event: StatusEvent): SimulationSummaryFacts {
   const facts = event.facts;
@@ -115,8 +139,8 @@ function summaryFactsOf(event: StatusEvent): SimulationSummaryFacts {
           measuredAudioBandHertz: facts.audio.measured_sample_rate_hz,
           recordingReference: facts.audio.recording,
         }),
-    startedAt: new Date(facts.started_at),
-    endedAt: new Date(facts.ended_at),
+    // Absent when incoherent, so the landing's own stamps stand for both.
+    ...(reportedMoments(facts) ?? {}),
   };
 }
 
@@ -309,8 +333,10 @@ async function applyRunning(
 /**
  * The terminal three — the landing, with the facts mapped in. A resend
  * matching the row's terminal state is absorbed; a document that would
- * rewrite a terminal row is refused; and a `canceled` nobody asked for fails
- * the landing's own guard and is refused honestly rather than recorded.
+ * rewrite a terminal row is refused; a `canceled` nobody asked for fails
+ * the landing's own guard and is refused honestly rather than recorded —
+ * and a `canceled` whose intent landed between the attempt and the answer
+ * is retried once rather than refused for being early.
  */
 async function applyTerminal(
   reply: FastifyReply,
@@ -345,6 +371,20 @@ async function applyTerminal(
     );
   }
 
+  // Said out loud when the reported pair cannot be believed: the landing
+  // below will stand on its own stamps, and the record of why is this line.
+  if (reportedMoments(facts) === undefined) {
+    reply.log.warn(
+      {
+        simulationId: standing.id,
+        reportedStartedAt: facts.started_at,
+        reportedEndedAt: facts.ended_at,
+      },
+      `simulation ${standing.id} reported ended_at before started_at; ` +
+        `landing with the server's own stamps for both moments`,
+    );
+  }
+
   const landed = await applyLanding(standing, event, facts.ending);
   if (landed !== undefined) return landed.status;
 
@@ -354,6 +394,28 @@ async function applyTerminal(
   const moved = await resolveSimulationStanding(standing.id);
   if (moved !== undefined && matchesTerminalRow(event, moved)) {
     return moved.status;
+  }
+  // A cancel that raced this document: at the attempt the intent was not
+  // yet stamped, and by this read it is — the guard's refusal is stale, not
+  // final. One bounded retry lands the transition that is valid at the
+  // moment this request answers; a second failure means the row moved
+  // again, and the freshest reading below says where it went. The route
+  // serves the contract here, not today's runtime — the shipped simulator
+  // cancels only after a directive, which implies the intent was already
+  // stamped, but nothing entitles this door to assume its caller.
+  if (
+    event.status === "canceled" &&
+    moved !== undefined &&
+    (moved.status === "claimed" || moved.status === "running") &&
+    moved.cancelRequestedAt !== null
+  ) {
+    const relanded = await applyLanding(moved, event, facts.ending);
+    if (relanded !== undefined) return relanded.status;
+    const settled = await resolveSimulationStanding(standing.id);
+    if (settled !== undefined && matchesTerminalRow(event, settled)) {
+      return settled.status;
+    }
+    return refusedByTheRecord(reply, settled ?? moved, event.status);
   }
   if (event.status === "canceled" && moved?.cancelRequestedAt === null) {
     return conflict(

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,437 @@
+import {
+  completeSimulation,
+  failSimulation,
+  markSimulationCanceled,
+  resolveSimulationStanding,
+  startSimulation,
+  type CompletedEndingReason,
+  type FailedEndingReason,
+  type Simulation,
+  type SimulationStanding,
+  type SimulationSummaryFacts,
+} from "@egma/db";
+import { reportComplaints } from "@egma/simulation-contract";
+import type { FastifyInstance, FastifyReply } from "fastify";
+
+import { acceptsServiceToken } from "../auth/service-token.ts";
+import {
+  conflict,
+  invalid,
+  notFound,
+  notTheService,
+  unprocessable,
+} from "../http/refusals.ts";
+
+/**
+ * The report door: `POST /v1/simulations/:simulationId/reports`, where the
+ * simulator says what happened — the lifecycle landing.
+ *
+ * It sits with the claim door on the claim door's exact terms: the service
+ * token is the whole gate and resolves to nothing, and the group is outside
+ * the per-organization rate limit because the caller is egma's own service
+ * standing behind every organization at once. What is different here is
+ * where authority over each row comes from. **The token gates the door, and
+ * the row names its conductor**: every write below is made under a context
+ * derived from the row's own tenancy, in the name of the row's own
+ * `claimed_by` — never in the name of anything the request said — so the one
+ * secret a simulator holds decides only whether it may knock, and which
+ * conversations it speaks for was decided when each row was claimed.
+ *
+ * **Idempotency without a ledger.** The client delivers at least once and
+ * resends byte-identically, so this door must absorb what it has already
+ * heard: a `running` for a row already running answers 200, a terminal event
+ * matching the row's terminal state answers 200, and only a document that
+ * would *rewrite* the record — a different ending, a different terminal
+ * status, a running for a finished conversation — is refused with 409. No
+ * table of seen event ids exists, on purpose: the row's own state says
+ * everything a duplicate check needs, and a ledger would be a second record
+ * to keep honest.
+ *
+ * The shipped simulator posts one event per document; the contract permits
+ * several, and they apply in order. Each application commits by itself, so a
+ * refusal partway leaves the earlier, valid transitions standing — exactly
+ * what a resend of the same document then absorbs as duplicates.
+ */
+
+export type ReportRoutesOptions = {
+  /** The deployment's service token, from configuration. */
+  readonly serviceToken: string;
+};
+
+export const REPORTS_PATH = "/v1/simulations/:simulationId/reports";
+
+/** The path one simulation's reports land on — the client's side of the route. */
+export function reportPathFor(simulationId: string): string {
+  return `/v1/simulations/${simulationId}/reports`;
+}
+
+type Body = Record<string, unknown>;
+
+/** One status event, after the contract check has vouched for its shape. */
+type StatusEvent = {
+  readonly status: "running" | "completed" | "failed" | "canceled";
+  readonly facts?: {
+    readonly ending: string;
+    readonly started_at: string;
+    readonly ended_at: string;
+    readonly turn_count: number;
+    readonly audio: {
+      readonly measured_sample_rate_hz: number;
+      readonly recording: string;
+    } | null;
+    readonly provider_reference: string | null;
+  };
+};
+
+/**
+ * The wire's failed endings, as the row's own vocabulary. The two honest
+ * absences keep their names; the wire's `error` is the row's
+ * `simulator_error` — same fact, and the row's word for it predates the
+ * contract's. Everything else — `orphaned` the sweep's word,
+ * `dispatch_failed` the claim path's, and the rest of the platform's own
+ * landings — never validates as a document, so it cannot reach this map.
+ */
+const FAILED_ENDING_OF: Record<
+  string,
+  Exclude<FailedEndingReason, "orphaned" | "dispatch_failed">
+> = {
+  agent_never_joined: "agent_never_joined",
+  not_answered: "not_answered",
+  error: "simulator_error",
+};
+
+/** The terminal facts, as the landings take them. */
+function summaryFactsOf(event: StatusEvent): SimulationSummaryFacts {
+  const facts = event.facts;
+  if (facts === undefined) return {};
+  return {
+    turnCount: facts.turn_count,
+    ...(facts.provider_reference === null
+      ? {}
+      : { providerReference: facts.provider_reference }),
+    ...(facts.audio === null
+      ? {}
+      : {
+          measuredAudioBandHertz: facts.audio.measured_sample_rate_hz,
+          recordingReference: facts.audio.recording,
+        }),
+    startedAt: new Date(facts.started_at),
+    endedAt: new Date(facts.ended_at),
+  };
+}
+
+/**
+ * What the row's terminal state would have to be for this event to be a
+ * resend of it: the same status, and the same ending reason — which for a
+ * canceled row is no reason at all, because the cancel intent is its own
+ * record.
+ */
+function matchesTerminalRow(
+  event: StatusEvent,
+  standing: SimulationStanding,
+): boolean {
+  if (standing.status !== event.status) return false;
+  if (event.status === "canceled") return true;
+  const ending = event.facts?.ending ?? "";
+  const reported =
+    event.status === "failed"
+      ? FAILED_ENDING_OF[ending]
+      : (ending as CompletedEndingReason);
+  return standing.endingReason === reported;
+}
+
+/** Where the row stands, said plainly for a refusal that has to name it. */
+function standingSentence(standing: SimulationStanding): string {
+  return standing.endingReason === null
+    ? standing.status
+    : `${standing.status} (${standing.endingReason})`;
+}
+
+/** The one shape every applied event answers with. */
+function landedOn(
+  reply: FastifyReply,
+  simulationId: string,
+  status: string,
+): FastifyReply {
+  return reply.code(200).send({ simulation_id: simulationId, status });
+}
+
+export async function reportRoutes(
+  app: FastifyInstance,
+  options: ReportRoutesOptions,
+): Promise<void> {
+  // The gate, as a hook on this scope rather than a line in the route, for
+  // the reason the claim door's is one: a route inside this group cannot run
+  // unguarded, and an unauthenticated request never has its body read.
+  app.addHook("onRequest", async (request, reply) => {
+    if (!acceptsServiceToken(request.headers.authorization, options.serviceToken)) {
+      return notTheService(reply);
+    }
+    return undefined;
+  });
+
+  /**
+   * One report document about one simulation: `status` events apply as
+   * lifecycle transitions, in order, and the answer names where the row
+   * stands after the last of them.
+   */
+  app.post(REPORTS_PATH, async (request, reply) => {
+    const { simulationId } = request.params as { simulationId: string };
+    const document = (request.body ?? {}) as Body;
+
+    // The contract check first, before a byte of the document is believed —
+    // the same schema the simulator compiled before sending, so the
+    // complaints going back are the ones its own check would have raised.
+    // This is also where the reportable vocabulary is held: an ending that
+    // is the platform's own word (`orphaned` is the sweep's, and the claim
+    // path lands its own failures) is not in the schema's enums and refuses
+    // here as a document, never reasoned about as a state.
+    const complaints = reportComplaints(document);
+    if (complaints.length > 0) {
+      return invalid(
+        reply,
+        `this is not a simulation report the contract accepts: ` +
+          `${complaints.join("; ")}. Fix the document against the report ` +
+          `schema, contract version 1; resending the same bytes cannot help.`,
+      );
+    }
+
+    // A document about another simulation is refused, not rerouted: the URL
+    // and the document each name the simulation, and when they disagree
+    // there is no honest way to pick one.
+    if (document.simulation_id !== simulationId) {
+      return invalid(
+        reply,
+        `this document says it is about ${String(document.simulation_id)}, ` +
+          `but it was posted to ${simulationId}. Post each report to the ` +
+          `simulation its own simulation_id names.`,
+      );
+    }
+
+    const standing = await resolveSimulationStanding(simulationId);
+    if (standing === undefined) {
+      return notFound(
+        reply,
+        `there is no simulation ${simulationId} on this egma. Reports land ` +
+          `on the simulation a claimed spec named in its simulation_id; ` +
+          `nothing about this document can be retried.`,
+      );
+    }
+
+    const events = document.events as readonly Record<string, unknown>[];
+    let lastKnownStatus: string = standing.status;
+
+    for (const event of events) {
+      // INTERIM: turn, timing and tool_call events are accepted and dropped
+      // here, whole. The simulator ships them today and conversation data is
+      // getting a real home — as spans through the trace store's own ingest,
+      // where a simulation reads like a production trace — so this door
+      // keeps the shipped reporter working end to end without building a
+      // second storage path those tickets would immediately retire.
+      if (event.kind !== "status") continue;
+
+      const applied = await applyStatusEvent(
+        reply,
+        simulationId,
+        event as unknown as StatusEvent,
+      );
+      if (typeof applied !== "string") return applied;
+      lastKnownStatus = applied;
+    }
+
+    return landedOn(reply, simulationId, lastKnownStatus);
+  });
+}
+
+/**
+ * One status event against the row as it now stands: the transition when the
+ * row is there to move, a 200-worthy nothing when the row already says what
+ * the event says, and a refusal when the document and the record disagree
+ * about history. Answers the row's status afterwards, or the refusal it sent.
+ *
+ * The row is re-read per event rather than once per document, because each
+ * event's application moves it and the next event's duplicate check must see
+ * where it landed. Each read is one indexed select; a document carries a
+ * handful of events at most.
+ */
+async function applyStatusEvent(
+  reply: FastifyReply,
+  simulationId: string,
+  event: StatusEvent,
+): Promise<FastifyReply | string> {
+  const standing = await resolveSimulationStanding(simulationId);
+  if (standing === undefined) {
+    // It answered moments ago and is gone: the run was deleted mid-request.
+    return notFound(
+      reply,
+      `simulation ${simulationId} is gone from this egma; there is nothing ` +
+        `left to report against.`,
+    );
+  }
+
+  return event.status === "running"
+    ? applyRunning(reply, standing)
+    : applyTerminal(reply, standing, event);
+}
+
+/**
+ * `running` — the conversation is underway. The claimant argument on the
+ * transition is the row's own `claimed_by`: the token gated the door, and
+ * the row names its conductor, so there is nothing in the request a caller
+ * could use to speak for somebody else's conversation.
+ */
+async function applyRunning(
+  reply: FastifyReply,
+  standing: SimulationStanding,
+): Promise<FastifyReply | string> {
+  // The duplicate the at-least-once client is owed: already running is what
+  // this event says, so it is absorbed rather than refused.
+  if (standing.status === "running") return "running";
+
+  if (standing.status === "claimed" && standing.claimedBy !== null) {
+    const started = await startSimulation(
+      standing.auth,
+      standing.id,
+      standing.claimedBy,
+    );
+    if (started !== undefined) return started.status;
+    // The guarded update matched nothing, so the row moved between the read
+    // and the write — a duplicate racing this one, or the sweep. Read again
+    // and answer as the first read would have, one race later.
+    const moved = await resolveSimulationStanding(standing.id);
+    if (moved?.status === "running") return "running";
+    return refusedByTheRecord(reply, moved ?? standing, "running");
+  }
+
+  return refusedByTheRecord(reply, standing, "running");
+}
+
+/**
+ * The terminal three — the landing, with the facts mapped in. A resend
+ * matching the row's terminal state is absorbed; a document that would
+ * rewrite a terminal row is refused; and a `canceled` nobody asked for fails
+ * the landing's own guard and is refused honestly rather than recorded.
+ */
+async function applyTerminal(
+  reply: FastifyReply,
+  standing: SimulationStanding,
+  event: StatusEvent,
+): Promise<FastifyReply | string> {
+  // A terminal row answers from what it already says: the matching resend
+  // is absorbed, anything else is a document trying to rewrite the record.
+  if (
+    standing.status === "completed" ||
+    standing.status === "failed" ||
+    standing.status === "canceled"
+  ) {
+    if (matchesTerminalRow(event, standing)) return standing.status;
+    return refusedByTheRecord(reply, standing, event.status);
+  }
+
+  const facts = event.facts;
+  if (facts === undefined || standing.claimedBy === null) {
+    // No facts cannot happen on a validated document; unclaimed means the
+    // conversation was never anybody's to land.
+    return refusedByTheRecord(reply, standing, event.status);
+  }
+
+  // The row knows its modality and refuses audio on a chat — said here in a
+  // sentence rather than surfacing as the database constraint it would trip.
+  if (facts.audio !== null && standing.modality === "chat") {
+    return unprocessable(
+      reply,
+      `simulation ${standing.id} is a chat conversation, and a chat has no ` +
+        `audio to measure. Send audio: null, the way the chat fixtures do.`,
+    );
+  }
+
+  const landed = await applyLanding(standing, event, facts.ending);
+  if (landed !== undefined) return landed.status;
+
+  // The guarded landing matched nothing. Either a duplicate raced this
+  // request and the row now says what this document says — absorbed — or
+  // the record genuinely disagrees, and the freshest reading names how.
+  const moved = await resolveSimulationStanding(standing.id);
+  if (moved !== undefined && matchesTerminalRow(event, moved)) {
+    return moved.status;
+  }
+  if (event.status === "canceled" && moved?.cancelRequestedAt === null) {
+    return conflict(
+      reply,
+      `nobody asked to cancel simulation ${standing.id}: no cancellation ` +
+        `was ever requested, so a canceled report would invent a stop order ` +
+        `the record does not hold. If the conversation could not continue, ` +
+        `report it failed with its honest reason.`,
+    );
+  }
+  return refusedByTheRecord(reply, moved ?? standing, event.status);
+}
+
+/** The landing itself, chosen by the event's status. */
+async function applyLanding(
+  standing: SimulationStanding,
+  event: StatusEvent,
+  ending: string,
+): Promise<Simulation | undefined> {
+  const conductor = standing.claimedBy ?? "";
+  const facts = summaryFactsOf(event);
+
+  if (event.status === "completed") {
+    return completeSimulation(standing.auth, standing.id, conductor, {
+      endingReason: ending as CompletedEndingReason,
+      transcript: null,
+      ...facts,
+    });
+  }
+  if (event.status === "failed") {
+    const reason = FAILED_ENDING_OF[ending];
+    if (reason === undefined) {
+      // Unreachable past the contract check; named rather than asserted so
+      // a schema drift fails a request, never the process.
+      throw new Error(`"${ending}" is not a failed ending the wire carries`);
+    }
+    return failSimulation(standing.auth, standing.id, conductor, {
+      reason,
+      ...facts,
+    });
+  }
+  return markSimulationCanceled(standing.auth, standing.id, conductor, facts);
+}
+
+/**
+ * The record's answer when a document and the row disagree: where the row
+ * stands, what the document claimed, and that resending cannot help — the
+ * client treats this refusal as final and keeps its write-ahead log, which
+ * is exactly the honest outcome for a disagreement about history. Three
+ * standings disagree three different ways, and each is told its own way.
+ */
+function refusedByTheRecord(
+  reply: FastifyReply,
+  standing: SimulationStanding,
+  said: string,
+): FastifyReply {
+  if (standing.status === "queued") {
+    return conflict(
+      reply,
+      `simulation ${standing.id} is queued and nothing has claimed it, so ` +
+        `there is no conductor this ${said} report could speak for. Work ` +
+        `is claimed through POST /v1/claims before anything about it is ` +
+        `reported.`,
+    );
+  }
+  if (standing.status === "claimed" && said !== "running") {
+    return conflict(
+      reply,
+      `simulation ${standing.id} is claimed and never reported running, so ` +
+        `a ${said} landing has no conversation under it. Report running ` +
+        `first; a conversation lands from the state the record says it was in.`,
+    );
+  }
+  return conflict(
+    reply,
+    `simulation ${standing.id} is ${standingSentence(standing)}, and this ` +
+      `document says ${said} — the record is not rewritten by a later ` +
+      `report. Resending the same document cannot help; the write-ahead log ` +
+      `is the simulator's own record of what it saw.`,
+  );
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -16,6 +16,7 @@ import { heartbeatRoutes } from "./routes/heartbeats.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { meRoutes } from "./routes/me.ts";
 import { memberRoutes } from "./routes/members.ts";
+import { reportRoutes } from "./routes/reports.ts";
 import { runRoutes } from "./routes/runs.ts";
 import { signOutRoutes } from "./routes/sign-out.ts";
 import { signupRoutes } from "./routes/signup.ts";
@@ -209,6 +210,13 @@ export function buildApi(options: ServerOptions): Api {
   // the more so, because a busy run beats every few seconds per conversation,
   // which is exactly the traffic a per-organization budget must never see.
   void app.register(heartbeatRoutes, {
+    serviceToken: config.simulatorServiceToken,
+  });
+
+  // And the report door, on the claim door's exact terms: the same gate,
+  // the same exemption, and each row's own claimant naming whose
+  // conversation a document may land.
+  void app.register(reportRoutes, {
     serviceToken: config.simulatorServiceToken,
   });
 

--- a/apps/api/test/reports-routes.test.ts
+++ b/apps/api/test/reports-routes.test.ts
@@ -1,0 +1,684 @@
+import { createPersona, getSimulation } from "@egma/db";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CLAIMS_PATH } from "../src/routes/claims.ts";
+import { reportPathFor } from "../src/routes/reports.ts";
+import { fixedWindowRateLimit } from "../src/http/rate-limit.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The report door, over real HTTP against real Postgres: the shipped
+ * simulator's one way of saying what happened to a simulation it conducts.
+ *
+ * What is asserted here is what that simulator observes and what the record
+ * then says: the token gate's one sentence, a contract violation answered
+ * with the same complaints the simulator's own check would raise, the
+ * lifecycle transitions landing with their facts, and the idempotency matrix
+ * the client's at-least-once delivery leans on — duplicate 200s, conflicting
+ * 409s, unknown 404s. The client resends byte-identical documents until one
+ * answer is final, so every 200 here is a resend the record absorbed and
+ * every 409 is a document the record refused to be rewritten by.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const RESCHEDULING = {
+  name: "Reschedules a booked appointment",
+  scenario:
+    "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+  expected_behaviors: ["confirms the new time back before finishing"],
+} as const;
+
+const RETELL = {
+  type: "retell",
+  modality: "chat",
+  config: { retellAgentId: "agent_in_retell_1" },
+  credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+} as const;
+
+/** The claimant every claim in this file conducts under. */
+const CONDUCTOR = "sim-under-test";
+
+/** The two moments every terminal fact block reports, fixed so rows can be checked. */
+const STARTED_AT = "2026-08-05T09:00:00.000000Z";
+const ENDED_AT = "2026-08-05T09:02:10.551000Z";
+
+/** One report as the simulator posts one: a document about one simulation. */
+async function report(
+  simulationId: string,
+  events: readonly Record<string, unknown>[],
+  options: { readonly token?: string | undefined; readonly about?: string } = {},
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  const token = options.token ?? api.config.simulatorServiceToken;
+  const response = await api.app.inject({
+    method: "POST",
+    url: reportPathFor(simulationId),
+    ...(token === "" ? {} : { headers: { authorization: `Bearer ${token}` } }),
+    payload: {
+      contract_version: 1,
+      simulation_id: options.about ?? simulationId,
+      events,
+    },
+  });
+  return {
+    statusCode: response.statusCode,
+    body: response.json() as Record<string, unknown>,
+  };
+}
+
+let eventNumber = 0;
+
+/** The next event id, unique within the file the way the simulator mints them. */
+function eventId(): string {
+  eventNumber += 1;
+  return `evt-${String(eventNumber).padStart(6, "0")}`;
+}
+
+function runningEvent(): Record<string, unknown> {
+  return {
+    kind: "status",
+    event_id: eventId(),
+    at: STARTED_AT,
+    status: "running",
+    reason: null,
+  };
+}
+
+/** The terminal facts exactly as the contract's fixtures carry them. */
+function factsOf(
+  ending: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    ending,
+    started_at: STARTED_AT,
+    ended_at: ENDED_AT,
+    turn_count: 14,
+    audio: null,
+    provider_reference: "chat_5d1f9a3b7c",
+    ...overrides,
+  };
+}
+
+function terminalEvent(
+  status: "completed" | "failed" | "canceled",
+  ending: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    kind: "status",
+    event_id: eventId(),
+    at: ENDED_AT,
+    status,
+    reason: status === "failed" ? "the platform refused the exchange" : null,
+    facts: factsOf(ending, overrides),
+  };
+}
+
+/** A customer with an agent, a persona, and a test — everything a run needs. */
+async function aCustomerReadyToRun(label: string): Promise<{
+  ada: Customer;
+  key: string;
+  agentId: string;
+  connectionId: string;
+  versionId: string;
+}> {
+  api = await createApi(label);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await ask(api.app, "POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: RETELL,
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+  const agentId = (registered.body.agent as { id: string }).id;
+  const connectionId = (registered.body.connection as { id: string }).id;
+
+  await createPersona(contextFor(ada, "member"), {
+    name: "Impatient Rita",
+    traits: NEUTRAL_TRAITS,
+  });
+  const pushed = await ask(api.app, "POST", "/api/tests", key, {
+    ...RESCHEDULING,
+    personas: ["Impatient Rita"],
+  });
+  expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
+
+  return {
+    ada,
+    key,
+    agentId,
+    connectionId,
+    versionId: String(pushed.body.version_id),
+  };
+}
+
+/** A run whose one simulation has been claimed through the real claim door. */
+async function aClaimedSimulation(
+  key: string,
+  connectionId: string,
+  versionId: string,
+): Promise<{ runId: string; simulationId: string }> {
+  const started = await ask(api.app, "POST", "/api/runs", key, {
+    connection: connectionId,
+    test_versions: [versionId],
+  });
+  expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+  const simulations = started.body.simulations as { id: string }[];
+  const first = simulations[0];
+  if (first === undefined) throw new Error("the run has no simulation");
+
+  const claimed = await api.app.inject({
+    method: "POST",
+    url: CLAIMS_PATH,
+    headers: { authorization: `Bearer ${api.config.simulatorServiceToken}` },
+    payload: { claimant: CONDUCTOR, capacity: 50, wait_seconds: 0 },
+  });
+  expect(claimed.statusCode).toBe(200);
+  const specs = (claimed.json() as { specs: { simulation_id: string }[] }).specs;
+  expect(specs.map((spec) => spec.simulation_id)).toContain(first.id);
+
+  return { runId: String(started.body.id), simulationId: first.id };
+}
+
+/** The same, walked one transition on: the conversation is underway. */
+async function aRunningSimulation(
+  key: string,
+  connectionId: string,
+  versionId: string,
+): Promise<{ runId: string; simulationId: string }> {
+  const claimed = await aClaimedSimulation(key, connectionId, versionId);
+  const answered = await report(claimed.simulationId, [runningEvent()]);
+  expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+  return claimed;
+}
+
+/** What the grading queue holds for one simulation — the minted work. */
+async function gradingJobsFor(simulationId: string): Promise<number> {
+  const { rows } = await api.database.sql<{ count: string }>(
+    "select count(*) as count from grading_job where simulation_id = $1",
+    [simulationId],
+  );
+  return Number(rows[0]?.count);
+}
+
+describe("the token gate", () => {
+  it("refuses a missing, wrong, or customer token with one actionable sentence", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_gate",
+    );
+    const { simulationId } = await aClaimedSimulation(key, connectionId, versionId);
+
+    const refusals = await Promise.all([
+      report(simulationId, [runningEvent()], { token: "" }),
+      report(simulationId, [runningEvent()], {
+        token: "egma_st_not-the-configured-one",
+      }),
+      // A customer's own real key: a credential for their data, and exactly
+      // the thing this door must never take a lifecycle claim from.
+      report(simulationId, [runningEvent()], { token: key }),
+    ]);
+
+    for (const refused of refusals) {
+      expect(refused.statusCode).toBe(401);
+      expect(refused.body.error).toBe("not_authenticated");
+      expect(String(refused.body.message)).toContain(
+        "EGMA_SIMULATOR_SERVICE_TOKEN",
+      );
+    }
+
+    // And nothing moved: the gate turned every one of them away unread.
+    const { rows } = await api.database.sql<{ status: string }>(
+      "select status from simulation where id = $1",
+      [simulationId],
+    );
+    expect(rows[0]?.status).toBe("claimed");
+  });
+});
+
+describe("what the door refuses before believing a word", () => {
+  it("refuses a document that does not speak the contract, complaints included", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_contract",
+    );
+    const { simulationId } = await aClaimedSimulation(key, connectionId, versionId);
+
+    const refused = await report(simulationId, [
+      { kind: "confession", event_id: eventId() },
+    ]);
+    expect(refused.statusCode).toBe(400);
+    expect(refused.body.error).toBe("invalid_request");
+    expect(String(refused.body.message)).toContain("/events/0");
+  });
+
+  it("refuses the endings that are the platform's own words, never a reporter's", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_vocabulary",
+    );
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    // `orphaned` is the sweep's word, `dispatch_failed` the claim path's,
+    // and the row's own vocabulary (`simulator_error`, `capacity`) never
+    // rides the wire — the contract's schema is the refusal for all four.
+    for (const ending of [
+      "orphaned",
+      "dispatch_failed",
+      "simulator_error",
+      "capacity",
+    ]) {
+      const refused = await report(simulationId, [
+        terminalEvent("failed", ending),
+      ]);
+      expect(refused.statusCode, `ending "${ending}" was believed`).toBe(400);
+      expect(refused.body.error).toBe("invalid_request");
+    }
+  });
+
+  it("refuses a document about another simulation, naming both ids", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_mismatch",
+    );
+    const { simulationId } = await aClaimedSimulation(key, connectionId, versionId);
+
+    const refused = await report(simulationId, [runningEvent()], {
+      about: "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+    });
+    expect(refused.statusCode).toBe(400);
+    expect(refused.body.error).toBe("invalid_request");
+    expect(String(refused.body.message)).toContain(simulationId);
+    expect(String(refused.body.message)).toContain(
+      "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+    );
+  });
+
+  it("answers an unknown simulation with 404, in words a coding agent can act on", async () => {
+    api = await createApi("reports_unknown");
+
+    const refused = await report("sim_01K3XQ7M4E8YB2FVN0H9TZQWER", [
+      runningEvent(),
+    ]);
+    expect(refused.statusCode).toBe(404);
+    expect(refused.body.error).toBe("not_found");
+    expect(String(refused.body.message)).toContain(
+      "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+    );
+  });
+});
+
+describe("the lifecycle lands", () => {
+  it("starts the conversation on a running event, conducted by the row's own claimant", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_running",
+    );
+    const { simulationId } = await aClaimedSimulation(key, connectionId, versionId);
+
+    const answered = await report(simulationId, [runningEvent()]);
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+    expect(answered.body).toEqual({
+      simulation_id: simulationId,
+      status: "running",
+    });
+
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("running");
+    expect(row?.startedAt).toBeInstanceOf(Date);
+    expect(row?.claimedBy).toBe(CONDUCTOR);
+  });
+
+  it("lands a completed conversation with its facts, mints grading work, finalizes the run", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_completed",
+    );
+    const { runId, simulationId } = await aRunningSimulation(
+      key,
+      connectionId,
+      versionId,
+    );
+
+    const answered = await report(simulationId, [
+      terminalEvent("completed", "persona_concluded"),
+    ]);
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+    expect(answered.body).toEqual({
+      simulation_id: simulationId,
+      status: "completed",
+    });
+
+    // The row says what the conduction measured, not what the wire clock saw.
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("completed");
+    expect(row?.endingReason).toBe("persona_concluded");
+    expect(row?.turnCount).toBe(14);
+    expect(row?.providerReference).toBe("chat_5d1f9a3b7c");
+    expect(row?.startedAt?.toISOString()).toBe("2026-08-05T09:00:00.000Z");
+    expect(row?.endedAt?.toISOString()).toBe("2026-08-05T09:02:10.551Z");
+    expect(row?.measuredAudioBandHertz).toBeNull();
+
+    // The landing minted the judgement and froze the header, exactly as the
+    // access layer promises every terminal transition does.
+    expect(await gradingJobsFor(simulationId)).toBe(1);
+    const header = await ask(api.app, "GET", `/api/runs/${runId}`, key);
+    expect(header.body.status).toBe("completed");
+    expect(header.body.completed_count).toBe(1);
+    expect(header.body.failed_count).toBe(0);
+  });
+
+  it("lands a voice conversation's measured band and recording reference", async () => {
+    const { ada, key, agentId, versionId } = await aCustomerReadyToRun(
+      "reports_voice",
+    );
+    const attached = await ask(api.app, "POST", `/api/agents/${agentId}/connections`, key, {
+      type: "retell",
+      modality: "voice",
+      config: { retellAgentId: "agent_in_retell_voice" },
+      credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    });
+    expect(attached.statusCode, JSON.stringify(attached.body)).toBe(201);
+    const voiceConnection = (attached.body.connection as { id: string }).id;
+
+    const { simulationId } = await aRunningSimulation(
+      key,
+      voiceConnection,
+      versionId,
+    );
+
+    const answered = await report(simulationId, [
+      terminalEvent("completed", "agent_ended", {
+        audio: {
+          measured_sample_rate_hz: 8_000,
+          recording: `${simulationId}/dual-channel.wav`,
+        },
+        provider_reference: "CA7e2b9c1d4f6a8e0b",
+        turn_count: 22,
+      }),
+    ]);
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.measuredAudioBandHertz).toBe(8_000);
+    expect(row?.recordingReference).toBe(`${simulationId}/dual-channel.wav`);
+    expect(row?.turnCount).toBe(22);
+    expect(row?.providerReference).toBe("CA7e2b9c1d4f6a8e0b");
+  });
+
+  it("refuses audio facts for a chat conversation, which has none to measure", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_chat_audio",
+    );
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    const refused = await report(simulationId, [
+      terminalEvent("completed", "persona_concluded", {
+        audio: {
+          measured_sample_rate_hz: 48_000,
+          recording: "somewhere/dual-channel.wav",
+        },
+      }),
+    ]);
+    expect(refused.statusCode).toBe(422);
+    expect(refused.body.error).toBe("unprocessable");
+    expect(String(refused.body.message)).toContain("chat");
+  });
+
+  it("lands a failed conversation's honest reason, the wire's `error` as the row's own word", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_failed",
+    );
+    const { runId, simulationId } = await aRunningSimulation(
+      key,
+      connectionId,
+      versionId,
+    );
+
+    const answered = await report(simulationId, [
+      terminalEvent("failed", "error", { turn_count: 3 }),
+    ]);
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("failed");
+    expect(row?.endingReason).toBe("simulator_error");
+    expect(row?.turnCount).toBe(3);
+
+    // A failed conversation is judged too — errored, never left unjudged.
+    expect(await gradingJobsFor(simulationId)).toBe(1);
+    const header = await ask(api.app, "GET", `/api/runs/${runId}`, key);
+    expect(header.body.status).toBe("completed");
+    expect(header.body.failed_count).toBe(1);
+  });
+
+  it("lands agent_never_joined from the claimed state, where nothing ever ran", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_never_joined",
+    );
+    // Deliberately never reported running: a failed landing is legal from
+    // `claimed` at the access seam — the way in opened and nothing tested —
+    // and the door keeps exactly that discipline rather than inventing a
+    // stricter one.
+    const { simulationId } = await aClaimedSimulation(key, connectionId, versionId);
+
+    const answered = await report(simulationId, [
+      terminalEvent("failed", "agent_never_joined", { turn_count: 0 }),
+    ]);
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("failed");
+    expect(row?.endingReason).toBe("agent_never_joined");
+    expect(row?.turnCount).toBe(0);
+  });
+
+  it("lands a canceled conversation once cancellation was actually requested", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_canceled",
+    );
+    const { runId, simulationId } = await aRunningSimulation(
+      key,
+      connectionId,
+      versionId,
+    );
+
+    const asked = await ask(api.app, "POST", `/api/runs/${runId}/cancel`, key);
+    expect(asked.statusCode, JSON.stringify(asked.body)).toBe(200);
+
+    const answered = await report(simulationId, [
+      terminalEvent("canceled", "canceled", { turn_count: 6 }),
+    ]);
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("canceled");
+    // The cancel intent is its own record; the reason column stays empty.
+    expect(row?.endingReason).toBeNull();
+    expect(row?.turnCount).toBe(6);
+
+    // A canceled conversation was never judged — no grading work minted.
+    expect(await gradingJobsFor(simulationId)).toBe(0);
+    const header = await ask(api.app, "GET", `/api/runs/${runId}`, key);
+    expect(header.body.status).toBe("canceled");
+    expect(header.body.canceled_count).toBe(1);
+  });
+
+  it("refuses to call a conversation canceled that nobody asked to cancel", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_uninvited_cancel",
+    );
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    const refused = await report(simulationId, [
+      terminalEvent("canceled", "canceled"),
+    ]);
+    expect(refused.statusCode).toBe(409);
+    expect(refused.body.error).toBe("conflict");
+    expect(String(refused.body.message)).toContain("cancel");
+
+    // The row stands exactly where it stood: still running, still honest.
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("running");
+  });
+});
+
+describe("idempotency without a ledger", () => {
+  it("absorbs a duplicate running event with 200", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_duplicate_running",
+    );
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    const again = await report(simulationId, [runningEvent()]);
+    expect(again.statusCode).toBe(200);
+    expect(again.body).toEqual({
+      simulation_id: simulationId,
+      status: "running",
+    });
+  });
+
+  it("absorbs a terminal resend that matches the row's terminal state", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_terminal_resend",
+    );
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    const landed = terminalEvent("completed", "persona_concluded");
+    expect((await report(simulationId, [landed])).statusCode).toBe(200);
+
+    // The client resends the same bytes; the record absorbs them.
+    const resent = await report(simulationId, [landed]);
+    expect(resent.statusCode).toBe(200);
+    expect(resent.body).toEqual({
+      simulation_id: simulationId,
+      status: "completed",
+    });
+  });
+
+  it("refuses a terminal document that conflicts with the terminal row, 409, saying both sides", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_conflict",
+    );
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    expect(
+      (
+        await report(simulationId, [
+          terminalEvent("completed", "persona_concluded"),
+        ])
+      ).statusCode,
+    ).toBe(200);
+
+    // A different ending for the same conversation: the record already says
+    // how it ended, and it is not rewritten by a later document.
+    const differentEnding = await report(simulationId, [
+      terminalEvent("completed", "agent_ended"),
+    ]);
+    expect(differentEnding.statusCode).toBe(409);
+    expect(differentEnding.body.error).toBe("conflict");
+    expect(String(differentEnding.body.message)).toContain("persona_concluded");
+
+    const differentStatus = await report(simulationId, [
+      terminalEvent("failed", "error"),
+    ]);
+    expect(differentStatus.statusCode).toBe(409);
+
+    const runningAgain = await report(simulationId, [runningEvent()]);
+    expect(runningAgain.statusCode).toBe(409);
+    expect(runningAgain.body.error).toBe("conflict");
+  });
+
+  it("refuses a completed landing for a conversation that never reported running", async () => {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_never_ran",
+    );
+    const { simulationId } = await aClaimedSimulation(key, connectionId, versionId);
+
+    const refused = await report(simulationId, [
+      terminalEvent("completed", "persona_concluded"),
+    ]);
+    expect(refused.statusCode).toBe(409);
+    expect(refused.body.error).toBe("conflict");
+  });
+});
+
+describe("what is accepted and deliberately dropped", () => {
+  it("takes turn, timing and tool_call events without storing a byte of them", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_dropped",
+    );
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    const answered = await report(simulationId, [
+      {
+        kind: "turn",
+        event_id: eventId(),
+        speaker: "human",
+        text: "I need to move my Tuesday cleaning to Thursday.",
+        started_at: STARTED_AT,
+        ended_at: null,
+      },
+      {
+        kind: "timing",
+        event_id: eventId(),
+        at: STARTED_AT,
+        measure: "first_response_latency",
+        milliseconds: 1214,
+      },
+      {
+        kind: "tool_call",
+        event_id: eventId(),
+        at: STARTED_AT,
+        name: "reschedule_appointment",
+        arguments: null,
+      },
+    ]);
+    expect(answered.statusCode).toBe(200);
+    expect(answered.body).toEqual({
+      simulation_id: simulationId,
+      status: "running",
+    });
+
+    // Dropped means dropped: nothing landed on the row, and the columns that
+    // once carried conversation data are untouched.
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("running");
+    expect(row?.transcript).toBeNull();
+    expect(row?.events).toBeNull();
+    expect(row?.metrics).toBeNull();
+  });
+});
+
+describe("what the report door never touches", () => {
+  it("spends no organization's request budget, and no budget stops a report", async () => {
+    api = await createApi("reports_budget", {
+      rateLimit: fixedWindowRateLimit({ limit: 3, windowMilliseconds: 60_000 }),
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    // Spend the organization's whole budget…
+    let refused = 0;
+    for (let i = 0; i < 8; i += 1) {
+      const answer = await ask(api.app, "GET", "/api/agents", key);
+      if (answer.statusCode === 429) refused += 1;
+    }
+    expect(refused).toBeGreaterThan(0);
+
+    // …and the report door is unmoved: its answer is a 404 about the row,
+    // never a 429 about anybody's budget.
+    const answered = await report("sim_01K3XQ7M4E8YB2FVN0H9TZQWER", [
+      runningEvent(),
+    ]);
+    expect(answered.statusCode).toBe(404);
+  });
+});

--- a/apps/api/test/reports-routes.test.ts
+++ b/apps/api/test/reports-routes.test.ts
@@ -376,6 +376,38 @@ describe("the lifecycle lands", () => {
     expect(header.body.failed_count).toBe(0);
   });
 
+  it("declines reported moments that cannot be true, and lands on its own stamps", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_skewed_clock",
+    );
+    const before = new Date();
+    const { simulationId } = await aRunningSimulation(key, connectionId, versionId);
+
+    // A skewed clock's confession: contract-valid, impossible on any clock —
+    // the exchange ends before it starts. Refusing it would punish delivery
+    // for the clock and leave a truthful conversation to the sweep, so the
+    // door lands it and simply declines the pair it cannot believe.
+    const answered = await report(simulationId, [
+      terminalEvent("completed", "persona_concluded", {
+        started_at: ENDED_AT,
+        ended_at: STARTED_AT,
+      }),
+    ]);
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+
+    const row = await getSimulation(contextFor(ada, "member"), simulationId);
+    expect(row?.status).toBe("completed");
+    // The server's own stamps stand for both moments: a coherent interval,
+    // inside this test's own wall clock — never the reported 2026-08-05 pair.
+    expect(row?.startedAt?.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(row?.endedAt?.getTime()).toBeGreaterThanOrEqual(
+      row?.startedAt?.getTime() ?? Number.POSITIVE_INFINITY,
+    );
+    // The facts the pair rode in with still land whole.
+    expect(row?.turnCount).toBe(14);
+    expect(row?.providerReference).toBe("chat_5d1f9a3b7c");
+  });
+
   it("lands a voice conversation's measured band and recording reference", async () => {
     const { ada, key, agentId, versionId } = await aCustomerReadyToRun(
       "reports_voice",
@@ -510,6 +542,75 @@ describe("the lifecycle lands", () => {
     const header = await ask(api.app, "GET", `/api/runs/${runId}`, key);
     expect(header.body.status).toBe("canceled");
     expect(header.body.canceled_count).toBe(1);
+  });
+
+  it("retries once when the cancellation lands between the attempt and the answer", async () => {
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "reports_cancel_race",
+    );
+    const { runId, simulationId } = await aRunningSimulation(
+      key,
+      connectionId,
+      versionId,
+    );
+    const asked = await ask(api.app, "POST", `/api/runs/${runId}/cancel`, key);
+    expect(asked.statusCode, JSON.stringify(asked.body)).toBe(200);
+
+    // The race, held open deterministically: a trigger suppresses the first
+    // canceled landing on this row — the update reports no row moved, which
+    // is exactly what the route sees when a cancelRun commits between its
+    // attempt and its re-read — and every later attempt passes. The route
+    // cannot tell this window from the real one; what it must do about it
+    // is the same: read again, see a live row whose cancellation stands,
+    // and retry once rather than refuse a transition that is valid at the
+    // moment it answers.
+    await api.database.sql(
+      "create table report_race_window (id text primary key)",
+    );
+    await api.database.sql(
+      `create function report_race_suppress_once() returns trigger
+       language plpgsql as $$
+       begin
+         if new.status = 'canceled' and old.status <> 'canceled'
+            and not exists (select 1 from report_race_window where id = old.id)
+         then
+           insert into report_race_window values (old.id);
+           return null; -- the attempt sees what a lost race sees: nothing moved
+         end if;
+         return new;
+       end $$`,
+    );
+    await api.database.sql(
+      `create trigger report_race_suppress before update on simulation
+       for each row execute function report_race_suppress_once()`,
+    );
+
+    try {
+      const answered = await report(simulationId, [
+        terminalEvent("canceled", "canceled", { turn_count: 6 }),
+      ]);
+      expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+      expect(answered.body).toEqual({
+        simulation_id: simulationId,
+        status: "canceled",
+      });
+
+      // The one attempt the window swallowed, and the one retry that landed.
+      const { rows } = await api.database.sql<{ id: string }>(
+        "select id from report_race_window",
+      );
+      expect(rows).toEqual([{ id: simulationId }]);
+
+      const row = await getSimulation(contextFor(ada, "member"), simulationId);
+      expect(row?.status).toBe("canceled");
+      expect(row?.turnCount).toBe(6);
+    } finally {
+      await api.database.sql(
+        "drop trigger report_race_suppress on simulation",
+      );
+      await api.database.sql("drop function report_race_suppress_once()");
+      await api.database.sql("drop table report_race_window");
+    }
   });
 
   it("refuses to call a conversation canceled that nobody asked to cancel", async () => {

--- a/apps/api/test/simulator-walk.test.ts
+++ b/apps/api/test/simulator-walk.test.ts
@@ -1,0 +1,433 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { createPersona } from "@egma/db";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { startInstance, type Instance } from "./support/instance.ts";
+import { NEUTRAL_TRAITS } from "./support/traces.ts";
+
+/**
+ * The whole wire, walked by the shipped simulator: a run started through the
+ * real API, its simulation claimed from the real claim door, conducted by
+ * the real Python service over a Retell-shaped counterpart on loopback, and
+ * reported back through the real report door — queued → claimed → running →
+ * completed, with every lifecycle column read back and checked for truth.
+ *
+ * Nothing here is a stand-in for egma's own halves: the API listens on a
+ * real port, the database is a real Postgres, and the simulator is the same
+ * process `docker compose up` starts. The one fake is the platform on the
+ * far side of the conversation — a local server speaking Retell's chat wire
+ * shape — because the agent under test is the customer's, and a test that
+ * needed a real Retell account would prove an account rather than the wire.
+ *
+ * The failed walk rides the same session: a second connection whose key the
+ * counterpart refuses, landing `failed` with the honest reason. The canceled
+ * walk is deliberately absent — the cancel directive travels on heartbeat
+ * answers, and the heartbeat route ships separately — so cancellation is
+ * proven at the report door's own seam instead (`reports-routes.test.ts`).
+ */
+
+const API_DIRECTORY = path.join(import.meta.dirname, "..");
+const SIMULATOR_DIRECTORY = path.join(
+  API_DIRECTORY,
+  "../simulator",
+);
+
+/** The token the instance support configures on the API's side. */
+const SERVICE_TOKEN = "egma_st_held-by-this-test-suite-alone";
+
+/** The key the Retell-shaped counterpart accepts, and the one it refuses. */
+const COUNTERPART_KEY = "retell-secret-A1B2C3D4WXYZ";
+const REFUSED_KEY = "retell-secret-NOBODY0000000";
+
+/**
+ * A Retell-shaped chat platform on loopback: the three endpoints the shipped
+ * plug speaks — create-chat, create-chat-completion, end-chat — with
+ * Retell's own field names, bearer-key auth, and a scripted agent behind
+ * them. Strict where the platform is: a wrong key answers 401, which is the
+ * failed walk's whole way in.
+ */
+class RetellCounterpart {
+  private server: http.Server | undefined;
+  private readonly replies = [
+    "Of course — we have Tuesday and Wednesday afternoon free next week.",
+    "Done: you are moved to Wednesday at half past two.",
+  ];
+
+  /** Reply cursor per chat, so two exchanges cannot eat each other's script. */
+  private readonly delivered = new Map<string, number>();
+  port = 0;
+
+  async start(): Promise<void> {
+    this.server = http.createServer((request, response) => {
+      let body = "";
+      request.on("data", (piece: Buffer) => {
+        body += piece.toString("utf8");
+      });
+      request.on("end", () => {
+        this.answer(request, response, body);
+      });
+    });
+    await new Promise<void>((resolve) => {
+      this.server?.listen(0, "127.0.0.1", resolve);
+    });
+    const address = this.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("the counterpart has no port");
+    }
+    this.port = address.port;
+  }
+
+  private answer(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    body: string,
+  ): void {
+    const send = (status: number, document: Record<string, unknown>): void => {
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify(document));
+    };
+
+    if (request.headers.authorization !== `Bearer ${COUNTERPART_KEY}`) {
+      send(401, { error: "invalid api key" });
+      return;
+    }
+
+    const url = request.url ?? "";
+    if (request.method === "POST" && url === "/create-chat") {
+      const chatId = `chat_${randomUUID().replaceAll("-", "").slice(0, 10)}`;
+      this.delivered.set(chatId, 0);
+      send(201, {
+        chat_id: chatId,
+        message_with_tool_calls: [
+          { role: "agent", content: "Lakeside Dental, how can I help?" },
+        ],
+      });
+      return;
+    }
+    if (request.method === "POST" && url === "/create-chat-completion") {
+      const { chat_id: chatId } = JSON.parse(body) as { chat_id?: string };
+      const turn = chatId === undefined ? undefined : this.delivered.get(chatId);
+      if (chatId === undefined || turn === undefined) {
+        send(422, { error: "no such chat" });
+        return;
+      }
+      const reply = this.replies[turn];
+      if (reply === undefined) {
+        send(422, { error: "the script ran dry" });
+        return;
+      }
+      this.delivered.set(chatId, turn + 1);
+      send(200, { messages: [{ role: "agent", content: reply }] });
+      return;
+    }
+    if (request.method === "PATCH" && url.startsWith("/end-chat/")) {
+      send(200, {});
+      return;
+    }
+    send(404, { error: `nothing at ${url}` });
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.server?.close(() => {
+        resolve();
+      });
+    });
+  }
+}
+
+let instance: Instance;
+let counterpart: RetellCounterpart;
+let simulator: ChildProcess | undefined;
+let simulatorSaid = "";
+let scratch: string;
+
+/** One request against the instance as a person's terminal makes one. */
+async function call(
+  method: string,
+  route: string,
+  options: { key?: string; body?: unknown; cookie?: string } = {},
+): Promise<{ status: number; body: Record<string, unknown>; setCookie: string }> {
+  const response = await fetch(`${instance.origin}${route}`, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      ...(options.key === undefined
+        ? {}
+        : { authorization: `Bearer ${options.key}` }),
+      ...(options.cookie === undefined ? {} : { cookie: options.cookie }),
+    },
+    ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    body: (text === "" ? {} : JSON.parse(text)) as Record<string, unknown>,
+    setCookie: response.headers.get("set-cookie") ?? "",
+  };
+}
+
+/**
+ * Sign up over the wire and come back holding a project-scoped key — plus
+ * the tenancy the persona seam needs, because no persona route ships yet
+ * and the caller authors one at the db seam this process shares.
+ */
+async function signedUpKey(): Promise<{
+  key: string;
+  userId: string;
+  organizationId: string;
+  projectId: string;
+}> {
+  const signedUp = await call("POST", "/api/signup", {
+    body: {
+      email: "ada@acme.example",
+      password: "a-password-long-enough-1",
+      organizationName: "Acme",
+    },
+  });
+  expect(signedUp.status, JSON.stringify(signedUp.body)).toBe(201);
+  const cookie = signedUp.setCookie.split(";", 1)[0] ?? "";
+  const landed = signedUp.body as unknown as {
+    userId: string;
+    organization: { id: string };
+    project: { id: string };
+  };
+
+  const minted = await call("POST", "/api/keys", {
+    cookie,
+    body: { name: "walking", project_id: landed.project.id },
+  });
+  expect(minted.status, JSON.stringify(minted.body)).toBe(201);
+  return {
+    key: String(minted.body.secret),
+    userId: landed.userId,
+    organizationId: landed.organization.id,
+    projectId: landed.project.id,
+  };
+}
+
+/** What the row itself says, read raw — the truth the walk must land. */
+async function rowOf(simulationId: string): Promise<Record<string, unknown>> {
+  const { rows } = await instance.database.sql(
+    `select status, ending_reason, claimed_by, started_at, ended_at,
+            turn_count, provider_reference, measured_audio_band_hertz,
+            cancel_requested_at
+       from simulation where id = $1`,
+    [simulationId],
+  );
+  const row = rows[0];
+  if (row === undefined) throw new Error(`no row for ${simulationId}`);
+  return row;
+}
+
+async function gradingJobsFor(simulationId: string): Promise<number> {
+  const { rows } = await instance.database.sql<{ count: string }>(
+    "select count(*) as count from grading_job where simulation_id = $1",
+    [simulationId],
+  );
+  return Number(rows[0]?.count);
+}
+
+/** Poll one run until it reaches a terminal status, or say what it was doing. */
+async function settledRun(
+  key: string,
+  runId: string,
+  within: number,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + within;
+  for (;;) {
+    const read = await call("GET", `/api/runs/${runId}`, { key });
+    expect(read.status, JSON.stringify(read.body)).toBe(200);
+    const status = String(read.body.status);
+    if (status === "completed" || status === "canceled") return read.body;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `run ${runId} is still ${status} after ${within}ms; the simulator said:\n` +
+          simulatorSaid,
+      );
+    }
+    await new Promise((resume) => setTimeout(resume, 250));
+  }
+}
+
+beforeAll(async () => {
+  scratch = await mkdtemp(path.join(os.tmpdir(), "egma-simulator-walk-"));
+  counterpart = new RetellCounterpart();
+  await counterpart.start();
+  instance = await startInstance("simulator_walk", { web: false });
+}, 120_000);
+
+afterAll(async () => {
+  simulator?.kill("SIGTERM");
+  await instance?.close();
+  await counterpart?.stop();
+  await rm(scratch, { recursive: true, force: true });
+});
+
+describe("the shipped simulator against the real API", () => {
+  it(
+    "walks queued → claimed → running → completed, and a refused key to an honest failed",
+    { timeout: 90_000 },
+    async () => {
+      const { key, userId, organizationId, projectId } = await signedUpKey();
+
+      // The agent and the way to reach it — a retell chat connection whose
+      // key the counterpart accepts, and a second whose key it refuses.
+      const registered = await call("POST", "/api/agents", {
+        key,
+        body: {
+          name: "Front desk",
+          connection: {
+            type: "retell",
+            modality: "chat",
+            config: { retellAgentId: "agent_under_walk" },
+            credentials: { apiKey: COUNTERPART_KEY },
+          },
+        },
+      });
+      expect(registered.status, JSON.stringify(registered.body)).toBe(201);
+      const agentId = (registered.body.agent as { id: string }).id;
+      const goodConnection = (registered.body.connection as { id: string }).id;
+
+      const attached = await call("POST", `/api/agents/${agentId}/connections`, {
+        key,
+        body: {
+          type: "retell",
+          modality: "chat",
+          config: { retellAgentId: "agent_under_walk" },
+          credentials: { apiKey: REFUSED_KEY },
+        },
+      });
+      expect(attached.status, JSON.stringify(attached.body)).toBe(201);
+      const refusedConnection = (attached.body.connection as { id: string }).id;
+
+      // Point both connections at the counterpart. `baseUrl` is the shipped
+      // plug's own documented config key — what lets an exchange land on a
+      // Retell-shaped server on loopback — but the connection factory does
+      // not take it from customers yet, so the harness writes it the way a
+      // deployment pointing at a proxy one day would. Raw SQL on purpose,
+      // and the only hand this test lays on any table.
+      await instance.database.sql(
+        `update connection
+            set config = config || jsonb_build_object('baseUrl', $1::text)
+          where id in ($2, $3)`,
+        [
+          `http://127.0.0.1:${counterpart.port}`,
+          goodConnection,
+          refusedConnection,
+        ],
+      );
+
+      // The persona is authored at the seam — no route ships for one — and
+      // the test then names her, which is what the claimed spec's traits
+      // come from. This process shares the instance's database connection.
+      await createPersona(
+        {
+          userId,
+          organizationId,
+          projectId,
+          role: "member",
+          via: "session",
+        },
+        { name: "Impatient Rita", traits: NEUTRAL_TRAITS },
+      );
+
+      const pushed = await call("POST", "/api/tests", {
+        key,
+        body: {
+          name: "Reschedules a booked appointment",
+          scenario:
+            "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+          expected_behaviors: ["confirms the new time back before finishing"],
+          personas: ["Impatient Rita"],
+        },
+      });
+      expect(pushed.status, JSON.stringify(pushed.body)).toBe(201);
+      const versionId = String(pushed.body.version_id);
+
+      // Both runs queued before the simulator exists, so the walk starts
+      // from the resting state a trigger leaves behind.
+      const startRunOver = async (connection: string) => {
+        const started = await call("POST", "/api/runs", {
+          key,
+          body: { connection, test_versions: [versionId] },
+        });
+        expect(started.status, JSON.stringify(started.body)).toBe(201);
+        const simulations = started.body.simulations as { id: string }[];
+        const first = simulations[0];
+        if (first === undefined) throw new Error("the run has no simulation");
+        return { runId: String(started.body.id), simulationId: first.id };
+      };
+      const conducted = await startRunOver(goodConnection);
+      const refused = await startRunOver(refusedConnection);
+
+      // The shipped service, exactly as compose starts it: pointed at this
+      // instance, holding the deployment's service token, everything else
+      // its defaults — the scripted persona model included.
+      simulator = spawn("uv", ["run", "--frozen", "egma-simulator"], {
+        cwd: SIMULATOR_DIRECTORY,
+        env: {
+          ...process.env,
+          EGMA_SIMULATOR_CONTROL_PLANE_URL: instance.origin,
+          EGMA_SIMULATOR_SERVICE_TOKEN: SERVICE_TOKEN,
+          EGMA_SIMULATOR_CLAIMANT: "walking-simulator-1",
+          EGMA_SIMULATOR_CLAIM_WAIT_SECONDS: "2",
+          EGMA_SIMULATOR_HEARTBEAT_SECONDS: "1",
+          EGMA_SIMULATOR_WAL_DIR: path.join(scratch, "wal"),
+          EGMA_SIMULATOR_BLOB_DIR: path.join(scratch, "blobs"),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      simulator.stdout?.on("data", (piece: Buffer) => {
+        simulatorSaid += piece.toString("utf8");
+      });
+      simulator.stderr?.on("data", (piece: Buffer) => {
+        simulatorSaid += piece.toString("utf8");
+      });
+
+      // The whole walk, as a person watching the run would see it settle.
+      const conductedRun = await settledRun(key, conducted.runId, 60_000);
+      const refusedRun = await settledRun(key, refused.runId, 60_000);
+
+      // The conversation that happened: completed, concluded by the persona,
+      // and every lifecycle column telling the truth about it.
+      const row = await rowOf(conducted.simulationId);
+      expect(row.status).toBe("completed");
+      expect(row.ending_reason).toBe("persona_concluded");
+      expect(row.claimed_by).toBe("walking-simulator-1");
+      // Greeting, the scenario's one sentence, the scripted answer, and the
+      // persona's goodbye: four turns, counted by the simulator itself.
+      expect(row.turn_count).toBe(4);
+      // Retell's own id for the exchange, echoed off the counterpart.
+      expect(String(row.provider_reference)).toMatch(/^chat_/);
+      expect(row.measured_audio_band_hertz).toBeNull();
+      const startedAt = new Date(String(row.started_at));
+      const endedAt = new Date(String(row.ended_at));
+      expect(startedAt.getTime()).toBeLessThanOrEqual(endedAt.getTime());
+      expect(await gradingJobsFor(conducted.simulationId)).toBe(1);
+
+      expect(conductedRun.status).toBe("completed");
+      expect(conductedRun.completed_count).toBe(1);
+      expect(conductedRun.failed_count).toBe(0);
+
+      // The conversation that could not happen: the platform refused the
+      // key, and the record says failed with the simulator's honest word —
+      // never a judgement of an agent nothing ever reached.
+      const refusedRow = await rowOf(refused.simulationId);
+      expect(refusedRow.status).toBe("failed");
+      expect(refusedRow.ending_reason).toBe("simulator_error");
+      expect(refusedRow.claimed_by).toBe("walking-simulator-1");
+      expect(await gradingJobsFor(refused.simulationId)).toBe(1);
+
+      expect(refusedRun.status).toBe("completed");
+      expect(refusedRun.completed_count).toBe(0);
+      expect(refusedRun.failed_count).toBe(1);
+    },
+  );
+});

--- a/packages/db/migrations/0016_simulation_summary_facts.sql
+++ b/packages/db/migrations/0016_simulation_summary_facts.sql
@@ -1,0 +1,14 @@
+-- Two summary facts the report's terminal events carry onto the simulation
+-- row: how many transcript turns the conversation reached, and the platform's
+-- own identifier for the exchange — each read alone to answer for one
+-- simulation, which is what puts them in Postgres rather than beside the
+-- conversation data. Nullable both, because every row written before this
+-- migration landed no such facts, and a report may honestly carry none.
+ALTER TABLE "simulation" ADD COLUMN "turn_count" integer;--> statement-breakpoint
+ALTER TABLE "simulation" ADD COLUMN "provider_reference" text;--> statement-breakpoint
+-- Terminal facts, like the report columns beside them — a check of their own
+-- rather than a rewrite of the report's, because an additive column takes an
+-- additive guard.
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_summary_facts_only_when_ended" CHECK ("simulation"."ended_at" is not null
+        or ("simulation"."turn_count" is null and "simulation"."provider_reference" is null));--> statement-breakpoint
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_turn_count_is_a_count" CHECK ("simulation"."turn_count" is null or "simulation"."turn_count" >= 0);

--- a/packages/db/migrations/meta/0016_snapshot.json
+++ b/packages/db/migrations/meta/0016_snapshot.json
@@ -1,0 +1,4256 @@
+{
+  "id": "4dcfe5c4-9e67-491c-8944-935093b0c471",
+  "prevId": "465858f7-1aea-4731-8de6-be8ccd40c9ad",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_rubric', 'metric_threshold', 'tool_calls', 'phrase_match')"
+        },
+        "grader_priority_allowed": {
+          "name": "grader_priority_allowed",
+          "value": "\"grader\".\"priority\" in ('P0', 'P1', 'P2')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_grader": {
+      "name": "test_grader",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_grader_grader_id_idx": {
+          "name": "test_grader_grader_id_idx",
+          "columns": [
+            {
+              "expression": "grader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_grader_test_version_id_test_version_id_fk": {
+          "name": "test_grader_test_version_id_test_version_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_grader_grader_id_grader_id_fk": {
+          "name": "test_grader_grader_id_grader_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_grader_pk": {
+          "name": "test_grader_pk",
+          "columns": [
+            "test_version_id",
+            "grader_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_grader_version_id_position_unique": {
+          "name": "test_grader_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_grader_test_version_id_prefix": {
+          "name": "test_grader_test_version_id_prefix",
+          "value": "\"test_grader\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0 and \"run\".\"canceled_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled')"
+        },
+        "simulation_connection_type_allowed": {
+          "name": "simulation_connection_type_allowed",
+          "value": "\"simulation\".\"connection_type\" in ('retell', 'phone')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"transcript\" is null and \"simulation\".\"events\" is null\n          and \"simulation\".\"metrics\" is null and \"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1786162961764,
       "tag": "0015_dispatch_failure",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1786175245112,
+      "tag": "0016_simulation_summary_facts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -377,6 +377,7 @@ export {
   markSimulationCanceled,
   recordSimulationHeartbeat,
   resolveSimulationConnection,
+  resolveSimulationStanding,
   startRun,
   startSimulation,
   sweepOrphanedSimulations,
@@ -396,6 +397,8 @@ export {
   type SimulationFailure,
   type SimulationHeartbeat,
   type SimulationReport,
+  type SimulationStanding,
+  type SimulationSummaryFacts,
   type StartedRun,
   type SweptSimulation,
 } from "./runs.ts";

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -60,18 +60,21 @@ import { within } from "./within.ts";
  * machinery is gated by `start_and_cancel_runs` throughout, because claiming
  * and reporting a simulation *is* conducting the run somebody started.
  *
- * Three exceptions, drawn on the grading queue's precedent and as narrowly:
- * `claimSimulations`, `recordSimulationHeartbeat` and
- * `sweepOrphanedSimulations` take no context and cannot be given one, because
- * each stands where the simulator does — behind every organization on the
- * deployment at once, with no honest credential to give it. The claim hands
- * work out; the heartbeat keeps one dispatch alive and steers it; the sweep
- * accounts for dispatches whose simulator died. All three reach only rows
- * egma's own machinery wrote — the queue, and the claims made from it — and
- * carry out identifiers and no content. The claim hands back with every row
- * the context the conducting is then done under, built from the row's own
- * tenancy and from nothing the service said; the other two derive their
- * narrowness the same way, from the row rather than from any caller.
+ * Four exceptions, drawn on the grading queue's precedent and as narrowly:
+ * `claimSimulations`, `recordSimulationHeartbeat`, `sweepOrphanedSimulations`
+ * and `resolveSimulationStanding` take no context and cannot be given one,
+ * because each stands where the simulator does — behind every organization on
+ * the deployment at once, with no honest credential to give it. The claim
+ * hands work out; the heartbeat keeps one dispatch alive and steers it; the
+ * sweep accounts for dispatches whose simulator died; the standing resolver
+ * answers where one dispatched row now stands, for the calls that come back
+ * about it. All four reach only rows egma's own machinery wrote — the queue,
+ * and the claims made from it — and carry out identifiers and no content.
+ * The claim hands back with every row the context the conducting is then
+ * done under, built from the row's own tenancy and from nothing the service
+ * said; the standing resolver derives that same context again from the row,
+ * and the other two derive their narrowness the same way, from the row
+ * rather than from any caller.
  * `resolveSimulationConnection` and `failSimulationDispatch` are the two
  * doors only such a claim-minted context may open — the secret the dispatch
  * needs, and the honest landing when the dispatch cannot happen — and each
@@ -194,6 +197,10 @@ export type Simulation = {
   readonly events: unknown;
   readonly metrics: unknown;
   readonly recordingReference: string | null;
+  /** How many transcript turns the conversation reached, both speakers counted. */
+  readonly turnCount: number | null;
+  /** The platform's own identifier for the exchange — the one join to the agent's telemetry. */
+  readonly providerReference: string | null;
   readonly createdAt: Date;
 };
 
@@ -216,15 +223,36 @@ export type ConductedSimulation = Simulation & {
 export type CompletedEndingReason = (typeof COMPLETED_ENDING_REASONS)[number];
 export type FailedEndingReason = (typeof FAILED_ENDING_REASONS)[number];
 
+/**
+ * The summary facts any terminal landing may carry, whatever its status: what
+ * the conversation reached, how the platform names it, what the audio
+ * measured, and the two moments the conduction itself stamped. Each is
+ * optional because a report may honestly hold none — a chat has no band, a
+ * plug may offer no reference — and everything given lands on the row as the
+ * terminal record.
+ *
+ * The moments are the simulator's own, not the arrival's: a report retried
+ * through a partition must not stretch the record by however long delivery
+ * took, so a landing given them writes them over its own stamps.
+ */
+export type SimulationSummaryFacts = {
+  /** How many transcript turns were reached, both speakers counted. */
+  readonly turnCount?: number | undefined;
+  /** The platform's own identifier for the exchange, verbatim. */
+  readonly providerReference?: string | undefined;
+  /** Measured, never declared; a chat simulation reports none. */
+  readonly measuredAudioBandHertz?: number | undefined;
+  readonly recordingReference?: string | undefined;
+  readonly startedAt?: Date | undefined;
+  readonly endedAt?: Date | undefined;
+};
+
 /** What the simulator reports about a conversation that happened. */
-export type SimulationReport = {
+export type SimulationReport = SimulationSummaryFacts & {
   readonly endingReason: CompletedEndingReason;
   readonly transcript: unknown;
   readonly events?: unknown;
   readonly metrics?: unknown;
-  /** Measured, never declared; a chat simulation reports none. */
-  readonly measuredAudioBandHertz?: number | undefined;
-  readonly recordingReference?: string | undefined;
 };
 
 /**
@@ -239,7 +267,7 @@ export type SimulationReport = {
  * handed over, which a simulator with something to report evidently
  * received.
  */
-export type SimulationFailure = {
+export type SimulationFailure = SimulationSummaryFacts & {
   readonly reason: Exclude<FailedEndingReason, "orphaned" | "dispatch_failed">;
   readonly transcript?: unknown;
   readonly events?: unknown;
@@ -295,6 +323,8 @@ const SIMULATION_COLUMNS = {
   events: simulation.events,
   metrics: simulation.metrics,
   recordingReference: simulation.recordingReference,
+  turnCount: simulation.turnCount,
+  providerReference: simulation.providerReference,
   createdAt: simulation.createdAt,
 } as const;
 
@@ -358,6 +388,47 @@ const REPORTABLE_FAILURE_REASONS: readonly FailedEndingReason[] =
   FAILED_ENDING_REASONS.filter(
     (reason) => reason !== "orphaned" && reason !== "dispatch_failed",
   );
+
+/**
+ * The summary facts as one landing will write them: checked, trimmed, and
+ * holding only the keys that were actually given — an absent fact must not
+ * become a written null over a column another path may already have filled.
+ * One helper, because all three landings owe the same facts on the same
+ * terms, and three copies of the checks would drift.
+ */
+function summaryFactsWrite(
+  facts: SimulationSummaryFacts,
+): Record<string, unknown> {
+  const write: Record<string, unknown> = {};
+
+  const { turnCount, providerReference, measuredAudioBandHertz } = facts;
+  if (turnCount !== undefined) {
+    if (!Number.isInteger(turnCount) || turnCount < 0) {
+      throw new Error(
+        "a turn count is a whole number of turns, zero or more",
+      );
+    }
+    write.turnCount = turnCount;
+  }
+  if (providerReference !== undefined) {
+    write.providerReference = providerReference.trim() || null;
+  }
+  if (measuredAudioBandHertz !== undefined) {
+    if (!Number.isInteger(measuredAudioBandHertz) || measuredAudioBandHertz <= 0) {
+      throw new Error(
+        "a measured audio band is a positive whole number of hertz",
+      );
+    }
+    write.measuredAudioBandHertz = measuredAudioBandHertz;
+  }
+  if (facts.recordingReference !== undefined) {
+    write.recordingReference = facts.recordingReference.trim() || null;
+  }
+  if (facts.startedAt !== undefined) write.startedAt = facts.startedAt;
+  if (facts.endedAt !== undefined) write.endedAt = facts.endedAt;
+
+  return write;
+}
 
 /**
  * The shape guards on every read. Stored jsonb comes back `unknown`, and a row
@@ -1682,6 +1753,82 @@ export async function claimSimulations(
 }
 
 /**
+ * Where one simulation stands, and the context its conducting continues
+ * under — what the report and heartbeat doors read before applying anything
+ * a simulator says about a row.
+ *
+ * Lifecycle stamps and identifiers, and no content: enough to tell an
+ * unknown simulation from a moved one, a duplicate from a conflict, and the
+ * claimant whose word the row takes — and nothing a customer wrote. What the
+ * work itself needs is read afterwards, through the scoped surface, under
+ * the context answered here.
+ *
+ * **It takes no `AuthContext` and cannot be given one**, on the claim's own
+ * discipline, one step later in the same lifecycle: the simulator holds no
+ * credential, so its calls about a claimed row arrive with the service
+ * token — which resolves to nobody — and the row itself is what names whose
+ * conducting this is. The context comes back built from the row's own
+ * tenancy and from nothing the caller said, exactly as the claim built it,
+ * and it is the context every write about the row then goes through. The
+ * one argument is the simulation's id — an identifier the claim itself
+ * handed out — and there is no argument by which a caller could name a
+ * customer.
+ */
+export async function resolveSimulationStanding(
+  simulationId: string,
+): Promise<SimulationStanding | undefined> {
+  const [row] = await db()
+    .select({
+      id: simulation.id,
+      runId: simulation.runId,
+      organizationId: simulation.organizationId,
+      projectId: simulation.projectId,
+      modality: simulation.modality,
+      status: simulation.status,
+      endingReason: simulation.endingReason,
+      claimedBy: simulation.claimedBy,
+      cancelRequestedAt: simulation.cancelRequestedAt,
+    })
+    .from(simulation)
+    .where(eq(simulation.id, simulationId))
+    .limit(1);
+
+  if (row === undefined) return undefined;
+
+  return {
+    id: row.id,
+    runId: row.runId,
+    modality: row.modality as Modality,
+    status: row.status as SimulationStatus,
+    endingReason: row.endingReason as SimulationEndingReason | null,
+    claimedBy: row.claimedBy,
+    cancelRequestedAt: row.cancelRequestedAt,
+    auth: conductingContext(row.organizationId, row.projectId),
+  };
+}
+
+/**
+ * What `resolveSimulationStanding` answers with: the row's lifecycle stamps,
+ * and the narrowed context every write about the row goes through.
+ */
+export type SimulationStanding = {
+  readonly id: string;
+  readonly runId: string;
+  readonly modality: Modality;
+  readonly status: SimulationStatus;
+  readonly endingReason: SimulationEndingReason | null;
+  /** The row's conductor — the claimant whose word the row takes. */
+  readonly claimedBy: string | null;
+  readonly cancelRequestedAt: Date | null;
+  /**
+   * Narrowed to this simulation's own organization and project, built here
+   * from the row and from nothing the caller said — the claim's context,
+   * derived again for the calls that come back later.
+   */
+  readonly auth: AuthContext;
+};
+
+/**
  * How the simulator reaches the agent of one claimed simulation: the
  * connection's type, its non-secret config, and the credentials unsealed — or
  * null where the customer supplies no secret for the type.
@@ -1882,7 +2029,11 @@ async function landSimulation(
   claimant: string,
   landing: {
     readonly from: readonly SimulationStatus[];
-    /** Everything this landing writes beside `ended_at` and the heartbeat. */
+    /**
+     * Everything this landing writes beside the heartbeat — including
+     * `ended_at`, when the report carried the conduction's own moment; the
+     * stamp below is only the fallback for a report that brought none.
+     */
     readonly write: Record<string, unknown>;
     /** Any further condition the landing requires of the row. */
     readonly onlyWhere?: SQL | undefined;
@@ -1892,7 +2043,7 @@ async function landSimulation(
   return db().transaction(async (tx) => {
     const [row] = await tx
       .update(simulation)
-      .set({ ...landing.write, endedAt: now, heartbeatAt: now })
+      .set({ endedAt: now, ...landing.write, heartbeatAt: now })
       .where(
         within(
           auth,
@@ -1935,7 +2086,7 @@ async function landSimulation(
 /**
  * A conversation happened and this is its record: `running → completed`, the
  * report written once with the terminal facts — how it ended, the transcript,
- * the measured audio band that can never be backfilled.
+ * the summary facts, the measured audio band that can never be backfilled.
  */
 export async function completeSimulation(
   auth: AuthContext,
@@ -1950,10 +2101,6 @@ export async function completeSimulation(
       `"${report.endingReason}" is not a way a conversation ends`,
     );
   }
-  const band = report.measuredAudioBandHertz;
-  if (band !== undefined && (!Number.isInteger(band) || band <= 0)) {
-    throw new Error("a measured audio band is a positive whole number of hertz");
-  }
 
   return landSimulation(auth, id, claimant, {
     from: ["running"],
@@ -1963,8 +2110,7 @@ export async function completeSimulation(
       transcript: report.transcript ?? null,
       events: report.events ?? null,
       metrics: report.metrics ?? null,
-      measuredAudioBandHertz: band ?? null,
-      recordingReference: report.recordingReference?.trim() || null,
+      ...summaryFactsWrite(report),
     },
   });
 }
@@ -1997,6 +2143,7 @@ export async function failSimulation(
       transcript: failure.transcript ?? null,
       events: failure.events ?? null,
       metrics: failure.metrics ?? null,
+      ...summaryFactsWrite(failure),
     },
   });
 }
@@ -2049,17 +2196,23 @@ export async function failSimulationDispatch(
  * recorded — a simulator abandoning a conversation nobody canceled is a
  * failure, not a cancellation, and is refused by the same guarded update
  * that checks everything else.
+ *
+ * A canceled conversation still landed somewhere, so the landing takes the
+ * summary facts the report carried — what had been reached by the time the
+ * directive was honored. Never an ending reason: the cancel intent is its
+ * own record, and the row's shape holds it to that.
  */
 export async function markSimulationCanceled(
   auth: AuthContext,
   id: string,
   claimant: string,
+  facts: SimulationSummaryFacts = {},
 ): Promise<Simulation | undefined> {
   authorize(auth, "start_and_cancel_runs", here(auth));
 
   return landSimulation(auth, id, claimant, {
     from: ["claimed", "running"],
-    write: { status: "canceled" },
+    write: { status: "canceled", ...summaryFactsWrite(facts) },
     onlyWhere: isNotNull(simulation.cancelRequestedAt),
   });
 }

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -233,7 +233,10 @@ export type FailedEndingReason = (typeof FAILED_ENDING_REASONS)[number];
  *
  * The moments are the simulator's own, not the arrival's: a report retried
  * through a partition must not stretch the record by however long delivery
- * took, so a landing given them writes them over its own stamps.
+ * took, so a landing given them writes them over its own stamps. Given is
+ * the caller's word to keep honest: the report door hands a pair over
+ * exactly when it can be true — an `ended_at` before its `started_at` is
+ * declined there, and the landing's own stamps stand for both.
  */
 export type SimulationSummaryFacts = {
   /** How many transcript turns were reached, both speakers counted. */

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -370,6 +370,21 @@ export const simulation = pgTable(
     metrics: jsonb("metrics"),
     /** The dual-channel recording's reference in the blob store, voice only. */
     recordingReference: text("recording_reference"),
+    /**
+     * How many transcript turns the conversation reached, both speakers
+     * counted — a terminal fact off the report, kept on the row because it is
+     * read alone to answer for one simulation. Null until a landing carries
+     * one, and null forever on a row whose report never did.
+     */
+    turnCount: integer("turn_count"),
+    /**
+     * The platform's own identifier for this exchange on the connection's
+     * side — a Retell chat id, a telephony provider's id for the dialed leg.
+     * The one join between egma's record and the agent's own telemetry, since
+     * no trace context crosses an audio channel. Verbatim from the report,
+     * never parsed; null when the plug had none to offer.
+     */
+    providerReference: text("provider_reference"),
     createdAt: createdAt(),
   },
   (table) => [
@@ -462,6 +477,18 @@ export const simulation = pgTable(
         or (${table.transcript} is null and ${table.events} is null
           and ${table.metrics} is null and ${table.recordingReference} is null
           and ${table.measuredAudioBandHertz} is null)`,
+    ),
+    // The two summary facts are terminal facts too; a check of their own
+    // beside the report's rather than a rewrite of it, because they arrived
+    // by a later migration and an additive column takes an additive guard.
+    check(
+      "simulation_summary_facts_only_when_ended",
+      sql`${table.endedAt} is not null
+        or (${table.turnCount} is null and ${table.providerReference} is null)`,
+    ),
+    check(
+      "simulation_turn_count_is_a_count",
+      sql`${table.turnCount} is null or ${table.turnCount} >= 0`,
     ),
     // A chat has no audio: a measured band or a recording on one would be a
     // number nothing produced, so the row refuses to hold it.

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -73,11 +73,12 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * afterwards. The grader and the simulator each stand behind every
  * organization on the deployment at once and hold no credential, because
  * there is no honest one to give them — so each is handed work rather than
- * asked for one, and the simulator's heartbeat and orphan sweep stand on the
- * same ground: a beat arrives bearing a token that resolves to nobody, and
- * silence is noticed by nobody in particular.
+ * asked for one, and the simulator's heartbeat, orphan sweep and standing
+ * resolver stand on the same ground: a beat arrives bearing a token that
+ * resolves to nobody, silence is noticed by nobody in particular, and a
+ * report about a held row is answered from the row.
  *
- * Five names, and a sixth is a decision somebody makes on purpose. None takes
+ * Six names, and a seventh is a decision somebody makes on purpose. None takes
  * an argument by which a caller could name a customer, and a build rule refuses
  * one that grows one; the only rows any of them reaches are egma's own queues —
  * grading jobs, and the simulations egma itself wrote and claimed. A claim
@@ -86,12 +87,15 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * heartbeat can stamp only a row already claimed under the caller's own name
  * and answers one boolean egma wrote; the sweep files each orphan's grading
  * work under the tenancy the row itself carries and answers identifiers and
- * no content.
+ * no content; `resolveSimulationStanding` is the claim's context derived
+ * again, by the id the claim handed out, for the report door — lifecycle
+ * stamps and no content.
  */
 const WORK_DISPATCHING = [
   "claimGradingJobs",
   "claimSimulations",
   "recordSimulationHeartbeat",
+  "resolveSimulationStanding",
   "sweepOrphanedSimulations",
   "watchGradingWork",
 ];

--- a/packages/db/test/migrations.test.ts
+++ b/packages/db/test/migrations.test.ts
@@ -707,6 +707,353 @@ describe("the re-grade's narrowing (0013)", () => {
   });
 });
 
+describe("the run-events record and the run's pin (0014)", () => {
+  let database: EmptyDatabase;
+  /** The schema as it stood before the record, in a directory of its own. */
+  let beforeTheRecord: string;
+  let client: pg.Client;
+
+  const organization = newId("org");
+  const project = newId("prj");
+  const agent = newId("agt");
+  const connection = newId("con");
+  const personaId = newId("prs");
+  const personaVersion = newId("prsv");
+  const run = newId("run");
+  const simulation = newId("sim");
+
+  beforeAll(async () => {
+    database = await createEmptyDatabase("run_events_upgrade");
+    beforeTheRecord = await mkdtemp(path.join(os.tmpdir(), "egma-before-0014-"));
+    for (const migration of await readMigrations()) {
+      if (migration.name < "0014") {
+        await writeFile(
+          path.join(beforeTheRecord, migration.name),
+          migration.sql,
+        );
+      }
+    }
+    await runMigrations(database.url, beforeTheRecord);
+
+    // A customer's work, written the way that release wrote it: a run over a
+    // connection, one conversation inside it, and no pinned-version column
+    // anywhere — which is exactly what 0014 has to upgrade over.
+    client = new pg.Client({ connectionString: database.url });
+    await client.connect();
+    await client.query(
+      "insert into organization (id, name, slug) values ($1, 'Acme', 'acme')",
+      [organization],
+    );
+    await client.query(
+      "insert into project (id, organization_id, name, slug) values ($1, $2, 'Default', 'default')",
+      [project, organization],
+    );
+    await client.query(
+      "insert into agent (id, organization_id, project_id, name) values ($1, $2, $3, 'Front desk')",
+      [agent, organization, project],
+    );
+    await client.query(
+      `insert into connection
+         (id, organization_id, project_id, agent_id, name, type, modality, topology, config)
+       values ($1, $2, $3, $4, 'retell-1', 'retell', 'chat', 'hosted-broker', '{}'::jsonb)`,
+      [connection, organization, project, agent],
+    );
+    await client.query("begin");
+    await client.query(
+      `insert into persona (id, organization_id, project_id, name, current_version_id)
+       values ($1, $2, $3, 'Impatient Rita', $4)`,
+      [personaId, organization, project, personaVersion],
+    );
+    await client.query(
+      "insert into persona_version (id, persona_id, version, traits) values ($1, $2, 1, '{}'::jsonb)",
+      [personaVersion, personaId],
+    );
+    await client.query("commit");
+    await client.query(
+      `insert into run
+         (id, organization_id, project_id, agent_id, connection_id, status,
+          triggered_via, requested_personas, connection_snapshot, expected_simulation_count)
+       values ($1, $2, $3, $4, $5, 'pending', 'manual', $6::jsonb, $7::jsonb, 1)`,
+      [
+        run,
+        organization,
+        project,
+        agent,
+        connection,
+        JSON.stringify({ personaIds: [personaId] }),
+        JSON.stringify({
+          type: "retell",
+          modality: "chat",
+          topology: "hosted-broker",
+          environment: null,
+          config: {},
+        }),
+      ],
+    );
+    await client.query(
+      `insert into simulation
+         (id, run_id, organization_id, project_id, agent_id, connection_id,
+          persona_id, persona_version_id, position, connection_type, modality, status)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, 1, 'retell', 'chat', 'queued')`,
+      [
+        simulation,
+        run,
+        organization,
+        project,
+        agent,
+        connection,
+        personaId,
+        personaVersion,
+      ],
+    );
+  });
+
+  afterAll(async () => {
+    await client.end();
+    await rm(beforeTheRecord, { recursive: true, force: true });
+    await database.drop();
+  });
+
+  it("is what is still pending on a database that already holds work", async () => {
+    const result = await runMigrations(database.url);
+    expect(result.applied[0]).toBe("0014_run_events.sql");
+    expect(result.applied.every((name) => name >= "0014")).toBe(true);
+  });
+
+  it("says what is true of the run that was already there: it pinned no version", async () => {
+    const { rows } = await client.query<{
+      pinned_test_versions: { testVersionIds: string[] };
+    }>("select pinned_test_versions from run where id = $1", [run]);
+    expect(rows[0]?.pinned_test_versions).toEqual({ testVersionIds: [] });
+  });
+
+  it("drops the backfill's default, so the next run has to say what it pinned", async () => {
+    await expect(
+      client.query(
+        `insert into run
+           (id, organization_id, project_id, agent_id, connection_id, status,
+            triggered_via, requested_personas, connection_snapshot, expected_simulation_count)
+         values ($1, $2, $3, $4, $5, 'pending', 'manual', '{}'::jsonb, '{}'::jsonb, 1)`,
+        [newId("run"), organization, project, agent, connection],
+      ),
+    ).rejects.toThrow(/pinned_test_versions/u);
+  });
+
+  it("brings a record that is a record: an event cannot be rewritten afterwards", async () => {
+    await client.query(
+      `insert into run_event
+         (run_id, seq, organization_id, project_id, kind, status)
+       values ($1, 1, $2, $3, 'run', 'pending')`,
+      [run, organization, project],
+    );
+    await expect(
+      client.query(
+        "update run_event set status = 'running' where run_id = $1 and seq = 1",
+        [run],
+      ),
+    ).rejects.toThrow(/is written once/u);
+  });
+});
+
+
+describe("the dispatch-failure vocabulary (0015)", () => {
+  let database: EmptyDatabase;
+  /** The schema as it stood before the widened word, in a directory of its own. */
+  let beforeTheWord: string;
+  let client: pg.Client;
+
+  const organization = newId("org");
+  const project = newId("prj");
+  const agent = newId("agt");
+  const connection = newId("con");
+  const personaId = newId("prs");
+  const personaVersion = newId("prsv");
+  const run = newId("run");
+  const claimed = newId("sim");
+  const landed = newId("sim");
+
+  beforeAll(async () => {
+    database = await createEmptyDatabase("dispatch_failure_upgrade");
+    beforeTheWord = await mkdtemp(path.join(os.tmpdir(), "egma-before-0015-"));
+    for (const migration of await readMigrations()) {
+      if (migration.name < "0015") {
+        await writeFile(path.join(beforeTheWord, migration.name), migration.sql);
+      }
+    }
+    await runMigrations(database.url, beforeTheWord);
+
+    // A customer's work as that release wrote it: a run over a connection,
+    // one conversation still queued, and one already landed with the old
+    // vocabulary — because 0015 re-validates the widened checks over every
+    // row that exists, so they have to hold for what the old release wrote.
+    client = new pg.Client({ connectionString: database.url });
+    await client.connect();
+    await client.query(
+      "insert into organization (id, name, slug) values ($1, 'Acme', 'acme')",
+      [organization],
+    );
+    await client.query(
+      "insert into project (id, organization_id, name, slug) values ($1, $2, 'Default', 'default')",
+      [project, organization],
+    );
+    await client.query(
+      "insert into agent (id, organization_id, project_id, name) values ($1, $2, $3, 'Front desk')",
+      [agent, organization, project],
+    );
+    await client.query(
+      `insert into connection
+         (id, organization_id, project_id, agent_id, name, type, modality, topology, config)
+       values ($1, $2, $3, $4, 'retell-1', 'retell', 'chat', 'hosted-broker', '{}'::jsonb)`,
+      [connection, organization, project, agent],
+    );
+    await client.query("begin");
+    await client.query(
+      `insert into persona (id, organization_id, project_id, name, current_version_id)
+       values ($1, $2, $3, 'Impatient Rita', $4)`,
+      [personaId, organization, project, personaVersion],
+    );
+    await client.query(
+      "insert into persona_version (id, persona_id, version, traits) values ($1, $2, 1, '{}'::jsonb)",
+      [personaVersion, personaId],
+    );
+    await client.query("commit");
+    await client.query(
+      `insert into run
+         (id, organization_id, project_id, agent_id, connection_id, status,
+          triggered_via, pinned_test_versions, requested_personas,
+          connection_snapshot, expected_simulation_count)
+       values ($1, $2, $3, $4, $5, 'pending', 'manual', $6::jsonb, $7::jsonb,
+          $8::jsonb, 2)`,
+      [
+        run,
+        organization,
+        project,
+        agent,
+        connection,
+        JSON.stringify({ testVersionIds: [] }),
+        JSON.stringify({ personaIds: [personaId] }),
+        JSON.stringify({
+          type: "retell",
+          modality: "chat",
+          topology: "hosted-broker",
+          environment: null,
+          config: {},
+        }),
+      ],
+    );
+    await client.query(
+      `insert into simulation
+         (id, run_id, organization_id, project_id, agent_id, connection_id,
+          persona_id, persona_version_id, position, connection_type, modality,
+          status, claimed_by, claimed_at, heartbeat_at)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, 1, 'retell', 'chat', 'claimed',
+          'simulator-blue-1', now(), now())`,
+      [
+        claimed,
+        run,
+        organization,
+        project,
+        agent,
+        connection,
+        personaId,
+        personaVersion,
+      ],
+    );
+    await client.query(
+      `insert into simulation
+         (id, run_id, organization_id, project_id, agent_id, connection_id,
+          persona_id, persona_version_id, position, connection_type, modality,
+          status, ending_reason, claimed_by, claimed_at, heartbeat_at, ended_at)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, 2, 'retell', 'chat',
+          'failed', 'simulator_error', 'simulator-blue-1', now(), now(), now())`,
+      [
+        landed,
+        run,
+        organization,
+        project,
+        agent,
+        connection,
+        personaId,
+        personaVersion,
+      ],
+    );
+  });
+
+  afterAll(async () => {
+    await client.end();
+    await rm(beforeTheWord, { recursive: true, force: true });
+    await database.drop();
+  });
+
+  it("is what is still pending on a database that already holds landed work", async () => {
+    const result = await runMigrations(database.url);
+    expect(result.applied[0]).toBe("0015_dispatch_failure.sql");
+    expect(result.applied.every((name) => name >= "0015")).toBe(true);
+  });
+
+  it("keeps what was already true: the landed conversation keeps its reason", async () => {
+    const { rows } = await client.query<{ ending_reason: string }>(
+      "select ending_reason from simulation where id = $1",
+      [landed],
+    );
+    expect(rows[0]?.ending_reason).toBe("simulator_error");
+  });
+
+  it("lets a claimed row the old release wrote take the landing the upgrade brings", async () => {
+    await client.query(
+      `update simulation
+       set status = 'failed', ending_reason = 'dispatch_failed', ended_at = now()
+       where id = $1`,
+      [claimed],
+    );
+    const { rows } = await client.query<{ ending_reason: string }>(
+      "select ending_reason from simulation where id = $1",
+      [claimed],
+    );
+    expect(rows[0]?.ending_reason).toBe("dispatch_failed");
+  });
+
+  it("holds the widened word to its class: a way to have failed, never to have ended", async () => {
+    await expect(
+      client.query(
+        `insert into simulation
+           (id, run_id, organization_id, project_id, agent_id, connection_id,
+            persona_id, persona_version_id, position, connection_type, modality,
+            status, ending_reason, claimed_by, claimed_at, heartbeat_at,
+            started_at, ended_at)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, 3, 'retell', 'chat',
+            'completed', 'dispatch_failed', 'simulator-blue-1', now(), now(),
+            now(), now())`,
+        [
+          newId("sim"),
+          run,
+          organization,
+          project,
+          agent,
+          connection,
+          personaId,
+          personaVersion,
+        ],
+      ),
+    ).rejects.toThrow(/simulation_ending_reason_agrees/u);
+  });
+
+  it("lets the record speak the widened word, and stay a record", async () => {
+    await client.query(
+      `insert into run_event
+         (run_id, seq, organization_id, project_id, kind, simulation_id, status, reason)
+       values ($1, 1, $2, $3, 'simulation', $4, 'failed', 'dispatch_failed')`,
+      [run, organization, project, claimed],
+    );
+    await expect(
+      client.query(
+        "update run_event set reason = 'simulator_error' where run_id = $1 and seq = 1",
+        [run],
+      ),
+    ).rejects.toThrow(/is written once/u);
+  });
+});
+
 /**
  * An instance that has been running since before a migration is the case a
  * migration is actually for, and it is the one an empty database never tests:
@@ -715,7 +1062,10 @@ describe("the re-grade's narrowing (0013)", () => {
  *
  * So this applies the schema as it stood one migration ago, puts a customer's
  * work into it, and then upgrades — which is what a self-hoster's `docker
- * compose pull` does on a Tuesday morning.
+ * compose pull` does on a Tuesday morning. It is about the *newest* migration
+ * on purpose, so its seed rows are written the way the release before that
+ * migration wrote them, and both move together: when a migration lands, its
+ * predecessor's upgrade story graduates into a pinned describe above.
  */
 describe("upgrading an instance that already holds work", () => {
   let database: EmptyDatabase;
@@ -745,8 +1095,11 @@ describe("upgrading an instance that already holds work", () => {
       migrations.slice(0, -1).map((migration) => migration.name),
     );
 
-    // A customer's work, written the way the release before this one wrote it:
-    // a run over a connection, and one conversation inside it.
+    // A customer's work, written the way the release before this one wrote
+    // it: a run over a connection, one conversation still queued inside it,
+    // and two already landed — a completed one, and one the release's own
+    // claim path landed as dispatch_failed — the rows the new summary-fact
+    // columns are about, and the rows their guards re-validate on the way in.
     const client = new pg.Client({ connectionString: database.url });
     await client.connect();
     const organization = newId("org");
@@ -756,7 +1109,9 @@ describe("upgrading an instance that already holds work", () => {
     const personaId = newId("prs");
     const personaVersion = newId("prsv");
     const run = newId("run");
-    const simulation = newId("sim");
+    const queued = newId("sim");
+    const landed = newId("sim");
+    const undispatched = newId("sim");
     try {
       await client.query(
         "insert into organization (id, name, slug) values ($1, 'Acme', 'acme')",
@@ -793,7 +1148,7 @@ describe("upgrading an instance that already holds work", () => {
             triggered_via, pinned_test_versions, requested_personas,
             connection_snapshot, expected_simulation_count)
          values ($1, $2, $3, $4, $5, 'pending', 'manual', $6::jsonb, $7::jsonb,
-            $8::jsonb, 2)`,
+            $8::jsonb, 3)`,
         [
           run,
           organization,
@@ -811,90 +1166,44 @@ describe("upgrading an instance that already holds work", () => {
           }),
         ],
       );
-      await client.query(
-        `insert into simulation
-           (id, run_id, organization_id, project_id, agent_id, connection_id,
-            persona_id, persona_version_id, position, connection_type, modality, status)
-         values ($1, $2, $3, $4, $5, $6, $7, $8, 1, 'retell', 'chat', 'queued')`,
-        [
-          simulation,
-          run,
-          organization,
-          project,
-          agent,
-          connection,
-          personaId,
-          personaVersion,
-        ],
-      );
-      // A conversation that already landed, wearing the old vocabulary. The
-      // upgrade re-validates its widened checks over every row that exists,
-      // so it has to hold for what the old release wrote, not just for what
-      // the new one will write.
-      const landed = newId("sim");
-      await client.query(
-        `insert into simulation
-           (id, run_id, organization_id, project_id, agent_id, connection_id,
-            persona_id, persona_version_id, position, connection_type, modality,
-            status, ending_reason, claimed_by, claimed_at, heartbeat_at, ended_at)
-         values ($1, $2, $3, $4, $5, $6, $7, $8, 2, 'retell', 'chat',
-            'failed', 'simulator_error', 'simulator-blue-1', now(), now(), now())`,
-        [
-          landed,
-          run,
-          organization,
-          project,
-          agent,
-          connection,
-          personaId,
-          personaVersion,
-        ],
-      );
-
-      // The upgrade itself, with that work sitting in the tables.
-      await writeFile(path.join(asItWas, newest.name), newest.sql);
-      const upgraded = await runMigrations(database.url, asItWas);
-      expect(upgraded.applied).toEqual([newest.name]);
-
-      // What was already true stays true: the conversation that landed under
-      // the old release keeps the reason it landed with.
-      const { rows: kept } = await client.query<{ ending_reason: string }>(
-        "select ending_reason from simulation where id = $1",
-        [landed],
-      );
-      expect(kept[0]?.ending_reason).toBe("simulator_error");
-
-      // And the queued one the old release wrote can take the landing the
-      // upgrade brings: claimed, then failed with the platform's own
-      // dispatch_failed — each step through the same lifecycle guard as ever.
-      await client.query(
-        `update simulation
-         set status = 'claimed', claimed_by = 'simulator-blue-1',
-             claimed_at = now(), heartbeat_at = now()
-         where id = $1`,
-        [simulation],
-      );
-      await client.query(
-        `update simulation
-         set status = 'failed', ending_reason = 'dispatch_failed', ended_at = now()
-         where id = $1`,
-        [simulation],
-      );
-
-      // The widened word keeps to its class: a way to have failed, and still
-      // no way for a conversation to have ended.
-      await expect(
+      const insertSimulation = (
+        id: string,
+        position: number,
+        shape: "queued" | "completed" | "dispatch_failed",
+      ) =>
         client.query(
           `insert into simulation
              (id, run_id, organization_id, project_id, agent_id, connection_id,
-              persona_id, persona_version_id, position, connection_type, modality,
-              status, ending_reason, claimed_by, claimed_at, heartbeat_at,
-              started_at, ended_at)
-           values ($1, $2, $3, $4, $5, $6, $7, $8, 3, 'retell', 'chat',
-              'completed', 'dispatch_failed', 'simulator-blue-1', now(), now(),
-              now(), now())`,
+              persona_id, persona_version_id, position, connection_type,
+              modality, status
+              ${
+                shape === "completed"
+                  ? `, claimed_by, claimed_at, heartbeat_at, started_at,
+                     ended_at, ending_reason`
+                  : ""
+              }
+              ${
+                shape === "dispatch_failed"
+                  ? `, claimed_by, claimed_at, heartbeat_at, ended_at,
+                     ending_reason`
+                  : ""
+              })
+           values ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'retell', 'chat'
+              ${
+                shape === "completed"
+                  ? `, 'completed', 'simulator-blue-1', now(), now(), now(),
+                     now(), 'persona_concluded'`
+                  : ""
+              }
+              ${
+                shape === "dispatch_failed"
+                  ? `, 'failed', 'simulator-blue-1', now(), now(), now(),
+                     'dispatch_failed'`
+                  : ""
+              }
+              ${shape === "queued" ? ", 'queued'" : ""})`,
           [
-            newId("sim"),
+            id,
             run,
             organization,
             project,
@@ -902,25 +1211,41 @@ describe("upgrading an instance that already holds work", () => {
             connection,
             personaId,
             personaVersion,
+            position,
           ],
-        ),
-      ).rejects.toThrow(/simulation_ending_reason_agrees/u);
+        );
+      await insertSimulation(queued, 1, "queued");
+      await insertSimulation(landed, 2, "completed");
+      await insertSimulation(undispatched, 3, "dispatch_failed");
 
-      // The record of that landing speaks the widened word too — and stays a
-      // record: written over the work that was already here, and never
-      // rewritten afterwards.
-      await client.query(
-        `insert into run_event
-           (run_id, seq, organization_id, project_id, kind, simulation_id, status, reason)
-         values ($1, 1, $2, $3, 'simulation', $4, 'failed', 'dispatch_failed')`,
-        [run, organization, project, simulation],
+      // The upgrade itself, with that work sitting in the tables.
+      await writeFile(path.join(asItWas, newest.name), newest.sql);
+      const upgraded = await runMigrations(database.url, asItWas);
+      expect(upgraded.applied).toEqual([newest.name]);
+
+      // The conversations that already landed say what is true of them: no
+      // turn count and no provider reference, because no report could carry
+      // either when they landed — never a number invented for them.
+      const { rows } = await client.query<{
+        turn_count: number | null;
+        provider_reference: string | null;
+      }>(
+        `select turn_count, provider_reference from simulation
+          where id in ($1, $2)`,
+        [landed, undispatched],
       );
+      expect(rows).toEqual([
+        { turn_count: null, provider_reference: null },
+        { turn_count: null, provider_reference: null },
+      ]);
+
+      // The columns arrive with their guard: summary facts are terminal
+      // facts, so the conversation still moving cannot be handed either.
       await expect(
-        client.query(
-          "update run_event set reason = 'simulator_error' where run_id = $1 and seq = 1",
-          [run],
-        ),
-      ).rejects.toThrow(/is written once/u);
+        client.query("update simulation set turn_count = 3 where id = $1", [
+          queued,
+        ]),
+      ).rejects.toThrow(/simulation_summary_facts_only_when_ended/u);
     } finally {
       await client.end();
     }

--- a/packages/db/test/runs-lifecycle-constraints.test.ts
+++ b/packages/db/test/runs-lifecycle-constraints.test.ts
@@ -404,6 +404,39 @@ describe("a simulation's shape", () => {
     );
   });
 
+  it("holds the summary facts to ended rows, exactly as the report's", async () => {
+    await expect(
+      insertSimulation("running", { turn_count: 6 }),
+    ).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.checkViolation,
+    );
+    await expect(
+      insertSimulation("claimed", { provider_reference: "chat_5d1f9a3b7c" }),
+    ).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.checkViolation,
+    );
+
+    // On a landed row they are exactly what the columns are for — canceled
+    // included, where the reason stays empty but the facts still landed.
+    await expect(
+      insertSimulation("completed", {
+        turn_count: 14,
+        provider_reference: "chat_5d1f9a3b7c",
+      }),
+    ).resolves.toBeDefined();
+    await expect(
+      insertSimulation("canceled", { turn_count: 0 }),
+    ).resolves.toBeDefined();
+  });
+
+  it("refuses a turn count below zero", async () => {
+    await expect(
+      insertSimulation("completed", { turn_count: -1 }),
+    ).rejects.toSatisfy(
+      (error) => errorCodeOf(error) === POSTGRES_ERROR.checkViolation,
+    );
+  });
+
   it("holds audio facts to voice: a chat cannot carry a band or a recording", async () => {
     await expect(
       insertSimulation("completed", { measured_audio_band_hertz: 48_000 }),

--- a/packages/db/test/runs.test.ts
+++ b/packages/db/test/runs.test.ts
@@ -24,6 +24,7 @@ import {
   markSimulationCanceled,
   NotPermittedError,
   recordSimulationHeartbeat,
+  resolveSimulationStanding,
   startRun,
   startSimulation,
   sweepOrphanedSimulations,
@@ -837,6 +838,197 @@ describe("the lifecycle, conducted by a claimant", () => {
     expect(kept?.transcript).toEqual([{ speaker: "agent", text: "Goodbye." }]);
     expect(kept?.endingReason).toBe("agent_ended");
     expect(kept?.measuredAudioBandHertz).toBeNull();
+  });
+});
+
+describe("the summary facts a terminal landing carries", () => {
+  const simulator = "simulator-blue-1";
+
+  async function runningOne(): Promise<{
+    started: StartedRun;
+    simulationId: string;
+  }> {
+    const started = await startRun(actingAsAcme(), aRun());
+    const simulationId = (await claimOwn(started.id)).id;
+    await startSimulation(actingAsAcme(), simulationId, simulator);
+    return { started, simulationId };
+  }
+
+  it("lands the turn count, the provider's reference, and the reported moments", async () => {
+    const { simulationId } = await runningOne();
+
+    const startedAt = new Date("2026-08-05T09:00:00.000Z");
+    const endedAt = new Date("2026-08-05T09:02:10.551Z");
+    const landed = await completeSimulation(actingAsAcme(), simulationId, simulator, {
+      endingReason: "persona_concluded",
+      transcript: [],
+      turnCount: 14,
+      providerReference: "chat_5d1f9a3b7c",
+      startedAt,
+      endedAt,
+    });
+
+    expect(landed?.turnCount).toBe(14);
+    expect(landed?.providerReference).toBe("chat_5d1f9a3b7c");
+    // The moments the conduction measured, not the moments the report
+    // happened to arrive: a retried report must not stretch the record.
+    expect(landed?.startedAt).toEqual(startedAt);
+    expect(landed?.endedAt).toEqual(endedAt);
+
+    const kept = await getSimulation(actingAsAcme(), simulationId);
+    expect(kept?.turnCount).toBe(14);
+    expect(kept?.providerReference).toBe("chat_5d1f9a3b7c");
+  });
+
+  it("keeps the stamps it made when a report brings no moments of its own", async () => {
+    const { simulationId } = await runningOne();
+
+    const landed = await completeSimulation(actingAsAcme(), simulationId, simulator, {
+      endingReason: "agent_ended",
+      transcript: [],
+    });
+
+    expect(landed?.turnCount).toBeNull();
+    expect(landed?.providerReference).toBeNull();
+    expect(landed?.startedAt).toBeInstanceOf(Date);
+    expect(landed?.endedAt).toBeInstanceOf(Date);
+  });
+
+  it("lands what a failed simulation still measured before it broke", async () => {
+    const { simulationId } = await runningOne();
+
+    const landed = await failSimulation(actingAsAcme(), simulationId, simulator, {
+      reason: "simulator_error",
+      turnCount: 3,
+      providerReference: "chat_9e8d7c6b5a",
+    });
+
+    expect(landed?.status).toBe("failed");
+    expect(landed?.turnCount).toBe(3);
+    expect(landed?.providerReference).toBe("chat_9e8d7c6b5a");
+  });
+
+  it("lands what a canceled conversation had by the time it stopped", async () => {
+    const { started, simulationId } = await runningOne();
+    await cancelRun(actingAsAcme(), started.id);
+
+    const landed = await markSimulationCanceled(
+      actingAsAcme(),
+      simulationId,
+      simulator,
+      { turnCount: 6, providerReference: "chat_1a2b3c4d5e" },
+    );
+
+    expect(landed?.status).toBe("canceled");
+    // The cancel intent is its own record; the reason column stays empty.
+    expect(landed?.endingReason).toBeNull();
+    expect(landed?.turnCount).toBe(6);
+    expect(landed?.providerReference).toBe("chat_1a2b3c4d5e");
+  });
+
+  it("lands a voice conversation's band and recording beside them", async () => {
+    // The seeded connection speaks chat, and the row would refuse audio facts
+    // on it — so the voice landing gets a voice connection of its own.
+    const voice = await addConnection(actingAsAcme(), agentId, {
+      type: "retell",
+      modality: "voice",
+      config: { retellAgentId: "agent_in_retell_voice" },
+      credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    });
+    if (voice === undefined) throw new Error("the voice connection was not attached");
+    const started = await startRun(
+      actingAsAcme(),
+      aRun({ connectionId: voice.id }),
+    );
+    const simulationId = (await claimOwn(started.id)).id;
+    await startSimulation(actingAsAcme(), simulationId, simulator);
+
+    const landed = await completeSimulation(actingAsAcme(), simulationId, simulator, {
+      endingReason: "agent_ended",
+      transcript: [],
+      measuredAudioBandHertz: 48_000,
+      recordingReference: `${simulationId}/dual-channel.wav`,
+      turnCount: 22,
+      providerReference: "CA7e2b9c1d4f6a8e0b",
+    });
+
+    expect(landed?.measuredAudioBandHertz).toBe(48_000);
+    expect(landed?.recordingReference).toBe(`${simulationId}/dual-channel.wav`);
+    expect(landed?.turnCount).toBe(22);
+  });
+
+  it("refuses a turn count that is not a count", async () => {
+    const { simulationId } = await runningOne();
+
+    for (const turnCount of [-1, 2.5]) {
+      await expect(
+        completeSimulation(actingAsAcme(), simulationId, simulator, {
+          endingReason: "persona_concluded",
+          transcript: [],
+          turnCount,
+        }),
+      ).rejects.toThrow(/turn count/);
+    }
+
+    await failSimulation(actingAsAcme(), simulationId, simulator, {
+      reason: "simulator_error",
+    });
+  });
+});
+
+describe("where a simulation stands, answered for the service's own routes", () => {
+  const simulator = "simulator-blue-1";
+
+  it("answers the lifecycle stamps and a context narrowed to the row's own tenancy", async () => {
+    const started = await startRun(actingAsAcme(), aRun());
+    const claimed = await claimOwn(started.id);
+
+    const standing = await resolveSimulationStanding(claimed.id);
+    expect(standing?.id).toBe(claimed.id);
+    expect(standing?.runId).toBe(started.id);
+    expect(standing?.status).toBe("claimed");
+    expect(standing?.claimedBy).toBe(simulator);
+    expect(standing?.endingReason).toBeNull();
+    expect(standing?.cancelRequestedAt).toBeNull();
+    expect(standing?.modality).toBe("chat");
+    // Built from the row and from nothing the caller said — the same context
+    // the claim itself would have handed over.
+    expect(standing?.auth).toEqual({
+      userId: "simulator",
+      organizationId: acme.organization,
+      projectId: acme.project,
+      role: "member",
+      via: "simulator",
+    });
+
+    // Lifecycle stamps and identifiers, and no content: what a customer
+    // wrote is read afterwards, through the scoped surface, under `auth`.
+    expect(standing).not.toHaveProperty("transcript");
+    expect(standing).not.toHaveProperty("events");
+    expect(standing).not.toHaveProperty("metrics");
+
+    await failSimulation(standing?.auth ?? actingAsAcme(), claimed.id, simulator, {
+      reason: "simulator_error",
+    });
+  });
+
+  it("follows the row as it moves, terminal facts included", async () => {
+    const started = await startRun(actingAsAcme(), aRun());
+    const claimed = await claimOwn(started.id);
+    await startSimulation(actingAsAcme(), claimed.id, simulator);
+    await completeSimulation(actingAsAcme(), claimed.id, simulator, {
+      endingReason: "limit_reached",
+      transcript: [],
+    });
+
+    const standing = await resolveSimulationStanding(claimed.id);
+    expect(standing?.status).toBe("completed");
+    expect(standing?.endingReason).toBe("limit_reached");
+  });
+
+  it("answers undefined for an id this deployment never issued", async () => {
+    expect(await resolveSimulationStanding(newId("sim"))).toBeUndefined();
+    expect(await resolveSimulationStanding("not-an-id-at-all")).toBeUndefined();
   });
 });
 

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -103,9 +103,10 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * key minted inside one customer would either see too little to do the job or
  * be shared between customers to do it. So each is handed work instead of
  * asked for a credential — the claims hand it out, and the simulator's
- * heartbeat and orphan sweep stand on the same ground for the same reason:
- * a beat arrives bearing the service token, which resolves to nobody, and
- * silence is noticed by nobody in particular.
+ * heartbeat, orphan sweep and standing resolver stand on the same ground for
+ * the same reason: a beat arrives bearing the service token, which resolves
+ * to nobody, silence is noticed by nobody in particular, and a report about
+ * a held row arrives from the same nobody the row must answer for.
  *
  * `claimSimulations` was added on 2026-08-08 with the simulator's claim door,
  * deliberately and after the rule stopped the build: the tenancy-scoped claim
@@ -117,6 +118,13 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * egma itself wrote, and the sweep moves only rows the claim machinery
  * stamped, filing each orphan's grading work under the tenancy the row
  * itself carries.
+ *
+ * `resolveSimulationStanding` was added the same day with the report door, on
+ * the same terms one step later in the same lifecycle: a simulator calling
+ * back about a row it already holds still has no credential, so the row is
+ * looked up by the id the claim itself handed out, and the answer carries the
+ * lifecycle stamps and the same narrowed context the claim built — which is
+ * what every write about the row then goes through.
  *
  * This category is narrower than it looks, and the rule enforces the property
  * that makes it safe: **nothing here may take an argument by which a caller
@@ -133,12 +141,13 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * every claim arrives with the `AuthContext` narrowed to that row's own
  * organization and project — which is what the work itself goes through.
  *
- * A sixth name here is a decision somebody has to make on purpose.
+ * A seventh name here is a decision somebody has to make on purpose.
  */
 const WORK_DISPATCHING = [
   "claimGradingJobs",
   "claimSimulations",
   "recordSimulationHeartbeat",
+  "resolveSimulationStanding",
   "sweepOrphanedSimulations",
   "watchGradingWork",
 ];

--- a/packages/simulation-contract/src/documents.ts
+++ b/packages/simulation-contract/src/documents.ts
@@ -15,44 +15,55 @@ const addFormats = ajvFormats as unknown as FormatsPlugin;
  * The schemas under `schemas/` are the authority, read from disk because the
  * other reader of those bytes is not TypeScript — the simulator compiles the
  * same files (`contract.py`) and holds every claimed spec to the spec schema.
- * This is the control plane's half of the same guarantee, pointed the other
- * way: a spec is checked *before it is sent*, so a document that does not
- * speak the contract is a fault caught on the sending side rather than a
- * refusal the simulator has to explain back.
+ * This is the control plane's half of the same guarantee, both ways round: a
+ * spec is checked *before it is sent*, so a document that does not speak the
+ * contract is a fault caught on the sending side rather than a refusal the
+ * simulator has to explain back — and a report is checked *as it arrives*,
+ * so nothing off the wire reaches a lifecycle write without having proven it
+ * speaks the contract the simulator's own check already applied on the way
+ * out.
  *
  * The answer is a list of complaints rather than a thrown violation, because
  * the caller's next move is not an exception's: one unbuildable spec is
- * skipped and said out loud, and the rest of the batch still goes. Each
- * complaint names the place and the problem — `/modality: must be equal to
- * one of the allowed values` — in the same shape the simulator's own check
- * logs, so the two sides of the wire read alike in two languages.
- *
- * Only the spec direction is checked from here today, because only specs are
- * composed on this side; the report direction's TypeScript half arrives with
- * the route that consumes reports.
+ * skipped and said out loud, and the rest of the batch still goes; one
+ * refused report is answered with its complaints, and the simulator's log
+ * shows the same sentences its own check would have raised. Each complaint
+ * names the place and the problem — `/modality: must be equal to one of the
+ * allowed values` — in the same shape the simulator's check logs, so the two
+ * sides of the wire read alike in two languages.
  */
 
 /**
- * Compiled once, on first use rather than at import, so loading the package
- * for its measure catalog never pays for — or fails on — schema compilation.
- * Compiling is itself part of the check: a schema that is not valid 2020-12
- * fails loudly here, rather than quietly accepting everything.
+ * Compiled once each, on first use rather than at import, so loading the
+ * package for its measure catalog never pays for — or fails on — schema
+ * compilation. Compiling is itself part of the check: a schema that is not
+ * valid 2020-12 fails loudly here, rather than quietly accepting everything.
  */
-let compiledSpec: ValidateFunction | undefined;
+function compileFromDisk(schemaFile: string): ValidateFunction {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv);
+  const schema: unknown = JSON.parse(
+    readFileSync(new URL(`../schemas/${schemaFile}`, import.meta.url), "utf8"),
+  );
+  return ajv.compile(schema as Record<string, unknown>);
+}
 
-function specValidator(): ValidateFunction {
-  if (compiledSpec === undefined) {
-    const ajv = new Ajv2020({ strict: true, allErrors: true });
-    addFormats(ajv);
-    const schema: unknown = JSON.parse(
-      readFileSync(
-        new URL("../schemas/simulation-spec.v1.schema.json", import.meta.url),
-        "utf8",
-      ),
-    );
-    compiledSpec = ajv.compile(schema as Record<string, unknown>);
-  }
-  return compiledSpec;
+let compiledSpec: ValidateFunction | undefined;
+let compiledReport: ValidateFunction | undefined;
+
+/**
+ * Everything wrong with a document by one validator's lights, or nothing.
+ * `allErrors`, deliberately, so one answer says everything wrong at once
+ * rather than one complaint per attempt.
+ */
+function complaintsFrom(
+  validate: ValidateFunction,
+  document: unknown,
+): readonly string[] {
+  if (validate(document)) return [];
+  return (validate.errors ?? []).map(
+    (error) => `${error.instancePath}: ${error.message ?? "does not validate"}`,
+  );
 }
 
 /**
@@ -60,14 +71,26 @@ function specValidator(): ValidateFunction {
  *
  * An empty answer is the green light: the document speaks the spec direction
  * of the contract and a simulator holding this contract version will accept
- * it. Anything else is the full list — `allErrors`, deliberately, so a log
- * line about a skipped simulation says everything wrong with it at once
- * rather than one complaint per attempt that will never be retried.
+ * it. Anything else is the full list, because a log line about a skipped
+ * simulation should say everything wrong with it at once rather than one
+ * complaint per attempt that will never be retried.
  */
 export function specComplaints(document: unknown): readonly string[] {
-  const validate = specValidator();
-  if (validate(document)) return [];
-  return (validate.errors ?? []).map(
-    (error) => `${error.instancePath}: ${error.message ?? "does not validate"}`,
-  );
+  compiledSpec ??= compileFromDisk("simulation-spec.v1.schema.json");
+  return complaintsFrom(compiledSpec, document);
+}
+
+/**
+ * Everything wrong with one arrived report document, or nothing.
+ *
+ * An empty answer means the document speaks the report direction of the
+ * contract, and only then does the control plane read anything out of it —
+ * which is also where the vocabulary line is held: the endings a caller may
+ * report are the ones the schema enumerates, so the platform's own words
+ * (`orphaned` is the sweep's, `dispatch_failed` the claim path's) are refused
+ * here as documents rather than reasoned about as states.
+ */
+export function reportComplaints(document: unknown): readonly string[] {
+  compiledReport ??= compileFromDisk("simulation-report.v1.schema.json");
+  return complaintsFrom(compiledReport, document);
 }

--- a/packages/simulation-contract/src/index.ts
+++ b/packages/simulation-contract/src/index.ts
@@ -5,11 +5,12 @@
  * both sides from disk, because the other reader of those bytes is not
  * TypeScript. What is here is what the control plane checks on its own side
  * of the wire: the measure catalog, which a grader's write door refuses an
- * unknown measure against, and the spec check every outgoing claim answer
- * passes through before a byte of it is sent.
+ * unknown measure against, the spec check every outgoing claim answer passes
+ * through before a byte of it is sent, and the report check every arriving
+ * document passes through before a byte of it is believed.
  */
 
-export { specComplaints } from "./documents.ts";
+export { reportComplaints, specComplaints } from "./documents.ts";
 
 export {
   catalogedMeasure,

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -7,7 +7,7 @@ import ajvFormats from "ajv-formats";
 import type { FormatsPlugin } from "ajv-formats";
 import { describe, expect, it } from "vitest";
 
-import { specComplaints } from "@egma/simulation-contract";
+import { reportComplaints, specComplaints } from "@egma/simulation-contract";
 
 // ajv-formats ships CommonJS whose module.exports is the plugin function
 // itself; under NodeNext TypeScript types the default import as a namespace,
@@ -425,5 +425,72 @@ describe("the exported spec check, which the control plane sends through", () =>
   it("complains about a document that is not an object at all", () => {
     expect(specComplaints(null).length).toBeGreaterThan(0);
     expect(specComplaints("a string").length).toBeGreaterThan(0);
+  });
+});
+
+describe("the exported report check, which the report route reads through", () => {
+  it("has no complaints about any valid golden fixture", async () => {
+    for (const fixture of await fixturesUnder("report", "valid")) {
+      expect(reportComplaints(fixture.document), fixture.name).toEqual([]);
+    }
+  });
+
+  it("complains about every deliberately invalid fixture", async () => {
+    for (const fixture of await fixturesUnder("report", "invalid")) {
+      expect(
+        reportComplaints(fixture.document).length,
+        `${fixture.name} raised no complaint`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("names the place a document is wrong, in the shape the spec check uses", async () => {
+    const carried = await readJson(
+      "fixtures",
+      "report",
+      "valid",
+      "completed-chat.json",
+    );
+
+    const { events: _events, ...missingEvents } = carried;
+    expect(reportComplaints(missingEvents)).toEqual([
+      ": must have required property 'events'",
+    ]);
+  });
+
+  it("refuses the endings that are the platform's own words, never a reporter's", async () => {
+    // `orphaned` is the sweep's verdict on a simulator that went silent, and
+    // a simulator still talking cannot claim it; `dispatch_failed` is the
+    // claim path's own landing for work it could not hand over. The wire's
+    // vocabulary carries neither, so a report claiming either is refused at
+    // validation — before any route has to reason about it.
+    const carried = await readJson(
+      "fixtures",
+      "report",
+      "valid",
+      "failed-agent-never-joined.json",
+    );
+
+    for (const ending of ["orphaned", "dispatch_failed", "capacity"]) {
+      const claiming = {
+        ...carried,
+        events: (carried.events as Record<string, unknown>[]).map((event) => ({
+          ...event,
+          facts: {
+            ...(event.facts as Record<string, unknown>),
+            ending,
+          },
+        })),
+      };
+      expect(
+        reportComplaints(claiming).length,
+        `a report claiming "${ending}" raised no complaint`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("complains about a document that is not an object at all", () => {
+    expect(reportComplaints(null).length).toBeGreaterThan(0);
+    expect(reportComplaints("a string").length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
The last of the simulator's three doors: reports land the lifecycle. With it, the whole wire is real — this PR's acceptance test walks the shipped simulator against the shipped API, queued to completed, and every column tells the truth.

- `POST /v1/simulations/:id/reports` — service-token gated, outside the per-organization budget. Arriving documents are held to the contract exactly as leaving specs already are (`reportComplaints`, sharing one compile path with `specComplaints`); an id mismatch with the URL refuses; the wire's closed ending vocabulary cannot express the platform-only words, and the route refuses them independently.
- `running` starts the simulation; the terminal three land through the row's own derived context, with the claimant taken from the row's `claimed_by` — the token gates the door, the row names its conductor. Grading work and run finalization ride the landings as built.
- Summary facts join the row: `turn_count` and `provider_reference` (migration `0016`), beside the measured audio band and recording reference. Reported `started_at`/`ended_at` write over the landing's own stamps — a report retried through a partition must not stretch the record by however long delivery took.
- Idempotent without a ledger: duplicate `running` answers 200; a terminal resend matching the row's terminal state answers 200; a conflicting terminal document answers 409 with a body written for coding agents; unknown answers 404; a canceled report for a never-requested cancellation is refused rather than invented.
- Turn, timing and tool-call events are accepted and dropped, marked interim in one place: conversation data is getting its real home as spans through the trace store's own ingest, and this door keeps the shipped reporter whole until that lands.
- New instance-wide `resolveSimulationStanding` answers where a simulation stands plus its row-derived context, on the claim's discipline, registered in the same census as its three siblings.

Tests: the 19-case route matrix over real Postgres; db-seam facts landings; raw-SQL constraint pins; the rolling-upgrade migration test re-aimed at 0016 with the dispatch-failure story pinned; and the end-to-end walk — the real Python simulator process claiming through the real claim door, conducting against a wire-shaped counterpart, reporting through this route: completed and failed walks both landing truthfully. Full suite 1889 TS + 331 simulator tests green.

Independently reviewed before opening: verdict mergeable as-is; the timestamps-override and claimant-from-row decisions adjudicated sound (including a probe that skewed clocks cannot 500 a landing); one comment reworded to keep the public repo self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the service-authenticated simulation report endpoint and connects simulator reports to the persisted lifecycle, summary facts, grading, and run finalization.
- Validates report documents and applies running, completed, failed, and canceled transitions.
- Adds idempotent handling for repeated lifecycle reports and conflict responses for contradictory reports.
- Persists simulation summary facts through migration 0016 and the database access layer.
- Registers the report route and expands contract, migration, lifecycle, route, and end-to-end coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported lifecycle issues are addressed by the current guarded retry and timestamp-pair fallback behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/reports.ts | Adds authenticated report validation, lifecycle application, idempotency, cancellation-race recovery, and coherent timestamp handling. |
| packages/db/src/access/runs.ts | Extends guarded simulation landings and standing resolution to persist report summary facts and drive existing terminal side effects. |
| packages/db/src/schema/runs.ts | Adds typed simulation summary fields corresponding to migration 0016. |
| packages/db/migrations/0016_simulation_summary_facts.sql | Adds turn-count and provider-reference persistence for terminal simulation reports. |
| packages/simulation-contract/src/documents.ts | Exposes report-document validation through the shared contract compilation path. |
| apps/api/src/server.ts | Registers the report endpoint with the configured simulator service token. |
| apps/api/test/reports-routes.test.ts | Covers authentication, validation, lifecycle transitions, idempotency, cancellation races, timestamp fallback, and persisted report facts. |
| apps/api/test/simulator-walk.test.ts | Exercises completed and failed simulator workflows through the real claim and report endpoints. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Simulator
    participant API as Report route
    participant DB as Simulation store
    participant G as Grading queue
    S->>API: POST /v1/simulations/:id/reports
    API->>API: Authenticate service token
    API->>API: Validate report contract and ID
    API->>DB: Resolve row-derived standing and context
    loop Status events in order
        API->>DB: Apply guarded lifecycle transition
        alt Transition lands
            DB-->>API: Updated simulation
        else Matching duplicate
            API->>DB: Re-read current standing
            DB-->>API: Matching lifecycle state
        else Conflicting state
            API-->>S: 409 conflict
        end
    end
    opt Completed or failed landing
        DB->>G: Enqueue grading work
        DB->>DB: Finalize run when eligible
    end
    API-->>S: 200 with persisted status
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Believe a report&#39;s moments only when the..."](https://github.com/egma-ai/egma/commit/c081973ac1c6e2f97607e05f986e163e873b430f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51437591)</sub>

<!-- /greptile_comment -->