### PR TITLE
The grader reads a simulation the way it reads production

### DIFF
--- a/apps/grader/package.json
+++ b/apps/grader/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@egma/db": "workspace:*",
-    "@egma/ids": "workspace:*"
+    "@egma/ids": "workspace:*",
+    "@egma/simulation-contract": "workspace:*"
   }
 }

--- a/apps/grader/src/conversation.ts
+++ b/apps/grader/src/conversation.ts
@@ -10,19 +10,26 @@ import type {
  *
  * **One shape for both sources**, which is the whole reason it exists as a type
  * rather than as "the simulation row". A grader judges a simulation and a
- * production trace with the same logic, and the difference between them is where
- * this was read from — the simulation's header row, or the trace's spans —
- * rather than what a grader is looking at. Anything a grader has to know about
- * *where* it came from would be a second grading path growing quietly inside the
- * first.
+ * production trace with the same logic, and the difference between them is who
+ * conducted the conversation rather than what a grader is looking at. Anything a
+ * grader has to know about *where* it came from would be a second grading path
+ * growing quietly inside the first.
  *
- * Two read paths, both settled. A finished simulation already carries its
- * transcript, its events and its measures on its own row, so grading it needs no
- * second store and no join. A production trace has no row of its own and never
- * will: its whole record is the spans it arrived as, so it is read from the
- * trace store and assembled below. The three fields are `unknown` because they
- * are stored jsonb and nothing has fixed their shape at the write door — each
- * grader reads what it needs and says honestly when what it needs is not there.
+ * **One read path now, and it is the spans.** A conversation's record is the
+ * spans it arrived as, whoever conducted it: a customer's agent posts them at
+ * the OTLP door, and egma's own simulator posts them at the same door while it
+ * is still talking. So a simulation and a production trace are assembled by the
+ * same code out of the same rows, and "passes in simulation, fails in
+ * production" is a join rather than two readers that could one day disagree
+ * about what a turn is.
+ *
+ * A simulation's row is still read for what only it knows — that this
+ * conversation was one egma conducted, which run it belongs to, what the
+ * simulator said about how it ended — and, for as long as the columns exist, as
+ * the fallback for rows written before any of this streamed. The three fields
+ * are `unknown` because the columns are stored jsonb and nothing fixed their
+ * shape at the write door; each grader reads what it needs and says honestly
+ * when what it needs is not there.
  */
 export type Conversation = {
   /** Which kind of conversation this is, in the verdict row's own vocabulary. */
@@ -39,15 +46,24 @@ export type Conversation = {
    */
   readonly traceId: string;
   /**
-   * **Whether there is a conversation here at all.**
+   * **Why there is nothing here to judge**, and null when there is something.
    *
-   * A simulation the simulator reported `failed` never produced one: the agent
-   * never joined, the line was never answered, egma's own runtime broke. Every
-   * grader's verdict on it is `errored`, never `failed`, and this is the flag
-   * that says so — a broken test is never a broken agent, and that line is the
-   * one normalisation a test product cannot get wrong.
+   * Two ways to arrive at it, and one consequence. A simulation the simulator
+   * reported `failed` never produced a conversation: the agent never joined,
+   * the line was never answered, egma's own runtime broke. A simulation that
+   * certainly happened can still be one egma cannot read: its spans never
+   * arrived, or only some of them did, and no column holds it either. Both are
+   * `errored` for every grader, never `failed` — a broken test is never a
+   * broken agent, and that line is the one normalisation a test product cannot
+   * get wrong.
+   *
+   * It carries the sentence rather than a flag because the sentence is what
+   * lands in the verdict's rationale, and the two cases are different things
+   * for a reader to go and do. Written where the fact is known — one field, one
+   * meaning, so nothing downstream has to assemble the reason a second time and
+   * risk assembling a different one.
    */
-  readonly happened: boolean;
+  readonly nothingToJudgeBecause: string | null;
   /**
    * Why it ended, in the simulator's own vocabulary, for the rationale. Null for
    * a production conversation: nothing on the wire says why a real caller hung
@@ -64,7 +80,32 @@ export type Conversation = {
 };
 
 /**
- * A finished simulation, read as a conversation.
+ * A finished simulation, read as a conversation — and the whole of the reading
+ * order, in one place.
+ *
+ * Three answers, asked in this order, and each of them is a different fact
+ * about what egma actually holds:
+ *
+ * 1. **The trace is complete — assemble it from the spans.** The root span is
+ *    what says so: it is authored first and sent last, in the flush that leaves
+ *    once the conversation is over, so a trace holding it is a trace holding
+ *    everything. That is the settled record, and it is read by exactly the code
+ *    a production trace is read by.
+ * 2. **The trace is incomplete or absent — fall back to the row's columns.**
+ *    A simulation with spans and no root is one egma holds part of, and a
+ *    partial transcript is not something to judge an agent against. A
+ *    simulation with no spans at all is older than the emitter. Either way the
+ *    columns are the record that exists, for as long as they exist — this is
+ *    the one interim branch here, and it goes when they do.
+ * 3. **Neither — say so, and judge nothing.** Every grader answers `errored`,
+ *    with the reason, because a check egma could not make is never a check the
+ *    agent failed.
+ *
+ * **The verdict still files under the simulation id.** The spans live under a
+ * trace id derived from it, and that derivation stays where the query is: the
+ * product's word for this conversation is the simulation id, in Postgres, in a
+ * URL and in a log, and nothing downstream of the grader changes because the
+ * evidence moved.
  *
  * `agent_version_id` is deliberately absent from what this produces and lands
  * empty on the verdict row: egma does not version agents yet, and an empty
@@ -72,18 +113,126 @@ export type Conversation = {
  * with the agent's own id would make a comparison of two versions answer with
  * nonsense the day versions arrive.
  */
-export function conversationOf(simulation: Simulation): Conversation {
-  return {
+export function conversationOfSimulation(
+  simulation: Simulation,
+  trace: TraceDetail | undefined,
+): Conversation {
+  // Whether there was a conversation at all is the row's answer and only the
+  // row's: a simulation the simulator reported failed produced none, and no
+  // amount of telemetry arriving afterwards makes one. So it is decided before
+  // anything is read, and every branch below carries it.
+  const neverHappened =
+    simulation.status === "completed" ? null : neverRan(simulation);
+
+  const filedUnderTheSimulation: Conversation = {
     source: "simulation",
     traceId: simulation.id,
-    happened: simulation.status === "completed",
+    nothingToJudgeBecause: neverHappened,
     endingReason: simulation.endingReason,
-    transcript: simulation.transcript,
-    events: simulation.events,
-    metrics: simulation.metrics,
+    transcript: [],
+    events: [],
+    metrics: {},
     runId: simulation.runId,
     agentId: simulation.agentId,
   };
+
+  if (trace !== undefined && rootArrivedIn(trace)) {
+    return {
+      ...filedUnderTheSimulation,
+      transcript: transcriptOf(trace),
+      // The same walk a production trace's tool calls come off, which is what
+      // makes the two lists the same list. A simulation's results are always
+      // empty and that is the emitter's fact rather than a rule applied here:
+      // the simulator observes the call from egma's side of the connection and
+      // not the return, so its vocabulary declares no result attribute and the
+      // door has nothing to write into the column.
+      events: toolCallsIn(trace),
+      metrics: measuresTimedIn(trace),
+    };
+  }
+
+  if (theColumnsHoldSomething(simulation)) {
+    // INTERIM: the row's three jsonb columns, which are the record for every
+    // conversation that landed before the simulator streamed one. This branch
+    // is the only reader of them left, and it goes in the migration that drops
+    // them.
+    return {
+      ...filedUnderTheSimulation,
+      transcript: simulation.transcript,
+      events: simulation.events,
+      metrics: simulation.metrics,
+    };
+  }
+
+  return {
+    ...filedUnderTheSimulation,
+    nothingToJudgeBecause: neverHappened ?? unreadable(simulation, trace),
+  };
+}
+
+/** A simulation that produced no conversation, in the simulator's own words. */
+function neverRan(simulation: Simulation): string {
+  return `this simulation ended ${simulation.endingReason ?? "without running"}, so there was no conversation to judge.`;
+}
+
+/**
+ * A conversation that happened and that egma cannot read — and which of the two
+ * ways it can happen, because they are different things to go and fix.
+ *
+ * Never `failed`, and this is where that is decided rather than in each grader:
+ * an agent that answered every question perfectly would be marked down for a
+ * flush that never landed, which is the exact false signal this product exists
+ * to kill.
+ */
+function unreadable(
+  simulation: Simulation,
+  trace: TraceDetail | undefined,
+): string {
+  const ended = `it ended ${simulation.endingReason ?? "without a recorded reason"}`;
+  return trace === undefined
+    ? `egma holds no record of this conversation — ${ended}, and no telemetry for it ever arrived — so there was nothing to judge.`
+    : `egma holds only part of this conversation — ${ended}, and the span that closes its trace never arrived — so there was nothing complete to judge.`;
+}
+
+/**
+ * Whether the trace is the whole conversation, which the root span is the one
+ * signal of.
+ *
+ * The simulator authors it first and sends it last, alone in the flush that
+ * leaves once the conversation is over — so its arrival means every other span
+ * is already stored, and its absence means the record is still open or the
+ * simulator never got to the end of it. A count of turns could not answer this:
+ * a conversation cut off after four turns and one recorded completely in four
+ * turns hold the same rows.
+ */
+function rootArrivedIn(trace: TraceDetail): boolean {
+  for (const span of everySpanIn(trace)) {
+    if (span.kind === ROOT) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether the row's columns hold a conversation at all.
+ *
+ * Null is what a landing writes today, and an empty list or object is what a
+ * conversation with nothing in it comes back as. Anything else is a record
+ * somebody can be judged against, however thin — a row with measures and no
+ * transcript is still the measures it holds.
+ */
+function theColumnsHoldSomething(simulation: Simulation): boolean {
+  return (
+    holdsSomething(simulation.transcript) ||
+    holdsSomething(simulation.events) ||
+    holdsSomething(simulation.metrics)
+  );
+}
+
+function holdsSomething(column: unknown): boolean {
+  if (column === null || column === undefined) return false;
+  if (Array.isArray(column)) return column.length > 0;
+  if (typeof column === "object") return Object.keys(column).length > 0;
+  return true;
 }
 
 /**
@@ -111,7 +260,7 @@ export function conversationOfTrace(trace: TraceDetail): Conversation {
   return {
     source: "production",
     traceId: trace.traceId,
-    happened: true,
+    nothingToJudgeBecause: null,
     endingReason: null,
     transcript: transcriptOf(trace),
     events: toolCallsIn(trace),
@@ -183,25 +332,18 @@ function speakerOf(kind: string): string {
 function toolCallsIn(trace: TraceDetail): readonly ToolCall[] {
   const called: (ToolCall & { readonly at: string })[] = [];
 
-  const walk = (spans: readonly TraceSpan[]): void => {
-    for (const span of spans) {
-      if (span.toolName !== "") {
-        called.push({
-          kind: "tool_call",
-          at: span.startedAt,
-          name: span.toolName,
-          arguments: span.toolArguments,
-          result: span.toolResult,
-        });
-      }
-      walk(span.spans);
-    }
-  };
+  for (const span of everySpanIn(trace)) {
+    if (span.toolName === "") continue;
+    called.push({
+      kind: "tool_call",
+      at: span.startedAt,
+      name: span.toolName,
+      arguments: span.toolArguments,
+      result: span.toolResult,
+    });
+  }
 
-  walk(trace.turns);
-  walk(trace.spans);
-
-  return called.sort((left, right) => (left.at < right.at ? -1 : left.at > right.at ? 1 : 0));
+  return called.sort(byWhenItStarted);
 }
 
 type ToolCall = {
@@ -214,7 +356,7 @@ type ToolCall = {
 };
 
 /**
- * What this conversation measured, which today is nothing — and the reason is
+ * What a production trace measured, which today is nothing — and the reason is
  * worth writing down rather than discovering twice.
  *
  * The measures a threshold grader names are the simulator's: egma stands on one
@@ -242,6 +384,108 @@ type ToolCall = {
  */
 function measuresIn(): Readonly<Record<string, never>> {
   return {};
+}
+
+/**
+ * What a simulation measured, from the timing spans — and there **is** a number
+ * here, which is the whole difference from a production trace.
+ *
+ * These are the simulator's own measurements: egma stood on one side of the
+ * conversation with a clock, and every measure it took is a span named for that
+ * measure. Nothing is derived from the shape of the transcript here — the same
+ * arithmetic that comes out negative on overlapping turns would come out
+ * negative on a simulation's, and the simulator already knows the answer.
+ *
+ * **The span's own duration is the measurement.** A timing span is opened one
+ * measurement before the moment it was taken and closed at it, so its start and
+ * end bracket the interval that was measured. There is deliberately no
+ * attribute carrying the number: a second copy of it would be free to disagree
+ * with the interval, and the vocabulary refuses to write one down twice.
+ *
+ * Nanoseconds on the wire, milliseconds in the catalog, so the conversion
+ * happens once and here. It is floating-point on purpose — a measure is
+ * `862.5ms` and a whole-number division would quietly floor every one of them —
+ * and the counts involved are tens of seconds, nowhere near where a double
+ * stops holding a nanosecond exactly.
+ *
+ * **A measure the conversation never took is simply absent**, which is what
+ * makes the voice measures free on chat: `time_to_first_word`,
+ * `agent_speech_duration` and `persona_speech_duration` come out of audio, a
+ * chat simulation has none, and a threshold grader asked for one answers
+ * `skipped` — out of the score's denominator, never an error and never a
+ * failure.
+ */
+function measuresTimedIn(trace: TraceDetail): Readonly<Record<string, number[]>> {
+  const NANOSECONDS_PER_MILLISECOND = 1_000_000;
+
+  const timed: (Measurement & { readonly at: string })[] = [];
+  for (const span of everySpanIn(trace)) {
+    if (span.kind !== TIMING) continue;
+    timed.push({
+      // The span is named for the measure it takes, which is what makes the
+      // catalog and the vocabulary the same list read twice.
+      measure: span.name,
+      at: span.startedAt,
+      milliseconds:
+        Number(span.durationNanoseconds) / NANOSECONDS_PER_MILLISECOND,
+    });
+  }
+
+  // In the order they were taken, so that a per-turn series is the conversation
+  // read forwards and two gradings of one conversation aggregate the same list.
+  const measured: Record<string, number[]> = {};
+  for (const measurement of timed.sort(byWhenItStarted)) {
+    (measured[measurement.measure] ??= []).push(measurement.milliseconds);
+  }
+  return measured;
+}
+
+type Measurement = {
+  readonly measure: string;
+  readonly milliseconds: number;
+};
+
+/**
+ * The kinds this file selects on, as the door normalised them — never the
+ * provider's own span names, which is what keeps one reading working for
+ * LiveKit, for the simulator and for whatever the registry learns next.
+ */
+const ROOT = "root";
+const TIMING = "timing";
+
+/**
+ * Every span the trace holds, exactly once: the turns, whatever hangs inside
+ * them, and everything filed beside them.
+ *
+ * A trace read hands back two lists — the turns lifted out for the transcript,
+ * and the top-level spans with their children beneath — and every span is under
+ * one of the two, once. Which of them a thing lands in depends on what its
+ * parent was: the simulator hangs its tool calls and its measurements off the
+ * root, so they arrive inside it, and a trace whose root never came holds those
+ * same spans at the top. Walking both lists is what makes the reading the same
+ * either way.
+ */
+function* everySpanIn(trace: TraceDetail): Generator<TraceSpan> {
+  const walk = function* (spans: readonly TraceSpan[]): Generator<TraceSpan> {
+    for (const span of spans) {
+      yield span;
+      yield* walk(span.spans);
+    }
+  };
+  yield* walk(trace.turns);
+  yield* walk(trace.spans);
+}
+
+/**
+ * By when it began, as the store wrote the instant — fixed-width RFC 3339 to
+ * the microsecond, so the strings sort exactly as the moments do and no `Date`
+ * is built to round the last three digits off.
+ */
+function byWhenItStarted(
+  left: { readonly at: string },
+  right: { readonly at: string },
+): number {
+  return left.at < right.at ? -1 : left.at > right.at ? 1 : 0;
 }
 
 /**

--- a/apps/grader/src/conversation.ts
+++ b/apps/grader/src/conversation.ts
@@ -136,7 +136,7 @@ export function conversationOfSimulation(
     agentId: simulation.agentId,
   };
 
-  if (trace !== undefined && rootArrivedIn(trace)) {
+  if (trace !== undefined && rootArrivedIn(trace) && !trace.truncated) {
     return {
       ...filedUnderTheSimulation,
       transcript: transcriptOf(trace),
@@ -189,8 +189,11 @@ function unreadable(
   trace: TraceDetail | undefined,
 ): string {
   const ended = `it ended ${simulation.endingReason ?? "without a recorded reason"}`;
-  return trace === undefined
-    ? `egma holds no record of this conversation — ${ended}, and no telemetry for it ever arrived — so there was nothing to judge.`
+  if (trace === undefined) {
+    return `egma holds no record of this conversation — ${ended}, and no telemetry for it ever arrived — so there was nothing to judge.`;
+  }
+  return trace.truncated
+    ? `egma holds more of this conversation than one reading returns — ${ended}, and its trace overran the reader's span limit — so judging the readable part would judge a different conversation.`
     : `egma holds only part of this conversation — ${ended}, and the span that closes its trace never arrived — so there was nothing complete to judge.`;
 }
 

--- a/apps/grader/src/grade.ts
+++ b/apps/grader/src/grade.ts
@@ -3,15 +3,21 @@ import {
   getGrader,
   getSimulation,
   readTrace,
+  MAXIMUM_WINDOW_MILLISECONDS,
+  type AuthContext,
   type Grader,
   type GradingClaim,
   type GradingSource,
   type NewVerdict,
   type Priority,
+  type Simulation,
+  type TimeWindow,
+  type TraceDetail,
 } from "@egma/db";
+import { traceIdOfSimulation } from "@egma/simulation-contract";
 
 import {
-  conversationOf,
+  conversationOfSimulation,
   conversationOfTrace,
   type Conversation,
 } from "./conversation.ts";
@@ -36,13 +42,15 @@ import { applicableGraders, applicableProductionGraders } from "./resolve.ts";
  * conversation or for its run — there is no such row anywhere, by design, and
  * the fold works one out at read time from exactly the rows this wrote.
  *
- * **The source decides the first two steps and nothing after them.** A
- * simulation is read from its header row and judged by the project's graders
- * plus its test's; a production trace is read from its spans and judged by the
- * project's production-scoped graders, sampled. From the moment a `Conversation`
- * and a grader list exist there is one path — one executor seam, one verdict row
- * builder, one write — because a second judging path would be a second set of
- * answers that could one day disagree about the same agent.
+ * **The source decides the first two steps and nothing after them.** Both are
+ * read from their spans; what differs is what egma knows besides. A simulation
+ * names its own row, which says whose conversation it was and how the simulator
+ * said it ended, and it is judged by the project's graders plus its test's; a
+ * production trace has no row and is judged by the project's production-scoped
+ * graders, sampled. From the moment a `Conversation` and a grader list exist
+ * there is one path — one executor seam, one verdict row builder, one write —
+ * because a second judging path would be a second set of answers that could one
+ * day disagree about the same agent.
  *
  * **The verdicts are written in one call.** A conversation's judgments land
  * together or not at all as far as any reader is concerned, and a job that fails
@@ -242,7 +250,22 @@ export async function gradeClaim(
   };
 }
 
-/** A finished simulation, read from the row that already holds everything. */
+/**
+ * A finished simulation: its own row for what egma knows about conducting it,
+ * and its spans for the conversation.
+ *
+ * The row is read first because it is what says this simulation exists, whose
+ * it is and when it ran — and the window comes off those two moments, because
+ * the trace store is filed by the minute a span started in and a read naming
+ * only an id would have nothing to prune with.
+ *
+ * A trace that comes back absent is not an error here, and that is the
+ * difference from the production path: a production job was written *by* the
+ * spans arriving, so their absence means telemetry has gone, while a
+ * simulation's job is written by the transaction that landed it and can
+ * legitimately reach a conversation whose spans never came. What to do about it
+ * is the reading order's decision, made in one place; this only goes and asks.
+ */
 async function theSimulation(claim: GradingClaim): Promise<Resolved> {
   if (claim.simulationId === null) {
     throw new NotGradable(
@@ -258,12 +281,73 @@ async function theSimulation(claim: GradingClaim): Promise<Resolved> {
   }
 
   return {
-    conversation: conversationOf(simulation),
+    conversation: conversationOfSimulation(
+      simulation,
+      await theSimulationsTrace(claim.auth, simulation),
+    ),
     graders: await judgingGraders(claim, () =>
       applicableGraders(claim.auth, simulation),
     ),
     simulationId: simulation.id,
   };
+}
+
+/**
+ * The spans this simulation streamed, or nothing at all if none did.
+ *
+ * **The trace id is derived, never stored.** A simulation's spans are filed
+ * under the 128 bits its own id carries, because an OpenTelemetry trace id is
+ * fixed-width binary and cannot hold one of egma's identifiers. The derivation
+ * is a term of the span contract and lives there, in one place, so that the
+ * simulator authoring a span and this query going to find it can never fall out
+ * of step. The verdict rows still file under the simulation id: the product's
+ * word for this conversation is unchanged, and only the query knows the other
+ * form.
+ */
+async function theSimulationsTrace(
+  auth: AuthContext,
+  simulation: Simulation,
+): Promise<TraceDetail | undefined> {
+  const traceId = traceIdOfSimulation(simulation.id);
+  // Unreachable: every simulation id egma reads is one egma minted. Answered
+  // rather than asserted, because a grading service is not the place to throw
+  // over an id that came out of its own database.
+  if (traceId === undefined) return undefined;
+
+  return readTrace(auth, traceId, { window: whenItRan(simulation) });
+}
+
+/**
+ * How wide a window a simulation's spans are looked for in.
+ *
+ * Five minutes at each end, which is not rounding slack. The row's two moments
+ * are the *simulator's* own, reported over the wire and written onto the row
+ * where they could be true — so the two clocks are different machines' — and
+ * where a report carried neither, the landing stamped its own arrival instead,
+ * which is later than the conversation by however long delivery took. A span
+ * that fell outside the window would be a hole in a transcript nobody could
+ * see, and the sort key prunes by the minute, so a generous cushion costs
+ * almost nothing to read.
+ */
+const A_GENEROUS_CUSHION_MICROSECONDS = 5n * 60n * 1_000_000n;
+
+function whenItRan(simulation: Simulation): TimeWindow {
+  // A row that never started is bracketed by its own creation, which is
+  // certainly before anything the simulator stamped; one that never landed by
+  // now, which is certainly after.
+  const began = BigInt((simulation.startedAt ?? simulation.createdAt).getTime());
+  const ended = BigInt((simulation.endedAt ?? new Date()).getTime());
+
+  const from =
+    (began < ended ? began : ended) * 1_000n - A_GENEROUS_CUSHION_MICROSECONDS;
+  const to =
+    (began < ended ? ended : began) * 1_000n + A_GENEROUS_CUSHION_MICROSECONDS;
+
+  // The store refuses a window wider than its cap rather than narrowing one, so
+  // a row that sat queued for longer than that is narrowed here — from the end,
+  // which is where the conversation was.
+  const widest = BigInt(MAXIMUM_WINDOW_MILLISECONDS) * 1_000n;
+  return { from: to - from > widest ? to - widest : from, to };
 }
 
 /**
@@ -316,13 +400,15 @@ async function theProductionTrace(claim: GradingClaim): Promise<Resolved> {
 /**
  * What one grader says about this conversation.
  *
- * **A simulation that never ran is `errored` for every grader, and no grader is
- * executed at all.** The agent never joined, the line was never answered, egma's
- * own runtime broke — there is no conversation to judge, and the one thing a
- * test product must never do is score that as the agent behaving badly. The word
- * is `errored` rather than `failed`, the fold keeps the two apart all the way up
- * to the run's headline, and the check is here rather than inside each executor
- * so that no future grader type can get it wrong.
+ * **A conversation with nothing to judge is `errored` for every grader, and no
+ * grader is executed at all.** Either it never happened — the agent never
+ * joined, the line was never answered, egma's own runtime broke — or it happened
+ * and egma cannot read it, because its spans never arrived and no column holds
+ * it. Both are things that went wrong on egma's side of the glass, and the one
+ * thing a test product must never do is score them as the agent behaving badly.
+ * The word is `errored` rather than `failed`, the fold keeps the two apart all
+ * the way up to the run's headline, and the check is here rather than inside
+ * each executor so that no future grader type can get it wrong.
  *
  * It answers with one row per grader, named by the grader's own one check —
  * which is the honest shape while every *authored* type executed makes one. The
@@ -337,13 +423,9 @@ export async function judgmentsOf(
   conversation: Conversation,
   judging: Judging,
 ): Promise<readonly Judgment[]> {
-  if (!conversation.happened) {
-    return [
-      couldNotJudge(
-        grader,
-        `this simulation ended ${conversation.endingReason ?? "without running"}, so there was no conversation to judge.`,
-      ),
-    ];
+  const nothingToJudge = conversation.nothingToJudgeBecause;
+  if (nothingToJudge !== null) {
+    return [couldNotJudge(grader, nothingToJudge)];
   }
 
   try {

--- a/apps/grader/src/graders/expected-behaviors.ts
+++ b/apps/grader/src/graders/expected-behaviors.ts
@@ -135,16 +135,16 @@ export async function judgeExpectedBehaviors(
   const behaviors = version.expectedBehaviors;
   if (behaviors.length === 0) return undefined;
 
-  if (!conversation.happened) {
+  // The same sentence the authored graders answer with, read off the
+  // conversation rather than written a second time here: two copies of it are
+  // two things a reader could be told about one conversation.
+  const nothingToJudge = conversation.nothingToJudgeBecause;
+  if (nothingToJudge !== null) {
     return {
       versionId: version.id,
       judgedBy: "engine",
       judged: behaviors.map((behavior, at) =>
-        couldNotJudge(
-          behavior,
-          at,
-          `this simulation ended ${conversation.endingReason ?? "without running"}, so there was no conversation to judge.`,
-        ),
+        couldNotJudge(behavior, at, nothingToJudge),
       ),
     };
   }

--- a/apps/grader/src/graders/metric-threshold.ts
+++ b/apps/grader/src/graders/metric-threshold.ts
@@ -14,11 +14,13 @@ import { theOneCheck, type ExecutionOf, type Judgment } from "./contract.ts";
  *
  * ## What it reads, and what it does when it is not there
  *
- * The measures a simulation produced live on its header row, as an object whose
- * keys are the measure names the simulator emits. A value is either one number
- * — a measure taken once, like the first response — or a list of numbers, a
- * measure taken per turn. Both are aggregated by the same eight aggregations;
- * one number aggregates to itself under every one of them.
+ * The measures a simulation produced arrive as an object whose keys are the
+ * measure names the simulator emits — assembled from the timing spans it
+ * streamed, one span per measurement, with the span's own duration as the
+ * number. A value is either one number — a measure taken once, like the first
+ * response — or a list of numbers, a measure taken per turn. Both are
+ * aggregated by the same eight aggregations; one number aggregates to itself
+ * under every one of them.
  *
  * Three absences, and they are deliberately not one:
  *

--- a/apps/grader/src/graders/tool-calls.ts
+++ b/apps/grader/src/graders/tool-calls.ts
@@ -91,10 +91,12 @@ export function executeToolCalls(
       rationale: passed
         ? heldRationale(whatHeld(config), "tools")
         : broken.join("; ") + ".",
-      // Empty, and honestly so. A tool call is not a turn: the simulator
-      // records it as its own event, with no position in the transcript, so
-      // there is no turn to point a reader at. When a simulation's tool calls
-      // arrive as spans of their own, this is the one line that changes.
+      // Empty, and honestly so. A tool call is not a turn: it has a span of its
+      // own, sitting beside the transcript rather than inside it, so there is no
+      // turn to point a reader at. A citation naming the tool span itself is a
+      // different reference from the turn positions this column otherwise
+      // carries, and adding it means teaching every reader of the column to
+      // resolve two kinds — which is a decision for whoever renders it.
       citedSpanIds: [],
     },
   ];
@@ -113,8 +115,10 @@ type ObservedCall = {
 /**
  * The tools the agent called, read off the event stream defensively.
  *
- * The events column is jsonb with no fixed shape at the write door, so anything
- * that is not a tool call event with a name on it is not a tool call. Read the
+ * Nothing fixes the shape of this list — it is assembled from spans for a
+ * conversation egma holds spans for, and read off a jsonb column with no write
+ * door behind it for one it does not — so anything that is not a tool call
+ * event with a name on it is not a tool call. Read the
  * same way `judgeInputOf` reads it, deliberately: a judge and this grader
  * looking at two different lists of tool calls would be two answers to one
  * question. The reading of a field is literally the judge input's `textOf`

--- a/apps/grader/src/judge/input.ts
+++ b/apps/grader/src/judge/input.ts
@@ -17,11 +17,12 @@ import type { Conversation } from "../conversation.ts";
  * reach another behavior's judge — not because the fan-out is careful, but
  * because there is nowhere in this type for it to be.
  *
- * Text-only in v1. The three jsonb columns a finished simulation carries have
- * no fixed shape at the write door, so everything here reads defensively and
- * says honestly when what it wanted is not there — an absent transcript is an
- * empty list, not a crash, and a judge shown an empty transcript answers that
- * it cannot determine anything, which is exactly right.
+ * Text-only in v1. Nothing fixes the shape of what arrives here — telemetry is
+ * written by whoever emitted it, and the columns a conversation falls back to
+ * had no write door behind them — so everything here reads defensively and says
+ * honestly when what it wanted is not there. An absent transcript is an empty
+ * list, not a crash, and a judge shown an empty transcript answers that it
+ * cannot determine anything, which is exactly right.
  */
 export type JudgeInput = {
   /** In the order they were spoken, numbered from one. */
@@ -76,12 +77,14 @@ export type Measure = {
 /**
  * How a judgment points at a turn.
  *
- * The verdict row's column is `cited_span_ids`, and a simulation read from its
- * own header row has no spans yet — the transcript is on the row and the OTLP
- * door is where the two converge later. So a citation names the turn it is
- * about, prefixed, and the prefix is the whole point: on the day a simulation's
- * turns arrive as spans, a reader looking at this column can tell a turn
- * reference from a span id without knowing when the row was written.
+ * The verdict row's column is `cited_span_ids`, and what a judgment cites is a
+ * turn's **position** rather than the id of the span it came on. That is
+ * deliberate on both sources: a judge is shown a numbered transcript and
+ * answers with the numbers it read, so a position is the one reference that is
+ * the same thing in the text the judge saw and in the row the judgment lands
+ * in — and it is still readable for a conversation whose spans have aged out of
+ * the store. The prefix is what lets a reader tell the two kinds apart without
+ * knowing when the row was written.
  */
 export const TURN_REFERENCE_PREFIX = "turn:";
 
@@ -100,7 +103,10 @@ export function judgeInputOf(conversation: Conversation): JudgeInput {
   return {
     transcript,
     outcome: {
-      happened: conversation.happened,
+      // Always true by the time a judge is asked anything: a conversation with
+      // nothing to judge is `errored` for every grader without a model being
+      // called, so the one place this could be false never reaches here.
+      happened: conversation.nothingToJudgeBecause === null,
       endingReason: conversation.endingReason,
       turns: transcript.length,
     },

--- a/apps/grader/test/llm-rubric.test.ts
+++ b/apps/grader/test/llm-rubric.test.ts
@@ -251,7 +251,7 @@ describe("a rubric with no judge to ask", () => {
     return {
       source: "simulation",
       traceId: "sim_01JQZ0000000000000000000AA",
-      happened: true,
+      nothingToJudgeBecause: null,
       endingReason: "persona_concluded",
       transcript: [{ speaker: "agent", text: "Booked for Thursday at four." }],
       events: [],

--- a/apps/grader/test/metric-threshold.test.ts
+++ b/apps/grader/test/metric-threshold.test.ts
@@ -23,7 +23,7 @@ function conversation(metrics: unknown): Conversation {
   return {
     source: "simulation",
     traceId: "sim_01JQZ0000000000000000000AA",
-    happened: true,
+    nothingToJudgeBecause: null,
     endingReason: "persona_concluded",
     transcript: [],
     events: [],

--- a/apps/grader/test/one-grader.test.ts
+++ b/apps/grader/test/one-grader.test.ts
@@ -18,7 +18,7 @@ function conversation(overrides: Partial<Conversation> = {}): Conversation {
   return {
     source: "simulation",
     traceId: "sim_01JQZ0000000000000000000AA",
-    happened: true,
+    nothingToJudgeBecause: null,
     endingReason: "persona_concluded",
     transcript: [],
     events: [],
@@ -72,7 +72,8 @@ describe("a simulation that never ran", () => {
     const [only] = await judgmentsOf(
       grader(),
       conversation({
-        happened: false,
+        nothingToJudgeBecause:
+          "this simulation ended agent_never_joined, so there was no conversation to judge.",
         endingReason: "agent_never_joined",
         // Measures the grader would happily have passed, so the answer cannot
         // be coming from the executor having looked at them.

--- a/apps/grader/test/phrase-match.test.ts
+++ b/apps/grader/test/phrase-match.test.ts
@@ -30,7 +30,7 @@ function conversation(transcript: unknown = A_CONVERSATION): Conversation {
   return {
     source: "simulation",
     traceId: "sim_01JQZ0000000000000000000AA",
-    happened: true,
+    nothingToJudgeBecause: null,
     endingReason: "persona_concluded",
     transcript,
     events: [],

--- a/apps/grader/test/production.test.ts
+++ b/apps/grader/test/production.test.ts
@@ -217,10 +217,11 @@ describe("a production trace whose root span closes", () => {
 
     expect(conversation.source).toBe("production");
     expect(conversation.traceId).toBe(traceId);
-    // It happened: spans exist, so somebody talked to something. `errored` is
-    // the answer to "did egma's own runtime manage to conduct this", and a real
-    // caller's conversation was conducted by the world.
-    expect(conversation.happened).toBe(true);
+    // There is something here to judge: spans exist, so somebody talked to
+    // something. `errored` is the answer to "did egma's own runtime manage to
+    // conduct this", and a real caller's conversation was conducted by the
+    // world.
+    expect(conversation.nothingToJudgeBecause).toBeNull();
     // Nothing on the wire says why a real caller hung up, and a guess dressed
     // up as a reason would be worse than the absence.
     expect(conversation.endingReason).toBeNull();

--- a/apps/grader/test/simulation-spans.test.ts
+++ b/apps/grader/test/simulation-spans.test.ts
@@ -1,0 +1,513 @@
+import { getSimulation, readTrace, readVerdicts } from "@egma/db";
+import { traceIdOfSimulation } from "@egma/simulation-contract";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { conversationOfSimulation } from "../src/conversation.ts";
+import {
+  aThreshold,
+  conductSimulation,
+  jobFor,
+  makeWorld,
+  oneServiceAtATime,
+  seedGrader,
+  seedTest,
+  type World,
+} from "./support/world.ts";
+import type { NewGrader } from "@egma/db";
+
+/**
+ * A simulation read the way a production trace is read: from its spans.
+ *
+ * **The seam is the verdict rows, and the assertions are on them.** What a
+ * conversation was assembled out of is not something a grader knows, so every
+ * case here conducts a conversation, lets the real service judge it, and reads
+ * back what it said. One case reaches through to the constructor, for the same
+ * reason the production suite does: no grader type egma executes prints a
+ * transcript, so nothing in a verdict row can show that the turns are the ones
+ * the spans describe.
+ *
+ * **Nothing here is about the wire.** The spans are filed through the same
+ * data-access call the ingest door files them through; the OTLP body, the
+ * service token and the resource attribute naming the simulation are the API's
+ * own tests, and repeating them would test Fastify rather than grading.
+ */
+
+let world: World;
+const service = oneServiceAtATime();
+
+beforeAll(async () => {
+  world = await makeWorld("grader_simulation_spans");
+});
+
+afterAll(async () => {
+  await service.stop();
+  await world.drop();
+});
+
+/** A phrase the agent has to have said: the one deterministic type that cites turns. */
+function aPhrase(overrides: Partial<NewGrader> = {}): NewGrader {
+  return {
+    name: "Reads the new time back",
+    type: "phrase_match",
+    config: {
+      required: [{ text: "Tuesday at four", match: "contains" }],
+      banned: [],
+      speaker: "agent",
+    },
+    ...overrides,
+  } as NewGrader;
+}
+
+/** A tool that has to have fired, judged from what egma observed and not said. */
+function aTool(overrides: Partial<NewGrader> = {}): NewGrader {
+  return {
+    name: "Actually reschedules",
+    type: "tool_calls",
+    config: {
+      required: [{ tool: "reschedule_appointment", arguments: null }],
+      forbidden: [],
+    },
+    ...overrides,
+  } as NewGrader;
+}
+
+/** The conversation every case in this file conducts, said once. */
+const A_CONVERSATION = [
+  { speaker: "human" as const, text: "Can you move my cleaning to Tuesday?" },
+  { speaker: "agent" as const, text: "Let me look at the diary." },
+  { speaker: "human" as const, text: "Any afternoon works." },
+  { speaker: "agent" as const, text: "Booked for Tuesday at four." },
+];
+
+/** The same conversation as the columns hold one, for the path being retired. */
+const A_CONVERSATION_IN_COLUMNS = A_CONVERSATION.map((turn) => ({
+  kind: "turn",
+  speaker: turn.speaker,
+  text: turn.text,
+}));
+
+describe("a simulation whose spans arrived complete", () => {
+  beforeAll(async () => {
+    await service.start();
+  });
+
+  it("is graded end to end, its verdicts citing turns assembled from spans", async () => {
+    const phrase = await seedGrader(world, aPhrase());
+    const tool = await seedGrader(world, aTool());
+    const latency = await seedGrader(
+      world,
+      aThreshold({ name: "Answers inside two seconds from spans" }),
+    );
+
+    const conducted = await conductSimulation(world, {
+      spans: {
+        said: A_CONVERSATION,
+        calledTool: {
+          name: "reschedule_appointment",
+          arguments: '{"when":"Tuesday"}',
+        },
+        measured: { turn_response_latency: [900, 1_100] },
+      },
+    });
+    await jobFor(world, conducted, "graded");
+
+    // Nothing on the row, so nothing a verdict says can have come from it. This
+    // is the whole point of the case: the conversation exists only as spans.
+    const row = await getSimulation(world.auth, conducted.simulationId);
+    expect(row?.transcript).toBeNull();
+    expect(row?.events).toBeNull();
+    expect(row?.metrics).toBeNull();
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    const by = (graderId: string) =>
+      verdicts.find((verdict) => verdict.graderId === graderId);
+
+    // The transcript: found, and cited at the turn it was found in — which is
+    // the fourth thing said, counted through the span-assembled transcript.
+    expect(by(phrase)).toMatchObject({ verdict: "passed" });
+    expect(by(phrase)?.citedSpanIds).toEqual(["turn:4"]);
+    // The tool calls, read off the columns the door normalised them into.
+    expect(by(tool)).toMatchObject({ verdict: "passed" });
+    // And the measures, off the timing spans.
+    expect(by(latency)).toMatchObject({ verdict: "passed" });
+  });
+
+  it("files its verdicts under the simulation id, exactly as before", async () => {
+    const graderId = await seedGrader(
+      world,
+      aPhrase({ name: "Filed under the simulation" }),
+    );
+
+    const conducted = await conductSimulation(world, {
+      spans: { said: A_CONVERSATION },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    const mine = verdicts.find((verdict) => verdict.graderId === graderId);
+
+    // The trace id on a verdict row is the product's word for this
+    // conversation, and it did not move: the derived hex names where the spans
+    // are filed and nothing else.
+    expect(mine).toMatchObject({
+      traceId: conducted.simulationId,
+      source: "simulation",
+      runId: conducted.runId,
+      agentId: world.agentId,
+    });
+    expect(conducted.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(conducted.traceId).not.toBe(conducted.simulationId);
+  });
+
+  it("reads the conversation from its spans — the transcript, the tools and the measures", async () => {
+    const conducted = await conductSimulation(world, {
+      spans: {
+        said: A_CONVERSATION,
+        calledTool: {
+          name: "reschedule_appointment",
+          arguments: '{"when":"Tuesday"}',
+        },
+        measured: {
+          first_response_latency: [1_214],
+          turn_response_latency: [862.5, 1_100],
+        },
+      },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const simulation = await getSimulation(world.auth, conducted.simulationId);
+    if (simulation === undefined) throw new Error("the row went missing");
+
+    const traceId = traceIdOfSimulation(simulation.id);
+    const trace = await readTrace(world.auth, traceId as string, {
+      window: {
+        from: BigInt(Date.now() - 600_000) * 1_000n,
+        to: BigInt(Date.now() + 600_000) * 1_000n,
+      },
+    });
+    if (trace === undefined) throw new Error("the trace store lost the spans");
+
+    const conversation = conversationOfSimulation(simulation, trace);
+
+    expect(conversation.source).toBe("simulation");
+    expect(conversation.traceId).toBe(simulation.id);
+    expect(conversation.nothingToJudgeBecause).toBeNull();
+    // The simulator's own word for how it ended, which only the row knows.
+    expect(conversation.endingReason).toBe("persona_concluded");
+
+    // The transcript, in the order it happened, with the speaker off the kind.
+    expect(conversation.transcript).toMatchObject(
+      A_CONVERSATION.map((turn) => ({ speaker: turn.speaker, text: turn.text })),
+    );
+
+    // The tool call, with no result — always, because the simulator observes
+    // the call from egma's side of the connection and not the return.
+    expect(conversation.events).toMatchObject([
+      {
+        kind: "tool_call",
+        name: "reschedule_appointment",
+        arguments: '{"when":"Tuesday"}',
+        result: "",
+      },
+    ]);
+
+    // The measures, in milliseconds, each one a timing span's own duration —
+    // including the half a millisecond, which a whole-number division would
+    // have floored away.
+    expect(conversation.metrics).toEqual({
+      first_response_latency: [1_214],
+      turn_response_latency: [862.5, 1_100],
+    });
+  });
+
+  it("keeps two turns that cross in time, in the order they began", async () => {
+    // What barge-in looks like: the persona starts answering before the agent
+    // has stopped talking. The transcript has to hold both — a reader that
+    // assumed turns take it in strict succession would drop one of them, or
+    // reorder the pair, and the record would say the conversation went
+    // differently than it did.
+    const conducted = await conductSimulation(world, {
+      spans: {
+        said: [
+          {
+            speaker: "agent",
+            text: "So that is Tuesday at four, and I will send you a text to—",
+            atMilliseconds: 0,
+            spokeForMilliseconds: 4_000,
+          },
+          {
+            speaker: "human",
+            text: "Sorry, make it Wednesday.",
+            atMilliseconds: 3_000,
+            spokeForMilliseconds: 1_500,
+          },
+        ],
+      },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const simulation = await getSimulation(world.auth, conducted.simulationId);
+    if (simulation === undefined) throw new Error("the row went missing");
+    const trace = await readTrace(
+      world.auth,
+      traceIdOfSimulation(simulation.id) as string,
+      {
+        window: {
+          from: BigInt(Date.now() - 600_000) * 1_000n,
+          to: BigInt(Date.now() + 600_000) * 1_000n,
+        },
+      },
+    );
+    if (trace === undefined) throw new Error("the trace store lost the spans");
+
+    const turns = conversationOfSimulation(simulation, trace).transcript as {
+      speaker: string;
+      started_at: string;
+      ended_at: string;
+    }[];
+
+    expect(turns.map((turn) => turn.speaker)).toEqual(["agent", "human"]);
+    // And they genuinely cross: the second began before the first had ended.
+    // Compared as the store's own fixed-width instants, which sort exactly as
+    // the moments do.
+    const [agentTurn, humanTurn] = turns;
+    expect(
+      (humanTurn?.started_at ?? "") < (agentTurn?.ended_at ?? ""),
+    ).toBe(true);
+  });
+});
+
+describe("one conversation graded through each path", () => {
+  beforeAll(async () => {
+    await service.start();
+  });
+
+  it("cites the same turns, in the same order, whichever it was read from", async () => {
+    const graderId = await seedGrader(
+      world,
+      aPhrase({
+        name: "Compared across both paths",
+        // Two phrases in two different turns, so the comparison is about the
+        // order of the citations rather than about there being one.
+        config: {
+          required: [
+            { text: "Tuesday at four", match: "contains" },
+            { text: "the diary", match: "contains" },
+          ],
+          banned: [],
+          speaker: "agent",
+        },
+      } as Partial<NewGrader>),
+    );
+
+    const fromSpans = await conductSimulation(world, {
+      spans: { said: A_CONVERSATION },
+    });
+    const fromColumns = await conductSimulation(world, {
+      transcript: A_CONVERSATION_IN_COLUMNS,
+    });
+    await jobFor(world, fromSpans, "graded");
+    await jobFor(world, fromColumns, "graded");
+
+    const judgedIn = async (simulationId: string) => {
+      const { verdicts } = await readVerdicts(world.auth, simulationId);
+      const mine = verdicts.find((verdict) => verdict.graderId === graderId);
+      return {
+        verdict: mine?.verdict,
+        rationale: mine?.rationale,
+        citedSpanIds: mine?.citedSpanIds,
+      };
+    };
+
+    const spans = await judgedIn(fromSpans.simulationId);
+    const columns = await judgedIn(fromColumns.simulationId);
+
+    // The same answer, about the same turns, in the same order. Written as one
+    // comparison rather than two assertions against a constant, because what is
+    // being proved is that the two paths agree — not that either says something
+    // somebody typed out here.
+    expect(spans).toEqual(columns);
+    expect(spans.verdict).toBe("passed");
+    expect(spans.citedSpanIds).toEqual(["turn:2", "turn:4"]);
+  });
+});
+
+describe("what the simulator measured", () => {
+  beforeAll(async () => {
+    await service.start();
+  });
+
+  it("is the timing span's own duration, and never a value beside it", async () => {
+    const graderId = await seedGrader(
+      world,
+      aThreshold({
+        name: "The first answer inside a second and a half",
+        config: {
+          measure: "first_response_latency",
+          aggregation: "max",
+          comparator: "below",
+          threshold: 1_500,
+        },
+      } as Partial<NewGrader>),
+    );
+
+    const conducted = await conductSimulation(world, {
+      spans: { said: A_CONVERSATION, measured: { first_response_latency: [1_214] } },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    const mine = verdicts.find((verdict) => verdict.graderId === graderId);
+
+    expect(mine?.verdict).toBe("passed");
+    // The number the span's start and end bracket, read back to the
+    // millisecond — nothing on the span carries it a second time.
+    expect(mine?.rationale).toContain("1214");
+  });
+
+  it("leaves a voice measure absent on a chat simulation — skipped, never failed", async () => {
+    const graderId = await seedGrader(
+      world,
+      aThreshold({
+        name: "How long the agent spoke for",
+        config: {
+          measure: "agent_speech_duration",
+          aggregation: "p90",
+          comparator: "below",
+          threshold: 20_000,
+        },
+      } as Partial<NewGrader>),
+    );
+
+    const conducted = await conductSimulation(world, {
+      spans: { said: A_CONVERSATION, measured: { turn_response_latency: [900] } },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    const mine = verdicts.find((verdict) => verdict.graderId === graderId);
+
+    // A chat conversation has no audio, so it measured no speech. The check did
+    // not apply; it did not fail, and it did not error either — the fold leaves
+    // a skipped check out of the score's denominator.
+    expect(mine?.verdict).toBe("skipped");
+  });
+});
+
+describe("a simulation whose trace never closed", () => {
+  beforeAll(async () => {
+    await service.start();
+  });
+
+  it("falls back to the row's columns, so nothing mid-migration breaks", async () => {
+    const graderId = await seedGrader(
+      world,
+      aPhrase({ name: "Read off the columns behind a half-sent trace" }),
+    );
+
+    const conducted = await conductSimulation(world, {
+      spans: {
+        // Turns went out; the flush carrying the root never did.
+        rootCloses: false,
+        said: [{ speaker: "agent", text: "Something else entirely." }],
+      },
+      transcript: A_CONVERSATION_IN_COLUMNS,
+    });
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    const mine = verdicts.find((verdict) => verdict.graderId === graderId);
+
+    // Judged, and judged from the columns: the phrase is in the column
+    // transcript and nowhere in the spans that did arrive, so a pass here can
+    // only have come from the fallback.
+    expect(mine?.verdict).toBe("passed");
+    expect(mine?.citedSpanIds).toEqual(["turn:4"]);
+  });
+
+  it("is errored for every grader when no column holds it either", async () => {
+    const graderId = await seedGrader(
+      world,
+      aPhrase({ name: "Asked about a conversation egma holds half of" }),
+    );
+
+    const conducted = await conductSimulation(world, {
+      spans: { rootCloses: false, said: A_CONVERSATION },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    const mine = verdicts.find((verdict) => verdict.graderId === graderId);
+
+    // Never `failed`. The required phrase is genuinely absent from what egma
+    // holds, and an agent that said it perfectly would be marked down for a
+    // flush that never landed.
+    expect(mine?.verdict).toBe("errored");
+    expect(mine?.rationale).toContain("only part of this conversation");
+    expect(verdicts.every((verdict) => verdict.verdict === "errored")).toBe(true);
+  });
+});
+
+describe("a simulation with no spans at all", () => {
+  beforeAll(async () => {
+    await service.start();
+  });
+
+  it("still grades from its columns — the row written before any of this streamed", async () => {
+    const graderId = await seedGrader(
+      world,
+      aPhrase({ name: "Judging a row that predates the emitter" }),
+    );
+
+    const conducted = await conductSimulation(world, {
+      transcript: A_CONVERSATION_IN_COLUMNS,
+      metrics: { turn_response_latency: [900, 1_100] },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    const mine = verdicts.find((verdict) => verdict.graderId === graderId);
+
+    expect(mine?.verdict).toBe("passed");
+    expect(mine?.citedSpanIds).toEqual(["turn:4"]);
+  });
+
+  it("is errored for every grader, and for every expected behavior, when its row holds nothing", async () => {
+    const graderId = await seedGrader(
+      world,
+      aPhrase({ name: "Asked about a conversation egma has no record of" }),
+    );
+    const testId = await seedTest(world, [], [
+      "confirms the new time back before finishing",
+      "never quotes a price",
+    ]);
+
+    // Nothing streamed and nothing landed on the row: a completed conversation
+    // whose evidence never reached egma at all.
+    const conducted = await conductSimulation(world, {
+      transcript: null,
+      metrics: null,
+      testId,
+    });
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+
+    expect(verdicts.length).toBeGreaterThan(0);
+    expect(verdicts.every((verdict) => verdict.verdict === "errored")).toBe(true);
+    expect(
+      verdicts.find((verdict) => verdict.graderId === graderId)?.rationale,
+    ).toContain("no record of this conversation");
+
+    // The built-in says the same thing, once per behavior, so a page shows the
+    // same list of checks whether egma could read the conversation or not.
+    const behaviors = verdicts.filter(
+      (verdict) => verdict.graderId === "expected_behaviors",
+    );
+    expect(behaviors).toHaveLength(2);
+    for (const behavior of behaviors) {
+      expect(behavior.verdict).toBe("errored");
+      expect(behavior.rationale).toContain("no record of this conversation");
+    }
+  });
+});

--- a/apps/grader/test/simulation-spans.test.ts
+++ b/apps/grader/test/simulation-spans.test.ts
@@ -446,6 +446,39 @@ describe("a simulation whose trace never closed", () => {
     expect(mine?.rationale).toContain("only part of this conversation");
     expect(verdicts.every((verdict) => verdict.verdict === "errored")).toBe(true);
   });
+
+  it("refuses to judge a reading the span limit cut short, root or no root", async () => {
+    const conducted = await conductSimulation(world, {
+      spans: { said: A_CONVERSATION },
+    });
+    await jobFor(world, conducted, "graded");
+
+    const simulation = await getSimulation(world.auth, conducted.simulationId);
+    if (simulation === undefined) throw new Error("the row went missing");
+    const trace = await readTrace(
+      world.auth,
+      traceIdOfSimulation(simulation.id) as string,
+      {
+        window: {
+          from: BigInt(Date.now() - 600_000) * 1_000n,
+          to: BigInt(Date.now() + 600_000) * 1_000n,
+        },
+      },
+    );
+    if (trace === undefined) throw new Error("the trace store lost the spans");
+
+    // Exactly what the trace read answers when a conversation overruns the
+    // reader's span limit: the same rows, the flag up. The root is present,
+    // so completeness is not the question — wholeness of the reading is, and
+    // judging the readable part would judge a different conversation.
+    const conversation = conversationOfSimulation(simulation, {
+      ...trace,
+      truncated: true,
+    });
+
+    expect(conversation.nothingToJudgeBecause).toContain("span limit");
+    expect(conversation.transcript).toEqual([]);
+  });
 });
 
 describe("a simulation with no spans at all", () => {

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -27,8 +27,10 @@ import {
   type NewGrader,
   type NewSpan,
   type RecordedVerdict,
+  type Simulation,
   type SimulationFailure,
 } from "@egma/db";
+import { traceIdOfSimulation } from "@egma/simulation-contract";
 
 import {
   createMigratedDatabase,
@@ -252,6 +254,8 @@ export function aRubric(overrides: Partial<NewGrader> = {}): NewGrader {
 export type ConductedSimulation = {
   readonly runId: string;
   readonly simulationId: string;
+  /** Where its spans are filed, for a test that wants to read them back. */
+  readonly traceId: string;
 };
 
 /**
@@ -263,6 +267,14 @@ export async function conductSimulation(
   landing: {
     readonly metrics?: unknown;
     readonly transcript?: unknown;
+    /**
+     * The conversation as spans, streamed while it runs — before the terminal
+     * transition, which is the order the simulator's one ordered sender puts
+     * them in. A conduct that streams them lands its row's columns **empty**
+     * unless a case explicitly asks for both, because empty is what the report
+     * door writes today.
+     */
+    readonly spans?: StreamedConversation | undefined;
     /**
      * Absent means it happened; a reason means it never ran. Typed as what a
      * simulator may report, because that is who this helper is playing.
@@ -315,6 +327,19 @@ export async function conductSimulation(
     throw new Error(`simulation ${only.id} would not start`);
   }
 
+  // Every span on the wire before the document that ends the conversation, which
+  // is the whole point of the simulator's one ordered sender: when the control
+  // plane lands a terminal transition, the evidence is already stored.
+  if (landing.spans !== undefined) {
+    await streamConversation(world, conducting, landing.spans);
+  }
+
+  // A column a case named is what that column gets, `null` included — asked by
+  // presence rather than by value, because "the row holds nothing" is a case
+  // this file has to be able to conduct. Unnamed, a column holds the default
+  // conversation for a conduct that streamed nothing, and nothing for one that
+  // streamed spans: empty is what the report door writes today.
+  const byDefault = landing.spans === undefined;
   const landed =
     landing.failedBecause !== undefined
       ? await failSimulation(world.auth, only.id, claimant, {
@@ -322,16 +347,225 @@ export async function conductSimulation(
         })
       : await completeSimulation(world.auth, only.id, claimant, {
           endingReason: "persona_concluded",
-          transcript: landing.transcript ?? [
-            { speaker: "agent", text: "Booked for Tuesday at four." },
-          ],
-          metrics: landing.metrics ?? { turn_response_latency: [900, 1_100] },
+          transcript:
+            "transcript" in landing
+              ? landing.transcript
+              : byDefault
+                ? [{ speaker: "agent", text: "Booked for Tuesday at four." }]
+                : null,
+          metrics:
+            "metrics" in landing
+              ? landing.metrics
+              : byDefault
+                ? { turn_response_latency: [900, 1_100] }
+                : null,
         });
   if (landed === undefined) {
     throw new Error(`simulation ${only.id} never reached a terminal transition`);
   }
 
-  return { runId: started.id, simulationId: only.id };
+  return {
+    runId: started.id,
+    simulationId: only.id,
+    traceId: traceIdOfSimulation(only.id) ?? "",
+  };
+}
+
+/* ------------------------------------------------------------------- *
+ * A simulation's conversation, as the spans it actually arrives as.
+ * ------------------------------------------------------------------- */
+
+/**
+ * What one conducted conversation streams, said in the terms the vocabulary
+ * uses rather than in rows.
+ */
+export type StreamedConversation = {
+  /**
+   * Absent leaves the root span unsent — a trace egma holds part of, which is
+   * what a simulator killed mid-conversation leaves behind.
+   */
+  readonly rootCloses?: boolean | undefined;
+  readonly said?: readonly StreamedTurn[] | undefined;
+  readonly calledTool?:
+    | { readonly name: string; readonly arguments: string }
+    | undefined;
+  /**
+   * What the simulator measured, in the milliseconds the catalog names — each
+   * sample authored as its own timing span whose duration *is* the number.
+   */
+  readonly measured?: Readonly<Record<string, readonly number[]>> | undefined;
+};
+
+/**
+ * One turn as it was spoken, which is two facts a transcript cannot carry.
+ *
+ * Both default to what a chat turn is — one instant, two seconds after the one
+ * before it — and both are here because a voice turn is neither. A turn is open
+ * for as long as it was spoken for, and two of them may **cross**: the persona
+ * starting before the agent has finished is what barge-in looks like, and the
+ * shape has to permit it rather than be widened for it later.
+ */
+export type StreamedTurn = {
+  readonly speaker: "human" | "agent";
+  readonly text: string;
+  /** When it began, counted from the start of the conversation. */
+  readonly atMilliseconds?: number | undefined;
+  /** How long the audio ran, ear to ear. Zero on chat. */
+  readonly spokeForMilliseconds?: number | undefined;
+};
+
+/**
+ * One simulation's spans, filed exactly as the ingest door files them.
+ *
+ * That one call *is* the door for these purposes — the OTLP wire, the service
+ * token and the resource attribute naming the simulation are the API's own
+ * tests, and repeating them here would test Fastify rather than grading. What
+ * matters on this side is that the rows land under the trace the simulation id
+ * derives, stamped `simulation` and `egma-runtime`, carrying the run and the
+ * agent the door resolves from egma's own row.
+ *
+ * **No queue row, deliberately.** A simulation's grading work is minted by the
+ * transaction that lands it terminal, so a span arriving has nothing to add —
+ * which is exactly the asymmetry with a production trace, whose spans are the
+ * only thing that could ever have created its job.
+ */
+async function streamConversation(
+  world: World,
+  simulation: Simulation,
+  streaming: StreamedConversation,
+): Promise<void> {
+  const traceId = traceIdOfSimulation(simulation.id);
+  if (traceId === undefined) {
+    throw new Error(`${simulation.id} names no trace`);
+  }
+
+  const began = Date.now();
+  const rootSpanId = nextSpanId();
+  const spans: NewSpan[] = [];
+
+  const spanning = (over: Partial<NewSpan>): NewSpan =>
+    simulationSpan(traceId, simulation, {
+      spanId: nextSpanId(),
+      parentSpanId: rootSpanId,
+      startedAtMicroseconds: BigInt(began) * 1_000n,
+      ...over,
+    });
+
+  const said = streaming.said ?? [
+    { speaker: "human" as const, text: "Can you move my cleaning to Tuesday?" },
+    { speaker: "agent" as const, text: "Booked for Tuesday at four." },
+  ];
+
+  said.forEach((turn, at) => {
+    spans.push(
+      spanning({
+        // The speaker rides the span name, and the door reads the kind off it.
+        name: turn.speaker === "human" ? "human_turn" : "agent_turn",
+        kind: `turn:${turn.speaker}`,
+        text: turn.text,
+        startedAtMicroseconds:
+          BigInt(began) * 1_000n +
+          BigInt(turn.atMilliseconds ?? at * 2_000) * 1_000n,
+        // One instant unless something measured how long it was spoken for,
+        // which on chat nothing ever does.
+        durationNanoseconds:
+          BigInt(turn.spokeForMilliseconds ?? 0) * 1_000_000n,
+      }),
+    );
+  });
+
+  if (streaming.calledTool !== undefined) {
+    spans.push(
+      spanning({
+        name: "tool_call",
+        kind: "tool",
+        toolName: streaming.calledTool.name,
+        toolArguments: streaming.calledTool.arguments,
+        // Always empty: the simulator observes the call and not the return, so
+        // its vocabulary declares no result attribute at all.
+        toolResult: "",
+        startedAtMicroseconds: BigInt(began) * 1_000n + 1_000_000n,
+        durationNanoseconds: 0n,
+      }),
+    );
+  }
+
+  let takenAt = 0n;
+  for (const [measure, samples] of Object.entries(streaming.measured ?? {})) {
+    for (const milliseconds of samples) {
+      takenAt += 500_000n;
+      spans.push(
+        spanning({
+          // A timing span is named for the measure it takes, and the door files
+          // every one of the catalog's timing measures as `timing`.
+          name: measure,
+          kind: "timing",
+          startedAtMicroseconds: BigInt(began) * 1_000n + takenAt,
+          durationNanoseconds: BigInt(Math.round(milliseconds * 1_000_000)),
+        }),
+      );
+    }
+  }
+
+  // While it is still happening: everything the walk observed, and nothing that
+  // closes it.
+  await appendSpans(world.auth, spans);
+
+  if (streaming.rootCloses ?? true) {
+    // And the flush that ends it, with the root alone — authored first, sent
+    // last, which is what makes its arrival mean the conversation is over.
+    await appendSpans(world.auth, [
+      simulationSpan(traceId, simulation, {
+        spanId: rootSpanId,
+        parentSpanId: "",
+        name: "simulation",
+        kind: "root",
+        startedAtMicroseconds: BigInt(began) * 1_000n,
+        durationNanoseconds: 20_000_000_000n,
+      }),
+    ]);
+  }
+}
+
+/** A simulation's span as the door writes one, with everything else empty. */
+function simulationSpan(
+  traceId: string,
+  simulation: Simulation,
+  over: Partial<NewSpan>,
+): NewSpan {
+  return {
+    traceId,
+    spanId: "",
+    parentSpanId: "",
+    // Explicit on the row rather than inferred from the run being set:
+    // comparing a simulation against a production trace is the premise of the
+    // product, so the two dimensions compose instead of sharing a slot.
+    source: "simulation",
+    emitter: "egma-runtime",
+    environment: "default",
+    startedAtMicroseconds: 0n,
+    durationNanoseconds: 0n,
+    name: "",
+    kind: "other",
+    status: "unset",
+    text: "",
+    audioUrl: "",
+    toolName: "",
+    toolArguments: "",
+    toolResult: "",
+    providerCallId: "",
+    connectionType: simulation.connectionType,
+    audioSampleRateHz: 0,
+    audioEncoding: "",
+    // Resolved by the door from egma's own row, never from the payload.
+    runId: simulation.runId,
+    agentId: simulation.agentId,
+    agentVersionId: "",
+    testVersionId: simulation.testVersionId ?? "",
+    personaVersionId: simulation.personaVersionId,
+    payload: "{}",
+    ...over,
+  };
 }
 
 /* ------------------------------------------------------------------- *
@@ -368,6 +602,15 @@ function wireId(ordinal: number, bytes: 8 | 16): string {
   return ordinal.toString(16).padStart(bytes * 2, "0");
 }
 
+/**
+ * One span id, never issued twice in a run of the suite — which is what the
+ * store's own dedup is keyed on, so a repeat would land as nothing at all.
+ */
+function nextSpanId(): string {
+  nextSpanOrdinal += 1;
+  return wireId(nextSpanOrdinal, 8);
+}
+
 export async function conductProductionTrace(
   world: World,
   conducting: {
@@ -380,10 +623,7 @@ export async function conductProductionTrace(
   nextTraceOrdinal += 1;
   const traceId = wireId(nextTraceOrdinal, 16);
   const startedAt = new Date();
-  const spanId = (): string => {
-    nextSpanOrdinal += 1;
-    return wireId(nextSpanOrdinal, 8);
-  };
+  const spanId = nextSpanId;
 
   const rootSpanId = spanId();
   const said = conducting.said ?? [
@@ -460,10 +700,9 @@ export async function exportALateFlush(
   world: World,
   traceId: string,
 ): Promise<void> {
-  nextSpanOrdinal += 1;
   await exportFlush(world, [
     productionSpan(traceId, {
-      spanId: wireId(nextSpanOrdinal, 8),
+      spanId: nextSpanId(),
       parentSpanId: "",
       name: "agent_session",
       kind: "root",

--- a/apps/grader/test/tool-calls.test.ts
+++ b/apps/grader/test/tool-calls.test.ts
@@ -30,7 +30,7 @@ function conversation(events: unknown): Conversation {
   return {
     source: "simulation",
     traceId: "sim_01JQZ0000000000000000000AA",
-    happened: true,
+    nothingToJudgeBecause: null,
     endingReason: "persona_concluded",
     transcript: A_TRANSCRIPT,
     events,

--- a/apps/grader/tsconfig.json
+++ b/apps/grader/tsconfig.json
@@ -6,5 +6,9 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../../packages/ids" }, { "path": "../../packages/db" }]
+  "references": [
+    { "path": "../../packages/ids" },
+    { "path": "../../packages/simulation-contract" },
+    { "path": "../../packages/db" }
+  ]
 }

--- a/packages/db/src/access/grading.ts
+++ b/packages/db/src/access/grading.ts
@@ -215,7 +215,10 @@ export type GradingClaim = {
   readonly traceId: string | null;
   /**
    * When the trace's earliest and latest spans began — the window its transcript
-   * is read inside. Null for a simulation, which is read from its own row.
+   * is read inside. Null for a simulation, whose window comes off its own row:
+   * a simulation was conducted between two moments egma recorded, and this job
+   * was written by the transaction that recorded the second one rather than by
+   * a span arriving.
    */
   readonly firstSpanAt: Date | null;
   readonly lastSpanAt: Date | null;

--- a/packages/simulation-contract/package.json
+++ b/packages/simulation-contract/package.json
@@ -20,6 +20,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
+    "@egma/ids": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1"
   }

--- a/packages/simulation-contract/src/index.ts
+++ b/packages/simulation-contract/src/index.ts
@@ -6,11 +6,15 @@
  * TypeScript. What is here is what the control plane checks on its own side
  * of the wire: the measure catalog, which a grader's write door refuses an
  * unknown measure against, the spec check every outgoing claim answer passes
- * through before a byte of it is sent, and the report check every arriving
- * document passes through before a byte of it is believed.
+ * through before a byte of it is sent, the report check every arriving
+ * document passes through before a byte of it is believed, and the one
+ * derivation that turns a simulation id into the trace its spans are filed
+ * under.
  */
 
 export { reportComplaints, specComplaints } from "./documents.ts";
+
+export { traceIdOfSimulation } from "./trace-identity.ts";
 
 export {
   catalogedMeasure,

--- a/packages/simulation-contract/src/trace-identity.ts
+++ b/packages/simulation-contract/src/trace-identity.ts
@@ -1,0 +1,71 @@
+import { CROCKFORD_ALPHABET, isId } from "@egma/ids";
+
+/**
+ * Trace identity: which trace a simulation's spans belong to.
+ *
+ * A simulation's telemetry is filed in the trace store under an OpenTelemetry
+ * trace id, which is 128 bits of fixed-width binary and cannot hold one of
+ * egma's own identifiers. So the two are not the same string, and something
+ * has to turn one into the other. That derivation is a term of the contract —
+ * `span-vocabulary.md` states it, with a worked example, because the emitter
+ * applies it when it authors a span and the platform applies it when it goes
+ * looking for one, and the two agreeing is what lets a verdict and the spans it
+ * cites find each other with nothing having stored a mapping.
+ *
+ * **This is the whole of the TypeScript side.** The simulator has its own, in
+ * Python, at the far end of the wire; the golden fixtures are the two held to
+ * each other. Inside this repository every production caller comes here, so a
+ * conversation is looked up one way — a second derivation would be a second
+ * answer, and the two disagreeing would look exactly like telemetry that never
+ * arrived.
+ */
+
+/**
+ * How wide a trace id is, in bits and in the hex it is written as. Both come
+ * from OpenTelemetry rather than from egma: a trace id is 16 bytes, always,
+ * and lowercase hex is the form the JSON mapping carries and the store holds.
+ */
+const TRACE_ID_BITS = 128n;
+const TRACE_ID_HEX_LENGTH = 32;
+
+/** Five bits a character, which is what base32 is. */
+const BITS_PER_CHARACTER = 5n;
+
+/**
+ * The trace a simulation's spans belong to, as 32 lowercase hex — or
+ * `undefined` for a string that is not one of egma's simulation ids.
+ *
+ * egma's ids carry 128 bits of their own: the 26 Crockford base32 characters
+ * after `sim_` are a ULID, and those bits *are* the trace. So
+ * `sim_01K3XQ7M4E8YB2FVN0H9TZQWER` is trace `0198fb73d08e479627eea08a75fbf1d8`,
+ * always and on both sides of the wire.
+ *
+ * **The absent answer is not a refusal a caller has to handle carefully.** Every
+ * simulation id the platform reads is one it minted itself, so there is no
+ * reachable path here that is not egma-shaped. Answering `undefined` rather
+ * than digesting an unrecognised string into something trace-shaped is what
+ * keeps that true: a made-up trace id would send a reader looking for spans
+ * that were never filed under it, and finding none looks precisely like
+ * telemetry that went missing. The simulator's own copy does digest, because
+ * over there a simulation id is opaque — echoed back from a claimed spec and
+ * never parsed — and it has to name a trace for whatever it was handed.
+ */
+export function traceIdOfSimulation(simulationId: string): string | undefined {
+  if (!isId("sim", simulationId)) return undefined;
+
+  let value = 0n;
+  for (const character of simulationId.slice("sim_".length)) {
+    value =
+      (value << BITS_PER_CHARACTER) |
+      BigInt(CROCKFORD_ALPHABET.indexOf(character));
+  }
+
+  // Twenty-six base32 characters hold 130 bits, so a value can be wider than a
+  // trace id is. egma's own never are — the top bits of a ULID's millisecond
+  // field stay zero for the next eight thousand years — and one that somehow
+  // were would silently truncate into a trace belonging to a different
+  // conversation, which is worse than having no answer.
+  if (value >= 1n << TRACE_ID_BITS) return undefined;
+
+  return value.toString(16).padStart(TRACE_ID_HEX_LENGTH, "0");
+}

--- a/packages/simulation-contract/test/trace-identity.test.ts
+++ b/packages/simulation-contract/test/trace-identity.test.ts
@@ -1,0 +1,125 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { traceIdOfSimulation } from "../src/trace-identity.ts";
+
+/**
+ * The derivation, held to the document that promises it.
+ *
+ * `span-vocabulary.md` states one worked example — a simulation id and the
+ * trace id it is, "always" — and this is that sentence executed. The fixtures
+ * are the same promise as bytes, so every one of them is checked through this
+ * export too: a fixture the emitter wrote and a trace id the platform derives
+ * have to be the same 32 characters, or a verdict and its evidence would file
+ * under two different traces and neither side would notice.
+ *
+ * `span-fixtures.test.ts` beside this file checks the fixtures against its own
+ * independent implementation of the same derivation, and deliberately does not
+ * import this one — two implementations that must agree is what catches a
+ * change to either. This file is the other half: the export, held to the
+ * document and to the fixtures.
+ */
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const document = await readFile(
+  path.join(packageRoot, "span-vocabulary.md"),
+  "utf8",
+);
+
+/** The worked example the vocabulary document carries, read out of it. */
+const WORKED_EXAMPLE = {
+  simulationId: "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  traceId: "0198fb73d08e479627eea08a75fbf1d8",
+} as const;
+
+describe("the trace a simulation's spans belong to", () => {
+  it("is the worked example the vocabulary document writes down", () => {
+    // The document is the contract; if this pair ever changes there, it changes
+    // here in the same edit or the two stop meaning the same thing.
+    expect(document).toContain(WORKED_EXAMPLE.simulationId);
+    expect(document).toContain(WORKED_EXAMPLE.traceId);
+    expect(traceIdOfSimulation(WORKED_EXAMPLE.simulationId)).toBe(
+      WORKED_EXAMPLE.traceId,
+    );
+  });
+
+  it("is 32 lowercase hex characters, which is what a trace id is on the wire", () => {
+    expect(traceIdOfSimulation("sim_01K3XQ7M4E8YB2FVN0H9TZQWER")).toMatch(
+      /^[0-9a-f]{32}$/,
+    );
+    // Leading zeros are kept rather than trimmed: a trace id is a fixed width,
+    // and a short one names no trace at all.
+    expect(traceIdOfSimulation("sim_00000000000000000000000001")).toBe(
+      "0".repeat(31) + "1",
+    );
+  });
+
+  it("answers the same thing every time, and something different for every id", () => {
+    const ids = [
+      "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+      "sim_01K3XQ7M4E8YB2FVN0H9TZQWES",
+      "sim_01K3XQ7M4E8YB2FVN0H9TZQWET",
+    ];
+    const derived = ids.map(traceIdOfSimulation);
+    expect(derived).toEqual(ids.map(traceIdOfSimulation));
+    expect(new Set(derived).size).toBe(ids.length);
+  });
+
+  it("names no trace for a string that is not one of egma's simulation ids", () => {
+    // Not a refusal a caller has to catch: the platform mints every simulation
+    // id it reads, so this is unreachable there — and answering `undefined`
+    // rather than a made-up trace is what keeps it that way.
+    expect(traceIdOfSimulation("sim_not-crockford-at-all")).toBeUndefined();
+    expect(traceIdOfSimulation("run_01K3XQ7M4E8YB2FVN0H9TZQWER")).toBeUndefined();
+    expect(traceIdOfSimulation("01K3XQ7M4E8YB2FVN0H9TZQWER")).toBeUndefined();
+    expect(traceIdOfSimulation("")).toBeUndefined();
+    // Twenty-six Crockford characters hold 130 bits and a trace id holds 128.
+    // egma's own ids never reach the top two — a UUIDv7's millisecond field
+    // does not — and one that somehow did would be truncated into somebody
+    // else's trace.
+    expect(traceIdOfSimulation("sim_ZZZZZZZZZZZZZZZZZZZZZZZZZZ")).toBeUndefined();
+  });
+
+  it("agrees with every golden fixture, which is what the emitter actually sends", async () => {
+    const directory = path.join(packageRoot, "fixtures", "spans", "valid");
+    const names = (await readdir(directory)).filter((name) =>
+      name.endsWith(".json"),
+    );
+    expect(names.length).toBeGreaterThan(0);
+
+    for (const name of names) {
+      const fixture = JSON.parse(
+        await readFile(path.join(directory, name), "utf8"),
+      ) as {
+        resourceSpans: readonly {
+          resource?: {
+            attributes?: readonly {
+              key: string;
+              value?: { stringValue?: string };
+            }[];
+          };
+          scopeSpans?: readonly { spans?: readonly { traceId?: string }[] }[];
+        }[];
+      };
+
+      for (const resource of fixture.resourceSpans) {
+        const simulationId = resource.resource?.attributes?.find(
+          (attribute) => attribute.key === "egma.simulation_id",
+        )?.value?.stringValue;
+        expect(simulationId, name).toBeDefined();
+        const traceId = traceIdOfSimulation(simulationId as string);
+        for (const scopeSpans of resource.scopeSpans ?? []) {
+          for (const span of scopeSpans.spans ?? []) {
+            expect(span.traceId, `${name} ${simulationId as string}`).toBe(
+              traceId,
+            );
+          }
+        }
+      }
+    }
+  });
+});

--- a/packages/simulation-contract/tsconfig.json
+++ b/packages/simulation-contract/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "./src",
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../ids" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       '@egma/ids':
         specifier: workspace:*
         version: link:../../packages/ids
+      '@egma/simulation-contract':
+        specifier: workspace:*
+        version: link:../../packages/simulation-contract
 
   apps/simulator: {}
 
@@ -142,6 +145,9 @@ importers:
 
   packages/simulation-contract:
     dependencies:
+      '@egma/ids':
+        specifier: workspace:*
+        version: link:../ids
       ajv:
         specifier: ^8.17.1
         version: 8.20.0


### PR DESCRIPTION
The expand step of the reader migration: a simulation's conversation is now assembled from its spans — the same path a production trace already walks — with the row's columns as a marked-interim fallback and honest classification when neither serves.

- The trace-id derivation gets one production home: `traceIdOfSimulation` in the contract package — the simulation id's 26 Crockford characters decoded to 32 lowercase hex. It answers `undefined` for anything not egma-shaped rather than digesting: on the platform side every id is one egma minted, and a made-up trace id would only send a reader hunting for spans never filed. The fixture suite's independent reimplementation stays independent — it is the drift detector, and it imports nothing from the new export.
- Turns flow from `turn:human`/`turn:agent` spans through the *same* assembly a production trace uses, so same-turns-same-order is a fact about the code, not a claim; tool calls ride the same walk (a result is always absent — the simulator observes the call, not the return); measures come from `timing` spans whose own duration is the measurement, no value attribute ever consulted.
- The reading order lives in one function, three branches: spans-with-root (the root travels last, so its arrival means everything landed) → the row's columns, marked interim → a reasoned "nothing to judge," whose sentence distinguishes telemetry that never arrived from telemetry that arrived incomplete. Above the executor seam, an unjudgeable conversation yields one `errored` verdict per grader and never reaches an executor — a phrase-match grader with a required phrase cannot answer `failed` about a conversation egma could not read.
- The trace query windows off the row's own moments with a skew cushion, narrowed under the store's retention cap. Verdicts still carry the simulation id; nothing downstream of the grader changes.

Tests: eleven new span-grading cases (end-to-end grading from seeded spans, the both-paths comparison, the fallback, the honest classifications, measures), five derivation cases against the vocabulary's worked example. Red-first proven by mutation: blinding the root check fails five of the eleven while the fallback stays green — the span path is load-bearing. Suites: grader 141, contract 48, full TS 1936, all green; typecheck and lint clean. Independently re-verified before opening (190/190 across both packages, hygiene checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqecH6s7crjVgNc4EGCX6R)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR now assembles simulation conversations from trace spans while retaining legacy row columns as an interim fallback.

- Adds shared simulation-to-trace ID derivation in the simulation contract.
- Reads simulation turns, tool calls, and timing measures through the production trace assembly path.
- Detects incomplete and truncated trace reads and emits unjudgeable results when no complete fallback exists.
- Adds focused grading and trace-identity coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported truncated-trace issue is addressed by rejecting truncated span assembly and producing errored verdicts when no complete fallback record exists.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/grader/src/conversation.ts | Introduces span-first simulation assembly, rejects truncated or rootless trace reads, and retains the legacy-column fallback. |
| apps/grader/src/grade.ts | Resolves simulation traces using derived IDs and bounded time windows before applying the unified grading path. |
| packages/simulation-contract/src/trace-identity.ts | Adds validated Crockford decoding from simulation IDs to fixed-width OpenTelemetry trace IDs. |
| packages/db/src/access/grading.ts | Updates grading trace access needed by the simulation span-reading path. |
| apps/grader/test/simulation-spans.test.ts | Covers span-backed grading, fallback behavior, incomplete and truncated telemetry, ordering, and timing measures. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load simulation row] --> B[Derive trace ID]
  B --> C[Read trace in simulation time window]
  C --> D{Complete, untruncated trace with root?}
  D -->|Yes| E[Assemble transcript, tool calls, and measures from spans]
  D -->|No| F{Legacy row columns contain data?}
  F -->|Yes| G[Use interim row-column fallback]
  F -->|No| H[Mark conversation unjudgeable]
  E --> I[Run applicable graders]
  G --> I
  H --> J[Write errored verdicts without executor calls]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Refuse to judge a reading the span limit..."](https://github.com/egma-ai/egma/commit/eb1a7d48c715818e81cee00af1c924e62d335f2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51521074)</sub>

<!-- /greptile_comment -->