### PR TITLE
A conducted simulation streams its conversation as spans

### DIFF
--- a/apps/api/test/simulator-walk.test.ts
+++ b/apps/api/test/simulator-walk.test.ts
@@ -8,22 +8,34 @@ import path from "node:path";
 import { createPersona } from "@egma/db";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { rowsIn } from "../../../packages/db/test/support/clickhouse.ts";
 import { startInstance, type Instance } from "./support/instance.ts";
 import { NEUTRAL_TRAITS } from "./support/traces.ts";
 
 /**
  * The whole wire, walked by the shipped simulator: a run started through the
  * real API, its simulation claimed from the real claim door, conducted by
- * the real Python service over a Retell-shaped counterpart on loopback, and
- * reported back through the real report door — queued → claimed → running →
- * completed, with every lifecycle column read back and checked for truth.
+ * the real Python service over a Retell-shaped counterpart on loopback,
+ * streamed span by span into the real ClickHouse through the real OTLP
+ * ingest, and reported back through the real report door — queued → claimed
+ * → running → completed, with every lifecycle column read back and checked
+ * for truth.
  *
  * Nothing here is a stand-in for egma's own halves: the API listens on a
- * real port, the database is a real Postgres, and the simulator is the same
- * process `docker compose up` starts. The one fake is the platform on the
- * far side of the conversation — a local server speaking Retell's chat wire
- * shape — because the agent under test is the customer's, and a test that
- * needed a real Retell account would prove an account rather than the wire.
+ * real port, the database is a real Postgres, the trace store is a real
+ * ClickHouse, and the simulator is the same process `docker compose up`
+ * starts. The one fake is the platform on the far side of the conversation —
+ * a local server speaking Retell's chat wire shape — because the agent under
+ * test is the customer's, and a test that needed a real Retell account would
+ * prove an account rather than the wire.
+ *
+ * **The ordering guarantee is proved here and nowhere better.** The
+ * simulator puts its span batches and its lifecycle documents through one
+ * write-ahead log and one ordered sender, so a terminal report leaves only
+ * after every span before it landed. What that buys is read back the way a
+ * grader will read it: the walk is watched while it runs, and the moment the
+ * simulation row turns terminal the conversation is already queryable in
+ * ClickHouse, root span included.
  *
  * The failed walk rides the same session: a second connection whose key the
  * counterpart refuses, landing `failed` with the honest reason. The canceled
@@ -226,12 +238,101 @@ async function rowOf(simulationId: string): Promise<Record<string, unknown>> {
   return row;
 }
 
+/**
+ * The trace a simulation's spans belong to, derived here independently of
+ * both the emitter and the ingest: the simulation id's own 128 bits, the 26
+ * Crockford base32 characters after `sim_` written as 32 lowercase hex. A
+ * derivation this test computed for itself is what makes finding the rows
+ * proof of anything — asking either side where it filed them would not be.
+ */
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+function traceIdOf(simulationId: string): string {
+  let value = 0n;
+  for (const character of simulationId.slice("sim_".length)) {
+    const digit = CROCKFORD_ALPHABET.indexOf(character);
+    expect(digit, `${simulationId} is not Crockford base32`).toBeGreaterThan(-1);
+    value = (value << 5n) | BigInt(digit);
+  }
+  return value.toString(16).padStart(32, "0");
+}
+
+type StoredSpan = {
+  readonly name: string;
+  readonly kind: string;
+  readonly text: string;
+  readonly duration_ns: string;
+  readonly span_id: string;
+  readonly parent_span_id: string;
+  readonly source: string;
+  readonly emitter: string;
+  readonly run_id: string;
+  readonly agent_id: string;
+};
+
+/** One conversation as it stands in the trace store, oldest span first. */
+async function storedSpans(traceId: string): Promise<StoredSpan[]> {
+  return rowsIn<StoredSpan>(
+    instance.traceStore,
+    `select name, kind, text, toString(duration_ns) as duration_ns, span_id,
+            parent_span_id, source, emitter, run_id, agent_id
+       from spans
+      where trace_id = '${traceId}'
+      order by started_at, span_id`,
+  );
+}
+
 async function gradingJobsFor(simulationId: string): Promise<number> {
   const { rows } = await instance.database.sql<{ count: string }>(
     "select count(*) as count from grading_job where simulation_id = $1",
     [simulationId],
   );
   return Number(rows[0]?.count);
+}
+
+/** What one poll of a running simulation saw, in both stores at once. */
+type Sighting = {
+  readonly status: string;
+  readonly spans: readonly string[];
+};
+
+/**
+ * Watch one simulation from queued to terminal, reading both stores as it
+ * goes, and answer with everything seen — including one last look taken the
+ * instant the row turned terminal.
+ *
+ * The order inside the loop is the whole point. Spans are read *first* and
+ * the row's status *second*, so a sighting that says terminal is saying the
+ * spans beside it were already there before the transition was visible. Then
+ * the terminal sighting is taken again, spans last, because what has to be
+ * true is the strong direction: when the control plane records a terminal
+ * transition, the evidence a verdict will cite is already stored.
+ */
+async function watchToTerminal(
+  simulationId: string,
+  traceId: string,
+  within: number,
+): Promise<{ seen: Sighting[]; atTerminal: readonly string[] }> {
+  const deadline = Date.now() + within;
+  const seen: Sighting[] = [];
+  for (;;) {
+    const spans = (await storedSpans(traceId)).map((span) => span.name);
+    const status = String((await rowOf(simulationId)).status);
+    seen.push({ status, spans });
+    if (status === "completed" || status === "failed" || status === "canceled") {
+      return {
+        seen,
+        atTerminal: (await storedSpans(traceId)).map((span) => span.name),
+      };
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `simulation ${simulationId} is still ${status} after ${within}ms; ` +
+          `the simulator said:\n${simulatorSaid}`,
+      );
+    }
+    await new Promise((resume) => setTimeout(resume, 25));
+  }
 }
 
 /** Poll one run until it reaches a terminal status, or say what it was doing. */
@@ -260,7 +361,9 @@ beforeAll(async () => {
   scratch = await mkdtemp(path.join(os.tmpdir(), "egma-simulator-walk-"));
   counterpart = new RetellCounterpart();
   await counterpart.start();
-  instance = await startInstance("simulator_walk", { web: false });
+  // The trace store gets its schema here, because this walk reads the
+  // conversation back out of it rather than only off the row.
+  instance = await startInstance("simulator_walk", { web: false, traces: true });
 }, 120_000);
 
 afterAll(async () => {
@@ -391,9 +494,37 @@ describe("the shipped simulator against the real API", () => {
         simulatorSaid += piece.toString("utf8");
       });
 
+      // The conversation watched as it happens, in both stores at once.
+      const traceId = traceIdOf(conducted.simulationId);
+      const watched = await watchToTerminal(
+        conducted.simulationId,
+        traceId,
+        60_000,
+      );
+
       // The whole walk, as a person watching the run would see it settle.
       const conductedRun = await settledRun(key, conducted.runId, 60_000);
       const refusedRun = await settledRun(key, refused.runId, 60_000);
+
+      // Streamed, not posted at the end: turns were queryable in ClickHouse
+      // while the simulation was still running.
+      const whileRunning = watched.seen.filter(
+        (sighting) => sighting.status === "running" && sighting.spans.length > 0,
+      );
+      expect(
+        whileRunning.length,
+        `no span was ever seen while the simulation ran; sightings: ${JSON.stringify(
+          watched.seen,
+        )}`,
+      ).toBeGreaterThan(0);
+      expect(whileRunning[0]?.spans).toContain("agent_turn");
+      // And partial while it ran: the root closes the trace, so a live
+      // reader seeing it would mean the conversation was already over.
+      expect(whileRunning[0]?.spans).not.toContain("simulation");
+
+      // The guarantee: at the moment the row went terminal, the whole
+      // conversation was already stored — root span and all.
+      expect(watched.atTerminal).toContain("simulation");
 
       // The conversation that happened: completed, concluded by the persona,
       // and every lifecycle column telling the truth about it.
@@ -412,6 +543,63 @@ describe("the shipped simulator against the real API", () => {
       expect(startedAt.getTime()).toBeLessThanOrEqual(endedAt.getTime());
       expect(await gradingJobsFor(conducted.simulationId)).toBe(1);
 
+      // The conversation itself, read back out of the trace store the way a
+      // grader will read it — one span per timed thing, nothing invented.
+      const spans = await storedSpans(traceId);
+      const names = spans.map((span) => span.name);
+      expect(names.filter((name) => name === "agent_turn")).toHaveLength(2);
+      expect(names.filter((name) => name === "human_turn")).toHaveLength(2);
+      expect(names.filter((name) => name === "turn_response_latency")).toHaveLength(1);
+      expect(names).toContain("first_response_latency");
+      expect(names.filter((name) => name === "simulation")).toHaveLength(1);
+      // What the row counted and what the store holds are one conversation.
+      expect(names.filter((name) => name.endsWith("_turn"))).toHaveLength(
+        Number(row.turn_count),
+      );
+
+      // What was said, in order, with the transcript's two labels riding the
+      // span names — the speaker is the name, so nothing can disagree with it.
+      expect(
+        spans
+          .filter((span) => span.name.endsWith("_turn"))
+          .map((span) => [span.name, span.text]),
+      ).toEqual([
+        ["agent_turn", "Lakeside Dental, how can I help?"],
+        [
+          "human_turn",
+          "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+        ],
+        [
+          "agent_turn",
+          "Of course — we have Tuesday and Wednesday afternoon free next week.",
+        ],
+        ["human_turn", "That covers everything I needed. Thank you, goodbye."],
+      ]);
+
+      // Filed under the customer's own row, from egma's own side of the
+      // conversation, and never from anything the payload claimed.
+      const root = spans.find((span) => span.name === "simulation");
+      expect(root?.kind).toBe("root");
+      expect(root?.parent_span_id).toBe("");
+      for (const span of spans) {
+        expect(span.source).toBe("simulation");
+        expect(span.emitter).toBe("egma-runtime");
+        expect(span.run_id).toBe(conducted.runId);
+        expect(span.agent_id).toBe(agentId);
+        if (span !== root) expect(span.parent_span_id).toBe(root?.span_id);
+      }
+
+      // A timing span's own duration is the measurement, in nanoseconds.
+      for (const span of spans) {
+        if (span.name.endsWith("_latency")) {
+          expect(Number(span.duration_ns)).toBeGreaterThan(0);
+        }
+      }
+
+      // Every span landed once. The simulator resends byte-identically and
+      // the store dedups on the ids it minted, so no retry can double a turn.
+      expect(new Set(spans.map((span) => span.span_id)).size).toBe(spans.length);
+
       expect(conductedRun.status).toBe("completed");
       expect(conductedRun.completed_count).toBe(1);
       expect(conductedRun.failed_count).toBe(0);
@@ -424,6 +612,11 @@ describe("the shipped simulator against the real API", () => {
       expect(refusedRow.ending_reason).toBe("simulator_error");
       expect(refusedRow.claimed_by).toBe("walking-simulator-1");
       expect(await gradingJobsFor(refused.simulationId)).toBe(1);
+
+      // A simulation that never got a conversation still says it happened:
+      // one root span, no turns, nothing invented to fill the silence.
+      const refusedSpans = await storedSpans(traceIdOf(refused.simulationId));
+      expect(refusedSpans.map((span) => span.name)).toEqual(["simulation"]);
 
       expect(refusedRun.status).toBe("completed");
       expect(refusedRun.completed_count).toBe(0);

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -105,6 +105,43 @@ specs exist only in memory, are handed only to the plug, and are scrubbed
 from every log line — the report schema has no place to put them even by
 accident.
 
+## The conversation, as spans
+
+Every turn, tool call and measurement is also authored as an OpenTelemetry
+span (`spans.py`) and streamed to the control plane's OTLP ingest while
+the simulation runs — the same door a customer's own agent exports to, so
+a simulation is readable the way a production trace is readable, live and
+partial included. The vocabulary — the scope, the span names, the
+attribute keys, how a batch names its simulation, and how a trace id is
+derived from a simulation id — is
+[`packages/simulation-contract/span-vocabulary.md`](../../packages/simulation-contract/span-vocabulary.md),
+pinned as golden fixtures beside it.
+
+Three things about it are worth knowing before reading the code:
+
+- **Delivery is the reporter's, not an exporter's.** Span batches go
+  through the same write-ahead log and the same single ordered sender the
+  lifecycle documents ride. So a resend is byte-identical with its ids,
+  which lets the store dedup on them, and the terminal report leaves only
+  after every span before it landed — when the control plane records a
+  simulation terminal, the conversation is already stored.
+- **A timing span's own duration is the measurement.** A span named for a
+  measure opens one measurement before the moment it was taken, so the
+  number is the interval in nanoseconds and there is no second field to
+  disagree with it.
+- **Turn spans may overlap.** A chat message is one instant; a voice turn
+  is as long as the audio, ear to ear, and two turns are free to cross in
+  time. Nothing crosses today, because the persona waits its turn — the
+  shape is what a full-duplex caller will need, and it exists now so that
+  making the caller real changes conduction and nothing downstream.
+
+Pipecat's own auto-tracing stays off. Its turn spans carry no text and
+ride the stock lossy pipeline; what the record needs is authored where the
+walk observes the conversation.
+
+The simulator reaches the ingest at the control-plane URL it already has.
+There is no second address to configure.
+
 ## Running it locally
 
 Both halves live here: the simulator, and the **workbench** — a dev/test
@@ -125,8 +162,9 @@ uv run egma-simulator
 ```
 
 The workbench prints one JSON line per observation — queued, the claim,
-each heartbeat, each reported event — which is a simulation going
-queued → claimed → running → completed, live. The two `scripted` fixtures
+each heartbeat, each reported event, each span as it arrives at its small
+OTLP sink — which is a simulation going queued → claimed → running →
+completed, live, with the conversation streaming past in between. The two `scripted` fixtures
 conduct whole exchanges over chat and the `loopback` one conducts a spoken
 one, leaving a real `.wav` under `EGMA_SIMULATOR_BLOB_DIR` that you can
 open and listen to a channel at a time; the `retell` fixture really does

--- a/apps/simulator/src/egma_simulator/client.py
+++ b/apps/simulator/src/egma_simulator/client.py
@@ -1,12 +1,17 @@
-"""The simulator's side of the wire: three outbound calls, nothing inbound.
+"""The simulator's side of the wire: four outbound calls, nothing inbound.
 
 The simulator pulls its own work rather than being sent it. It claims
 simulations with a capacity declaration, on a request the control plane may
 hold open until there is something to give; it heartbeats each running
-simulation and receives any directive on the answer; and it posts report
-documents as events happen. Every arrow points out, so the simulator needs
-no inbound network surface at all — which is what makes it one more
-container that only dials out.
+simulation and receives any directive on the answer; it posts report
+documents as events happen; and it posts the conversation itself as OTLP
+span batches, at the same ingest door a customer's agent exports to. Every
+arrow points out, so the simulator needs no inbound network surface at all
+— which is what makes it one more container that only dials out.
+
+All four reach the same deployment, so there is one address to configure
+and the telemetry path is derived from it rather than named separately: a
+simulator that can claim work can always file the evidence of it.
 
 In development and test the other end is the workbench. Nothing here knows
 the difference, and nothing here changes when the real control plane
@@ -15,6 +20,7 @@ answers instead: both ends speak the contract, not each other.
 
 from __future__ import annotations
 
+import json
 import logging
 
 import aiohttp
@@ -45,12 +51,23 @@ class HeartbeatFailure(Exception):
     """A heartbeat did not reach the control plane, or came back unreadable."""
 
 
-class ReportRejected(Exception):
-    """The control plane refused a report document; resending cannot help."""
+class DocumentRejected(Exception):
+    """The control plane refused a document; resending cannot help.
+
+    Either kind the ordered sender carries: a report the control plane
+    will not apply, or a span batch the ingest door will not file. Both
+    are terminal for that document and neither is terminal for the
+    simulation."""
 
 
-class TransientReportFailure(Exception):
-    """A report did not get through this time; the same bytes may next time."""
+class TransientDeliveryFailure(Exception):
+    """A document did not get through this time; the same bytes may next time."""
+
+
+# The OTLP/HTTP path, which is the specification's and not egma's: an
+# exporter posts here, and so does the simulator, because a simulation
+# arriving the way a customer's agent arrives is the point.
+OTLP_TRACES_PATH = "/v1/traces"
 
 
 class ControlPlaneClient:
@@ -149,23 +166,87 @@ class ControlPlaneClient:
 
     async def report(self, simulation_id: str, serialized: bytes) -> None:
         """Post one already-serialized report document, byte-identically."""
+        await self._post_document(
+            f"{self._base_url}/v1/simulations/{simulation_id}/reports", serialized
+        )
+
+    async def spans(self, simulation_id: str, serialized: bytes) -> None:
+        """Post one already-serialized OTLP span batch, byte-identically.
+
+        The specification's own path, JSON encoding, the service token as
+        bearer — an ordinary OTLP export, refused and retried on exactly
+        the terms a report is. A 400 is the door saying the batch names no
+        simulation it can file under, which resending cannot fix.
+
+        A 200 may still carry a partial success, which is how the
+        specification says an ingest reports data it will not store.
+        Nothing is retried on it — the specification is explicit that
+        rejected data must not be — but the count is said out loud, because
+        evidence quietly dropped is exactly what a verdict must never rest
+        on.
+        """
+        body = await self._post_document(
+            f"{self._base_url}{OTLP_TRACES_PATH}", serialized
+        )
+        rejected, why = _partial_success(body)
+        if rejected:
+            logger.error(
+                "the ingest refused %d of %s's spans and will refuse them "
+                "again, so they are not resent: %s",
+                rejected,
+                simulation_id,
+                why or "it gave no reason",
+            )
+
+    async def _post_document(self, url: str, serialized: bytes) -> str:
+        """One document, posted as the bytes it already is.
+
+        Both directions the ordered sender carries come through here, so
+        what counts as refused and what counts as try-again is decided
+        once. A 4xx says the document is wrong and the same bytes will be
+        wrong next time — except for the two that say "not now": a timeout
+        and a rate limit both mean try again.
+        """
         try:
             async with self._live_session().post(
-                f"{self._base_url}/v1/simulations/{simulation_id}/reports",
+                url,
                 data=serialized,
                 headers={"content-type": "application/json"},
                 timeout=self._brisk_timeout,
             ) as response:
                 if response.status in (200, 202, 204):
-                    return
+                    return await response.text()
                 text = await response.text()
-                # A 4xx says the document is wrong, and the same bytes will
-                # be wrong next time — except for the two that say "not now":
-                # a timeout and a rate limit both mean try again.
                 if response.status in (408, 429):
-                    raise TransientReportFailure(f"{response.status}: {text}")
+                    raise TransientDeliveryFailure(f"{response.status}: {text}")
                 if 400 <= response.status < 500:
-                    raise ReportRejected(f"{response.status}: {text}")
-                raise TransientReportFailure(f"{response.status}: {text}")
+                    raise DocumentRejected(f"{response.status}: {text}")
+                raise TransientDeliveryFailure(f"{response.status}: {text}")
         except UNREACHABLE as error:
-            raise TransientReportFailure(f"{error!r}") from error
+            raise TransientDeliveryFailure(f"{error!r}") from error
+
+
+def _partial_success(body: str) -> tuple[int, str]:
+    """What an OTLP answer says it refused, if it says anything at all.
+
+    An empty body is the whole batch landed, which is the ordinary case
+    and the one worth staying quiet about. Anything unreadable is treated
+    the same way: the status already said the request was accepted, and
+    inventing a refusal out of a body nobody can parse would be worse than
+    trusting the code.
+    """
+    if not body.strip():
+        return 0, ""
+    try:
+        document = json.loads(body)
+    except ValueError:
+        return 0, ""
+    partial = document.get("partialSuccess") if isinstance(document, dict) else None
+    if not isinstance(partial, dict):
+        return 0, ""
+    try:
+        rejected = int(partial.get("rejectedSpans", 0))
+    except (TypeError, ValueError):
+        rejected = 0
+    message = partial.get("errorMessage")
+    return rejected, message if isinstance(message, str) else ""

--- a/apps/simulator/src/egma_simulator/pipeline.py
+++ b/apps/simulator/src/egma_simulator/pipeline.py
@@ -78,7 +78,7 @@ from .speech import (
     spoken_seconds,
     voice_from_traits,
 )
-from .walk import OnTiming
+from .walk import OnSpeech, OnTiming
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +174,7 @@ def assemble(
     blobs: BlobStore,
     speech: SpeechProviders = SCRIPTED_PAIR,
     on_timing: OnTiming | None = None,
+    on_speech: OnSpeech | None = None,
 ) -> Assembled:
     """Build one simulation's pipeline from its spec.
 
@@ -208,6 +209,7 @@ def assemble(
         blobs=blobs,
         recording_key=f"{spec.simulation_id}/{RECORDING_NAME}",
         on_timing=on_timing,
+        on_speech=on_speech,
     )
     return Assembled(plug=speech_legs, voice=speech_legs)
 
@@ -285,12 +287,14 @@ class VoicePipeline:
         recording_key: str,
         speech: SpeechProviders = SCRIPTED_PAIR,
         on_timing: OnTiming | None = None,
+        on_speech: OnSpeech | None = None,
     ) -> None:
         self._transport = transport
         self._band_hz = transport.sample_rate_hz
         self._blobs = blobs
         self._recording_key = recording_key
         self._on_timing = on_timing
+        self._on_speech = on_speech
 
         self._legs = build_legs(
             speech, voice=voice, sample_rate_hz=self._band_hz
@@ -401,8 +405,14 @@ class VoicePipeline:
         spoken = await self._speak(text)
         answer = await self._transport.deliver(spoken)
         if answer.audio is None:
-            return AgentReply(text=None, ended=answer.ended)
-        return AgentReply(text=await self._hear(answer.audio), ended=answer.ended)
+            return AgentReply(
+                text=None, ended=answer.ended, tool_calls=answer.tool_calls
+            )
+        return AgentReply(
+            text=await self._hear(answer.audio),
+            ended=answer.ended,
+            tool_calls=answer.tool_calls,
+        )
 
     async def close(self) -> None:
         try:
@@ -432,9 +442,12 @@ class VoicePipeline:
         )
         await self._reach(self._sink.spoken)
         pcm = self._sink.spoken_audio()
-        await self._measure(
-            "persona_speech_duration", duration_seconds(pcm, self._band_hz)
-        )
+        spoken_for = duration_seconds(pcm, self._band_hz)
+        await self._measure("persona_speech_duration", spoken_for)
+        # The persona's words were recorded when they were decided, a
+        # moment before this; how long they took to say is known only now,
+        # and it is what gives that turn its length on the record.
+        await self._spoke("human", spoken_for)
         return Utterance(pcm=pcm, sample_rate_hz=self._band_hz)
 
     async def _hear(self, speech: Utterance) -> str:
@@ -446,6 +459,13 @@ class VoicePipeline:
         await self._measure(
             "agent_speech_duration",
             spoken_seconds(speech.pcm, speech.sample_rate_hz),
+        )
+        # The whole utterance, ear to ear — silence inside it included,
+        # because that is the length of the turn even though it is not the
+        # length of the speech. The turn it belongs to is recorded after
+        # the words come back out of the transcriber.
+        await self._spoke(
+            "agent", duration_seconds(speech.pcm, speech.sample_rate_hz)
         )
         self._before_turn()
         self._sink.before_hearing()
@@ -483,6 +503,10 @@ class VoicePipeline:
     async def _measure(self, measure: str, seconds: float) -> None:
         if self._on_timing is not None:
             await self._on_timing(measure, seconds * 1000)
+
+    async def _spoke(self, speaker: str, seconds: float) -> None:
+        if self._on_speech is not None:
+            await self._on_speech(speaker, seconds)
 
     async def _reach(
         self, event: asyncio.Event, *, within: float | None = None

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -141,6 +141,21 @@ from ..contract import ERROR
 
 
 @dataclass(frozen=True)
+class ToolCall:
+    """One tool the agent called, as observed from egma's side of the wire.
+
+    The name and the arguments exactly as the platform reported them, and
+    nothing else: the simulator observes the call and not the return, so
+    there is no result here. A platform that reports the invocation
+    without its arguments leaves them ``None``, which is the honest record
+    of what was seen.
+    """
+
+    name: str
+    arguments: str | None = None
+
+
+@dataclass(frozen=True)
 class AgentReply:
     """The agent's answer to one delivered persona turn."""
 
@@ -150,6 +165,12 @@ class AgentReply:
     ended: bool = False
     """True when this answer ended the exchange — the agent's goodbye,
     a hang-up, or the platform closing it from its side."""
+
+    tool_calls: tuple[ToolCall, ...] = ()
+    """The tool calls this answer made, where the platform exposes them.
+    Empty is the ordinary case and never a claim that none happened: most
+    ways of reaching an agent say nothing about its tools, and a plug that
+    cannot see them reports none rather than guessing."""
 
 
 @dataclass(frozen=True)
@@ -171,6 +192,10 @@ class AgentSpeech:
     ended: bool = False
     """True when this answer ended the exchange — the same meaning as on
     :class:`AgentReply`, one modality over."""
+
+    tool_calls: tuple[ToolCall, ...] = ()
+    """The same meaning as on :class:`AgentReply`. A voice platform that
+    reports its agent's tool traffic beside the audio names it here."""
 
 
 class PlugError(Exception):

--- a/apps/simulator/src/egma_simulator/plugs/retell.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell.py
@@ -45,7 +45,7 @@ import aiohttp
 
 from ..client import UNREACHABLE
 from ..redaction import REDACTED
-from . import AgentReply, PlugError
+from . import AgentReply, PlugError, ToolCall
 
 DEFAULT_BASE_URL = "https://api.retellai.com"
 """Retell's own API, where a connection with no base URL is reached."""
@@ -157,7 +157,11 @@ class RetellChat:
         messages = completion.get("messages")
         if not isinstance(messages, list):
             raise PlugError("retell answered a completion with no messages list")
-        return AgentReply(text=_agent_words(messages), ended=_ended(messages))
+        return AgentReply(
+            text=_agent_words(messages),
+            ended=_ended(messages),
+            tool_calls=_tool_calls(messages),
+        )
 
     async def close(self) -> None:
         session, self._session = self._session, None
@@ -253,8 +257,44 @@ def _agent_words(messages: object) -> str | None:
 def _ended(messages: list) -> bool:
     """Whether the agent ended the exchange with this answer."""
     return any(
-        isinstance(message, dict)
-        and message.get("role") == "tool_call_invocation"
+        _invocation(message) is not None
         and message.get("name") in END_TOOL_NAMES
         for message in messages
     )
+
+
+def _tool_calls(messages: list) -> tuple[ToolCall, ...]:
+    """The tools the agent called while producing this answer.
+
+    Retell reports its invocations inline with the agent's words, which
+    makes it one of the few platforms where a tool call is observable from
+    egma's side at all. What is kept is exactly what it said — the name,
+    and the arguments as the bytes they arrived as — and never the return,
+    which Retell reports separately and this plug does not read: the
+    conversation is what egma observes, and inventing the other half of a
+    call would poison every comparison across platforms.
+
+    The ending tool is not filtered out. It is a tool the agent called, and
+    the record of the conversation says so; that it *also* ends the
+    exchange is a separate reading of the same fact.
+    """
+    return tuple(
+        ToolCall(name=name, arguments=_arguments(message))
+        for message in messages
+        if _invocation(message) is not None
+        and isinstance(name := message.get("name"), str)
+        and name
+    )
+
+
+def _invocation(message: object) -> dict | None:
+    """One message, if it is Retell reporting a tool being called."""
+    if isinstance(message, dict) and message.get("role") == "tool_call_invocation":
+        return message
+    return None
+
+
+def _arguments(message: dict) -> str | None:
+    """The arguments as observed: Retell sends them JSON-encoded already."""
+    arguments = message.get("arguments")
+    return arguments if isinstance(arguments, str) and arguments else None

--- a/apps/simulator/src/egma_simulator/plugs/scripted.py
+++ b/apps/simulator/src/egma_simulator/plugs/scripted.py
@@ -21,6 +21,12 @@ Its config keys, like every plug's, are its own:
   cancellation testable.
 - ``provider_reference`` (string, optional) — offered as the platform's
   own identifier for the exchange, the way a real plug offers a chat id.
+- ``tool_calls`` (list of objects, default empty) — tools the scripted
+  agent calls while producing its first answer, each ``{"name": …}`` with
+  an optional ``"arguments"`` string, the way a platform that exposes its
+  agent's tool traffic reports it alongside the words. One position is
+  enough: what a script has to be able to produce is the shape, and where
+  in an exchange it lands is the real platform's business.
 """
 
 from __future__ import annotations
@@ -28,7 +34,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from . import AgentReply, PlugError
+from . import AgentReply, PlugError, ToolCall
 
 FALLBACK_REPLY = "Is there anything else I can help you with?"
 """What the agent says once its script is spent but the exchange holds."""
@@ -39,6 +45,7 @@ _KNOWN_KEYS = {
     "ends_after_replies",
     "turn_seconds",
     "provider_reference",
+    "tool_calls",
 }
 
 
@@ -96,6 +103,7 @@ class ScriptedCounterpart:
         self._ends_after_replies = ends_after_replies
         self._turn_seconds = float(turn_seconds)
         self._provider_reference = reference
+        self._tool_calls = _scripted_tool_calls(config.get("tool_calls", []))
         self._delivered = 0
 
     @property
@@ -112,16 +120,40 @@ class ScriptedCounterpart:
 
         position = self._delivered
         self._delivered += 1
+        called = self._tool_calls if position == 0 else ()
 
         if position < len(self._replies):
             is_last = position == len(self._replies) - 1
             return AgentReply(
                 text=self._replies[position],
                 ended=self._ends_after_replies and is_last,
+                tool_calls=called,
             )
         if self._ends_after_replies:
-            return AgentReply(text=None, ended=True)
-        return AgentReply(text=FALLBACK_REPLY, ended=False)
+            return AgentReply(text=None, ended=True, tool_calls=called)
+        return AgentReply(text=FALLBACK_REPLY, ended=False, tool_calls=called)
 
     async def close(self) -> None:
         return None
+
+
+def _scripted_tool_calls(configured: object) -> tuple[ToolCall, ...]:
+    """The tool calls a script says its agent makes, held to the same shape
+    a real platform's would be read into."""
+    if not isinstance(configured, list):
+        raise PlugError("scripted config: tool_calls must be a list of objects")
+    calls = []
+    for entry in configured:
+        if not isinstance(entry, dict) or set(entry) - {"name", "arguments"}:
+            raise PlugError(
+                "scripted config: each tool call is an object with a name "
+                "and an optional arguments string"
+            )
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise PlugError("scripted config: a tool call needs a name")
+        arguments = entry.get("arguments")
+        if arguments is not None and not isinstance(arguments, str):
+            raise PlugError("scripted config: tool call arguments must be a string")
+        calls.append(ToolCall(name=name, arguments=arguments))
+    return tuple(calls)

--- a/apps/simulator/src/egma_simulator/plugs/scripted.py
+++ b/apps/simulator/src/egma_simulator/plugs/scripted.py
@@ -10,8 +10,10 @@ Its config keys, like every plug's, are its own:
 
 - ``greeting`` (string, optional) — spoken by the agent the moment the
   exchange opens. Absent: the persona speaks first.
-- ``replies`` (list of strings, default empty) — the agent's answers, in
-  order, one per persona turn.
+- ``replies`` (list, default empty) — the agent's answers, in order, one
+  per persona turn. An entry may be ``null`` instead of a string, which
+  is an answer that carried no words — what a real platform hands back
+  when its agent called a tool and said nothing.
 - ``ends_after_replies`` (bool, default false) — when true, the last
   scripted reply ends the exchange (with no replies at all, the exchange
   ends silently on the first persona turn). When false, a spent script
@@ -78,9 +80,12 @@ class ScriptedCounterpart:
 
         replies = config.get("replies", [])
         if not isinstance(replies, list) or not all(
-            isinstance(reply, str) for reply in replies
+            reply is None or isinstance(reply, str) for reply in replies
         ):
-            raise PlugError("scripted config: replies must be a list of strings")
+            raise PlugError(
+                "scripted config: replies must be a list of strings, with "
+                "null for an answer that carried no words"
+            )
 
         ends_after_replies = config.get("ends_after_replies", False)
         if not isinstance(ends_after_replies, bool):

--- a/apps/simulator/src/egma_simulator/reporting.py
+++ b/apps/simulator/src/egma_simulator/reporting.py
@@ -1,13 +1,29 @@
-"""Reporting: events minted as they happen, delivered in order, at least once.
+"""Reporting: everything minted as it happens, delivered in order, at least once.
 
-One ``Reporter`` serves one simulation. Every event is stamped and
-serialized at the moment it happens; the serialized bytes are appended to a
-local write-ahead log and then posted to the control plane by a single
-sender task, so delivery is ordered and a resend replays byte-identical
-documents — ids and timestamps included, which is what lets the control
-plane dedup on event ids. The report schema is applied to every document
-before it is logged or sent: an invalid report is a bug in this process,
-and it fails here, loudly, rather than at the receiver.
+One ``Reporter`` serves one simulation and carries two kinds of document
+to the control plane: the lifecycle report events, and the conversation
+itself as OTLP span batches. Both are stamped and serialized at the moment
+they happen; the serialized bytes are appended to a local write-ahead log
+and then posted by a single sender task, so delivery is ordered and a
+resend replays byte-identical documents — ids and timestamps included,
+which is what lets the control plane dedup on event ids and the trace
+store dedup on span ids. The report schema is applied to every report
+document before it is logged or sent: an invalid report is a bug in this
+process, and it fails here, loudly, rather than at the receiver.
+
+**One queue for both kinds, and that is the design rather than a saving.**
+Because span batches and lifecycle documents share the one ordered sender,
+the terminal report leaves only after every span batch minted before it
+landed. So when the control plane records a simulation terminal, the
+evidence a verdict will cite is already in the trace store — there is no
+window in which a conversation is finished and its transcript is still in
+flight.
+
+The log on disk holds both, interleaved in the order the events happened,
+each line exactly the bytes that went on the wire. The two kinds are told
+apart by their own shape — a report names its ``contract_version``, a span
+batch its ``resourceSpans`` — because a log line that was not what was
+sent would not be a record of what was sent.
 
 A document that will not go through is resent, same bytes, with widening
 backoff until a deadline. Past that the reporter is *abandoned*: it stops
@@ -26,9 +42,10 @@ import json
 import logging
 import re
 from datetime import UTC, datetime
+from enum import Enum
 from pathlib import Path
 
-from .client import ControlPlaneClient, ReportRejected, TransientReportFailure
+from .client import ControlPlaneClient, DocumentRejected, TransientDeliveryFailure
 from .contract import validate_report
 
 logger = logging.getLogger(__name__)
@@ -44,6 +61,20 @@ MAX_BACKOFF_SECONDS = 5.0
 
 _UNSAFE_IN_A_FILENAME = re.compile(r"[^A-Za-z0-9._-]")
 _READABLE_PREFIX_LIMIT = 64
+
+
+class Destination(Enum):
+    """Which door one queued document is bound for.
+
+    The queue carries the pair rather than the bytes alone, because one
+    ordered sender serving two doors has to know which it is knocking on —
+    and knowing it here, at the moment the document was minted, is what
+    keeps the ordering between them a property of when things happened
+    rather than of how they were routed.
+    """
+
+    REPORT = "report"
+    SPANS = "spans"
 
 
 def moment() -> str:
@@ -86,7 +117,7 @@ class Reporter:
         self._sequence = 0
         self.turn_count = 0
         self.started_at: str | None = None
-        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+        self._queue: asyncio.Queue[tuple[Destination, bytes]] = asyncio.Queue()
         self._sender: asyncio.Task | None = None
         self.abandoned = False
         """Set once delivery has given up; from then on the WAL is the record."""
@@ -109,13 +140,28 @@ class Reporter:
             "events": [event],
         }
         validate_report(document)
+        self._log_and_queue(Destination.REPORT, document)
+
+    def spans(self, document: dict) -> None:
+        """Take one span batch into the same log and the same ordered queue.
+
+        This is the whole of what makes the ordering guarantee true: a
+        batch handed over here is ahead of every document minted after it,
+        the terminal report included. The batch is not schema-validated —
+        it is an OTLP export document, which the vocabulary's golden
+        fixtures pin and the ingest door checks — but it travels on exactly
+        the report's terms.
+        """
+        self._log_and_queue(Destination.SPANS, document)
+
+    def _log_and_queue(self, destination: Destination, document: dict) -> None:
         serialized = json.dumps(document, separators=(",", ":")).encode()
         self._append_to_wal(serialized)
         if self._sender is None:
             self._sender = asyncio.create_task(
                 self._send_in_order(), name=f"reporter:{self.simulation_id}"
             )
-        self._queue.put_nowait(serialized)
+        self._queue.put_nowait((destination, serialized))
 
     def _append_to_wal(self, serialized: bytes) -> None:
         # The filename is one flat component by construction, so this only
@@ -126,10 +172,10 @@ class Reporter:
 
     async def _send_in_order(self) -> None:
         while True:
-            serialized = await self._queue.get()
+            destination, serialized = await self._queue.get()
             try:
                 if not self.abandoned:
-                    await self._deliver(serialized)
+                    await self._deliver(destination, serialized)
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -150,33 +196,40 @@ class Reporter:
             finally:
                 self._queue.task_done()
 
-    async def _deliver(self, serialized: bytes) -> None:
+    async def _deliver(self, destination: Destination, serialized: bytes) -> None:
         """Send one document, resending the same bytes until it lands or time is up."""
         loop = asyncio.get_running_loop()
         deadline = loop.time() + self._delivery_deadline_seconds
         backoff = FIRST_BACKOFF_SECONDS
         attempt = 0
+        send = (
+            self._client.report
+            if destination is Destination.REPORT
+            else self._client.spans
+        )
         while True:
             attempt += 1
             try:
-                await self._client.report(self.simulation_id, serialized)
+                await send(self.simulation_id, serialized)
                 if attempt > 1:
                     logger.info(
-                        "a report for %s landed on attempt %d",
+                        "a %s document for %s landed on attempt %d",
+                        destination.value,
                         self.simulation_id,
                         attempt,
                     )
                 return
-            except ReportRejected as refusal:
+            except DocumentRejected as refusal:
                 # The control plane refused the document outright. Resending
                 # the same bytes cannot succeed; the WAL holds the record.
                 logger.error(
-                    "control plane refused a report for %s: %s",
+                    "control plane refused a %s document for %s: %s",
+                    destination.value,
                     self.simulation_id,
                     refusal,
                 )
                 return
-            except TransientReportFailure as failure:
+            except TransientDeliveryFailure as failure:
                 remaining = deadline - loop.time()
                 if remaining <= 0:
                     # Ordered delivery is over for this simulation: sending
@@ -184,10 +237,10 @@ class Reporter:
                     # control plane cannot be reached to receive it anyway.
                     self.abandoned = True
                     logger.error(
-                        "gave up delivering reports for %s after %d attempt(s) "
-                        "over %.0fs (%s); the events are in %s, and a simulator "
-                        "the control plane cannot hear is what its heartbeat "
-                        "sweep is for",
+                        "gave up delivering for %s after %d attempt(s) "
+                        "over %.0fs (%s); everything it saw is in %s, and a "
+                        "simulator the control plane cannot hear is what its "
+                        "heartbeat sweep is for",
                         self.simulation_id,
                         attempt,
                         self._delivery_deadline_seconds,
@@ -199,7 +252,7 @@ class Reporter:
                 backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
 
     async def drain(self) -> None:
-        """Wait until every event minted so far has been delivered or given up."""
+        """Wait until everything minted so far has been delivered or given up."""
         await self._queue.join()
 
     async def close(self) -> None:

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -231,6 +231,7 @@ class RunningSimulation:
                     on_turn=self._on_turn,
                     on_timing=self._on_timing,
                     on_tool_call=self._on_tool_call,
+                    on_answered=self._on_answered,
                     controls=self._controls,
                     name=f"sim:{self.simulation_id}",
                 )
@@ -286,14 +287,21 @@ class RunningSimulation:
             self._reporter.timing("first_response_latency", elapsed_ms)
             self._spans.measure("first_response_latency", elapsed_ms)
 
-        if speaker == "agent":
-            # One flush per exchange, which is where the conversation
-            # actually has a seam: the persona's turn, whatever the agent
-            # did while answering, and the answer itself go together, and
-            # the flush after them is the moment a reader could watch this
-            # simulation live. Finer would be a request per span; coarser
-            # would be a transcript that only exists once it is over.
-            self._spans.flush()
+    async def _on_answered(self) -> None:
+        """One flush per answer, which is where the conversation actually
+        has a seam: the persona's turn, whatever the agent did while
+        answering, and the answer itself go together, and the flush after
+        them is the moment a reader could watch this simulation live.
+        Finer would be a request per span; coarser would be a transcript
+        that only exists once it is over.
+
+        The walk says when an answer is whole rather than this file
+        inferring it from a turn arriving, because an answer that made a
+        tool call and said nothing produces no turn — and it is precisely
+        that answer whose evidence must not sit in a buffer waiting for
+        the agent to speak again.
+        """
+        self._spans.flush()
 
     async def _on_timing(self, measure: str, milliseconds: float) -> None:
         self._reporter.timing(measure, milliseconds)

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -6,6 +6,12 @@ the executor has room for. Each claimed spec becomes one running simulation
 cancel directive arriving on a beat's answer stops the walk at that beat.
 Every arrow points out: the simulator is never dialled into.
 
+A running simulation writes two records of itself and this is where they
+are joined. The lifecycle goes to the control plane as report events; the
+conversation goes to the OTLP ingest as spans, authored here from what the
+walk and the pipeline observe. Both go through one reporter, so they are
+delivered in the order they happened and the terminal document is last.
+
 The executor is deliberately a seam. Today it runs each simulation as one
 asyncio task in this process; a process- or container-per-simulation
 executor implements the same handful of methods and the claim loop never
@@ -34,6 +40,7 @@ from .pipeline import assemble
 from .plugs import failed_ending, plug_for
 from .redaction import SecretRegistry
 from .reporting import Reporter, moment
+from .spans import SpanEmitter
 from .spec import SimulationSpec
 from .speech import SpeechProviders
 from .walk import Conducted, WalkControls, conduct
@@ -129,7 +136,14 @@ class AsyncioExecutor:
 
 
 class RunningSimulation:
-    """One claimed spec being conducted: the pipe walk and its heartbeat."""
+    """One claimed spec being conducted: the pipe walk and its heartbeat.
+
+    It is also the one place that sees everything the walk observes, which
+    is why the conversation's spans are authored here rather than deeper
+    in: the walk knows turns and tool calls, the pipeline knows the audio,
+    and neither knows the other. Both report to the callbacks below, and
+    what comes out is one emitter for chat and voice alike.
+    """
 
     def __init__(
         self,
@@ -152,6 +166,11 @@ class RunningSimulation:
             config.wal_dir,
             delivery_deadline_seconds=config.report_deadline_seconds,
         )
+        # The conversation's own record, authored here and delivered by the
+        # reporter — the same log, the same ordered sender. Which is what
+        # puts every span ahead of the terminal document rather than
+        # alongside it.
+        self._spans = SpanEmitter(spec.simulation_id, flush=self._reporter.spans)
         self._controls = WalkControls()
         self._first_human_at: float | None = None
         self._first_latency_reported = False
@@ -182,6 +201,7 @@ class RunningSimulation:
     async def _conduct_and_report(self) -> None:
         reporter = self._reporter
         reporter.running()
+        self._spans.opened()
         try:
             # The model first, because the pipeline below holds things that
             # have to be given back and only the walk gives them back.
@@ -196,6 +216,7 @@ class RunningSimulation:
                 blobs=self._blobs,
                 speech=SpeechProviders.from_config(self._config),
                 on_timing=self._on_timing,
+                on_speech=self._on_speech,
             )
             try:
                 conducted = await conduct(
@@ -209,6 +230,7 @@ class RunningSimulation:
                     max_duration_seconds=self._spec.limits.max_duration_seconds,
                     on_turn=self._on_turn,
                     on_timing=self._on_timing,
+                    on_tool_call=self._on_tool_call,
                     controls=self._controls,
                     name=f"sim:{self.simulation_id}",
                 )
@@ -230,12 +252,18 @@ class RunningSimulation:
             # phone that rang out is not the same record as a simulator
             # that broke, and only the plug knows the difference. See
             # `plugs.failed_ending`.
+            self._spans.sealed()
             reporter.failed(failed_ending(fault), reason)
             return
 
         self._report_terminal(conducted)
 
     def _report_terminal(self, conducted: Conducted) -> None:
+        # Sealed first, always: the conversation's last spans are minted
+        # ahead of the terminal document, and the one ordered sender does
+        # the rest. That is what makes "the record is terminal" also mean
+        # "the evidence is stored".
+        self._spans.sealed()
         self._reporter.provider_reference = conducted.provider_reference
         if conducted.status == "canceled":
             self._reporter.canceled("cancel directive on heartbeat")
@@ -244,6 +272,7 @@ class RunningSimulation:
 
     async def _on_turn(self, speaker: str, text: str) -> None:
         self._reporter.turn(speaker, text, started_at=moment())
+        self._spans.turn(speaker, text)
         loop = asyncio.get_running_loop()
         if speaker == "human" and self._first_human_at is None:
             self._first_human_at = loop.time()
@@ -255,9 +284,26 @@ class RunningSimulation:
             self._first_latency_reported = True
             elapsed_ms = (loop.time() - self._first_human_at) * 1000
             self._reporter.timing("first_response_latency", elapsed_ms)
+            self._spans.measure("first_response_latency", elapsed_ms)
+
+        if speaker == "agent":
+            # One flush per exchange, which is where the conversation
+            # actually has a seam: the persona's turn, whatever the agent
+            # did while answering, and the answer itself go together, and
+            # the flush after them is the moment a reader could watch this
+            # simulation live. Finer would be a request per span; coarser
+            # would be a transcript that only exists once it is over.
+            self._spans.flush()
 
     async def _on_timing(self, measure: str, milliseconds: float) -> None:
         self._reporter.timing(measure, milliseconds)
+        self._spans.measure(measure, milliseconds)
+
+    async def _on_speech(self, speaker: str, seconds: float) -> None:
+        self._spans.spoke(speaker, seconds)
+
+    async def _on_tool_call(self, name: str, arguments: str | None) -> None:
+        self._spans.tool_call(name, arguments)
 
     async def _heartbeat_forever(self) -> None:
         while True:

--- a/apps/simulator/src/egma_simulator/spans.py
+++ b/apps/simulator/src/egma_simulator/spans.py
@@ -1,0 +1,387 @@
+"""The conversation, authored as OpenTelemetry spans.
+
+One ``SpanEmitter`` serves one simulation. Everything the walk observes —
+each turn with who said it and what was said, each tool call the platform
+reported, each measurement — becomes a span, stamped when it happened and
+handed to a flush as an ordinary OTLP export document. On the wire that
+document is what any exporter would send, which is the whole point of
+speaking OTLP: a simulation arrives at the same ingest door a customer's
+agent posts to, and is the same shape at rest.
+
+What the platform and this emitter agree on is written down once, in
+``packages/simulation-contract/span-vocabulary.md``, and pinned as golden
+fixtures beside it: the scope, the span names, the attribute keys, and how
+a batch names the simulation it is evidence of. Nothing here may drift
+from that document without the fixtures failing on both sides.
+
+**Delivery is not this module's business.** A flush hands the document to
+whoever built the emitter, and the reporter puts it through the same
+write-ahead log and the same single ordered sender the lifecycle documents
+ride — which is what makes a resend byte-identical and puts every span on
+the wire before the terminal document leaves. That ordering is the whole
+design: when the control plane records a terminal transition, the evidence
+is already stored.
+
+Two things follow from that and shape everything below.
+
+**Ids are minted here, once, and never re-derived.** A span id is minted
+when the span is authored and travels with it; a resend replays the same
+bytes, so the store's id-keyed dedup lands nothing twice. The trace id is
+derived from the simulation id deterministically, so a conversation's
+spans and its verdicts can always find each other without either side
+having stored a mapping.
+
+**Timestamps say when the thing happened**, never when it was sent. A
+timing span is named for the measure it takes and its own duration *is*
+the number, so it is opened one measurement before the moment it was
+taken. A turn is opened for as long as it was spoken — one instant on
+chat, where a message has no duration, and ear to ear on voice. Two turns
+may cross in time: that is how barge-in will be represented when the
+persona becomes a full-duplex caller, and the shape already permits it
+rather than being widened later.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+SERVICE_NAME = "egma-simulator"
+"""What a well-formed OpenTelemetry resource calls itself. It decides
+nothing: the ingest recognises this vocabulary by its scope."""
+
+SCOPE_NAME = "egma-simulator"
+SCOPE_VERSION = "1"
+"""The instrumentation scope every span rides, and the contract version it
+speaks. The ingest is gated on the name, so another framework that happens
+to call something ``agent_turn`` is never read as this one."""
+
+SIMULATION_ID_ATTRIBUTE = "egma.simulation_id"
+"""How a resource names the simulation its spans are evidence of. Echoed
+verbatim from the claimed spec — opaque, never rewritten."""
+
+ROOT_SPAN = "simulation"
+TOOL_CALL_SPAN = "tool_call"
+TURN_SPAN_OF = {"human": "human_turn", "agent": "agent_turn"}
+"""The transcript's two labels, exactly. The speaker rides the span name,
+so there is no second field free to disagree with it."""
+
+TURN_TEXT_ATTRIBUTE = "egma.turn.text"
+TOOL_NAME_ATTRIBUTE = "egma.tool.name"
+TOOL_ARGUMENTS_ATTRIBUTE = "egma.tool.arguments"
+
+SPAN_KIND = "SPAN_KIND_INTERNAL"
+"""Every span here is work this process did itself. Nothing egma emits is a
+client or server span: the conversation is not an RPC."""
+
+_CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_EGMA_SIMULATION_ID = re.compile(r"^sim_([0-9A-HJKMNP-TV-Z]{26})$")
+
+_NANOSECONDS_PER_SECOND = 1_000_000_000
+_NANOSECONDS_PER_MILLISECOND = 1_000_000
+
+Flush = Callable[[dict], None]
+"""What an emitter does with a finished document: hand it to delivery."""
+
+Clock = Callable[[], int]
+"""Wall-clock nanoseconds since the epoch, which is what OTLP timestamps
+are. Injected so a test can hold time still."""
+
+
+def trace_id_for(simulation_id: str) -> str:
+    """The trace a simulation's spans belong to, as 32 lowercase hex.
+
+    egma's own ids carry 128 bits of their own — 26 Crockford base32
+    characters after ``sim_``, which is a ULID — and those bits *are* the
+    trace, so ``sim_01K3XQ7M4E8YB2FVN0H9TZQWER`` is trace
+    ``0198fb73d08e479627eea08a75fbf1d8``, always and on both sides.
+
+    The contract calls a simulation id opaque, though — never parsed,
+    never minted, never rewritten — so this cannot depend on the id being
+    egma's own shape. An id that is not gets a digest of itself instead:
+    still 128 bits, still the same answer every time, still different for
+    every id. What it is not is reversible, which nothing needs.
+    """
+    egma_shaped = _EGMA_SIMULATION_ID.match(simulation_id)
+    if egma_shaped is not None:
+        value = 0
+        for character in egma_shaped.group(1):
+            value = (value << 5) | _CROCKFORD_ALPHABET.index(character)
+        # 26 base32 characters hold 130 bits, so a value can be wider than a
+        # trace id is. egma's own ids never are — the top bits of a ULID's
+        # millisecond field are zero for the next eight thousand years — and
+        # one that somehow were would be silently truncated, which is worse
+        # than being digested like any other id this did not recognise.
+        if value < 1 << 128:
+            return format(value, "032x")
+    return hashlib.blake2b(simulation_id.encode(), digest_size=16).hexdigest()
+
+
+def span_id_for(trace_id: str, sequence: int) -> str:
+    """One span's own id: 16 hex characters, unique inside its trace.
+
+    Derived rather than random, so that the bytes a flush carries are a
+    function of what happened and nothing else — the same conversation
+    replayed mints the same ids, which is what a store deduping on them
+    needs, and what makes a document a test can pin.
+    """
+    digest = hashlib.blake2b(
+        f"{trace_id}:{sequence}".encode(), digest_size=8
+    )
+    return digest.hexdigest()
+
+
+@dataclass
+class _Span:
+    """One authored span, held until its flush."""
+
+    span_id: str
+    name: str
+    started_unix_nano: int
+    ended_unix_nano: int
+    attributes: dict[str, str] = field(default_factory=dict)
+
+    def as_otlp(self, *, trace_id: str, parent_span_id: str | None) -> dict:
+        document: dict = {
+            "traceId": trace_id,
+            "spanId": self.span_id,
+        }
+        if parent_span_id is not None:
+            document["parentSpanId"] = parent_span_id
+        document |= {
+            "name": self.name,
+            "kind": SPAN_KIND,
+            "startTimeUnixNano": str(self.started_unix_nano),
+            "endTimeUnixNano": str(self.ended_unix_nano),
+        }
+        if self.attributes:
+            document["attributes"] = [
+                {"key": key, "value": {"stringValue": value}}
+                for key, value in self.attributes.items()
+            ]
+        return document
+
+
+class SpanEmitter:
+    """Authors one simulation's spans and hands them over in flushes."""
+
+    def __init__(
+        self,
+        simulation_id: str,
+        *,
+        flush: Flush,
+        clock: Clock = time.time_ns,
+    ) -> None:
+        self.simulation_id = simulation_id
+        self.trace_id = trace_id_for(simulation_id)
+        self._flush = flush
+        self._clock = clock
+        self._sequence = 0
+        # Minted first and sent last. Every other span names it, so it has
+        # to exist before any of them; it leaves in the final flush, when
+        # the conversation is over and everything else is already on the
+        # wire.
+        self._root = _Span(
+            span_id=self._mint(), name=ROOT_SPAN, started_unix_nano=0, ended_unix_nano=0
+        )
+        self._pending: list[_Span] = []
+        self._open_turn: dict[str, _Span] = {}
+        """A turn authored before anything measured how long it was spoken
+        for — the persona's own words, which are decided a moment before
+        they are said. It stays open until the flush that carries it."""
+        self._unspoken_for: dict[str, float] = {}
+        """The other order: audio measured before its words are known,
+        which is every turn the agent takes, since it is heard and then
+        read. Spent by the next turn that speaker takes."""
+        self._sealed = False
+
+    def _mint(self) -> str:
+        self._sequence += 1
+        return span_id_for(self.trace_id, self._sequence)
+
+    def _author(
+        self,
+        name: str,
+        *,
+        started_unix_nano: int,
+        ended_unix_nano: int,
+        attributes: dict[str, str] | None = None,
+    ) -> _Span:
+        span = _Span(
+            span_id=self._mint(),
+            name=name,
+            started_unix_nano=started_unix_nano,
+            ended_unix_nano=ended_unix_nano,
+            attributes=attributes or {},
+        )
+        self._pending.append(span)
+        return span
+
+    # -- What the walk observes ----------------------------------------------
+
+    def opened(self) -> None:
+        """The conversation began. Stamps the root's start and nothing else."""
+        self._root.started_unix_nano = self._clock()
+
+    def turn(self, speaker: str, text: str) -> None:
+        """One transcript turn, by whichever of the two speakers took it.
+
+        A turn is one instant unless something measured how long it was
+        spoken for — which on chat nothing ever does, because a message has
+        no duration. On voice the audio says, and it arrives on either side
+        of this call: the agent's is heard before it is read, and the
+        persona's is said after it is decided. Both are joined by
+        :meth:`spoke`, and a turn nobody timed is left the instant it
+        honestly was rather than given a made-up length.
+        """
+        name = TURN_SPAN_OF.get(speaker)
+        if name is None:
+            raise ValueError(f"a turn was taken by {speaker!r}, who is not a speaker")
+
+        now = self._clock()
+        spoken_seconds = self._unspoken_for.pop(speaker, None)
+        began = (
+            now
+            if spoken_seconds is None
+            else now - int(spoken_seconds * _NANOSECONDS_PER_SECOND)
+        )
+        span = self._author(
+            name,
+            started_unix_nano=began,
+            ended_unix_nano=now,
+            attributes={TURN_TEXT_ATTRIBUTE: text},
+        )
+        if spoken_seconds is None:
+            self._open_turn[speaker] = span
+
+    def spoke(self, speaker: str, seconds: float) -> None:
+        """How long one side's audio ran for one turn, ear to ear.
+
+        Voice only, and the one fact a transcript cannot carry. It reaches
+        the turn it belongs to whichever way round the two were observed.
+        """
+        span = self._open_turn.pop(speaker, None)
+        if span is None:
+            self._unspoken_for[speaker] = seconds
+            return
+        span.started_unix_nano = span.ended_unix_nano - int(
+            seconds * _NANOSECONDS_PER_SECOND
+        )
+
+    def tool_call(self, name: str, arguments: str | None) -> None:
+        """A tool call, as observed from egma's side of the connection.
+
+        One instant: the platform reports the invocation, not its span, and
+        stretching it over a guess would be inventing a fact nobody
+        measured. There is no result attribute for the same reason.
+        """
+        attributes = {TOOL_NAME_ATTRIBUTE: name}
+        if arguments is not None:
+            attributes[TOOL_ARGUMENTS_ATTRIBUTE] = arguments
+        now = self._clock()
+        self._author(
+            TOOL_CALL_SPAN,
+            started_unix_nano=now,
+            ended_unix_nano=now,
+            attributes=attributes,
+        )
+
+    def measure(self, measure: str, milliseconds: float) -> None:
+        """One measurement, as the span whose duration *is* the number.
+
+        The span is named for the measure and closed at the moment the
+        measurement was taken, opening one measurement earlier — so its
+        start and end bracket the interval that was measured, in
+        nanoseconds, with nothing to disagree with.
+        """
+        ended = self._clock()
+        self._author(
+            measure,
+            started_unix_nano=ended
+            - int(milliseconds * _NANOSECONDS_PER_MILLISECOND),
+            ended_unix_nano=ended,
+        )
+
+    # -- Handing them over ----------------------------------------------------
+
+    def flush(self) -> None:
+        """Send everything authored since the last flush, and nothing else.
+
+        A span is authored once and drained once, so no two flushes ever
+        carry the same id — which is what lets a resend be at-least-once
+        while the store lands nothing twice.
+        """
+        self._hand_over(self._pending)
+        self._pending = []
+        self._forget_unjoined_audio()
+
+    def sealed(self) -> None:
+        """Close the conversation: everything left, with the root last.
+
+        Called once, before the terminal lifecycle document is minted, so
+        that the one ordered sender puts every span ahead of it.
+        """
+        if self._sealed:
+            return
+        self._sealed = True
+        self._root.ended_unix_nano = self._clock()
+        self._hand_over([*self._pending, self._root])
+        self._pending = []
+        self._forget_unjoined_audio()
+
+    def _forget_unjoined_audio(self) -> None:
+        """End of an exchange: nothing measured in it reaches the next one.
+
+        A turn still waiting on its own length has left — nothing can widen
+        a span already on the wire, so it stays the instant it honestly
+        was — and a length that never found its turn is dropped rather than
+        given to whoever speaks next.
+        """
+        self._open_turn.clear()
+        self._unspoken_for.clear()
+
+    def _hand_over(self, spans: list[_Span]) -> None:
+        if not spans:
+            return
+        self._flush(
+            {
+                "resourceSpans": [
+                    {
+                        "resource": {
+                            "attributes": [
+                                {
+                                    "key": "service.name",
+                                    "value": {"stringValue": SERVICE_NAME},
+                                },
+                                {
+                                    "key": SIMULATION_ID_ATTRIBUTE,
+                                    "value": {"stringValue": self.simulation_id},
+                                },
+                            ]
+                        },
+                        "scopeSpans": [
+                            {
+                                "scope": {
+                                    "name": SCOPE_NAME,
+                                    "version": SCOPE_VERSION,
+                                },
+                                "spans": [
+                                    span.as_otlp(
+                                        trace_id=self.trace_id,
+                                        parent_span_id=(
+                                            None
+                                            if span is self._root
+                                            else self._root.span_id
+                                        ),
+                                    )
+                                    for span in spans
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )

--- a/apps/simulator/src/egma_simulator/walk.py
+++ b/apps/simulator/src/egma_simulator/walk.py
@@ -37,6 +37,21 @@ reported from where the audio is actually observed — the pipeline — because
 a transcript cannot carry it and a clock around the turn would be timing
 this process rather than the conversation."""
 
+OnAnswered = Callable[[], Awaitable[None]]
+"""Everything one agent answer produced is on the record — the words it
+carried, the tool calls it made, the time it took.
+
+It carries nothing, because it is not an observation: it is the boundary
+between one answer and the next, and turn-taking is the only thing that
+knows where that falls. An answer that produced no words is still an
+answer that ended, which is exactly the case a reader of the turns alone
+would miss. An agent that speaks first has finished saying its piece the
+same way, so the opening counts as one.
+
+The last answer of a conversation is deliberately not announced: the walk
+is over, and whatever it produced belongs with the record of the whole
+thing rather than in a boundary of its own."""
+
 # The two causes a WalkControls can carry. Writer and reader both name
 # these constants, so a stop can never be misread as the other cause.
 CANCEL_DIRECTIVE = "cancel directive"
@@ -127,6 +142,7 @@ async def conduct(
     controls: WalkControls,
     name: str,
     on_tool_call: OnToolCall | None = None,
+    on_answered: OnAnswered | None = None,
 ) -> Conducted:
     """Walk one simulation through one exchange, and say how it went."""
     loop = asyncio.get_running_loop()
@@ -135,6 +151,10 @@ async def conduct(
     async def record(speaker: str, text: str) -> None:
         history.append(Turn(speaker, text))
         await on_turn(speaker, text)
+
+    async def answered() -> None:
+        if on_answered is not None:
+            await on_answered()
 
     def budget_spent() -> bool:
         return len(history) >= max_turns
@@ -158,6 +178,7 @@ async def conduct(
         greeting = await controls.guard(plug.open())
         if greeting is not None:
             await record("agent", greeting)
+        await answered()
 
         while True:
             # The persona's move — unless the budget is already spent.
@@ -191,6 +212,11 @@ async def conduct(
                 await record("agent", answer.text)
             if answer.ended:
                 return ended("agent_ended", "the agent ended the exchange")
+            # The answer is whole, whatever it turned out to carry. Said
+            # here rather than beside the turn above, because an answer
+            # with no words is still an answer, and a boundary read off
+            # the transcript alone would miss exactly that one.
+            await answered()
     except _WalkStopped:
         if controls.cause == CANCEL_DIRECTIVE:
             return Conducted(

--- a/apps/simulator/src/egma_simulator/walk.py
+++ b/apps/simulator/src/egma_simulator/walk.py
@@ -30,6 +30,12 @@ logger = logging.getLogger(__name__)
 
 OnTurn = Callable[[str, str], Awaitable[None]]
 OnTiming = Callable[[str, float], Awaitable[None]]
+OnToolCall = Callable[[str, str | None], Awaitable[None]]
+OnSpeech = Callable[[str, float], Awaitable[None]]
+"""How long one side's audio ran for one turn, ear to ear. Voice only, and
+reported from where the audio is actually observed — the pipeline — because
+a transcript cannot carry it and a clock around the turn would be timing
+this process rather than the conversation."""
 
 # The two causes a WalkControls can carry. Writer and reader both name
 # these constants, so a stop can never be misread as the other cause.
@@ -120,6 +126,7 @@ async def conduct(
     on_timing: OnTiming | None,
     controls: WalkControls,
     name: str,
+    on_tool_call: OnToolCall | None = None,
 ) -> Conducted:
     """Walk one simulation through one exchange, and say how it went."""
     loop = asyncio.get_running_loop()
@@ -174,6 +181,12 @@ async def conduct(
                 await on_timing(
                     "turn_response_latency", (loop.time() - asked_at) * 1000
                 )
+            # What the agent did while answering, before what it said: a
+            # tool call happened during the turn, and only a platform that
+            # exposes one reports any at all.
+            if on_tool_call is not None:
+                for call in answer.tool_calls:
+                    await on_tool_call(call.name, call.arguments)
             if answer.text is not None:
                 await record("agent", answer.text)
             if answer.ended:

--- a/apps/simulator/src/egma_simulator/workbench/__main__.py
+++ b/apps/simulator/src/egma_simulator/workbench/__main__.py
@@ -1,9 +1,10 @@
 """``python -m egma_simulator.workbench`` — the fake control plane, standing.
 
 Point it at spec fixtures and start a simulator against it; every claim,
-heartbeat, report and refusal prints as a JSON line the moment it happens,
-which is how you watch a simulation go queued → claimed → running →
-completed without a database anywhere.
+heartbeat, report, arriving span and refusal prints as a JSON line the
+moment it happens, which is how you watch a simulation go queued →
+claimed → running → completed, conversation and all, without a database
+anywhere.
 """
 
 from __future__ import annotations

--- a/apps/simulator/src/egma_simulator/workbench/app.py
+++ b/apps/simulator/src/egma_simulator/workbench/app.py
@@ -1,11 +1,19 @@
 """The workbench: a fake control plane that speaks the contract from fixtures.
 
-Dev and test only. It serves the three endpoints the simulator dials —
-claim, heartbeat, report — from spec documents loaded off disk, validates
-everything both ways against the contract schemas, and records every
-observation in order. The records are the whole point: the acceptance
-suite asserts against nothing else, and a person watching the log watches
-a simulation go queued → claimed → running → completed.
+Dev and test only. It serves the four endpoints the simulator dials —
+claim, heartbeat, report, and the OTLP ingest the conversation's spans go
+to — from spec documents loaded off disk, validates everything both ways
+against the contract schemas, and records every observation in order. The
+records are the whole point: the acceptance suite asserts against nothing
+else, and a person watching the log watches a simulation go queued →
+claimed → running → completed with its turns arriving in between.
+
+The span sink is deliberately the smallest thing that can be called one: it
+checks a batch parses and names a simulation this workbench knows, records
+each span, and answers what the OTLP specification says to. It stores
+nothing, indexes nothing and joins nothing — the real ingest does all of
+that, and a second implementation of it here would be a second thing to
+keep true.
 
 When the real claim API lands in the control plane, the workbench retires
 from the critical path and stays what it already is: the local rig for
@@ -23,12 +31,17 @@ from aiohttp import web
 
 from ..contract import ContractViolation, validate_report, validate_spec
 from ..reporting import moment
+from ..spans import SIMULATION_ID_ATTRIBUTE
 
 logger = logging.getLogger(__name__)
 
 
 class RefusedReport(Exception):
     """A report document the workbench refused, with the words it refused in."""
+
+
+class RefusedSpans(Exception):
+    """A span batch the workbench refused, with the words it refused in."""
 
 
 class WorkbenchState:
@@ -48,6 +61,10 @@ class WorkbenchState:
         self._cancel_flags: set[str] = set()
         self._arrival = asyncio.Condition()
         self.records: list[dict] = []
+        self._flushes = 0
+        """How many span batches have arrived. Stamped on every span
+        recorded, so a suite can tell one flush from the next without
+        having to reconstruct the grouping from what landed."""
 
     def _record(self, kind: str, **details: object) -> None:
         entry = {"seq": len(self.records), "at": moment(), "kind": kind, **details}
@@ -150,6 +167,55 @@ class WorkbenchState:
                 "report", simulation_id=simulation_id, event=event, raw=body
             )
 
+    def spans(self, raw: bytes) -> None:
+        """Validate and record one OTLP span batch; refusals are records too.
+
+        Two checks, which are the two the real ingest makes at the batch
+        grain: it has to parse, and every resource in it has to name a
+        simulation this deployment conducted. A batch that fails either is
+        refused whole — there is nowhere honest to file part of it — and
+        the refusal is a record like everything else.
+        """
+        body = raw.decode("utf-8", errors="replace")
+        try:
+            document = json.loads(body)
+        except ValueError:
+            self._record("refusal", why="spans unparseable", raw=body)
+            raise RefusedSpans("not JSON") from None
+
+        resources = (
+            document.get("resourceSpans") if isinstance(document, dict) else None
+        )
+        if not isinstance(resources, list) or not resources:
+            self._record("refusal", why="not an OTLP export", raw=body)
+            raise RefusedSpans("no resourceSpans")
+
+        self._flushes += 1
+        for resource in resources:
+            simulation_id = _simulation_named_by(resource)
+            if simulation_id is None:
+                self._record("refusal", why="spans naming no simulation", raw=body)
+                raise RefusedSpans(
+                    f"a resource carries no {SIMULATION_ID_ATTRIBUTE} attribute"
+                )
+            if not self.known(simulation_id):
+                self._record(
+                    "refusal",
+                    simulation_id=simulation_id,
+                    why="spans for an unknown simulation",
+                    raw=body,
+                )
+                raise RefusedSpans(f"no simulation {simulation_id} was ever offered")
+            for scope in resource.get("scopeSpans", []):
+                for span in scope.get("spans", []):
+                    self._record(
+                        "span",
+                        simulation_id=simulation_id,
+                        flush=self._flushes,
+                        scope=scope.get("scope", {}),
+                        span=span,
+                    )
+
     def cancel(self, simulation_id: str) -> None:
         self._cancel_flags.add(simulation_id)
         self._record("cancel_directive", simulation_id=simulation_id)
@@ -190,6 +256,19 @@ def build_app(state: WorkbenchState) -> web.Application:
             raise web.HTTPBadRequest(text=str(refusal)) from refusal
         return web.Response(status=204)
 
+    async def traces(request: web.Request) -> web.Response:
+        try:
+            state.spans(await request.read())
+        except RefusedSpans as refusal:
+            # The specification's own refusal shape, so the sender reads it
+            # the way it would read the real door's.
+            raise web.HTTPBadRequest(
+                text=json.dumps({"code": 3, "message": str(refusal)}),
+                content_type="application/json",
+            ) from refusal
+        # An empty ExportTraceServiceResponse: everything landed.
+        return web.json_response({})
+
     async def records(_request: web.Request) -> web.Response:
         return web.json_response({"records": state.records})
 
@@ -216,10 +295,26 @@ def build_app(state: WorkbenchState) -> web.Application:
     app.router.add_post("/v1/claims", claim)
     app.router.add_post("/v1/simulations/{simulation_id}/heartbeats", heartbeat)
     app.router.add_post("/v1/simulations/{simulation_id}/reports", report)
+    app.router.add_post("/v1/traces", traces)
     app.router.add_get("/workbench/records", records)
     app.router.add_post("/workbench/specs", offer)
     app.router.add_post("/workbench/simulations/{simulation_id}/cancel", cancel)
     return app
+
+
+def _simulation_named_by(resource: object) -> str | None:
+    """Which simulation one OTLP resource says its spans are evidence of."""
+    if not isinstance(resource, dict):
+        return None
+    attributes = resource.get("resource", {}).get("attributes", [])
+    for attribute in attributes:
+        if not isinstance(attribute, dict):
+            continue
+        if attribute.get("key") != SIMULATION_ID_ATTRIBUTE:
+            continue
+        named = attribute.get("value", {}).get("stringValue")
+        return named if isinstance(named, str) and named else None
+    return None
 
 
 def load_spec_documents(path: Path) -> list[dict]:

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -289,7 +289,7 @@ def scripted_spec(
     scenario: str = A_SCENARIO,
     personality: str = A_PERSONALITY,
     greeting: str | None = None,
-    replies: list[str] | None = None,
+    replies: list[str | None] | None = None,
     ends_after_replies: bool = False,
     turn_seconds: float = 0.0,
     provider_reference: str | None = None,

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -293,6 +293,7 @@ def scripted_spec(
     ends_after_replies: bool = False,
     turn_seconds: float = 0.0,
     provider_reference: str | None = None,
+    tool_calls: list[dict] | None = None,
     max_turns: int = 60,
     max_duration_seconds: int = 600,
     credentials: dict | None = None,
@@ -311,6 +312,8 @@ def scripted_spec(
         config["ends_after_replies"] = True
     if provider_reference is not None:
         config["provider_reference"] = provider_reference
+    if tool_calls is not None:
+        config["tool_calls"] = tool_calls
     return a_spec(
         simulation_id,
         connection={
@@ -601,6 +604,23 @@ def terminal_event_for(records: list[dict], simulation_id: str) -> dict | None:
     for event in events_for(records, simulation_id, "status"):
         if event["status"] in ("completed", "failed", "canceled"):
             return event
+    return None
+
+
+def spans_for(records: list[dict], simulation_id: str) -> list[dict]:
+    """Every span the workbench's OTLP sink recorded for one simulation,
+    in arrival order — the record with its flush number kept."""
+    return [
+        record
+        for record in records
+        if record["kind"] == "span" and record["simulation_id"] == simulation_id
+    ]
+
+
+def span_attribute(span: dict, key: str) -> str | None:
+    for entry in span.get("attributes", []):
+        if entry["key"] == key:
+            return entry["value"]["stringValue"]
     return None
 
 

--- a/apps/simulator/tests/retell_stub.py
+++ b/apps/simulator/tests/retell_stub.py
@@ -54,6 +54,12 @@ class RetellStub:
     """When true the last scripted reply carries the end-tool invocation,
     the way an agent ending its own exchange does."""
 
+    tool_calls: Sequence[dict] = ()
+    """Invocations the agent makes while producing its first answer, each
+    ``{"name": …}`` with an optional ``"arguments"`` string. Retell reports
+    these inline with the words, which is what makes a tool call visible
+    from egma's side at all."""
+
     turn_seconds: float = 0.0
     """How long a completion takes, the way a real agent takes time."""
 
@@ -154,6 +160,17 @@ class RetellStub:
         position = chat["delivered"]
         chat["delivered"] += 1
         messages: list[dict] = []
+        if position == 0:
+            messages.extend(
+                {
+                    "message_id": f"msg_{len(self.calls)}_tool_{index}",
+                    "role": "tool_call_invocation",
+                    "tool_call_id": f"tool_call_{index}",
+                    "created_timestamp": _now_ms(),
+                    **call,
+                }
+                for index, call in enumerate(self.tool_calls)
+            )
         if position < len(self.replies):
             answer = self.replies[position]
             bubbles = [answer] if isinstance(answer, str) else list(answer)

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -34,6 +34,8 @@ from conftest import (
     phone_spec,
     retell_spec,
     scripted_spec,
+    span_attribute,
+    spans_for,
     status_events_for,
     terminal_event_for,
 )
@@ -1127,3 +1129,174 @@ async def test_a_voice_simulation_lets_no_credential_out_either(
     for channel in channels_of(recording)[:2]:
         spoken = decode_speech(channel, channels_of(recording)[2])
         assert sentinel not in spoken, "the credential was spoken into the audio"
+
+
+# -- The conversation, streamed as spans ----------------------------------
+
+
+def flush_of(record: dict) -> int:
+    return record["flush"]
+
+
+async def test_a_chat_simulation_streams_its_conversation_as_spans(
+    workbench, start_simulator
+):
+    """The whole conversation arrives as OTLP, while it happens — and the
+    terminal report arrives after the last span."""
+    spec = scripted_spec(
+        "sim-spans-chat",
+        scenario="Move my Tuesday cleaning to Thursday. My name is Margaret Hale.",
+        greeting="Lakeside Dental, how can I help?",
+        replies=[
+            "Of course — could I take your name?",
+            "Done: you are moved to Thursday at half past two.",
+        ],
+        tool_calls=[
+            {
+                "name": "reschedule_appointment",
+                "arguments": '{"appointment_id":"apt-88213"}',
+            },
+            {"name": "send_confirmation_sms"},
+        ],
+    )
+    await workbench.offer(spec)
+    start_simulator(workbench)
+
+    records = await workbench.wait_for(has_terminal("sim-spans-chat"))
+    recorded = spans_for(records, "sim-spans-chat")
+    spans = [record["span"] for record in recorded]
+    names = [span["name"] for span in spans]
+
+    # Every turn of the transcript, with the speaker in the span name and
+    # the words in the one attribute the vocabulary declares.
+    turns = events_for(records, "sim-spans-chat", "turn")
+    assert names.count("human_turn") == sum(
+        1 for turn in turns if turn["speaker"] == "human"
+    )
+    assert names.count("agent_turn") == sum(
+        1 for turn in turns if turn["speaker"] == "agent"
+    )
+    said = [
+        span_attribute(span, "egma.turn.text")
+        for span in spans
+        if span["name"] in ("human_turn", "agent_turn")
+    ]
+    assert said == [turn["text"] for turn in turns]
+
+    # The measurements, as spans whose own duration is the number.
+    assert names.count("first_response_latency") == 1
+    assert names.count("turn_response_latency") == 2
+    for span in spans:
+        if span["name"].endswith("_latency"):
+            duration = int(span["endTimeUnixNano"]) - int(span["startTimeUnixNano"])
+            assert duration > 0
+
+    # The tool calls the platform reported, arguments where it gave them.
+    calls = [span for span in spans if span["name"] == "tool_call"]
+    assert [span_attribute(span, "egma.tool.name") for span in calls] == [
+        "reschedule_appointment",
+        "send_confirmation_sms",
+    ]
+    assert span_attribute(calls[0], "egma.tool.arguments") == (
+        '{"appointment_id":"apt-88213"}'
+    )
+    assert span_attribute(calls[1], "egma.tool.arguments") is None
+
+    # One trace, the root last, and every other span named under it.
+    root = next(span for span in spans if span["name"] == "simulation")
+    assert names[-1] == "simulation"
+    assert "parentSpanId" not in root
+    for span in spans:
+        assert span["traceId"] == root["traceId"]
+        if span is not root:
+            assert span["parentSpanId"] == root["spanId"]
+
+    # Every flush disjoint from every other, so a resend lands nothing twice.
+    by_flush: dict[int, set[str]] = {}
+    for record in recorded:
+        by_flush.setdefault(flush_of(record), set()).add(record["span"]["spanId"])
+    assert len(by_flush) > 1, "the whole conversation arrived in one batch"
+    seen: set[str] = set()
+    for ids in by_flush.values():
+        assert seen.isdisjoint(ids)
+        seen |= ids
+
+    # And the ordering the whole design leans on: every span landed before
+    # the terminal report did.
+    last_span = max(record["seq"] for record in recorded)
+    terminal_seq = next(
+        record["seq"]
+        for record in records
+        if record["kind"] == "report"
+        and record["simulation_id"] == "sim-spans-chat"
+        and record["event"]["kind"] == "status"
+        and record["event"]["status"] in ("completed", "failed", "canceled")
+    )
+    assert last_span < terminal_seq
+
+    # Streamed rather than posted at the end: turns were on the record
+    # before the conversation was over.
+    assert min(record["seq"] for record in recorded) < terminal_seq - len(spans)
+
+    # Nothing was refused on the way.
+    assert [record for record in records if record["kind"] == "refusal"] == []
+
+
+async def test_a_voice_simulation_produces_the_same_shapes_plus_its_audio_facts(
+    workbench, start_simulator
+):
+    """The same conversation-span shapes as chat, and the turns carry the
+    length of the audio rather than being instants."""
+    spec = loopback_spec(
+        "sim-spans-voice",
+        scenario="First point. Second point.",
+        greeting="Front desk, hello.",
+        replies=["Certainly.", "Done."],
+        answer_delay_seconds=0.3,
+    )
+    await workbench.offer(spec)
+    start_simulator(workbench)
+
+    records = await workbench.wait_for(has_terminal("sim-spans-voice"))
+    spans = [record["span"] for record in spans_for(records, "sim-spans-voice")]
+    names = [span["name"] for span in spans]
+
+    # The same shapes chat produces, named identically.
+    assert names.count("human_turn") == 3
+    assert names.count("agent_turn") == 3
+    assert names.count("first_response_latency") == 1
+    assert names.count("turn_response_latency") == 2
+    assert names[-1] == "simulation"
+
+    # Plus what only voice can measure, one span per measurement.
+    assert names.count("time_to_first_word") == 3
+    assert names.count("agent_speech_duration") == 3
+    assert names.count("persona_speech_duration") == 2
+
+    def durations(name: str) -> list[int]:
+        return [
+            int(span["endTimeUnixNano"]) - int(span["startTimeUnixNano"])
+            for span in spans
+            if span["name"] == name
+        ]
+
+    # A voice turn has a length, where a chat turn is one instant: what the
+    # simulator heard and what it spoke, ear to ear.
+    assert all(length > 0 for length in durations("agent_turn"))
+    # Every persona turn the counterpart actually heard, except the last —
+    # the persona's goodbye concludes the scenario, so the walk ends before
+    # it is ever spoken, and a turn nobody said is honestly an instant.
+    assert all(length > 0 for length in durations("human_turn")[:-1])
+    assert durations("human_turn")[-1] == 0
+
+    # The quiet before the agent's first word is the delay the counterpart
+    # was told to wait — measured out of the audio, and the span's own
+    # duration is that number.
+    assert all(
+        abs(length - 300_000_000) < 20_000_000 for length in durations(
+            "time_to_first_word"
+        )
+    ), durations("time_to_first_word")
+
+    # A persona turn is exactly as long as the audio the persona spoke.
+    assert durations("persona_speech_duration") == durations("human_turn")[:-1]

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -1300,3 +1300,80 @@ async def test_a_voice_simulation_produces_the_same_shapes_plus_its_audio_facts(
 
     # A persona turn is exactly as long as the audio the persona spoke.
     assert durations("persona_speech_duration") == durations("human_turn")[:-1]
+
+
+async def test_an_answer_that_only_called_a_tool_is_flushed_like_any_other(
+    workbench, start_simulator
+):
+    """A flush closes an answer, not a turn.
+
+    An agent that calls a tool and says nothing produces no transcript
+    turn, so a flush keyed on turns would leave that answer's tool calls
+    and its measurement sitting in a buffer until the agent next spoke —
+    or until the conversation was over, which is the one moment live
+    evidence is no longer live.
+    """
+    spec = scripted_spec(
+        "sim-spans-tool-only",
+        scenario="Move my Tuesday cleaning to Thursday. Any afternoon suits.",
+        greeting="Lakeside Dental, how can I help?",
+        replies=[None, "Moved — Thursday at three."],
+        tool_calls=[
+            {
+                "name": "reschedule_appointment",
+                "arguments": '{"appointment_id":"apt-88213"}',
+            }
+        ],
+    )
+    await workbench.offer(spec)
+    start_simulator(workbench)
+
+    records = await workbench.wait_for(has_terminal("sim-spans-tool-only"))
+    recorded = spans_for(records, "sim-spans-tool-only")
+
+    # The wordless answer said nothing, so the transcript never mentions
+    # it — the agent's two turns are the greeting and the later words.
+    turns = events_for(records, "sim-spans-tool-only", "turn")
+    assert [turn["text"] for turn in turns if turn["speaker"] == "agent"] == [
+        "Lakeside Dental, how can I help?",
+        "Moved — Thursday at three.",
+    ]
+
+    def flush_carrying(name: str, said: str | None = None) -> int:
+        for record in recorded:
+            span = record["span"]
+            if span["name"] != name:
+                continue
+            if said is not None and span_attribute(span, "egma.turn.text") != said:
+                continue
+            return record["flush"]
+        raise AssertionError(f"no {name} span was ever recorded")
+
+    tool_flush = flush_carrying("tool_call")
+    words_flush = flush_carrying("agent_turn", "Moved — Thursday at three.")
+    root_flush = flush_carrying("simulation")
+
+    # It left while the conversation was still going, not with the root.
+    assert tool_flush < root_flush
+    # And on its own account: the words that came an answer later rode a
+    # later flush, so nothing swept the tool call along with them.
+    assert tool_flush < words_flush
+
+    # The whole answer went together — its measurement rode the same flush
+    # as the call it measured, which is what "a flush is an answer" means.
+    assert any(
+        record["flush"] == tool_flush
+        and record["span"]["name"] == "turn_response_latency"
+        for record in recorded
+    ), "the wordless answer's measurement was split from its tool call"
+
+    # The invariants the design rests on, unchanged by the extra flush.
+    by_flush: dict[int, set[str]] = {}
+    for record in recorded:
+        by_flush.setdefault(record["flush"], set()).add(record["span"]["spanId"])
+    seen: set[str] = set()
+    for ids in by_flush.values():
+        assert seen.isdisjoint(ids)
+        seen |= ids
+    assert [record["span"]["name"] for record in recorded][-1] == "simulation"
+    assert [record for record in records if record["kind"] == "refusal"] == []

--- a/apps/simulator/tests/test_client_auth.py
+++ b/apps/simulator/tests/test_client_auth.py
@@ -41,10 +41,15 @@ async def listening_control_plane() -> AsyncIterator[tuple[str, list[str | None]
         offered.append(request.headers.get("Authorization"))
         return web.Response(status=204)
 
+    async def traces(request: web.Request) -> web.Response:
+        offered.append(request.headers.get("Authorization"))
+        return web.json_response({})
+
     app = web.Application()
     app.router.add_post("/v1/claims", claim)
     app.router.add_post("/v1/simulations/{simulation_id}/heartbeats", heartbeat)
     app.router.add_post("/v1/simulations/{simulation_id}/reports", report)
+    app.router.add_post("/v1/traces", traces)
 
     runner = web.AppRunner(app)
     await runner.setup()
@@ -56,10 +61,11 @@ async def listening_control_plane() -> AsyncIterator[tuple[str, list[str | None]
         await runner.cleanup()
 
 
-async def _make_all_three_calls(client: ControlPlaneClient) -> None:
+async def _make_every_call(client: ControlPlaneClient) -> None:
     await client.claim("sim-under-test", 1)
     await client.heartbeat("sim-1", "sim-under-test")
     await client.report("sim-1", b"{}")
+    await client.spans("sim-1", b'{"resourceSpans":[]}')
 
 
 async def test_a_service_token_rides_every_outbound_call(listening_control_plane):
@@ -68,9 +74,9 @@ async def test_a_service_token_rides_every_outbound_call(listening_control_plane
     async with ControlPlaneClient(
         base_url, claim_wait_seconds=1, service_token="egma_service_token_under_test"
     ) as client:
-        await _make_all_three_calls(client)
+        await _make_every_call(client)
 
-    assert offered == ["Bearer egma_service_token_under_test"] * 3
+    assert offered == ["Bearer egma_service_token_under_test"] * 4
 
 
 async def test_no_token_means_no_header(listening_control_plane):
@@ -78,9 +84,9 @@ async def test_no_token_means_no_header(listening_control_plane):
     base_url, offered = listening_control_plane
 
     async with ControlPlaneClient(base_url, claim_wait_seconds=1) as client:
-        await _make_all_three_calls(client)
+        await _make_every_call(client)
 
-    assert offered == [None] * 3
+    assert offered == [None] * 4
 
 
 # -- And nowhere else --------------------------------------------------------

--- a/apps/simulator/tests/test_client_failures.py
+++ b/apps/simulator/tests/test_client_failures.py
@@ -22,9 +22,9 @@ from aiohttp import web
 from egma_simulator.client import (
     ClaimFailure,
     ControlPlaneClient,
+    DocumentRejected,
     HeartbeatFailure,
-    ReportRejected,
-    TransientReportFailure,
+    TransientDeliveryFailure,
 )
 
 
@@ -88,7 +88,7 @@ async def test_a_slow_report_is_a_transient_failure(
     async with ControlPlaneClient(
         stalling_control_plane, claim_wait_seconds=1
     ) as client:
-        with pytest.raises(TransientReportFailure):
+        with pytest.raises(TransientDeliveryFailure):
             await client.report("sim-1", b"{}")
 
 
@@ -100,7 +100,7 @@ async def test_nothing_reachable_at_all_is_still_a_declared_failure():
             await client.claim("test", 1)
         with pytest.raises(HeartbeatFailure):
             await client.heartbeat("sim-1", "test")
-        with pytest.raises(TransientReportFailure):
+        with pytest.raises(TransientDeliveryFailure):
             await client.report("sim-1", b"{}")
 
 
@@ -120,10 +120,102 @@ async def test_the_two_four_hundreds_that_mean_try_again_are_transient():
     try:
         async with ControlPlaneClient(base, claim_wait_seconds=1) as client:
             for status in ("408", "429", "503"):
-                with pytest.raises(TransientReportFailure):
+                with pytest.raises(TransientDeliveryFailure):
                     await client.report(status, b"{}")
             for status in ("400", "404", "422"):
-                with pytest.raises(ReportRejected):
+                with pytest.raises(DocumentRejected):
                     await client.report(status, b"{}")
     finally:
         await runner.cleanup()
+
+
+# -- The ingest door, refused and retried on the report's own terms --------
+
+
+async def test_the_ingest_door_is_reached_at_the_specifications_own_path():
+    """OTLP/HTTP, JSON, on the control-plane URL already configured — the
+    simulator has one address and files its evidence at it."""
+    seen: list[tuple[str, str | None, bytes]] = []
+
+    async def traces(request: web.Request) -> web.Response:
+        seen.append(
+            (
+                str(request.path),
+                request.headers.get("content-type"),
+                await request.read(),
+            )
+        )
+        return web.json_response({})
+
+    app = web.Application()
+    app.router.add_post("/v1/traces", traces)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    base = f"http://127.0.0.1:{runner.addresses[0][1]}"
+    try:
+        async with ControlPlaneClient(base, claim_wait_seconds=1) as client:
+            await client.spans("sim-1", b'{"resourceSpans":[]}')
+    finally:
+        await runner.cleanup()
+
+    assert seen == [("/v1/traces", "application/json", b'{"resourceSpans":[]}')]
+
+
+async def test_a_refused_span_batch_is_rejected_and_a_stalled_one_is_transient():
+    """The attribution refusal is a 400, which resending cannot fix; a
+    wedged or overloaded door says try again."""
+
+    async def answer(request: web.Request) -> web.Response:
+        return web.Response(status=int(await request.text()))
+
+    app = web.Application()
+    app.router.add_post("/v1/traces", answer)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    base = f"http://127.0.0.1:{runner.addresses[0][1]}"
+    try:
+        async with ControlPlaneClient(base, claim_wait_seconds=1) as client:
+            for status in (b"408", b"429", b"503"):
+                with pytest.raises(TransientDeliveryFailure):
+                    await client.spans("sim-1", status)
+            for status in (b"400", b"404", b"415"):
+                with pytest.raises(DocumentRejected):
+                    await client.spans("sim-1", status)
+    finally:
+        await runner.cleanup()
+
+
+async def test_a_partial_success_is_not_retried_and_is_not_a_failure(caplog):
+    """The specification says rejected data must not be resent — so it is
+    not, and the count is said out loud instead of vanishing."""
+
+    async def traces(_request: web.Request) -> web.Response:
+        return web.json_response(
+            {
+                "partialSuccess": {
+                    "rejectedSpans": "2",
+                    "errorMessage": "two spans weighed more than one insert holds",
+                }
+            }
+        )
+
+    app = web.Application()
+    app.router.add_post("/v1/traces", traces)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    base = f"http://127.0.0.1:{runner.addresses[0][1]}"
+    try:
+        async with ControlPlaneClient(base, claim_wait_seconds=1) as client:
+            with caplog.at_level("ERROR"):
+                await client.spans("sim-1", b'{"resourceSpans":[]}')
+    finally:
+        await runner.cleanup()
+
+    assert "refused 2 of sim-1's spans" in caplog.text
+    assert "weighed more than one insert holds" in caplog.text

--- a/apps/simulator/tests/test_plug_retell.py
+++ b/apps/simulator/tests/test_plug_retell.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import pytest
 from retell_stub import END_TOOL
 
-from egma_simulator.plugs import AgentReply, PlugError, plug_for
+from egma_simulator.plugs import AgentReply, PlugError, ToolCall, plug_for
 from egma_simulator.plugs.retell import DEFAULT_BASE_URL, END_TOOL_NAMES, RetellChat
 from egma_simulator.redaction import REDACTED
 
@@ -104,9 +104,43 @@ async def test_the_agent_ending_the_exchange_is_read_from_its_end_tool(
         text="Anything else?", ended=False
     )
     # The last reply carries the end-tool invocation: the agent's final
-    # words are still recorded, and the exchange is over.
+    # words are still recorded, the exchange is over, and the call itself
+    # is reported like any other — ending the chat is something the agent
+    # did, and the record of the conversation says so.
     assert await plug.deliver("No, that is everything.") == AgentReply(
-        text="All sorted, goodbye now.", ended=True
+        text="All sorted, goodbye now.",
+        ended=True,
+        tool_calls=(ToolCall(name="end_call", arguments="{}"),),
+    )
+    await plug.close()
+
+
+async def test_the_tools_an_answer_called_are_read_off_it(start_retell_stub):
+    """Retell reports its invocations beside the words, which is what makes
+    a tool call observable from egma's side of the wire at all."""
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY,
+        replies=["Done — moved to Thursday."],
+        tool_calls=[
+            {
+                "name": "reschedule_appointment",
+                "arguments": '{"appointment_id":"apt-88213"}',
+            },
+            {"name": "send_confirmation_sms"},
+        ],
+    )
+    plug = retell({"retellAgentId": "agent_tooled", "baseUrl": running.base_url})
+    await plug.open()
+
+    answer = await plug.deliver("Move my cleaning to Thursday.")
+    assert answer.tool_calls == (
+        ToolCall(
+            name="reschedule_appointment",
+            arguments='{"appointment_id":"apt-88213"}',
+        ),
+        # Reported without arguments: absence is the honest record of what
+        # the platform said, never an empty object standing in for it.
+        ToolCall(name="send_confirmation_sms", arguments=None),
     )
     await plug.close()
 

--- a/apps/simulator/tests/test_reporting.py
+++ b/apps/simulator/tests/test_reporting.py
@@ -7,28 +7,45 @@ import json
 
 import pytest
 
-from egma_simulator.client import TransientReportFailure
+from egma_simulator.client import TransientDeliveryFailure
 from egma_simulator.contract import ContractViolation
 from egma_simulator.reporting import Reporter, wal_filename
+from egma_simulator.spans import SpanEmitter
 
 
 class FakeClient:
-    """Receives report posts; can be told to fail transiently, or forever."""
+    """Receives both kinds of post; can be told to fail transiently, or forever."""
 
     def __init__(self) -> None:
         self.delivered: list[bytes] = []
         self.attempts: list[bytes] = []
+        self.doors: list[str] = []
+        """Which door each delivered document went to, in order."""
         self.failures_left = 0
+        self.span_failures_left = 0
+        """Refusals aimed at the ingest door alone, so a test can shake one
+        kind of document without the other absorbing the failures."""
         self.unreachable = False
 
     async def report(self, simulation_id: str, serialized: bytes) -> None:
+        await self._post("report", serialized)
+
+    async def spans(self, simulation_id: str, serialized: bytes) -> None:
+        if self.span_failures_left > 0:
+            self.attempts.append(serialized)
+            self.span_failures_left -= 1
+            raise TransientDeliveryFailure("the ingest door was told to fail")
+        await self._post("spans", serialized)
+
+    async def _post(self, door: str, serialized: bytes) -> None:
         self.attempts.append(serialized)
         if self.unreachable:
-            raise TransientReportFailure("nothing is listening")
+            raise TransientDeliveryFailure("nothing is listening")
         if self.failures_left > 0:
             self.failures_left -= 1
-            raise TransientReportFailure("told to fail")
+            raise TransientDeliveryFailure("told to fail")
         self.delivered.append(serialized)
+        self.doors.append(door)
 
 
 async def test_events_arrive_in_order_with_the_wal_written_first(tmp_path):
@@ -167,3 +184,133 @@ async def test_an_unreachable_control_plane_is_given_up_on_without_hanging(
         "status",
     ]
     assert json.loads(wal_lines[-1])["events"][0]["status"] == "completed"
+
+
+# -- The one ordered sender, carrying both kinds ---------------------------
+
+
+async def test_spans_and_lifecycle_share_one_log_in_the_order_they_happened(
+    tmp_path,
+):
+    """Interleaved, both on the wire and on disk, exactly as minted."""
+    client = FakeClient()
+    reporter = Reporter(client, "sim-order-1", tmp_path)
+    spans = SpanEmitter("sim-order-1", flush=reporter.spans)
+
+    reporter.running()
+    spans.opened()
+    spans.turn("agent", "Lakeside Dental.")
+    spans.flush()
+    reporter.turn("agent", "Lakeside Dental.", started_at="2026-08-05T09:00:00.000000Z")
+    spans.turn("human", "Could we move my cleaning?")
+    spans.flush()
+    reporter.turn(
+        "human", "Could we move my cleaning?", started_at="2026-08-05T09:00:01.000000Z"
+    )
+    spans.sealed()
+    reporter.completed("persona_concluded")
+    await reporter.close()
+
+    assert client.doors == [
+        "report",  # running
+        "spans",  # the greeting
+        "report",  # the greeting as a transcript turn
+        "spans",  # the persona's turn
+        "report",  # the same turn on the lifecycle side
+        "spans",  # the closing flush, root last
+        "report",  # completed, and only now
+    ]
+
+    # The log on disk is what was sent, line for line, in the same order.
+    wal_lines = (tmp_path / wal_filename("sim-order-1")).read_bytes().splitlines()
+    assert wal_lines == client.delivered
+
+
+async def test_the_terminal_report_leaves_after_every_span_batch(tmp_path):
+    """The guarantee the whole design leans on: when the control plane
+    lands a terminal transition, the evidence is already stored."""
+    client = FakeClient()
+    reporter = Reporter(client, "sim-order-2", tmp_path)
+    spans = SpanEmitter("sim-order-2", flush=reporter.spans)
+
+    reporter.running()
+    spans.opened()
+    for turn in range(5):
+        spans.turn("human", f"Turn {turn}.")
+        spans.measure("turn_response_latency", 40.0)
+        spans.turn("agent", f"Answer {turn}.")
+        spans.flush()
+    spans.sealed()
+    reporter.completed("persona_concluded")
+    await reporter.close()
+
+    last_span_batch = max(
+        position for position, door in enumerate(client.doors) if door == "spans"
+    )
+    terminal = json.loads(client.delivered[-1])["events"][0]
+    assert terminal["status"] == "completed"
+    assert last_span_batch < len(client.doors) - 1, (
+        "a span batch left after the terminal report"
+    )
+
+    # And every span the conversation authored is on the wire, root included.
+    names = [
+        span["name"]
+        for position, document in enumerate(client.delivered)
+        if client.doors[position] == "spans"
+        for span in json.loads(document)["resourceSpans"][0]["scopeSpans"][0]["spans"]
+    ]
+    assert names[-1] == "simulation"
+    assert names.count("human_turn") == 5
+    assert names.count("agent_turn") == 5
+
+
+async def test_a_span_batch_that_will_not_land_is_resent_byte_identically(
+    tmp_path, quick_backoff
+):
+    """Same bytes, ids included — which is what lets a store deduping on
+    span ids land nothing twice however many times it hears this."""
+    client = FakeClient()
+    client.span_failures_left = 3
+    reporter = Reporter(client, "sim-order-3", tmp_path)
+    spans = SpanEmitter("sim-order-3", flush=reporter.spans)
+
+    reporter.running()
+    spans.opened()
+    spans.turn("agent", "Lakeside Dental.")
+    spans.flush()
+    await reporter.close()
+
+    # The running report landed first, then the batch was attempted four
+    # times: three refusals and the one that got through.
+    assert len(client.attempts) == 5
+    batch_attempts = client.attempts[1:]
+    assert len(set(batch_attempts)) == 1, "a resend changed the batch"
+    assert client.delivered[-1] == batch_attempts[0]
+
+
+async def test_a_refused_span_batch_costs_only_itself(tmp_path):
+    """A 400 from the ingest is terminal for that document, exactly as a
+    report rejection is — and the simulation carries on reporting."""
+
+    class RefusingClient(FakeClient):
+        async def spans(self, simulation_id: str, serialized: bytes) -> None:
+            from egma_simulator.client import DocumentRejected
+
+            self.attempts.append(serialized)
+            raise DocumentRejected("400: a resource in this export names no simulation")
+
+    client = RefusingClient()
+    reporter = Reporter(client, "sim-order-4", tmp_path)
+    spans = SpanEmitter("sim-order-4", flush=reporter.spans)
+
+    reporter.running()
+    spans.opened()
+    spans.turn("agent", "Lakeside Dental.")
+    spans.flush()
+    reporter.completed("persona_concluded")
+    await reporter.close()
+
+    assert reporter.abandoned is False
+    assert client.doors == ["report", "report"]
+    assert json.loads(client.delivered[-1])["events"][0]["status"] == "completed"

--- a/apps/simulator/tests/test_spans.py
+++ b/apps/simulator/tests/test_spans.py
@@ -1,0 +1,375 @@
+"""The span emitter, held to the vocabulary and its golden fixtures.
+
+What these prove is the emitter contract, not the conversation: the trace
+identity a simulation id derives, the ids the emitter mints and replays,
+the shapes a flush carries, and the one rule that makes a timing span a
+measurement — its own duration *is* the number. The fixtures under
+``packages/simulation-contract/fixtures/spans`` are the same document as
+bytes, and this suite reads them rather than restating them, so a shape
+that drifts on either side fails here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from egma_simulator.contract import contract_dir
+from egma_simulator.spans import (
+    SCOPE_NAME,
+    SCOPE_VERSION,
+    SERVICE_NAME,
+    SIMULATION_ID_ATTRIBUTE,
+    SpanEmitter,
+    trace_id_for,
+)
+
+# The vocabulary's own worked example, quoted from the document.
+WORKED_EXAMPLE_ID = "sim_01K3XQ7M4E8YB2FVN0H9TZQWER"
+WORKED_EXAMPLE_TRACE = "0198fb73d08e479627eea08a75fbf1d8"
+
+
+def fixture(name: str) -> dict:
+    path = contract_dir() / "fixtures" / "spans" / "valid" / name
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class Sink:
+    """Catches the documents a flush hands over, in order."""
+
+    def __init__(self) -> None:
+        self.documents: list[dict] = []
+
+    def __call__(self, document: dict) -> None:
+        self.documents.append(document)
+
+
+class Clock:
+    """A wall clock that only moves when a test says so, in nanoseconds."""
+
+    def __init__(self, at: int = 1_785_920_400_000_000_000) -> None:
+        self.at = at
+
+    def __call__(self) -> int:
+        return self.at
+
+    def tick(self, seconds: float) -> None:
+        self.at += int(seconds * 1_000_000_000)
+
+
+def emitter(simulation_id: str = WORKED_EXAMPLE_ID) -> tuple[SpanEmitter, Sink, Clock]:
+    sink = Sink()
+    clock = Clock()
+    return SpanEmitter(simulation_id, flush=sink, clock=clock), sink, clock
+
+
+def spans_of(document: dict) -> list[dict]:
+    return document["resourceSpans"][0]["scopeSpans"][0]["spans"]
+
+
+def named(document: dict, name: str) -> list[dict]:
+    return [span for span in spans_of(document) if span["name"] == name]
+
+
+def attribute(span: dict, key: str) -> str | None:
+    for entry in span.get("attributes", []):
+        if entry["key"] == key:
+            return entry["value"]["stringValue"]
+    return None
+
+
+def duration_ns(span: dict) -> int:
+    return int(span["endTimeUnixNano"]) - int(span["startTimeUnixNano"])
+
+
+# -- Trace identity -------------------------------------------------------
+
+
+def test_the_trace_id_is_the_simulation_ids_own_bits():
+    """The vocabulary's worked example, and the fixtures' second id too."""
+    assert trace_id_for(WORKED_EXAMPLE_ID) == WORKED_EXAMPLE_TRACE
+    assert (
+        trace_id_for("sim_01K3XSW9GJ2Q4RD8VXH0MEKAFP")
+        == "0198fb9e261215c986a37d8828e9a9f6"
+    )
+
+
+def test_every_span_fixture_derives_its_trace_id_from_its_simulation():
+    """The golden files and this emitter agree on the derivation, both ways."""
+    for name in ("chat-flush-1-turns.json", "voice-overlapping-turns.json"):
+        document = fixture(name)
+        resource = document["resourceSpans"][0]
+        simulation_id = next(
+            entry["value"]["stringValue"]
+            for entry in resource["resource"]["attributes"]
+            if entry["key"] == SIMULATION_ID_ATTRIBUTE
+        )
+        expected = trace_id_for(simulation_id)
+        for span in resource["scopeSpans"][0]["spans"]:
+            assert span["traceId"] == expected
+
+
+def test_an_id_that_is_not_egmas_own_shape_still_gets_one_trace():
+    """The contract calls a simulation id opaque, so a derivation must hold
+    for one this deployment did not mint — and hold to the same id."""
+    for opaque in ("sim-chat-001", "", "sim_not-crockford", "sim_" + "Z" * 26):
+        derived = trace_id_for(opaque)
+        assert len(derived) == 32
+        assert int(derived, 16) >= 0
+        assert derived == trace_id_for(opaque)
+    assert trace_id_for("sim-chat-001") != trace_id_for("sim-chat-002")
+
+
+# -- What a flush carries -------------------------------------------------
+
+
+def test_a_flush_names_its_simulation_and_rides_the_one_scope():
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.turn("agent", "Lakeside Dental, how can I help?")
+    spans.flush()
+
+    resource = sink.documents[0]["resourceSpans"][0]
+    assert resource["resource"]["attributes"] == [
+        {"key": "service.name", "value": {"stringValue": SERVICE_NAME}},
+        {
+            "key": SIMULATION_ID_ATTRIBUTE,
+            "value": {"stringValue": WORKED_EXAMPLE_ID},
+        },
+    ]
+    assert resource["scopeSpans"][0]["scope"] == {
+        "name": SCOPE_NAME,
+        "version": SCOPE_VERSION,
+    }
+
+
+def test_a_turn_carries_its_speaker_in_its_name_and_its_words_in_one_attribute():
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.turn("human", "Could we do Thursday instead?")
+    spans.turn("agent", "You're all set for Thursday at three.")
+    spans.flush()
+
+    turns = spans_of(sink.documents[0])
+    assert [span["name"] for span in turns] == ["human_turn", "agent_turn"]
+    assert attribute(turns[0], "egma.turn.text") == "Could we do Thursday instead?"
+    assert attribute(turns[1], "egma.turn.text") == (
+        "You're all set for Thursday at three."
+    )
+
+
+def test_a_chat_turn_is_one_instant():
+    """A message has no duration, and the fixtures say so to the byte."""
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.turn("human", "Hello.")
+    spans.flush()
+
+    turn = spans_of(sink.documents[0])[0]
+    assert turn["startTimeUnixNano"] == turn["endTimeUnixNano"]
+
+
+def test_a_tool_call_is_one_instant_carrying_what_was_observed():
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.tool_call("reschedule_appointment", '{"appointment_id":"apt-88213"}')
+    spans.tool_call("send_confirmation_sms", None)
+    spans.flush()
+
+    calls = named(sink.documents[0], "tool_call")
+    assert len(calls) == 2
+    assert calls[0]["startTimeUnixNano"] == calls[0]["endTimeUnixNano"]
+    assert attribute(calls[0], "egma.tool.name") == "reschedule_appointment"
+    assert attribute(calls[0], "egma.tool.arguments") == (
+        '{"appointment_id":"apt-88213"}'
+    )
+    # Absent rather than null: the platform reported the invocation and not
+    # its arguments, and an absent fact is the honest record of that.
+    assert attribute(calls[1], "egma.tool.name") == "send_confirmation_sms"
+    assert attribute(calls[1], "egma.tool.arguments") is None
+
+
+@pytest.mark.parametrize(
+    "measure",
+    [
+        "first_response_latency",
+        "turn_response_latency",
+        "time_to_first_word",
+        "agent_speech_duration",
+        "persona_speech_duration",
+    ],
+)
+def test_a_timing_spans_own_duration_is_the_measurement(measure):
+    """All five of the catalog's timing measures, each one its own span."""
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.measure(measure, 1214.0)
+    spans.flush()
+
+    timing = named(sink.documents[0], measure)[0]
+    assert duration_ns(timing) == 1_214_000_000
+    assert "attributes" not in timing
+
+
+def test_a_measure_brackets_the_interval_it_measured():
+    """It ends when the measurement was taken and opens one measurement back."""
+    spans, sink, clock = emitter()
+    spans.opened()
+    clock.tick(5.0)
+    spans.measure("turn_response_latency", 900.0)
+    spans.flush()
+
+    timing = spans_of(sink.documents[0])[0]
+    assert int(timing["endTimeUnixNano"]) == clock.at
+    assert int(timing["startTimeUnixNano"]) == clock.at - 900_000_000
+
+
+# -- Overlap, which is what voice needs -----------------------------------
+
+
+def test_two_turns_may_cross_in_time():
+    """Barge-in's record format, proved on the shape rather than promised."""
+    spans, sink, clock = emitter()
+    spans.opened()
+
+    # The agent speaks for 7.3 seconds; the persona starts answering 5.75
+    # seconds in and runs 1.62 seconds past the end of it.
+    clock.tick(7.3)
+    spans.spoke("agent", 7.3)
+    spans.turn("agent", "Thursday at three, or Friday at ten?")
+    clock.tick(1.62)
+    spans.turn("human", "Sorry — Friday, Friday at ten is perfect.")
+    spans.spoke("human", 3.17)
+    spans.flush()
+
+    agent = named(sink.documents[0], "agent_turn")[0]
+    human = named(sink.documents[0], "human_turn")[0]
+    assert duration_ns(agent) == 7_300_000_000
+    assert duration_ns(human) == 3_170_000_000
+    # They cross: the persona began before the agent had finished.
+    assert int(human["startTimeUnixNano"]) < int(agent["endTimeUnixNano"])
+    assert int(human["endTimeUnixNano"]) > int(agent["endTimeUnixNano"])
+
+
+def test_a_turn_spoken_before_its_words_are_known_still_gets_its_interval():
+    """The agent's audio is heard, then read; the turn is one thing either way."""
+    spans, sink, clock = emitter()
+    spans.opened()
+    clock.tick(4.0)
+    spans.spoke("agent", 4.0)
+    spans.turn("agent", "Of course — could I take your name?")
+    spans.flush()
+
+    turn = named(sink.documents[0], "agent_turn")[0]
+    assert duration_ns(turn) == 4_000_000_000
+
+
+def test_a_turn_whose_speech_is_never_measured_stays_an_instant():
+    """Chat never measures speech, and a turn nobody timed is not invented."""
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.turn("human", "Hello.")
+    spans.flush()
+    spans.spoke("human", 2.0)
+    spans.turn("human", "Still there?")
+    spans.flush()
+
+    first = named(sink.documents[0], "human_turn")[0]
+    second = named(sink.documents[1], "human_turn")[0]
+    assert duration_ns(first) == 0
+    assert duration_ns(second) == 2_000_000_000
+
+
+# -- The trace's own shape ------------------------------------------------
+
+
+def test_every_span_names_the_root_as_its_parent_and_the_root_names_none():
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.turn("human", "Hello.")
+    spans.flush()
+    spans.measure("turn_response_latency", 10.0)
+    spans.sealed()
+
+    everything = [span for document in sink.documents for span in spans_of(document)]
+    root = next(span for span in everything if span["name"] == "simulation")
+    assert "parentSpanId" not in root
+    for span in everything:
+        if span is root:
+            continue
+        assert span["parentSpanId"] == root["spanId"]
+        assert span["traceId"] == root["traceId"] == WORKED_EXAMPLE_TRACE
+
+
+def test_the_root_goes_last_and_covers_the_whole_conversation():
+    spans, sink, clock = emitter()
+    began = clock.at
+    spans.opened()
+    clock.tick(50.0)
+    spans.turn("agent", "Anything else?")
+    spans.sealed()
+
+    last = sink.documents[-1]
+    assert spans_of(last)[-1]["name"] == "simulation"
+    root = named(last, "simulation")[0]
+    assert int(root["startTimeUnixNano"]) == began
+    assert int(root["endTimeUnixNano"]) == clock.at
+    assert duration_ns(root) == 50_000_000_000
+
+
+def test_no_span_is_ever_sent_twice_and_every_flush_is_disjoint():
+    spans, sink, _clock = emitter()
+    spans.opened()
+    for turn in range(6):
+        spans.turn("human", f"Turn {turn}.")
+        spans.measure("turn_response_latency", 12.0)
+        spans.turn("agent", f"Answer {turn}.")
+        spans.flush()
+    spans.sealed()
+
+    per_flush = [
+        {span["spanId"] for span in spans_of(document)} for document in sink.documents
+    ]
+    everything = [span for document in sink.documents for span in spans_of(document)]
+    assert len(everything) == len({span["spanId"] for span in everything})
+    for position, ids in enumerate(per_flush):
+        for other in per_flush[position + 1 :]:
+            assert ids.isdisjoint(other)
+
+
+def test_an_empty_flush_sends_nothing():
+    """A document with no spans is a request nobody needed to make."""
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.flush()
+    spans.flush()
+    assert sink.documents == []
+
+
+def test_a_conversation_that_authored_nothing_still_says_it_happened():
+    """A simulation that failed before its first turn is still a simulation."""
+    spans, sink, _clock = emitter()
+    spans.opened()
+    spans.sealed()
+
+    assert [span["name"] for span in spans_of(sink.documents[0])] == ["simulation"]
+
+
+def test_the_ids_a_conversation_mints_are_stable_across_resends():
+    """The same conversation, replayed: identical ids, so a resend lands
+    nothing twice at a store that dedups on them."""
+
+    def conversation() -> list[dict]:
+        spans, sink, clock = emitter()
+        spans.opened()
+        clock.tick(1.0)
+        spans.turn("agent", "Lakeside Dental.")
+        spans.flush()
+        spans.sealed()
+        return sink.documents
+
+    first = conversation()
+    again = conversation()
+    assert json.dumps(first) == json.dumps(again)

--- a/apps/simulator/tests/test_workbench.py
+++ b/apps/simulator/tests/test_workbench.py
@@ -7,8 +7,9 @@ import json
 
 import aiohttp
 import pytest
-from conftest import load_fixture_spec, scripted_spec
+from conftest import load_fixture_spec, scripted_spec, spans_for
 
+from egma_simulator.spans import SIMULATION_ID_ATTRIBUTE
 from egma_simulator.workbench.app import dialling
 
 
@@ -186,3 +187,131 @@ def test_a_number_with_nothing_to_dial_it_is_refused_rather_than_ignored():
         dialling([load_fixture_spec("chat-scripted-hurried.json")], "+12025550143")
 
     assert "+12025550143" in str(refused.value)
+
+
+# -- The OTLP sink, so the developer's rig stays whole ---------------------
+
+
+def a_batch(simulation_id: str, *spans: dict) -> dict:
+    """One OTLP export the way the emitter writes it."""
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {
+                            "key": "service.name",
+                            "value": {"stringValue": "egma-simulator"},
+                        },
+                        *(
+                            [
+                                {
+                                    "key": SIMULATION_ID_ATTRIBUTE,
+                                    "value": {"stringValue": simulation_id},
+                                }
+                            ]
+                            if simulation_id
+                            else []
+                        ),
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "egma-simulator", "version": "1"},
+                        "spans": list(spans),
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def a_span(name: str, **extra: object) -> dict:
+    return {
+        "traceId": "0198fb73d08e479627eea08a75fbf1d8",
+        "spanId": "aa10000000000002",
+        "name": name,
+        "kind": "SPAN_KIND_INTERNAL",
+        "startTimeUnixNano": "1785920401214000000",
+        "endTimeUnixNano": "1785920401214000000",
+        **extra,
+    }
+
+
+async def post_spans(workbench, document: dict) -> tuple[int, str]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{workbench.base_url}/v1/traces",
+            data=json.dumps(document),
+            headers={"content-type": "application/json"},
+        ) as response:
+            return response.status, await response.text()
+
+
+async def test_the_sink_records_arriving_spans_against_their_simulation(workbench):
+    await workbench.offer(scripted_spec("sim-wb-spans"))
+
+    status, body = await post_spans(
+        workbench,
+        a_batch(
+            "sim-wb-spans",
+            a_span("human_turn"),
+            a_span("turn_response_latency"),
+        ),
+    )
+
+    assert status == 200
+    assert json.loads(body) == {}
+    recorded = spans_for(await workbench.records(), "sim-wb-spans")
+    assert [record["span"]["name"] for record in recorded] == [
+        "human_turn",
+        "turn_response_latency",
+    ]
+    # The scope rides along, because that is what the real ingest reads the
+    # vocabulary by, and what a person watching the log wants to see.
+    assert recorded[0]["scope"] == {"name": "egma-simulator", "version": "1"}
+
+
+async def test_the_sink_tells_one_flush_from_the_next(workbench):
+    await workbench.offer(scripted_spec("sim-wb-flushes"))
+
+    await post_spans(workbench, a_batch("sim-wb-flushes", a_span("human_turn")))
+    await post_spans(workbench, a_batch("sim-wb-flushes", a_span("agent_turn")))
+
+    recorded = spans_for(await workbench.records(), "sim-wb-flushes")
+    assert [record["flush"] for record in recorded] == [1, 2]
+
+
+async def test_the_sink_refuses_a_batch_naming_no_simulation(workbench):
+    """The one refusal the real ingest makes at the batch grain."""
+    status, body = await post_spans(workbench, a_batch("", a_span("human_turn")))
+
+    assert status == 400
+    assert SIMULATION_ID_ATTRIBUTE in body
+    refusals = [
+        record
+        for record in await workbench.records()
+        if record["kind"] == "refusal"
+    ]
+    assert len(refusals) == 1
+    assert refusals[0]["why"] == "spans naming no simulation"
+
+
+async def test_the_sink_refuses_spans_for_a_simulation_it_never_offered(workbench):
+    status, body = await post_spans(
+        workbench, a_batch("sim-wb-stranger", a_span("human_turn"))
+    )
+
+    assert status == 400
+    assert "sim-wb-stranger" in body
+    assert spans_for(await workbench.records(), "sim-wb-stranger") == []
+
+
+async def test_the_sink_refuses_a_body_that_is_not_an_otlp_export(workbench):
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{workbench.base_url}/v1/traces",
+            data=b"not json at all",
+            headers={"content-type": "application/json"},
+        ) as response:
+            assert response.status == 400


### PR DESCRIPTION
The simulator now speaks its conversations as OpenTelemetry spans, streamed to the trace store while the simulation runs — a simulation reads like a production trace, live and partial included, and the terminal report can never outrun its own evidence.

- A `SpanEmitter` per simulation, authored where the conduction loop observes the conversation — one emitter for chat and voice. Trace identity is the simulation id's own 128 bits (Crockford-decoded to 32 hex, the vocabulary's worked example verified to the byte); span ids minted deterministically so a resend is byte-identical. Turns carry speaker and text; tool calls carry name and arguments as observed, never a result; each catalog measure is a span whose own duration is the measurement. Pipecat's auto-tracing stays off, with the reasoning in-file.
- Delivery rides the shipped machinery, not a stock exporter: span batches and lifecycle documents share one write-ahead log and one ordered sender, interleaved as events happened — so the terminal document leaves only after every span before it landed. Flushes are one-per-exchange (the conversation's natural seam), ids disjoint by construction, the root `simulation` span sent last: its presence is a safe "this trace is complete" signal.
- The client posts OTLP JSON to the traces door with the report path's exact refusal semantics; partial success is logged, never retried. Tool calls became observable at the plug seam — the Retell plug reads its inline tool invocations, the scripted counterpart scripts them, so CI still needs no network.
- The workbench grew a small OTLP sink, recording arriving spans beside everything else it records — the simulator developer's rig stays whole.

Tests: fixture byte-conformance against the contract's golden flushes (the trace-id derivation reproduced independently in three places); span-id stability across resends; WAL interleaving and terminal-last ordering at the unit seam; workbench-sink acceptance for chat and voice; and the crown proof — the end-to-end walk polls both stores at 25ms and shows turns queryable in ClickHouse while the row still says `running`, the root absent until the instant the row turns terminal, at which point the whole conversation is already stored. Suites: 368 simulator tests + ruff clean, 1920 TS tests, typecheck green — re-verified independently before opening (pytest 368/368, the e2e walk, the contract fixtures 9/9, zero planning references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR streams simulation conversations as deterministic OpenTelemetry spans through the existing ordered WAL delivery path.
- Adds span emission for turns, tool calls, measurements, speech durations, and the terminal root span.
- Flushes non-terminal tool-only exchanges at the answer boundary.
- Adds OTLP delivery, workbench ingestion, and end-to-end trace-ordering coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/walk.py | Introduces answer-boundary and tool-call callbacks, including a flush boundary for non-terminal tool-only replies. |
| apps/simulator/src/egma_simulator/service.py | Wires one span emitter into each running simulation and seals its trace before queuing terminal lifecycle state. |
| apps/simulator/src/egma_simulator/spans.py | Implements deterministic trace/span identifiers and OTLP batches for conversation observations. |
| apps/simulator/src/egma_simulator/reporting.py | Extends the WAL and ordered sender to interleave span batches with lifecycle documents. |
| apps/simulator/src/egma_simulator/client.py | Adds OTLP trace posting with the existing permanent-refusal and transient-retry delivery semantics. |
| apps/simulator/tests/test_acceptance.py | Covers live span emission and confirms tool-only answers flush independently of later textual replies. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Conversation walk
    participant E as SpanEmitter
    participant R as Reporter/WAL
    participant O as OTLP ingest
    participant C as Lifecycle API
    W->>E: Emit turns, tool calls, and timings
    W->>E: Answer completed (including tool-only)
    E->>R: Flush span batch
    R->>O: Deliver batches in WAL order
    W->>E: Seal conversation
    E->>R: Flush pending spans and root
    R->>O: Deliver terminal span batch
    W->>R: Queue terminal lifecycle report
    R->>C: Deliver terminal report last
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Close a flush on the answer, not on the ..."](https://github.com/egma-ai/egma/commit/fe2508c1b259517009f36038ee10453f46c62a28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51477758)</sub>

<!-- /greptile_comment -->