### PR TITLE
Add a Planning-aware implementation coordinator

### DIFF
--- a/.agents/skills/ask-matt/SKILL.md
+++ b/.agents/skills/ask-matt/SKILL.md
@@ -4,6 +4,13 @@ description: Ask which skill or flow fits your situation. A router over the skil
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Ask Matt
 
 You don't remember every skill, so ask.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -3,6 +3,13 @@ name: code-review
 description: Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes — Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/spec asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to "review since X".
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
 
 - **Standards** — does the code conform to this repo's documented coding standards?

--- a/.agents/skills/codebase-design/SKILL.md
+++ b/.agents/skills/codebase-design/SKILL.md
@@ -3,6 +3,13 @@ name: codebase-design
 description: Shared vocabulary for designing deep modules. Use when the user wants to design or improve a module's interface, find deepening opportunities, decide where a seam goes, make code more testable or AI-navigable, or when another skill needs the deep-module vocabulary.
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Codebase Design
 
 Design **deep modules**: a lot of behaviour behind a small interface, placed at a clean seam, testable through that interface. Use this language and these principles wherever code is being designed or restructured. The aim is leverage for callers, locality for maintainers, and testability for everyone.

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -191,10 +191,11 @@ Before merging:
 3. Update it against that exact integration commit.
 4. Resolve conflicts in the ticket branch.
 5. Run the full suite.
-6. Rerun independent review if conflict resolution changed code.
-7. Confirm the integration commit has not moved.
+6. Rerun independent review against that exact integration commit, even when the refresh was conflict-free.
+7. Require the refreshed branch to pass the review gate again.
+8. Confirm the integration commit has not moved.
 
-If the integration branch moved, repeat the refresh and verification.
+If the integration branch moved, repeat the refresh, full suite, and independent review.
 
 Merge only while the verified integration commit is still current. Confirm the integration branch remains green after the merge.
 

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -219,12 +219,16 @@ Dispatch newly unblocked tickets while the next completed ticket moves through t
 
 After all selected tickets are resolved:
 
-1. Update the integration branch against the latest base branch.
-2. Resolve conflicts on the integration branch.
-3. Run the full suite.
-4. Push the integration branch.
-5. Open one pull request into the base branch.
-6. Leave it open.
+1. Record the latest base commit.
+2. Update the integration branch against that exact base commit.
+3. Resolve conflicts on the integration branch.
+4. Run the full suite.
+5. Run independent `/code-review` against that base commit, using the effort specification and resolved tickets as the specification source.
+6. Resolve findings, then repeat the full suite and independent review until the result is clean.
+7. Confirm the base commit has not moved. If it moved, repeat the final refresh, full suite, and independent review.
+8. Push the integration branch.
+9. Open one pull request into the base branch.
+10. Leave it open.
 
 Report the final pull request, integration branch, Planning commits, ticket results, and any unresolved risk.
 

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: coordinate-implementation
+description: Drive one ticketed effort through parallel implementation, independent review, serial integration, and one open pull request.
+disable-model-invocation: true
+---
+
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
+# Coordinate Implementation
+
+Drive one approved effort to one open pull request.
+
+You are the coordinator. Dispatch implementation, control the review gates, land ticket branches, and update the tracker. Do not implement tickets yourself.
+
+Implementation can run in parallel. Landing is always serial.
+
+## Completion contract
+
+The effort is complete when:
+
+- every selected ticket is merged into the integration branch;
+- every ticket is verified and marked `resolved` in the Planning root;
+- the integration branch passes the full test suite against the latest base;
+- one final pull request is open against the base branch;
+- the final pull request remains unmerged for the user.
+
+## Coordinator heartbeat
+
+Create one repeating monitor for the whole effort before starting the first worker, test run, CI run, or pull-request review.
+
+Use the harness-native monitor or wake-up mechanism. When it is unavailable, wait for no more than 60 seconds and schedule the next check before yielding.
+
+Use this cadence:
+
+- every minute while workers, reviewers, tests, or builds are active;
+- every three minutes while waiting only for CI or the pull-request review bot.
+
+Track each active item with its owner, branch, last commit, state, and time of last evidence.
+
+On every heartbeat:
+
+1. Inspect every worker and reviewer.
+2. Read new command or test output.
+3. Inspect branch commits and worktree state.
+4. Poll pull-request checks and review threads.
+5. Advance completed work immediately.
+6. Record the latest evidence.
+7. Schedule the next heartbeat before yielding.
+
+Treat quiet work in stages:
+
+- First quiet heartbeat: continue monitoring.
+- Second quiet heartbeat: contact the same worker and inspect its branch, worktree, and command output.
+- Third quiet heartbeat: treat it as stalled, diagnose the environment, and resume or replace the worker only after preserving its branch and commits.
+
+Silence is never completion. Verify a terminal state from commits, test output, pull-request state, or a clear agent report.
+
+Keep the heartbeat active while any work is pending. Stop it only when:
+
+- the final pull request is open;
+- a user decision is required;
+- an external blocker prevents progress and has been reported with evidence.
+
+Cancel the monitor when the coordination run ends. Leave no orphaned monitors. Do not end the coordinator task while non-terminal work remains. Yield to the heartbeat and resume from its next check.
+
+## 1. Resolve the roots
+
+Resolve the Code root and Planning root from repository configuration.
+
+Stop if the Planning root or its `AGENTS.md` is missing. The environment owns repository provisioning.
+
+Read:
+
+- Planning `AGENTS.md`;
+- `CONTEXT.md`;
+- `docs/agents/issue-tracker.md`;
+- relevant ADRs;
+- `.scratch/<effort>/spec.md`;
+- every ticket under `.scratch/<effort>/issues/`.
+
+Use one shared Planning checkout for the whole effort. Pass its absolute path to every worker and reviewer.
+
+The coordinator is the only Planning writer. Workers and reviewers treat it as read-only.
+
+Record existing changes in both repositories. Preserve unrelated changes. Stop if a selected ticket already has uncommitted changes.
+
+## 2. Build the ticket graph
+
+Select tickets with `Status: ready-for-agent`.
+
+Validate:
+
+- every blocker exists;
+- the graph has no cycles;
+- resolved blockers are verified;
+- every selected ticket has acceptance criteria;
+- the effort has at least one unblocked ticket.
+
+The frontier is every selected ticket whose blockers are resolved.
+
+Before dispatch, change each frontier ticket to `Status: claimed`. Commit only the explicit tracker files that changed.
+
+## 3. Create the integration branch
+
+Resolve the repository's default base branch. Do not assume it is `main`.
+
+Create or resume one integration branch for the effort. Follow the environment's required branch prefix.
+
+Create one ticket branch and one Code worktree per frontier ticket. Base each ticket branch on the integration commit recorded at dispatch time.
+
+Push the integration branch so ticket pull requests can use it as their base.
+
+## 4. Dispatch the frontier
+
+Dispatch as many frontier tickets as the current agent harness can run safely. Every ticket gets a stable worker name such as `impl-NN`.
+
+Give each worker:
+
+- its Code worktree path;
+- the absolute Planning root;
+- the recorded Planning commit;
+- the full ticket text;
+- the ticket and specification paths;
+- the recorded integration base commit;
+- the ticket branch name.
+
+Its first action is to read Planning `AGENTS.md`, `CONTEXT.md`, the ticket, specification, and relevant ADRs.
+
+Tell it to:
+
+1. Use `/implement`.
+2. Keep Planning read-only.
+3. Implement only the ticket.
+4. Run focused tests during development.
+5. Run typechecking and the full suite.
+6. Commit and push the ticket branch.
+7. Report what changed, what did not change, and any ticket defect.
+
+A worker that cannot read the Planning root must stop.
+
+Register every dispatched worker and long-running command with the coordinator heartbeat.
+
+## 5. Run the independent review loop
+
+After implementation, send the ticket branch to a separate reviewer.
+
+The reviewer uses `/code-review` with:
+
+- the recorded integration base commit as the fixed point;
+- the ticket as the specification;
+- the Code worktree as the review target;
+- the Planning root as read-only context.
+
+Send findings back to the original implementer. Reuse the same implementer and reviewer for up to three rounds.
+
+The result must be one of:
+
+- `clean`: no findings remain;
+- `capped`: findings remain after three rounds;
+- `escalated`: the ticket or specification is wrong.
+
+Only `clean` passes the gate. Stop and ask the user about `capped` or `escalated` work.
+
+Register every reviewer with the coordinator heartbeat.
+
+## 6. Run the pull-request review gate
+
+Open a ticket pull request into the integration branch.
+
+Wait for the configured review bot to finish against the latest push. Send valid findings to the original implementer. Answer findings that are not applied.
+
+The gate passes when every review thread is fixed or answered.
+
+If the repository has no configured review bot, report that fact and continue only when repository configuration allows it.
+
+Register CI and pull-request review with the coordinator heartbeat. Let the heartbeat own their polling.
+
+## 7. Land one ticket
+
+Land one clean ticket at a time.
+
+Before merging:
+
+1. Record the current integration commit.
+2. Send the branch back to its implementer.
+3. Update it against that exact integration commit.
+4. Resolve conflicts in the ticket branch.
+5. Run the full suite.
+6. Rerun independent review if conflict resolution changed code.
+7. Confirm the integration commit has not moved.
+
+If the integration branch moved, repeat the refresh and verification.
+
+Merge only while the verified integration commit is still current. Confirm the integration branch remains green after the merge.
+
+Then update the ticket in the Planning root:
+
+- set `Status: resolved`;
+- record the ticket pull request;
+- record what landed;
+- mark each verified acceptance criterion;
+- record what each review gate found.
+
+Commit only that ticket file. Remove its Code worktree after its branch is pushed, merged, and recoverable.
+
+## 8. Advance the frontier
+
+Recompute the graph after every merge.
+
+Dispatch newly unblocked tickets while the next completed ticket moves through the serial landing gate.
+
+## 9. Open the final pull request
+
+After all selected tickets are resolved:
+
+1. Update the integration branch against the latest base branch.
+2. Resolve conflicts on the integration branch.
+3. Run the full suite.
+4. Push the integration branch.
+5. Open one pull request into the base branch.
+6. Leave it open.
+
+Report the final pull request, integration branch, Planning commits, ticket results, and any unresolved risk.
+
+Never merge the final pull request.
+
+## Recovery
+
+Before restarting work, inspect existing branches, worktrees, pull requests, ticket states, and heartbeat state. Resume valid work instead of recreating it.
+
+Silence is not success. Verify branches, commits, test results, and pull-request state directly.
+
+If a worker stops responding, contact the same worker before replacing it. A replacement must read the ticket and branch state from the beginning.
+
+Restore or recreate the coordinator heartbeat before resuming any non-terminal work.

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -221,16 +221,18 @@ Dispatch newly unblocked tickets while the next completed ticket moves through t
 
 After all selected tickets are resolved:
 
-1. Record the latest base commit.
+1. Fetch the remote base branch and record its commit.
 2. Update the integration branch against that exact base commit.
 3. Resolve conflicts on the integration branch.
 4. Run the full suite.
 5. Run independent `/code-review` against that base commit, using the effort specification and resolved tickets as the specification source.
 6. Resolve findings, then repeat the full suite and independent review until the result is clean.
-7. Confirm the base commit has not moved. If it moved, repeat the final refresh, full suite, and independent review.
+7. Fetch the remote base branch again immediately before pushing and require its commit to equal the recorded commit. If it moved, repeat the final refresh, full suite, and independent review.
 8. Push the integration branch.
 9. Open one pull request into the base branch.
-10. Leave it open.
+10. Register the final pull request with the coordinator heartbeat and wait for required CI and review against its current head and base.
+11. If the base moves or the checks become stale, repeat the refresh, full suite, independent review, and final pull-request checks.
+12. Leave the green pull request open.
 
 Report the final pull request, integration branch, Planning commits, ticket results, and any unresolved risk.
 

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -13,60 +13,45 @@ Skill-local paths remain unchanged.
 
 # Coordinate Implementation
 
-Drive one approved effort to one open pull request.
-
-You are the coordinator. Dispatch implementation, control the review gates, land ticket branches, and update the tracker. Do not implement tickets yourself.
-
-Implementation can run in parallel. Landing is always serial.
+Coordinate one approved effort. Dispatch workers, control review gates, land ticket branches, and update the tracker. Keep implementation parallel and landing serial. Leave implementation to workers.
 
 ## Completion contract
 
 The effort is complete when:
 
-- every selected ticket is merged into the integration branch;
+- every selected ticket is on the integration branch;
 - every ticket is verified and marked `resolved` in the Planning root;
 - the integration branch passes the full test suite against the latest base;
-- one final pull request is open against the base branch with required checks green;
-- the final pull request remains unmerged for the user.
+- one final pull request is open, green, and unmerged for the user.
 
 ## Completion notifications and watchdogs
 
-Use harness completion notifications as the primary signal for workers and reviewers. Wait for those notifications instead of polling healthy agents.
+Use harness completion notifications for workers and reviewers. Use bounded polling only for external systems.
 
-Before dispatching an agent or starting a long-running command, register the active item with its owner, branch, last commit, state, time of last evidence, and a watchdog deadline 15 minutes after that evidence. Wait until the next harness notification, command event, or nearest watchdog deadline.
+Register each agent and long-running command with its owner, branch, last commit, state, last evidence, and a watchdog deadline 15 minutes later. Wait for the next harness event, command event, or nearest deadline.
 
-When a completion notification arrives:
+On completion, verify a durable terminal result, cancel the watchdog, and advance the work. On timeout:
 
-1. Read the report immediately.
-2. Verify the terminal state from commits, test output, pull-request state, or another durable result.
-3. Cancel that item's watchdog.
-4. Advance the work.
+1. Inspect the harness state, branch, worktree, and command output once.
+2. Reset the 15-minute deadline when a progress report, new output, commit, or external state change proves progress.
+3. Otherwise ask the same worker for a status report and checkpoint.
+4. After another 15 minutes without evidence, preserve its branch and commits, diagnose the environment, then resume or replace it.
 
-When a watchdog expires:
-
-1. Inspect the item once: its harness state, branch, worktree, and command output.
-2. If there is new evidence or clear progress, record it and set a new deadline 15 minutes later.
-3. If there is no progress, contact the same worker and request a status report and checkpoint.
-4. If the worker responds and can continue, record the evidence and set a new deadline 15 minutes later.
-5. If another 15 minutes pass without evidence, treat the item as stalled. Preserve its branch and commits, diagnose the environment, then resume or replace the worker.
-
-Reset a watchdog only for meaningful evidence: a completion or progress report, new command output, a new commit, or a verified external state change. Silence is never completion.
+Silence is never completion.
 
 CI and pull-request review bots are external systems and might not send harness notifications. Poll each pending external system with a bounded wait of at most three minutes. Stop polling as soon as it reaches a terminal state.
 
-Keep the coordinator task active while work is pending. End it only when:
+Keep the coordinator active until:
 
 - the final pull request is open and its required checks are green;
 - a user decision is required;
 - an external blocker prevents progress and has been reported with evidence.
 
-Cancel all watchdogs and external monitors when coordination ends. Leave no orphaned monitors.
+Cancel all watchdogs and external monitors when coordination ends.
 
 ## 1. Resolve the roots
 
-Resolve the Code root and Planning root from repository configuration.
-
-Stop if the Planning root or its `AGENTS.md` is missing. The environment owns repository provisioning.
+Resolve the Code and Planning roots from repository configuration. Stop if the Planning root or its `AGENTS.md` is missing; the environment owns provisioning.
 
 Read:
 
@@ -77,41 +62,23 @@ Read:
 - `.scratch/<effort>/spec.md`;
 - every ticket under `.scratch/<effort>/issues/`.
 
-Use one shared Planning checkout for the whole effort. Pass its absolute path to every worker and reviewer.
+Use one shared Planning checkout. The coordinator is its only writer; pass its absolute path to workers and reviewers as read-only context.
 
-The coordinator is the only Planning writer. Workers and reviewers treat it as read-only.
-
-Record existing changes in both repositories. Preserve unrelated changes. Stop if a selected ticket already has uncommitted changes.
+Record existing changes in both repositories and preserve unrelated work. Stop when uncommitted work overlaps a selected ticket.
 
 ## 2. Preflight user inputs
 
-Read the effort specification and every ticket before creating branches, claiming tickets, or dispatching workers.
+Before branches, claims, or dispatch, read the specification and every ticket. Predict user-only inputs: credentials, access, infrastructure, datasets, devices, phone numbers, fixtures, approvals, and product decisions.
 
-Predict everything the effort may need from the user, including:
+Inspect configured environment and secret locations first. Confirm availability without printing values. Ask once for all missing inputs, grouped by ticket with the reason and `hard blocker` or `optional`. Use the secure secret workflow, not chat.
 
-- API keys, credentials, and secrets;
-- account, organization, repository, or service access;
-- environment configuration and infrastructure;
-- external datasets, devices, phone numbers, or test fixtures;
-- approvals, product decisions, and other human-only actions.
-
-Inspect the configured environment and secret locations before asking. Confirm availability without printing secret values.
-
-For each missing input, identify the ticket that needs it, explain why it is required, and classify it as a hard blocker or optional input. Ask the user once with one grouped checklist before implementation starts. Use the repository's secure secret workflow instead of asking the user to paste secrets into chat.
-
-Start only after every hard blocker is available or the user explicitly narrows the effort. If no user input is needed, state that the preflight is clear and continue.
+Start after all hard blockers are available or the user narrows the effort. State when preflight needs no input.
 
 ## 3. Build the ticket graph
 
 Select tickets with `Status: ready-for-agent`.
 
-Validate:
-
-- every blocker exists;
-- the graph has no cycles;
-- resolved blockers are verified;
-- every selected ticket has acceptance criteria;
-- the effort has at least one unblocked ticket.
+Require every blocker to exist, no cycles, verified resolved blockers, acceptance criteria on every selected ticket, and at least one unblocked ticket.
 
 The frontier is every selected ticket whose blockers are resolved.
 
@@ -121,41 +88,32 @@ Before dispatch, change each frontier ticket to `Status: claimed`. Commit only t
 
 Resolve the repository's default base branch. Do not assume it is `main`.
 
-Create or resume one integration branch for the effort. Follow the environment's required branch prefix.
-
-Create one ticket branch and one Code worktree per frontier ticket. Base each ticket branch on the integration commit recorded at dispatch time.
+Create or resume one integration branch using the required branch prefix. Create one ticket branch and Code worktree per frontier ticket, based on the integration commit recorded at dispatch.
 
 Push the integration branch so ticket pull requests can use it as their base.
 
 ## 5. Dispatch the frontier
 
-Dispatch as many frontier tickets as the current agent harness can run safely. Every ticket gets a stable worker name such as `impl-NN`.
+Dispatch as many frontier tickets as the harness can run safely. Give each worker a stable name such as `impl-NN`.
 
 Give each worker:
 
 - its Code worktree path;
 - the absolute Planning root;
 - the recorded Planning commit;
-- the full ticket text;
 - the ticket and specification paths;
 - the recorded integration base commit;
 - the ticket branch name.
 
-Its first action is to read Planning `AGENTS.md`, `CONTEXT.md`, the ticket, specification, and relevant ADRs.
-
-Tell it to:
+Require its first action to read Planning `AGENTS.md`, `CONTEXT.md`, the ticket, specification, and relevant ADRs. Tell it to:
 
 1. Use `/implement`.
 2. Keep Planning read-only.
 3. Implement only the ticket.
-4. Run focused tests during development.
-5. Run typechecking and the full suite.
-6. Commit and push the ticket branch.
-7. Report what changed, what did not change, and any ticket defect.
+4. Commit and push the ticket branch.
+5. Report what changed, what did not change, and any ticket defect.
 
 A worker that cannot read the Planning root must stop.
-
-Register every dispatched worker and long-running command with the coordinator watchdog registry.
 
 ## 6. Run the independent review loop
 
@@ -168,7 +126,7 @@ The reviewer uses `/code-review` with:
 - the Code worktree as the review target;
 - the Planning root as read-only context.
 
-Send findings back to the original implementer. Reuse the same implementer and reviewer for up to three rounds.
+Send findings to the original implementer. Reuse the same implementer and reviewer for up to three rounds.
 
 The result must be one of:
 
@@ -176,27 +134,23 @@ The result must be one of:
 - `capped`: findings remain after three rounds;
 - `escalated`: the ticket or specification is wrong.
 
-Only `clean` passes the gate. Stop and ask the user about `capped` or `escalated` work.
-
-Register every reviewer with the coordinator watchdog registry.
+Only `clean` passes. Ask the user about `capped` or `escalated` work.
 
 ## 7. Run the pull-request review gate
 
 Open a ticket pull request into the integration branch.
 
-Wait for the configured review bot to finish against the latest push. Send valid findings to the original implementer. Answer findings that are not applied.
-
-The gate passes when every review thread is fixed or answered.
+Wait for the configured review bot against the latest push. Send valid findings to the original implementer and answer findings that are not applied. Pass when every thread is fixed or answered.
 
 If the repository has no configured review bot, report that fact and continue only when repository configuration allows it.
 
-Register CI and pull-request review with the bounded external wait loop.
+Track CI and review with the bounded external wait loop.
 
 ## 8. Land one ticket
 
-Land one clean ticket at a time. Hold one coordinator-owned landing lock from the first refresh through the integration push. No other ticket may land while the lock is held.
+Land one clean ticket at a time. Hold one coordinator-owned landing lock from the first refresh through the integration push.
 
-Before merging:
+Before landing:
 
 1. Fetch and record the current remote integration commit.
 2. Send the branch back to its implementer.
@@ -207,11 +161,11 @@ Before merging:
 7. Require the refreshed branch to pass the review gate again.
 8. Fetch the remote integration branch again and require its commit to equal the recorded commit.
 9. Fast-forward the local integration branch to the reviewed ticket branch.
-10. Push the integration branch normally. Treat a rejected push as evidence that the remote branch moved; never force it.
+10. Push normally. A rejected push means the remote moved; never force it.
 
 If the integration branch moved or the push was rejected, repeat the refresh, full suite, and independent review while keeping landing serial.
 
-The successful guarded push is the merge. Confirm the integration branch remains green, then release the landing lock.
+The guarded push is the merge. Confirm the integration branch remains green, then release the lock.
 
 Then update the ticket in the Planning root:
 
@@ -221,11 +175,11 @@ Then update the ticket in the Planning root:
 - mark each verified acceptance criterion;
 - record what each review gate found.
 
-Commit only that ticket file. Remove its Code worktree after its branch is pushed, merged, and recoverable.
+Commit only that ticket file. Remove its Code worktree after the branch is pushed, landed, and recoverable.
 
 ## 9. Advance the frontier
 
-Recompute the graph after every merge.
+Recompute the graph after every landing.
 
 Dispatch newly unblocked tickets while the next completed ticket moves through the serial landing gate.
 
@@ -241,20 +195,16 @@ After all selected tickets are resolved:
 6. Resolve findings, then repeat the full suite and independent review until the result is clean.
 7. Push the integration branch.
 8. Open one pull request into the base branch.
-9. Register the final pull request with the bounded external wait loop and wait for required CI and review to turn green.
+9. Wait for required CI and review with the bounded external wait loop.
 10. Leave the green pull request open.
 
-The final pull request is the handoff point. Later movement on the base branch does not restart coordination; the user decides when to update or merge it.
+The open green pull request is the handoff. Later base movement does not restart coordination; the user decides when to update or merge it.
 
 Report the final pull request, integration branch, Planning commits, ticket results, and any unresolved risk.
-
-Never merge the final pull request.
 
 ## Recovery
 
 Before restarting work, inspect existing branches, worktrees, pull requests, ticket states, and watchdog state. Resume valid work instead of recreating it.
-
-Silence is not success. Verify branches, commits, test results, and pull-request state directly.
 
 If a worker stops responding, contact the same worker before replacing it. A replacement must read the ticket and branch state from the beginning.
 

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -29,44 +29,38 @@ The effort is complete when:
 - one final pull request is open against the base branch with required checks green;
 - the final pull request remains unmerged for the user.
 
-## Coordinator heartbeat
+## Completion notifications and watchdogs
 
-Create one repeating monitor for the whole effort before starting the first worker, test run, CI run, or pull-request review.
+Use harness completion notifications as the primary signal for workers and reviewers. Wait for those notifications instead of polling healthy agents.
 
-Use the harness-native monitor or wake-up mechanism. When it is unavailable, wait for no more than 60 seconds and schedule the next check before yielding.
+Before dispatching an agent or starting a long-running command, register the active item with its owner, branch, last commit, state, time of last evidence, and a watchdog deadline 15 minutes after that evidence. Wait until the next harness notification, command event, or nearest watchdog deadline.
 
-Use this cadence:
+When a completion notification arrives:
 
-- every minute while workers, reviewers, tests, or builds are active;
-- every three minutes while waiting only for CI or the pull-request review bot.
+1. Read the report immediately.
+2. Verify the terminal state from commits, test output, pull-request state, or another durable result.
+3. Cancel that item's watchdog.
+4. Advance the work.
 
-Track each active item with its owner, branch, last commit, state, and time of last evidence.
+When a watchdog expires:
 
-On every heartbeat:
+1. Inspect the item once: its harness state, branch, worktree, and command output.
+2. If there is new evidence or clear progress, record it and set a new deadline 15 minutes later.
+3. If there is no progress, contact the same worker and request a status report and checkpoint.
+4. If the worker responds and can continue, record the evidence and set a new deadline 15 minutes later.
+5. If another 15 minutes pass without evidence, treat the item as stalled. Preserve its branch and commits, diagnose the environment, then resume or replace the worker.
 
-1. Inspect every worker and reviewer.
-2. Read new command or test output.
-3. Inspect branch commits and worktree state.
-4. Poll pull-request checks and review threads.
-5. Advance completed work immediately.
-6. Record the latest evidence.
-7. Schedule the next heartbeat before yielding.
+Reset a watchdog only for meaningful evidence: a completion or progress report, new command output, a new commit, or a verified external state change. Silence is never completion.
 
-Treat quiet work in stages:
+CI and pull-request review bots are external systems and might not send harness notifications. Poll each pending external system with a bounded wait of at most three minutes. Stop polling as soon as it reaches a terminal state.
 
-- First quiet heartbeat: continue monitoring.
-- Second quiet heartbeat: contact the same worker and inspect its branch, worktree, and command output.
-- Third quiet heartbeat: treat it as stalled, diagnose the environment, and resume or replace the worker only after preserving its branch and commits.
-
-Silence is never completion. Verify a terminal state from commits, test output, pull-request state, or a clear agent report.
-
-Keep the heartbeat active while any work is pending. Stop it only when:
+Keep the coordinator task active while work is pending. End it only when:
 
 - the final pull request is open and its required checks are green;
 - a user decision is required;
 - an external blocker prevents progress and has been reported with evidence.
 
-Cancel the monitor when the coordination run ends. Leave no orphaned monitors. Do not end the coordinator task while non-terminal work remains. Yield to the heartbeat and resume from its next check.
+Cancel all watchdogs and external monitors when coordination ends. Leave no orphaned monitors.
 
 ## 1. Resolve the roots
 
@@ -161,7 +155,7 @@ Tell it to:
 
 A worker that cannot read the Planning root must stop.
 
-Register every dispatched worker and long-running command with the coordinator heartbeat.
+Register every dispatched worker and long-running command with the coordinator watchdog registry.
 
 ## 6. Run the independent review loop
 
@@ -184,7 +178,7 @@ The result must be one of:
 
 Only `clean` passes the gate. Stop and ask the user about `capped` or `escalated` work.
 
-Register every reviewer with the coordinator heartbeat.
+Register every reviewer with the coordinator watchdog registry.
 
 ## 7. Run the pull-request review gate
 
@@ -196,7 +190,7 @@ The gate passes when every review thread is fixed or answered.
 
 If the repository has no configured review bot, report that fact and continue only when repository configuration allows it.
 
-Register CI and pull-request review with the coordinator heartbeat. Let the heartbeat own their polling.
+Register CI and pull-request review with the bounded external wait loop.
 
 ## 8. Land one ticket
 
@@ -247,7 +241,7 @@ After all selected tickets are resolved:
 6. Resolve findings, then repeat the full suite and independent review until the result is clean.
 7. Push the integration branch.
 8. Open one pull request into the base branch.
-9. Register the final pull request with the coordinator heartbeat and wait for required CI and review to turn green.
+9. Register the final pull request with the bounded external wait loop and wait for required CI and review to turn green.
 10. Leave the green pull request open.
 
 The final pull request is the handoff point. Later movement on the base branch does not restart coordination; the user decides when to update or merge it.
@@ -258,10 +252,10 @@ Never merge the final pull request.
 
 ## Recovery
 
-Before restarting work, inspect existing branches, worktrees, pull requests, ticket states, and heartbeat state. Resume valid work instead of recreating it.
+Before restarting work, inspect existing branches, worktrees, pull requests, ticket states, and watchdog state. Resume valid work instead of recreating it.
 
 Silence is not success. Verify branches, commits, test results, and pull-request state directly.
 
 If a worker stops responding, contact the same worker before replacing it. A replacement must read the ticket and branch state from the beginning.
 
-Restore or recreate the coordinator heartbeat before resuming any non-terminal work.
+Restore or recreate watchdog deadlines and external waits before resuming any non-terminal work.

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -182,22 +182,24 @@ Register CI and pull-request review with the coordinator heartbeat. Let the hear
 
 ## 7. Land one ticket
 
-Land one clean ticket at a time.
+Land one clean ticket at a time. Hold one coordinator-owned landing lock from the first refresh through the integration push. No other ticket may land while the lock is held.
 
 Before merging:
 
-1. Record the current integration commit.
+1. Fetch and record the current remote integration commit.
 2. Send the branch back to its implementer.
 3. Update it against that exact integration commit.
 4. Resolve conflicts in the ticket branch.
 5. Run the full suite.
 6. Rerun independent review against that exact integration commit, even when the refresh was conflict-free.
 7. Require the refreshed branch to pass the review gate again.
-8. Confirm the integration commit has not moved.
+8. Fetch the remote integration branch again and require its commit to equal the recorded commit.
+9. Fast-forward the local integration branch to the reviewed ticket branch.
+10. Push the integration branch normally. Treat a rejected push as evidence that the remote branch moved; never force it.
 
-If the integration branch moved, repeat the refresh, full suite, and independent review.
+If the integration branch moved or the push was rejected, repeat the refresh, full suite, and independent review while keeping landing serial.
 
-Merge only while the verified integration commit is still current. Confirm the integration branch remains green after the merge.
+The successful guarded push is the merge. Confirm the integration branch remains green, then release the landing lock.
 
 Then update the ticket in the Planning root:
 

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -158,12 +158,14 @@ Before landing:
 4. Resolve conflicts in the ticket branch.
 5. Run the full suite.
 6. Rerun independent review against that exact integration commit, even when the refresh was conflict-free.
-7. Require the refreshed branch to pass the review gate again.
-8. Fetch the remote integration branch again and require its commit to equal the recorded commit.
-9. Fast-forward the local integration branch to the reviewed ticket branch.
-10. Push normally. A rejected push means the remote moved; never force it.
+7. Push the reviewed refresh to the ticket branch.
+8. Run the pull-request review gate against that pushed commit.
+9. If either gate causes changes, have the implementer commit and push them, then repeat the full suite and both gates against that commit.
+10. Fetch the remote integration branch again and require its commit to equal the recorded commit.
+11. Fast-forward the local integration branch to the reviewed ticket branch.
+12. Push normally. A rejected push means the remote moved; never force it.
 
-If the integration branch moved or the push was rejected, repeat the refresh, full suite, and independent review while keeping landing serial.
+If the integration branch moved or the push was rejected, repeat the whole landing gate while keeping landing serial.
 
 The guarded push is the merge. Confirm the integration branch remains green, then release the lock.
 

--- a/.agents/skills/coordinate-implementation/SKILL.md
+++ b/.agents/skills/coordinate-implementation/SKILL.md
@@ -26,7 +26,7 @@ The effort is complete when:
 - every selected ticket is merged into the integration branch;
 - every ticket is verified and marked `resolved` in the Planning root;
 - the integration branch passes the full test suite against the latest base;
-- one final pull request is open against the base branch;
+- one final pull request is open against the base branch with required checks green;
 - the final pull request remains unmerged for the user.
 
 ## Coordinator heartbeat
@@ -62,7 +62,7 @@ Silence is never completion. Verify a terminal state from commits, test output, 
 
 Keep the heartbeat active while any work is pending. Stop it only when:
 
-- the final pull request is open;
+- the final pull request is open and its required checks are green;
 - a user decision is required;
 - an external blocker prevents progress and has been reported with evidence.
 
@@ -89,7 +89,25 @@ The coordinator is the only Planning writer. Workers and reviewers treat it as r
 
 Record existing changes in both repositories. Preserve unrelated changes. Stop if a selected ticket already has uncommitted changes.
 
-## 2. Build the ticket graph
+## 2. Preflight user inputs
+
+Read the effort specification and every ticket before creating branches, claiming tickets, or dispatching workers.
+
+Predict everything the effort may need from the user, including:
+
+- API keys, credentials, and secrets;
+- account, organization, repository, or service access;
+- environment configuration and infrastructure;
+- external datasets, devices, phone numbers, or test fixtures;
+- approvals, product decisions, and other human-only actions.
+
+Inspect the configured environment and secret locations before asking. Confirm availability without printing secret values.
+
+For each missing input, identify the ticket that needs it, explain why it is required, and classify it as a hard blocker or optional input. Ask the user once with one grouped checklist before implementation starts. Use the repository's secure secret workflow instead of asking the user to paste secrets into chat.
+
+Start only after every hard blocker is available or the user explicitly narrows the effort. If no user input is needed, state that the preflight is clear and continue.
+
+## 3. Build the ticket graph
 
 Select tickets with `Status: ready-for-agent`.
 
@@ -105,7 +123,7 @@ The frontier is every selected ticket whose blockers are resolved.
 
 Before dispatch, change each frontier ticket to `Status: claimed`. Commit only the explicit tracker files that changed.
 
-## 3. Create the integration branch
+## 4. Create the integration branch
 
 Resolve the repository's default base branch. Do not assume it is `main`.
 
@@ -115,7 +133,7 @@ Create one ticket branch and one Code worktree per frontier ticket. Base each ti
 
 Push the integration branch so ticket pull requests can use it as their base.
 
-## 4. Dispatch the frontier
+## 5. Dispatch the frontier
 
 Dispatch as many frontier tickets as the current agent harness can run safely. Every ticket gets a stable worker name such as `impl-NN`.
 
@@ -145,7 +163,7 @@ A worker that cannot read the Planning root must stop.
 
 Register every dispatched worker and long-running command with the coordinator heartbeat.
 
-## 5. Run the independent review loop
+## 6. Run the independent review loop
 
 After implementation, send the ticket branch to a separate reviewer.
 
@@ -168,7 +186,7 @@ Only `clean` passes the gate. Stop and ask the user about `capped` or `escalated
 
 Register every reviewer with the coordinator heartbeat.
 
-## 6. Run the pull-request review gate
+## 7. Run the pull-request review gate
 
 Open a ticket pull request into the integration branch.
 
@@ -180,7 +198,7 @@ If the repository has no configured review bot, report that fact and continue on
 
 Register CI and pull-request review with the coordinator heartbeat. Let the heartbeat own their polling.
 
-## 7. Land one ticket
+## 8. Land one ticket
 
 Land one clean ticket at a time. Hold one coordinator-owned landing lock from the first refresh through the integration push. No other ticket may land while the lock is held.
 
@@ -211,28 +229,28 @@ Then update the ticket in the Planning root:
 
 Commit only that ticket file. Remove its Code worktree after its branch is pushed, merged, and recoverable.
 
-## 8. Advance the frontier
+## 9. Advance the frontier
 
 Recompute the graph after every merge.
 
 Dispatch newly unblocked tickets while the next completed ticket moves through the serial landing gate.
 
-## 9. Open the final pull request
+## 10. Open the final pull request
 
 After all selected tickets are resolved:
 
-1. Fetch the remote base branch and record its commit.
+1. Fetch the remote base branch and record its latest commit.
 2. Update the integration branch against that exact base commit.
 3. Resolve conflicts on the integration branch.
 4. Run the full suite.
 5. Run independent `/code-review` against that base commit, using the effort specification and resolved tickets as the specification source.
 6. Resolve findings, then repeat the full suite and independent review until the result is clean.
-7. Fetch the remote base branch again immediately before pushing and require its commit to equal the recorded commit. If it moved, repeat the final refresh, full suite, and independent review.
-8. Push the integration branch.
-9. Open one pull request into the base branch.
-10. Register the final pull request with the coordinator heartbeat and wait for required CI and review against its current head and base.
-11. If the base moves or the checks become stale, repeat the refresh, full suite, independent review, and final pull-request checks.
-12. Leave the green pull request open.
+7. Push the integration branch.
+8. Open one pull request into the base branch.
+9. Register the final pull request with the coordinator heartbeat and wait for required CI and review to turn green.
+10. Leave the green pull request open.
+
+The final pull request is the handoff point. Later movement on the base branch does not restart coordination; the user decides when to update or merge it.
 
 Report the final pull request, integration branch, Planning commits, ticket results, and any unresolved risk.
 

--- a/.agents/skills/coordinate-implementation/agents/openai.yaml
+++ b/.agents/skills/coordinate-implementation/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Coordinate Implementation"
+  short_description: "Drive a ticketed effort to one open PR"
+  default_prompt: "Use $coordinate-implementation to drive this ticketed effort to one reviewed open PR."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/diagnosing-bugs/SKILL.md
+++ b/.agents/skills/diagnosing-bugs/SKILL.md
@@ -3,6 +3,13 @@ name: diagnosing-bugs
 description: Diagnosis loop for hard bugs and performance regressions. Use when the user says "diagnose"/"debug this", or reports something broken/throwing/failing/slow.
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Diagnosing Bugs
 
 A discipline for hard bugs. Skip phases only when explicitly justified.

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -3,6 +3,13 @@ name: domain-modeling
 description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Domain Modeling
 
 Actively build and sharpen the project's domain model as you design. This is the *active* discipline — challenging terms, inventing edge-case scenarios, and writing the glossary and decisions down the moment they crystallise. (Merely *reading* `CONTEXT.md` for vocabulary is not this skill — that's a one-line habit any skill can do. This skill is for when you're changing the model, not just consuming it.)

--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -4,4 +4,11 @@ description: A relentless interview to sharpen a plan or design.
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Run a `/grilling` session.

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -4,4 +4,11 @@ description: A relentless interview to sharpen a plan or design, which also crea
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -3,6 +3,13 @@ name: grilling
 description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
 
 Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -5,6 +5,13 @@ argument-hint: "What will the next session be used for?"
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
 
 Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -4,6 +4,13 @@ description: "Implement a piece of work based on a spec or set of tickets."
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Implement the work described by the user in the spec or tickets.
 
 Use /tdd where possible, at pre-agreed seams.

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -4,6 +4,13 @@ description: Scan a codebase for deepening opportunities, present them as a visu
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Improve Codebase Architecture
 
 Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.

--- a/.agents/skills/prototype/SKILL.md
+++ b/.agents/skills/prototype/SKILL.md
@@ -3,6 +3,13 @@ name: prototype
 description: Build a throwaway prototype to answer a design question. Use when the user wants to sanity-check whether a state model or logic feels right, or explore what a UI should look like.
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Prototype
 
 A prototype is **throwaway code that answers a question**. The question decides the shape.

--- a/.agents/skills/research/SKILL.md
+++ b/.agents/skills/research/SKILL.md
@@ -3,6 +3,13 @@ name: research
 description: Investigate a question against high-trust primary sources and capture the findings as a Markdown file in the repo. Use when the user wants a topic researched, docs or API facts gathered, or reading legwork delegated to a background agent.
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Spin up a **background agent** to do the research, so you keep working while it reads.
 
 Its job:

--- a/.agents/skills/resolving-merge-conflicts/SKILL.md
+++ b/.agents/skills/resolving-merge-conflicts/SKILL.md
@@ -3,6 +3,13 @@ name: resolving-merge-conflicts
 description: "Use when you need to resolve an in-progress git merge/rebase conflict."
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 1. **See the current state** of the merge/rebase. Check git history, and the conflicting files.
 
 2. **Find the primary sources** for each conflict. Understand deeply why each change was made, and what the original intent was. Read the commit messages, check the PRs, check original issues/tickets.

--- a/.agents/skills/setup-matt-pocock-skills/SKILL.md
+++ b/.agents/skills/setup-matt-pocock-skills/SKILL.md
@@ -4,6 +4,13 @@ description: Configure this repo for the engineering skills — set up its issue
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Setup Matt Pocock's Skills
 
 Scaffold the per-repo configuration that the engineering skills assume:

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -3,6 +3,13 @@ name: tdd
 description: Test-driven development. Use when the user wants to build features or fix bugs test-first, mentions "red-green-refactor", or wants integration tests.
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Test-Driven Development
 
 TDD is the red → green loop. This skill is the reference that makes that loop produce tests worth keeping: what a good test is, where tests go, the anti-patterns, and the rules of the loop. Every section applies on every cycle — consult them before and during the loop, not after.

--- a/.agents/skills/teach/SKILL.md
+++ b/.agents/skills/teach/SKILL.md
@@ -5,6 +5,13 @@ disable-model-invocation: true
 argument-hint: "What would you like to learn about?"
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 The user has asked you to teach them something. This is a stateful request - they intend to learn the topic over multiple sessions.
 
 ## Teaching Workspace

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -4,6 +4,13 @@ description: Turn the current conversation into a spec and publish it to the pro
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 This skill takes the current conversation context and codebase understanding and produces a spec. Do NOT interview the user — just synthesize what you already know.
 
 The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.

--- a/.agents/skills/to-tickets/SKILL.md
+++ b/.agents/skills/to-tickets/SKILL.md
@@ -4,6 +4,13 @@ description: Break a plan, spec, or the current conversation into a set of trace
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # To Tickets
 
 Break a plan, spec, or conversation into a set of **tickets** — tracer-bullet vertical slices, each declaring the tickets that **block** it.

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -4,6 +4,13 @@ description: Move issues and external PRs through a state machine of triage role
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 # Triage
 
 Move issues on the project issue tracker through a small state machine of triage roles.

--- a/.agents/skills/wait-what/SKILL.md
+++ b/.agents/skills/wait-what/SKILL.md
@@ -4,4 +4,11 @@ description: Stop. That last message did not land — re-pitch it.
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 Wait — I don't understand where you've got to here. Re-pitch that: give me a little bit of context, talk in ASD-STE100 Simplified Technical English, and use the ubiquitous language from `CONTEXT.md`.

--- a/.agents/skills/wayfinder/SKILL.md
+++ b/.agents/skills/wayfinder/SKILL.md
@@ -4,6 +4,13 @@ description: Plan a huge chunk of work — more than one agent session can hold 
 disable-model-invocation: true
 ---
 
+<!-- path-routing:start -->
+Repository configuration overrides this skill's default planning paths.
+If a Planning root is defined, resolve `CONTEXT.md`, `docs/adr/`,
+`docs/agents/`, `.scratch/`, and `.out-of-scope/` from that root.
+Skill-local paths remain unchanged.
+<!-- path-routing:end -->
+
 A loose idea has arrived — too big for one agent session, and wrapped in fog: the way from here to the **destination** isn't visible yet. Wayfinding is about finding that way, not charging at the destination. This skill charts the way as a **shared map** on the repo's issue tracker, then works its **decision tickets** — questions whose resolution is a decision, not slices of a build to execute — one at a time until the route is clear.
 
 The destination varies per effort, and naming it is the first act of charting — it shapes every ticket. It might be a spec to hand off and iterate on, a decision to lock before planning starts, or a change made in place like a data-structure migration. The map is domain-agnostic — engineering work, course content, whatever fits the shape.

--- a/.claude/skills/coordinate-implementation
+++ b/.claude/skills/coordinate-implementation
@@ -1,0 +1,1 @@
+../../.agents/skills/coordinate-implementation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 The first open-source platform purpose-built to help teams shipping voice agents gain trust in the agent they ship to production.
 
-**If `egma-planning/.agents/AGENTS.md` exists in your checkout, read it now and follow it in full** — it carries additional instructions for this repo. If it doesn't exist, ignore this and carry on; nothing here depends on it.
+**If `egma-planning/AGENTS.md` exists in your checkout, read it now and follow it in full** — it carries additional instructions for this repo. If it doesn't exist, ignore this and carry on; nothing here depends on it.
 
 # communication rules
 


### PR DESCRIPTION
## Summary

This replaces the approach in #58 with the repository-routing system now used by Egma.

- Adds a user-invoked `coordinate-implementation` skill for driving a whole ticketed effort.
- Routes the installed Matt skills through repository-defined Planning paths.
- Uses the one Planning root supplied by the environment. Workers and reviewers receive its absolute path and keep it read-only; only the coordinator updates tickets.
- Removes the need to clone, mount, or link the Planning repository into every Code worktree.
- Runs implementation in parallel, then reviews and lands ticket branches serially against the exact integration head they were tested with.
- Leaves one final pull request open for the user to merge.

## Coordinator heartbeat

The coordinator creates one repeating monitor for the whole effort:

- every minute while agents, tests, or builds are active;
- every three minutes while waiting only for CI or the pull-request review bot;
- after two quiet checks it contacts and inspects the existing worker;
- after three quiet checks it diagnoses and recovers the stalled work;
- it re-arms before every yield and cancels itself at a terminal state.

Silence is never treated as completion.

## Files

- `.agents/skills/coordinate-implementation/SKILL.md`
- `.agents/skills/coordinate-implementation/agents/openai.yaml`
- `.claude/skills/coordinate-implementation`
- Generic `path-routing` blocks in the 22 locked Matt skills
- Updated conditional Planning pointer in `AGENTS.md`

No private Planning document or private repository path is included.

## Validation

- `node egma-planning/scripts/patch-matt-skills.mjs check`
- `node --test egma-planning/scripts/tests/patch-matt-skills.test.mjs` — 7 passed
- Repository-compatible skill metadata, route-marker, heartbeat, and symlink checks passed
- `git diff --check origin/main...HEAD`

The generic `quick_validate.py` rejects `disable-model-invocation`, including on existing user-invoked skills in this repository. The repository-supported field remains in place, with `allow_implicit_invocation: false` also set in `agents/openai.yaml`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a planning-aware implementation coordinator and routes the repository’s Matt skills through an environment-provided Planning root.
- Coordinates parallel ticket implementation with serial, exact-commit landing gates.
- Adds independent and pull-request review loops for refreshed ticket branches and the final integration branch.
- Adds generic Planning path-routing guidance across the installed skills.
- Exposes the coordinator through OpenAI metadata and a Claude skill alias.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .agents/skills/coordinate-implementation/SKILL.md | Defines the coordinator’s planning-root setup, parallel worker lifecycle, exact-state ticket landing gates, recovery behavior, and final pull-request handoff. |
| .agents/skills/coordinate-implementation/agents/openai.yaml | Registers coordinator display metadata and disables implicit invocation. |
| AGENTS.md | Updates repository instructions to route Planning artifacts through the environment-provided Planning root. |
| .claude/skills/coordinate-implementation | Adds the Claude-facing alias for the coordinator skill. |
| .agents/skills/code-review/SKILL.md | Adds the generic Planning-root path-routing block used across the locked Matt skills. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Resolve Code and Planning roots] --> B[Preflight user inputs]
    B --> C[Build ticket dependency graph]
    C --> D[Dispatch frontier workers in parallel]
    D --> E[Independent ticket review]
    E --> F[Push ticket branch and run PR review]
    F --> G{Integration head unchanged?}
    G -- No --> E
    G -- Yes --> H[Land one ticket serially]
    H --> I{More tickets unblocked?}
    I -- Yes --> D
    I -- No --> J[Refresh integration branch against base]
    J --> K[Full suite and final independent review]
    K --> L[Open final PR and wait for green checks]
    L --> M[Leave PR open for user]
```
</details>

<sub>Reviews (9): Last reviewed commit: ["Review the pushed landing candidate"](https://github.com/egma-ai/egma/commit/59edb233194f59c1e52f4712b3de6361ee984a7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51717786)</sub>

<!-- /greptile_comment -->