### PR TITLE
The ingest door accepts the simulator's spans

### DIFF
--- a/apps/api/src/auth/service-token.ts
+++ b/apps/api/src/auth/service-token.ts
@@ -61,3 +61,15 @@ export function acceptsServiceToken(
     createHash("sha256").update(value, "utf8").digest();
   return timingSafeEqual(digest(presented), digest(configured));
 }
+
+/**
+ * Whether this request is at least *trying* to be the service — a bearer
+ * wearing the service prefix, whatever its secret. On a door that serves the
+ * service token beside customer credentials, this is what lets a stale or
+ * mistyped token be refused in the service's own vocabulary instead of being
+ * told to sign in: the prefix means it can never be a customer key, so the
+ * advice a customer needs would send the simulator's operator the wrong way.
+ */
+export function wearsServiceTokenPrefix(header: string | undefined): boolean {
+  return serviceTokenOn(header) !== null;
+}

--- a/apps/api/src/http/refusals.ts
+++ b/apps/api/src/http/refusals.ts
@@ -121,6 +121,24 @@ export function notTheService(reply: FastifyReply): FastifyReply {
   );
 }
 
+/**
+ * A bearer wearing the service prefix that is not this deployment's secret, on
+ * the one door that serves the service token beside customer credentials. Its
+ * own sentence because the general one would say "sign in", and the reader is
+ * a simulator's log: the prefix means this was never a customer key, and the
+ * fix is the token, not a session.
+ */
+export function wrongServiceToken(reply: FastifyReply): FastifyReply {
+  return refuse(
+    reply,
+    "not_authenticated",
+    "this bearer starts egma_st_ and is not this deployment's " +
+      "EGMA_SIMULATOR_SERVICE_TOKEN. The api and simulator containers read " +
+      "the same value — restart whichever holds a stale one. A customer key " +
+      "starts egma_sk_ and files under its own account instead.",
+  );
+}
+
 /** The organization's request budget is spent; the header says when to retry. */
 export function tooManyRequests(
   reply: FastifyReply,

--- a/apps/api/src/otlp/normalise.ts
+++ b/apps/api/src/otlp/normalise.ts
@@ -1,4 +1,4 @@
-import type { NewSpan } from "@egma/db";
+import type { NewSpan, SpanEmitter, SpanSource } from "@egma/db";
 
 import type {
   OtlpAttribute,
@@ -30,27 +30,54 @@ import type {
  * **Tenancy is not the payload's business.** A resource attribute naming an
  * organization or a project is read by nothing here, deliberately. The customer
  * comes from the credential, which is what makes a copied key unable to write
- * into somebody else's account by asking nicely.
+ * into somebody else's account by asking nicely. The one resource attribute the
+ * simulator path does read — `egma.simulation_id` — names a conversation, not
+ * a customer: the door resolves whose it is from egma's own row, so the
+ * payload's claim still decides nothing.
  */
 
-/** What this door can know about a span's provenance, and it is not much. */
-const INGESTED_AT_THIS_DOOR = {
+/**
+ * What the door knows about an export beyond what the payload says: which kind
+ * of traffic it is, which side measured it, and — for a simulation — the run
+ * and pins the door resolved from egma's own row. Everything a row carries
+ * that the wire cannot be trusted to carry.
+ */
+export type SpanAttribution = {
+  readonly source: SpanSource;
+  readonly emitter: SpanEmitter;
+  readonly runId: string;
+  readonly agentId: string;
+  readonly testVersionId: string;
+  readonly personaVersionId: string;
+};
+
+/** What this door can know about a customer key's spans, and it is not much. */
+const INGESTED_AT_THIS_DOOR: SpanAttribution = {
   /**
-   * Everything arriving here is `production`. This door cannot know a run
-   * exists: a run is created by a simulation runtime that does not yet exist,
+   * Everything arriving on a customer key is `production`. This path cannot
+   * know a run exists: a run's conversations are conducted by egma's own
+   * simulator, which posts through the same door holding the service token,
    * and `source` is an explicit column precisely so it is never inferred from
-   * `run_id` being empty. When the runtime lands it arrives through this same
-   * door and says which it is.
+   * `run_id` being empty.
    */
   source: "production",
   /**
-   * And it came from the customer's agent, which is the only thing emitting
-   * today. egma's own runtime will emit `egma-runtime` through this door and
-   * the two views of one trace will find each other by `provider_call_id`,
-   * since there is no way to carry trace context across an audio channel.
+   * And it came from the customer's agent, which is the only thing a customer
+   * key speaks for. egma's own runtime emits `egma-runtime` through this door
+   * on the service path, and the two views of one trace will find each other
+   * by `provider_call_id`, since there is no way to carry trace context across
+   * an audio channel.
    */
   emitter: "agent",
-} as const;
+  /**
+   * A run, an agent and the versions it pinned are the control plane's, and a
+   * trace arriving on a customer key was not started by egma.
+   */
+  runId: "",
+  agentId: "",
+  testVersionId: "",
+  personaVersionId: "",
+};
 
 /** The sentinel the schema declares for telemetry that named no environment. */
 const DEFAULT_ENVIRONMENT = "default";
@@ -133,6 +160,67 @@ const LIVEKIT_TOOL = {
   arguments: "lk.function_tool.arguments",
   result: "lk.function_tool.output",
 } as const;
+
+/**
+ * How egma's own simulator names the timed things inside a conversation — the
+ * scope-gated entry beside LiveKit's, and the ingest half of the emitter
+ * contract: the scope, the span names and the attribute keys are pinned by the
+ * golden fixtures in `packages/simulation-contract`, whose document says what
+ * each shape means. The simulator emits exactly those shapes; this table is
+ * what they land as.
+ *
+ * A timing span is named for the measure it takes and its duration *is* the
+ * measurement, so the five names here are the measure catalog's own
+ * timing-event entries. A measure joining the catalog adds a line here, or its
+ * spans read `other` until it does — stored either way, payload intact.
+ */
+const SIMULATOR_SCOPE = "egma-simulator";
+
+const SIMULATOR_KINDS: Readonly<Record<string, string>> = {
+  // The one span the whole conversation happened inside, emitted last: when it
+  // arrives, the conversation is over.
+  simulation: "root",
+  human_turn: "turn:human",
+  agent_turn: "turn:agent",
+  tool_call: "tool",
+  first_response_latency: "timing",
+  turn_response_latency: "timing",
+  time_to_first_word: "timing",
+  agent_speech_duration: "timing",
+  persona_speech_duration: "timing",
+};
+
+/** The two turn names, which are where the one text attribute is read. */
+const SIMULATOR_TURN_NAMES: ReadonlySet<string> = new Set([
+  "human_turn",
+  "agent_turn",
+]);
+
+const SIMULATOR_TURN_TEXT = "egma.turn.text";
+
+/**
+ * No `result` key, deliberately: the simulator observes the call from egma's
+ * side of the connection and not the return, and a key for a fact nobody
+ * observes would be the invented structure this file refuses. When a platform
+ * starts reporting results, the vocabulary grows the line.
+ */
+const SIMULATOR_TOOL = {
+  name: "egma.tool.name",
+  arguments: "egma.tool.arguments",
+} as const;
+
+/**
+ * How a resource on the service path names the simulation its spans are
+ * evidence of. Read by the door, which resolves everything tenant-shaped from
+ * the named row; on the customer path it is not consulted at all — it rides
+ * the payload like any other attribute.
+ */
+export const SIMULATION_ID_ATTRIBUTE = "egma.simulation_id";
+
+/** Which simulation this resource speaks for, or `""` for naming none. */
+export function simulationNamedBy(resourceSpans: OtlpResourceSpans): string {
+  return attribute(resourceSpans.resource?.attributes, SIMULATION_ID_ATTRIBUTE);
+}
 
 /**
  * The connection an agent was reached over, when the telemetry says so. Only
@@ -278,23 +366,51 @@ function wireId(id: string | undefined, bytes: 8 | 16): string {
   return WIRE_ID_PATTERNS[bytes]?.test(lowered) === true ? lowered : "";
 }
 
+/** The registry itself: which vocabulary each known scope's names land as. */
+const KINDS_BY_SCOPE: Readonly<
+  Record<string, Readonly<Record<string, string>>>
+> = {
+  [LIVEKIT_SCOPE]: LIVEKIT_KINDS,
+  [SIMULATOR_SCOPE]: SIMULATOR_KINDS,
+};
+
 function kindOf(scope: OtlpScope | undefined, span: OtlpSpan): string {
-  if (scope?.name === LIVEKIT_SCOPE) {
-    const known = LIVEKIT_KINDS[span.name ?? ""];
-    if (known !== undefined) return known;
-  }
+  const known = KINDS_BY_SCOPE[scope?.name ?? ""]?.[span.name ?? ""];
+  if (known !== undefined) return known;
   // A scope this table does not know is `other`, including one emitting the
-  // GenAI semantic conventions: reading those arrives with the first non-LiveKit
+  // GenAI semantic conventions: reading those arrives with the first unknown
   // provider, recognised by scope like everything else here rather than by an
   // attribute any framework might set on any span.
   return "other";
 }
 
 function textFor(scope: OtlpScope | undefined, span: OtlpSpan): string {
-  if (scope?.name !== LIVEKIT_SCOPE) return "";
-  const key = LIVEKIT_TURN_TEXT[span.name ?? ""];
-  return key === undefined ? "" : attribute(span.attributes, key);
+  if (scope?.name === LIVEKIT_SCOPE) {
+    const key = LIVEKIT_TURN_TEXT[span.name ?? ""];
+    return key === undefined ? "" : attribute(span.attributes, key);
+  }
+  if (scope?.name === SIMULATOR_SCOPE) {
+    return SIMULATOR_TURN_NAMES.has(span.name ?? "")
+      ? attribute(span.attributes, SIMULATOR_TURN_TEXT)
+      : "";
+  }
+  return "";
 }
+
+/**
+ * Where a scope's tool spans keep their facts, or nothing for a scope whose
+ * vocabulary this table does not know. `result` is optional because not every
+ * emitter observes one, and an absent fact stays absent.
+ */
+const TOOL_KEYS_BY_SCOPE: Readonly<
+  Record<
+    string,
+    { readonly name: string; readonly arguments: string; readonly result?: string }
+  >
+> = {
+  [LIVEKIT_SCOPE]: LIVEKIT_TOOL,
+  [SIMULATOR_SCOPE]: SIMULATOR_TOOL,
+};
 
 /**
  * The environment this resource's spans were recorded in, discovered here on
@@ -359,7 +475,21 @@ const TOO_MANY_BYTES =
   "before the body does. The spans that fitted were stored and the rest were " +
   "refused rather than retried; flush smaller batches.";
 
-export function normaliseOtlpExport(request: OtlpExport): NormalisedExport {
+/**
+ * Turn one export into rows.
+ *
+ * `attributionFor` is the door's knowledge of each resource, resolved before
+ * this runs: absent on the customer path, where every resource is production
+ * traffic from the customer's agent; present on the service path, where the
+ * door has already resolved each resource's simulation row and answers the
+ * stamp its spans carry. It is asked once per resource, because attribution is
+ * a fact about where the spans came from and every span of a resource came
+ * from the same place.
+ */
+export function normaliseOtlpExport(
+  request: OtlpExport,
+  attributionFor?: (resourceSpans: OtlpResourceSpans) => SpanAttribution,
+): NormalisedExport {
   const spans: NewSpan[] = [];
   const rejected: RejectedSpan[] = [];
 
@@ -371,6 +501,8 @@ export function normaliseOtlpExport(request: OtlpExport): NormalisedExport {
 
   for (const resourceSpans of request.resourceSpans ?? []) {
     const environment = environmentOf(resourceSpans);
+    const attribution =
+      attributionFor?.(resourceSpans) ?? INGESTED_AT_THIS_DOOR;
 
     for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
       const scope = scopeSpans.scope;
@@ -432,7 +564,7 @@ export function normaliseOtlpExport(request: OtlpExport): NormalisedExport {
 
         const attributes = span.attributes;
         const kind = kindOf(scope, span);
-        const isLiveKit = scope?.name === LIVEKIT_SCOPE;
+        const tool = TOOL_KEYS_BY_SCOPE[scope?.name ?? ""];
 
         payloadPrefix ??= payloadPrefixFor(resourceSpans, scopeSpans);
         const payload = `${payloadPrefix}${JSON.stringify(span)}}`;
@@ -449,8 +581,8 @@ export function normaliseOtlpExport(request: OtlpExport): NormalisedExport {
           // still in the payload, and the nesting ticket treats a span whose
           // parent is not in the trace as top-level under the real root.
           parentSpanId: wireId(span.parentSpanId, 8),
-          source: INGESTED_AT_THIS_DOOR.source,
-          emitter: INGESTED_AT_THIS_DOOR.emitter,
+          source: attribution.source,
+          emitter: attribution.emitter,
           environment: environment.environment,
           // Microseconds, because the column is DateTime64(6). The nanoseconds
           // are not lost — the full-precision duration is the column beside it,
@@ -461,14 +593,16 @@ export function normaliseOtlpExport(request: OtlpExport): NormalisedExport {
           kind,
           status: statusOf(span),
           text: textFor(scope, span),
-          // Nothing here holds audio, and the fixture's provider does not offer
-          // a reference to any. A guess would be worse than an empty column.
+          // Nothing here holds audio, and neither emitter offers a reference
+          // to any yet. A guess would be worse than an empty column.
           audioUrl: "",
-          toolName: isLiveKit ? attribute(attributes, LIVEKIT_TOOL.name) : "",
-          toolArguments: isLiveKit
-            ? attribute(attributes, LIVEKIT_TOOL.arguments)
-            : "",
-          toolResult: isLiveKit ? attribute(attributes, LIVEKIT_TOOL.result) : "",
+          toolName: tool === undefined ? "" : attribute(attributes, tool.name),
+          toolArguments:
+            tool === undefined ? "" : attribute(attributes, tool.arguments),
+          toolResult:
+            tool?.result === undefined
+              ? ""
+              : attribute(attributes, tool.result),
           providerCallId: firstAttribute(
             [attributes, resourceSpans.resource?.attributes],
             PROVIDER_CALL_ID_ATTRIBUTES,
@@ -477,14 +611,15 @@ export function normaliseOtlpExport(request: OtlpExport): NormalisedExport {
           // Measured, never declared — and nothing on this path measured it.
           audioSampleRateHz: 0,
           audioEncoding: "",
-          // A run, an agent and the versions it pinned are the control plane's,
-          // and this door has none of them: a trace arriving here was not
-          // started by egma.
-          runId: "",
-          agentId: "",
+          // The run and pins ride the attribution: the door resolved them from
+          // egma's own simulation row on the service path, and a customer
+          // key's traffic has none — a trace arriving there was not started by
+          // egma. Agents are not versioned, so nothing has a version to pin.
+          runId: attribution.runId,
+          agentId: attribution.agentId,
           agentVersionId: "",
-          testVersionId: "",
-          personaVersionId: "",
+          testVersionId: attribution.testVersionId,
+          personaVersionId: attribution.personaVersionId,
           payload,
         });
       }

--- a/apps/api/src/routes/traces.ts
+++ b/apps/api/src/routes/traces.ts
@@ -382,7 +382,6 @@ async function simulatorExport(
     };
   };
 
-  let stored = 0;
   const rejected: { count: number; firstReason: string } = {
     count: 0,
     firstReason: "",
@@ -396,12 +395,23 @@ async function simulatorExport(
       { resourceSpans: group.resources },
       attributionFor,
     );
-    stored += normalised.spans.length;
     rejected.count += normalised.rejected.length;
     rejected.firstReason ||= normalised.rejected[0]?.reason ?? "";
     appends.push({ auth: group.auth, spans: normalised.spans });
   }
 
+  // Every group is attempted, whatever happened to the one before it: one
+  // customer's refused rows must never sink another customer's evidence, and
+  // never claim it was sunk. A store that *refuses* a group — rows it has
+  // looked at and will refuse forever — costs exactly that group, counted and
+  // answered as rejected below so the sender stops resending it. A store that
+  // merely *fails* still escapes as the error it is: the whole document comes
+  // back as a retry, and the groups that landed re-append idempotently — the
+  // resend's identical flushes carry identical dedup tokens.
+  const storeRefused: { spans: number; firstMessage: string } = {
+    spans: 0,
+    firstMessage: "",
+  };
   for (const append of appends) {
     // The same function every write in the product goes through, asked with
     // the narrowed context the row resolved to. It cannot refuse a context
@@ -417,19 +427,11 @@ async function simulatorExport(
     } catch (cause) {
       if (!(cause instanceof TraceStoreRefusedError)) throw cause;
 
-      // The store looked at these rows and said no, on the customer path's
-      // exact terms: accepted request, every span rejected, reason given,
-      // because a 5xx would be retried forever. A group that landed before
-      // this one stays landed — the resend's identical flushes carry
-      // identical dedup tokens, so nothing lands twice on the way back in.
       request.log.error({ err: cause }, "the trace store refused a batch");
-      return exportResponse(
-        reply,
-        encoding,
-        stored + rejected.count,
+      storeRefused.spans += append.spans.length;
+      storeRefused.firstMessage ||=
         `the trace store refused these spans: ${cause.message}. They were ` +
-          "not stored and re-sending the same batch will not change that.",
-      );
+        "not stored and re-sending the same batch will not change that.";
     }
   }
 
@@ -437,7 +439,16 @@ async function simulatorExport(
   // grading work is minted by the transaction that lands it terminal, so the
   // telemetry path has nothing to add — a queue row from here would be the
   // second job the landing already guards against.
-  return exportResponse(reply, encoding, rejected.count, rejected.firstReason);
+  //
+  // One truthful answer: what was rejected is the normaliser's rejects plus
+  // the refused groups' spans, and nothing that landed. The field is one
+  // string, and a store refusal is the graver news, so it speaks first.
+  return exportResponse(
+    reply,
+    encoding,
+    rejected.count + storeRefused.spans,
+    storeRefused.firstMessage || rejected.firstReason,
+  );
 }
 
 export async function traceRoutes(

--- a/apps/api/src/routes/traces.ts
+++ b/apps/api/src/routes/traces.ts
@@ -5,20 +5,41 @@ import {
   authorize,
   NotPermittedError,
   recordProductionTraces,
+  resolveSimulationStanding,
   TraceStoreRefusedError,
+  type AuthContext,
+  type NewSpan,
+  type SimulationStanding,
 } from "@egma/db";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
-import { credentialed, requesterOf } from "../http/credentialed.ts";
+import { requesterOf } from "../http/credentialed.ts";
+import {
+  notAuthenticated,
+  tooManyRequests,
+  wrongServiceToken,
+} from "../http/refusals.ts";
 import type { RateLimit } from "../http/rate-limit.ts";
+import { resolveRequester } from "../auth/requester.ts";
+import {
+  acceptsServiceToken,
+  wearsServiceTokenPrefix,
+} from "../auth/service-token.ts";
 import type { SessionIdentityProvider } from "../auth/seam.ts";
+import { toIdentityRequest } from "../http/web-handler.ts";
 import {
   decodeOtlpExport,
   encodingOf,
   NotOtlpError,
   type OtlpEncoding,
+  type OtlpResourceSpans,
 } from "../otlp/decode.ts";
-import { normaliseOtlpExport } from "../otlp/normalise.ts";
+import {
+  normaliseOtlpExport,
+  simulationNamedBy,
+  SIMULATION_ID_ATTRIBUTE,
+  type SpanAttribution,
+} from "../otlp/normalise.ts";
 import {
   EXPORT_TRACE_SERVICE_RESPONSE,
   RPC_STATUS_MESSAGE,
@@ -29,17 +50,29 @@ import {
  *
  * It is the standard path an OpenTelemetry exporter posts to, so a customer's
  * agent reaches egma by setting two environment variables and writing no
- * integration code. **One door**, for the customer's agent now and for egma's
- * own simulation runtime later — one wire format, one code path, and a
- * simulation and a production trace therefore arrive the same way and are the
- * same shape at rest.
+ * integration code. **One door**, for the customer's agent and for egma's own
+ * simulator — one wire format, one code path, and a simulation and a
+ * production trace therefore arrive the same way and are the same shape at
+ * rest.
  *
- * **The organization and the project come from the credential.** A tenancy
- * attribute in the payload is not refused and not obeyed — it is simply not
- * consulted, the way a reserved attribute is treated by every platform that
- * learned this lesson the expensive way. The rows the data-access module writes
- * have no organization on them for a handler to set, so this is a property of
- * the shape rather than of anyone's care.
+ * **The door branches on the credential, and only there.** A customer key
+ * resolves tenancy as it always has. The deployment's own service token — the
+ * same secret the claim door answers to — resolves to no customer at all:
+ * each arriving resource must say which simulation its spans are evidence of
+ * (`egma.simulation_id`), and the door resolves the organization, the project
+ * and the run from that simulation's own row. Spans are accepted for any
+ * simulation this deployment conducted, whatever its status: a late-returning
+ * orphan's spans are evidence and are kept, even as its lifecycle claims are
+ * refused elsewhere.
+ *
+ * **The organization and the project come from the credential, or from egma's
+ * own row — never from the payload.** A tenancy attribute in the payload is
+ * not refused and not obeyed — it is simply not consulted, the way a reserved
+ * attribute is treated by every platform that learned this lesson the
+ * expensive way. The rows the data-access module writes have no organization
+ * on them for a handler to set, so this is a property of the shape rather than
+ * of anyone's care. The simulation id a resource names is not a tenancy claim:
+ * it names a conversation, and whose it is is read off the row egma wrote.
  *
  * **What one request may ask for is bounded, and the bound is reported rather
  * than enforced in silence.** A body stops at the size the OpenTelemetry
@@ -65,12 +98,16 @@ import {
  * Judging belongs to a service that holds no request open, and it stays there:
  * a door that judged would make an exporter's timeout depend on how many
  * graders a customer wrote and on how fast somebody else's judge model felt
- * like answering.
+ * like answering. The service path writes no queue row at all — a simulation's
+ * grading work is minted by the transaction that lands it terminal, so a span
+ * arriving here has nothing to add.
  */
 
 export type TraceRoutesOptions = {
   readonly provider: SessionIdentityProvider;
   readonly rateLimit: RateLimit;
+  /** The deployment's service token, from configuration — the second credential. */
+  readonly serviceToken: string;
 };
 
 /** The path OTLP/HTTP defines. Nothing else is served here. */
@@ -207,6 +244,202 @@ function carriesACredential(request: FastifyRequest): boolean {
   );
 }
 
+declare module "fastify" {
+  interface FastifyRequest {
+    /** Set by the gate below: this request holds the deployment's own token. */
+    simulatorIngest: boolean;
+  }
+}
+
+/**
+ * The spans of one customer's simulations, with the context they are filed
+ * under. One export may carry several simulations — even several customers' —
+ * so the resources are gathered by the tenancy their rows resolved to, and
+ * each gathering is appended under its own narrowed context, because that
+ * context is the only place an organization ever enters a row.
+ */
+type AttributedGroup = {
+  readonly auth: AuthContext;
+  readonly resources: OtlpResourceSpans[];
+};
+
+/**
+ * The simulator's own path through the door.
+ *
+ * By the time this runs, the gate has already matched the service token, and
+ * the token resolves to nobody — so the first real work is attribution: every
+ * resource must name its simulation, every named simulation must be one this
+ * deployment conducted, and both are settled before a single row is built.
+ * Attribution is all-or-nothing on purpose. A resource that cannot be
+ * attributed is an emitter defect, not a partial success: answering 200 for
+ * it would tell the sender's write-ahead log the evidence landed when it has
+ * nowhere to land, and the refusal is terminal (a 400 is never retried) so
+ * the defect surfaces in the simulator's log instead of looping.
+ *
+ * Whatever the simulation's status. The row is looked up, never inspected: a
+ * late flush for a simulation the sweep already called orphaned is evidence
+ * arriving after the verdict on the messenger, and it is kept.
+ *
+ * A refusal here is `google.rpc.Status`, like every refusal on this door —
+ * the sender is an OTLP exporter before it is anything else — with the
+ * sentence written for whoever reads the simulator's log: what happened, and
+ * what to send instead.
+ */
+async function simulatorExport(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  encoding: OtlpEncoding,
+): Promise<FastifyReply> {
+  const body = Buffer.isBuffer(request.body) ? request.body : Buffer.alloc(0);
+
+  let decoded;
+  try {
+    decoded = decodeOtlpExport(
+      encoding,
+      decompressed(body, request.headers["content-encoding"]),
+    );
+  } catch (cause) {
+    if (cause instanceof NotOtlpError) {
+      return statusResponse(reply, encoding, 400, RPC_INVALID_ARGUMENT, cause.message);
+    }
+    throw cause;
+  }
+
+  const resources = decoded.resourceSpans ?? [];
+  const named: string[] = [];
+  for (const resourceSpans of resources) {
+    const simulationId = simulationNamedBy(resourceSpans);
+    if (simulationId === "") {
+      return statusResponse(
+        reply,
+        encoding,
+        400,
+        RPC_INVALID_ARGUMENT,
+        "a resource in this export names no simulation. Spans posted with " +
+          `the service token are a simulation's evidence, so every resource ` +
+          `carries the ${SIMULATION_ID_ATTRIBUTE} resource attribute holding ` +
+          "the simulation_id from the claimed spec, exactly as it was handed " +
+          "over. Nothing from this request was stored.",
+      );
+    }
+    named.push(simulationId);
+  }
+
+  // Each named simulation resolved to where it stands — the same asking the
+  // heartbeat and report doors make about a row, because arriving spans are
+  // one more call coming back about it. The standing is looked up and never
+  // inspected: whatever state the row is in, its telemetry files under it.
+  const targets = new Map<string, SimulationStanding>();
+  for (const simulationId of new Set(named)) {
+    const standing = await resolveSimulationStanding(simulationId);
+    if (standing !== undefined) targets.set(simulationId, standing);
+  }
+  const unknown = named.find((simulationId) => !targets.has(simulationId));
+  if (unknown !== undefined) {
+    return statusResponse(
+      reply,
+      encoding,
+      400,
+      RPC_INVALID_ARGUMENT,
+      `there is no simulation ${unknown} on this egma, so its spans have ` +
+        "nowhere to file. A simulation id arrives inside a claimed spec and " +
+        "is echoed verbatim — check the resource attribute against the spec, " +
+        "and check the simulator is pointed at the deployment that handed " +
+        "the work out. Nothing from this request was stored.",
+    );
+  }
+
+  // Gathered by the customer each simulation resolved to, in arrival order —
+  // the stamp is per resource, the append is per customer, and neither is
+  // anything the payload said.
+  const groups = new Map<string, AttributedGroup>();
+  for (const [index, resourceSpans] of resources.entries()) {
+    const target = targets.get(named[index] ?? "");
+    if (target === undefined) continue;
+    const key = `${target.auth.organizationId}/${target.auth.projectId ?? ""}`;
+    const group = groups.get(key);
+    if (group === undefined) {
+      groups.set(key, { auth: target.auth, resources: [resourceSpans] });
+    } else {
+      group.resources.push(resourceSpans);
+    }
+  }
+
+  const attributionFor = (resourceSpans: OtlpResourceSpans): SpanAttribution => {
+    const target = targets.get(simulationNamedBy(resourceSpans));
+    if (target === undefined) {
+      // Every resource was checked against the map before any group was
+      // normalised, so this is this file having lost track of its own input.
+      throw new Error("a resource lost its simulation between checks");
+    }
+    return {
+      source: "simulation",
+      emitter: "egma-runtime",
+      runId: target.runId,
+      agentId: target.agentId,
+      testVersionId: target.testVersionId ?? "",
+      personaVersionId: target.personaVersionId,
+    };
+  };
+
+  let stored = 0;
+  const rejected: { count: number; firstReason: string } = {
+    count: 0,
+    firstReason: "",
+  };
+  const appends: { auth: AuthContext; spans: readonly NewSpan[] }[] = [];
+  for (const group of groups.values()) {
+    // Normalised per gathering, so the row caps guard each customer's append
+    // rather than the request: a bound loosened only by naming more
+    // customers' simulations, which only the deployment's own simulator can.
+    const normalised = normaliseOtlpExport(
+      { resourceSpans: group.resources },
+      attributionFor,
+    );
+    stored += normalised.spans.length;
+    rejected.count += normalised.rejected.length;
+    rejected.firstReason ||= normalised.rejected[0]?.reason ?? "";
+    appends.push({ auth: group.auth, spans: normalised.spans });
+  }
+
+  for (const append of appends) {
+    // The same function every write in the product goes through, asked with
+    // the narrowed context the row resolved to. It cannot refuse a context
+    // the module itself built — which is the point of asking: a change that
+    // made it refusable would surface here, not in a customer's missing rows.
+    authorize(append.auth, "ingest_traces", {
+      organizationId: append.auth.organizationId,
+      projectId: append.auth.projectId,
+    });
+
+    try {
+      await appendSpans(append.auth, append.spans);
+    } catch (cause) {
+      if (!(cause instanceof TraceStoreRefusedError)) throw cause;
+
+      // The store looked at these rows and said no, on the customer path's
+      // exact terms: accepted request, every span rejected, reason given,
+      // because a 5xx would be retried forever. A group that landed before
+      // this one stays landed — the resend's identical flushes carry
+      // identical dedup tokens, so nothing lands twice on the way back in.
+      request.log.error({ err: cause }, "the trace store refused a batch");
+      return exportResponse(
+        reply,
+        encoding,
+        stored + rejected.count,
+        `the trace store refused these spans: ${cause.message}. They were ` +
+          "not stored and re-sending the same batch will not change that.",
+      );
+    }
+  }
+
+  // And nothing goes to the grading queue, deliberately: a simulation's
+  // grading work is minted by the transaction that lands it terminal, so the
+  // telemetry path has nothing to add — a queue row from here would be the
+  // second job the landing already guards against.
+  return exportResponse(reply, encoding, rejected.count, rejected.firstReason);
+}
+
 export async function traceRoutes(
   app: FastifyInstance,
   options: TraceRoutesOptions,
@@ -236,14 +469,48 @@ export async function traceRoutes(
     },
   );
 
-  credentialed(app, {
-    provider: options.provider,
-    rateLimit: options.rateLimit,
+  // This door serves two credentials, so it carries `credentialed`'s hook
+  // spelled out rather than calling it: the service token is checked first,
+  // in constant time, and resolves to nobody — there is no requester to hand
+  // the shared hook, and no organization to key its rate limit on. The token
+  // is the gate here, exactly as on the claim door, and everything after it
+  // is checked per resolved row. Anything else falls through to the customer
+  // branch, which is `credentialed`'s own body line for line: the same
+  // resolver, the same budget, the same refusals — so the customer path is
+  // the path it always was.
+  app.decorateRequest("requester", null);
+  app.decorateRequest("simulatorIngest", false);
+  app.addHook("onRequest", async (request, reply) => {
+    if (acceptsServiceToken(request.headers.authorization, options.serviceToken)) {
+      request.simulatorIngest = true;
+      return undefined;
+    }
+    // Wearing the prefix without the secret is a mis-provisioned simulator,
+    // not a customer: it gets the fix in the service's own vocabulary rather
+    // than advice about signing in, and it never reaches the resolver — the
+    // prefix already says no customer key could be under it.
+    if (wearsServiceTokenPrefix(request.headers.authorization)) {
+      return wrongServiceToken(reply);
+    }
+
+    const requester = await resolveRequester(
+      options.provider,
+      toIdentityRequest(request),
+    );
+    if (requester === null) {
+      return notAuthenticated(reply);
+    }
+
+    const verdict = options.rateLimit.reached(requester.auth.organizationId);
+    if (!verdict.allowed) {
+      return tooManyRequests(reply, verdict.retryAfterSeconds);
+    }
+
+    request.requester = requester;
+    return undefined;
   });
 
   app.post(OTLP_TRACES_PATH, async (request, reply) => {
-    const { auth } = requesterOf(request);
-
     const encoding = encodingOf(request.headers["content-type"]);
     if (encoding === null) {
       return statusResponse(
@@ -255,6 +522,12 @@ export async function traceRoutes(
           `and this request said ${request.headers["content-type"] ?? "nothing"}.`,
       );
     }
+
+    if (request.simulatorIngest) {
+      return simulatorExport(request, reply, encoding);
+    }
+
+    const { auth } = requesterOf(request);
 
     // Writing telemetry is a write, so it goes through the same function every
     // other write in the product goes through, before the body is looked at.

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -223,8 +223,15 @@ export function buildApi(options: ServerOptions): Api {
   // The OTLP door, registered without `fastify-plugin` for the same reason the
   // provider's adapter is: it replaces every body parser inside its own scope
   // so that telemetry arrives as the bytes that were sent, and encapsulation is
-  // what stops that reaching the JSON routes above.
-  void app.register(traceRoutes, { provider: identity.provider, rateLimit });
+  // what stops that reaching the JSON routes above. It takes the service token
+  // beside the customer credentials because it is the one door with two: a
+  // customer key files an agent's traces, and the simulator's own spans arrive
+  // through this same door naming the simulation they are evidence of.
+  void app.register(traceRoutes, {
+    provider: identity.provider,
+    rateLimit,
+    serviceToken: config.simulatorServiceToken,
+  });
 
   // The v1 read surface, in its own scope beside the door rather than inside
   // it. It shares the `/v1/traces` path and none of the door's arrangements: a

--- a/apps/api/test/otlp-simulation-ingest.test.ts
+++ b/apps/api/test/otlp-simulation-ingest.test.ts
@@ -5,9 +5,11 @@ import { fileURLToPath } from "node:url";
 import {
   claimSimulations,
   completeSimulation,
+  connectClickHouse,
   createAgent,
   createPersona,
   createTest,
+  disconnectClickHouse,
   startRun,
   startSimulation,
 } from "@egma/db";
@@ -562,6 +564,125 @@ describe("a payload that claims a tenant on the service path", () => {
     expect(rows[0]?.project_id).toBe(acme.projectId);
     // Not obeyed, and not thrown away either: it is somebody's data.
     expect(rows[0]?.payload).toContain(globex.organizationId);
+  });
+});
+
+describe("a batch carrying two customers' evidence when the store refuses one of them", () => {
+  /** One turn for each simulation, on span ids nothing else in this file mints. */
+  function twoTenantBatch(): string {
+    const turn = (
+      simulationId: string,
+      traceId: string,
+      spanId: string,
+    ): Record<string, unknown> => ({
+      resource: {
+        attributes: [
+          { key: "egma.simulation_id", value: { stringValue: simulationId } },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: { name: "egma-simulator", version: "1" },
+          spans: [
+            {
+              traceId,
+              spanId,
+              name: "agent_turn",
+              startTimeUnixNano: "1785920401214000000",
+              endTimeUnixNano: "1785920401214000000",
+              attributes: [
+                {
+                  key: "egma.turn.text",
+                  value: { stringValue: "Said while the store was fussy." },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    // The refusing tenant deliberately first: a door that stopped at the first
+    // refusal would never reach the second tenant at all, and this batch is
+    // shaped to catch exactly that.
+    return JSON.stringify({
+      resourceSpans: [
+        turn(VOICE_SIMULATION, VOICE_TRACE, "ff60000000000001"),
+        turn(CHAT_SIMULATION, CHAT_TRACE, "ff60000000000002"),
+      ],
+    });
+  }
+
+  /**
+   * One customer's refused rows cost exactly that customer's spans — the
+   * other group still lands, and the answer counts as rejected only what was
+   * genuinely not stored. Nothing that landed is reported rejected: the
+   * sender's write-ahead log believes this count, and a landed span reported
+   * rejected would be evidence the sender stops owing.
+   */
+  it("lands the other customer's group, and counts only the refused one rejected", async () => {
+    await store().command(
+      "alter table spans add constraint refuses_globex check " +
+        `organization_id != '${globex.organizationId}'`,
+    );
+
+    try {
+      const response = await post(twoTenantBatch());
+
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json()).toEqual({
+        partialSuccess: {
+          rejectedSpans: "1",
+          errorMessage: expect.stringContaining("the trace store refused"),
+        },
+      });
+    } finally {
+      await store().command("alter table spans drop constraint refuses_globex");
+    }
+
+    // The tenant the store refused lost its span, and only it.
+    expect(
+      await countOf(
+        "select count() as n from spans where span_id = 'ff60000000000001'",
+      ),
+    ).toBe(0);
+    const landed = await store().rows<{ organization_id: string; text: string }>(
+      "select organization_id, text from spans where span_id = 'ff60000000000002'",
+    );
+    expect(landed).toEqual([
+      {
+        organization_id: acme.organizationId,
+        text: "Said while the store was fussy.",
+      },
+    ]);
+  });
+
+  /**
+   * The other kind of store trouble stays the error it is: rows a minute of
+   * patience would land must reach the sender as a retry, never as a
+   * rejection its write-ahead log would believe forever. The resend is safe
+   * on the groups that landed before the fault — identical flushes carry
+   * identical dedup tokens.
+   */
+  it("still answers a store that merely failed as an error the sender will retry", async () => {
+    await disconnectClickHouse();
+    try {
+      const response = await post(twoTenantBatch());
+      expect(response.statusCode).toBe(500);
+    } finally {
+      connectClickHouse({ clickhouseUrl: store().url, maxOpenConnections: 4 });
+    }
+
+    // And the same document goes through whole once the store is back.
+    const retried = await post(twoTenantBatch());
+    expect(retried.statusCode, retried.body).toBe(200);
+    expect(retried.json()).toEqual({});
+    expect(
+      await countOf(
+        "select count() as n from spans where span_id in " +
+          "('ff60000000000001', 'ff60000000000002')",
+      ),
+    ).toBe(2);
   });
 });
 

--- a/apps/api/test/otlp-simulation-ingest.test.ts
+++ b/apps/api/test/otlp-simulation-ingest.test.ts
@@ -1,0 +1,672 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  claimSimulations,
+  completeSimulation,
+  createAgent,
+  createPersona,
+  createTest,
+  startRun,
+  startSimulation,
+} from "@egma/db";
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
+import {
+  EXPORT_TRACE_SERVICE_REQUEST,
+  EXPORT_TRACE_SERVICE_RESPONSE,
+} from "../src/otlp/schema.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  signUp,
+  NEUTRAL_TRAITS,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The simulator's spans, at the same door a customer's agent posts to.
+ *
+ * The service token opens the second path through the OTLP ingest: no customer
+ * context at all, each resource naming the simulation its spans are evidence
+ * of, and the door resolving the organization, the project and the run from
+ * the simulation row — never from anything the payload claims. What is posted
+ * here is the contract's own golden fixtures, byte for byte, because those
+ * files are the meeting point with the emitter: if the door mis-files what
+ * they carry, it would mis-file the simulator.
+ *
+ * The seeded simulations are real rows made by `startRun`, then renamed by raw
+ * SQL to the ids the fixtures pin — the one edit no exported function offers,
+ * made before anything references the row, so the golden bytes can post
+ * unchanged against a database whose every other fact is genuine.
+ */
+
+const contractRoot = fileURLToPath(
+  new URL("../../../packages/simulation-contract", import.meta.url),
+);
+
+async function fixture(expectation: string, name: string): Promise<string> {
+  return readFile(
+    path.join(contractRoot, "fixtures", "spans", expectation, name),
+    "utf8",
+  );
+}
+
+/** The ids the fixtures pin, and the trace each one derives. */
+const CHAT_SIMULATION = "sim_01K3XQ7M4E8YB2FVN0H9TZQWER";
+const CHAT_TRACE = "0198fb73d08e479627eea08a75fbf1d8";
+const VOICE_SIMULATION = "sim_01K3XSW9GJ2Q4RD8VXH0MEKAFP";
+const VOICE_TRACE = "0198fb9e261215c986a37d8828e9a9f6";
+
+/** What the test API's configuration holds, and the simulator would be started with. */
+const SERVICE_TOKEN = "egma_st_held-by-this-test-suite-alone";
+
+let api: TestApi;
+let acme: Customer;
+let globex: Customer;
+let chatRunId: string;
+let voiceRunId: string;
+let acmeSeed: { agentId: string; testVersionId: string; personaVersionId: string };
+
+function store(): NonNullable<TestApi["traceStore"]> {
+  const traceStore = api.traceStore;
+  if (traceStore === undefined) throw new Error("this API has no trace store");
+  return traceStore;
+}
+
+async function countOf(query: string): Promise<number> {
+  const [row] = await store().rows<{ n: string }>(query);
+  return Number(row?.n ?? -1);
+}
+
+async function post(
+  body: string | Buffer,
+  token: string | null = SERVICE_TOKEN,
+  contentType = "application/json",
+) {
+  return api.app.inject({
+    method: "POST",
+    url: OTLP_TRACES_PATH,
+    headers: {
+      "content-type": contentType,
+      ...(token === null ? {} : { authorization: `Bearer ${token}` }),
+    },
+    payload: body,
+  });
+}
+
+/**
+ * One conversation queued for a customer, its simulation renamed to the id a
+ * fixture pins. The rename happens straight after the run starts, while no
+ * other row references the simulation, so every foreign key keeps holding.
+ */
+async function seedSimulationNamed(
+  person: Customer,
+  label: string,
+  fixtureId: string,
+): Promise<{
+  runId: string;
+  agentId: string;
+  testVersionId: string;
+  personaVersionId: string;
+}> {
+  const auth = contextFor(person, "member");
+  const created = await createAgent(auth, {
+    name: `Front desk ${label}`,
+    connection: {
+      type: "retell",
+      modality: "chat",
+      config: { retellAgentId: `agent_${label}` },
+      credentials: { apiKey: `retell-secret-${label}` },
+    },
+  });
+  const personaId = (
+    await createPersona(auth, {
+      name: `Impatient Rita ${label}`,
+      traits: NEUTRAL_TRAITS,
+    })
+  ).id;
+  const testVersionId = (
+    await createTest(auth, {
+      name: `Reschedules ${label}`,
+      scenario: "Their cleaning has to move to any afternoon next week.",
+      expectedBehaviors: ["confirms the new time back before finishing"],
+      personaIds: [personaId],
+    })
+  ).versionId;
+
+  const started = await startRun(auth, {
+    connectionId: created.connection?.id ?? "",
+    testVersionIds: [testVersionId],
+  });
+  const simulation = started.simulations[0];
+  if (simulation === undefined) throw new Error("the run has no simulation");
+
+  await api.database.sql("update simulation set id = $1 where id = $2", [
+    fixtureId,
+    simulation.id,
+  ]);
+
+  return {
+    runId: started.id,
+    agentId: created.id,
+    testVersionId,
+    personaVersionId: simulation.personaVersionId,
+  };
+}
+
+beforeAll(async () => {
+  api = await createApi("otlp_simulation", { traceStore: true });
+  acme = await signUp(api.app, "ada@acme.example", "Acme");
+  globex = await signUp(api.app, "grace@globex.example", "Globex");
+
+  const chat = await seedSimulationNamed(acme, "chat", CHAT_SIMULATION);
+  chatRunId = chat.runId;
+  acmeSeed = chat;
+  const voice = await seedSimulationNamed(globex, "voice", VOICE_SIMULATION);
+  voiceRunId = voice.runId;
+});
+
+afterAll(async () => {
+  await api?.close();
+});
+
+describe("the contract's golden flushes, posted with the service token", () => {
+  it("land under the simulation's own customer and run, marked as simulation traffic from egma's runtime", async () => {
+    const flush = await post(await fixture("valid", "chat-flush-1-turns.json"));
+    expect(flush.statusCode, flush.body).toBe(200);
+    expect(flush.json()).toEqual({});
+
+    const rows = await store().rows<{
+      organization_id: string;
+      project_id: string;
+      source: string;
+      emitter: string;
+      run_id: string;
+      agent_id: string;
+      test_version_id: string;
+      persona_version_id: string;
+      environment: string;
+    }>(
+      "select distinct organization_id, project_id, source, emitter, run_id, " +
+        "agent_id, test_version_id, persona_version_id, environment " +
+        `from spans where trace_id = '${CHAT_TRACE}'`,
+    );
+
+    expect(rows).toEqual([
+      {
+        organization_id: acme.organizationId,
+        project_id: acme.projectId,
+        source: "simulation",
+        emitter: "egma-runtime",
+        run_id: chatRunId,
+        agent_id: acmeSeed.agentId,
+        test_version_id: acmeSeed.testVersionId,
+        persona_version_id: acmeSeed.personaVersionId,
+        environment: "default",
+      },
+    ]);
+  });
+
+  it("read as the conversation they carry: turns with their text, and the measure spans' durations being the measurements", async () => {
+    const rows = await store().rows<{
+      name: string;
+      kind: string;
+      text: string;
+      duration_ns: number;
+    }>(
+      "select name, kind, text, duration_ns from spans " +
+        `where trace_id = '${CHAT_TRACE}' order by started_at, name`,
+    );
+
+    expect(rows).toEqual([
+      // The first-response measure brackets the quiet before the greeting, so
+      // its duration is the measurement: 1214 milliseconds, in nanoseconds.
+      {
+        name: "first_response_latency",
+        kind: "timing",
+        text: "",
+        duration_ns: 1_214_000_000,
+      },
+      {
+        name: "agent_turn",
+        kind: "turn:agent",
+        text: "Thanks for reaching Lakeside Dental, how can I help today?",
+        duration_ns: 0,
+      },
+      {
+        name: "human_turn",
+        kind: "turn:human",
+        text: "Oh, hello — I'm so sorry, I need to move my cleaning. It's on Tuesday, I think? Could we do Thursday instead?",
+        duration_ns: 0,
+      },
+    ]);
+
+    // And the turn view already reads them, because the kinds are the store's
+    // own turn vocabulary.
+    expect(
+      await countOf(
+        `select count() as n from turns where trace_id = '${CHAT_TRACE}'`,
+      ),
+    ).toBe(2);
+  });
+
+  /**
+   * Whatever its status. The chat simulation lands terminal here, and the
+   * remaining flushes — the tool calls, the closing turn, the root — are still
+   * accepted: with the ordered sender, spans trail the terminal document only
+   * when something was retrying, and refusing them would punch the exact hole
+   * in the record the retry existed to close.
+   */
+  it("keep landing after the simulation lands terminal", async () => {
+    const claimant = "simulator-otlp-1";
+    const claims = await claimSimulations({ claimant, capacity: 50 });
+    const ours = claims.find((claim) => claim.id === CHAT_SIMULATION);
+    if (ours === undefined) throw new Error("the claim missed the simulation");
+    await startSimulation(ours.auth, CHAT_SIMULATION, claimant);
+    await completeSimulation(ours.auth, CHAT_SIMULATION, claimant, {
+      endingReason: "persona_concluded",
+      transcript: null,
+    });
+
+    for (const name of ["chat-flush-2-tools.json", "chat-flush-3-root.json"]) {
+      const landed = await post(await fixture("valid", name));
+      expect(landed.statusCode, name).toBe(200);
+    }
+
+    const tools = await store().rows<{ tool_name: string; tool_arguments: string }>(
+      "select tool_name, tool_arguments from spans " +
+        `where trace_id = '${CHAT_TRACE}' and kind = 'tool' order by started_at`,
+    );
+    expect(tools).toEqual([
+      {
+        tool_name: "reschedule_appointment",
+        tool_arguments:
+          '{"appointment_id":"apt-88213","from":"2026-08-11T15:00:00Z","to":"2026-08-13T15:00:00Z"}',
+      },
+      // The platform reported the invocation and not its arguments, and an
+      // absent fact stays absent.
+      { tool_name: "send_confirmation_sms", tool_arguments: "" },
+    ]);
+
+    const [root] = await store().rows<{ kind: string; parent_span_id: string }>(
+      `select kind, parent_span_id from spans where trace_id = '${CHAT_TRACE}' ` +
+        "and name = 'simulation'",
+    );
+    expect(root).toEqual({ kind: "root", parent_span_id: "" });
+
+    expect(
+      await countOf(`select count() as n from spans where trace_id = '${CHAT_TRACE}'`),
+    ).toBe(8);
+  });
+
+  /**
+   * The dedup round trip at the door: the simulator's sender resends a flush
+   * byte-identically until acknowledged, and an acknowledgement it never heard
+   * makes the resend ordinary. Each flush is one insert bearing a token
+   * derived from its writer-minted ids, so the replay lands nothing.
+   */
+  it("land nothing twice when every flush is sent again", async () => {
+    const before = await countOf(
+      `select count() as n from spans where trace_id = '${CHAT_TRACE}'`,
+    );
+    const turnsBefore = await countOf(
+      `select count() as n from turns where trace_id = '${CHAT_TRACE}'`,
+    );
+    expect(before).toBe(8);
+
+    for (const name of [
+      "chat-flush-1-turns.json",
+      "chat-flush-2-tools.json",
+      "chat-flush-3-root.json",
+    ]) {
+      const again = await post(await fixture("valid", name));
+      expect(again.statusCode, name).toBe(200);
+    }
+
+    expect(
+      await countOf(`select count() as n from spans where trace_id = '${CHAT_TRACE}'`),
+    ).toBe(before);
+    expect(
+      await countOf(`select count() as n from turns where trace_id = '${CHAT_TRACE}'`),
+    ).toBe(turnsBefore);
+  });
+
+  it("file another customer's simulation under that customer, resolved through the same tokenless asking", async () => {
+    const landed = await post(await fixture("valid", "voice-overlapping-turns.json"));
+    expect(landed.statusCode, landed.body).toBe(200);
+
+    const rows = await store().rows<{
+      organization_id: string;
+      project_id: string;
+      run_id: string;
+      n: number;
+    }>(
+      "select organization_id, project_id, run_id, toUInt32(count()) as n " +
+        `from spans where trace_id = '${VOICE_TRACE}' ` +
+        "group by organization_id, project_id, run_id",
+    );
+    expect(rows).toEqual([
+      {
+        organization_id: globex.organizationId,
+        project_id: globex.projectId,
+        run_id: voiceRunId,
+        n: 4,
+      },
+    ]);
+
+    // The two turns genuinely overlap — the shape the vocabulary promises the
+    // full-duplex persona — and both are stored as they were measured.
+    const [overlap] = await store().rows<{ n: string }>(
+      "select count() as n from spans as human, spans as agent " +
+        `where human.trace_id = '${VOICE_TRACE}' and agent.trace_id = '${VOICE_TRACE}' ` +
+        "and human.kind = 'turn:human' and agent.kind = 'turn:agent' " +
+        "and human.started_at < agent.started_at + intDivOrZero(agent.duration_ns, 1000) / 1000000 " +
+        "and agent.started_at < human.started_at + intDivOrZero(human.duration_ns, 1000) / 1000000",
+    );
+    expect(Number(overlap?.n)).toBe(1);
+  });
+});
+
+/**
+ * The fixture's spans as the protobuf encoding carries them: identical in
+ * every field, with the three ids as the bytes the hex spells — which is the
+ * one place the two encodings disagree, and exactly what the door's decoder
+ * settles back to hex.
+ */
+function protobufBodyOf(fixtureJson: string): Buffer {
+  const parsed = JSON.parse(fixtureJson) as {
+    resourceSpans: {
+      scopeSpans: {
+        spans: {
+          traceId?: string;
+          spanId?: string;
+          parentSpanId?: string;
+        }[];
+      }[];
+    }[];
+  };
+  for (const resource of parsed.resourceSpans) {
+    for (const scope of resource.scopeSpans) {
+      scope.spans = scope.spans.map((span) => ({
+        ...span,
+        traceId: Buffer.from(span.traceId ?? "", "hex"),
+        spanId: Buffer.from(span.spanId ?? "", "hex"),
+        ...(span.parentSpanId === undefined
+          ? {}
+          : { parentSpanId: Buffer.from(span.parentSpanId, "hex") }),
+      })) as never;
+    }
+  }
+  return Buffer.from(
+    EXPORT_TRACE_SERVICE_REQUEST.encode(
+      EXPORT_TRACE_SERVICE_REQUEST.fromObject(parsed),
+    ).finish(),
+  );
+}
+
+describe("the same path in the other encoding", () => {
+  /**
+   * The strongest form of the dedup question: the voice flush already landed
+   * as JSON, and here it is again as protobuf — different bytes on the wire,
+   * different payload column had it landed, the same writer-minted ids. The
+   * token is derived from the ids, so the cross-encoding resend lands
+   * nothing, which no content hash could have promised.
+   */
+  it("dedups a protobuf resend of a flush that landed as JSON, because identity is the ids", async () => {
+    const before = await countOf(
+      `select count() as n from spans where trace_id = '${VOICE_TRACE}'`,
+    );
+    expect(before).toBe(4);
+
+    const resent = await post(
+      protobufBodyOf(await fixture("valid", "voice-overlapping-turns.json")),
+      SERVICE_TOKEN,
+      "application/x-protobuf",
+    );
+    expect(resent.statusCode, resent.body).toBe(200);
+    expect(resent.headers["content-type"]).toContain("application/x-protobuf");
+    expect(
+      EXPORT_TRACE_SERVICE_RESPONSE.toObject(
+        EXPORT_TRACE_SERVICE_RESPONSE.decode(resent.rawPayload),
+        { defaults: false },
+      ),
+    ).toEqual({});
+
+    expect(
+      await countOf(
+        `select count() as n from spans where trace_id = '${VOICE_TRACE}'`,
+      ),
+    ).toBe(before);
+  });
+
+  it("lands a genuinely new protobuf flush, attributed exactly as the JSON ones", async () => {
+    const late = JSON.parse(
+      await fixture("valid", "voice-overlapping-turns.json"),
+    ) as {
+      resourceSpans: {
+        scopeSpans: { spans: Record<string, unknown>[] }[];
+      }[];
+    };
+    const scope = late.resourceSpans[0]?.scopeSpans[0];
+    if (scope === undefined) throw new Error("the fixture is empty");
+    scope.spans = [
+      {
+        traceId: VOICE_TRACE,
+        spanId: "bb20000000000006",
+        parentSpanId: "bb20000000000001",
+        name: "time_to_first_word",
+        kind: "SPAN_KIND_INTERNAL",
+        startTimeUnixNano: "1785924902100000000",
+        endTimeUnixNano: "1785924902950000000",
+      },
+    ];
+
+    const landed = await post(
+      protobufBodyOf(JSON.stringify(late)),
+      SERVICE_TOKEN,
+      "application/x-protobuf",
+    );
+    expect(landed.statusCode).toBe(200);
+
+    const rows = await store().rows<{
+      kind: string;
+      duration_ns: number;
+      run_id: string;
+      source: string;
+    }>(
+      "select kind, duration_ns, run_id, source from spans " +
+        `where trace_id = '${VOICE_TRACE}' and span_id = 'bb20000000000006'`,
+    );
+    expect(rows).toEqual([
+      {
+        kind: "timing",
+        duration_ns: 850_000_000,
+        run_id: voiceRunId,
+        source: "simulation",
+      },
+    ]);
+  });
+});
+
+describe("a resource that names no simulation, or one egma never conducted", () => {
+  it("is refused whole, with a body saying what to send", async () => {
+    const before = await countOf("select count() as n from spans");
+
+    const unnamed = await post(
+      await fixture("invalid", "resource-naming-no-simulation.json"),
+    );
+    expect(unnamed.statusCode).toBe(400);
+    const refusal = unnamed.json() as { code: number; message: string };
+    expect(refusal.message).toContain("egma.simulation_id");
+
+    expect(await countOf("select count() as n from spans")).toBe(before);
+  });
+
+  it("is refused by name when the simulation never existed, and stores nothing", async () => {
+    const invented = newId("sim");
+    const body = (
+      await fixture("valid", "chat-flush-1-turns.json")
+    ).replaceAll(CHAT_SIMULATION, invented);
+
+    const before = await countOf("select count() as n from spans");
+    const refused = await post(body);
+    expect(refused.statusCode).toBe(400);
+    const refusal = refused.json() as { code: number; message: string };
+    expect(refusal.message).toContain(invented);
+
+    expect(await countOf("select count() as n from spans")).toBe(before);
+  });
+});
+
+describe("a payload that claims a tenant on the service path", () => {
+  it("is stored verbatim and decides nothing: the customer comes from the simulation row", async () => {
+    const claimed = JSON.parse(
+      await fixture("valid", "chat-flush-1-turns.json"),
+    ) as {
+      resourceSpans: {
+        resource: { attributes: { key: string; value: unknown }[] };
+        scopeSpans: { spans: Record<string, unknown>[] }[];
+      }[];
+    };
+    const resource = claimed.resourceSpans[0];
+    if (resource === undefined) throw new Error("the fixture is empty");
+    resource.resource.attributes.push(
+      { key: "organization_id", value: { stringValue: globex.organizationId } },
+      { key: "egma.organization_id", value: { stringValue: globex.organizationId } },
+      { key: "project_id", value: { stringValue: globex.projectId } },
+    );
+    // Its own span ids, so this lands beside the golden flush instead of
+    // being dropped as its resend.
+    const spans = resource.scopeSpans[0]?.spans ?? [];
+    for (const [index, span] of spans.entries()) {
+      span.spanId = `dd4000000000000${index}`;
+    }
+
+    const landed = await post(JSON.stringify(claimed));
+    expect(landed.statusCode).toBe(200);
+
+    const rows = await store().rows<{
+      organization_id: string;
+      project_id: string;
+      payload: string;
+    }>(
+      "select organization_id, project_id, payload from spans " +
+        `where trace_id = '${CHAT_TRACE}' and span_id = 'dd40000000000000'`,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.organization_id).toBe(acme.organizationId);
+    expect(rows[0]?.project_id).toBe(acme.projectId);
+    // Not obeyed, and not thrown away either: it is somebody's data.
+    expect(rows[0]?.payload).toContain(globex.organizationId);
+  });
+});
+
+describe("the customer-key path, beside it", () => {
+  /**
+   * The naming attribute belongs to the service path alone. A customer's
+   * exporter is free to send it — nothing about a customer request is refused
+   * for it — and it decides nothing: tenancy still comes from the key, the
+   * rows are still production traffic, and no run is pinned.
+   */
+  it("ignores egma.simulation_id: the key names the customer, and the rows stay production", async () => {
+    const traceId = "eeee5555eeee5555eeee5555eeee5555";
+    const body = JSON.stringify({
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              {
+                key: "egma.simulation_id",
+                value: { stringValue: CHAT_SIMULATION },
+              },
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: { name: "egma-simulator", version: "1" },
+              spans: [
+                {
+                  traceId,
+                  spanId: "ee50000000000001",
+                  name: "agent_turn",
+                  startTimeUnixNano: "1785920401214000000",
+                  endTimeUnixNano: "1785920401214000000",
+                  attributes: [
+                    {
+                      key: "egma.turn.text",
+                      value: { stringValue: "Said over a customer's key." },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const landed = await post(body, globex.secret);
+    expect(landed.statusCode, landed.body).toBe(200);
+
+    const rows = await store().rows<{
+      organization_id: string;
+      project_id: string;
+      source: string;
+      emitter: string;
+      run_id: string;
+      kind: string;
+      payload: string;
+    }>(
+      "select organization_id, project_id, source, emitter, run_id, kind, " +
+        `payload from spans where trace_id = '${traceId}'`,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      // Globex's key, so Globex's rows — not the Acme simulation the payload
+      // names, and not simulation traffic.
+      organization_id: globex.organizationId,
+      project_id: "default",
+      source: "production",
+      emitter: "agent",
+      run_id: "",
+      // The scope still gates the vocabulary, whoever posts it: the span
+      // reads as a turn either way.
+      kind: "turn:agent",
+    });
+    expect(rows[0]?.payload).toContain("egma.simulation_id");
+  });
+
+  it("refuses a stale service secret in the service's own vocabulary, not with advice about signing in", async () => {
+    const wrongSecret = await post(
+      await fixture("valid", "chat-flush-1-turns.json"),
+      "egma_st_not-the-configured-value-at-all",
+    );
+    expect(wrongSecret.statusCode).toBe(401);
+    const refusal = wrongSecret.json() as { error: string; message: string };
+    expect(refusal.error).toBe("not_authenticated");
+    // The reader is a simulator's log, and the fix is the token — the prefix
+    // already says this was never a customer key.
+    expect(refusal.message).toContain("EGMA_SIMULATOR_SERVICE_TOKEN");
+  });
+});
+
+describe("what the service path leaves alone", () => {
+  /**
+   * A simulation's grading work is minted by the transaction that lands it
+   * terminal, so the door writes no queue row for simulation spans — one had
+   * already been minted when the chat simulation completed, and a second
+   * would be the double-judging the landing guards against.
+   */
+  it("mints no grading work from a simulation's spans", async () => {
+    const jobs = await api.database.sql<{ n: string }>(
+      "select count(*) as n from grading_job where trace_id = $1",
+      [CHAT_TRACE],
+    );
+    expect(Number(jobs.rows[0]?.n)).toBe(0);
+  });
+});

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -35,21 +35,25 @@
  * is asked by the one caller with no credential at all — somebody looking at a
  * signup form — and the same test names it.
  *
- * **Work-dispatching.** `claimGradingJobs`, `watchGradingWork` and
- * `claimSimulations`, and only those three. They are asked by egma's own two
- * services — the grader and the simulator — each of which stands behind every
- * organization on the deployment at once and holds no credential, because
- * there is no honest one to give it. The exemption is narrow and each half of
- * it is enforced: none takes an argument by which a caller could name a
- * customer, and a build rule refuses one that grows one; the only rows any of
- * them reaches are egma's own queues — grading jobs, and the simulations egma
- * itself wrote as queued; a claim carries out identifiers and tenancy and
- * never anything a customer wrote; and every claim arrives with the
- * `AuthContext` narrowed to that row's own organization and project, which is
- * what all of the work afterwards goes through. `grading.ts` writes the
- * reasoning out in full and `runs.ts` inherits it whole. A fourth name in this
- * category is a deliberate act: a test names all three and fails when another
- * appears.
+ * **Work-dispatching.** `claimGradingJobs`, `watchGradingWork`,
+ * `claimSimulations`, `recordSimulationHeartbeat`, `sweepOrphanedSimulations`
+ * and `resolveSimulationStanding`, and only those six. They are asked by
+ * egma's own two services — the grader and the simulator — each of which
+ * stands behind every organization on the deployment at once and holds no
+ * credential, because there is no honest one to give it: the claims hand the
+ * work out, and the simulator's heartbeat, orphan sweep and standing resolver
+ * stand on the same ground for every call that comes back about a dispatched
+ * row — its beats, its silence, its lifecycle claims and its arriving spans.
+ * The exemption is narrow and each half of it is enforced: none takes an
+ * argument by which a caller could name a customer, and a build rule refuses
+ * one that grows one; the only rows any of them reaches are egma's own —
+ * grading jobs, and the simulations egma itself wrote and claimed; an answer
+ * carries identifiers and tenancy and never anything a customer wrote; and
+ * every answer arrives with the `AuthContext` narrowed to that row's own
+ * organization and project, which is what all of the work afterwards goes
+ * through. `grading.ts` writes the reasoning out in full and `runs.ts`
+ * inherits it whole. A seventh name in this category is a deliberate act: a
+ * test names all six and fails when another appears.
  *
  * **Deciding.** The role list, the action list, and the one function every
  * action in the product passes through. They take an `AuthContext` like

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -68,7 +68,8 @@ import { within } from "./within.ts";
  * hands work out; the heartbeat keeps one dispatch alive and steers it; the
  * sweep accounts for dispatches whose simulator died; the standing resolver
  * answers where one dispatched row now stands, for the calls that come back
- * about it. All four reach only rows egma's own machinery wrote — the queue,
+ * about it — its lifecycle claims and its arriving telemetry alike. All four
+ * reach only rows egma's own machinery wrote — the queue,
  * and the claims made from it — and carry out identifiers and no content.
  * The claim hands back with every row the context the conducting is then
  * done under, built from the row's own tenancy and from nothing the service
@@ -1757,14 +1758,17 @@ export async function claimSimulations(
 
 /**
  * Where one simulation stands, and the context its conducting continues
- * under — what the report and heartbeat doors read before applying anything
- * a simulator says about a row.
+ * under — what the report, heartbeat and telemetry doors read before applying
+ * anything a simulator says about a row.
  *
  * Lifecycle stamps and identifiers, and no content: enough to tell an
  * unknown simulation from a moved one, a duplicate from a conflict, and the
- * claimant whose word the row takes — and nothing a customer wrote. What the
- * work itself needs is read afterwards, through the scoped surface, under
- * the context answered here.
+ * claimant whose word the row takes — and nothing a customer wrote. The pins
+ * ride along for the row's arriving evidence: a span filed under the
+ * simulation carries the run and the versions its conversation executed, and
+ * they come off this same row rather than off anything the wire claimed.
+ * What the work itself needs is read afterwards, through the scoped surface,
+ * under the context answered here.
  *
  * **It takes no `AuthContext` and cannot be given one**, on the claim's own
  * discipline, one step later in the same lifecycle: the simulator holds no
@@ -1776,6 +1780,12 @@ export async function claimSimulations(
  * one argument is the simulation's id — an identifier the claim itself
  * handed out — and there is no argument by which a caller could name a
  * customer.
+ *
+ * The row is answered in whatever state it stands, terminal and swept
+ * included, and each door decides what that standing permits: the lifecycle
+ * doors refuse a claim about a row beyond help, while the telemetry door
+ * keeps a late-returning orphan's spans — evidence arriving after the
+ * verdict on the messenger.
  */
 export async function resolveSimulationStanding(
   simulationId: string,
@@ -1786,6 +1796,9 @@ export async function resolveSimulationStanding(
       runId: simulation.runId,
       organizationId: simulation.organizationId,
       projectId: simulation.projectId,
+      agentId: simulation.agentId,
+      testVersionId: simulation.testVersionId,
+      personaVersionId: simulation.personaVersionId,
       modality: simulation.modality,
       status: simulation.status,
       endingReason: simulation.endingReason,
@@ -1801,6 +1814,9 @@ export async function resolveSimulationStanding(
   return {
     id: row.id,
     runId: row.runId,
+    agentId: row.agentId,
+    testVersionId: row.testVersionId,
+    personaVersionId: row.personaVersionId,
     modality: row.modality as Modality,
     status: row.status as SimulationStatus,
     endingReason: row.endingReason as SimulationEndingReason | null,
@@ -1812,11 +1828,16 @@ export async function resolveSimulationStanding(
 
 /**
  * What `resolveSimulationStanding` answers with: the row's lifecycle stamps,
- * and the narrowed context every write about the row goes through.
+ * the pins its evidence is filed under, and the narrowed context every write
+ * about the row goes through.
  */
 export type SimulationStanding = {
   readonly id: string;
   readonly runId: string;
+  readonly agentId: string;
+  /** Absent only on an upgraded instance's history, exactly as on the claim. */
+  readonly testVersionId: string | null;
+  readonly personaVersionId: string;
   readonly modality: Modality;
   readonly status: SimulationStatus;
   readonly endingReason: SimulationEndingReason | null;

--- a/packages/db/src/access/spans.ts
+++ b/packages/db/src/access/spans.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Readable } from "node:stream";
 
 import { ClickHouseError } from "@clickhouse/client";
@@ -19,10 +20,14 @@ import { TraceStoreRefusedError } from "./errors.ts";
  * update, no delete, no merge of a later part into an earlier one. A span
  * arrives once, complete. Duplicates are not resolved at read time on this
  * table — the obligation not to send twice belongs to whoever wrote the span,
- * and ClickHouse's block-level insert dedup is the backstop under it, which is
- * why the rows this function builds are a pure function of its arguments: an
- * exporter's retry of the same batch has to produce the same bytes or the
- * backstop does not fire.
+ * and the store's insert dedup is the backstop under it. The backstop is keyed
+ * on the ids: every insert carries a deduplication token derived from the
+ * writer-minted span ids it holds, so a resend of the same batch is recognised
+ * as the same batch *by identity* — it dedups even if the bytes around the ids
+ * were re-serialised on the way, which is the guarantee a content hash alone
+ * cannot give. That only works because block construction is a pure function of
+ * this function's arguments: the same batch has to become the same blocks in
+ * the same order, or the same batch would mint a different token.
  */
 
 /**
@@ -265,7 +270,8 @@ function rowFor(auth: AuthContext, span: NewSpan): Record<string, unknown> {
  * One row, serialised exactly once.
  *
  * The line is what is sent, its byte count is what the batch budget is spent
- * from, and its month is which partition it lands in — three questions off one
+ * from, its month is which partition it lands in, and its two ids are what the
+ * block's dedup token is derived from — four questions off one
  * `JSON.stringify` instead of one throwaway serialisation per row for the
  * sizing and a second one inside the client for the wire.
  */
@@ -274,6 +280,9 @@ type SerialisedRow = {
   readonly bytes: number;
   /** `YYYY-MM`, which is `toYYYYMM(started_at)` written the way the literal is. */
   readonly month: string;
+  /** The writer-minted identity, which is what a resend repeats. */
+  readonly traceId: string;
+  readonly spanId: string;
 };
 
 function serialised(auth: AuthContext, span: NewSpan): SerialisedRow {
@@ -283,7 +292,33 @@ function serialised(auth: AuthContext, span: NewSpan): SerialisedRow {
     line,
     bytes: Buffer.byteLength(line),
     month: String(row["started_at"]).slice(0, "YYYY-MM".length),
+    traceId: span.traceId,
+    spanId: span.spanId,
   };
+}
+
+/** One insert as it goes to the store: its rows, and the token naming them. */
+type InsertBlock = {
+  readonly lines: readonly string[];
+  readonly token: string;
+};
+
+/**
+ * The block's `insert_deduplication_token`: a digest over whose spans these are
+ * and which — the tenancy, then every row's writer-minted ids, in block order.
+ *
+ * The ids alone are deliberately not enough. Nothing coordinates id minting
+ * between customers, so two of them can collide honestly, and a token that
+ * ignored tenancy would drop the second customer's telemetry as a duplicate of
+ * the first's. Tenancy plus ids is exactly what makes two spans the same span.
+ * The store tracks tokens per partition; a block is one month by construction,
+ * so the token never has to say which.
+ */
+function tokenFor(auth: AuthContext, rows: readonly SerialisedRow[]): string {
+  const digest = createHash("sha256");
+  digest.update(`spans\n${auth.organizationId}\n${auth.projectId ?? "default"}`);
+  for (const row of rows) digest.update(`\n${row.traceId}/${row.spanId}`);
+  return digest.digest("hex");
 }
 
 /**
@@ -299,9 +334,13 @@ function serialised(auth: AuthContext, span: NewSpan): SerialisedRow {
  *
  * A single row larger than the byte cap still goes, alone: splitting is how a
  * big batch gets written, never a reason to refuse one. Deterministic, because
- * an exporter's retry only dedups if it produces the identical blocks.
+ * a retry only dedups if it produces the identical blocks bearing the
+ * identical tokens.
  */
-function inserts(rows: readonly SerialisedRow[]): string[][] {
+function inserts(
+  auth: AuthContext,
+  rows: readonly SerialisedRow[],
+): InsertBlock[] {
   // Insertion-ordered, so the first month to arrive is the first block written
   // and a retry of the same batch produces the same blocks in the same order.
   const months = new Map<string, SerialisedRow[]>();
@@ -311,9 +350,16 @@ function inserts(rows: readonly SerialisedRow[]): string[][] {
     else month.push(row);
   }
 
-  const blocks: string[][] = [];
+  const blocks: InsertBlock[] = [];
+  const close = (block: readonly SerialisedRow[]): void => {
+    blocks.push({
+      lines: block.map((row) => row.line),
+      token: tokenFor(auth, block),
+    });
+  };
+
   for (const month of months.values()) {
-    let block: string[] = [];
+    let block: SerialisedRow[] = [];
     let bytes = 0;
 
     for (const row of month) {
@@ -322,15 +368,15 @@ function inserts(rows: readonly SerialisedRow[]): string[][] {
         (block.length >= MAXIMUM_ROWS_PER_INSERT ||
           bytes + row.bytes > MAXIMUM_BYTES_PER_INSERT)
       ) {
-        blocks.push(block);
+        close(block);
         block = [];
         bytes = 0;
       }
-      block.push(row.line);
+      block.push(row);
       bytes += row.bytes;
     }
 
-    if (block.length > 0) blocks.push(block);
+    if (block.length > 0) close(block);
   }
 
   return blocks;
@@ -397,10 +443,13 @@ function* lines(block: readonly string[]): Generator<string> {
  * File these spans under the caller's organization and project.
  *
  * Nothing is read first and nothing is overwritten. Sending the same batch
- * twice is not an error and is not a second copy: ClickHouse drops a repeat of
- * a byte-identical insert block, which is the one protection that works on the
- * path egma does not own — an OpenTelemetry exporter's retry is byte-identical
- * by design.
+ * twice is not an error and is not a second copy: every insert carries a
+ * deduplication token derived from its rows' writer-minted ids, and ClickHouse
+ * drops a block whose token it has already accepted. A byte-identical resend —
+ * which is what an OpenTelemetry exporter's retry is by design — repeats the
+ * ids and therefore the token; and so does a resend whose bytes drifted in
+ * re-serialisation, which is the case content-hash identity alone would land
+ * twice.
  */
 export async function appendSpans(
   auth: AuthContext,
@@ -408,18 +457,25 @@ export async function appendSpans(
 ): Promise<AppendedSpans> {
   if (spans.length === 0) return { appended: 0, batches: 0 };
 
-  const batches = inserts(spans.map((span) => serialised(auth, span)));
+  const batches = inserts(
+    auth,
+    spans.map((span) => serialised(auth, span)),
+  );
   for (const block of batches) {
     // The rows go out as the lines they were already serialised into. The
     // client's own `insert` would take the objects and stringify each one
     // again, which on a batch of fat payloads is the whole batch materialised
     // twice for no gain — so the pre-serialised body is handed to the raw
-    // path instead. The bytes ClickHouse sees are the same either way, which
-    // is what the dedup backstop is computed over.
+    // path instead.
     try {
       const { stream } = await traceStore().exec({
         query: `INSERT INTO ${SPANS_TABLE} FORMAT JSONEachRow`,
-        values: Readable.from(lines(block), { objectMode: false }),
+        values: Readable.from(lines(block.lines), { objectMode: false }),
+        clickhouse_settings: {
+          // The block's identity, stated rather than inferred from its bytes.
+          // A repeated token inside the table's dedup window is dropped whole.
+          insert_deduplication_token: block.token,
+        },
       });
       // An insert answers with an empty body, and the empty body still has to
       // be read: a response left undrained keeps its socket out of the pool

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -88,8 +88,9 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * and answers one boolean egma wrote; the sweep files each orphan's grading
  * work under the tenancy the row itself carries and answers identifiers and
  * no content; `resolveSimulationStanding` is the claim's context derived
- * again, by the id the claim handed out, for the report door — lifecycle
- * stamps and no content.
+ * again, by the id the claim handed out, for every call that comes back
+ * about a row — the report door's lifecycle claims and the ingest door's
+ * arriving spans alike — lifecycle stamps and filing pins, and no content.
  */
 const WORK_DISPATCHING = [
   "claimGradingJobs",

--- a/packages/db/test/simulation-telemetry.test.ts
+++ b/packages/db/test/simulation-telemetry.test.ts
@@ -1,0 +1,216 @@
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  claimSimulations,
+  createAgent,
+  createPersona,
+  createTest,
+  resolveSimulationStanding,
+  startRun,
+  sweepOrphanedSimulations,
+  type AuthContext,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * The standing resolver's telemetry duty: where a simulation's arriving spans
+ * file.
+ *
+ * The OTLP ingest door meets the simulator's spans holding no customer
+ * context at all — the service token resolves to nobody — and each arriving
+ * resource names only a simulation. The door asks `resolveSimulationStanding`
+ * the same way the report and heartbeat doors do, and files the spans under
+ * what it answers. The resolver's own lifecycle answers are proven beside the
+ * report machinery in `runs.test.ts`; what this file pins down is the part
+ * the telemetry door leans on: the answer carries the row's pins — the run,
+ * the agent, the versions the conversation executed — so a span row is
+ * stamped from egma's own row and never from the wire; it reaches every
+ * customer's simulations, because the evidence door stands behind them all;
+ * and it answers for a row the sweep already called orphaned, because a
+ * late-returning orphan's spans are evidence and are kept.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const globex = { organization: newId("org"), project: newId("prj") };
+
+const ada = newId("usr");
+const grace = newId("usr");
+
+function actingAsAcme(): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role: "member",
+    via: "session",
+  };
+}
+
+function actingAsGlobex(): AuthContext {
+  return {
+    userId: grace,
+    organizationId: globex.organization,
+    projectId: globex.project,
+    role: "member",
+    via: "session",
+  };
+}
+
+const NEUTRAL_TRAITS = {
+  personality: "Speaks plainly, stays patient, asks one question at a time.",
+  language: "en-US",
+  voice: {
+    provider: "elevenlabs",
+    voiceId: "EXAVITQu4vr4xnSDxMaL",
+    speed: 1,
+  },
+} as const;
+
+type SeededSimulation = {
+  readonly runId: string;
+  readonly simulationId: string;
+  readonly agentId: string;
+  readonly testVersionId: string;
+  readonly personaVersionId: string;
+};
+
+/** One queued conversation, with everything a run needs seeded around it. */
+async function oneQueuedSimulation(
+  auth: AuthContext,
+  label: string,
+): Promise<SeededSimulation> {
+  const created = await createAgent(auth, {
+    name: `Front desk ${label}`,
+    connection: {
+      type: "retell",
+      modality: "chat",
+      config: { retellAgentId: `agent_${label}` },
+      credentials: { apiKey: `retell-secret-${label}` },
+    },
+  });
+
+  const personaId = (
+    await createPersona(auth, {
+      name: `Impatient Rita ${label}`,
+      traits: NEUTRAL_TRAITS,
+    })
+  ).id;
+
+  const testVersionId = (
+    await createTest(auth, {
+      name: `Reschedules ${label}`,
+      scenario:
+        "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+      expectedBehaviors: ["confirms the new time back before finishing"],
+      personaIds: [personaId],
+    })
+  ).versionId;
+
+  const started = await startRun(auth, {
+    agentId: created.id,
+    connectionId: created.connection?.id ?? "",
+    testVersionIds: [testVersionId],
+  });
+  const simulation = started.simulations[0];
+  if (simulation === undefined) throw new Error("the run has no simulation");
+
+  return {
+    runId: started.id,
+    simulationId: simulation.id,
+    agentId: created.id,
+    testVersionId,
+    personaVersionId: simulation.personaVersionId,
+  };
+}
+
+let ours: SeededSimulation;
+let elsewhere: SeededSimulation;
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("simulation_telemetry");
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "acme" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "globex" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedUser(database, grace, "grace@globex.example");
+
+  ours = await oneQueuedSimulation(actingAsAcme(), "ours");
+  elsewhere = await oneQueuedSimulation(actingAsGlobex(), "elsewhere");
+});
+
+afterAll(async () => {
+  await database?.drop();
+});
+
+describe("where a simulation's telemetry files", () => {
+  it("carries the pins a span row is stamped from, beside the narrowed context", async () => {
+    const standing = await resolveSimulationStanding(ours.simulationId);
+
+    expect(standing).toMatchObject({
+      id: ours.simulationId,
+      runId: ours.runId,
+      agentId: ours.agentId,
+      testVersionId: ours.testVersionId,
+      personaVersionId: ours.personaVersionId,
+    });
+    // The context the spans are then filed under: this row's customer and no
+    // more, marked as the simulator's own doing — the claim's context,
+    // derived again from the row.
+    expect(standing?.auth).toEqual({
+      userId: "simulator",
+      organizationId: acme.organization,
+      projectId: acme.project,
+      role: "member",
+      via: "simulator",
+    });
+  });
+
+  it("reaches every customer's simulations, because the evidence door stands behind them all", async () => {
+    const here = await resolveSimulationStanding(ours.simulationId);
+    const there = await resolveSimulationStanding(elsewhere.simulationId);
+
+    expect(here?.auth.organizationId).toBe(acme.organization);
+    expect(there?.auth.organizationId).toBe(globex.organization);
+    expect(there?.runId).toBe(elsewhere.runId);
+  });
+
+  /**
+   * The orphan case, by name: a swept simulator that comes back has its late
+   * spans kept as evidence even as its late lifecycle claims are refused —
+   * so the row must still answer, whatever the sweep said about it.
+   */
+  it("answers for a simulation the sweep already called orphaned", async () => {
+    const abandoned = await oneQueuedSimulation(actingAsAcme(), "abandoned");
+    const claimant = "simulator-telemetry-1";
+    const claims = await claimSimulations({ claimant, capacity: 50 });
+    const claimed = claims.find((claim) => claim.id === abandoned.simulationId);
+    if (claimed === undefined) throw new Error("the claim missed the simulation");
+
+    // Silence long past the window, then the sweep tells the truth about it.
+    await database.sql(
+      `update simulation set heartbeat_at = now() - interval '1 hour' where id = $1`,
+      [abandoned.simulationId],
+    );
+    const swept = await sweepOrphanedSimulations();
+    expect(swept.map((row) => row.id)).toContain(abandoned.simulationId);
+
+    const standing = await resolveSimulationStanding(abandoned.simulationId);
+    expect(standing).toMatchObject({
+      runId: abandoned.runId,
+      status: "failed",
+      endingReason: "orphaned",
+      testVersionId: abandoned.testVersionId,
+    });
+  });
+});

--- a/packages/db/test/spans.test.ts
+++ b/packages/db/test/spans.test.ts
@@ -345,6 +345,65 @@ describe("sending the same batch twice", () => {
       ),
     ).toBe(2);
   });
+
+  /**
+   * The stronger half of the guarantee, and the reason the writer sends an
+   * explicit dedup token rather than leaning on ClickHouse's content hash
+   * alone: identity is the writer-minted ids, not the bytes. A resend that was
+   * re-serialised on the way — different field, same ids — is the same spans
+   * saying the same thing twice, and it lands once.
+   */
+  it("lands a resend once even when its bytes changed, because the ids say it is the same batch", async () => {
+    const traceId = "aaaa2222aaaa2222aaaa2222aaaa2222";
+    const batch = Array.from({ length: 5 }, (_, index) =>
+      span({ traceId, spanId: index.toString(16).padStart(16, "0") }),
+    );
+
+    await appendSpans(at(acme), batch);
+    await appendSpans(
+      at(acme),
+      batch.map((one) => ({ ...one, text: "re-serialised on the way" })),
+    );
+
+    expect(
+      await countOf(
+        `select count() as n from spans where trace_id = '${traceId}'`,
+      ),
+    ).toBe(batch.length);
+    // What landed is the first telling, which is the one that was acknowledged.
+    expect(
+      await countOf(
+        `select count() as n from spans where trace_id = '${traceId}' ` +
+          `and text = 're-serialised on the way'`,
+      ),
+    ).toBe(0);
+    // A dropped block feeds the turn view nothing either: the human is not
+    // heard saying the same thing twice because a resend changed its spelling.
+    expect(
+      await countOf(
+        `select count() as n from turns where trace_id = '${traceId}'`,
+      ),
+    ).toBe(batch.length);
+  });
+
+  /**
+   * The token says whose spans these are as well as which. Two customers can
+   * mint colliding ids — nothing coordinates them — and the second customer's
+   * telemetry must never be dropped as a duplicate of the first's.
+   */
+  it("never mistakes two customers' identical ids for one batch", async () => {
+    const traceId = "bbbb3333bbbb3333bbbb3333bbbb3333";
+    const batch = [span({ traceId, spanId: "abcdefabcdefabcd" })];
+
+    await appendSpans(at(acme), batch);
+    await appendSpans(at(globex), batch);
+
+    expect(
+      await countOf(
+        `select count() as n from spans where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+  });
 });
 
 describe("the recorded start time", () => {

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -124,7 +124,10 @@ const INSTANCE_SCOPED = ["instanceIsClaimed"];
  * back about a row it already holds still has no credential, so the row is
  * looked up by the id the claim itself handed out, and the answer carries the
  * lifecycle stamps and the same narrowed context the claim built — which is
- * what every write about the row then goes through.
+ * what every write about the row then goes through. The ingest door's
+ * service path asks it the same way for arriving telemetry, added the same
+ * day: the answer's pins are what a simulation's spans are filed under, read
+ * off egma's own row rather than off anything the payload claimed.
  *
  * This category is narrower than it looks, and the rule enforces the property
  * that makes it safe: **nothing here may take an argument by which a caller

--- a/packages/simulation-contract/fixtures/spans/invalid/resource-naming-no-simulation.json
+++ b/packages/simulation-contract/fixtures/spans/invalid/resource-naming-no-simulation.json
@@ -1,0 +1,32 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "egma-simulator" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "egma-simulator", "version": "1" },
+          "spans": [
+            {
+              "traceId": "cccc1111cccc1111cccc1111cccc1111",
+              "spanId": "cc30000000000001",
+              "name": "agent_turn",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920401214000000",
+              "endTimeUnixNano": "1785920401214000000",
+              "attributes": [
+                {
+                  "key": "egma.turn.text",
+                  "value": { "stringValue": "A turn with no simulation to file under." }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/spans/valid/chat-flush-1-turns.json
+++ b/packages/simulation-contract/fixtures/spans/valid/chat-flush-1-turns.json
@@ -1,0 +1,58 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "egma-simulator" } },
+          { "key": "egma.simulation_id", "value": { "stringValue": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "egma-simulator", "version": "1" },
+          "spans": [
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000002",
+              "parentSpanId": "aa10000000000001",
+              "name": "agent_turn",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920401214000000",
+              "endTimeUnixNano": "1785920401214000000",
+              "attributes": [
+                {
+                  "key": "egma.turn.text",
+                  "value": { "stringValue": "Thanks for reaching Lakeside Dental, how can I help today?" }
+                }
+              ]
+            },
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000004",
+              "parentSpanId": "aa10000000000001",
+              "name": "first_response_latency",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920400000000000",
+              "endTimeUnixNano": "1785920401214000000"
+            },
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000003",
+              "parentSpanId": "aa10000000000001",
+              "name": "human_turn",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920407902000000",
+              "endTimeUnixNano": "1785920407902000000",
+              "attributes": [
+                {
+                  "key": "egma.turn.text",
+                  "value": { "stringValue": "Oh, hello — I'm so sorry, I need to move my cleaning. It's on Tuesday, I think? Could we do Thursday instead?" }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/spans/valid/chat-flush-2-tools.json
+++ b/packages/simulation-contract/fixtures/spans/valid/chat-flush-2-tools.json
@@ -1,0 +1,56 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "egma-simulator" } },
+          { "key": "egma.simulation_id", "value": { "stringValue": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "egma-simulator", "version": "1" },
+          "spans": [
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000005",
+              "parentSpanId": "aa10000000000001",
+              "name": "turn_response_latency",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920410617500000",
+              "endTimeUnixNano": "1785920411480000000"
+            },
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000006",
+              "parentSpanId": "aa10000000000001",
+              "name": "tool_call",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920441377000000",
+              "endTimeUnixNano": "1785920441377000000",
+              "attributes": [
+                { "key": "egma.tool.name", "value": { "stringValue": "reschedule_appointment" } },
+                {
+                  "key": "egma.tool.arguments",
+                  "value": { "stringValue": "{\"appointment_id\":\"apt-88213\",\"from\":\"2026-08-11T15:00:00Z\",\"to\":\"2026-08-13T15:00:00Z\"}" }
+                }
+              ]
+            },
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000007",
+              "parentSpanId": "aa10000000000001",
+              "name": "tool_call",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920444020000000",
+              "endTimeUnixNano": "1785920444020000000",
+              "attributes": [
+                { "key": "egma.tool.name", "value": { "stringValue": "send_confirmation_sms" } }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/spans/valid/chat-flush-3-root.json
+++ b/packages/simulation-contract/fixtures/spans/valid/chat-flush-3-root.json
@@ -1,0 +1,42 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "egma-simulator" } },
+          { "key": "egma.simulation_id", "value": { "stringValue": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "egma-simulator", "version": "1" },
+          "spans": [
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000008",
+              "parentSpanId": "aa10000000000001",
+              "name": "agent_turn",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920444980000000",
+              "endTimeUnixNano": "1785920444980000000",
+              "attributes": [
+                {
+                  "key": "egma.turn.text",
+                  "value": { "stringValue": "You're all set for Thursday at three. Anything else I can help with?" }
+                }
+              ]
+            },
+            {
+              "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+              "spanId": "aa10000000000001",
+              "name": "simulation",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785920400000000000",
+              "endTimeUnixNano": "1785920450000000000"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/simulation-contract/fixtures/spans/valid/voice-overlapping-turns.json
+++ b/packages/simulation-contract/fixtures/spans/valid/voice-overlapping-turns.json
@@ -1,0 +1,67 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "egma-simulator" } },
+          { "key": "egma.simulation_id", "value": { "stringValue": "sim_01K3XSW9GJ2Q4RD8VXH0MEKAFP" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "egma-simulator", "version": "1" },
+          "spans": [
+            {
+              "traceId": "0198fb9e261215c986a37d8828e9a9f6",
+              "spanId": "bb20000000000002",
+              "parentSpanId": "bb20000000000001",
+              "name": "agent_turn",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785924902100000000",
+              "endTimeUnixNano": "1785924909400000000",
+              "attributes": [
+                {
+                  "key": "egma.turn.text",
+                  "value": { "stringValue": "I can offer Thursday at three or Friday at ten — which works better for you?" }
+                }
+              ]
+            },
+            {
+              "traceId": "0198fb9e261215c986a37d8828e9a9f6",
+              "spanId": "bb20000000000003",
+              "parentSpanId": "bb20000000000001",
+              "name": "human_turn",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785924907850000000",
+              "endTimeUnixNano": "1785924911020000000",
+              "attributes": [
+                {
+                  "key": "egma.turn.text",
+                  "value": { "stringValue": "Sorry — Friday, Friday at ten is perfect." }
+                }
+              ]
+            },
+            {
+              "traceId": "0198fb9e261215c986a37d8828e9a9f6",
+              "spanId": "bb20000000000004",
+              "parentSpanId": "bb20000000000001",
+              "name": "agent_speech_duration",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785924903250000000",
+              "endTimeUnixNano": "1785924909400000000"
+            },
+            {
+              "traceId": "0198fb9e261215c986a37d8828e9a9f6",
+              "spanId": "bb20000000000005",
+              "parentSpanId": "bb20000000000001",
+              "name": "persona_speech_duration",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1785924907850000000",
+              "endTimeUnixNano": "1785924911020000000"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/simulation-contract/package.json
+++ b/packages/simulation-contract/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist",
     "schemas",
-    "measure-catalog.md"
+    "measure-catalog.md",
+    "span-vocabulary.md"
   ],
   "scripts": {
     "build": "tsc -b"

--- a/packages/simulation-contract/span-vocabulary.md
+++ b/packages/simulation-contract/span-vocabulary.md
@@ -1,0 +1,109 @@
+# The span vocabulary
+
+**Contract version: 1**
+
+Every span the simulator emits, named once, so that the emitter and the
+platform's OTLP ingest agree on the same shapes and neither can change them
+quietly.
+
+This is a contract document, not a schema. On the wire a conversation is an
+ordinary OpenTelemetry `ExportTraceServiceRequest`, posted at the same ingest
+door a customer's agent posts to — that is the point of speaking OTLP at all.
+What this document pins down is the part OTLP leaves open: what the spans are
+called, which attributes carry the conversation, and how a batch names the
+simulation it is evidence of. It sits beside `measure-catalog.md` because it is
+the same kind of fact: what the simulator emits, agreed between the simulator
+and the control plane, versioned so drift breaks a build instead of a customer.
+
+The golden fixtures under `fixtures/spans/` are this document as bytes. The
+`valid/` files are flushes of real conversations — the simulator emits exactly
+these shapes, and the ingest's own suite posts these same files and asserts
+what lands. The `invalid/` file is the one refusal the ingest makes at the
+batch grain: a resource that names no simulation. Both suites read the same
+files, which is what keeps the two sides from drifting apart silently.
+
+## How a batch names its simulation
+
+Every OTLP resource in a batch carries one resource attribute:
+
+| Resource attribute | Value |
+| --- | --- |
+| `egma.simulation_id` | The simulation this telemetry is evidence of, echoed verbatim from the claimed spec. Opaque to the simulator: never parsed, never minted, never rewritten. |
+
+The ingest resolves the organization, the project and the run from the
+simulation row on the platform's own side — a resource attribute claiming a
+tenant is stored in the payload like any other attribute and never consulted.
+A resource naming no simulation, or naming one the deployment never conducted,
+refuses the whole request; there is nowhere honest to file it.
+
+`service.name` is carried too, because that is what a well-formed
+OpenTelemetry resource does. It decides nothing.
+
+## Trace identity
+
+The trace id is derived from the simulation id, deterministically, so the
+conversation's spans and its verdicts can always find each other:
+
+- **trace id** — the simulation id's own 128 bits: the 26 Crockford base32
+  characters after `sim_` decoded to a 128-bit integer, written as 32 lowercase
+  hex characters. `sim_01K3XQ7M4E8YB2FVN0H9TZQWER` is trace
+  `0198fb73d08e479627eea08a75fbf1d8`, always.
+- **span ids** — minted by the emitter when the span is authored, unique within
+  the trace, and stable across resends: a resent flush replays the same bytes,
+  ids and timestamps included, which is what lets delivery be at-least-once
+  while the store's id-keyed dedup lands nothing twice.
+
+## The instrumentation scope
+
+Every span rides the scope named **`egma-simulator`**. The ingest recognises
+the vocabulary by this scope, never by span names alone — another framework
+that happens to call something `agent_turn` is not read as the simulator, and
+the simulator's names can never collide with a provider's.
+
+## The spans
+
+A span is one timed thing inside the conversation. Timestamps are stamped when
+the thing happened and replayed byte-identically on resends — never re-derived
+at send time. Shapes permit overlap: two turns may cross in time, which is how
+barge-in is represented when the persona becomes full-duplex, and
+`voice-overlapping-turns.json` shows a pair doing it.
+
+| Span name | One per | Duration | Attributes |
+| --- | --- | --- | --- |
+| `simulation` | conversation | The whole conversation. The root: it names no parent, every other span names it, and it is emitted last — when it arrives, the conversation is over and every other span is already on the wire. | none |
+| `human_turn` | transcript turn spoken by the persona | The turn, ear to ear. Zero on chat, where a message is one instant. | `egma.turn.text` |
+| `agent_turn` | transcript turn spoken by the agent under test | Same terms as `human_turn`. | `egma.turn.text` |
+| `tool_call` | tool call observed from egma's side of the connection | One instant: the platform reports the invocation, not its span. | `egma.tool.name`, `egma.tool.arguments` |
+| *measure name* | measurement | **The measurement itself.** A timing span is named for the measure it takes — `first_response_latency`, `turn_response_latency`, `time_to_first_word`, `agent_speech_duration`, `persona_speech_duration` — and its start and end bracket the measured interval, so the span's duration *is* the number, in nanoseconds. The catalog (`measure-catalog.md`) says what each measure means and who emits it. | none |
+
+The speaker of a turn rides the span name — `human_turn` and `agent_turn` are
+the transcript's two labels, exactly — so there is no second field free to
+disagree with it.
+
+## The attributes
+
+| Attribute | On | Value |
+| --- | --- | --- |
+| `egma.turn.text` | `human_turn`, `agent_turn` | What was said, as text — spoken and transcribed on voice, sent verbatim on chat. May be empty for a turn that carried no words. |
+| `egma.tool.name` | `tool_call` | The tool's name, exactly as the platform reported it. |
+| `egma.tool.arguments` | `tool_call` | The arguments, JSON-encoded, exactly as observed — absent where the platform reports the invocation but not its arguments. A string deliberately: the observed bytes are the fact worth keeping. |
+
+There is no tool-result attribute, because the simulator observes the call and
+not the return; an attribute for a fact nobody observes would be invented
+structure. When a platform starts reporting results, the vocabulary grows a
+line — and until then, absence is honest.
+
+## What the fixtures show
+
+- `chat-flush-1-turns.json`, `chat-flush-2-tools.json`,
+  `chat-flush-3-root.json` — one chat conversation as the three flushes the
+  simulator actually sends: turns and a first-response measurement while the
+  conversation runs, tool calls and a per-turn measurement as they happen, and
+  the closing turn with the root last. Together they are the whole trace;
+  resending any flush byte-identically lands nothing twice.
+- `voice-overlapping-turns.json` — a mid-conversation voice flush where the
+  persona starts speaking before the agent finishes: two turns whose intervals
+  cross, with the two speech-duration measures beside them.
+- `invalid/resource-naming-no-simulation.json` — a resource with no
+  `egma.simulation_id`, which the ingest refuses whole with a body saying what
+  to send instead.

--- a/packages/simulation-contract/test/span-fixtures.test.ts
+++ b/packages/simulation-contract/test/span-fixtures.test.ts
@@ -1,0 +1,309 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { MEASURE_CATALOG } from "../src/measures.ts";
+
+/**
+ * The span fixtures, held to the vocabulary document beside them.
+ *
+ * These files are the meeting point between the simulator's emitter and the
+ * platform's OTLP ingest: the emitter produces exactly these shapes, and the
+ * ingest's own suite posts these same files and asserts what lands. What this
+ * suite holds is the contract itself — every fixture speaks the one scope,
+ * names its simulation on the resource, uses only the span names and attribute
+ * keys the document declares, and derives its trace identity from the
+ * simulation id the way the document says to. A shape used in a fixture and
+ * missing from the document, or the other way round, fails here rather than
+ * surfacing as two sides that each believed the other.
+ */
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const document = await readFile(
+  path.join(packageRoot, "span-vocabulary.md"),
+  "utf8",
+);
+
+/** The one scope the vocabulary rides, and the ingest's registry is gated on. */
+const SCOPE = "egma-simulator";
+
+/** How a resource names the simulation its spans are evidence of. */
+const SIMULATION_ID_ATTRIBUTE = "egma.simulation_id";
+
+/** The conversation's own span names — everything that is not a measure. */
+const CONVERSATION_SPAN_NAMES = [
+  "simulation",
+  "human_turn",
+  "agent_turn",
+  "tool_call",
+] as const;
+
+/**
+ * A timing span is named for the measure it takes, so the rest of the legal
+ * names are the catalog's own timing measures. Derived rather than listed: a
+ * measure joining the catalog joins this vocabulary in the same edit.
+ */
+const MEASURE_SPAN_NAMES = MEASURE_CATALOG.filter(
+  (entry) => entry.origin === "timing_event",
+).map((entry) => entry.measure);
+
+const SPAN_ATTRIBUTE_KEYS = [
+  "egma.turn.text",
+  "egma.tool.name",
+  "egma.tool.arguments",
+] as const;
+
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/**
+ * The derivation the document promises: the simulation id's own 128 bits as 32
+ * lowercase hex characters. Implemented here independently of both sides, so a
+ * fixture whose trace id drifted from its simulation id fails no matter which
+ * side wrote it.
+ */
+function traceIdOf(simulationId: string): string {
+  const body = simulationId.slice("sim_".length);
+  let value = 0n;
+  for (const character of body) {
+    const digit = CROCKFORD_ALPHABET.indexOf(character);
+    expect(digit, `${simulationId} is not Crockford base32`).toBeGreaterThan(-1);
+    value = (value << 5n) | BigInt(digit);
+  }
+  return value.toString(16).padStart(32, "0");
+}
+
+type FixtureSpan = {
+  readonly traceId?: string;
+  readonly spanId?: string;
+  readonly parentSpanId?: string;
+  readonly name?: string;
+  readonly startTimeUnixNano?: string;
+  readonly endTimeUnixNano?: string;
+  readonly attributes?: readonly {
+    readonly key: string;
+    readonly value?: { readonly stringValue?: string };
+  }[];
+};
+
+type Fixture = {
+  readonly name: string;
+  readonly resourceSpans: readonly {
+    readonly resource?: {
+      readonly attributes?: readonly {
+        readonly key: string;
+        readonly value?: { readonly stringValue?: string };
+      }[];
+    };
+    readonly scopeSpans?: readonly {
+      readonly scope?: { readonly name?: string; readonly version?: string };
+      readonly spans?: readonly FixtureSpan[];
+    }[];
+  }[];
+};
+
+async function fixturesUnder(expectation: "valid" | "invalid"): Promise<Fixture[]> {
+  const directory = path.join(packageRoot, "fixtures", "spans", expectation);
+  const names = (await readdir(directory))
+    .filter((name) => name.endsWith(".json"))
+    .sort();
+  return Promise.all(
+    names.map(async (name) => ({
+      name,
+      ...(JSON.parse(
+        await readFile(path.join(directory, name), "utf8"),
+      ) as Omit<Fixture, "name">),
+    })),
+  );
+}
+
+const valid = await fixturesUnder("valid");
+const invalid = await fixturesUnder("invalid");
+
+function attributeOf(
+  attributes:
+    | readonly { key: string; value?: { stringValue?: string } }[]
+    | undefined,
+  key: string,
+): string | undefined {
+  return attributes?.find((entry) => entry.key === key)?.value?.stringValue;
+}
+
+function spansOf(fixture: Fixture): FixtureSpan[] {
+  return fixture.resourceSpans.flatMap((resource) =>
+    (resource.scopeSpans ?? []).flatMap((scope) => scope.spans ?? []),
+  );
+}
+
+describe("the golden span fixtures", () => {
+  it("exist on both sides of the contract, so there is something to hold", () => {
+    expect(valid.length).toBeGreaterThan(0);
+    expect(invalid.length).toBeGreaterThan(0);
+  });
+
+  it("all ride the one scope the ingest's registry is gated on", () => {
+    for (const fixture of [...valid, ...invalid]) {
+      for (const resource of fixture.resourceSpans) {
+        for (const scopeSpans of resource.scopeSpans ?? []) {
+          expect(scopeSpans.scope?.name, fixture.name).toBe(SCOPE);
+        }
+      }
+    }
+  });
+
+  it("name their simulation on every resource, except the refusal fixture whose whole point is not to", () => {
+    for (const fixture of valid) {
+      for (const resource of fixture.resourceSpans) {
+        const named = attributeOf(
+          resource.resource?.attributes,
+          SIMULATION_ID_ATTRIBUTE,
+        );
+        expect(named, fixture.name).toMatch(/^sim_[0-9A-HJKMNP-TV-Z]{26}$/);
+      }
+    }
+    for (const fixture of invalid) {
+      for (const resource of fixture.resourceSpans) {
+        expect(
+          attributeOf(resource.resource?.attributes, SIMULATION_ID_ATTRIBUTE),
+          fixture.name,
+        ).toBeUndefined();
+      }
+    }
+  });
+
+  it("derive every trace id from the simulation id, the way the document promises", () => {
+    for (const fixture of valid) {
+      for (const resource of fixture.resourceSpans) {
+        const simulationId = attributeOf(
+          resource.resource?.attributes,
+          SIMULATION_ID_ATTRIBUTE,
+        );
+        if (simulationId === undefined) continue;
+        const traceId = traceIdOf(simulationId);
+        for (const scopeSpans of resource.scopeSpans ?? []) {
+          for (const span of scopeSpans.spans ?? []) {
+            expect(span.traceId, `${fixture.name} ${span.name}`).toBe(traceId);
+          }
+        }
+      }
+    }
+  });
+
+  it("use only span names the vocabulary declares, and mint well-formed ids that repeat nowhere", () => {
+    const legal = new Set<string>([...CONVERSATION_SPAN_NAMES, ...MEASURE_SPAN_NAMES]);
+    const minted = new Set<string>();
+
+    for (const fixture of valid) {
+      for (const span of spansOf(fixture)) {
+        expect(legal.has(span.name ?? ""), `${fixture.name} ${span.name}`).toBe(true);
+        expect(span.spanId, fixture.name).toMatch(/^[0-9a-f]{16}$/);
+        // Unique across the whole fixture set: the flushes of one conversation
+        // are disjoint, so posting them all lands each span exactly once.
+        const key = `${span.traceId}/${span.spanId}`;
+        expect(minted.has(key), `${fixture.name} repeats ${key}`).toBe(false);
+        minted.add(key);
+        // Stamped when the span happened, as decimal nanoseconds; an interval
+        // never ends before it starts.
+        expect(span.startTimeUnixNano, fixture.name).toMatch(/^\d+$/);
+        expect(span.endTimeUnixNano, fixture.name).toMatch(/^\d+$/);
+        expect(
+          BigInt(span.endTimeUnixNano ?? "0") >=
+            BigInt(span.startTimeUnixNano ?? "0"),
+          `${fixture.name} ${span.name}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("carry the conversation on the attributes the vocabulary declares, and no others", () => {
+    for (const fixture of [...valid, ...invalid]) {
+      for (const span of spansOf(fixture)) {
+        for (const attribute of span.attributes ?? []) {
+          expect(
+            (SPAN_ATTRIBUTE_KEYS as readonly string[]).includes(attribute.key),
+            `${fixture.name} ${span.name} carries ${attribute.key}`,
+          ).toBe(true);
+        }
+        if (span.name === "human_turn" || span.name === "agent_turn") {
+          expect(
+            attributeOf(span.attributes, "egma.turn.text"),
+            `${fixture.name} ${span.name}`,
+          ).toBeTypeOf("string");
+        }
+        if (span.name === "tool_call") {
+          expect(
+            attributeOf(span.attributes, "egma.tool.name"),
+            fixture.name,
+          ).toBeTruthy();
+        }
+        if (MEASURE_SPAN_NAMES.includes(span.name ?? "")) {
+          // A measure span's value is its duration; an attribute repeating the
+          // number would be a second copy free to disagree.
+          expect(span.attributes ?? [], `${fixture.name} ${span.name}`).toEqual([]);
+        }
+      }
+    }
+  });
+
+  it("parent every conversation span on the root, which alone names no parent and arrives last", () => {
+    for (const fixture of valid) {
+      for (const span of spansOf(fixture)) {
+        if (span.name === "simulation") {
+          expect(span.parentSpanId, fixture.name).toBeUndefined();
+        } else {
+          expect(span.parentSpanId, `${fixture.name} ${span.name}`).toMatch(
+            /^[0-9a-f]{16}$/,
+          );
+        }
+      }
+      // The root, where present, is the last span of its flush: when it goes
+      // out, everything else of the conversation is already on the wire.
+      for (const resource of fixture.resourceSpans) {
+        for (const scopeSpans of resource.scopeSpans ?? []) {
+          const spans = scopeSpans.spans ?? [];
+          const rootAt = spans.findIndex((span) => span.name === "simulation");
+          if (rootAt !== -1) expect(rootAt, fixture.name).toBe(spans.length - 1);
+        }
+      }
+    }
+  });
+
+  it("show a voice flush whose turns genuinely overlap, because the shape has to permit it", () => {
+    const voice = valid.find((fixture) => fixture.name.startsWith("voice-"));
+    expect(voice).toBeDefined();
+    const turns = spansOf(voice as Fixture).filter(
+      (span) => span.name === "human_turn" || span.name === "agent_turn",
+    );
+    const crossing = turns.some((one, index) =>
+      turns.some(
+        (other, otherIndex) =>
+          index !== otherIndex &&
+          BigInt(one.startTimeUnixNano ?? "0") <
+            BigInt(other.endTimeUnixNano ?? "0") &&
+          BigInt(other.startTimeUnixNano ?? "0") <
+            BigInt(one.endTimeUnixNano ?? "0"),
+      ),
+    );
+    expect(crossing).toBe(true);
+  });
+
+  it("are all named in the vocabulary document, which is what a person reads first", () => {
+    for (const name of [...CONVERSATION_SPAN_NAMES, ...MEASURE_SPAN_NAMES]) {
+      expect(document, `span-vocabulary.md names ${name}`).toContain(name);
+    }
+    for (const key of [SIMULATION_ID_ATTRIBUTE, ...SPAN_ATTRIBUTE_KEYS]) {
+      expect(document, `span-vocabulary.md names ${key}`).toContain(key);
+    }
+    for (const fixture of [...valid, ...invalid]) {
+      expect(document, `span-vocabulary.md names ${fixture.name}`).toContain(
+        fixture.name,
+      );
+    }
+    expect(document).toContain(SCOPE);
+    // The worked example in the document is the derivation actually applied.
+    expect(document).toContain("sim_01K3XQ7M4E8YB2FVN0H9TZQWER");
+    expect(document).toContain(traceIdOf("sim_01K3XQ7M4E8YB2FVN0H9TZQWER"));
+  });
+});


### PR DESCRIPTION
Simulation conversations get their real home: the same span table, the same door, the same shape as production traces — the premise the trace store was built on, now served.

- The OTLP ingest branches on credential. A customer key resolves tenancy exactly as before — that path is provably unchanged, and a customer's payload naming `egma.simulation_id` is ignored. The service token opens the second path: every resource must name its simulation, and the door resolves organization, project and run from the simulation row — never from the payload's claims. Rows land marked as simulation traffic, stamped with the run and the pinned agent/test-version/persona-version identities off the row.
- The span-vocabulary contract joins the contract package: scope `egma-simulator`, trace identity derived from the simulation id's own 128 bits, turn spans carrying speaker and text with intervals that may overlap (the barge-in shape), tool-call spans, and the five catalog timing measures where the span's own duration is the measurement. Golden fixtures cut as the flushes a conversation actually streams; the fixture suite reimplements the trace-id derivation independently so both sides are held to it.
- Dedup is id-keyed: every insert carries a ClickHouse `insert_deduplication_token` digested from the block's writer-minted span ids with tenancy in the digest — a byte-identical resend lands once, a byte-different same-ids resend lands once, and two customers' colliding ids never dedup each other. Proven against real ClickHouse.
- Spans are accepted for any simulation this deployment conducted, whatever its status — a late-returning orphan's spans are evidence, kept. A resource naming no simulation, or one that never existed, refuses the whole request with an actionable body: a partial 200 would tell the sender's write-ahead log the evidence landed when it has nowhere to land.
- The telemetry lookup folded into the widened `resolveSimulationStanding` — one instance-wide batch resolver carrying lifecycle stamps, claimant, and the filing pins, both call sites (this door and the report route) on it, the no-context census one name shorter.

Tests: fixture batches through the token path landing under the right tenant; the dedup round-trips; payload-tenant-claims ignored; unknown refused; terminal accepted; the customer path's suites untouched and green plus the ignores-simulation-id proof; cross-encoding (protobuf/JSON) resend dedup. Verified before opening: 60/60 across the five span/ingest/contract suites on the final rebased head, typecheck green, census and exports reconciled truthfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds service-token OTLP ingest for simulator spans, resolves tenancy and execution pins from simulation rows, and introduces identity-based ClickHouse insert deduplication.
- Adds simulator span vocabulary, fixtures, and cross-encoding contract coverage.
- Groups service-token exports by resolved tenant and reports per-group storage refusals.
- Extends simulation-standing lookup with run, agent, test-version, and persona-version attribution.
- Adds deterministic insert deduplication tokens scoped by tenant and span IDs.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because multi-block tenant groups can lose valid later spans after a refusal, and simulation trace identity remains unenforced.

A refused ClickHouse block terminates the rest of its tenant group's inserts while the response marks the entire group rejected, and the ingest path still stores simulator spans under unchecked wire trace IDs despite the deterministic identity contract.

**Files Needing Attention:** apps/api/src/routes/traces.ts, packages/db/src/access/spans.ts, apps/api/src/otlp/normalise.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/traces.ts | Adds simulator authentication, attribution, tenant grouping, and refusal handling, but a refusal within a multi-block group can leave valid later blocks unattempted and misreported. |
| apps/api/src/otlp/normalise.ts | Adds simulator vocabulary and control-plane attribution; the previously reported missing simulation-derived trace-ID validation remains. |
| packages/db/src/access/spans.ts | Adds tenant-scoped, span-ID-derived deduplication tokens while retaining sequential multi-block insertion semantics relevant to partial refusal handling. |
| packages/db/src/access/runs.ts | Extends simulation-standing results with the execution identities needed to attribute simulator telemetry. |
| packages/simulation-contract/span-vocabulary.md | Defines simulator scope, deterministic trace identity, turn, tool, and timing-span contracts. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Simulator
    participant API as OTLP ingest
    participant DB as Simulation store
    participant CH as ClickHouse
    S->>API: Export resources with service token
    API->>DB: Resolve each simulation standing
    DB-->>API: Tenant, run, and version pins
    API->>API: Group and normalize by tenant
    loop Tenant groups
        API->>CH: Insert span blocks with dedup tokens
        CH-->>API: Success or refusal
    end
    API-->>S: OTLP partial-success response
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22simulation-dispatch-t05%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22simulation-dispatch-t05%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Froutes%2Ftraces.ts%3A431%0A**Partial%20block%20refusal%20misreports%20group**%0A%0AWhen%20a%20tenant%20group's%20spans%20are%20split%20into%20multiple%20ClickHouse%20insert%20blocks%20and%20a%20later%20block%20is%20refused%2C%20%60appendSpans%60%20exits%20before%20attempting%20the%20remaining%20blocks%20while%20this%20handler%20counts%20the%20entire%20group%20as%20rejected.%20Earlier%20blocks%20can%20already%20be%20stored%20and%20valid%20later%20blocks%20remain%20unwritten%2C%20causing%20the%20terminal%20OTLP%20response%20to%20misreport%20which%20spans%20landed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=52&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Froutes%2Ftraces.ts%3A431%0A**Partial%20block%20refusal%20misreports%20group**%0A%0AWhen%20a%20tenant%20group's%20spans%20are%20split%20into%20multiple%20ClickHouse%20insert%20blocks%20and%20a%20later%20block%20is%20refused%2C%20%60appendSpans%60%20exits%20before%20attempting%20the%20remaining%20blocks%20while%20this%20handler%20counts%20the%20entire%20group%20as%20rejected.%20Earlier%20blocks%20can%20already%20be%20stored%20and%20valid%20later%20blocks%20remain%20unwritten%2C%20causing%20the%20terminal%20OTLP%20response%20to%20misreport%20which%20spans%20landed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=52&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Hold a store refusal to its own group, n..."](https://github.com/egma-ai/egma/commit/f5d54c5bf1896bb70257844dd55d604bf8ddd1d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51457765)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->