### PR TITLE
Add the coordinate-implementation agent skill

### DIFF
--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -21,17 +21,38 @@ The branches fan out and back in. One **integration branch** per effort, cut fro
 
 The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if it is missing.
 
+## The whole context, in every worktree
+
+A worktree carries tracked files only. Anything this repo ignores is absent from a fresh one, and nothing announces the absence.
+
+The tracker does not live here, and `AGENTS.md` reaches it with a conditional: read it if it is in your checkout, carry on if it is not. **In a fresh worktree it is never there.** So a dispatched agent takes the second branch and builds without the ticket it was given, without the settled vocabulary, and without knowing either existed. Nothing errors. The work comes back fluent and unmoored — and the reviewer, in an identical worktree, grades it against the same blank.
+
+So a worktree is not ready when the code is in it. Cut the code worktree, then cut the tracker into it, at the path `AGENTS.md` names:
+
+```
+git -C <tracker-repo> fetch origin
+git -C <tracker-repo> worktree add --detach <agent-worktree>/<path> origin/main
+```
+
+`--detach` is what lets this happen more than once. A branch can be checked out in one worktree only, so the second agent that asks for `main` is refused outright; detached, every agent gets its own copy at the same commit. Fetch first, so an agent dispatched later sees tracker updates you have already landed.
+
+The path is already ignored here, so no agent can commit it into this repo by accident.
+
+**Agents read the tracker. Only you write it** — on `main`, in your own checkout. A commit made on a detached HEAD inside an agent's copy is unreachable the moment that worktree is removed.
+
 ## Per-ticket checklist
 
 Copy this for each ticket and tick it off as you go:
 
 ```
 NN — <ticket>
+- [ ] worktree cut, with the tracker in it
 - [ ] branch <effort>-tNN cut from <effort>
 - [ ] implemented, full suite green
 - [ ] review loop closed — clean, or capped and reported
 - [ ] PR opened against <effort>
 - [ ] every PR review bot thread fixed or answered
+- [ ] re-run against the current <effort> head, still green
 - [ ] merged into <effort>, ticket recorded
 ```
 
@@ -58,8 +79,9 @@ Fetch, cut `<effort>` from `origin/main` if it does not exist, and push it so ti
 One message, one `Agent` call per frontier ticket, so they run in parallel. Each gets:
 
 - **A name**: `impl-NN`. Unnamed agents cannot be messaged later, and a name reused across tickets makes a send refuse rather than reach the wrong agent.
-- **Opus 5 at the highest reasoning effort available**, and `isolation: "worktree"` so parallel agents never share a checkout.
-- **A self-contained prompt**: the ticket in full; branch `<effort>-tNN` based on the integration branch; follow `/implement` — TDD at pre-agreed seams, typecheck and single test files often, full suite at the end; push the ticket branch and stop there.
+- **Opus 5 at the highest reasoning effort available.**
+- **Its own worktree, with the tracker in it.** Parallel agents must never share a checkout. On Claude Code the code worktree comes from the `isolation: "worktree"` flag; on Codex there is no such flag, so cut it yourself with `git worktree add` and pass the path. The tracker is yours to cut either way — no harness flag knows about a second repo.
+- **A self-contained prompt**: the ticket in full; where its worktree is and where the tracker sits inside it; branch `<effort>-tNN` based on the integration branch; follow `/implement` — TDD at pre-agreed seams, typecheck and single test files often, full suite at the end; push the ticket branch and stop there.
 - **A reporting brief**: branch, commits, what it built, what it deliberately did not build, anything it found that the ticket got wrong.
 
 Agents run in the background and report as they finish. Take each one as it lands rather than waiting for the set — the moment a ticket's last blocker merges, dispatch it.
@@ -69,6 +91,8 @@ Agents run in the background and report as they finish. Take each one as it land
 Spawn `review-NN` **after** `impl-NN` exists, never before. Where the roster of siblings an agent may message is a snapshot taken when it starts, a reviewer spawned first cannot see the implementer at all.
 
 The reviewer runs `/code-review` on the ticket branch: the integration branch as the fixed point, the ticket as the spec. It is not the implementer, because an author reviewing its own work shares its blind spot. It reports findings and changes no code.
+
+It needs the tracker too, cut the same way — a reviewer that cannot read the ticket cannot check the code against it, and grades the work against its own guess instead. That is worse than no review, because it reports back clean.
 
 Then loop, up to three rounds: findings go to `impl-NN`, which fixes what is right and answers what is wrong rather than obeying it; `review-NN` re-checks. Keep the same two agents throughout. The reviewer remembers what it already raised and what was answered, so nothing rejected comes back, and independence was established the moment it was not the author.
 
@@ -84,7 +108,11 @@ The loop ends in one of three states, and you report which:
 
 The bot's comments arrive minutes after the PR opens, sometimes in waves as later pushes get re-reviewed. Fix in the same branch, never a follow-up PR. Reply on the thread when a comment is wrong and it is not acting on it, so the record shows the comment was weighed. Ready when every thread is fixed or answered.
 
-**You merge, not the agent.** Only you know what else is in flight. Check the git state, merge one PR at a time, and record the outcome on the ticket — status resolved, the PR, what landed, what each gate found — committed wherever the tracker lives, which may not be this repo.
+**You merge, not the agent.** Only you know what else is in flight. Check the git state and merge one PR at a time.
+
+**Each merge makes every other open ticket branch stale.** They were built and reviewed against an integration head that no longer exists. Git stops a textual conflict; it does not stop a sibling that renamed what this branch still calls, or changed a behaviour this branch still assumes — the merge is clean and the suite is broken. So after each merge, send every open ticket branch back to its `impl-NN` to take the new integration head and re-run the full suite. It still holds the context, so this is cheap. A branch that has not been run against the head it is merging into is unverified, whatever the review said earlier.
+
+Record the outcome on the ticket once it is merged and green — status resolved, the PR, what landed, what each gate found. That commit goes wherever the tracker lives, from your own checkout, not this repo and not an agent's.
 
 ### 6. Advance
 
@@ -92,7 +120,7 @@ A ticket is done when it is merged. Recompute the frontier and dispatch whatever
 
 ### 7. Close the effort out
 
-When every ticket has folded in, merge the latest `main` **into** the integration branch and resolve the conflicts there, not in the final PR. Run the full suite — this is where the tickets meet each other for real.
+When every ticket has folded in, merge the latest `main` **into** the integration branch and resolve the conflicts there, not in the final PR. Run the full suite. The tickets have already met each other one merge at a time; this is where they meet everything else that landed on `main` while you worked.
 
 Open one PR, integration branch → `main`, and **leave it open**.
 
@@ -107,6 +135,7 @@ A wide refactor cannot be split into parallel rewrites of the same call sites. E
 Nothing supervises this but you.
 
 - **Silence is not success.** Check the branch — does it exist, does it carry commits, does the suite pass? Never mark a ticket done on an absent report, and never guess at a pending agent's result.
+- **An agent that never quotes its ticket probably cannot see it.** A missing tracker raises nothing; it just reads as an agent working from a thin brief. Check the path before you accept the work.
 - **Message before you respawn.** A stalled agent still holds everything it knew, and a message wakes it. A fresh agent starts from nothing.
 - **A whole quiet wave means the machine, not the model** — a dead container daemon, a missing service, a command that failed for permissions without saying so. Fix it and resume; the work on the branches normally survives.
 - **Give suites and builds generous timeouts**, and poll on the work's cadence.

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -52,7 +52,7 @@ NN — <ticket>
 - [ ] review loop closed — clean, or capped and reported
 - [ ] PR opened against <effort>
 - [ ] every PR review bot thread fixed or answered
-- [ ] re-run against the current <effort> head, still green
+- [ ] re-run against the exact head it merges into, still green
 - [ ] merged into <effort>, ticket recorded
 ```
 
@@ -108,9 +108,15 @@ The loop ends in one of three states, and you report which:
 
 The bot's comments arrive minutes after the PR opens, sometimes in waves as later pushes get re-reviewed. Fix in the same branch, never a follow-up PR. Reply on the thread when a comment is wrong and it is not acting on it, so the record shows the comment was weighed. Ready when every thread is fixed or answered.
 
-**You merge, not the agent.** Only you know what else is in flight. Check the git state and merge one PR at a time.
+**You merge, not the agent.** Only you know what else is in flight. Read the git state before every merge.
 
-**Each merge makes every other open ticket branch stale.** They were built and reviewed against an integration head that no longer exists. Git stops a textual conflict; it does not stop a sibling that renamed what this branch still calls, or changed a behaviour this branch still assumes — the merge is clean and the suite is broken. So after each merge, send every open ticket branch back to its `impl-NN` to take the new integration head and re-run the full suite. It still holds the context, so this is cheap. A branch that has not been run against the head it is merging into is unverified, whatever the review said earlier.
+**One rule governs landing: a branch may merge only if its last full-suite run was against the exact commit it is merging into.** Everything else here follows from that.
+
+Every merge moves the integration head, so every other open branch fails the rule the instant one lands. They were built and reviewed against a head that no longer exists. Git stops a textual conflict; it does not stop a sibling that renamed what this branch still calls, or changed a behaviour this branch still assumes — the merge is clean and the suite is broken.
+
+So land one branch at a time, and refresh only the branch you are landing next: send it back to its `impl-NN` to take the current head and re-run the full suite, then merge it while that head still stands. It holds the context, so each refresh is cheap.
+
+Refreshing the whole queue at once looks faster and is not. The first merge invalidates every run still in flight, and those branches have to go round again — the same staleness, one level down. Implementation stays parallel; only landing is serial. That is the price of an integration branch that is green at every commit rather than green at the end.
 
 Record the outcome on the ticket once it is merged and green — status resolved, the PR, what landed, what each gate found. That commit goes wherever the tracker lives, from your own checkout, not this repo and not an agent's.
 

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: coordinate-implementation
+description: "Drive a whole ticketed effort to done — dispatch each ticket to its own implementation sub-agent, gate it behind a review sub-agent that talks back to the implementer until the findings stop, and fold every ticket into one integration branch that ends as a single open PR into main. Use when the user has a set of tickets and wants the effort built, not one ticket."
+argument-hint: "Which effort's tickets to drive"
+disable-model-invocation: true
+---
+
+# Coordinate Implementation
+
+Drive a set of tickets to done. You are the **coordinator** — you dispatch the code, gate it, land it, and keep it alive. You do not write it.
+
+Every ticket passes three gates: **implementation** by a sub-agent, a **review loop** between that sub-agent and a reviewer, then **the PR review bot**.
+
+The loop is the reason this runs in conversation rather than as a script. A finished sub-agent that receives a message wakes up with its context intact, so the reviewer's findings go back to the agent that wrote the code and the fix costs almost nothing. Give every agent a name when you spawn it — that is what makes it addressable afterwards.
+
+**One harness difference, and it is mechanical.** Waking a finished agent and messaging one agent from another work on both Claude Code and Codex. Isolation differs only in who does it: Claude Code takes an `isolation: "worktree"` flag, while Codex has no such flag, so cut the worktree yourself with `git worktree add` and give each agent its path. Same result, one extra command.
+
+The branches fan out and back in. One **integration branch** per effort, cut from `main`. One **ticket branch** per ticket, cut from the integration branch and merged back into it. The integration branch ends as one PR into `main`, so `main` stays shippable and the user gets one branch to test and one PR to review.
+
+**Never merge into `main`.** The final merge is the user's.
+
+The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if it is missing.
+
+## Per-ticket checklist
+
+Copy this for each ticket and tick it off as you go:
+
+```
+NN — <ticket>
+- [ ] branch <effort>-tNN cut from <effort>
+- [ ] implemented, full suite green
+- [ ] review loop closed — clean, or capped and reported
+- [ ] PR opened against <effort>
+- [ ] every PR review bot thread fixed or answered
+- [ ] merged into <effort>, ticket recorded
+```
+
+## Process
+
+### 1. Read the tickets, build the graph
+
+Fetch every ticket in the effort and read each in full, including its **Blocked by** line and its status.
+
+Reject before spending: cycles, blockers that do not exist, tickets that are not `ready-for-agent`.
+
+The **frontier** is every ticket whose blockers are all merged into the integration branch.
+
+Show the user the graph and the first wave in a few lines, then start. Stop only for a broken graph, an ambiguous effort name, or a ticket that is not ready.
+
+### 2. Cut the integration branch
+
+Read the branch and the working tree now — parallel sessions move checkouts.
+
+Fetch, cut `<effort>` from `origin/main` if it does not exist, and push it so ticket PRs have a base.
+
+### 3. Dispatch the whole frontier at once
+
+One message, one `Agent` call per frontier ticket, so they run in parallel. Each gets:
+
+- **A name**: `impl-NN`. Unnamed agents cannot be messaged later, and a name reused across tickets makes a send refuse rather than reach the wrong agent.
+- **Opus 5 at the highest reasoning effort available**, and `isolation: "worktree"` so parallel agents never share a checkout.
+- **A self-contained prompt**: the ticket in full; branch `<effort>-tNN` based on the integration branch; follow `/implement` — TDD at pre-agreed seams, typecheck and single test files often, full suite at the end; push the ticket branch and stop there.
+- **A reporting brief**: branch, commits, what it built, what it deliberately did not build, anything it found that the ticket got wrong.
+
+Agents run in the background and report as they finish. Take each one as it lands rather than waiting for the set — the moment a ticket's last blocker merges, dispatch it.
+
+### 4. The review loop
+
+Spawn `review-NN` **after** `impl-NN` exists, never before. Where the roster of siblings an agent may message is a snapshot taken when it starts, a reviewer spawned first cannot see the implementer at all.
+
+The reviewer runs `/code-review` on the ticket branch: the integration branch as the fixed point, the ticket as the spec. It is not the implementer, because an author reviewing its own work shares its blind spot. It reports findings and changes no code.
+
+Then loop, up to three rounds: findings go to `impl-NN`, which fixes what is right and answers what is wrong rather than obeying it; `review-NN` re-checks. Keep the same two agents throughout. The reviewer remembers what it already raised and what was answered, so nothing rejected comes back, and independence was established the moment it was not the author.
+
+The loop ends in one of three states, and you report which:
+
+- **Clean** — a round raised nothing new.
+- **Capped** — three rounds ran and findings remain. Name them. A cap that goes unreported reads as a pass.
+- **Escalated** — the finding is not a code fault; the ticket is wrong. Land what is sound, leave the ticket open, and bring it to the user.
+
+### 5. Land
+
+`impl-NN` opens the PR against the **integration branch** and works the PR review bot. It still holds the context, so a fix is cheap.
+
+The bot's comments arrive minutes after the PR opens, sometimes in waves as later pushes get re-reviewed. Fix in the same branch, never a follow-up PR. Reply on the thread when a comment is wrong and it is not acting on it, so the record shows the comment was weighed. Ready when every thread is fixed or answered.
+
+**You merge, not the agent.** Only you know what else is in flight. Check the git state, merge one PR at a time, and record the outcome on the ticket — status resolved, the PR, what landed, what each gate found — committed wherever the tracker lives, which may not be this repo.
+
+### 6. Advance
+
+A ticket is done when it is merged. Recompute the frontier and dispatch whatever just came unblocked. Immediately.
+
+### 7. Close the effort out
+
+When every ticket has folded in, merge the latest `main` **into** the integration branch and resolve the conflicts there, not in the final PR. Run the full suite — this is where the tickets meet each other for real.
+
+Open one PR, integration branch → `main`, and **leave it open**.
+
+Report the branch to check out, the PR to review, and per-ticket status.
+
+## Sequencing
+
+A wide refactor cannot be split into parallel rewrites of the same call sites. Expand, migrate in batches, contract — the batches share the integration branch, and green is promised only at the end.
+
+## Keeping it alive
+
+Nothing supervises this but you.
+
+- **Silence is not success.** Check the branch — does it exist, does it carry commits, does the suite pass? Never mark a ticket done on an absent report, and never guess at a pending agent's result.
+- **Message before you respawn.** A stalled agent still holds everything it knew, and a message wakes it. A fresh agent starts from nothing.
+- **A whole quiet wave means the machine, not the model** — a dead container daemon, a missing service, a command that failed for permissions without saying so. Fix it and resume; the work on the branches normally survives.
+- **Give suites and builds generous timeouts**, and poll on the work's cadence.

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -27,18 +27,20 @@ A worktree carries tracked files only. Anything this repo ignores is absent from
 
 The tracker does not live here, and `AGENTS.md` reaches it with a conditional: read it if it is in your checkout, carry on if it is not. **In a fresh worktree it is never there.** So a dispatched agent takes the second branch and builds without the ticket it was given, without the settled vocabulary, and without knowing either existed. Nothing errors. The work comes back fluent and unmoored — and the reviewer, in an identical worktree, grades it against the same blank.
 
-So a worktree is not ready when the code is in it. Cut the code worktree, then cut the tracker into it, at the path `AGENTS.md` names:
+So a worktree is not ready when the code is in it. Don't hand-roll this — `scripts/mount-tracker.sh` does it and then proves it:
 
 ```
-git -C <tracker-repo> fetch origin
-git -C <tracker-repo> worktree add --detach <agent-worktree>/<path> origin/main
+bash .agents/skills/coordinate-implementation/scripts/mount-tracker.sh \
+  --tracker <tracker-repo> --into . --expect .agents/AGENTS.md
 ```
 
-`--detach` is what lets this happen more than once. A branch can be checked out in one worktree only, so the second agent that asks for `main` is refused outright; detached, every agent gets its own copy at the same commit. Fetch first, so an agent dispatched later sees tracker updates you have already landed.
+`--expect` is the point. The script exits non-zero when the file is not there, which turns the one failure that was silent into a stop. The rest it handles so nobody has to remember it: it fetches first, so a later agent sees tracker updates you have already landed; it mounts detached, because a branch can be checked out in one worktree only and the second agent asking for `main` is refused outright; it converges on the ref you ask for rather than accepting a mount left at an older commit; and it leaves nothing half-mounted when it fails, so a retry starts clean. `--remove` unmounts.
 
-The path is already ignored here, so no agent can commit it into this repo by accident.
+**The agent runs it as its first step, from inside its own worktree.** On Claude Code the harness cuts the worktree, so its path is not known until the agent is already running — giving the job to the agent works the same on both harnesses.
 
-**Agents read the tracker. Only you write it** — on `main`, in your own checkout. A commit made on a detached HEAD inside an agent's copy is unreachable the moment that worktree is removed.
+The mount path is already ignored by this repo, so no agent can commit the tracker into it by accident.
+
+**Agents read the tracker. Only you write it** — on `main`, in your own checkout. A commit made in a detached mount is unreachable the moment that worktree is removed.
 
 ## Per-ticket checklist
 
@@ -46,7 +48,7 @@ Copy this for each ticket and tick it off as you go:
 
 ```
 NN — <ticket>
-- [ ] worktree cut, with the tracker in it
+- [ ] worktree cut, mount-tracker.sh exited 0
 - [ ] branch <effort>-tNN cut from <effort>
 - [ ] implemented, full suite green
 - [ ] review loop closed — clean, or capped and reported
@@ -80,8 +82,9 @@ One message, one `Agent` call per frontier ticket, so they run in parallel. Each
 
 - **A name**: `impl-NN`. Unnamed agents cannot be messaged later, and a name reused across tickets makes a send refuse rather than reach the wrong agent.
 - **Opus 5 at the highest reasoning effort available.**
-- **Its own worktree, with the tracker in it.** Parallel agents must never share a checkout. On Claude Code the code worktree comes from the `isolation: "worktree"` flag; on Codex there is no such flag, so cut it yourself with `git worktree add` and pass the path. The tracker is yours to cut either way — no harness flag knows about a second repo.
-- **A self-contained prompt**: the ticket in full; where its worktree is and where the tracker sits inside it; branch `<effort>-tNN` based on the integration branch; follow `/implement` — TDD at pre-agreed seams, typecheck and single test files often, full suite at the end; push the ticket branch and stop there.
+- **Its own worktree.** Parallel agents must never share a checkout. On Claude Code it comes from the `isolation: "worktree"` flag; on Codex there is no such flag, so cut it yourself with `git worktree add` and pass the path.
+- **The mount command, verbatim**, with the tracker repo's path filled in, and the instruction to run it first and stop if it fails. No harness flag knows about a second repo, so this is the only thing that puts the ticket in front of the agent.
+- **A self-contained prompt**: the ticket in full; branch `<effort>-tNN` based on the integration branch; follow `/implement` — TDD at pre-agreed seams, typecheck and single test files often, full suite at the end; push the ticket branch and stop there.
 - **A reporting brief**: branch, commits, what it built, what it deliberately did not build, anything it found that the ticket got wrong.
 
 Agents run in the background and report as they finish. Take each one as it lands rather than waiting for the set — the moment a ticket's last blocker merges, dispatch it.
@@ -92,7 +95,7 @@ Spawn `review-NN` **after** `impl-NN` exists, never before. Where the roster of 
 
 The reviewer runs `/code-review` on the ticket branch: the integration branch as the fixed point, the ticket as the spec. It is not the implementer, because an author reviewing its own work shares its blind spot. It reports findings and changes no code.
 
-It needs the tracker too, cut the same way — a reviewer that cannot read the ticket cannot check the code against it, and grades the work against its own guess instead. That is worse than no review, because it reports back clean.
+It runs the same mount command first, for the same reason — a reviewer that cannot read the ticket cannot check the code against it, and grades the work against its own guess instead. That is worse than no review, because it reports back clean.
 
 Then loop, up to three rounds: findings go to `impl-NN`, which fixes what is right and answers what is wrong rather than obeying it; `review-NN` re-checks. Keep the same two agents throughout. The reviewer remembers what it already raised and what was answered, so nothing rejected comes back, and independence was established the moment it was not the author.
 
@@ -141,7 +144,7 @@ A wide refactor cannot be split into parallel rewrites of the same call sites. E
 Nothing supervises this but you.
 
 - **Silence is not success.** Check the branch — does it exist, does it carry commits, does the suite pass? Never mark a ticket done on an absent report, and never guess at a pending agent's result.
-- **An agent that never quotes its ticket probably cannot see it.** A missing tracker raises nothing; it just reads as an agent working from a thin brief. Check the path before you accept the work.
+- **An agent that never quotes its ticket probably cannot see it.** This is what `mount-tracker.sh --expect` is for: an agent that skipped it, or was dispatched without it, fails no differently from one working off a thin brief. Ask for the line the script printed.
 - **Message before you respawn.** A stalled agent still holds everything it knew, and a message wakes it. A fresh agent starts from nothing.
 - **A whole quiet wave means the machine, not the model** — a dead container daemon, a missing service, a command that failed for permissions without saying so. Fix it and resume; the work on the branches normally survives.
 - **Give suites and builds generous timeouts**, and poll on the work's cadence.

--- a/.agents/skills/coordinate-implementation/agents/openai.yaml
+++ b/.agents/skills/coordinate-implementation/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Coordinate Implementation"
+  short_description: "Drive a ticketed effort to one open PR"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/coordinate-implementation/scripts/mount-tracker.sh
+++ b/.agents/skills/coordinate-implementation/scripts/mount-tracker.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Mount the issue tracker into a worktree, and prove it landed.
+#
+# A worktree carries tracked files only. A tracker that lives in a separate
+# repo is therefore absent from every fresh one, and nothing reports the
+# absence — the agent just works without its ticket. This script closes that
+# hole and fails loudly when it cannot.
+#
+# Usage:
+#   bash mount-tracker.sh --tracker <repo> --into <worktree> [options]
+#   bash mount-tracker.sh --remove --tracker <repo> --into <worktree> [--at <dir>]
+#
+#   --tracker <repo>    path to the tracker repo (its own checkout)
+#   --into <worktree>   the agent's worktree, already cut
+#   --at <dir>          mount point inside it (default: basename of --tracker)
+#   --ref <ref>         what to mount (default: origin/main)
+#   --expect <relpath>  file that must exist under the mount point once done
+#   --remove            unmount instead, and prune
+#
+# Mounting is detached on purpose. A branch can be checked out in one worktree
+# only, so the second agent asking for main is refused outright; detached, any
+# number of agents hold their own copy at the same commit. The flip side is
+# that a commit made in a mounted copy is unreachable once the worktree goes —
+# agents read the tracker, the coordinator writes it.
+#
+# Rerunning is safe and always converges on --ref: a mount already at that
+# commit is kept, anything else is replaced. Nothing is ever left half-mounted,
+# so a retry after a failure starts clean rather than inheriting a wrong commit.
+
+set -euo pipefail
+
+die() { printf 'mount-tracker: %s\n' "$1" >&2; exit 1; }
+
+tracker="" into="" at="" ref="origin/main" expect="" remove=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tracker) tracker="${2:-}"; shift 2 ;;
+    --into)    into="${2:-}";    shift 2 ;;
+    --at)      at="${2:-}";      shift 2 ;;
+    --ref)     ref="${2:-}";     shift 2 ;;
+    --expect)  expect="${2:-}";  shift 2 ;;
+    --remove)  remove=1;         shift ;;
+    -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$tracker" ] || die "--tracker is required"
+[ -n "$into" ]    || die "--into is required"
+
+[ -d "$tracker" ] || die "tracker repo not found: $tracker"
+git -C "$tracker" rev-parse --git-dir >/dev/null 2>&1 || die "not a git repo: $tracker"
+tracker="$(cd "$tracker" && pwd)"
+
+[ -d "$into" ] || die "worktree not found: $into — cut the code worktree first"
+into="$(cd "$into" && pwd)"
+
+[ -n "$at" ] || at="$(basename "$tracker")"
+case "$at" in
+  /*|*..*) die "--at must be a plain relative path inside the worktree: $at" ;;
+esac
+mount="$into/$at"
+
+unmount() {
+  [ -e "$mount" ] || return 0
+  git -C "$tracker" worktree remove --force "$mount" 2>/dev/null || rm -rf "$mount"
+  git -C "$tracker" worktree prune
+}
+
+if [ "$remove" -eq 1 ]; then
+  unmount
+  printf 'mount-tracker: unmounted %s\n' "$mount"
+  exit 0
+fi
+
+# Drop registrations whose directory was deleted by hand, or the add below
+# fails on a path git still believes it owns.
+git -C "$tracker" worktree prune
+
+if ! git -C "$tracker" fetch origin >/dev/null 2>&1; then
+  printf 'mount-tracker: WARNING could not fetch %s — using the local ref, which may be behind\n' \
+    "$tracker" >&2
+fi
+
+target="$(git -C "$tracker" rev-parse --verify --quiet "$ref^{commit}")" \
+  || die "ref not found in $tracker: $ref"
+
+# Resolve the target before looking at what is already there, so a mount left
+# at a stale commit is replaced rather than silently accepted.
+if [ -d "$mount" ] && [ -n "$(ls -A "$mount" 2>/dev/null)" ]; then
+  current="$(git -C "$mount" rev-parse HEAD 2>/dev/null || echo none)"
+  if [ "$current" = "$target" ]; then
+    kept=1
+  else
+    printf 'mount-tracker: replacing mount at %s (was %s)\n' "$mount" "${current:0:7}" >&2
+    unmount
+  fi
+fi
+
+if [ -z "${kept:-}" ]; then
+  mkdir -p "$(dirname "$mount")"
+  git -C "$tracker" worktree add --detach "$mount" "$target" >/dev/null \
+    || die "could not mount $ref at $mount"
+fi
+
+# Prove it, rather than trusting that the command above did what it said.
+[ -d "$mount" ] && [ -n "$(ls -A "$mount" 2>/dev/null)" ] \
+  || die "mount point is missing or empty after mounting: $mount"
+
+if [ -n "$expect" ] && [ ! -e "$mount/$expect" ]; then
+  unmount
+  die "mounted $ref, but $expect is not there — wrong ref or wrong repo? unmounted again"
+fi
+
+printf 'mount-tracker: %s @ %s -> %s%s\n' \
+  "$ref" "$(git -C "$mount" rev-parse --short HEAD)" "$mount" \
+  "$([ -n "${kept:-}" ] && echo ' (already current)' || true)"

--- a/.claude/skills/coordinate-implementation
+++ b/.claude/skills/coordinate-implementation
@@ -1,0 +1,1 @@
+../../.agents/skills/coordinate-implementation


### PR DESCRIPTION
Adds one agent skill and nothing else. No other untracked work from the local checkout rides along.

## What it does

`coordinate-implementation` drives a whole ticketed effort to done. The coordinator dispatches, gates, and lands the work — it does not write the code.

Every ticket passes three gates:

1. **Implementation** — one sub-agent per ticket, on its own branch, in its own worktree, dispatched a whole frontier at a time.
2. **Review loop** — a separate reviewer runs `/code-review` on the ticket branch and sends findings back to the agent that wrote the code. Because a finished sub-agent wakes with its context intact, the fix is cheap. Up to three rounds, and the loop reports which of three states it ended in: clean, capped, or escalated.
3. **The PR review bot** — the implementer works its threads in the same branch.

Branches fan out and back in: one integration branch per effort cut from `main`, one ticket branch per ticket merged back into it. The effort ends as a single PR into `main` that stays open. `main` is never merged into by an agent — that call stays with the user.

## Files

| File | What it is |
| --- | --- |
| `.agents/skills/coordinate-implementation/SKILL.md` | the skill |
| `.agents/skills/coordinate-implementation/agents/openai.yaml` | Codex interface + no implicit invocation |
| `.claude/skills/coordinate-implementation` | symlink into `.agents/skills/`, same as every other skill here |

Layout matches the existing skills, so it works in both Claude Code and Codex.

## Review notes

The skill is documentation — there is no code path to run and nothing to test. Worth reading for whether the process matches how this team actually wants efforts driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a cross-harness skill for coordinating ticket implementation through isolated worktrees, independent review loops, serialized integration, and a final open PR.
- Adds the coordinator workflow and per-ticket gates.
- Adds a tracker-worktree mounting helper.
- Adds Codex metadata and the Claude skill symlink.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .agents/skills/coordinate-implementation/SKILL.md | Defines the coordinator workflow, including cross-harness worktree isolation, review gates, and serial landing against the current integration head. |
| .agents/skills/coordinate-implementation/scripts/mount-tracker.sh | Adds a helper that fetches and mounts the external tracker as a detached worktree and validates the expected tracker instructions. |
| .agents/skills/coordinate-implementation/agents/openai.yaml | Registers the Codex-facing skill metadata and disables implicit invocation. |
| .claude/skills/coordinate-implementation | Exposes the shared skill to Claude through the repository’s symlink layout. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read tickets and build dependency graph] --> B[Create integration branch]
  B --> C[Dispatch ready tickets in isolated worktrees]
  C --> D[Implementation and full suite]
  D --> E[Independent review loop]
  E --> F[Ticket PR review bot]
  F --> G[Refresh next branch against current integration head]
  G --> H[Run full suite]
  H --> I[Merge serially into integration branch]
  I --> J{More tickets ready?}
  J -- Yes --> C
  J -- No --> K[Merge latest main into integration branch]
  K --> L[Run full suite and open final PR to main]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Mount the tracker with a script that fai..."](https://github.com/egma-ai/egma/commit/7b7eef80609b2becfb4b9f88c209615051385530) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51660821)</sub>

<!-- /greptile_comment -->