### PR TITLE
Simulation row stops copying its run's connection type

### DIFF
--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -564,7 +564,10 @@ function simulationSpan(
     toolArguments: "",
     toolResult: "",
     providerCallId: "",
-    connectionType: simulation.connectionType,
+    // Empty, as the door writes it here: the type is read off the emitting
+    // instrumentation's scope name, and only LiveKit's is one egma knows —
+    // this world reaches its agent over a Retell chat connection.
+    connectionType: "",
     audioSampleRateHz: 0,
     audioEncoding: "",
     // Resolved by the door from egma's own row, never from the payload.

--- a/packages/db/migrations/0019_simulation_connection_type_leaves_the_row.sql
+++ b/packages/db/migrations/0019_simulation_connection_type_leaves_the_row.sql
@@ -1,7 +1,7 @@
 -- The connection's type leaves the simulation row. A run reaches its agent
 -- over exactly one connection, and the run header already holds that
 -- connection's whole non-secret shape in `connection_snapshot` — which is
--- where every reader of a connection type takes one from. The per-simulation
+-- where a run's own connection type is read back from. The per-simulation
 -- copy was written out of the same object as the snapshot, in the same
 -- transaction, and nothing ever read it back: a duplicate of a per-run fact,
 -- stored per row, on the largest table there is.

--- a/packages/db/migrations/0019_simulation_connection_type_leaves_the_row.sql
+++ b/packages/db/migrations/0019_simulation_connection_type_leaves_the_row.sql
@@ -1,0 +1,21 @@
+-- The connection's type leaves the simulation row. A run reaches its agent
+-- over exactly one connection, and the run header already holds that
+-- connection's whole non-secret shape in `connection_snapshot` — which is
+-- where every reader of a connection type takes one from. The per-simulation
+-- copy was written out of the same object as the snapshot, in the same
+-- transaction, and nothing ever read it back: a duplicate of a per-run fact,
+-- stored per row, on the largest table there is.
+--
+-- `modality` stays, and the two columns are not one pattern. Modality is an
+-- operand in the row's own check — `simulation_audio_facts_are_voice_facts`
+-- refuses a measured band or a recording on a conversation that was not voice,
+-- and a CHECK cannot join, so the column it compares has to sit on the row it
+-- guards. Nothing about the connection type is guarded that way.
+--
+-- The constraint goes first, because a check cannot outlive the column it
+-- names; and the pair goes together rather than one of them, because
+-- `connection_type` without `simulation_connection_type_allowed` is
+-- unconstrained text. What a connection may be is still checked where that is
+-- the source of truth, by `connection_type_allowed` on `connection.type`.
+ALTER TABLE "simulation" DROP CONSTRAINT "simulation_connection_type_allowed";--> statement-breakpoint
+ALTER TABLE "simulation" DROP COLUMN "connection_type";

--- a/packages/db/migrations/meta/0019_snapshot.json
+++ b/packages/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,4228 @@
+{
+  "id": "a178e921-67e2-4bb6-8d82-e69a733b07b4",
+  "prevId": "a6f265bb-ad4a-4192-89b0-d16d7c1994ba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_rubric', 'metric_threshold', 'tool_calls', 'phrase_match')"
+        },
+        "grader_priority_allowed": {
+          "name": "grader_priority_allowed",
+          "value": "\"grader\".\"priority\" in ('P0', 'P1', 'P2')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_grader": {
+      "name": "test_grader",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_grader_grader_id_idx": {
+          "name": "test_grader_grader_id_idx",
+          "columns": [
+            {
+              "expression": "grader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_grader_test_version_id_test_version_id_fk": {
+          "name": "test_grader_test_version_id_test_version_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_grader_grader_id_grader_id_fk": {
+          "name": "test_grader_grader_id_grader_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_grader_pk": {
+          "name": "test_grader_pk",
+          "columns": [
+            "test_version_id",
+            "grader_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_grader_version_id_position_unique": {
+          "name": "test_grader_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_grader_test_version_id_prefix": {
+          "name": "test_grader_test_version_id_prefix",
+          "value": "\"test_grader\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0 and \"run\".\"canceled_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1786310576443,
       "tag": "0018_livekit_connection_type",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1786319406614,
+      "tag": "0019_simulation_connection_type_leaves_the_row",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -183,7 +183,6 @@ export type Simulation = {
   readonly testId: string | null;
   readonly testVersionId: string | null;
   readonly position: number;
-  readonly connectionType: ConnectionType;
   readonly modality: Modality;
   readonly status: SimulationStatus;
   readonly endingReason: SimulationEndingReason | null;
@@ -312,7 +311,6 @@ const SIMULATION_COLUMNS = {
   testId: simulation.testId,
   testVersionId: simulation.testVersionId,
   position: simulation.position,
-  connectionType: simulation.connectionType,
   modality: simulation.modality,
   status: simulation.status,
   endingReason: simulation.endingReason,
@@ -534,11 +532,10 @@ function runFromRow(row: RunRow): Run {
  * inside the vocabulary, so reading one back is a narrowing, not a guess. */
 type SimulationRow = Omit<
   Simulation,
-  "status" | "endingReason" | "connectionType" | "modality"
+  "status" | "endingReason" | "modality"
 > & {
   readonly status: string;
   readonly endingReason: string | null;
-  readonly connectionType: string;
   readonly modality: string;
 };
 
@@ -547,7 +544,6 @@ function simulationFromRow(row: SimulationRow): Simulation {
     ...row,
     status: row.status as SimulationStatus,
     endingReason: row.endingReason as SimulationEndingReason | null,
-    connectionType: row.connectionType as ConnectionType,
     modality: row.modality as Modality,
   };
 }
@@ -1147,7 +1143,6 @@ export async function startRun(
           testId: version.testId,
           testVersionId: version.versionId,
           position: index + 1,
-          connectionType: reached.type,
           modality: reached.modality,
           status: "queued",
           createdAt: now,
@@ -1551,7 +1546,6 @@ export type SimulationClaim = {
   /** What is being checked; both absent only on an upgraded instance's history. */
   readonly testId: string | null;
   readonly testVersionId: string | null;
-  readonly connectionType: ConnectionType;
   readonly modality: Modality;
   readonly claimedBy: string;
   readonly claimedAt: Date;
@@ -1575,7 +1569,6 @@ const SIMULATION_CLAIM_COLUMNS = {
   personaVersionId: simulation.personaVersionId,
   testId: simulation.testId,
   testVersionId: simulation.testVersionId,
-  connectionType: simulation.connectionType,
   modality: simulation.modality,
   claimedBy: simulation.claimedBy,
   claimedAt: simulation.claimedAt,
@@ -1744,7 +1737,6 @@ export async function claimSimulations(
       personaVersionId: row.personaVersionId,
       testId: row.testId,
       testVersionId: row.testVersionId,
-      connectionType: row.connectionType as ConnectionType,
       modality: row.modality as Modality,
       claimedBy: row.claimedBy ?? claimant,
       claimedAt: row.claimedAt ?? now,

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -12,7 +12,7 @@ import {
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 
-import { agent, connection, CONNECTION_TYPES, MODALITIES } from "./agents.ts";
+import { agent, connection, MODALITIES } from "./agents.ts";
 import { persona, personaVersion } from "./personas.ts";
 import { test, testVersion } from "./tests.ts";
 import { organization, project } from "./tenancy.ts";
@@ -327,11 +327,16 @@ export const simulation = pgTable(
     /** Where in the run's requested order this conversation sits, from one. */
     position: integer("position").notNull(),
     /**
-     * The connection's type and modality as they were at execution, stamped
-     * here because the connection row is mutable and unversioned: editing it
-     * next month must not rewrite what this simulation's numbers meant.
+     * The connection's modality as it was at execution — the one thing about
+     * the connection this row keeps its own copy of, and it keeps it because
+     * its own check names it. `simulation_audio_facts_are_voice_facts` below
+     * refuses a measured band or a recording on a conversation that was not
+     * voice, and a Postgres CHECK cannot join: the column it compares has to
+     * sit on the row it guards. Reaching the connection for it instead would
+     * make that guarantee a trigger — a second mechanism on the report-write
+     * path, and one an operator can switch off — so the fact rides here
+     * rather than being looked up.
      */
-    connectionType: text("connection_type").notNull(),
     modality: text("modality").notNull(),
     status: text("status").notNull(),
     /**
@@ -386,9 +391,6 @@ export const simulation = pgTable(
   (table) => [
     prefixCheck("simulation_id_prefix", table.id, "sim"),
     oneOf("simulation_status_allowed", table.status, [...SIMULATION_STATUSES]),
-    oneOf("simulation_connection_type_allowed", table.connectionType, [
-      ...CONNECTION_TYPES,
-    ]),
     oneOf("simulation_modality_allowed", table.modality, [...MODALITIES]),
     check(
       "simulation_position_counts_from_one",

--- a/packages/db/test/migrations.test.ts
+++ b/packages/db/test/migrations.test.ts
@@ -1147,6 +1147,12 @@ async function seedACustomersWork(
  */
 type SimulationShape = "queued" | "completed" | "dispatch_failed";
 
+/**
+ * Writes `connection_type`, which 0019 drops — so this helper can only seed
+ * a schema that has not migrated that far yet. Every block that uses it
+ * replays to a pinned point before inserting; a block that migrates to the
+ * head first must write its own insert.
+ */
 async function insertSimulation(
   client: pg.Client,
   work: ACustomersWork,
@@ -1540,7 +1546,7 @@ describe("the livekit connection type (0018)", () => {
   });
 
   it("is what is still pending on a database that already holds connections", async () => {
-    // Through 0018 and no further, the way the block below it stops at 0017.
+    // Through 0018 and no further, the way the 0017 block above it stops.
     // What this block asserts next — the two checks the one list of types
     // feeds — is true of the schema 0018 left behind and stopped being true of
     // the newest schema the moment a later migration dropped one of them. A
@@ -1658,7 +1664,7 @@ describe("the connection type leaving the simulation row (0019)", () => {
     expect(result.applied.every((name) => name >= "0019")).toBe(true);
   });
 
-  it("takes the check and the column, in that order and both", async () => {
+  it("takes the check and the column, both of them", async () => {
     // Asked of the schema rather than of a row: a column nothing selects any
     // more is not the same fact as a column that does not exist, and a check
     // left behind on a dropped column could not exist at all — so the two
@@ -1701,9 +1707,10 @@ describe("the connection type leaving the simulation row (0019)", () => {
         where conname = 'connection_type_allowed'`,
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.definition).toContain(
-      "ARRAY['retell'::text, 'phone'::text, 'livekit'::text]",
-    );
+    // Containment, not the exact list: the next transport widens this check,
+    // and that upgrade's story belongs to its own block — the exact list as
+    // 0018 left it is already pinned in 0018's.
+    expect(rows[0]?.definition).toContain("'livekit'::text");
   });
 
   it("keeps modality, which rides the row for a reason the type never had", async () => {

--- a/packages/db/test/migrations.test.ts
+++ b/packages/db/test/migrations.test.ts
@@ -1018,10 +1018,10 @@ describe("the dispatch-failure vocabulary (0015)", () => {
       client.query(
         `insert into simulation
            (id, run_id, organization_id, project_id, agent_id, connection_id,
-            persona_id, persona_version_id, position, connection_type, modality,
+            persona_id, persona_version_id, position, modality,
             status, ending_reason, claimed_by, claimed_at, heartbeat_at,
             started_at, ended_at)
-         values ($1, $2, $3, $4, $5, $6, $7, $8, 3, 'retell', 'chat',
+         values ($1, $2, $3, $4, $5, $6, $7, $8, 3, 'chat',
             'completed', 'dispatch_failed', 'simulator-blue-1', now(), now(),
             now(), now())`,
         [
@@ -1540,7 +1540,19 @@ describe("the livekit connection type (0018)", () => {
   });
 
   it("is what is still pending on a database that already holds connections", async () => {
-    const result = await runMigrations(database.url);
+    // Through 0018 and no further, the way the block below it stops at 0017.
+    // What this block asserts next — the two checks the one list of types
+    // feeds — is true of the schema 0018 left behind and stopped being true of
+    // the newest schema the moment a later migration dropped one of them. A
+    // migration's own describe is about the upgrade that migration is, so it
+    // names the file it is about rather than reading whatever is newest.
+    const widening = (await readMigrations()).find((migration) =>
+      migration.name.startsWith("0018_"),
+    );
+    if (widening === undefined) throw new Error("0018 is missing");
+    await writeFile(path.join(beforeLiveKit, widening.name), widening.sql);
+
+    const result = await runMigrations(database.url, beforeLiveKit);
     expect(result.applied).toEqual(["0018_livekit_connection_type.sql"]);
   });
 
@@ -1582,5 +1594,150 @@ describe("the livekit connection type (0018)", () => {
       [livekitId],
     );
     expect(rows).toEqual([{ type: "livekit" }]);
+  });
+});
+
+describe("the connection type leaving the simulation row (0019)", () => {
+  let database: EmptyDatabase;
+  /** The schema as it stood while the copy was still there, on its own. */
+  let beforeTheDrop: string;
+  let client: pg.Client;
+
+  const work: ACustomersWork = {
+    organization: newId("org"),
+    project: newId("prj"),
+    agent: newId("agt"),
+    connection: newId("con"),
+    personaId: newId("prs"),
+    personaVersion: newId("prsv"),
+    run: newId("run"),
+    expected: 2,
+  };
+  const queued = newId("sim");
+  const landed = newId("sim");
+
+  beforeAll(async () => {
+    database = await createEmptyDatabase("connection_type_drop");
+    beforeTheDrop = await mkdtemp(path.join(os.tmpdir(), "egma-before-0019-"));
+    for (const migration of await readMigrations()) {
+      if (migration.name < "0019") {
+        await writeFile(path.join(beforeTheDrop, migration.name), migration.sql);
+      }
+    }
+    await runMigrations(database.url, beforeTheDrop);
+
+    // A customer's work as the release before this one wrote it: every
+    // simulation carrying its own copy of the connection type, which is the
+    // column the upgrade takes away underneath them.
+    client = new pg.Client({ connectionString: database.url });
+    await client.connect();
+    await seedACustomersWork(client, work);
+    await insertSimulation(client, work, {
+      id: queued,
+      position: 1,
+      shape: "queued",
+    });
+    await insertSimulation(client, work, {
+      id: landed,
+      position: 2,
+      shape: "completed",
+    });
+  });
+
+  afterAll(async () => {
+    await client.end();
+    await rm(beforeTheDrop, { recursive: true, force: true });
+    await database.drop();
+  });
+
+  it("is what is still pending on a database that already holds conversations", async () => {
+    const result = await runMigrations(database.url);
+    expect(result.applied[0]).toBe(
+      "0019_simulation_connection_type_leaves_the_row.sql",
+    );
+    expect(result.applied.every((name) => name >= "0019")).toBe(true);
+  });
+
+  it("takes the check and the column, in that order and both", async () => {
+    // Asked of the schema rather than of a row: a column nothing selects any
+    // more is not the same fact as a column that does not exist, and a check
+    // left behind on a dropped column could not exist at all — so the two
+    // questions together are what say the drop happened as one piece.
+    const { rows: left } = await client.query<{ column_name: string }>(
+      `select column_name from information_schema.columns
+        where table_name = 'simulation' and column_name = 'connection_type'`,
+    );
+    expect(left).toEqual([]);
+
+    const { rows: guards } = await client.query<{ name: string }>(
+      `select conname as name from pg_constraint
+        where conname = 'simulation_connection_type_allowed'`,
+    );
+    expect(guards).toEqual([]);
+  });
+
+  it("leaves the conversations that were already there exactly as they were", async () => {
+    const { rows } = await client.query<{
+      id: string;
+      status: string;
+      ending_reason: string | null;
+    }>(
+      `select id, status, ending_reason from simulation
+        where run_id = $1 order by position`,
+      [work.run],
+    );
+    expect(rows).toEqual([
+      { id: queued, status: "queued", ending_reason: null },
+      { id: landed, status: "completed", ending_reason: "persona_concluded" },
+    ]);
+  });
+
+  it("keeps the check that guards what a connection may be, which is the other one", async () => {
+    // The type is still enumerated where it is the source of truth. Dropping
+    // this one instead would leave the copy constrained and the original open,
+    // which is the mistake this asks about by name.
+    const { rows } = await client.query<{ definition: string }>(
+      `select pg_get_constraintdef(oid) as definition from pg_constraint
+        where conname = 'connection_type_allowed'`,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.definition).toContain(
+      "ARRAY['retell'::text, 'phone'::text, 'livekit'::text]",
+    );
+  });
+
+  it("keeps modality, which rides the row for a reason the type never had", async () => {
+    // The row's own check names it, and a CHECK cannot join — which is why
+    // this column stayed where the type went. A recording on a conversation
+    // that was not voice is still refused by the row itself, and the write
+    // that proves it names no connection type at all.
+    await expect(
+      client.query(
+        `insert into simulation
+           (id, run_id, organization_id, project_id, agent_id, connection_id,
+            persona_id, persona_version_id, position, modality, status,
+            ending_reason, claimed_by, claimed_at, heartbeat_at, started_at,
+            ended_at, recording_reference)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, 3, 'chat', 'completed',
+            'persona_concluded', 'simulator-blue-1', now(), now(), now(),
+            now(), 'r.wav')`,
+        [
+          newId("sim"),
+          work.run,
+          work.organization,
+          work.project,
+          work.agent,
+          work.connection,
+          work.personaId,
+          work.personaVersion,
+        ],
+      ),
+    ).rejects.toThrow(/simulation_audio_facts_are_voice_facts/u);
+
+    const { rows } = await client.query<{ name: string }>(
+      `select conname as name from pg_constraint
+        where conname = 'simulation_modality_allowed'`,
+    );
+    expect(rows).toHaveLength(1);
   });
 });

--- a/packages/db/test/runs-lifecycle-constraints.test.ts
+++ b/packages/db/test/runs-lifecycle-constraints.test.ts
@@ -205,7 +205,6 @@ async function insertSimulation(
     test_id: testId,
     test_version_id: testVersionId,
     position: 1,
-    connection_type: "retell",
     modality: "chat",
     status,
     ...shapeOf(status),

--- a/packages/db/test/runs.test.ts
+++ b/packages/db/test/runs.test.ts
@@ -348,7 +348,6 @@ describe("starting a run", () => {
     expect(started.connectionSnapshot.type).toBe("retell");
     expect(started.connectionSnapshot.modality).toBe("chat");
     expect(started.connectionSnapshot.environment).toBe("staging");
-    expect(started.simulations[0]?.connectionType).toBe("retell");
     expect(started.simulations[0]?.modality).toBe("chat");
 
     await updateConnection(actingAsAcme(), agentId, connectionId, {

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -307,7 +307,6 @@ describe("every enumerated value", () => {
       { table: "run", column: "triggered_via" },
       { table: "simulation", column: "status" },
       { table: "simulation", column: "ending_reason" },
-      { table: "simulation", column: "connection_type" },
       { table: "simulation", column: "modality" },
       { table: "run_event", column: "kind" },
       { table: "run_event", column: "verdict" },

--- a/packages/db/test/simulation-claims.test.ts
+++ b/packages/db/test/simulation-claims.test.ts
@@ -230,7 +230,6 @@ describe("the instance-wide claim", () => {
     expect(claim.personaId).toBe(acmeSeed.personaId);
     expect(claim.personaVersionId).toMatch(/^prsv_/);
     expect(claim.testVersionId).toBe(acmeSeed.testVersionId);
-    expect(claim.connectionType).toBe("retell");
     expect(claim.modality).toBe("chat");
     expect(claim.claimedBy).toBe("simulator-blue-1");
     expect(claim.claimedAt).toBeInstanceOf(Date);


### PR DESCRIPTION
Drops `simulation.connection_type` and its CHECK `simulation_connection_type_allowed`, in one migration (0019). The column was a per-row copy of a per-run fact: a run reaches its agent over exactly one connection, the run header snapshots that connection's whole non-secret shape in `connection_snapshot` at start, and that snapshot is what the API answers `connection_type` from. Nothing anywhere read the per-simulation copy back — it was written thirty lines from the snapshot, in the same transaction, out of the same object.

**`modality` stays, and the comment now says the real reason.** It is an operand in the row's own CHECK — `simulation_audio_facts_are_voice_facts` refuses a measured band or a recording on a conversation that was not voice, and a Postgres CHECK cannot join, so the column it compares has to sit on the row it guards. The old comment told a mutability story that was false: `updateConnection` refuses edits to `type`, `modality` and `topology` by name, so history was never at risk. Left in place, that comment would keep regenerating dead arguments in reviewers' heads.

**What deliberately stays put:**

- `connection_type_allowed` on `connection.type` — the type is still enumerated where it is the source of truth. The new replay-suite block asserts it survived, with a comment naming the alternative as the mistake it would be.
- `simulation_modality_allowed`, untouched next to `modality`.
- Every consumer: the API still answers the same `connection_type` from `run.connection_snapshot`, the claim path still reads the live connection row, and span facts still come from the emitting scope name — proven by the existing API and CLI tests, which are unmodified.

**The migration replay suite** got the care this file demands: fixtures that replay schema states before 0019 keep naming the column; the one fixture that replays past it stopped; the 0018 block now pins itself to its own migration (the way 0017 already did) instead of reading whatever is newest; and a new 0019 block owns the head-of-history story — the drop happened as one piece, existing rows survived it, and both kept checks still fire.

No write path grew a second query, and none needed one: no production code read the field off any of the four `RETURNING` sites, so deleting it from the column lists was the whole job.

**Gates:** typecheck clean · vitest 2033 passed (migration replay suite 48/48) · simulator 465 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the redundant connection type copy from simulation rows while retaining connection type in the run snapshot and live connection record.
- Adds migration 0019 to drop `simulation.connection_type` and its row-level constraint.
- Updates the Drizzle schema, run access types, inserts, claims, and return projections.
- Adds migration replay coverage for existing rows and retained modality and connection constraints.
- Aligns grader simulation-span fixtures with the ingest representation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete changed-code failure remains after tracing simulation consumers, migration dependencies, and retained constraints.

Connection type remains available from the run snapshot for API reads and from the scoped connection lookup for simulation assembly, while migration replay coverage confirms that existing rows and the required source and modality constraints survive.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/migrations/0019_simulation_connection_type_leaves_the_row.sql | Drops the simulation-specific check before dropping its referenced redundant column. |
| packages/db/src/schema/runs.ts | Removes simulation.connectionType while retaining modality and its audio-fact invariant. |
| packages/db/src/access/runs.ts | Removes the redundant field from simulation writes, reads, public types, and claims while preserving run snapshots. |
| packages/db/test/migrations.test.ts | Pins migration 0018 replay and adds 0019 coverage for row preservation and retained constraints. |
| apps/grader/test/support/world.ts | Makes synthetic simulation spans carry the empty connection type produced for the simulator instrumentation scope. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Connection row] -->|snapshot at run start| R[Run connection_snapshot]
  C -->|live scoped lookup| S[Simulator connection specification]
  R -->|connection_type response| A[Run API]
  R --> M[Simulation rows]
  M -->|retain modality for row CHECK| V[Audio-fact validation]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["An applied migration can never be edited..."](https://github.com/egma-ai/egma/commit/8dd0b055cad86f66178b5b0831ec5a3b22785556) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51670701)</sub>

<!-- /greptile_comment -->