### PR TITLE
Bind each agent repository to one Egma platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,18 @@ EGMA_ENCRYPTION_KEY=
 # Where a browser reaches this instance. The pages and the API answer on one
 # origin, so this is both of them, and it is always your own — nothing about
 # logging in reaches a domain egma runs.
+#
+# It must be the whole address people use and nothing more: scheme, host and
+# port. An agent repository reads this instance's identity here before it sends
+# anything, and it will not follow an instance to an address the developer did
+# not give it — so an instance that others reach at 192.168.1.10 or at
+# egma.example must say so here rather than leave the localhost default, or
+# their first command refuses and says which of the two addresses to fix.
+#
+# Changed in the self-hosted release: a value carrying a path, query, fragment
+# or credentials is now refused at startup instead of being trimmed. Serving
+# egma under a subpath was never supported; if yours is set that way, drop
+# everything after the port. The startup message names the part to remove.
 EGMA_BASE_URL=http://localhost:3101
 
 # One organization on this deployment, and the first person to sign up claims

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ environment; see `.env.example` for the names and their defaults.
 one.** Compose supplies a development default so that `docker compose up` works
 out of the box. Change it before anybody else can reach your instance.
 
+**`EGMA_BASE_URL` is the whole address people reach this instance at, and
+nothing more than that** — scheme, host and port. It is what the pages, the
+login flow and an agent repository all use, and an agent repository will not
+follow an instance to an address the developer did not type: if others reach
+yours at `http://192.168.1.10:3101` while this says `http://localhost:3101`,
+their first command stops and names both addresses instead of quietly talking
+to their own machine.
+
+*Upgrading:* a value carrying a path, query, fragment or credentials is now
+refused when the API starts, where it used to have its trailing slashes trimmed
+and the rest kept. Serving egma under a subpath such as
+`https://egma.example/egma` never worked — the API answers at the root of this
+address — so the fix is to drop everything after the port. The startup message
+names the part to remove.
+
 **`EGMA_SIMULATOR_SERVICE_TOKEN` is what the simulator shows the API to claim
 work, and the API refuses to start without one.** The answers to a claim carry
 your live provider credentials, and port 3100 is published on the host, so the

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -222,6 +222,9 @@ export function loadConfig(
   }
 
   const givenBaseUrl = environment.EGMA_BASE_URL?.trim() || "http://localhost:3101";
+  // Keep this check at the service boundary. The CLI is a public package that
+  // is compiled, not bundled, so shared runtime code would also have to be
+  // published. The platform-origin agreement test keeps both checks aligned.
   let parsedBaseUrl: URL;
   try {
     parsedBaseUrl = new URL(givenBaseUrl);

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -241,8 +241,25 @@ export function loadConfig(
     parsedBaseUrl.search !== "" ||
     parsedBaseUrl.hash !== ""
   ) {
+    // Named part by part, and with the value it should be, because this is a
+    // narrowing: a deployment that has run happily on a base URL with a path
+    // meets it for the first time on an upgrade, and "must be only the origin"
+    // is not something to have to work out at three in the morning. The
+    // password is never repeated back; only the fact that one is there is.
+    const wrong = [
+      parsedBaseUrl.username !== "" || parsedBaseUrl.password !== ""
+        ? "a username or password"
+        : "",
+      parsedBaseUrl.pathname !== "" && parsedBaseUrl.pathname !== "/"
+        ? `the path ${parsedBaseUrl.pathname}`
+        : "",
+      parsedBaseUrl.search !== "" ? "a query" : "",
+      parsedBaseUrl.hash !== "" ? "a fragment" : "",
+    ].filter((part) => part !== "");
     throw new Error(
-      "EGMA_BASE_URL must be only the platform origin, with no credentials, path, query, or fragment",
+      `EGMA_BASE_URL must be only the address egma is reached at — scheme, host and port, nothing else — and this one carries ${wrong.join(
+        " and ",
+      )}. Set it to ${parsedBaseUrl.origin} and start egma again. Egma serves its whole public surface, including the platform identity the CLI reads, at the root of this address; anything after the port cannot be honoured and is a sign that a proxy is putting egma under a subpath, which is not supported.`,
     );
   }
   const baseUrl = parsedBaseUrl.origin;

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -221,12 +221,28 @@ export function loadConfig(
     );
   }
 
-  const baseUrl = environment.EGMA_BASE_URL?.trim() || "http://localhost:3101";
+  const givenBaseUrl = environment.EGMA_BASE_URL?.trim() || "http://localhost:3101";
+  let parsedBaseUrl: URL;
   try {
-    new URL(baseUrl);
+    parsedBaseUrl = new URL(givenBaseUrl);
   } catch {
-    throw new Error(`EGMA_BASE_URL is not a URL: ${baseUrl}`);
+    throw new Error("EGMA_BASE_URL is not a URL");
   }
+  if (!["http:", "https:"].includes(parsedBaseUrl.protocol)) {
+    throw new Error("EGMA_BASE_URL is not an HTTP origin");
+  }
+  if (
+    parsedBaseUrl.username !== "" ||
+    parsedBaseUrl.password !== "" ||
+    (parsedBaseUrl.pathname !== "" && parsedBaseUrl.pathname !== "/") ||
+    parsedBaseUrl.search !== "" ||
+    parsedBaseUrl.hash !== ""
+  ) {
+    throw new Error(
+      "EGMA_BASE_URL must be only the platform origin, with no credentials, path, query, or fragment",
+    );
+  }
+  const baseUrl = parsedBaseUrl.origin;
 
   return {
     smtp: smtpSettings(environment, baseUrl),
@@ -234,7 +250,7 @@ export function loadConfig(
     clickhouseUrl,
     host: environment.HOST?.trim() || "0.0.0.0",
     port,
-    baseUrl: baseUrl.replace(/\/+$/, ""),
+    baseUrl,
     authSecret,
     encryptionKey,
     singleOrganization: flag(environment, "EGMA_SINGLE_ORGANIZATION", true),

--- a/apps/api/src/routes/platform.ts
+++ b/apps/api/src/routes/platform.ts
@@ -6,12 +6,22 @@ export type PlatformRouteOptions = {
   readonly origin: string;
 };
 
+/**
+ * Where this contract answers.
+ *
+ * The CLI reads it at the origin a self-hoster was given, which is the web
+ * process rather than this one, so the web rewrites have to carry the same
+ * path. It is a constant here so the agreement between the three can be
+ * checked rather than remembered.
+ */
+export const PLATFORM_IDENTITY_PATH = "/api/platform";
+
 /** Public platform facts used before device login and repository binding. */
 export const platformRoutes: FastifyPluginAsync<PlatformRouteOptions> = async (
   app,
   options,
 ) => {
-  app.get("/api/platform", async (_request, reply) =>
+  app.get(PLATFORM_IDENTITY_PATH, async (_request, reply) =>
     reply.send({
       instance_id: await platformInstanceId(),
       origin: options.origin,

--- a/apps/api/src/routes/platform.ts
+++ b/apps/api/src/routes/platform.ts
@@ -1,0 +1,20 @@
+import { platformInstanceId } from "@egma/db";
+import type { FastifyPluginAsync } from "fastify";
+
+export type PlatformRouteOptions = {
+  /** The one browser/API origin configured for this platform. */
+  readonly origin: string;
+};
+
+/** Public platform facts used before device login and repository binding. */
+export const platformRoutes: FastifyPluginAsync<PlatformRouteOptions> = async (
+  app,
+  options,
+) => {
+  app.get("/api/platform", async (_request, reply) =>
+    reply.send({
+      instance_id: await platformInstanceId(),
+      origin: options.origin,
+    }),
+  );
+};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -16,6 +16,7 @@ import { heartbeatRoutes } from "./routes/heartbeats.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { meRoutes } from "./routes/me.ts";
 import { memberRoutes } from "./routes/members.ts";
+import { platformRoutes } from "./routes/platform.ts";
 import { reportRoutes } from "./routes/reports.ts";
 import { runRoutes } from "./routes/runs.ts";
 import { signOutRoutes } from "./routes/sign-out.ts";
@@ -149,6 +150,10 @@ export function buildApi(options: ServerOptions): Api {
       .code(healthy ? 200 : 503)
       .send({ status: healthy ? "ok" : "unavailable", postgres, clickhouse });
   });
+
+  // Read before login and before any repository identifier is sent. It is
+  // public because the CLI uses it to decide whether login is safe to start.
+  void app.register(platformRoutes, { origin: config.baseUrl });
 
   // Registered without `fastify-plugin` on purpose: the adapter replaces every
   // body parser inside its own scope so the provider sees the bytes that were

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -1,6 +1,7 @@
 import type { Browser, Page } from "playwright-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { PLATFORM_IDENTITY_PATH } from "../src/routes/platform.ts";
 import { openBrowser } from "./support/browser.ts";
 import {
   capturedRequests,
@@ -78,6 +79,39 @@ beforeAll(async () => {
 afterAll(async () => {
   await browser?.close();
   await instance?.close();
+});
+
+describe("what a self-hoster's origin answers before anybody logs in", () => {
+  /**
+   * The address a self-hoster is handed is this one — the pages — and it is the
+   * address they paste into `npx egma --url`. The CLI reads the platform's
+   * identity there before it sends a single repository identifier, so the read
+   * has to survive the trip through this process. Proved here rather than
+   * against the API's own port, because a rewrite that forgot this path would
+   * pass every test that talks straight to the API and would still make a
+   * running platform unusable from an agent repository.
+   */
+  it("serves the platform identity through the pages, at the origin the CLI is given", async () => {
+    const read = await fetch(`${origin}${PLATFORM_IDENTITY_PATH}`, {
+      headers: { accept: "application/json" },
+    });
+    expect(read.status).toBe(200);
+
+    const identity = (await read.json()) as {
+      instance_id: string;
+      origin: string;
+    };
+    expect(identity.instance_id).toMatch(/^pf_[0-9A-HJKMNP-TV-Z]{26}$/u);
+    expect(identity.origin).toBe(origin);
+
+    // The API's own port answers the same thing. One platform, one identity,
+    // whichever door it is read through.
+    const direct = await instance.api.inject({
+      method: "GET",
+      url: PLATFORM_IDENTITY_PATH,
+    });
+    expect(direct.json()).toEqual(identity);
+  });
 });
 
 describe("logging in from a terminal", () => {

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -116,18 +116,32 @@ describe("configuration", () => {
     );
   });
 
-  it("refuses a base URL that is not one HTTP origin", () => {
+  /**
+   * This one narrowed: a base URL carrying a path used to have its trailing
+   * slashes trimmed and the rest kept. A deployment that had been running that
+   * way meets the refusal for the first time on an upgrade, so the message has
+   * to name the part to remove and the value to use — and it must never repeat
+   * a password back, only the fact that there is one.
+   */
+  it("refuses a base URL that is not one HTTP origin, and says what to change", () => {
     expect(() =>
       loadConfig({ ...enough, EGMA_BASE_URL: "ftp://egma.acme.example" }),
     ).toThrow(/not an HTTP origin/);
-    for (const given of [
-      "https://user:password@egma.acme.example",
-      "https://egma.acme.example/api",
-      "https://egma.acme.example?one=two",
-      "https://egma.acme.example#part",
-    ]) {
+
+    const cases: readonly [string, RegExp][] = [
+      ["https://user:hunter2-not-real@egma.acme.example", /a username or password/],
+      ["https://egma.acme.example/api", /the path \/api/],
+      ["https://egma.acme.example?one=two", /a query/],
+      ["https://egma.acme.example#part", /a fragment/],
+    ];
+    for (const [given, names] of cases) {
+      expect(() => loadConfig({ ...enough, EGMA_BASE_URL: given })).toThrow(names);
+      // The value to put there instead, so nobody has to work it out.
       expect(() => loadConfig({ ...enough, EGMA_BASE_URL: given })).toThrow(
-        /must be only the platform origin/,
+        /Set it to https:\/\/egma\.acme\.example and start egma again/,
+      );
+      expect(() => loadConfig({ ...enough, EGMA_BASE_URL: given })).not.toThrow(
+        /hunter2-not-real/,
       );
     }
   });

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -116,6 +116,22 @@ describe("configuration", () => {
     );
   });
 
+  it("refuses a base URL that is not one HTTP origin", () => {
+    expect(() =>
+      loadConfig({ ...enough, EGMA_BASE_URL: "ftp://egma.acme.example" }),
+    ).toThrow(/not an HTTP origin/);
+    for (const given of [
+      "https://user:password@egma.acme.example",
+      "https://egma.acme.example/api",
+      "https://egma.acme.example?one=two",
+      "https://egma.acme.example#part",
+    ]) {
+      expect(() => loadConfig({ ...enough, EGMA_BASE_URL: given })).toThrow(
+        /must be only the platform origin/,
+      );
+    }
+  });
+
   it("defaults to the port the compose file publishes", () => {
     expect(loadConfig(enough).port).toBe(3100);
   });

--- a/apps/api/test/platform-info.test.ts
+++ b/apps/api/test/platform-info.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createApi, type TestApi } from "./support/api.ts";
+
+/**
+ * The public identity of one Egma platform.
+ *
+ * The CLI reads this before it has a credential and before it sends one
+ * repository identifier. A real database is part of this seam because the
+ * instance identity must survive an API restart instead of changing with the
+ * process that happened to answer.
+ */
+describe("the public platform identity", () => {
+  let api: TestApi;
+
+  beforeAll(async () => {
+    api = await createApi("platform_info");
+  });
+
+  afterAll(async () => {
+    await api.close();
+  });
+
+  it("returns one stable, non-secret identity and the canonical origin without a credential", async () => {
+    const first = await api.app.inject({ method: "GET", url: "/api/platform" });
+    const second = await api.app.inject({ method: "GET", url: "/api/platform" });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+
+    const identity = first.json<Record<string, unknown>>();
+    expect(Object.keys(identity).sort()).toEqual(["instance_id", "origin"]);
+    expect(identity).toEqual({
+      instance_id: expect.stringMatching(/^pf_[0-9A-HJKMNP-TV-Z]{26}$/u),
+      origin: api.config.baseUrl,
+    });
+    expect(second.json()).toEqual(identity);
+
+    const shown = JSON.stringify(identity);
+    expect(shown).not.toMatch(/secret|token|credential|cloud/iu);
+  });
+});

--- a/apps/api/test/platform-info.test.ts
+++ b/apps/api/test/platform-info.test.ts
@@ -1,42 +1,54 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { connect, disconnect } from "@egma/db";
+import type { FastifyInstance } from "fastify";
+import { expect, it } from "vitest";
 
-import { createApi, type TestApi } from "./support/api.ts";
+import { buildApi } from "../src/server.ts";
+import {
+  createMigratedDatabase,
+  TEST_ENCRYPTION_KEY,
+} from "../../../packages/db/test/support/database.ts";
+import { testConfig } from "./support/api.ts";
 
 /**
- * The public identity of one Egma platform.
+ * The public identity survives the API object that first read it.
  *
- * The CLI reads this before it has a credential and before it sends one
- * repository identifier. A real database is part of this seam because the
- * instance identity must survive an API restart instead of changing with the
- * process that happened to answer.
+ * Both objects use the same real Postgres database. Closing the first object
+ * before building the second makes this a restart proof, not two reads from
+ * one process-local value.
  */
-describe("the public platform identity", () => {
-  let api: TestApi;
-
-  beforeAll(async () => {
-    api = await createApi("platform_info");
+it("keeps one public platform identity across an API restart", async () => {
+  const database = await createMigratedDatabase("platform_info_restart");
+  connect({
+    databaseUrl: database.url,
+    maxConnections: 4,
+    encryptionKey: TEST_ENCRYPTION_KEY,
   });
+  const config = testConfig({ databaseUrl: database.url });
+  let app: FastifyInstance | undefined;
 
-  afterAll(async () => {
-    await api.close();
-  });
-
-  it("returns one stable, non-secret identity and the canonical origin without a credential", async () => {
-    const first = await api.app.inject({ method: "GET", url: "/api/platform" });
-    const second = await api.app.inject({ method: "GET", url: "/api/platform" });
-
+  try {
+    app = buildApi({ config }).app;
+    await app.ready();
+    const first = await app.inject({ method: "GET", url: "/api/platform" });
     expect(first.statusCode).toBe(200);
-    expect(second.statusCode).toBe(200);
-
     const identity = first.json<Record<string, unknown>>();
     expect(Object.keys(identity).sort()).toEqual(["instance_id", "origin"]);
     expect(identity).toEqual({
       instance_id: expect.stringMatching(/^pf_[0-9A-HJKMNP-TV-Z]{26}$/u),
-      origin: api.config.baseUrl,
+      origin: config.baseUrl,
     });
-    expect(second.json()).toEqual(identity);
 
-    const shown = JSON.stringify(identity);
-    expect(shown).not.toMatch(/secret|token|credential|cloud/iu);
-  });
+    await app.close();
+    app = buildApi({ config }).app;
+    await app.ready();
+    const afterRestart = await app.inject({ method: "GET", url: "/api/platform" });
+
+    expect(afterRestart.statusCode).toBe(200);
+    expect(afterRestart.json()).toEqual(identity);
+    expect(JSON.stringify(identity)).not.toMatch(/secret|token|credential|cloud/iu);
+  } finally {
+    await app?.close();
+    await disconnect();
+    await database.drop();
+  }
 });

--- a/apps/api/test/platform-info.test.ts
+++ b/apps/api/test/platform-info.test.ts
@@ -2,6 +2,7 @@ import { connect, disconnect } from "@egma/db";
 import type { FastifyInstance } from "fastify";
 import { expect, it } from "vitest";
 
+
 import { buildApi } from "../src/server.ts";
 import {
   createMigratedDatabase,
@@ -46,6 +47,83 @@ it("keeps one public platform identity across an API restart", async () => {
     expect(afterRestart.statusCode).toBe(200);
     expect(afterRestart.json()).toEqual(identity);
     expect(JSON.stringify(identity)).not.toMatch(/secret|token|credential|cloud/iu);
+  } finally {
+    await app?.close();
+    await disconnect();
+    await database.drop();
+  }
+});
+
+/**
+ * The route is public and unauthenticated, so an insert on every request is an
+ * open invitation: a conflicting speculative insert still writes a tuple, an
+ * index entry and a log record before discarding them, and anybody who can
+ * reach the platform could grow dead rows on this table for nothing.
+ *
+ * Both halves of the fix are proved the same way — by making the write
+ * impossible and by making the read impossible, and asking anyway.
+ */
+it("reads its identity rather than writing on every public request", async () => {
+  const database = await createMigratedDatabase("platform_info_read_only");
+  connect({
+    databaseUrl: database.url,
+    maxConnections: 4,
+    encryptionKey: TEST_ENCRYPTION_KEY,
+  });
+  const config = testConfig({ databaseUrl: database.url });
+  let app: FastifyInstance | undefined;
+
+  try {
+    app = buildApi({ config }).app;
+    await app.ready();
+    const minted = (
+      await app.inject({ method: "GET", url: "/api/platform" })
+    ).json<{ instance_id: string }>();
+    expect(minted.instance_id).toMatch(/^pf_[0-9A-HJKMNP-TV-Z]{26}$/u);
+
+    // Every later request on this process answers from what it already knows.
+    // With the row gone, an answer can only have come from memory — so this
+    // proves the requests after the first touch the table neither way.
+    await database.sql("delete from platform_instance");
+    for (let asked = 0; asked < 5; asked += 1) {
+      const again = await app.inject({ method: "GET", url: "/api/platform" });
+      expect(again.json()).toEqual({ instance_id: minted.instance_id, origin: config.baseUrl });
+    }
+    expect(
+      (await database.sql<{ count: string }>("select count(*) from platform_instance")).rows,
+    ).toEqual([{ count: "0" }]);
+
+    // And a process that has to go and look reads before it writes. The guard
+    // fires on a speculative insert too: a BEFORE INSERT trigger runs before
+    // Postgres discovers the conflict, so an insert-first implementation would
+    // fail this request instead of answering it.
+    await app.close();
+    await disconnect();
+    await database.sql(
+      "insert into platform_instance (singleton, id) values (true, $1)",
+      [minted.instance_id],
+    );
+    await database.sql(`
+      create function refuse_any_insert() returns trigger language plpgsql as $$
+      begin raise exception 'platform_instance was written to on a public read'; end $$;
+      create trigger no_write_on_read before insert on platform_instance
+        for each row execute function refuse_any_insert();
+    `);
+
+    connect({
+      databaseUrl: database.url,
+      maxConnections: 4,
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+    app = buildApi({ config }).app;
+    await app.ready();
+    const cold = await app.inject({ method: "GET", url: "/api/platform" });
+
+    expect(cold.statusCode).toBe(200);
+    expect(cold.json()).toEqual({
+      instance_id: minted.instance_id,
+      origin: config.baseUrl,
+    });
   } finally {
     await app?.close();
     await disconnect();

--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -110,6 +110,7 @@ describe("the provider's footprint on the schema", () => {
     "organization_settings",
     "persona",
     "persona_version",
+    "platform_instance",
     "project",
     "run",
     "run_event",

--- a/apps/api/test/support/instance.ts
+++ b/apps/api/test/support/instance.ts
@@ -86,6 +86,14 @@ export type InstanceOptions = {
    * answers.
    */
   readonly web?: boolean;
+  /** Every request after its body is parsed, for boundary tests. */
+  readonly observeRequest?: (request: ObservedInstanceRequest) => void;
+};
+
+export type ObservedInstanceRequest = {
+  readonly method: string;
+  readonly url: string;
+  readonly body: unknown;
 };
 
 /** A port nothing is listening on, so two test files never collide. */
@@ -161,6 +169,15 @@ export async function startInstance(
       EGMA_SINGLE_ORGANIZATION: "false",
     }),
   });
+  if (options.observeRequest !== undefined) {
+    app.addHook("preHandler", async (request) => {
+      options.observeRequest?.({
+        method: request.method,
+        url: request.url,
+        body: request.body,
+      });
+    });
+  }
   await app.listen({ host: "127.0.0.1", port: apiPort });
 
   const web: ChildProcess | undefined = withPages

--- a/apps/api/test/support/instance.ts
+++ b/apps/api/test/support/instance.ts
@@ -86,14 +86,18 @@ export type InstanceOptions = {
    * answers.
    */
   readonly web?: boolean;
-  /** Every request after its body is parsed, for boundary tests. */
+  /**
+   * Every raw HTTP request, before Fastify or authentication can refuse it.
+   * Test evidence only: this listener changes no production server.
+   */
   readonly observeRequest?: (request: ObservedInstanceRequest) => void;
 };
 
 export type ObservedInstanceRequest = {
   readonly method: string;
   readonly url: string;
-  readonly body: unknown;
+  /** The bytes seen so far. The getter holds the complete body after `end`. */
+  readonly rawBody: string;
 };
 
 /** A port nothing is listening on, so two test files never collide. */
@@ -170,11 +174,20 @@ export async function startInstance(
     }),
   });
   if (options.observeRequest !== undefined) {
-    app.addHook("preHandler", async (request) => {
+    // `prependListener` puts this before Fastify's own request listener. A
+    // Fastify hook added here would come after the route's `onRequest` auth
+    // hook and would miss the exact 401 that this boundary evidence must see.
+    app.server.prependListener("request", (request) => {
+      let rawBody = "";
+      request.on("data", (chunk: Buffer) => {
+        rawBody += chunk.toString("utf8");
+      });
       options.observeRequest?.({
-        method: request.method,
-        url: request.url,
-        body: request.body,
+        method: request.method ?? "GET",
+        url: request.url ?? "/",
+        get rawBody() {
+          return rawBody;
+        },
       });
     });
   }

--- a/apps/cli/smoke/real-platform-login.ts
+++ b/apps/cli/smoke/real-platform-login.ts
@@ -31,6 +31,7 @@ import type { Browser, Page } from "playwright-core";
 
 import { openBrowser } from "../../api/test/support/browser.ts";
 import { startInstance, type Instance } from "../../api/test/support/instance.ts";
+import { readCredentials } from "../src/platform/credentials.ts";
 import { runInTerminal } from "../test/support/pty.ts";
 import {
   approveOnly,
@@ -69,11 +70,12 @@ function envFor(home: Home): NodeJS.ProcessEnv {
 }
 
 /** What is on disk after a login, and what the file is readable by. */
-async function heldIn(home: Home): Promise<{ url: string; key: string; mode: string }> {
-  const held = JSON.parse(await readFile(home.credentials, "utf8")) as {
-    url: string;
-    key: string;
-  };
+async function heldIn(
+  home: Home,
+  origin: string,
+): Promise<{ url: string; key: string; mode: string }> {
+  const held = await readCredentials(home.credentials, origin);
+  if (held === null) throw new Error(`no credential was stored for ${origin}`);
   const mode = ((await stat(home.credentials)).mode & 0o777).toString(8);
   return { ...held, mode };
 }
@@ -178,7 +180,7 @@ async function theWizard(instance: Instance, page: Page): Promise<void> {
     say("");
     say(`scrollback: ${terminal.scrollback().trim()}`);
 
-    const held = await heldIn(home);
+    const held = await heldIn(home, instance.origin);
     check(held.url === instance.origin, "the key is stored against this instance");
     check(held.key.startsWith("egma_sk_"), "the key is a real minted key");
     check(held.mode === "600", `the credentials file is 0600 (it is 0${held.mode})`);
@@ -228,13 +230,17 @@ async function theVerb(instance: Instance, page: Page): Promise<void> {
     check(stdout.includes("status: stored"), "egma login said it stored a key");
     saysNothingAboutTenancy(stdout, "egma login");
 
-    const held = await heldIn(home);
+    const held = await heldIn(home, instance.origin);
     check(held.mode === "600", `the credentials file is 0600 (it is 0${held.mode})`);
     check(await keyWorks(instance.origin, held.key), "the stored key works on a real request");
 
-    // The second run needs nothing said at all: the address rode along with the
-    // key, and a key already held is not minted twice.
-    const again = await run(process.execPath, [CLI_ENTRY, "login"], { env: envFor(home) });
+    // The second run names the platform again because a login is machine state,
+    // not an agent repository binding. The held key is still reused.
+    const again = await run(
+      process.execPath,
+      [CLI_ENTRY, "login", "--url", instance.origin],
+      { env: envFor(home) },
+    );
     check(
       again.stdout.includes("status: already-stored") &&
         again.stdout.includes(`url: ${instance.origin}`),

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -13,8 +13,12 @@
  * nobody reads.
  */
 
-import type { PlatformAccess } from "../platform/credentials.ts";
-import { readCredentials } from "../platform/credentials.ts";
+import {
+  bindRepositoryPlatform,
+  folderPathsIn,
+  updateConfig,
+} from "../folder/egma-folder.ts";
+import { readCredentials, type VerifiedPlatformAccess } from "../platform/credentials.ts";
 import { RetellKey } from "../retell/key.ts";
 import {
   connect,
@@ -77,7 +81,7 @@ export function argumentRefusal(argument: string): string {
 
 export type ConnectCommandOptions = {
   /** Which egma, and where this machine's key is. Resolved once, by the caller. */
-  readonly access: PlatformAccess;
+  readonly access: VerifiedPlatformAccess;
   /** The folder a repository prompt path is resolved against. */
   readonly cwd: string;
   /** `--retell-agent`, when one was named. */
@@ -163,7 +167,7 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
 
   options.out(`url: ${options.access.url}`);
 
-  const held = await readCredentials(options.access.credentialsFile);
+  const held = await readCredentials(options.access.credentialsFile, options.access.url);
   if (held === null) {
     options.out("status: not-signed-in");
     options.fail(
@@ -208,6 +212,17 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
   switch (outcome.kind) {
     case "connected": {
       const { registered, config } = outcome;
+      await bindRepositoryPlatform(options.cwd, {
+        origin: options.access.url,
+        instance: options.access.instanceId,
+      });
+      await updateConfig(folderPathsIn(options.cwd).config, {
+        agent: { name: registered.agent.name, id: registered.agent.id },
+        connection: {
+          name: registered.connection.name,
+          id: registered.connection.id,
+        },
+      });
       options.out(`retell_agents: ${outcome.onTheAccount}`);
       options.out(`retell_agent_id: ${config.agentId}`);
       options.out(`retell_response_engine: ${config.engine}`);

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -176,28 +176,20 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
     return CONNECT_EXIT.notSignedIn;
   }
 
-  // Before the platform is asked to create anything, and for the same reason
-  // the wizard binds where it does: nothing that only one platform can resolve
-  // may exist in this folder without that platform written down beside it. It
-  // also refuses here, on a repository already bound elsewhere, rather than
-  // after an agent has been registered on the wrong one.
-  try {
-    await bindRepositoryPlatform(options.cwd, {
-      origin: options.access.url,
-      instance: options.access.instanceId,
-    });
-  } catch (cause) {
-    options.out("status: refused");
-    options.fail(cause instanceof Error ? cause.message : String(cause));
-    return CONNECT_EXIT.unreachable;
-  }
-
   // Read once, before anything else could consume it, and held in one local
   // for the length of the command.
   const typed = (await fromStdin(options.stdin)) || fromEnv(options.env);
   let asked = false;
 
-  const outcome = await connect({
+  // A binding written before the key was even read would leave an egma folder
+  // behind every time this command ends at "no key given" — which is the same
+  // wart the wizard used to have, and it belongs here for the same reason it
+  // belonged there. So the binding is written from inside the flow, at the one
+  // moment after which this repository owns something only this platform can
+  // resolve.
+  const binding: { refused: Error | null } = { refused: null };
+
+  const attempt = connect({
     platform: { url: held.url, key: held.key },
     cwd: options.cwd,
     repoPrompts: options.repoPrompt,
@@ -205,6 +197,20 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
     retell: options.retell,
     fetchImpl: options.fetchImpl,
     say: (line) => options.out(`note: ${line}`),
+    beforeRegistering: async () => {
+      try {
+        await bindRepositoryPlatform(options.cwd, {
+          origin: options.access.url,
+          instance: options.access.instanceId,
+        });
+      } catch (cause) {
+        // Carried out rather than answered from in here: the flow has no
+        // ending for this, and an agent must not be registered on a platform
+        // this repository has already refused.
+        binding.refused = cause instanceof Error ? cause : new Error(String(cause));
+        throw cause;
+      }
+    },
     askForKey: () => {
       // The same two lines the wizard's screen draws, so a coding agent reading
       // this is told exactly what a person is told. There is nobody to ask
@@ -224,6 +230,16 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
       return Promise.resolve(named === "" ? null : named);
     },
   });
+
+  let outcome: ConnectOutcome;
+  try {
+    outcome = await attempt;
+  } catch (cause) {
+    if (binding.refused === null) throw cause;
+    options.out("status: refused");
+    options.fail(binding.refused.message);
+    return CONNECT_EXIT.unreachable;
+  }
 
   switch (outcome.kind) {
     case "connected": {

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -176,6 +176,22 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
     return CONNECT_EXIT.notSignedIn;
   }
 
+  // Before the platform is asked to create anything, and for the same reason
+  // the wizard binds where it does: nothing that only one platform can resolve
+  // may exist in this folder without that platform written down beside it. It
+  // also refuses here, on a repository already bound elsewhere, rather than
+  // after an agent has been registered on the wrong one.
+  try {
+    await bindRepositoryPlatform(options.cwd, {
+      origin: options.access.url,
+      instance: options.access.instanceId,
+    });
+  } catch (cause) {
+    options.out("status: refused");
+    options.fail(cause instanceof Error ? cause.message : String(cause));
+    return CONNECT_EXIT.unreachable;
+  }
+
   // Read once, before anything else could consume it, and held in one local
   // for the length of the command.
   const typed = (await fromStdin(options.stdin)) || fromEnv(options.env);
@@ -212,10 +228,6 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
   switch (outcome.kind) {
     case "connected": {
       const { registered, config } = outcome;
-      await bindRepositoryPlatform(options.cwd, {
-        origin: options.access.url,
-        instance: options.access.instanceId,
-      });
       await updateConfig(folderPathsIn(options.cwd).config, {
         agent: { name: registered.agent.name, id: registered.agent.id },
         connection: {

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -34,6 +34,7 @@ function named(name: string | null): NamedThing | null {
 
 export async function runInitCommand(options: InitCommandOptions): Promise<number> {
   const config: FolderConfig = {
+    platform: null,
     agent: named(options.names.agent),
     connection: named(options.names.connection),
     suite: named(options.names.suite),

--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -60,18 +60,32 @@ export type NamedThing = {
   readonly id: string | null;
 };
 
+/** The non-secret identity of the one Egma platform that owns this folder. */
+export type PlatformBinding = {
+  /** The platform's canonical, normalized web origin. */
+  readonly origin: string;
+  /** The stable platform-instance identifier read from that origin. */
+  readonly instance: string;
+};
+
 /**
  * What the folder points at. Each may be unset — the folder can exist before
  * the thing it names does, which is what lets `egma init` run in a repository
  * that has not been connected to anything yet.
  */
 export type FolderConfig = {
+  readonly platform: PlatformBinding | null;
   readonly agent: NamedThing | null;
   readonly connection: NamedThing | null;
   readonly suite: NamedThing | null;
 };
 
-export const EMPTY_CONFIG: FolderConfig = { agent: null, connection: null, suite: null };
+export const EMPTY_CONFIG: FolderConfig = {
+  platform: null,
+  agent: null,
+  connection: null,
+  suite: null,
+};
 
 /** The three keys, in the order they are written and read. */
 const CONFIG_KEYS = ["agent", "connection", "suite"] as const;
@@ -85,6 +99,13 @@ const CONFIG_HEADER = [
 
 export function serializeConfig(config: FolderConfig): string {
   const lines = [...CONFIG_HEADER];
+  if (config.platform == null) {
+    lines.push("platform:");
+  } else {
+    lines.push("platform:");
+    lines.push(`  origin: ${yamlScalar(config.platform.origin)}`);
+    lines.push(`  instance: ${yamlScalar(config.platform.instance)}`);
+  }
   for (const key of CONFIG_KEYS) {
     const named = config[key];
     if (named === null) {
@@ -102,6 +123,28 @@ export function serializeConfig(config: FolderConfig): string {
 
 export function parseConfig(document: string, where: string): FolderConfig {
   const mapping = readYaml(document, where);
+  const platformMapping = mappingAtKey(mapping, "platform");
+  const platformScalar = textAt(mapping, "platform");
+  const platform =
+    platformMapping === null
+      ? (() => {
+          if (platformScalar !== null) {
+            throw new Error(
+              `${where} has a platform value without an origin and instance. Run the Egma wizard to repair the repository binding.`,
+            );
+          }
+          return null;
+        })()
+      : (() => {
+          const origin = textAt(platformMapping, "origin");
+          const instance = textAt(platformMapping, "instance");
+          if (origin === null || instance === null) {
+            throw new Error(
+              `${where} has an incomplete platform binding. Run the Egma wizard to repair it.`,
+            );
+          }
+          return { origin, instance };
+        })();
   const read = (key: (typeof CONFIG_KEYS)[number]): NamedThing | null => {
     const under = mappingAtKey(mapping, key);
     if (under === null) {
@@ -114,7 +157,12 @@ export function parseConfig(document: string, where: string): FolderConfig {
     return name === null ? null : { name, id: textAt(under, "id") };
   };
 
-  return { agent: read("agent"), connection: read("connection"), suite: read("suite") };
+  return {
+    platform,
+    agent: read("agent"),
+    connection: read("connection"),
+    suite: read("suite"),
+  };
 }
 
 export async function readConfig(file: string): Promise<FolderConfig> {
@@ -136,12 +184,54 @@ export async function updateConfig(
 ): Promise<FolderConfig> {
   const held = await readConfig(file);
   const updated: FolderConfig = {
+    platform: changes.platform === undefined ? held.platform : changes.platform,
     agent: changes.agent === undefined ? held.agent : changes.agent,
     connection: changes.connection === undefined ? held.connection : changes.connection,
     suite: changes.suite === undefined ? held.suite : changes.suite,
   };
   await writeConfig(file, updated);
   return updated;
+}
+
+/**
+ * Commit the verified platform before the wizard can create platform-owned
+ * resource identifiers.
+ *
+ * A retry is byte-stable. A verified canonical-origin change for the same
+ * stable instance is recorded. A different instance is refused because
+ * repository rebinding is a separate product operation.
+ */
+export async function bindRepositoryPlatform(
+  repository: string,
+  binding: PlatformBinding,
+): Promise<FolderConfig> {
+  const paths = folderPathsIn(repository);
+  let held: FolderConfig;
+  try {
+    held = await readConfig(paths.config);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+    return (
+      await createEgmaFolder({
+        repository,
+        config: { ...EMPTY_CONFIG, platform: binding },
+      })
+    ).config;
+  }
+
+  if (held.platform !== null) {
+    if (held.platform.instance !== binding.instance) {
+      throw new Error(
+        `This repository is already bound to Egma platform ${held.platform.instance} at ${held.platform.origin}. Rebinding is not supported yet.`,
+      );
+    }
+    // The stable instance is the boundary. Its canonical origin can change,
+    // and the public identity read is the source of truth for that origin.
+    return held.platform.origin === binding.origin
+      ? held
+      : updateConfig(paths.config, { platform: binding });
+  }
+  return updateConfig(paths.config, { platform: binding });
 }
 
 export type CreateFolderOptions = {

--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -194,12 +194,15 @@ export async function updateConfig(
 }
 
 /**
- * Commit the verified platform before the wizard can create platform-owned
- * resource identifiers.
+ * Commit the verified platform before anything creates platform-owned resource
+ * identifiers.
  *
- * A retry is byte-stable. A verified canonical-origin change for the same
- * stable instance is recorded. A different instance is refused because
- * repository rebinding is a separate product operation.
+ * A retry is byte-stable. **A binding that is already here is never rewritten,
+ * not in either field.** The instance is the identity boundary, and the origin
+ * is the address every clone of this repository will use — so a run that
+ * quietly changed either would be moving other people's repository for them.
+ * Both differences are refused and say what to do about it, and the address one
+ * is normally caught earlier still, before any address is asked anything.
  */
 export async function bindRepositoryPlatform(
   repository: string,
@@ -225,11 +228,12 @@ export async function bindRepositoryPlatform(
         `This repository is already bound to Egma platform ${held.platform.instance} at ${held.platform.origin}. Rebinding is not supported yet.`,
       );
     }
-    // The stable instance is the boundary. Its canonical origin can change,
-    // and the public identity read is the source of truth for that origin.
-    return held.platform.origin === binding.origin
-      ? held
-      : updateConfig(paths.config, { platform: binding });
+    if (held.platform.origin !== binding.origin) {
+      throw new Error(
+        `This repository records Egma platform ${held.platform.instance} at ${held.platform.origin}, and this run reached it at ${binding.origin}. egma will not move a committed platform address for you. Use ${held.platform.origin}, or edit egma/config.yaml on purpose.`,
+      );
+    }
+    return held;
   }
   return updateConfig(paths.config, { platform: binding });
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -30,11 +30,23 @@ import { runLoginCommand } from "./commands/login.ts";
 import { runPullCommand } from "./commands/pull.ts";
 import { runPushCommand } from "./commands/push.ts";
 import { runRunCommand } from "./commands/run.ts";
-import { resolvePlatformAccess, UnusableUrlError } from "./platform/credentials.ts";
+import {
+  BoundPlatformUnavailableError,
+  credentialsFileIn,
+  DEFAULT_PLATFORM_URL,
+  PlatformBindingMismatchError,
+  RepositoryPlatformConfigError,
+  resolvePlatformAccess,
+  UnusableUrlError,
+  type PlatformAccess,
+  type VerifiedPlatformAccess,
+} from "./platform/credentials.ts";
+import { PlatformUnreachableError } from "./platform/device-flow.ts";
+import { PlatformIdentityError } from "./platform/identity.ts";
 import { RETELL_API } from "./retell/client.ts";
 import { HeadlessUI } from "./ui/headless-ui.ts";
 import { buildExitNotice, exitLines, type ExitReport } from "./wizard/exit-line.ts";
-import type { PlatformAccess } from "./wizard/login-step.ts";
+import type { PlatformAccess as WizardPlatformAccess } from "./wizard/login-step.ts";
 import { pasteFallbackMessage } from "./wizard/no-coding-agent.ts";
 import type { StopReason } from "./wizard/stop.ts";
 
@@ -216,9 +228,9 @@ export function helpText(): string {
     "  --coding-agent <id>  Which coding agent to drive, named as the agent",
     `                       registry names it. Default: ${DEFAULT_DRIVEN_AGENT_ID}`,
     "  --cwd <path>         The folder to work in. Default: this folder.",
-    "  --url <address>      The egma to talk to, for a self-hosted one. Kept",
-    "                       after the first login, so it is set once. EGMA_URL",
-    "                       does the same for a whole shell.",
+    "  --url <address>      The egma to talk to. The wizard records its verified",
+    "                       identity in egma/config.yaml. EGMA_URL selects one",
+    "                       for a whole shell.",
     "  --force              With login: sign in again even when this machine",
     "                       already holds a key.",
     "  --no-follow          With run: start the run and return at once, without",
@@ -242,7 +254,8 @@ export function helpText(): string {
     "",
     "Environment:",
     "  EGMA_URL             The egma to talk to, for a whole shell. Same as --url.",
-    "  EGMA_HOME            The folder egma keeps this machine's key in.",
+    "  EGMA_HOME            The folder egma keeps this machine's keys in, one",
+    "                       for each platform origin.",
     "                       Default: ~/.egma",
     `  ${KEY_VARIABLES[0]}  Your Retell key, for egma connect. ${KEY_VARIABLES[1]}`,
     "                       is read too, so an environment that already has one",
@@ -411,7 +424,7 @@ async function runHeadless(
   invocation: Invocation,
   launch: DrivenAgentLaunch,
   cwd: string,
-  platform: PlatformAccess,
+  platform: WizardPlatformAccess,
 ): Promise<number> {
   const controller = new AbortController();
   const stop = (reason: StopReason): void => controller.abort(reason);
@@ -446,7 +459,7 @@ async function runHeadless(
 async function runWizard(
   launch: DrivenAgentLaunch,
   cwd: string,
-  platform: PlatformAccess,
+  platform: WizardPlatformAccess,
 ): Promise<number> {
   const { startTui, walk } = await wizardMachinery();
   const controller = new AbortController();
@@ -551,7 +564,10 @@ async function runLogin(invocation: Invocation, access: PlatformAccess): Promise
 }
 
 /** The connect verb: a key from a pipe or the environment, and plain lines. */
-async function runConnect(invocation: Invocation, access: PlatformAccess): Promise<number> {
+async function runConnect(
+  invocation: Invocation,
+  access: VerifiedPlatformAccess,
+): Promise<number> {
   const controller = new AbortController();
   const onSignal = (): void => controller.abort("interrupt");
   process.on("SIGINT", onSignal);
@@ -607,16 +623,71 @@ export async function main(argv: readonly string[]): Promise<void> {
     return;
   }
 
+  const cwd = path.resolve(invocation.cwd ?? process.cwd());
+
+  // `init` is only a local folder write. It never verifies a platform, signs
+  // in, or sends an identifier anywhere.
+  if (invocation.verb === "init") {
+    process.exitCode = await runFolderVerb(invocation.verb, invocation, {
+      url: DEFAULT_PLATFORM_URL,
+      credentialsFile: credentialsFileIn(process.env),
+    });
+    return;
+  }
+
+  let launch: DrivenAgentLaunch | undefined;
+  if (invocation.verb === null) {
+    // Consent is checked before a network read. A piped bare command cannot
+    // start either the wizard or platform selection.
+    const drawable = process.stdout.isTTY === true && process.stdin.isTTY === true;
+    if (!invocation.headless && !drawable) {
+      process.stderr.write(`${noTerminalRefusal()}\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    try {
+      launch = launchFrom(invocation);
+    } catch (error) {
+      if (error instanceof UnlaunchableDrivenAgentError) {
+        process.stdout.write(`${error.message}\n\n${pasteFallbackMessage()}\n`);
+        return;
+      }
+      throw error;
+    }
+  }
+
   // Which egma, resolved once for every path below, and refused here when the
   // address a developer named is not one. A bad address is turned away before
   // anything is started on it rather than after.
-  let access: PlatformAccess;
+  let access: VerifiedPlatformAccess;
   try {
-    access = await resolvePlatformAccess({ env: process.env, flag: invocation.url });
+    access = await resolvePlatformAccess({
+      env: process.env,
+      flag: invocation.url,
+      cwd,
+    });
   } catch (error) {
     if (error instanceof UnusableUrlError) {
       process.stderr.write(`${error.message}\n`);
       process.exitCode = 1;
+      return;
+    }
+    if (
+      error instanceof PlatformUnreachableError ||
+      error instanceof PlatformIdentityError ||
+      error instanceof PlatformBindingMismatchError ||
+      error instanceof BoundPlatformUnavailableError ||
+      error instanceof RepositoryPlatformConfigError
+    ) {
+      const status =
+        error instanceof PlatformBindingMismatchError ||
+        error instanceof RepositoryPlatformConfigError
+          ? "refused"
+          : "unreachable";
+      process.stdout.write(`status: ${status}\nreason: ${error.message}\n`);
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 4;
       return;
     }
     throw error;
@@ -633,7 +704,6 @@ export async function main(argv: readonly string[]): Promise<void> {
     return;
   }
   if (
-    invocation.verb === "init" ||
     invocation.verb === "pull" ||
     invocation.verb === "push" ||
     invocation.verb === "run"
@@ -642,33 +712,7 @@ export async function main(argv: readonly string[]): Promise<void> {
     return;
   }
 
-  // The wizard earns consent with one keystroke, and a terminal that cannot
-  // deliver one cannot give it. Falling back to a run nobody agreed to would
-  // drive the developer's coding agent because a pipe was on the end of the
-  // command, so egma refuses and names the flag that means "I agree".
-  const drawable = process.stdout.isTTY === true && process.stdin.isTTY === true;
-  if (!invocation.headless && !drawable) {
-    process.stderr.write(`${noTerminalRefusal()}\n`);
-    process.exitCode = 1;
-    return;
-  }
-
-  const cwd = path.resolve(invocation.cwd ?? process.cwd());
-
-  let launch: DrivenAgentLaunch;
-  try {
-    launch = launchFrom(invocation);
-  } catch (error) {
-    if (error instanceof UnlaunchableDrivenAgentError) {
-      // There is no coding agent here for egma to drive, so there is nothing to
-      // open a wizard for. The developer gets the words that work anyway.
-      process.stdout.write(`${error.message}\n\n${pasteFallbackMessage()}\n`);
-      return;
-    }
-    throw error;
-  }
-
   process.exitCode = invocation.headless
-    ? await runHeadless(invocation, launch, cwd, access)
-    : await runWizard(launch, cwd, access);
+    ? await runHeadless(invocation, launch!, cwd, access)
+    : await runWizard(launch!, cwd, access);
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -31,6 +31,7 @@ import { runPullCommand } from "./commands/pull.ts";
 import { runPushCommand } from "./commands/push.ts";
 import { runRunCommand } from "./commands/run.ts";
 import {
+  BoundPlatformAddressError,
   BoundPlatformUnavailableError,
   credentialsFileIn,
   DEFAULT_PLATFORM_URL,
@@ -42,7 +43,10 @@ import {
   type VerifiedPlatformAccess,
 } from "./platform/credentials.ts";
 import { PlatformUnreachableError } from "./platform/device-flow.ts";
-import { PlatformIdentityError } from "./platform/identity.ts";
+import {
+  PlatformIdentityError,
+  PlatformOriginMismatchError,
+} from "./platform/identity.ts";
 import { RETELL_API } from "./retell/client.ts";
 import { HeadlessUI } from "./ui/headless-ui.ts";
 import { buildExitNotice, exitLines, type ExitReport } from "./wizard/exit-line.ts";
@@ -635,7 +639,12 @@ export async function main(argv: readonly string[]): Promise<void> {
     return;
   }
 
-  let launch: DrivenAgentLaunch | undefined;
+  // The wizard's remaining work, held as one closure rather than a launch the
+  // compiler cannot prove is there. Everything a bare command needs — the
+  // keystroke of consent, the coding agent it will drive — is settled here,
+  // before a single network read, and what comes out is either the rest of the
+  // walk or nothing at all.
+  let theWizard: ((access: VerifiedPlatformAccess) => Promise<number>) | null = null;
   if (invocation.verb === null) {
     // Consent is checked before a network read. A piped bare command cannot
     // start either the wizard or platform selection.
@@ -646,6 +655,7 @@ export async function main(argv: readonly string[]): Promise<void> {
       return;
     }
 
+    let launch: DrivenAgentLaunch;
     try {
       launch = launchFrom(invocation);
     } catch (error) {
@@ -655,6 +665,10 @@ export async function main(argv: readonly string[]): Promise<void> {
       }
       throw error;
     }
+    theWizard = async (access) =>
+      invocation.headless
+        ? runHeadless(invocation, launch, cwd, access)
+        : runWizard(launch, cwd, access);
   }
 
   // Which egma, resolved once for every path below, and refused here when the
@@ -673,20 +687,24 @@ export async function main(argv: readonly string[]): Promise<void> {
       process.exitCode = 1;
       return;
     }
+    // Two shapes, and the difference is whether anything is worth retrying.
+    // `unreachable` is nobody answering; `refused` is egma declining to send
+    // this repository's identifiers to the address on offer.
+    const refused =
+      error instanceof PlatformBindingMismatchError ||
+      error instanceof BoundPlatformAddressError ||
+      error instanceof PlatformOriginMismatchError ||
+      error instanceof RepositoryPlatformConfigError;
     if (
+      refused ||
       error instanceof PlatformUnreachableError ||
       error instanceof PlatformIdentityError ||
-      error instanceof PlatformBindingMismatchError ||
-      error instanceof BoundPlatformUnavailableError ||
-      error instanceof RepositoryPlatformConfigError
+      error instanceof BoundPlatformUnavailableError
     ) {
-      const status =
-        error instanceof PlatformBindingMismatchError ||
-        error instanceof RepositoryPlatformConfigError
-          ? "refused"
-          : "unreachable";
-      process.stdout.write(`status: ${status}\nreason: ${error.message}\n`);
-      process.stderr.write(`${error.message}\n`);
+      const status = refused ? "refused" : "unreachable";
+      const message = (error as Error).message;
+      process.stdout.write(`status: ${status}\nreason: ${message}\n`);
+      process.stderr.write(`${message}\n`);
       process.exitCode = 4;
       return;
     }
@@ -712,7 +730,7 @@ export async function main(argv: readonly string[]): Promise<void> {
     return;
   }
 
-  process.exitCode = invocation.headless
-    ? await runHeadless(invocation, launch!, cwd, access)
-    : await runWizard(launch!, cwd, access);
+  // Every verb has returned by now, so what is left is the bare command, and
+  // the walk it needs was built above.
+  if (theWizard !== null) process.exitCode = await theWizard(access);
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -35,6 +35,9 @@ import {
   BoundPlatformUnavailableError,
   credentialsFileIn,
   DEFAULT_PLATFORM_URL,
+  DefaultPlatformUnusableError,
+  KEYS_UNUSABLE,
+  KeysUnusableError,
   PlatformBindingMismatchError,
   RepositoryPlatformConfigError,
   resolvePlatformAccess,
@@ -268,6 +271,10 @@ export function helpText(): string {
     `  ${RETELL_URL_VARIABLE}      The Retell to talk to. Default: ${RETELL_API}`,
     `  ${EXISTING_TESTS_VARIABLE}  Your existing test cases, same as --existing-tests.`,
     "  VISUAL, EDITOR       What e opens a generated test in, at the gate.",
+    "",
+    "When egma cannot use this machine's keys — the file is damaged, or another",
+    `egma is holding it — every command prints status: ${KEYS_UNUSABLE} with the`,
+    "reason, changes nothing, and answers 1.",
     "",
     "What egma login prints, one fact per line:",
     "  url, code, approve_url, browser, waiting, status, credentials",
@@ -699,7 +706,8 @@ export async function main(argv: readonly string[]): Promise<void> {
       refused ||
       error instanceof PlatformUnreachableError ||
       error instanceof PlatformIdentityError ||
-      error instanceof BoundPlatformUnavailableError
+      error instanceof BoundPlatformUnavailableError ||
+      error instanceof DefaultPlatformUnusableError
     ) {
       const status = refused ? "refused" : "unreachable";
       const message = (error as Error).message;
@@ -711,26 +719,38 @@ export async function main(argv: readonly string[]): Promise<void> {
     throw error;
   }
 
-  // A verb needs no terminal and takes no keystroke: it drives no coding agent,
-  // so there is nothing for a keystroke to agree to.
-  if (invocation.verb === "login") {
-    process.exitCode = await runLogin(invocation, access);
-    return;
-  }
-  if (invocation.verb === "connect") {
-    process.exitCode = await runConnect(invocation, access);
-    return;
-  }
-  if (
-    invocation.verb === "pull" ||
-    invocation.verb === "push" ||
-    invocation.verb === "run"
-  ) {
-    process.exitCode = await runFolderVerb(invocation.verb, invocation, access);
-    return;
-  }
+  try {
+    // A verb needs no terminal and takes no keystroke: it drives no coding
+    // agent, so there is nothing for a keystroke to agree to.
+    if (invocation.verb === "login") {
+      process.exitCode = await runLogin(invocation, access);
+      return;
+    }
+    if (invocation.verb === "connect") {
+      process.exitCode = await runConnect(invocation, access);
+      return;
+    }
+    if (
+      invocation.verb === "pull" ||
+      invocation.verb === "push" ||
+      invocation.verb === "run"
+    ) {
+      process.exitCode = await runFolderVerb(invocation.verb, invocation, access);
+      return;
+    }
 
-  // Every verb has returned by now, so what is left is the bare command, and
-  // the walk it needs was built above.
-  if (theWizard !== null) process.exitCode = await theWizard(access);
+    // Every verb has returned by now, so what is left is the bare command, and
+    // the walk it needs was built above.
+    if (theWizard !== null) process.exitCode = await theWizard(access);
+  } catch (error) {
+    if (!(error instanceof KeysUnusableError)) throw error;
+    // Whatever is wrong with this machine's keys file, egma decided not to
+    // write over it — and a decision is a sentence, not a stack trace. Every
+    // verb can hit this and none of them owns it, so it is caught in the one
+    // place they all pass through, and it answers the same way everywhere
+    // rather than borrowing a number that means something else per verb.
+    process.stdout.write(`status: ${KEYS_UNUSABLE}\nreason: ${error.message}\n`);
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/apps/cli/src/platform/address.ts
+++ b/apps/cli/src/platform/address.ts
@@ -14,12 +14,6 @@
  * the one thing that cannot start anything.
  */
 
-/** True when this is a whole address egma can talk to: http or https, no more. */
-export function isWebAddress(candidate: string): boolean {
-  const parsed = parse(candidate);
-  return parsed !== null;
-}
-
 /**
  * Characters an address does not need and a command interpreter reads as
  * syntax. Whitespace and control characters are in here for the same reason:

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -24,7 +24,14 @@ import {
 } from "./identity.ts";
 import { PlatformUnreachableError, type Fetch } from "./device-flow.ts";
 
-/** The egma a command talks to when nothing says otherwise. */
+/**
+ * The address a command falls back to when nothing else names one.
+ *
+ * It is egma's own built-in default and not a platform the developer runs, so
+ * nothing that goes wrong there is theirs to go and inspect. Anything it
+ * answers is reported as "egma's default address is not usable, name yours" —
+ * never as a deployment somebody ought to go and fix.
+ */
 export const DEFAULT_PLATFORM_URL = "https://app.egma.ai";
 
 /** Owner only, on the file and on the folder that holds it. */
@@ -67,13 +74,35 @@ type CredentialEntries = ReadonlyMap<string, string>;
  * nothing, renames itself over the file, and every other platform's key is
  * gone. A truncated file is recoverable; a file egma overwrote is not.
  */
-export class CredentialsFileUnreadableError extends Error {
+/**
+ * Something is wrong with this machine's keys file, and egma stopped.
+ *
+ * One family, because every command reaches this file and none of them owns
+ * it: whoever is driving needs one word to branch on rather than a list to
+ * keep up with.
+ */
+export abstract class KeysUnusableError extends Error {}
+
+/** The `status:` line every command prints when the keys file cannot be used. */
+export const KEYS_UNUSABLE = "unusable-keys";
+
+export class CredentialsFileUnreadableError extends KeysUnusableError {
   constructor(file: string, cause: unknown) {
     super(
       `egma could not read the keys in ${file}, so it stopped rather than write over them. Look at that file. If it is damaged, move it aside and sign in again — you will be signed out of every platform, which is why egma will not do that for you.`,
       { cause },
     );
     this.name = "CredentialsFileUnreadableError";
+  }
+}
+
+/** Another egma held the keys file for longer than this one would wait. */
+export class CredentialsFileBusyError extends KeysUnusableError {
+  constructor(file: string, lock: string) {
+    super(
+      `egma waited for another egma to finish writing ${file} and it did not. If nothing else is running, delete ${lock} and try again.`,
+    );
+    this.name = "CredentialsFileBusyError";
   }
 }
 
@@ -187,11 +216,7 @@ async function whileLocked<T>(file: string, work: () => Promise<T>): Promise<T> 
         await rm(lock, { force: true });
         continue;
       }
-      if (Date.now() > until) {
-        throw new Error(
-          `egma waited for another egma to finish writing ${file} and it did not. If nothing else is running, delete ${lock} and try again.`,
-        );
-      }
+      if (Date.now() > until) throw new CredentialsFileBusyError(file, lock);
       await new Promise((resume) => setTimeout(resume, 50));
     }
   }
@@ -397,6 +422,25 @@ export class BoundPlatformUnavailableError extends Error {
   }
 }
 
+/**
+ * Nothing named a platform, and the built-in default is not one.
+ *
+ * The developer never typed this address, does not run what is at it, and
+ * cannot fix it — so the sentence points at the one move that is theirs: name
+ * their own platform. Every other refusal in this file describes a deployment
+ * somebody can go and look at, and saying that about this address would send a
+ * developer off to inspect a website that is not theirs.
+ */
+export class DefaultPlatformUnusableError extends Error {
+  constructor(cause: unknown) {
+    super(
+      `This repository names no Egma platform, so egma tried its built-in default at ${DEFAULT_PLATFORM_URL}, and that did not answer as an Egma platform. Point egma at yours: run it again with --url <address>, or set EGMA_URL for this shell. Nothing was sent.`,
+      { cause },
+    );
+    this.name = "DefaultPlatformUnusableError";
+  }
+}
+
 /** The committed config could not safely take part in platform resolution. */
 export class RepositoryPlatformConfigError extends Error {
   constructor(cause: unknown) {
@@ -451,11 +495,12 @@ export async function resolvePlatformAccess(choice: {
   } catch (cause) {
     // Safe to name the binding here, and only here: any address that is not the
     // bound one was already refused above, so a bound repository that got this
-    // far was reaching its own platform. An unbound one is told about the
-    // address it actually named, which is the only one it has.
+    // far was reaching its own platform.
     if (binding !== null && cause instanceof PlatformUnreachableError) {
       throw new BoundPlatformUnavailableError(binding, cause);
     }
+    // Nobody chose this address, so nobody can be sent to go and look at it.
+    if (selected.source === "cloud") throw new DefaultPlatformUnusableError(cause);
     throw cause;
   }
 

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -102,7 +102,7 @@ function entriesIn(raw: string): CredentialEntries {
 /** What is on disk for one platform, or `null` when none is usable there. */
 export async function readCredentials(
   file: string,
-  platformUrl?: string,
+  platformUrl: string,
 ): Promise<Credentials | null> {
   let raw: string;
   try {
@@ -112,21 +112,12 @@ export async function readCredentials(
   }
 
   const entries = entriesIn(raw);
-  let origin: string | undefined;
-  if (platformUrl === undefined) {
-    // Compatibility for readers that inspect a one-platform file. Product
-    // resolution never calls this branch: a machine-wide recent login must
-    // not choose a repository target.
-    if (entries.size !== 1) return null;
-    origin = entries.keys().next().value as string | undefined;
-  } else {
-    try {
-      origin = normalizePlatformOrigin(platformUrl);
-    } catch {
-      return null;
-    }
+  let origin: string;
+  try {
+    origin = normalizePlatformOrigin(platformUrl);
+  } catch {
+    return null;
   }
-  if (origin === undefined) return null;
   const key = entries.get(origin);
   return key === undefined ? null : { url: origin, key };
 }

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -150,18 +150,36 @@ function entriesIn(raw: string, file: string): CredentialEntries {
   return entries;
 }
 
+/**
+ * The keys file's bytes, or `null` when there is no keys file yet.
+ *
+ * **Only `ENOENT` means nobody has signed in here.** Every other way a read can
+ * fail — a permission change, a directory standing where the file goes, a
+ * machine out of descriptors — means the keys are there and egma cannot see
+ * them, which is the one thing that must never be mistaken for an empty file.
+ * The write below merges what this returns, so a read that quietly answered
+ * nothing would be every other platform's key deleted by the next login.
+ *
+ * Both callers go through here rather than each opening the file themselves,
+ * because this distinction is exactly the kind that gets fixed on one path and
+ * left on the other.
+ */
+async function bytesOf(file: string): Promise<string | null> {
+  try {
+    return await readFile(file, "utf8");
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new CredentialsFileUnreadableError(file, cause);
+  }
+}
+
 /** What is on disk for one platform, or `null` when none is usable there. */
 export async function readCredentials(
   file: string,
   platformUrl: string,
 ): Promise<Credentials | null> {
-  let raw: string;
-  try {
-    raw = await readFile(file, "utf8");
-  } catch {
-    // No file is not a damaged file. Nobody has signed in here yet.
-    return null;
-  }
+  const raw = await bytesOf(file);
+  if (raw === null) return null;
 
   const entries = entriesIn(raw, file);
   let origin: string;
@@ -264,13 +282,12 @@ export async function writeCredentials(
 
   // Read, merge and replace, with nothing else allowed in between.
   await whileLocked(file, async () => {
-    let existing = "";
-    try {
-      existing = await readFile(file, "utf8");
-    } catch {
-      // The first login has nothing to merge.
-    }
-    const entries = new Map(entriesIn(existing, file));
+    // `null` here is the first login, which has nothing to merge. A file that
+    // is there and cannot be read stops this instead: what follows renames a
+    // freshly built document over the target, so carrying on with nothing
+    // merged would replace every platform's key with just this one.
+    const existing = await bytesOf(file);
+    const entries = new Map(entriesIn(existing ?? "", file));
     const origin = normalizePlatformOrigin(credentials.url);
     entries.set(origin, credentials.key);
 

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -1,11 +1,9 @@
 /**
- * The key egma mints for this machine, and which egma it belongs to.
+ * The keys Egma mints for this machine, keyed by platform origin.
  *
- * One flat file in the developer's home folder, readable by nobody else. It
- * holds two facts, and they are kept together because they always travel
- * together: a key minted against one instance means nothing against another, so
- * remembering the key without remembering the address would leave a developer
- * re-typing the address on every command afterwards.
+ * One file in the developer's home folder is readable by nobody else. Each key
+ * stays beside the normalized origin that minted it. The file never chooses a
+ * repository target; the repository binding does that.
  *
  * The folder is resolved rather than assumed. That is what lets a test and a
  * check against a real instance each run a whole login without ever reading or
@@ -18,7 +16,13 @@ import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
-import { isWebAddress } from "./address.ts";
+import { folderPathsIn, readConfig, type PlatformBinding } from "../folder/egma-folder.ts";
+import {
+  normalizePlatformOrigin,
+  readPlatformIdentity,
+  type PlatformIdentity,
+} from "./identity.ts";
+import { PlatformUnreachableError, type Fetch } from "./device-flow.ts";
 
 /** The egma a command talks to when nothing says otherwise. */
 export const DEFAULT_PLATFORM_URL = "https://app.egma.ai";
@@ -53,19 +57,53 @@ export function credentialsFileIn(env: NodeJS.ProcessEnv): string {
   return path.join(egmaFolderIn(env), "credentials");
 }
 
-/**
- * An address in the one shape everything else compares against.
- *
- * A trailing slash and a stored address that differs from a typed one only by
- * that slash are the same instance, and treating them as two would mint a
- * second key for the same egma.
- */
-export function tidyUrl(url: string): string {
-  return url.trim().replace(/\/+$/u, "");
+type CredentialEntries = ReadonlyMap<string, string>;
+
+function entriesIn(raw: string): CredentialEntries {
+  try {
+    const held = JSON.parse(raw) as {
+      url?: unknown;
+      key?: unknown;
+      platforms?: unknown;
+    };
+
+    const entries = new Map<string, string>();
+
+    // The first shipped format held one pair. It is read so an upgrade does
+    // not sign a developer out, and the next write moves it into the map.
+    if (typeof held.url === "string" && typeof held.key === "string") {
+      try {
+        const origin = normalizePlatformOrigin(held.url);
+        const key = held.key.trim();
+        if (key !== "") entries.set(origin, key);
+      } catch {
+        // Not a usable legacy entry.
+      }
+    }
+
+    if (typeof held.platforms === "object" && held.platforms !== null) {
+      for (const [givenOrigin, value] of Object.entries(held.platforms)) {
+        if (typeof value !== "object" || value === null || !("key" in value)) continue;
+        const key = typeof value.key === "string" ? value.key.trim() : "";
+        if (key === "") continue;
+        try {
+          entries.set(normalizePlatformOrigin(givenOrigin), key);
+        } catch {
+          // One bad hand-edited key must not hide every usable platform entry.
+        }
+      }
+    }
+    return entries;
+  } catch {
+    return new Map();
+  }
 }
 
-/** What is on disk, or `null` when there is nothing usable there. */
-export async function readCredentials(file: string): Promise<Credentials | null> {
+/** What is on disk for one platform, or `null` when none is usable there. */
+export async function readCredentials(
+  file: string,
+  platformUrl?: string,
+): Promise<Credentials | null> {
   let raw: string;
   try {
     raw = await readFile(file, "utf8");
@@ -73,18 +111,24 @@ export async function readCredentials(file: string): Promise<Credentials | null>
     return null;
   }
 
-  try {
-    const held = JSON.parse(raw) as { url?: unknown; key?: unknown };
-    const url = typeof held.url === "string" ? tidyUrl(held.url) : "";
-    const key = typeof held.key === "string" ? held.key.trim() : "";
-    if (url === "" || key === "") return null;
-    return { url, key };
-  } catch {
-    // A file somebody edited by hand, or half a write. Either way there is
-    // nothing to log in with, and saying so sends the developer through login
-    // rather than through a parse error.
-    return null;
+  const entries = entriesIn(raw);
+  let origin: string | undefined;
+  if (platformUrl === undefined) {
+    // Compatibility for readers that inspect a one-platform file. Product
+    // resolution never calls this branch: a machine-wide recent login must
+    // not choose a repository target.
+    if (entries.size !== 1) return null;
+    origin = entries.keys().next().value as string | undefined;
+  } else {
+    try {
+      origin = normalizePlatformOrigin(platformUrl);
+    } catch {
+      return null;
+    }
   }
+  if (origin === undefined) return null;
+  const key = entries.get(origin);
+  return key === undefined ? null : { url: origin, key };
 }
 
 export type WriteOptions = {
@@ -126,11 +170,22 @@ export async function writeCredentials(
     );
   }
 
-  const document = `${JSON.stringify(
-    { url: tidyUrl(credentials.url), key: credentials.key },
-    null,
-    2,
-  )}\n`;
+  let existing = "";
+  try {
+    existing = await readFile(file, "utf8");
+  } catch {
+    // The first login has nothing to merge.
+  }
+  const entries = new Map(entriesIn(existing));
+  const origin = normalizePlatformOrigin(credentials.url);
+  entries.set(origin, credentials.key);
+
+  const platforms = Object.fromEntries(
+    [...entries.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([url, key]) => [url, { key }]),
+  );
+  const document = `${JSON.stringify({ version: 1, platforms }, null, 2)}\n`;
 
   const fresh = path.join(folder, `.credentials-${process.pid}-${randomBytes(6).toString("hex")}`);
   await writeFile(fresh, document, { encoding: "utf8", mode: FILE_MODE, flag: "wx" });
@@ -150,15 +205,15 @@ export type PlatformChoice = {
   readonly flag?: string | null;
   /** `EGMA_URL`, which is how a self-hoster sets it for a whole shell. */
   readonly env?: string | undefined;
-  /** What the last successful login wrote, so it is set once and not again. */
-  readonly stored?: string | null;
+  /** The platform committed in this agent repository. */
+  readonly binding?: string | null;
 };
 
 /** What a developer is told when the address they named is not one. */
 export class UnusableUrlError extends Error {
-  constructor(where: string, given: string) {
+  constructor(where: string) {
     super(
-      `${where} is ${given}, and egma cannot talk to that. Give a whole address that starts with http:// or https://.`,
+      `${where} is not a platform origin Egma can use. Give a whole address that starts with http:// or https:// and contains no credentials, path, query, or fragment.`,
     );
     this.name = "UnusableUrlError";
   }
@@ -167,32 +222,30 @@ export class UnusableUrlError extends Error {
 /**
  * Which egma this command talks to.
  *
- * Deliberate beats ambient beats remembered: a flag on the command, then the
- * environment, then what login already stored, then egma's own address. The
- * order is what makes "set it once" true — after a first login against a
- * self-hosted instance, every later command finds it without being told again.
+ * Deliberate beats ambient beats committed: a flag on the command, then the
+ * environment, then the repository binding, then Egma Cloud for an unbound
+ * repository. A machine-level login never chooses a repository target.
  *
  * An address a person typed is checked here, at the edge that takes it, and a
- * bad one is refused by name rather than carried into the flow — because the
- * next thing that happens to it is that a browser is started on it. What login
- * stored is only ever an address that already passed this, so a file somebody
- * edited by hand is stepped over rather than made into a refusal on every
- * command afterwards.
+ * bad one is refused by name rather than carried into the flow.
  */
 export function resolvePlatformUrl(choice: PlatformChoice): string {
   const named: readonly [string, string | null | undefined][] = [
     ["--url", choice.flag],
     ["EGMA_URL", choice.env],
+    ["the repository platform binding", choice.binding],
   ];
   for (const [where, candidate] of named) {
-    const tidy = typeof candidate === "string" ? tidyUrl(candidate) : "";
+    const tidy = typeof candidate === "string" ? candidate.trim() : "";
     if (tidy === "") continue;
-    if (!isWebAddress(tidy)) throw new UnusableUrlError(where, tidy);
-    return tidy;
+    try {
+      return normalizePlatformOrigin(tidy);
+    } catch {
+      // The rejected value can itself contain a supplied password. Name only
+      // the source, never the value.
+      throw new UnusableUrlError(where);
+    }
   }
-
-  const stored = typeof choice.stored === "string" ? tidyUrl(choice.stored) : "";
-  if (stored !== "" && isWebAddress(stored)) return stored;
   return DEFAULT_PLATFORM_URL;
 }
 
@@ -201,6 +254,52 @@ export type PlatformAccess = {
   readonly url: string;
   readonly credentialsFile: string;
 };
+
+/** Platform access after its public identity has answered. */
+export type VerifiedPlatformAccess = PlatformAccess & {
+  readonly instanceId: string;
+};
+
+/** A selected instance is not the platform committed in this repository. */
+export class PlatformBindingMismatchError extends Error {
+  constructor(binding: PlatformBinding, selected: PlatformIdentity) {
+    super(
+      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, but the selected address identifies platform ${selected.instanceId} at ${selected.origin}. Remove --url or EGMA_URL to use the bound platform. Rebinding is not supported yet. No repository identifiers were sent.`,
+    );
+    this.name = "PlatformBindingMismatchError";
+  }
+}
+
+/** The bound platform did not answer, and Cloud was deliberately not tried. */
+export class BoundPlatformUnavailableError extends Error {
+  constructor(binding: PlatformBinding, selected: string, cause: unknown) {
+    super(
+      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and Egma at ${selected} did not answer. Start the bound platform and run this again. Egma Cloud was not used, and no repository identifiers were sent.`,
+      { cause },
+    );
+    this.name = "BoundPlatformUnavailableError";
+  }
+}
+
+/** The committed config could not safely take part in platform resolution. */
+export class RepositoryPlatformConfigError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "Egma could not read this repository's egma/config.yaml, so it did not select a platform. Fix that file and run this again. Egma Cloud was not used.",
+      { cause },
+    );
+    this.name = "RepositoryPlatformConfigError";
+  }
+}
+
+async function bindingIn(repository: string): Promise<PlatformBinding | null> {
+  try {
+    return (await readConfig(folderPathsIn(repository).config)).platform;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new RepositoryPlatformConfigError(cause);
+  }
+}
 
 /**
  * Resolved once, in one place, so the wizard and every verb read the same
@@ -212,15 +311,35 @@ export async function resolvePlatformAccess(choice: {
   readonly env: NodeJS.ProcessEnv;
   /** `--url`, when one was given. */
   readonly flag: string | null;
-}): Promise<PlatformAccess> {
+  /** The agent repository whose binding is part of resolution. */
+  readonly cwd: string;
+  readonly fetchImpl?: Fetch;
+}): Promise<VerifiedPlatformAccess> {
   const credentialsFile = credentialsFileIn(choice.env);
-  const stored = await readCredentials(credentialsFile);
+  const binding = await bindingIn(choice.cwd);
+  const selected = resolvePlatformUrl({
+    flag: choice.flag,
+    env: choice.env.EGMA_URL,
+    binding: binding?.origin ?? null,
+  });
+
+  let identity: PlatformIdentity;
+  try {
+    identity = await readPlatformIdentity(selected, choice.fetchImpl);
+  } catch (cause) {
+    if (binding !== null && cause instanceof PlatformUnreachableError) {
+      throw new BoundPlatformUnavailableError(binding, selected, cause);
+    }
+    throw cause;
+  }
+
+  if (binding !== null && binding.instance !== identity.instanceId) {
+    throw new PlatformBindingMismatchError(binding, identity);
+  }
+
   return {
-    url: resolvePlatformUrl({
-      flag: choice.flag,
-      env: choice.env.EGMA_URL,
-      stored: stored?.url ?? null,
-    }),
+    url: identity.origin,
+    instanceId: identity.instanceId,
     credentialsFile,
   };
 }

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -11,7 +11,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -59,44 +59,66 @@ export function credentialsFileIn(env: NodeJS.ProcessEnv): string {
 
 type CredentialEntries = ReadonlyMap<string, string>;
 
-function entriesIn(raw: string): CredentialEntries {
-  try {
-    const held = JSON.parse(raw) as {
-      url?: unknown;
-      key?: unknown;
-      platforms?: unknown;
-    };
-
-    const entries = new Map<string, string>();
-
-    // The first shipped format held one pair. It is read so an upgrade does
-    // not sign a developer out, and the next write moves it into the map.
-    if (typeof held.url === "string" && typeof held.key === "string") {
-      try {
-        const origin = normalizePlatformOrigin(held.url);
-        const key = held.key.trim();
-        if (key !== "") entries.set(origin, key);
-      } catch {
-        // Not a usable legacy entry.
-      }
-    }
-
-    if (typeof held.platforms === "object" && held.platforms !== null) {
-      for (const [givenOrigin, value] of Object.entries(held.platforms)) {
-        if (typeof value !== "object" || value === null || !("key" in value)) continue;
-        const key = typeof value.key === "string" ? value.key.trim() : "";
-        if (key === "") continue;
-        try {
-          entries.set(normalizePlatformOrigin(givenOrigin), key);
-        } catch {
-          // One bad hand-edited key must not hide every usable platform entry.
-        }
-      }
-    }
-    return entries;
-  } catch {
-    return new Map();
+/**
+ * The file is here and egma cannot make sense of it.
+ *
+ * This is a refusal and not a shrug on purpose. Treating an unreadable file as
+ * an empty one reads well until the next login writes: the write starts from
+ * nothing, renames itself over the file, and every other platform's key is
+ * gone. A truncated file is recoverable; a file egma overwrote is not.
+ */
+export class CredentialsFileUnreadableError extends Error {
+  constructor(file: string, cause: unknown) {
+    super(
+      `egma could not read the keys in ${file}, so it stopped rather than write over them. Look at that file. If it is damaged, move it aside and sign in again — you will be signed out of every platform, which is why egma will not do that for you.`,
+      { cause },
+    );
+    this.name = "CredentialsFileUnreadableError";
   }
+}
+
+function entriesIn(raw: string, file: string): CredentialEntries {
+  // An empty file is an empty file: a first login can find one where a folder
+  // was made and nothing was written yet.
+  if (raw.trim() === "") return new Map();
+
+  let held: { url?: unknown; key?: unknown; platforms?: unknown };
+  try {
+    held = JSON.parse(raw) as typeof held;
+  } catch (cause) {
+    throw new CredentialsFileUnreadableError(file, cause);
+  }
+  if (typeof held !== "object" || held === null) {
+    throw new CredentialsFileUnreadableError(file, new Error("not a JSON object"));
+  }
+
+  const entries = new Map<string, string>();
+
+  // The first shipped format held one pair. It is read so an upgrade does not
+  // sign a developer out, and the next write moves it into the map.
+  if (typeof held.url === "string" && typeof held.key === "string") {
+    try {
+      const origin = normalizePlatformOrigin(held.url);
+      const key = held.key.trim();
+      if (key !== "") entries.set(origin, key);
+    } catch {
+      // Not a usable legacy entry.
+    }
+  }
+
+  if (typeof held.platforms === "object" && held.platforms !== null) {
+    for (const [givenOrigin, value] of Object.entries(held.platforms)) {
+      if (typeof value !== "object" || value === null || !("key" in value)) continue;
+      const key = typeof value.key === "string" ? value.key.trim() : "";
+      if (key === "") continue;
+      try {
+        entries.set(normalizePlatformOrigin(givenOrigin), key);
+      } catch {
+        // One bad hand-edited key must not hide every usable platform entry.
+      }
+    }
+  }
+  return entries;
 }
 
 /** What is on disk for one platform, or `null` when none is usable there. */
@@ -108,10 +130,11 @@ export async function readCredentials(
   try {
     raw = await readFile(file, "utf8");
   } catch {
+    // No file is not a damaged file. Nobody has signed in here yet.
     return null;
   }
 
-  const entries = entriesIn(raw);
+  const entries = entriesIn(raw, file);
   let origin: string;
   try {
     origin = normalizePlatformOrigin(platformUrl);
@@ -126,6 +149,59 @@ export type WriteOptions = {
   /** Where a folder egma could not lock down is said out loud. */
   readonly warn?: (line: string) => void;
 };
+
+/** How long a write waits for another one to finish before giving up. */
+const LOCK_WAIT_MS = 5_000;
+/** After this, a lock is a leftover from something that died holding it. */
+const LOCK_STALE_MS = 30_000;
+
+/**
+ * Hold the file while it is read, merged and replaced.
+ *
+ * The write is a read-modify-write over everybody's keys, so two of them
+ * running together is one platform's key being dropped: both read the same
+ * file, both merge their own entry into it, and the second rename wins. Two
+ * terminals in two repositories signing in at once is an ordinary Tuesday, and
+ * the loser finds out the next time a command says "not signed in".
+ *
+ * A neighbouring file taken with `wx` is the whole mechanism, because `wx` is
+ * one atomic question the filesystem answers for exactly one caller. A lock
+ * left behind by something that died is taken over once it is plainly old, so
+ * a crash cannot lock a developer out of signing in.
+ */
+async function whileLocked<T>(file: string, work: () => Promise<T>): Promise<T> {
+  const lock = `${file}.lock`;
+  const until = Date.now() + LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      await writeFile(lock, `${String(process.pid)}\n`, {
+        encoding: "utf8",
+        mode: FILE_MODE,
+        flag: "wx",
+      });
+      break;
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+      const held = await stat(lock).catch(() => undefined);
+      if (held !== undefined && Date.now() - held.mtimeMs > LOCK_STALE_MS) {
+        await rm(lock, { force: true });
+        continue;
+      }
+      if (Date.now() > until) {
+        throw new Error(
+          `egma waited for another egma to finish writing ${file} and it did not. If nothing else is running, delete ${lock} and try again.`,
+        );
+      }
+      await new Promise((resume) => setTimeout(resume, 50));
+    }
+  }
+
+  try {
+    return await work();
+  } finally {
+    await rm(lock, { force: true });
+  }
+}
 
 /**
  * Write the key, owner-readable and no wider.
@@ -161,34 +237,40 @@ export async function writeCredentials(
     );
   }
 
-  let existing = "";
-  try {
-    existing = await readFile(file, "utf8");
-  } catch {
-    // The first login has nothing to merge.
-  }
-  const entries = new Map(entriesIn(existing));
-  const origin = normalizePlatformOrigin(credentials.url);
-  entries.set(origin, credentials.key);
+  // Read, merge and replace, with nothing else allowed in between.
+  await whileLocked(file, async () => {
+    let existing = "";
+    try {
+      existing = await readFile(file, "utf8");
+    } catch {
+      // The first login has nothing to merge.
+    }
+    const entries = new Map(entriesIn(existing, file));
+    const origin = normalizePlatformOrigin(credentials.url);
+    entries.set(origin, credentials.key);
 
-  const platforms = Object.fromEntries(
-    [...entries.entries()]
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([url, key]) => [url, { key }]),
-  );
-  const document = `${JSON.stringify({ version: 1, platforms }, null, 2)}\n`;
+    const platforms = Object.fromEntries(
+      [...entries.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([url, key]) => [url, { key }]),
+    );
+    const document = `${JSON.stringify({ version: 1, platforms }, null, 2)}\n`;
 
-  const fresh = path.join(folder, `.credentials-${process.pid}-${randomBytes(6).toString("hex")}`);
-  await writeFile(fresh, document, { encoding: "utf8", mode: FILE_MODE, flag: "wx" });
-  try {
-    // The umask can only narrow what a file is created with, never widen it, so
-    // this is the one that makes 0600 true rather than 0600-or-less.
-    await chmod(fresh, FILE_MODE);
-    await rename(fresh, file);
-  } catch (cause) {
-    await rm(fresh, { force: true });
-    throw cause;
-  }
+    const fresh = path.join(
+      folder,
+      `.credentials-${process.pid}-${randomBytes(6).toString("hex")}`,
+    );
+    await writeFile(fresh, document, { encoding: "utf8", mode: FILE_MODE, flag: "wx" });
+    try {
+      // The umask can only narrow what a file is created with, never widen it,
+      // so this is the one that makes 0600 true rather than 0600-or-less.
+      await chmod(fresh, FILE_MODE);
+      await rename(fresh, file);
+    } catch (cause) {
+      await rm(fresh, { force: true });
+      throw cause;
+    }
+  });
 }
 
 export type PlatformChoice = {
@@ -210,34 +292,59 @@ export class UnusableUrlError extends Error {
   }
 }
 
+/** Where a selected address came from. It decides who a refusal names. */
+export type PlatformSource = "--url" | "EGMA_URL" | "binding" | "cloud";
+
+export type SelectedPlatform = {
+  readonly url: string;
+  readonly source: PlatformSource;
+};
+
+const SOURCE_NAMES: Record<PlatformSource, string> = {
+  "--url": "--url",
+  EGMA_URL: "EGMA_URL",
+  binding: "the repository platform binding",
+  cloud: "Egma Cloud",
+};
+
 /**
- * Which egma this command talks to.
+ * Which egma this command talks to, and which of the four places said so.
  *
  * Deliberate beats ambient beats committed: a flag on the command, then the
  * environment, then the repository binding, then Egma Cloud for an unbound
  * repository. A machine-level login never chooses a repository target.
  *
+ * The source travels with the address because a refusal that names the wrong
+ * platform sends a developer to fix something they did not ask for: told to
+ * start the platform this repository is bound to when what they actually named
+ * on the command line is the one that is down.
+ *
  * An address a person typed is checked here, at the edge that takes it, and a
  * bad one is refused by name rather than carried into the flow.
  */
-export function resolvePlatformUrl(choice: PlatformChoice): string {
-  const named: readonly [string, string | null | undefined][] = [
+export function selectPlatform(choice: PlatformChoice): SelectedPlatform {
+  const named: readonly [PlatformSource, string | null | undefined][] = [
     ["--url", choice.flag],
     ["EGMA_URL", choice.env],
-    ["the repository platform binding", choice.binding],
+    ["binding", choice.binding],
   ];
-  for (const [where, candidate] of named) {
+  for (const [source, candidate] of named) {
     const tidy = typeof candidate === "string" ? candidate.trim() : "";
     if (tidy === "") continue;
     try {
-      return normalizePlatformOrigin(tidy);
+      return { url: normalizePlatformOrigin(tidy), source };
     } catch {
       // The rejected value can itself contain a supplied password. Name only
       // the source, never the value.
-      throw new UnusableUrlError(where);
+      throw new UnusableUrlError(SOURCE_NAMES[source]);
     }
   }
-  return DEFAULT_PLATFORM_URL;
+  return { url: DEFAULT_PLATFORM_URL, source: "cloud" };
+}
+
+/** The address alone, for callers that do not have to say where it came from. */
+export function resolvePlatformUrl(choice: PlatformChoice): string {
+  return selectPlatform(choice).url;
 }
 
 /** Which egma a run signs in to, and where the key it gets is kept. */
@@ -261,11 +368,29 @@ export class PlatformBindingMismatchError extends Error {
   }
 }
 
+/**
+ * A bound repository was pointed at a different address than the one it
+ * recorded, whoever is answering there.
+ *
+ * Separate from the instance mismatch above because it is refused before
+ * anybody answers: rebinding is out of this effort either way, and the same
+ * instance served at a new address is still a change to a committed file that
+ * a developer has to make on purpose rather than have made for them.
+ */
+export class BoundPlatformAddressError extends Error {
+  constructor(binding: PlatformBinding, source: PlatformSource, selected: string) {
+    super(
+      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and ${SOURCE_NAMES[source]} names ${selected} instead. Drop it to use the bound platform. If the platform really has moved, edit the platform origin in egma/config.yaml on purpose — rebinding is not supported yet. No repository identifiers were sent.`,
+    );
+    this.name = "BoundPlatformAddressError";
+  }
+}
+
 /** The bound platform did not answer, and Cloud was deliberately not tried. */
 export class BoundPlatformUnavailableError extends Error {
-  constructor(binding: PlatformBinding, selected: string, cause: unknown) {
+  constructor(binding: PlatformBinding, cause: unknown) {
     super(
-      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and Egma at ${selected} did not answer. Start the bound platform and run this again. Egma Cloud was not used, and no repository identifiers were sent.`,
+      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and it did not answer. Start the bound platform and run this again. Egma Cloud was not used, and no repository identifiers were sent.`,
       { cause },
     );
     this.name = "BoundPlatformUnavailableError";
@@ -308,18 +433,28 @@ export async function resolvePlatformAccess(choice: {
 }): Promise<VerifiedPlatformAccess> {
   const credentialsFile = credentialsFileIn(choice.env);
   const binding = await bindingIn(choice.cwd);
-  const selected = resolvePlatformUrl({
+  const selected = selectPlatform({
     flag: choice.flag,
     env: choice.env.EGMA_URL,
     binding: binding?.origin ?? null,
   });
 
+  // Refused before anybody is asked anything: a bound repository is reached at
+  // the address it recorded, and at no other.
+  if (binding !== null && selected.url !== binding.origin) {
+    throw new BoundPlatformAddressError(binding, selected.source, selected.url);
+  }
+
   let identity: PlatformIdentity;
   try {
-    identity = await readPlatformIdentity(selected, choice.fetchImpl);
+    identity = await readPlatformIdentity(selected.url, choice.fetchImpl);
   } catch (cause) {
+    // Safe to name the binding here, and only here: any address that is not the
+    // bound one was already refused above, so a bound repository that got this
+    // far was reaching its own platform. An unbound one is told about the
+    // address it actually named, which is the only one it has.
     if (binding !== null && cause instanceof PlatformUnreachableError) {
-      throw new BoundPlatformUnavailableError(binding, selected, cause);
+      throw new BoundPlatformUnavailableError(binding, cause);
     }
     throw cause;
   }

--- a/apps/cli/src/platform/identity.ts
+++ b/apps/cli/src/platform/identity.ts
@@ -1,0 +1,84 @@
+/**
+ * The public identity read every Egma platform serves before login.
+ *
+ * The CLI asks this before it sends a repository identifier. That makes an
+ * instance mismatch a local refusal instead of a 404 from the wrong platform.
+ */
+
+import { PlatformUnreachableError, type Fetch } from "./device-flow.ts";
+
+const PLATFORM_INSTANCE_ID = /^pf_[0-9A-HJKMNP-TV-Z]{26}$/u;
+
+export type PlatformIdentity = {
+  readonly instanceId: string;
+  readonly origin: string;
+};
+
+/** One origin shape for comparison, configuration, and credential lookup. */
+export function normalizePlatformOrigin(candidate: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate.trim());
+  } catch {
+    throw new Error("not a web address");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("not an HTTP web address");
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new Error("an origin cannot contain a username or password");
+  }
+  if (
+    (parsed.pathname !== "" && parsed.pathname !== "/") ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new Error("an origin cannot contain a path, query, or fragment");
+  }
+  return parsed.origin;
+}
+
+/** A platform answered, but not with the public contract the CLI requires. */
+export class PlatformIdentityError extends Error {
+  constructor(origin: string) {
+    super(
+      `egma at ${origin} did not return a usable platform identity. Check the address and update egma before you try again.`,
+    );
+    this.name = "PlatformIdentityError";
+  }
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export async function readPlatformIdentity(
+  selected: string,
+  fetchImpl: Fetch = fetch,
+): Promise<PlatformIdentity> {
+  const selectedOrigin = normalizePlatformOrigin(selected);
+  let response: Response;
+  try {
+    response = await fetchImpl(`${selectedOrigin}/api/platform`, {
+      method: "GET",
+      headers: { accept: "application/json" },
+    });
+  } catch (cause) {
+    throw new PlatformUnreachableError(selectedOrigin, cause);
+  }
+
+  if (!response.ok) throw new PlatformIdentityError(selectedOrigin);
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  const instanceId = text(body.instance_id);
+  const statedOrigin = text(body.origin);
+
+  let origin: string;
+  try {
+    origin = normalizePlatformOrigin(statedOrigin);
+  } catch {
+    throw new PlatformIdentityError(selectedOrigin);
+  }
+  if (!PLATFORM_INSTANCE_ID.test(instanceId)) throw new PlatformIdentityError(selectedOrigin);
+
+  return { instanceId, origin };
+}

--- a/apps/cli/src/platform/identity.ts
+++ b/apps/cli/src/platform/identity.ts
@@ -9,6 +9,18 @@ import { PlatformUnreachableError, type Fetch } from "./device-flow.ts";
 
 const PLATFORM_INSTANCE_ID = /^pf_[0-9A-HJKMNP-TV-Z]{26}$/u;
 
+/**
+ * The one path this contract lives at, on every platform.
+ *
+ * It is a constant rather than a literal because three places have to agree on
+ * it: the API that serves it, the web process that forwards it at the origin a
+ * self-hoster was actually given, and this reader. A rewrite that missed it
+ * would leave a self-hosted platform unable to prove its own identity, and the
+ * agreement test names the constant so that disagreement fails a check instead
+ * of a developer's first command.
+ */
+export const PLATFORM_IDENTITY_PATH = "/api/platform";
+
 export type PlatformIdentity = {
   readonly instanceId: string;
   readonly origin: string;
@@ -62,7 +74,7 @@ export async function readPlatformIdentity(
   const selectedOrigin = normalizePlatformOrigin(selected);
   let response: Response;
   try {
-    response = await fetchImpl(`${selectedOrigin}/api/platform`, {
+    response = await fetchImpl(`${selectedOrigin}${PLATFORM_IDENTITY_PATH}`, {
       method: "GET",
       headers: { accept: "application/json" },
     });

--- a/apps/cli/src/platform/identity.ts
+++ b/apps/cli/src/platform/identity.ts
@@ -16,6 +16,9 @@ export type PlatformIdentity = {
 
 /** One origin shape for comparison, configuration, and credential lookup. */
 export function normalizePlatformOrigin(candidate: string): string {
+  // This public CLI is compiled, not bundled. Importing the API check would
+  // create a private runtime dependency. The agreement test keeps both checks
+  // aligned until the CLI distribution changes.
   let parsed: URL;
   try {
     parsed = new URL(candidate.trim());

--- a/apps/cli/src/platform/identity.ts
+++ b/apps/cli/src/platform/identity.ts
@@ -108,6 +108,17 @@ export class PlatformTimedOutError extends PlatformUnreachableError {
   }
 }
 
+/** Whether an address only means anything on the machine that says it. */
+function isLoopback(origin: string): boolean {
+  const host = new URL(origin).hostname.toLowerCase();
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "[::1]" ||
+    /^127\./u.test(host)
+  );
+}
+
 /**
  * The platform answered to a different address than the one it was asked at.
  *
@@ -117,11 +128,28 @@ export class PlatformTimedOutError extends PlatformUnreachableError {
  * would be the whole failure this ticket exists to prevent: the CLI would leave
  * for an address nobody chose, and a repository bound on the platform's own
  * host would commit `http://localhost:3101` into a file every teammate clones.
+ *
+ * There are two of these and they want different advice. `localhost` against
+ * `127.0.0.1` is one machine calling itself two names, and either name works —
+ * so offering the other one is useful. A platform on the network still calling
+ * itself `localhost` is the failure above, and offering `localhost` to somebody
+ * on another machine sends them to their own laptop, where nothing is
+ * listening. So the second half of the advice is only given when it is true.
  */
 export class PlatformOriginMismatchError extends Error {
   constructor(asked: string, stated: string) {
+    const statedIsOnlyItsOwnMachine = isLoopback(stated) && !isLoopback(asked);
     super(
-      `egma asked ${asked} which platform it is, and it answered that it lives at ${stated}. egma uses the address you gave it and never follows a platform to another one. Set EGMA_BASE_URL on the platform to the address people reach it at and restart it, or use ${stated} here. Nothing was sent.`,
+      [
+        `egma asked ${asked} which platform it is, and it answered that it lives at ${stated}.`,
+        "egma uses the address you gave it and never follows a platform to another one.",
+        `Set EGMA_BASE_URL on the platform to the address people reach it at and restart it${
+          statedIsOnlyItsOwnMachine
+            ? ` — ${stated} names only the platform's own machine, so nobody else can reach it there.`
+            : `, or use ${stated} here.`
+        }`,
+        "Nothing was sent.",
+      ].join(" "),
     );
     this.name = "PlatformOriginMismatchError";
   }

--- a/apps/cli/src/platform/identity.ts
+++ b/apps/cli/src/platform/identity.ts
@@ -53,13 +53,77 @@ export function normalizePlatformOrigin(candidate: string): string {
   return parsed.origin;
 }
 
+/**
+ * How long egma waits for a platform to say who it is.
+ *
+ * This read is in front of every command — push, pull, run, connect, the whole
+ * wizard — so a platform that accepts the connection and then says nothing must
+ * not be able to hang all of them with no output at all. A socket that is
+ * accepted never times out on its own.
+ */
+export const IDENTITY_TIMEOUT_MS = 10_000;
+
+/** What egma says when it cannot tell what the address in front of it is. */
+const NOT_A_PLATFORM =
+  "Check the address. If it is right, this is probably not an Egma platform, or it is older than this copy of egma.";
+
 /** A platform answered, but not with the public contract the CLI requires. */
 export class PlatformIdentityError extends Error {
-  constructor(origin: string) {
-    super(
-      `egma at ${origin} did not return a usable platform identity. Check the address and update egma before you try again.`,
-    );
+  constructor(origin: string, because: string, advice: string = NOT_A_PLATFORM) {
+    super(`egma asked ${origin} which platform it is, and ${because} ${advice}`);
     this.name = "PlatformIdentityError";
+  }
+}
+
+/**
+ * The address answered with a redirect.
+ *
+ * Worth its own sentence, and its own advice, because it is what a sign-in wall
+ * in front of a deployment looks like from here. Following it would turn a
+ * login page into "your egma is out of date", which sends the developer after a
+ * problem they do not have — and this read is on the path of every command, so
+ * the wrong diagnosis would be the first thing they ever see.
+ */
+export class PlatformRedirectedError extends PlatformIdentityError {
+  constructor(origin: string, to: string) {
+    super(
+      origin,
+      to === ""
+        ? "it answered with a redirect somewhere else instead."
+        : `it redirected to ${to} instead.`,
+      "egma does not follow that. Something in front of this address is answering for it — a sign-in page or a proxy — so this is where to look, not at your copy of egma.",
+    );
+    this.name = "PlatformRedirectedError";
+  }
+}
+
+/** The platform accepted the connection and then said nothing. */
+export class PlatformTimedOutError extends PlatformUnreachableError {
+  constructor(origin: string, cause: unknown) {
+    super(origin, cause);
+    this.message = `egma at ${origin} took the connection but did not answer within ${String(
+      IDENTITY_TIMEOUT_MS / 1000,
+    )} seconds. Check that the instance is healthy, then run this again.`;
+    this.name = "PlatformTimedOutError";
+  }
+}
+
+/**
+ * The platform answered to a different address than the one it was asked at.
+ *
+ * egma talks to the address the developer gave it and to no other. A platform
+ * that names a different canonical origin is misconfigured — its
+ * `EGMA_BASE_URL` is not the address people reach it at — and following it
+ * would be the whole failure this ticket exists to prevent: the CLI would leave
+ * for an address nobody chose, and a repository bound on the platform's own
+ * host would commit `http://localhost:3101` into a file every teammate clones.
+ */
+export class PlatformOriginMismatchError extends Error {
+  constructor(asked: string, stated: string) {
+    super(
+      `egma asked ${asked} which platform it is, and it answered that it lives at ${stated}. egma uses the address you gave it and never follows a platform to another one. Set EGMA_BASE_URL on the platform to the address people reach it at and restart it, or use ${stated} here. Nothing was sent.`,
+    );
+    this.name = "PlatformOriginMismatchError";
   }
 }
 
@@ -67,6 +131,16 @@ function text(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+/**
+ * Who answers at this address.
+ *
+ * The origin that comes back is the origin that was asked, always. The body's
+ * own `origin` is read only to be checked against it, because the one thing
+ * this read must never do is move the conversation somewhere else: everything
+ * after it — the key that is written, the identifiers that are sent, the
+ * binding that is committed to a file other people clone — is addressed to
+ * whatever this returns.
+ */
 export async function readPlatformIdentity(
   selected: string,
   fetchImpl: Fetch = fetch,
@@ -77,23 +151,53 @@ export async function readPlatformIdentity(
     response = await fetchImpl(`${selectedOrigin}${PLATFORM_IDENTITY_PATH}`, {
       method: "GET",
       headers: { accept: "application/json" },
+      // Not followed, and not merely for safety: a redirect is a fact about
+      // this address that the developer needs told, and following it would
+      // hide a sign-in wall behind a contract complaint.
+      redirect: "manual",
+      signal: AbortSignal.timeout(IDENTITY_TIMEOUT_MS),
     });
   } catch (cause) {
-    throw new PlatformUnreachableError(selectedOrigin, cause);
+    const timedOut = cause instanceof Error && cause.name === "TimeoutError";
+    throw timedOut
+      ? new PlatformTimedOutError(selectedOrigin, cause)
+      : new PlatformUnreachableError(selectedOrigin, cause);
   }
 
-  if (!response.ok) throw new PlatformIdentityError(selectedOrigin);
+  if (response.status >= 300 && response.status < 400) {
+    throw new PlatformRedirectedError(
+      selectedOrigin,
+      text(response.headers.get("location")),
+    );
+  }
+  if (!response.ok) {
+    throw new PlatformIdentityError(
+      selectedOrigin,
+      `it answered ${String(response.status)} rather than its identity.`,
+    );
+  }
+
   const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
   const instanceId = text(body.instance_id);
-  const statedOrigin = text(body.origin);
-
-  let origin: string;
-  try {
-    origin = normalizePlatformOrigin(statedOrigin);
-  } catch {
-    throw new PlatformIdentityError(selectedOrigin);
+  if (!PLATFORM_INSTANCE_ID.test(instanceId)) {
+    throw new PlatformIdentityError(
+      selectedOrigin,
+      "what came back carries no platform identity egma can use.",
+    );
   }
-  if (!PLATFORM_INSTANCE_ID.test(instanceId)) throw new PlatformIdentityError(selectedOrigin);
 
-  return { instanceId, origin };
+  let stated: string;
+  try {
+    stated = normalizePlatformOrigin(text(body.origin));
+  } catch {
+    throw new PlatformIdentityError(
+      selectedOrigin,
+      "what came back names no address egma can use.",
+    );
+  }
+  if (stated !== selectedOrigin) {
+    throw new PlatformOriginMismatchError(selectedOrigin, stated);
+  }
+
+  return { instanceId, origin: selectedOrigin };
 }

--- a/apps/cli/src/platform/login.ts
+++ b/apps/cli/src/platform/login.ts
@@ -188,7 +188,7 @@ export async function logIn(options: LogInOptions): Promise<LoginResult> {
   const now = options.now ?? Date.now;
   const fetchImpl = options.fetchImpl ?? fetch;
 
-  const held = await readCredentials(options.credentialsFile);
+  const held = await readCredentials(options.credentialsFile, options.url);
   if (options.force !== true && held !== null && held.url === options.url) {
     return { kind: "already-stored", url: held.url, key: held.key };
   }

--- a/apps/cli/src/platform/signed-in.ts
+++ b/apps/cli/src/platform/signed-in.ts
@@ -21,7 +21,7 @@ export type SignedIn = {
  * key for a different address is no key at all here.
  */
 export async function signedInAt(access: PlatformAccess): Promise<SignedIn | null> {
-  const held = await readCredentials(access.credentialsFile);
+  const held = await readCredentials(access.credentialsFile, access.url);
   if (held === null || held.url !== access.url) return null;
   return { url: access.url, key: held.key };
 }

--- a/apps/cli/src/retell/connect.ts
+++ b/apps/cli/src/retell/connect.ts
@@ -137,6 +137,17 @@ export type ConnectOptions = {
   readonly chooseAgent: (agents: readonly RetellAgent[]) => Promise<string | null>;
   /** One line about what is happening, for whoever is watching. */
   readonly say: (line: string) => void;
+  /**
+   * Run at the last moment before egma is asked to create anything, and only
+   * then.
+   *
+   * This is where the caller writes down which platform is about to own what
+   * comes back. It is a hook rather than something the caller does first
+   * because "the last moment" is in here: every ending above it — no key, a key
+   * Retell will not take, an empty account, an unanswered choice — leaves the
+   * platform with nothing in it, and must leave the repository the same way.
+   */
+  readonly beforeRegistering?: () => Promise<void>;
   /** Where Retell is. Retell's own address when omitted. */
   readonly retell?: RetellReach | undefined;
   readonly fetchImpl?: RegisterOptions["fetchImpl"];
@@ -330,6 +341,7 @@ export async function connect(options: ConnectOptions): Promise<ConnectOutcome> 
   }
 
   const config = pulled.config;
+  await options.beforeRegistering?.();
   const written = await register(keyed, config);
   if (written.kind !== "registered") return written;
 

--- a/apps/cli/src/wizard/connect-step.ts
+++ b/apps/cli/src/wizard/connect-step.ts
@@ -92,7 +92,10 @@ export type Connected = {
 export async function connectStep(options: ConnectStepOptions): Promise<Connected> {
   const { ui, signal } = options;
 
-  const held = await readCredentials(options.platform.credentialsFile);
+  const held = await readCredentials(
+    options.platform.credentialsFile,
+    options.platform.url,
+  );
   if (held === null) {
     return {
       report: {

--- a/apps/cli/src/wizard/generate-step.ts
+++ b/apps/cli/src/wizard/generate-step.ts
@@ -325,9 +325,22 @@ async function folderFor(options: GenerateStepOptions): Promise<FolderPaths> {
 
   const folder = await createEgmaFolder({
     repository: options.cwd,
-    config: { agent, connection, suite: { name: DEFAULT_SUITE_NAME, id: null } },
+    config: {
+      platform: null,
+      agent,
+      connection,
+      suite: { name: DEFAULT_SUITE_NAME, id: null },
+    },
   });
-  if (!folder.created) await updateConfig(folder.paths.config, { agent, connection });
+  if (!folder.created) {
+    await updateConfig(folder.paths.config, {
+      agent,
+      connection,
+      ...(folder.config.suite === null
+        ? { suite: { name: DEFAULT_SUITE_NAME, id: null } }
+        : {}),
+    });
+  }
   return folder.paths;
 }
 

--- a/apps/cli/src/wizard/login-step.ts
+++ b/apps/cli/src/wizard/login-step.ts
@@ -12,7 +12,7 @@
  */
 
 import { openInBrowser } from "../platform/browser.ts";
-import type { PlatformAccess as ResolvedPlatform } from "../platform/credentials.ts";
+import type { VerifiedPlatformAccess as ResolvedPlatform } from "../platform/credentials.ts";
 import { logIn, type LogInOptions } from "../platform/login.ts";
 import type { WizardUI } from "../ui/wizard-ui.ts";
 import type { ExitReport } from "./exit-line.ts";

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -117,11 +117,6 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
       ui.setExit(refusal);
       return refusal;
     }
-    await bindRepositoryPlatform(cwd, {
-      origin: options.platform.url,
-      instance: options.platform.instanceId,
-    });
-    ui.pushStatus(`Bound this repository to Egma platform ${options.platform.instanceId}.`);
   }
 
   const found = await findTheAgent({ ui, launch, cwd, signal, log });
@@ -135,6 +130,17 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
     ui.setExit(found.report);
     return found.report;
   }
+
+  // The last moment before this repository owns anything that only one platform
+  // can resolve. Committed here rather than earlier so a walk that found no
+  // agent leaves the repository exactly as it was, and rather than later so no
+  // identifier can ever exist in this folder without the platform that issued
+  // it written down beside it.
+  await bindRepositoryPlatform(cwd, {
+    origin: options.platform.url,
+    instance: options.platform.instanceId,
+  });
+  ui.pushStatus(`Bound this repository to Egma platform ${options.platform.instanceId}.`);
 
   const connected = await connectStep({
     ui,

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -17,6 +17,7 @@
 import process from "node:process";
 
 import type { DrivenAgentLaunch } from "../acp/registry.ts";
+import { bindRepositoryPlatform } from "../folder/egma-folder.ts";
 import { signedInAt } from "../platform/signed-in.ts";
 import type { ConnectOptions } from "../retell/connect.ts";
 import { homeIn } from "../skills/install.ts";
@@ -116,6 +117,11 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
       ui.setExit(refusal);
       return refusal;
     }
+    await bindRepositoryPlatform(cwd, {
+      origin: options.platform.url,
+      instance: options.platform.instanceId,
+    });
+    ui.pushStatus(`Bound this repository to Egma platform ${options.platform.instanceId}.`);
   }
 
   const found = await findTheAgent({ ui, launch, cwd, signal, log });

--- a/apps/cli/test/assembly.test.ts
+++ b/apps/cli/test/assembly.test.ts
@@ -31,6 +31,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { readConfig } from "../src/folder/egma-folder.ts";
 import { parseTestFile } from "../src/folder/test-file.ts";
+import { readCredentials } from "../src/platform/credentials.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
 import { buildExitNotice, exitLines } from "../src/wizard/exit-line.ts";
 import { walk } from "../src/wizard/walk.ts";
@@ -214,6 +215,7 @@ describe("the whole walk, offline", () => {
         signal: new AbortController().signal,
         platform: {
           url: platform.url,
+          instanceId: platform.instanceId,
           credentialsFile: workspace.credentialsFile,
           openBrowser: async (url) => {
             const code = new URL(url).searchParams.get("user_code") ?? "";
@@ -263,12 +265,9 @@ describe("the whole walk, offline", () => {
 
     /* this machine is signed in, and to this egma */
 
-    const held = JSON.parse(await readFile(workspace.credentialsFile, "utf8")) as {
-      url: string;
-      key: string;
-    };
-    expect(held.url).toBe(platform.url);
-    expect(platform.device.keys).toContain(held.key);
+    const held = await readCredentials(workspace.credentialsFile, platform.url);
+    expect(held?.url).toBe(platform.url);
+    expect(platform.device.keys).toContain(held?.key ?? "");
 
     /* the agent and the way to reach it are on egma */
 
@@ -359,6 +358,10 @@ describe("the whole walk, offline", () => {
     // The folder's config names what egma registered, so a second developer
     // cloning this repository lands on the same agent.
     const config = await readConfig(path.join(workspace.dir, "egma", "config.yaml"));
+    expect(config.platform).toEqual({
+      origin: platform.url,
+      instance: platform.instanceId,
+    });
     expect(config.agent).toMatchObject({
       name: "order-line",
       id: platform.registered.agents[0]?.id,

--- a/apps/cli/test/cli.test.ts
+++ b/apps/cli/test/cli.test.ts
@@ -10,6 +10,7 @@ import { promisify } from "node:util";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
 import {
   CLI_ENTRY,
   FAKE_AGENT,
@@ -22,6 +23,7 @@ import {
 } from "./support/workspace.ts";
 
 const run = promisify(execFile);
+let platform: Platform;
 
 async function egma(
   args: readonly string[],
@@ -30,7 +32,7 @@ async function egma(
   try {
     const { stdout, stderr } = await run(process.execPath, [CLI_ENTRY, ...args], {
       cwd: workspace.dir,
-      env: workspace.env(),
+      env: workspace.env({ EGMA_URL: platform.url }),
     });
     return { stdout, stderr, code: 0 };
   } catch (error) {
@@ -43,14 +45,16 @@ describe("the egma command", () => {
   let workspace: Workspace;
 
   beforeEach(async () => {
+    platform = await startPlatform();
     workspace = await makeWorkspace({ "package.json": MANIFEST });
     // These checks are about driving a coding agent, so the machine they run on
     // is already signed in and login costs them nothing. Login itself is proved
     // in the checks that are about login.
-    await workspace.signIn("https://egma.invalid");
+    await workspace.signIn(platform.url);
   });
 
   afterEach(async () => {
+    await platform.close();
     await workspace.remove();
   });
 
@@ -59,7 +63,7 @@ describe("the egma command", () => {
       const child = spawn(
         process.execPath,
         ["--import", PRETEND_OLD_NODE, CLI_ENTRY, "--help"],
-        { cwd: workspace.dir, env: workspace.env() },
+        { cwd: workspace.dir, env: workspace.env({ EGMA_URL: platform.url }) },
       );
       let stderr = "";
       child.stderr.setEncoding("utf8");
@@ -229,7 +233,7 @@ describe("the egma command", () => {
     const child = spawn(
       process.execPath,
       [CLI_ENTRY, "--headless", "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
-      { cwd: workspace.dir, env: workspace.env() },
+      { cwd: workspace.dir, env: workspace.env({ EGMA_URL: platform.url }) },
     );
     let stdout = "";
     child.stdout.setEncoding("utf8");

--- a/apps/cli/test/connect-command.test.ts
+++ b/apps/cli/test/connect-command.test.ts
@@ -17,7 +17,7 @@ import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { CONNECT_EXIT } from "../src/commands/connect.ts";
-import { readConfig } from "../src/folder/egma-folder.ts";
+import { folderPathsIn, readConfig } from "../src/folder/egma-folder.ts";
 import { DRIFT_LINE } from "../src/retell/prompt-drift.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
@@ -199,6 +199,27 @@ describe("egma connect", () => {
     expect(refused.code).toBe(CONNECT_EXIT.invalidKey);
     expect(facts(refused.stdout).status).toBe("invalid-key");
     expect(refused.stderr).toContain("Retell would not take that key");
+  });
+
+  /**
+   * The platform is written down before it is asked to create anything.
+   *
+   * The order is the whole point of the binding: an identifier only one
+   * platform can resolve must never exist in this folder without that platform
+   * recorded beside it. A run that bound afterwards would leave exactly that
+   * gap every time it failed in between — and this run does fail in between,
+   * on a key Retell will not take, with nothing registered.
+   */
+  it("commits the platform before it asks the platform to create anything", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+
+    const refused = await egma(["connect"], { stdin: "key_not-on-this-account" });
+    expect(refused.code).toBe(CONNECT_EXIT.invalidKey);
+
+    expect(platform.registered.agents).toHaveLength(0);
+    expect(
+      (await readConfig(folderPathsIn(workspace.dir).config)).platform,
+    ).toEqual({ origin: platform.url, instance: platform.instanceId });
   });
 
   it("says an empty account is an empty account, not a bad key", async () => {

--- a/apps/cli/test/connect-command.test.ts
+++ b/apps/cli/test/connect-command.test.ts
@@ -202,24 +202,45 @@ describe("egma connect", () => {
   });
 
   /**
-   * The platform is written down before it is asked to create anything.
+   * The platform is written down at one moment: after the last thing that
+   * could still end this command with nothing created, and before the first
+   * thing that creates something.
    *
-   * The order is the whole point of the binding: an identifier only one
-   * platform can resolve must never exist in this folder without that platform
-   * recorded beside it. A run that bound afterwards would leave exactly that
-   * gap every time it failed in between — and this run does fail in between,
-   * on a key Retell will not take, with nothing registered.
+   * Both halves matter. Bind later and an identifier could exist in this folder
+   * with no record of which platform can resolve it. Bind earlier and every
+   * ending that creates nothing — no key, a key Retell will not take, an empty
+   * account, an unanswered choice — leaves an egma folder behind in a
+   * repository the developer had not decided to use egma in yet.
    */
+  it("writes no folder for an ending that created nothing", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+    const config = folderPathsIn(workspace.dir).config;
+
+    const noKey = await egma(["connect"], { stdin: "" });
+    expect(noKey.code).toBe(CONNECT_EXIT.noKey);
+    await expect(readConfig(config)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const badKey = await egma(["connect"], { stdin: "key_not-on-this-account" });
+    expect(badKey.code).toBe(CONNECT_EXIT.invalidKey);
+    await expect(readConfig(config)).rejects.toMatchObject({ code: "ENOENT" });
+
+    expect(platform.registered.agents).toHaveLength(0);
+  });
+
   it("commits the platform before it asks the platform to create anything", async () => {
     retell = await startFakeRetell(ONE_AGENT);
 
-    const refused = await egma(["connect"], { stdin: "key_not-on-this-account" });
-    expect(refused.code).toBe(CONNECT_EXIT.invalidKey);
+    const connected = await egma(["connect"], { stdin: KEY });
+    expect(connected.code).toBe(CONNECT_EXIT.connected);
 
-    expect(platform.registered.agents).toHaveLength(0);
-    expect(
-      (await readConfig(folderPathsIn(workspace.dir).config)).platform,
-    ).toEqual({ origin: platform.url, instance: platform.instanceId });
+    const written = await readConfig(folderPathsIn(workspace.dir).config);
+    expect(written.platform).toEqual({
+      origin: platform.url,
+      instance: platform.instanceId,
+    });
+    // The order is what makes the file trustworthy: the agent that exists on
+    // the platform is named in the same file as the platform that issued it.
+    expect(written.agent?.id).toBe(platform.registered.agents[0]?.id);
   });
 
   it("says an empty account is an empty account, not a bad key", async () => {

--- a/apps/cli/test/connect-command.test.ts
+++ b/apps/cli/test/connect-command.test.ts
@@ -17,6 +17,7 @@ import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { CONNECT_EXIT } from "../src/commands/connect.ts";
+import { readConfig } from "../src/folder/egma-folder.ts";
 import { DRIFT_LINE } from "../src/retell/prompt-drift.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
@@ -146,6 +147,12 @@ describe("egma connect", () => {
 
     expect(platform.registered.agents).toHaveLength(1);
     expect(platform.registered.sealed).toEqual([KEY]);
+    expect(await readConfig(path.join(workspace.dir, "egma", "config.yaml"))).toEqual({
+      platform: { origin: platform.url, instance: platform.instanceId },
+      agent: { name: said.agent_name, id: said.agent_id },
+      connection: { name: said.connection_name, id: said.connection_id },
+      suite: null,
+    });
   });
 
   it("takes the key from the environment, under either name", async () => {

--- a/apps/cli/test/connect.test.ts
+++ b/apps/cli/test/connect.test.ts
@@ -126,7 +126,11 @@ async function run(options: RunOptions) {
 
   const { report, connected } = await connectStep({
     ui,
-    platform: { url: platform.url, credentialsFile: workspace.credentialsFile },
+    platform: {
+      url: platform.url,
+      instanceId: platform.instanceId,
+      credentialsFile: workspace.credentialsFile,
+    },
     cwd: workspace.dir,
     repoPrompts: options.repoPrompts ?? null,
     signal: new AbortController().signal,

--- a/apps/cli/test/egma-folder.test.ts
+++ b/apps/cli/test/egma-folder.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  bindRepositoryPlatform,
   createEgmaFolder,
   folderPathsIn,
   parseConfig,
@@ -305,10 +306,43 @@ describe("the test file format", () => {
 });
 
 describe("the egma folder", () => {
+  it("updates the canonical origin only when the stable platform instance is unchanged", async () => {
+    const instance = "pf_01K3XQ7M4E8YB2FVN0H9TZQWEP";
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: { origin: "https://old.example", instance },
+        agent: null,
+        connection: null,
+        suite: null,
+      },
+    });
+
+    const updated = await bindRepositoryPlatform(workspace.dir, {
+      origin: "https://canonical.example",
+      instance,
+    });
+    expect(updated.platform).toEqual({
+      origin: "https://canonical.example",
+      instance,
+    });
+
+    await expect(
+      bindRepositoryPlatform(workspace.dir, {
+        origin: "https://other.example",
+        instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEQ",
+      }),
+    ).rejects.toThrow("Rebinding is not supported yet");
+  });
+
   it("is a config file and a tests directory, and nothing else", async () => {
     const folder = await createEgmaFolder({
       repository: workspace.dir,
       config: {
+        platform: {
+          origin: "http://127.0.0.1:3101",
+          instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEP",
+        },
         agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
         connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
         suite: { name: "first-suite", id: null },
@@ -332,6 +366,9 @@ describe("the egma folder", () => {
         "#",
         "# Committed on purpose: nothing in this folder is secret. egma writes an id",
         "# beside each name once it has registered one.",
+        "platform:",
+        "  origin: http://127.0.0.1:3101",
+        "  instance: pf_01K3XQ7M4E8YB2FVN0H9TZQWEP",
         "agent:",
         "  name: receptionist",
         "  id: agt_01K3XQ7M4E8YB2FVN0H9TZQWER",
@@ -352,7 +389,12 @@ describe("the egma folder", () => {
     expect(written).toContain("agent:");
     expect(written).toContain("connection:");
     expect(written).toContain("suite:");
-    expect(folder.config).toEqual({ agent: null, connection: null, suite: null });
+    expect(folder.config).toEqual({
+      platform: null,
+      agent: null,
+      connection: null,
+      suite: null,
+    });
     // And what it wrote is what it reads back.
     expect(parseConfig(written, "config.yaml")).toEqual(folder.config);
   });
@@ -360,14 +402,24 @@ describe("the egma folder", () => {
   it("recognises a folder that is already here and changes not one byte of it", async () => {
     const first = await createEgmaFolder({
       repository: workspace.dir,
-      config: { agent: { name: "receptionist", id: null }, connection: null, suite: null },
+      config: {
+        platform: null,
+        agent: { name: "receptionist", id: null },
+        connection: null,
+        suite: null,
+      },
     });
     const before = await readFile(first.paths.config, "utf8");
     await writeFile(path.join(first.paths.tests, "kept.md"), GENERATED, "utf8");
 
     const second = await createEgmaFolder({
       repository: workspace.dir,
-      config: { agent: { name: "something-else", id: null }, connection: null, suite: null },
+      config: {
+        platform: null,
+        agent: { name: "something-else", id: null },
+        connection: null,
+        suite: null,
+      },
     });
 
     expect(second.created).toBe(false);
@@ -393,7 +445,12 @@ describe("the egma folder", () => {
   it("writes an id beside a name once egma has registered one", async () => {
     const folder = await createEgmaFolder({
       repository: workspace.dir,
-      config: { agent: { name: "receptionist", id: null }, connection: null, suite: null },
+      config: {
+        platform: null,
+        agent: { name: "receptionist", id: null },
+        connection: null,
+        suite: null,
+      },
     });
 
     const updated = await updateConfig(folder.paths.config, {
@@ -418,11 +475,13 @@ describe("the egma folder", () => {
 
   it("reads what it writes, and steps over comments while it does", () => {
     const document = serializeConfig({
+      platform: null,
       agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
       connection: null,
       suite: null,
     });
     expect(readYaml(document, "config.yaml")).toEqual({
+      platform: null,
       agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
       connection: null,
       suite: null,
@@ -432,6 +491,7 @@ describe("the egma folder", () => {
   it("writes a name that needs quoting, and reads it back with its own spaces", () => {
     for (const name of ["the front desk: mornings", "shift #2", "  padded  ", "2026", "yes"]) {
       const written = serializeConfig({
+        platform: null,
         agent: { name, id: null },
         connection: null,
         suite: null,

--- a/apps/cli/test/egma-folder.test.ts
+++ b/apps/cli/test/egma-folder.test.ts
@@ -306,33 +306,48 @@ describe("the test file format", () => {
 });
 
 describe("the egma folder", () => {
-  it("updates the canonical origin only when the stable platform instance is unchanged", async () => {
+  /**
+   * A binding that is already here is never rewritten, in either field.
+   *
+   * This file is committed and every clone of the repository reads it, so a run
+   * that quietly changed it would be moving other people's target for them —
+   * and the origin is the field that would do the most damage, because a
+   * platform that names `http://localhost:3101` as its own address would send
+   * every teammate to their own laptop.
+   */
+  it("never rewrites a platform binding that is already committed", async () => {
     const instance = "pf_01K3XQ7M4E8YB2FVN0H9TZQWEP";
+    const platform = { origin: "https://old.example", instance };
+    const paths = folderPathsIn(workspace.dir);
     await createEgmaFolder({
       repository: workspace.dir,
-      config: {
-        platform: { origin: "https://old.example", instance },
-        agent: null,
-        connection: null,
-        suite: null,
-      },
+      config: { platform, agent: null, connection: null, suite: null },
     });
+    const asCommitted = await readFile(paths.config, "utf8");
 
-    const updated = await bindRepositoryPlatform(workspace.dir, {
-      origin: "https://canonical.example",
-      instance,
-    });
-    expect(updated.platform).toEqual({
-      origin: "https://canonical.example",
-      instance,
-    });
+    // Binding again with what is there is the retry, and it changes no byte.
+    expect((await bindRepositoryPlatform(workspace.dir, platform)).platform).toEqual(
+      platform,
+    );
+    expect(await readFile(paths.config, "utf8")).toBe(asCommitted);
 
+    // The same platform reached at another address is refused, not recorded.
     await expect(
       bindRepositoryPlatform(workspace.dir, {
-        origin: "https://other.example",
+        origin: "https://canonical.example",
+        instance,
+      }),
+    ).rejects.toThrow("will not move a committed platform address");
+
+    // And another platform entirely is the refusal it always was.
+    await expect(
+      bindRepositoryPlatform(workspace.dir, {
+        origin: "https://old.example",
         instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEQ",
       }),
     ).rejects.toThrow("Rebinding is not supported yet");
+
+    expect(await readFile(paths.config, "utf8")).toBe(asCommitted);
   });
 
   it("is a config file and a tests directory, and nothing else", async () => {

--- a/apps/cli/test/failure-branches.test.ts
+++ b/apps/cli/test/failure-branches.test.ts
@@ -19,7 +19,6 @@ import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { INVALID_KEY_LINE } from "../src/retell/connect.ts";
-import { readConfig } from "../src/folder/egma-folder.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
 import { buildExitLine, buildExitNotice } from "../src/wizard/exit-line.ts";
 import { walk } from "../src/wizard/walk.ts";
@@ -215,15 +214,13 @@ describe("no voice agent anywhere", () => {
       "egma found no voice agent to test. Run egma again where your agent is defined.",
     );
 
-    // Nothing was registered. The verified platform binding remains so a later
-    // wizard run cannot silently move this repository to another platform.
+    // Nothing was registered and no folder was made, because egma never got as
+    // far as knowing what it would have been for. The platform binding is
+    // written at the last moment before this repository owns its first
+    // platform-issued identifier, and that moment never arrived — so a walk
+    // that found nothing leaves the repository exactly as it was.
     expect(platform.registered.agents).toHaveLength(0);
-    expect(await readConfig(path.join(workspace.dir, "egma", "config.yaml"))).toEqual({
-      platform: { origin: platform.url, instance: platform.instanceId },
-      agent: null,
-      connection: null,
-      suite: null,
-    });
+    await expect(readFile(path.join(workspace.dir, "egma", "config.yaml"), "utf8")).rejects.toThrow();
   });
 });
 

--- a/apps/cli/test/failure-branches.test.ts
+++ b/apps/cli/test/failure-branches.test.ts
@@ -19,6 +19,7 @@ import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { INVALID_KEY_LINE } from "../src/retell/connect.ts";
+import { readConfig } from "../src/folder/egma-folder.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
 import { buildExitLine, buildExitNotice } from "../src/wizard/exit-line.ts";
 import { walk } from "../src/wizard/walk.ts";
@@ -116,7 +117,11 @@ async function walkWith(options: {
       launch: workspace.launch(options.script),
       cwd: workspace.dir,
       signal: new AbortController().signal,
-      platform: { url: platform.url, credentialsFile: workspace.credentialsFile },
+      platform: {
+        url: platform.url,
+        instanceId: platform.instanceId,
+        credentialsFile: workspace.credentialsFile,
+      },
       retell: { url: retell.url },
       howManyTests: 1,
       home: path.join(workspace.dir, "pretend-home"),
@@ -210,10 +215,15 @@ describe("no voice agent anywhere", () => {
       "egma found no voice agent to test. Run egma again where your agent is defined.",
     );
 
-    // Nothing was registered and no folder was made, because egma never got as
-    // far as knowing what it would have been for.
+    // Nothing was registered. The verified platform binding remains so a later
+    // wizard run cannot silently move this repository to another platform.
     expect(platform.registered.agents).toHaveLength(0);
-    await expect(readFile(path.join(workspace.dir, "egma", "config.yaml"), "utf8")).rejects.toThrow();
+    expect(await readConfig(path.join(workspace.dir, "egma", "config.yaml"))).toEqual({
+      platform: { origin: platform.url, instance: platform.instanceId },
+      agent: null,
+      connection: null,
+      suite: null,
+    });
   });
 });
 

--- a/apps/cli/test/generate.test.ts
+++ b/apps/cli/test/generate.test.ts
@@ -171,7 +171,11 @@ async function runWalk(options: {
       launch: workspace.launch(options.script),
       cwd: workspace.dir,
       signal: new AbortController().signal,
-      platform: { url: platform.url, credentialsFile: workspace.credentialsFile },
+      platform: {
+        url: platform.url,
+        instanceId: platform.instanceId,
+        credentialsFile: workspace.credentialsFile,
+      },
       retell: { url: retell.url },
       home: path.join(workspace.dir, "pretend-home"),
       runPollMs: 20,

--- a/apps/cli/test/key-custody.test.ts
+++ b/apps/cli/test/key-custody.test.ts
@@ -146,7 +146,11 @@ describe("a whole run, swept afterwards", () => {
         launch: workspace.launch(script),
         cwd: workspace.dir,
         signal: new AbortController().signal,
-        platform: { url: platform.url, credentialsFile: workspace.credentialsFile },
+        platform: {
+          url: platform.url,
+          instanceId: platform.instanceId,
+          credentialsFile: workspace.credentialsFile,
+        },
         retell: { url: retell.url },
         home: path.join(workspace.dir, "pretend-home"),
         runPollMs: 20,

--- a/apps/cli/test/login-command.test.ts
+++ b/apps/cli/test/login-command.test.ts
@@ -15,6 +15,7 @@ import { promisify } from "node:util";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { readCredentials } from "../src/platform/credentials.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
 import { CLI_ENTRY, makeWorkspace, type Workspace } from "./support/workspace.ts";
 
@@ -84,10 +85,9 @@ describe("egma login", () => {
     expect((await readFile(browser.opened, "utf8")).trim()).toBe(said.approve_url);
 
     // The key is on disk, and nobody else on the machine can read it.
-    const held = JSON.parse(await readFile(workspace.credentialsFile, "utf8")) as {
-      url: string;
-      key: string;
-    };
+    const held = await readCredentials(workspace.credentialsFile, platform.url);
+    expect(held).not.toBeNull();
+    if (held === null) throw new Error("login did not store credentials");
     expect(held.url).toBe(platform.url);
     expect(held.key).toBe(platform.device.keys.at(-1));
     expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
@@ -125,15 +125,15 @@ describe("egma login", () => {
     expect(facts(stdout).status).toBe("stored");
   });
 
-  it("keeps the address it was given, so later commands never repeat it", async () => {
-    // A self-hoster sets it once, for one shell.
+  it("does not use the most recent login as the next command's target", async () => {
+    // A self-hoster selects the platform for this command.
     const first = await egma(["login"], { EGMA_URL: platform.url });
     expect(first.code).toBe(0);
     expect(facts(first.stdout).status).toBe("stored");
 
-    // And the next command finds it with nothing said at all: no flag, and the
-    // variable gone from the environment.
-    const second = await egma(["login"]);
+    // The held key does not choose a platform. Name the platform again because
+    // this repository is not bound by the standalone login command.
+    const second = await egma(["login", "--url", platform.url]);
     expect(second.code).toBe(0);
     const said = facts(second.stdout);
     expect(said.url).toBe(platform.url);
@@ -146,13 +146,15 @@ describe("egma login", () => {
 
   it("signs in again when told to, even though a key is already held", async () => {
     await egma(["login", "--url", platform.url]);
-    const again = await egma(["login", "--force"]);
+    const again = await egma(["login", "--url", platform.url, "--force"]);
 
     expect(again.code).toBe(0);
     expect(facts(again.stdout).status).toBe("stored");
     expect(platform.device.keys).toHaveLength(2);
 
-    const held = JSON.parse(await readFile(workspace.credentialsFile, "utf8")) as { key: string };
+    const held = await readCredentials(workspace.credentialsFile, platform.url);
+    expect(held).not.toBeNull();
+    if (held === null) throw new Error("login did not replace credentials");
     expect(held.key).toBe(platform.device.keys.at(-1));
   });
 
@@ -317,5 +319,19 @@ describe("egma login", () => {
     // Nothing was asked of anything: the address was turned away at the door.
     expect(platform.records).toHaveLength(0);
     expect((await readFile(browser.opened, "utf8").catch(() => ""))).toBe("");
+  });
+
+  it("never repeats a supplied password from an invalid platform URL", async () => {
+    const suppliedSecret = "supplied-password-must-stay-private";
+    const result = await egma([
+      "login",
+      "--url",
+      `https://person:${suppliedSecret}@egma.example`,
+    ]);
+
+    expect(result.code).toBe(1);
+    expect(result.stdout + result.stderr).not.toContain(suppliedSecret);
+    expect(result.stderr).toContain("--url");
+    expect(platform.records).toHaveLength(0);
   });
 });

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -557,6 +557,47 @@ describe("writing the key down", () => {
     expect((folder.mode & 0o777).toString(8)).toBe("700");
   });
 
+  it("migrates the old single-platform file without losing or exposing its key", async () => {
+    const legacy = {
+      url: "https://OLD.example/",
+      key: "egma_sk_preserved-from-the-old-format",
+    };
+    const next = {
+      url: "https://second.example",
+      key: "egma_sk_added-after-the-upgrade",
+    };
+    await mkdir(path.dirname(workspace.credentialsFile), { recursive: true });
+    await writeFile(workspace.credentialsFile, `${JSON.stringify(legacy)}\n`, {
+      encoding: "utf8",
+      mode: 0o644,
+    });
+
+    expect(await readCredentials(workspace.credentialsFile, legacy.url)).toEqual({
+      url: "https://old.example",
+      key: legacy.key,
+    });
+    const said: string[] = [];
+    await writeCredentials(workspace.credentialsFile, next, {
+      warn: (line) => said.push(line),
+    });
+
+    expect(await readCredentials(workspace.credentialsFile, legacy.url)).toEqual({
+      url: "https://old.example",
+      key: legacy.key,
+    });
+    expect(await readCredentials(workspace.credentialsFile, next.url)).toEqual(next);
+    expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
+    expect(said.join("\n")).not.toContain(legacy.key);
+    expect(said.join("\n")).not.toContain(next.key);
+    expect(JSON.parse(await readFile(workspace.credentialsFile, "utf8"))).toEqual({
+      version: 1,
+      platforms: {
+        "https://old.example": { key: legacy.key },
+        "https://second.example": { key: next.key },
+      },
+    });
+  });
+
   it("keeps one key per normalized platform origin", async () => {
     const first = { url: "https://ONE.example/", key: "egma_sk_for-one" };
     const second = { url: "http://localhost:4310", key: "egma_sk_for-two" };

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -114,7 +114,7 @@ describe("signing a machine in", () => {
     expect(watched.opened).toEqual([shown.url]);
 
     // The key landed, against the egma that minted it.
-    const held = await readCredentials(workspace.credentialsFile);
+    const held = await readCredentials(workspace.credentialsFile, platform.url);
     expect(held?.url).toBe(platform.url);
     expect(held?.key).toMatch(/^egma_sk_/u);
     expect(held?.key).toBe(platform.device.keys.at(-1));
@@ -131,7 +131,7 @@ describe("signing a machine in", () => {
       whenPrompted: (prompt) => void platform.device.approve(prompt.userCode),
     });
 
-    const held = await readCredentials(workspace.credentialsFile);
+    const held = await readCredentials(workspace.credentialsFile, platform.url);
     const used = await fetch(`${platform.url}/api/keys`, {
       headers: { authorization: `Bearer ${held?.key ?? ""}` },
     });
@@ -151,7 +151,9 @@ describe("signing a machine in", () => {
     });
 
     expect(result.kind).toBe("denied");
-    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+    expect(
+      await readCredentials(workspace.credentialsFile, platform.url),
+    ).toBeNull();
   });
 
   it("says the code ran out, which is not the same as being told no", async () => {
@@ -162,7 +164,9 @@ describe("signing a machine in", () => {
     });
 
     expect(result.kind).toBe("expired");
-    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+    expect(
+      await readCredentials(workspace.credentialsFile, platform.url),
+    ).toBeNull();
   });
 
   it("backs off by five seconds when told it is asking too fast, and stays there", async () => {
@@ -230,7 +234,9 @@ describe("signing a machine in", () => {
 
     expect(result.kind).toBe("unreachable");
     expect(result.kind === "unreachable" && result.reason).toContain("127.0.0.1:1");
-    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+    expect(
+      await readCredentials(workspace.credentialsFile, "http://127.0.0.1:1"),
+    ).toBeNull();
   });
 
   it("stops where it stands when the developer stops it", async () => {
@@ -244,7 +250,9 @@ describe("signing a machine in", () => {
     });
 
     expect(result.kind).toBe("interrupted");
-    expect(await readCredentials(workspace.credentialsFile)).toBeNull();
+    expect(
+      await readCredentials(workspace.credentialsFile, platform.url),
+    ).toBeNull();
   });
 });
 
@@ -272,7 +280,7 @@ describe("a machine that is already signed in", () => {
     });
 
     expect(result.kind).toBe("stored");
-    const held = await readCredentials(workspace.credentialsFile);
+    const held = await readCredentials(workspace.credentialsFile, platform.url);
     expect(held?.key).not.toBe("egma_sk_held-already");
     expect(held?.key).toBe(platform.device.keys.at(-1));
   });
@@ -357,9 +365,9 @@ describe("coming back from a browser on another machine", () => {
 
       expect(result.kind).toBe("stored");
       expect(watched.said).toContain("Checking that one now.");
-      expect((await readCredentials(workspace.credentialsFile))?.key).toBe(
-        platform.device.keys.at(-1),
-      );
+      expect(
+        (await readCredentials(workspace.credentialsFile, platform.url))?.key,
+      ).toBe(platform.device.keys.at(-1));
     });
   }
 
@@ -523,7 +531,7 @@ describe("writing the key down", () => {
     // The key landed in a file nobody else can read — which is only true
     // because a fresh file was renamed over this one rather than written into.
     expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
-    expect(await readCredentials(workspace.credentialsFile)).toEqual(held);
+    expect(await readCredentials(workspace.credentialsFile, held.url)).toEqual(held);
   });
 
   it("does not follow a link standing where the key goes", async () => {
@@ -539,7 +547,7 @@ describe("writing the key down", () => {
     expect(await readFile(elsewhere, "utf8")).toBe("not the key\n");
     expect((await lstat(workspace.credentialsFile)).isSymbolicLink()).toBe(false);
     expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
-    expect(await readCredentials(workspace.credentialsFile)).toEqual(held);
+    expect(await readCredentials(workspace.credentialsFile, held.url)).toEqual(held);
   });
 
   it("locks the folder down too, and says nothing when it could", async () => {

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -287,7 +287,15 @@ describe("a machine that is already signed in", () => {
     });
 
     expect(result.kind).toBe("stored");
-    expect((await readCredentials(workspace.credentialsFile))?.url).toBe(platform.url);
+    expect((await readCredentials(workspace.credentialsFile, platform.url))?.url).toBe(
+      platform.url,
+    );
+    expect(
+      await readCredentials(workspace.credentialsFile, "https://somewhere.else.example"),
+    ).toEqual({
+      url: "https://somewhere.else.example",
+      key: "egma_sk_for-somewhere-else",
+    });
   });
 });
 
@@ -394,26 +402,26 @@ describe("reading a code out of whatever was pasted", () => {
 });
 
 describe("which egma a command talks to", () => {
-  it("takes the flag first, then the environment, then what was stored", () => {
+  it("takes the flag first, then the environment, then the repository binding", () => {
     expect(
       resolvePlatformUrl({
         flag: "http://flag.example/",
         env: "http://env.example",
-        stored: "http://stored.example",
+        binding: "http://bound.example",
       }),
     ).toBe("http://flag.example");
 
     expect(
-      resolvePlatformUrl({ flag: null, env: "http://env.example", stored: "http://stored.example" }),
+      resolvePlatformUrl({ flag: null, env: "http://env.example", binding: "http://bound.example" }),
     ).toBe("http://env.example");
 
-    // Which is what "set it once" means: after the first login, nothing has to
-    // say the address again.
-    expect(resolvePlatformUrl({ flag: null, stored: "http://stored.example/" })).toBe(
-      "http://stored.example",
+    // The repository, not the latest login on the machine, is what makes the
+    // selection stable after onboarding.
+    expect(resolvePlatformUrl({ flag: null, binding: "http://bound.example/" })).toBe(
+      "http://bound.example",
     );
 
-    expect(resolvePlatformUrl({ flag: null, env: "", stored: null })).toBe(DEFAULT_PLATFORM_URL);
+    expect(resolvePlatformUrl({ flag: null, env: "", binding: null })).toBe(DEFAULT_PLATFORM_URL);
   });
 
   it("refuses an address that is not one, and names where it came from", () => {
@@ -427,11 +435,10 @@ describe("which egma a command talks to", () => {
     expect(() => resolvePlatformUrl({ flag: "ftp://egma.example" })).toThrow(/--url/u);
     expect(() => resolvePlatformUrl({ flag: null, env: "ftp://egma.example" })).toThrow(/EGMA_URL/u);
 
-    // A credentials file somebody edited by hand is stepped over rather than
-    // made into a refusal on every command afterwards.
-    expect(resolvePlatformUrl({ flag: null, stored: "javascript:alert(1)" })).toBe(
-      DEFAULT_PLATFORM_URL,
-    );
+    // A committed binding is never stepped over in favour of Cloud.
+    expect(() =>
+      resolvePlatformUrl({ flag: null, binding: "javascript:alert(1)" }),
+    ).toThrow(/repository platform binding/u);
   });
 });
 
@@ -548,5 +555,22 @@ describe("writing the key down", () => {
     expect(said).toEqual([]);
     const folder = await stat(path.dirname(workspace.credentialsFile));
     expect((folder.mode & 0o777).toString(8)).toBe("700");
+  });
+
+  it("keeps one key per normalized platform origin", async () => {
+    const first = { url: "https://ONE.example/", key: "egma_sk_for-one" };
+    const second = { url: "http://localhost:4310", key: "egma_sk_for-two" };
+
+    await writeCredentials(workspace.credentialsFile, first);
+    await writeCredentials(workspace.credentialsFile, second);
+
+    expect(await readCredentials(workspace.credentialsFile, "https://one.example")).toEqual({
+      url: "https://one.example",
+      key: first.key,
+    });
+    expect(await readCredentials(workspace.credentialsFile, second.url)).toEqual(second);
+    expect(
+      await readCredentials(workspace.credentialsFile, "https://not-signed-in.example"),
+    ).toBeNull();
   });
 });

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { openInBrowser } from "../src/platform/browser.ts";
 import { codeFromPaste, startDeviceAuthorization } from "../src/platform/device-flow.ts";
 import {
+  CredentialsFileUnreadableError,
   readCredentials,
   resolvePlatformUrl,
   writeCredentials,
@@ -535,19 +536,79 @@ describe("writing the key down", () => {
   });
 
   it("does not follow a link standing where the key goes", async () => {
+    // Somebody else's keys, in their own file, which this run must leave
+    // exactly as it found them. A write that went through the link rather than
+    // over it would put the fresh key in here.
+    const theirs = `${JSON.stringify(
+      { version: 1, platforms: { "https://theirs.example": { key: "egma_sk_theirs" } } },
+      null,
+      2,
+    )}\n`;
     const elsewhere = path.join(workspace.dir, "somebody-elses-file");
-    await writeFile(elsewhere, "not the key\n", "utf8");
+    await writeFile(elsewhere, theirs, "utf8");
     await mkdir(path.dirname(workspace.credentialsFile), { recursive: true });
     await symlink(elsewhere, workspace.credentialsFile);
 
     await writeCredentials(workspace.credentialsFile, held);
 
     // The link itself was replaced. Nothing was written through it, so the file
-    // it pointed at is exactly as it was.
-    expect(await readFile(elsewhere, "utf8")).toBe("not the key\n");
+    // it pointed at is exactly as it was, byte for byte.
+    expect(await readFile(elsewhere, "utf8")).toBe(theirs);
     expect((await lstat(workspace.credentialsFile)).isSymbolicLink()).toBe(false);
     expect(((await stat(workspace.credentialsFile)).mode & 0o777).toString(8)).toBe("600");
     expect(await readCredentials(workspace.credentialsFile, held.url)).toEqual(held);
+  });
+
+  /**
+   * A file egma cannot make sense of is not an empty file.
+   *
+   * Reading a damaged file as "no keys at all" reads harmlessly and then does
+   * the worst thing in the package: the next login merges into nothing and
+   * renames itself over the file, and every other platform's key is gone. A
+   * truncated file can be repaired by whoever damaged it; one egma has already
+   * overwritten cannot.
+   */
+  it("refuses a damaged file rather than starting from empty and writing over it", async () => {
+    const damaged = '{"version": 1, "platforms": {"https://one.example": {"ke';
+    await mkdir(path.dirname(workspace.credentialsFile), { recursive: true });
+    await writeFile(workspace.credentialsFile, damaged, "utf8");
+
+    await expect(
+      readCredentials(workspace.credentialsFile, "https://one.example"),
+    ).rejects.toBeInstanceOf(CredentialsFileUnreadableError);
+    await expect(
+      writeCredentials(workspace.credentialsFile, held),
+    ).rejects.toBeInstanceOf(CredentialsFileUnreadableError);
+
+    // Still exactly what it was, so whoever can repair it still can.
+    expect(await readFile(workspace.credentialsFile, "utf8")).toBe(damaged);
+
+    // An empty file is a different thing and stays ordinary: a folder can be
+    // made before anything is written into it.
+    await writeFile(workspace.credentialsFile, "", "utf8");
+    await writeCredentials(workspace.credentialsFile, held);
+    expect(await readCredentials(workspace.credentialsFile, held.url)).toEqual(held);
+  });
+
+  /**
+   * Two terminals, two repositories, one machine, one file. The write is a
+   * read-modify-write over everybody's keys, so without a lock the second
+   * rename wins and the first platform's key is gone — and the developer finds
+   * out the next time a command says they are not signed in.
+   */
+  it("keeps every key when several logins land at once", async () => {
+    const many = Array.from({ length: 8 }, (_, index) => ({
+      url: `https://platform-${String(index)}.example`,
+      key: `egma_sk_written-at-the-same-moment-${String(index)}`,
+    }));
+
+    await Promise.all(
+      many.map((one) => writeCredentials(workspace.credentialsFile, one)),
+    );
+
+    for (const one of many) {
+      expect(await readCredentials(workspace.credentialsFile, one.url)).toEqual(one);
+    }
   });
 
   it("locks the folder down too, and says nothing when it could", async () => {

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -7,8 +7,18 @@
  * screen, what landed on disk, and what the file it landed in is readable by.
  */
 
-import { chmod, lstat, mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
+import process from "node:process";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -589,6 +599,61 @@ describe("writing the key down", () => {
     await writeCredentials(workspace.credentialsFile, held);
     expect(await readCredentials(workspace.credentialsFile, held.url)).toEqual(held);
   });
+
+  /**
+   * A file egma cannot open is not a file that is not there.
+   *
+   * Only `ENOENT` means nobody has signed in yet. Everything else — a
+   * permission change, a directory standing where the file goes — means the
+   * keys exist and cannot be seen, and the write merges what it reads: treat
+   * that as an empty file and the rename replaces every platform's key with
+   * whichever one this run happened to be writing.
+   *
+   * A directory is used here because no user, root included, can read one as a
+   * file, so this half of the proof holds wherever it is run.
+   */
+  it("refuses a keys file it cannot open, rather than taking it for an absent one", async () => {
+    await mkdir(workspace.credentialsFile, { recursive: true });
+
+    await expect(
+      readCredentials(workspace.credentialsFile, held.url),
+    ).rejects.toBeInstanceOf(CredentialsFileUnreadableError);
+    await expect(
+      writeCredentials(workspace.credentialsFile, held),
+    ).rejects.toBeInstanceOf(CredentialsFileUnreadableError);
+
+    // Nothing was put anywhere: not into the path, and not beside it.
+    expect((await stat(workspace.credentialsFile)).isDirectory()).toBe(true);
+    expect(await readdir(workspace.credentialsFile)).toEqual([]);
+  });
+
+  /**
+   * The same rule, with the thing that would have been lost actually present.
+   *
+   * Skipped only for a user who can read anything, because there is no way to
+   * stage an unreadable file for one — and every other run proves it.
+   */
+  it.skipIf(process.getuid?.() === 0)(
+    "keeps another platform's key when the file is there and cannot be read",
+    async () => {
+      const theirs = {
+        url: "https://already-signed-in.example",
+        key: "egma_sk_must-survive-a-refused-write",
+      };
+      await writeCredentials(workspace.credentialsFile, theirs);
+      const asWritten = await readFile(workspace.credentialsFile, "utf8");
+      await chmod(workspace.credentialsFile, 0o000);
+
+      await expect(
+        writeCredentials(workspace.credentialsFile, held),
+      ).rejects.toBeInstanceOf(CredentialsFileUnreadableError);
+
+      await chmod(workspace.credentialsFile, 0o600);
+      expect(await readFile(workspace.credentialsFile, "utf8")).toBe(asWritten);
+      expect(await readCredentials(workspace.credentialsFile, theirs.url)).toEqual(theirs);
+      expect(await readCredentials(workspace.credentialsFile, held.url)).toBeNull();
+    },
+  );
 
   /**
    * Two terminals, two repositories, one machine, one file. The write is a

--- a/apps/cli/test/platform-binding-process.test.ts
+++ b/apps/cli/test/platform-binding-process.test.ts
@@ -10,9 +10,16 @@ import process from "node:process";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { createEgmaFolder, writeTestFile } from "../src/folder/egma-folder.ts";
+import { DEFAULT_TEST_COUNT } from "../src/wizard/test-generation.ts";
 import { startFakeRetell, type FakeRetell } from "./support/fake-retell.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
-import { CLI_ENTRY, makeWorkspace, type Workspace } from "./support/workspace.ts";
+import { gradeEveryRun } from "./support/grading.ts";
+import {
+  CLI_ENTRY,
+  FAKE_AGENT,
+  makeWorkspace,
+  type Workspace,
+} from "./support/workspace.ts";
 
 const PROVIDER_KEY = "synthetic-retell-key-for-binding-process-test";
 
@@ -81,9 +88,12 @@ describe("commands after a repository is bound", () => {
     args: readonly string[],
     extra: NodeJS.ProcessEnv = {},
   ): Promise<CommandResult> {
+    const env = workspace.env({ EGMA_RETELL_URL: retell.url, ...extra });
+    expect(args).not.toContain("--url");
+    expect(env.EGMA_URL).toBeUndefined();
     const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_RETELL_URL: retell.url, ...extra }),
+      env,
     });
     let stdout = "";
     let stderr = "";
@@ -120,7 +130,7 @@ describe("commands after a repository is bound", () => {
     return result;
   }
 
-  it("uses the binding for connect, push, pull, and run", async () => {
+  it("uses the binding for connect, push, pull, run, and the bare wizard", async () => {
     const connected = await reachesBound(
       ["connect"],
       "/api/agents",
@@ -129,13 +139,16 @@ describe("commands after a repository is bound", () => {
     expect(connected.code).toBe(0);
     expect(connected.stdout).toContain("status: connected");
 
-    await writeTestFile(path.join(workspace.dir, "egma", "tests", "moves-appointment.md"), {
-      name: "moves-appointment",
-      personas: [],
-      version: null,
-      scenario: "The persona needs a different appointment time.",
-      expectedBehaviors: ["The agent confirms the new time."],
-    });
+    for (let number = 1; number <= DEFAULT_TEST_COUNT; number += 1) {
+      const name = `moves-appointment-${number}`;
+      await writeTestFile(path.join(workspace.dir, "egma", "tests", `${name}.md`), {
+        name,
+        personas: [],
+        version: null,
+        scenario: `The persona needs a different appointment time in case ${number}.`,
+        expectedBehaviors: ["The agent confirms the new time."],
+      });
+    }
 
     const pushed = await reachesBound(["push"], "/api/tests");
     expect(pushed.code).toBe(0);
@@ -150,5 +163,39 @@ describe("commands after a repository is bound", () => {
     expect(started.stdout).toContain("status: started");
     expect(bound.running.runs).toHaveLength(1);
     expect(other.running.runs).toHaveLength(0);
+
+    const script = await workspace.script({
+      steps: [
+        { kind: "say", text: "egma:found framework retell-sdk\n" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+    const beforeRequests = bound.records.length;
+    const beforeRuns = bound.running.runs.length;
+    const grading = gradeEveryRun(bound);
+    let wizard: CommandResult;
+    try {
+      // No verb and no platform selector: this is the wizard, with headless
+      // consent only so a real terminal is not needed in CI.
+      wizard = await command(
+        ["--headless", "--", process.execPath, FAKE_AGENT, script],
+        { EGMA_RETELL_API_KEY: PROVIDER_KEY },
+      );
+    } finally {
+      grading.stop();
+    }
+
+    const wizardRequests = bound.records.slice(beforeRequests);
+    expect(wizard.code, wizard.stderr).toBe(0);
+    expect(wizard.stdout).toMatch(/^first-verdict: /mu);
+    expect(wizardRequests[0]).toMatchObject({ method: "GET", path: "/api/platform" });
+    for (const expectedPath of ["/api/agents", "/api/tests", "/api/runs"]) {
+      expect(
+        wizardRequests.some((request) => request.path === expectedPath),
+        expectedPath,
+      ).toBe(true);
+    }
+    expect(bound.running.runs).toHaveLength(beforeRuns + 1);
+    expect(other.records).toEqual([]);
   });
 });

--- a/apps/cli/test/platform-binding-process.test.ts
+++ b/apps/cli/test/platform-binding-process.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Every later headless command, as a real CLI process, follows the committed
+ * repository binding with no flag or environment URL to help it.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { createEgmaFolder, writeTestFile } from "../src/folder/egma-folder.ts";
+import { startFakeRetell, type FakeRetell } from "./support/fake-retell.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { CLI_ENTRY, makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+const PROVIDER_KEY = "synthetic-retell-key-for-binding-process-test";
+
+type CommandResult = {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly code: number;
+};
+
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
+describe("commands after a repository is bound", () => {
+  let bound: Platform;
+  let other: Platform;
+  let retell: FakeRetell;
+  let workspace: Workspace;
+
+  beforeAll(async () => {
+    [bound, other, retell, workspace] = await Promise.all([
+      startPlatform(),
+      startPlatform(),
+      startFakeRetell({
+        keys: [PROVIDER_KEY],
+        agents: [
+          {
+            agent_id: "synthetic-retell-agent",
+            agent_name: "Bound receptionist",
+            response_engine: { type: "retell-llm", llm_id: "synthetic-llm" },
+          },
+        ],
+        llms: [
+          {
+            llm_id: "synthetic-llm",
+            general_prompt: "Help each persona move an appointment.",
+          },
+        ],
+      }),
+      makeWorkspace(),
+    ]);
+
+    const boundKey = "egma_sk_for-the-bound-platform";
+    const otherKey = "egma_sk_for-the-other-platform";
+    bound.signedInWith(boundKey);
+    other.signedInWith(otherKey);
+    await workspace.signIn(bound.url, boundKey);
+    // Written second on purpose. A machine login can hold this key, but it
+    // cannot select this repository's platform.
+    await workspace.signIn(other.url, otherKey);
+
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: { origin: bound.url, instance: bound.instanceId },
+        agent: null,
+        connection: null,
+        suite: null,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all([bound.close(), other.close(), retell.close(), workspace.remove()]);
+  });
+
+  async function command(
+    args: readonly string[],
+    extra: NodeJS.ProcessEnv = {},
+  ): Promise<CommandResult> {
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+      cwd: workspace.dir,
+      env: workspace.env({ EGMA_RETELL_URL: retell.url, ...extra }),
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    // `connect` checks standard input before its environment. End the pipe so
+    // the real process sees the same promptless EOF a coding agent sends.
+    child.stdin.end();
+    const code = await new Promise<number>((resolve) => {
+      child.on("close", (value) => resolve(value ?? 1));
+    });
+    return { stdout, stderr, code };
+  }
+
+  async function reachesBound(
+    args: readonly string[],
+    expectedPath: string,
+    extra: NodeJS.ProcessEnv = {},
+  ): Promise<CommandResult> {
+    const before = bound.records.length;
+    const result = await command(args, extra);
+    const requests = bound.records.slice(before);
+
+    expect(result.stdout, result.stderr).toContain(`url: ${bound.url}`);
+    expect(requests[0]).toMatchObject({ method: "GET", path: "/api/platform" });
+    expect(requests.some((request) => request.path === expectedPath)).toBe(true);
+    expect(other.records).toEqual([]);
+    return result;
+  }
+
+  it("uses the binding for connect, push, pull, and run", async () => {
+    const connected = await reachesBound(
+      ["connect"],
+      "/api/agents",
+      { EGMA_RETELL_API_KEY: PROVIDER_KEY },
+    );
+    expect(connected.code).toBe(0);
+    expect(connected.stdout).toContain("status: connected");
+
+    await writeTestFile(path.join(workspace.dir, "egma", "tests", "moves-appointment.md"), {
+      name: "moves-appointment",
+      personas: [],
+      version: null,
+      scenario: "The persona needs a different appointment time.",
+      expectedBehaviors: ["The agent confirms the new time."],
+    });
+
+    const pushed = await reachesBound(["push"], "/api/tests");
+    expect(pushed.code).toBe(0);
+    expect(pushed.stdout).toContain("status: pushed");
+
+    const pulled = await reachesBound(["pull"], "/api/tests");
+    expect(pulled.code).toBe(0);
+    expect(pulled.stdout).toContain("status: pulled");
+
+    const started = await reachesBound(["run", "--no-follow"], "/api/runs");
+    expect(started.code).toBe(0);
+    expect(started.stdout).toContain("status: started");
+    expect(bound.running.runs).toHaveLength(1);
+    expect(other.running.runs).toHaveLength(0);
+  });
+});

--- a/apps/cli/test/platform-binding-process.test.ts
+++ b/apps/cli/test/platform-binding-process.test.ts
@@ -22,6 +22,8 @@ import {
 } from "./support/workspace.ts";
 
 const PROVIDER_KEY = "synthetic-retell-key-for-binding-process-test";
+const BOUND_KEY = "egma_sk_for-the-bound-platform";
+const OTHER_KEY = "egma_sk_for-the-other-platform";
 
 type CommandResult = {
   readonly stdout: string;
@@ -60,14 +62,12 @@ describe("commands after a repository is bound", () => {
       makeWorkspace(),
     ]);
 
-    const boundKey = "egma_sk_for-the-bound-platform";
-    const otherKey = "egma_sk_for-the-other-platform";
-    bound.signedInWith(boundKey);
-    other.signedInWith(otherKey);
-    await workspace.signIn(bound.url, boundKey);
+    bound.signedInWith(BOUND_KEY);
+    other.signedInWith(OTHER_KEY);
+    await workspace.signIn(bound.url, BOUND_KEY);
     // Written second on purpose. A machine login can hold this key, but it
     // cannot select this repository's platform.
-    await workspace.signIn(other.url, otherKey);
+    await workspace.signIn(other.url, OTHER_KEY);
 
     await createEgmaFolder({
       repository: workspace.dir,
@@ -163,6 +163,20 @@ describe("commands after a repository is bound", () => {
     expect(started.stdout).toContain("status: started");
     expect(bound.running.runs).toHaveLength(1);
     expect(other.running.runs).toHaveLength(0);
+
+    // The address a developer is handed to watch the run is on the platform
+    // that holds the run, and it carries no key. An address on the wrong
+    // platform would 404 for the developer; an address with a key in it would
+    // put that key in a terminal, a shell history, and whatever they paste it
+    // into.
+    const runId = bound.running.runs[0]?.id ?? "";
+    expect(runId).not.toBe("");
+    expect(started.stdout).toContain(`results: ${bound.url}/runs/${runId}`);
+    expect(started.stdout).not.toContain(other.url);
+    for (const secret of [BOUND_KEY, OTHER_KEY, PROVIDER_KEY]) {
+      expect(started.stdout).not.toContain(secret);
+      expect(started.stderr).not.toContain(secret);
+    }
 
     const script = await workspace.script({
       steps: [

--- a/apps/cli/test/platform-binding-real.test.ts
+++ b/apps/cli/test/platform-binding-real.test.ts
@@ -1,10 +1,16 @@
 import { execFile } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
 
 import { expect, it, vi } from "vitest";
 
-import { startInstance, type Instance } from "../../api/test/support/instance.ts";
-import { createEgmaFolder } from "../src/folder/egma-folder.ts";
+import {
+  startInstance,
+  type Instance,
+  type ObservedInstanceRequest,
+} from "../../api/test/support/instance.ts";
+import { signUp } from "../../api/test/support/traces.ts";
+import { createEgmaFolder, writeTestFile } from "../src/folder/egma-folder.ts";
 import { CLI_ENTRY, makeWorkspace } from "./support/workspace.ts";
 
 const run = promisify(execFile);
@@ -35,6 +41,41 @@ it("refuses a repository bound to another real local platform before sending its
   try {
     first = await startInstance("cli_platform_binding_first", { web: false });
     const firstIdentity = await identityOf(first);
+    const customer = await signUp(first.api, "binding@acme.example", "Acme Binding");
+    const registered = await first.api.inject({
+      method: "POST",
+      url: "/api/agents",
+      headers: { authorization: `Bearer ${customer.secret}` },
+      payload: {
+        name: "Real receptionist",
+        connection: {
+          name: "real-retell-1",
+          type: "retell",
+          modality: "chat",
+          config: { retellAgentId: "synthetic-agent-on-platform-a" },
+          credentials: { apiKey: "synthetic-key-used-only-by-this-test" },
+        },
+      },
+    });
+    expect(registered.statusCode, registered.body).toBe(201);
+    const resources = registered.json() as {
+      agent: { id: string; name: string };
+      connection: { id: string; name: string };
+    };
+
+    const createdTest = await first.api.inject({
+      method: "POST",
+      url: "/api/tests",
+      headers: { authorization: `Bearer ${customer.secret}` },
+      payload: {
+        name: "Real boundary test",
+        scenario: "The persona asks to move an appointment.",
+        expected_behaviors: ["The agent confirms the new time."],
+        personas: [],
+      },
+    });
+    expect(createdTest.statusCode, createdTest.body).toBe(201);
+    const testResource = createdTest.json() as { id: string; version_id: string };
 
     await createEgmaFolder({
       repository: workspace.dir,
@@ -43,16 +84,36 @@ it("refuses a repository bound to another real local platform before sending its
           origin: firstIdentity.origin,
           instance: firstIdentity.instance_id,
         },
-        agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
-        connection: { name: "phone-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+        agent: { name: resources.agent.name, id: resources.agent.id },
+        connection: {
+          name: resources.connection.name,
+          id: resources.connection.id,
+        },
         suite: { name: "first-suite", id: null },
       },
     });
+    await writeTestFile(path.join(workspace.dir, "egma", "tests", "boundary.md"), {
+      name: "Real boundary test",
+      personas: [],
+      version: testResource.version_id,
+      scenario: "The persona asks to move an appointment.",
+      expectedBehaviors: ["The agent confirms the new time."],
+    });
+    const repositoryIds = [
+      resources.agent.id,
+      resources.connection.id,
+      testResource.id,
+      testResource.version_id,
+    ];
 
     await first.close();
     first = undefined;
 
-    second = await startInstance("cli_platform_binding_second", { web: false });
+    const observedBySecond: ObservedInstanceRequest[] = [];
+    second = await startInstance("cli_platform_binding_second", {
+      web: false,
+      observeRequest: (request) => observedBySecond.push(request),
+    });
     const secondIdentity = await identityOf(second);
     expect(secondIdentity.instance_id).not.toBe(firstIdentity.instance_id);
 
@@ -75,6 +136,17 @@ it("refuses a repository bound to another real local platform before sending its
     expect(result.stderr).toContain(firstIdentity.instance_id);
     expect(result.stderr).toContain(secondIdentity.instance_id);
     expect(result.stderr).toContain("No repository identifiers were sent");
+
+    const identifierBearing = observedBySecond.filter((request) => {
+      const shown = JSON.stringify(request);
+      return repositoryIds.some((identifier) => shown.includes(identifier));
+    });
+    expect(identifierBearing).toEqual([]);
+    expect(
+      observedBySecond
+        .filter((request) => request.url.startsWith("/api/"))
+        .map((request) => `${request.method} ${request.url}`),
+    ).toEqual(["GET /api/platform", "GET /api/platform"]);
 
     const stored = await second.database.sql<{ count: string }>("select count(*) from run");
     expect(stored.rows).toEqual([{ count: "0" }]);

--- a/apps/cli/test/platform-binding-real.test.ts
+++ b/apps/cli/test/platform-binding-real.test.ts
@@ -23,6 +23,23 @@ async function identityOf(instance: Instance): Promise<PublicIdentity> {
   return (await response.json()) as PublicIdentity;
 }
 
+type Ended = { readonly code: number; readonly stdout: string; readonly stderr: string };
+
+/** The built CLI, run the way a developer runs it, never throwing on a refusal. */
+async function egma(
+  args: readonly string[],
+  where: { readonly cwd: string; readonly env: NodeJS.ProcessEnv },
+): Promise<Ended> {
+  return run(process.execPath, [CLI_ENTRY, ...args], where).then(
+    ({ stdout, stderr }) => ({ code: 0, stdout, stderr }),
+    (error: { code?: number; stdout?: string; stderr?: string }) => ({
+      code: error.code ?? 1,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+    }),
+  );
+}
+
 vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
 /**
@@ -150,17 +167,9 @@ it("refuses a repository bound to another real local platform before sending its
     // including one B rejects before parsing A's identifiers.
     await identityOf(second);
 
-    const result = await run(
-      process.execPath,
-      [CLI_ENTRY, "run", "--url", second.origin, "--cwd", workspace.dir, "--no-follow"],
+    const result = await egma(
+      ["run", "--url", second.origin, "--cwd", workspace.dir, "--no-follow"],
       { cwd: workspace.dir, env: workspace.env() },
-    ).then(
-      ({ stdout, stderr }) => ({ code: 0, stdout, stderr }),
-      (error: { code?: number; stdout?: string; stderr?: string }) => ({
-        code: error.code ?? 1,
-        stdout: error.stdout ?? "",
-        stderr: error.stderr ?? "",
-      }),
     );
 
     expect(result.code).toBe(4);
@@ -186,6 +195,144 @@ it("refuses a repository bound to another real local platform before sending its
   } finally {
     await first?.close();
     await second?.close();
+    await workspace.remove();
+  }
+});
+
+/**
+ * The other half of the safety rule, and the one a self-hoster meets by
+ * accident: the platform this repository is bound to is simply not running.
+ *
+ * The tempting behaviour is to carry on with Egma Cloud, and it is the one
+ * failure this ticket exists to make impossible — a repository full of
+ * local-platform identifiers would start posting them at a platform that has
+ * never seen them. So the command stops, names the platform it wanted, and says
+ * what to do. A second real platform is left running throughout, standing in
+ * for every platform this machine could have wandered to, and it must see
+ * nothing at all.
+ */
+it("refuses when the bound real platform is down, and reaches no other platform", async () => {
+  const workspace = await makeWorkspace();
+  let bound: Instance | undefined;
+  let stillRunning: Instance | undefined;
+
+  try {
+    bound = await startInstance("cli_bound_platform_down", { web: false });
+    const boundIdentity = await identityOf(bound);
+    const boundOrigin = bound.origin;
+    const customer = await signUp(bound.api, "down@acme.example", "Acme Down");
+
+    const registered = await bound.api.inject({
+      method: "POST",
+      url: "/api/agents",
+      headers: { authorization: `Bearer ${customer.secret}` },
+      payload: {
+        name: "Real receptionist",
+        connection: {
+          name: "real-retell-down",
+          type: "retell",
+          modality: "chat",
+          config: { retellAgentId: "synthetic-agent-on-the-bound-platform" },
+          credentials: { apiKey: "synthetic-key-used-only-by-this-test" },
+        },
+      },
+    });
+    expect(registered.statusCode, registered.body).toBe(201);
+    const resources = registered.json() as {
+      agent: { id: string; name: string };
+      connection: { id: string; name: string };
+    };
+
+    const createdTest = await bound.api.inject({
+      method: "POST",
+      url: "/api/tests",
+      headers: { authorization: `Bearer ${customer.secret}` },
+      payload: {
+        name: "Real unavailable-platform test",
+        scenario: "The persona asks to move an appointment.",
+        expected_behaviors: ["The agent confirms the new time."],
+        personas: [],
+      },
+    });
+    expect(createdTest.statusCode, createdTest.body).toBe(201);
+    const testResource = createdTest.json() as { id: string; version_id: string };
+
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: { origin: boundOrigin, instance: boundIdentity.instance_id },
+        agent: { name: resources.agent.name, id: resources.agent.id },
+        connection: {
+          name: resources.connection.name,
+          id: resources.connection.id,
+        },
+        suite: { name: "down-suite", id: null },
+      },
+    });
+    await writeTestFile(path.join(workspace.dir, "egma", "tests", "unavailable.md"), {
+      name: "Real unavailable-platform test",
+      personas: [],
+      version: testResource.version_id,
+      scenario: "The persona asks to move an appointment.",
+      expectedBehaviors: ["The agent confirms the new time."],
+    });
+    const repositoryIds = [
+      resources.agent.id,
+      resources.connection.id,
+      testResource.id,
+      testResource.version_id,
+    ];
+
+    await bound.close();
+    bound = undefined;
+
+    const observed: ObservedInstanceRequest[] = [];
+    stillRunning = await startInstance("cli_bound_platform_down_other", {
+      web: false,
+      observeRequest: (request) => observed.push(request),
+    });
+    // A freed port can be handed out again. If that happened the bound origin
+    // would be answering after all, so say so here rather than let the run
+    // prove a different thing than it claims to.
+    expect(stillRunning.origin).not.toBe(boundOrigin);
+
+    // The machine holds a key for the platform that is up. It is still not this
+    // repository's platform, and a held key is not a target.
+    const otherCustomer = await signUp(
+      stillRunning.api,
+      "elsewhere@beta.example",
+      "Beta Elsewhere",
+    );
+    await workspace.signIn(stillRunning.origin, otherCustomer.secret);
+    observed.length = 0;
+
+    // No flag and no environment URL: this is the repository binding alone.
+    const env = workspace.env();
+    expect(env.EGMA_URL).toBeUndefined();
+    const result = await egma(["run", "--cwd", workspace.dir, "--no-follow"], {
+      cwd: workspace.dir,
+      env,
+    });
+
+    expect(result.code).toBe(4);
+    expect(result.stdout).toContain("status: unreachable");
+    expect(result.stderr).toContain(boundIdentity.instance_id);
+    expect(result.stderr).toContain(boundOrigin);
+    expect(result.stderr).toContain("Egma Cloud was not used");
+    expect(result.stderr).toContain("no repository identifiers were sent");
+
+    // The platform that is up saw nothing: not a request carrying an
+    // identifier, and not a request at all.
+    expect(observed).toEqual([]);
+    const shown = result.stdout + result.stderr;
+    for (const identifier of repositoryIds) expect(shown).not.toContain(identifier);
+    const stored = await stillRunning.database.sql<{ count: string }>(
+      "select count(*) from run",
+    );
+    expect(stored.rows).toEqual([{ count: "0" }]);
+  } finally {
+    await bound?.close();
+    await stillRunning?.close();
     await workspace.remove();
   }
 });

--- a/apps/cli/test/platform-binding-real.test.ts
+++ b/apps/cli/test/platform-binding-real.test.ts
@@ -1,0 +1,86 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { expect, it, vi } from "vitest";
+
+import { startInstance, type Instance } from "../../api/test/support/instance.ts";
+import { createEgmaFolder } from "../src/folder/egma-folder.ts";
+import { CLI_ENTRY, makeWorkspace } from "./support/workspace.ts";
+
+const run = promisify(execFile);
+
+type PublicIdentity = { readonly instance_id: string; readonly origin: string };
+
+async function identityOf(instance: Instance): Promise<PublicIdentity> {
+  const response = await fetch(`${instance.origin}/api/platform`);
+  expect(response.status).toBe(200);
+  return (await response.json()) as PublicIdentity;
+}
+
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
+/**
+ * Real-process acceptance for the safety rule.
+ *
+ * Both platforms use the real API application and their own real Postgres
+ * database. The built CLI is a separate process. Fixture tests cover branches;
+ * this proves that an identifier bound to one actual platform never reaches a
+ * second actual platform.
+ */
+it("refuses a repository bound to another real local platform before sending its identifiers", async () => {
+  const workspace = await makeWorkspace();
+  let first: Instance | undefined;
+  let second: Instance | undefined;
+
+  try {
+    first = await startInstance("cli_platform_binding_first", { web: false });
+    const firstIdentity = await identityOf(first);
+
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: {
+          origin: firstIdentity.origin,
+          instance: firstIdentity.instance_id,
+        },
+        agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+        connection: { name: "phone-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+        suite: { name: "first-suite", id: null },
+      },
+    });
+
+    await first.close();
+    first = undefined;
+
+    second = await startInstance("cli_platform_binding_second", { web: false });
+    const secondIdentity = await identityOf(second);
+    expect(secondIdentity.instance_id).not.toBe(firstIdentity.instance_id);
+
+    const result = await run(
+      process.execPath,
+      [CLI_ENTRY, "run", "--url", second.origin, "--cwd", workspace.dir, "--no-follow"],
+      { cwd: workspace.dir, env: workspace.env() },
+    ).then(
+      ({ stdout, stderr }) => ({ code: 0, stdout, stderr }),
+      (error: { code?: number; stdout?: string; stderr?: string }) => ({
+        code: error.code ?? 1,
+        stdout: error.stdout ?? "",
+        stderr: error.stderr ?? "",
+      }),
+    );
+
+    expect(result.code).toBe(4);
+    expect(result.stdout).toContain("status: refused");
+    expect(result.stdout).toContain("No repository identifiers were sent");
+    expect(result.stderr).toContain(firstIdentity.instance_id);
+    expect(result.stderr).toContain(secondIdentity.instance_id);
+    expect(result.stderr).toContain("No repository identifiers were sent");
+
+    const stored = await second.database.sql<{ count: string }>("select count(*) from run");
+    expect(stored.rows).toEqual([{ count: "0" }]);
+  } finally {
+    await first?.close();
+    await second?.close();
+    await workspace.remove();
+  }
+});

--- a/apps/cli/test/platform-binding-real.test.ts
+++ b/apps/cli/test/platform-binding-real.test.ts
@@ -117,6 +117,39 @@ it("refuses a repository bound to another real local platform before sending its
     const secondIdentity = await identityOf(second);
     expect(secondIdentity.instance_id).not.toBe(firstIdentity.instance_id);
 
+    // Prove the observer is in front of authentication. Platform A's key is
+    // unknown on B, so the old preHandler observer missed this request when B
+    // answered 401. The raw observer must see it, body included.
+    const observerProbe = await fetch(`${second.origin}/api/runs`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${customer.secret}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ probe: "visible-before-authentication" }),
+    });
+    expect(observerProbe.status).toBe(401);
+    expect(
+      observedBySecond.some(
+        (request) =>
+          request.method === "POST" &&
+          request.url === "/api/runs" &&
+          request.rawBody.includes("visible-before-authentication"),
+      ),
+    ).toBe(true);
+    observedBySecond.length = 0;
+
+    // Put A's key in the exact credential slot a broken command would read for
+    // B. Correct code refuses on identity before it reads this slot. If that
+    // fence regresses, the run reaches B with A's key and repository ids, and
+    // the raw request assertions below fail even though B answers 401.
+    await workspace.signIn(second.origin, customer.secret);
+
+    // One public read belongs to the test. The other public read below belongs
+    // to the CLI process. Any command request at all would make this list fail,
+    // including one B rejects before parsing A's identifiers.
+    await identityOf(second);
+
     const result = await run(
       process.execPath,
       [CLI_ENTRY, "run", "--url", second.origin, "--cwd", workspace.dir, "--no-follow"],

--- a/apps/cli/test/platform-binding-real.test.ts
+++ b/apps/cli/test/platform-binding-real.test.ts
@@ -10,7 +10,12 @@ import {
   type ObservedInstanceRequest,
 } from "../../api/test/support/instance.ts";
 import { signUp } from "../../api/test/support/traces.ts";
-import { createEgmaFolder, writeTestFile } from "../src/folder/egma-folder.ts";
+import {
+  createEgmaFolder,
+  folderPathsIn,
+  updateConfig,
+  writeTestFile,
+} from "../src/folder/egma-folder.ts";
 import { CLI_ENTRY, makeWorkspace } from "./support/workspace.ts";
 
 const run = promisify(execFile);
@@ -47,8 +52,15 @@ vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
  *
  * Both platforms use the real API application and their own real Postgres
  * database. The built CLI is a separate process. Fixture tests cover branches;
- * this proves that an identifier bound to one actual platform never reaches a
+ * this proves that an identifier issued by one actual platform never reaches a
  * second actual platform.
+ *
+ * The repository is bound to the address the second platform answers at while
+ * naming the first platform's instance, which is what a developer's committed
+ * file really looks like after a colleague rebuilt the local stack: same
+ * address, new database, new platform. It is also the one thing an origin alone
+ * cannot catch, and therefore the reason the instance identifier is committed
+ * beside it.
  */
 it("refuses a repository bound to another real local platform before sending its identifiers", async () => {
   const workspace = await makeWorkspace();
@@ -94,28 +106,6 @@ it("refuses a repository bound to another real local platform before sending its
     expect(createdTest.statusCode, createdTest.body).toBe(201);
     const testResource = createdTest.json() as { id: string; version_id: string };
 
-    await createEgmaFolder({
-      repository: workspace.dir,
-      config: {
-        platform: {
-          origin: firstIdentity.origin,
-          instance: firstIdentity.instance_id,
-        },
-        agent: { name: resources.agent.name, id: resources.agent.id },
-        connection: {
-          name: resources.connection.name,
-          id: resources.connection.id,
-        },
-        suite: { name: "first-suite", id: null },
-      },
-    });
-    await writeTestFile(path.join(workspace.dir, "egma", "tests", "boundary.md"), {
-      name: "Real boundary test",
-      personas: [],
-      version: testResource.version_id,
-      scenario: "The persona asks to move an appointment.",
-      expectedBehaviors: ["The agent confirms the new time."],
-    });
     const repositoryIds = [
       resources.agent.id,
       resources.connection.id,
@@ -133,6 +123,31 @@ it("refuses a repository bound to another real local platform before sending its
     });
     const secondIdentity = await identityOf(second);
     expect(secondIdentity.instance_id).not.toBe(firstIdentity.instance_id);
+
+    // The committed file: the first platform's resources and instance, at the
+    // address the second platform now answers at.
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: {
+          origin: secondIdentity.origin,
+          instance: firstIdentity.instance_id,
+        },
+        agent: { name: resources.agent.name, id: resources.agent.id },
+        connection: {
+          name: resources.connection.name,
+          id: resources.connection.id,
+        },
+        suite: { name: "first-suite", id: null },
+      },
+    });
+    await writeTestFile(path.join(workspace.dir, "egma", "tests", "boundary.md"), {
+      name: "Real boundary test",
+      personas: [],
+      version: testResource.version_id,
+      scenario: "The persona asks to move an appointment.",
+      expectedBehaviors: ["The agent confirms the new time."],
+    });
 
     // Prove the observer is in front of authentication. Platform A's key is
     // unknown on B, so the old preHandler observer missed this request when B
@@ -167,10 +182,14 @@ it("refuses a repository bound to another real local platform before sending its
     // including one B rejects before parsing A's identifiers.
     await identityOf(second);
 
-    const result = await egma(
-      ["run", "--url", second.origin, "--cwd", workspace.dir, "--no-follow"],
-      { cwd: workspace.dir, env: workspace.env() },
-    );
+    // No flag: the committed binding chooses the address, and what answers
+    // there is not the platform that issued anything in this folder.
+    const env = workspace.env();
+    expect(env.EGMA_URL).toBeUndefined();
+    const result = await egma(["run", "--cwd", workspace.dir, "--no-follow"], {
+      cwd: workspace.dir,
+      env,
+    });
 
     expect(result.code).toBe(4);
     expect(result.stdout).toContain("status: refused");
@@ -192,6 +211,28 @@ it("refuses a repository bound to another real local platform before sending its
 
     const stored = await second.database.sql<{ count: string }>("select count(*) from run");
     expect(stored.rows).toEqual([{ count: "0" }]);
+
+    // And the cheaper refusal in front of that one: a repository bound to one
+    // address, pointed at another on the command line, stops without asking
+    // anybody anything at all.
+    observedBySecond.length = 0;
+    await updateConfig(folderPathsIn(workspace.dir).config, {
+      platform: {
+        origin: firstIdentity.origin,
+        instance: firstIdentity.instance_id,
+      },
+    });
+    const elsewhere = await egma(
+      ["run", "--url", second.origin, "--cwd", workspace.dir, "--no-follow"],
+      { cwd: workspace.dir, env },
+    );
+
+    expect(elsewhere.code).toBe(4);
+    expect(elsewhere.stdout).toContain("status: refused");
+    expect(elsewhere.stderr).toContain(firstIdentity.origin);
+    expect(elsewhere.stderr).toContain(secondIdentity.origin);
+    expect(elsewhere.stderr).toContain("No repository identifiers were sent");
+    expect(observedBySecond).toEqual([]);
   } finally {
     await first?.close();
     await second?.close();

--- a/apps/cli/test/platform-credentials-real.test.ts
+++ b/apps/cli/test/platform-credentials-real.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Two real platforms, two real logins, one machine.
+ *
+ * A developer who self-hosts and also uses Egma Cloud signs in to both from the
+ * same laptop. The promise is that the second login does not sign them out of
+ * the first, and that the key each platform minted is only ever offered back to
+ * that platform. Both halves are proved here against real API processes with
+ * their own databases, driving the real `egma login` as a separate process
+ * through the real device flow — a fixture could agree with the reader about
+ * the file format and prove neither.
+ */
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+import { expect, it, vi } from "vitest";
+
+import { startInstance, type Instance } from "../../api/test/support/instance.ts";
+import { signUp, type Customer } from "../../api/test/support/traces.ts";
+import { readCredentials } from "../src/platform/credentials.ts";
+import { CLI_ENTRY, makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+vi.setConfig({ testTimeout: 180_000, hookTimeout: 180_000 });
+
+type Ended = { readonly code: number; readonly stdout: string; readonly stderr: string };
+
+/**
+ * Sign in for real: the CLI asks for a code, somebody approves it where they
+ * are signed in, and the CLI collects the key its own polling earned.
+ *
+ * The approval is done through the platform's own endpoints rather than a
+ * browser because what is under test here is the file the CLI writes, not the
+ * page a person clicks. `browser.test.ts` owns the page.
+ */
+async function logInThrough(
+  instance: Instance,
+  customer: Customer,
+  workspace: Workspace,
+): Promise<Ended> {
+  const child = spawn(
+    process.execPath,
+    [CLI_ENTRY, "login", "--url", instance.origin],
+    { cwd: workspace.dir, env: workspace.env() },
+  );
+  child.stdin.end();
+
+  let stdout = "";
+  let stderr = "";
+  let approving: Promise<void> | undefined;
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+    const code = /^code: (?<code>.+)$/mu.exec(stdout)?.groups?.code;
+    if (code === undefined || approving !== undefined) return;
+    approving = approve(instance, customer, code.trim());
+  });
+
+  const code = await new Promise<number>((resolve) => {
+    child.on("close", (value) => resolve(value ?? 1));
+  });
+  await approving;
+  return { code, stdout, stderr };
+}
+
+async function approve(
+  instance: Instance,
+  customer: Customer,
+  userCode: string,
+): Promise<void> {
+  const looked = await instance.api.inject({
+    method: "GET",
+    url: `/api/device/authorization?user_code=${encodeURIComponent(userCode)}`,
+    headers: { cookie: customer.cookie },
+  });
+  expect(looked.statusCode, looked.body).toBe(200);
+  const projectId = (looked.json() as { projects: { id: string }[] }).projects[0]?.id;
+
+  const approved = await instance.api.inject({
+    method: "POST",
+    url: "/api/device/approve",
+    headers: { cookie: customer.cookie },
+    payload: { user_code: userCode, project_id: projectId },
+  });
+  expect(approved.statusCode, approved.body).toBe(200);
+}
+
+/** Whether this platform accepts this key, asked the way every command asks. */
+async function keyWorks(instance: Instance, key: string): Promise<boolean> {
+  const asked = await instance.api.inject({
+    method: "GET",
+    url: "/api/tests",
+    headers: { authorization: `Bearer ${key}` },
+  });
+  return asked.statusCode === 200;
+}
+
+it("keeps one key per platform when a machine signs in to two of them", async () => {
+  const workspace = await makeWorkspace();
+  let first: Instance | undefined;
+  let second: Instance | undefined;
+
+  try {
+    first = await startInstance("cli_two_platform_credentials_first", { web: false });
+    const firstOrigin = first.origin;
+    const onFirst = await signUp(first.api, "two-platforms@acme.example", "Acme First");
+
+    const firstLogin = await logInThrough(first, onFirst, workspace);
+    expect(firstLogin.code, firstLogin.stderr).toBe(0);
+    expect(firstLogin.stdout).toContain("status: stored");
+
+    const heldForFirst = await readCredentials(workspace.credentialsFile, firstOrigin);
+    expect(heldForFirst?.url).toBe(firstOrigin);
+    expect(heldForFirst?.key).toMatch(/^egma_sk_/u);
+    expect(await keyWorks(first, heldForFirst?.key ?? "")).toBe(true);
+
+    // One at a time: each instance owns the process-wide database connection
+    // while it is up, exactly as `platform-binding-real.test.ts` arranges it.
+    await first.close();
+    first = undefined;
+
+    second = await startInstance("cli_two_platform_credentials_second", { web: false });
+    const onSecond = await signUp(second.api, "two-platforms@beta.example", "Beta Second");
+
+    const secondLogin = await logInThrough(second, onSecond, workspace);
+    expect(secondLogin.code, secondLogin.stderr).toBe(0);
+    expect(secondLogin.stdout).toContain("status: stored");
+
+    // The second login did not sign this machine out of the first platform.
+    const stillFirst = await readCredentials(workspace.credentialsFile, firstOrigin);
+    expect(stillFirst).toEqual(heldForFirst);
+
+    const heldForSecond = await readCredentials(
+      workspace.credentialsFile,
+      second.origin,
+    );
+    expect(heldForSecond?.url).toBe(second.origin);
+    expect(heldForSecond?.key).toMatch(/^egma_sk_/u);
+    expect(heldForSecond?.key).not.toBe(heldForFirst?.key);
+
+    // Each key is only good where it was minted, so a file that mixed them up
+    // would be caught here rather than by a 401 in front of a developer.
+    expect(await keyWorks(second, heldForSecond?.key ?? "")).toBe(true);
+    expect(await keyWorks(second, heldForFirst?.key ?? "")).toBe(false);
+
+    // Two entries, each under its own normalized origin, and no leftover
+    // top-level pair that a command could read as "the platform".
+    const onDisk = JSON.parse(await readFile(workspace.credentialsFile, "utf8")) as {
+      version: number;
+      platforms: Record<string, { key: string }>;
+      url?: unknown;
+    };
+    expect(onDisk.url).toBeUndefined();
+    expect(Object.keys(onDisk.platforms).sort()).toEqual(
+      [firstOrigin, second.origin].sort(),
+    );
+  } finally {
+    await first?.close();
+    await second?.close();
+    await workspace.remove();
+  }
+});

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -2,12 +2,17 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createEgmaFolder } from "../src/folder/egma-folder.ts";
 import {
+  BoundPlatformAddressError,
   BoundPlatformUnavailableError,
   DEFAULT_PLATFORM_URL,
   PlatformBindingMismatchError,
   resolvePlatformAccess,
 } from "../src/platform/credentials.ts";
-import { readPlatformIdentity } from "../src/platform/identity.ts";
+import {
+  PlatformOriginMismatchError,
+  PlatformTimedOutError,
+  readPlatformIdentity,
+} from "../src/platform/identity.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
 import { makeWorkspace, type Workspace } from "./support/workspace.ts";
 
@@ -60,7 +65,7 @@ describe("verifying an Egma platform", () => {
     });
   });
 
-  it("refuses a different explicit platform before any repository identifier is sent", async () => {
+  it("refuses a different explicit address before asking anybody anything", async () => {
     const other = await startPlatform();
     try {
       await createEgmaFolder({
@@ -79,15 +84,47 @@ describe("verifying an Egma platform", () => {
           flag: other.url,
           cwd: workspace.dir,
         }),
-      ).rejects.toBeInstanceOf(PlatformBindingMismatchError);
+      ).rejects.toBeInstanceOf(BoundPlatformAddressError);
 
-      expect(other.records.map((record) => `${record.method} ${record.path}`)).toEqual([
-        "GET /api/platform",
-      ]);
+      // Neither platform was asked so much as who it is. The address a bound
+      // repository uses is decided by the file, so an address that is not the
+      // one in the file is refused without anything leaving this machine.
+      expect(other.records).toEqual([]);
       expect(platform.records).toEqual([]);
     } finally {
       await other.close();
     }
+  });
+
+  /**
+   * The one thing an origin alone cannot tell you, and the reason the instance
+   * identifier is committed beside it: the platform at this address is not the
+   * platform that issued these identifiers. A colleague who rebuilt the local
+   * stack has a new database and therefore a new instance, at the very same
+   * address the repository recorded.
+   */
+  it("refuses a replaced platform answering at the address the repository recorded", async () => {
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: {
+          origin: platform.url,
+          instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEA",
+        },
+        agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+        connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+        suite: null,
+      },
+    });
+
+    await expect(
+      resolvePlatformAccess({ env: workspace.env(), flag: null, cwd: workspace.dir }),
+    ).rejects.toBeInstanceOf(PlatformBindingMismatchError);
+
+    // One question asked, and it was the public one that carries nothing.
+    expect(platform.records.map((record) => `${record.method} ${record.path}`)).toEqual([
+      "GET /api/platform",
+    ]);
   });
 
   it("takes the explicit URL before EGMA_URL, then verifies the selected instance", async () => {
@@ -107,37 +144,86 @@ describe("verifying an Egma platform", () => {
     }
   });
 
-  it("accepts an alias when it reports the bound instance and canonical origin", async () => {
+  /**
+   * The failure this refusal exists for is quiet and expensive.
+   *
+   * `EGMA_BASE_URL` defaults to `http://localhost:3101`. A self-hoster who
+   * never changes it and reaches the stack at `192.168.1.10` gets a clean
+   * identity read — and, if the platform's answer were believed, a CLI that
+   * walks away to `localhost`, where nothing is listening. Bind on the
+   * platform's own host and it is worse: the committed file says `localhost`,
+   * and every teammate who clones it targets their own machine.
+   *
+   * So the address the developer gave is the address egma uses, and a platform
+   * that calls itself something else is a misconfiguration to be told about.
+   */
+  it("refuses a platform that answers to a different address than it was asked at", async () => {
     const canonicalOrigin = "https://canonical.egma.example";
     const alias = await startPlatform({ canonicalOrigin });
     try {
-      await createEgmaFolder({
-        repository: workspace.dir,
-        config: {
-          platform: { origin: canonicalOrigin, instance: alias.instanceId },
-          agent: null,
-          connection: null,
-          suite: null,
-        },
-      });
+      await expect(readPlatformIdentity(alias.url)).rejects.toBeInstanceOf(
+        PlatformOriginMismatchError,
+      );
+      await expect(readPlatformIdentity(alias.url)).rejects.toThrow(canonicalOrigin);
+      await expect(readPlatformIdentity(alias.url)).rejects.toThrow("EGMA_BASE_URL");
 
-      const access = await resolvePlatformAccess({
-        env: workspace.env(),
-        flag: alias.url,
-        cwd: workspace.dir,
-      });
-
-      expect(alias.url).not.toBe(canonicalOrigin);
-      expect(access).toMatchObject({
-        url: canonicalOrigin,
-        instanceId: alias.instanceId,
-      });
-      expect(alias.records.map((record) => `${record.method} ${record.path}`)).toEqual([
-        "GET /api/platform",
-      ]);
+      await expect(
+        resolvePlatformAccess({
+          env: workspace.env(),
+          flag: alias.url,
+          cwd: workspace.dir,
+        }),
+      ).rejects.toBeInstanceOf(PlatformOriginMismatchError);
     } finally {
       await alias.close();
     }
+  });
+
+  it("keeps the address it was given, whatever the platform calls itself", async () => {
+    // The address that comes back is the address that was asked, always: every
+    // key, identifier and committed line downstream is addressed to it.
+    const access = await resolvePlatformAccess({
+      env: workspace.env(),
+      flag: `${platform.url}/`,
+      cwd: workspace.dir,
+    });
+    expect(access.url).toBe(platform.url);
+  });
+
+  it("does not follow a redirect, and says that is what happened", async () => {
+    const requested: string[] = [];
+    await expect(
+      resolvePlatformAccess({
+        env: workspace.env(),
+        flag: "https://behind-a-login.example",
+        cwd: workspace.dir,
+        fetchImpl: async (input) => {
+          requested.push(String(input));
+          return new Response(null, {
+            status: 307,
+            headers: { location: "https://sign-in.example/login" },
+          });
+        },
+      }),
+    ).rejects.toThrow(/redirected to https:\/\/sign-in\.example\/login/u);
+    expect(requested).toEqual(["https://behind-a-login.example/api/platform"]);
+  });
+
+  it("gives up on a platform that takes the connection and says nothing", async () => {
+    const stalled = resolvePlatformAccess({
+      env: workspace.env(),
+      flag: "https://accepts-and-waits.example",
+      cwd: workspace.dir,
+      fetchImpl: async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason ?? new Error("aborted"));
+          });
+        }),
+    });
+
+    await expect(stalled).rejects.toBeInstanceOf(PlatformTimedOutError);
+    await expect(stalled).rejects.toThrow("did not answer within");
   });
 
   it("uses Egma Cloud only when the repository is unbound", async () => {
@@ -160,6 +246,38 @@ describe("verifying an Egma platform", () => {
 
     expect(access.url).toBe(DEFAULT_PLATFORM_URL);
     expect(requested).toEqual([`${DEFAULT_PLATFORM_URL}/api/platform`]);
+  });
+
+  /**
+   * A refusal names the platform the developer asked about.
+   *
+   * Being told to start the platform this repository is bound to, when what you
+   * typed on the command line is a different address that is down, sends you to
+   * fix something you did not ask for.
+   */
+  it("names the address the developer gave when that is the one that is down", async () => {
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: { origin: platform.url, instance: platform.instanceId },
+        agent: null,
+        connection: null,
+        suite: null,
+      },
+    });
+    const elsewhere = "http://127.0.0.1:1";
+
+    const refusal = resolvePlatformAccess({
+      env: workspace.env(),
+      flag: elsewhere,
+      cwd: workspace.dir,
+    });
+
+    await expect(refusal).rejects.toBeInstanceOf(BoundPlatformAddressError);
+    await expect(refusal).rejects.toThrow(elsewhere);
+    await expect(refusal).rejects.toThrow("--url");
+    // Nothing was asked at either address, so nothing hung on a dead port.
+    expect(platform.records).toEqual([]);
   });
 
   it("refuses an unavailable bound platform and does not try Egma Cloud", async () => {

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createEgmaFolder } from "../src/folder/egma-folder.ts";
+import {
+  BoundPlatformUnavailableError,
+  DEFAULT_PLATFORM_URL,
+  PlatformBindingMismatchError,
+  resolvePlatformAccess,
+} from "../src/platform/credentials.ts";
+import { readPlatformIdentity } from "../src/platform/identity.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+describe("verifying an Egma platform", () => {
+  let platform: Platform;
+  let workspace: Workspace;
+
+  beforeEach(async () => {
+    platform = await startPlatform();
+    workspace = await makeWorkspace();
+  });
+
+  afterEach(async () => {
+    await platform.close();
+    await workspace.remove();
+  });
+
+  it("reads the stable instance identity and normalized canonical origin before login", async () => {
+    expect(await readPlatformIdentity(`${platform.url}/`)).toEqual({
+      instanceId: platform.instanceId,
+      origin: platform.url,
+    });
+
+    expect(platform.records.map((record) => `${record.method} ${record.path}`)).toEqual([
+      "GET /api/platform",
+    ]);
+  });
+
+  it("uses the repository binding when no flag or environment URL is present", async () => {
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: { origin: platform.url, instance: platform.instanceId },
+        agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+        connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+        suite: null,
+      },
+    });
+
+    await workspace.signIn("https://a-recent-login-must-not-win.example");
+    const access = await resolvePlatformAccess({
+      env: workspace.env(),
+      flag: null,
+      cwd: workspace.dir,
+    });
+
+    expect(access).toMatchObject({
+      url: platform.url,
+      instanceId: platform.instanceId,
+    });
+  });
+
+  it("refuses a different explicit platform before any repository identifier is sent", async () => {
+    const other = await startPlatform();
+    try {
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: platform.url, instance: platform.instanceId },
+          agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+          connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+          suite: null,
+        },
+      });
+
+      await expect(
+        resolvePlatformAccess({
+          env: workspace.env(),
+          flag: other.url,
+          cwd: workspace.dir,
+        }),
+      ).rejects.toBeInstanceOf(PlatformBindingMismatchError);
+
+      expect(other.records.map((record) => `${record.method} ${record.path}`)).toEqual([
+        "GET /api/platform",
+      ]);
+      expect(platform.records).toEqual([]);
+    } finally {
+      await other.close();
+    }
+  });
+
+  it("takes the explicit URL before EGMA_URL, then verifies the selected instance", async () => {
+    const ambient = await startPlatform();
+    try {
+      const access = await resolvePlatformAccess({
+        env: workspace.env({ EGMA_URL: ambient.url }),
+        flag: platform.url,
+        cwd: workspace.dir,
+      });
+
+      expect(access.url).toBe(platform.url);
+      expect(platform.records.map((record) => record.path)).toEqual(["/api/platform"]);
+      expect(ambient.records).toEqual([]);
+    } finally {
+      await ambient.close();
+    }
+  });
+
+  it("uses Egma Cloud only when the repository is unbound", async () => {
+    const requested: string[] = [];
+    const access = await resolvePlatformAccess({
+      env: workspace.env(),
+      flag: null,
+      cwd: workspace.dir,
+      fetchImpl: async (input) => {
+        requested.push(String(input));
+        return new Response(
+          JSON.stringify({
+            instance_id: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEA",
+            origin: DEFAULT_PLATFORM_URL,
+          }),
+          { status: 200 },
+        );
+      },
+    });
+
+    expect(access.url).toBe(DEFAULT_PLATFORM_URL);
+    expect(requested).toEqual([`${DEFAULT_PLATFORM_URL}/api/platform`]);
+  });
+
+  it("refuses an unavailable bound platform and does not try Egma Cloud", async () => {
+    const boundOrigin = "http://127.0.0.1:1";
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: {
+          origin: boundOrigin,
+          instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEA",
+        },
+        agent: null,
+        connection: null,
+        suite: null,
+      },
+    });
+    const requested: string[] = [];
+
+    const resolution = resolvePlatformAccess({
+      env: workspace.env(),
+      flag: null,
+      cwd: workspace.dir,
+      fetchImpl: async (input) => {
+        requested.push(String(input));
+        throw new Error("offline");
+      },
+    });
+
+    await expect(resolution).rejects.toBeInstanceOf(BoundPlatformUnavailableError);
+    await expect(resolution).rejects.toThrow("Egma Cloud was not used");
+    expect(requested).toEqual([`${boundOrigin}/api/platform`]);
+  });
+});

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -5,6 +5,7 @@ import {
   BoundPlatformAddressError,
   BoundPlatformUnavailableError,
   DEFAULT_PLATFORM_URL,
+  DefaultPlatformUnusableError,
   PlatformBindingMismatchError,
   resolvePlatformAccess,
 } from "../src/platform/credentials.ts";
@@ -15,6 +16,16 @@ import {
 } from "../src/platform/identity.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
 import { makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+/** The refusal a promise ended with, or a failure saying it did not refuse. */
+async function refusalFrom(work: Promise<unknown>): Promise<Error> {
+  try {
+    await work;
+  } catch (cause) {
+    return cause as Error;
+  }
+  throw new Error("that was supposed to be refused, and it was not");
+}
 
 describe("verifying an Egma platform", () => {
   let platform: Platform;
@@ -177,6 +188,81 @@ describe("verifying an Egma platform", () => {
     } finally {
       await alias.close();
     }
+  });
+
+  /**
+   * The same refusal, told two ways, because the two situations want different
+   * things done about them.
+   *
+   * `localhost` against `127.0.0.1` is one machine calling itself two names,
+   * and either name reaches it — so saying "or use the other one" is help. A
+   * platform on the network that still calls itself `localhost` is the failure
+   * this refusal exists for, and telling somebody on another machine to use
+   * `localhost` sends them to their own laptop, where nothing is listening.
+   */
+  it("does not offer a loopback address to somebody who is not on that machine", async () => {
+    const onlyItsOwnMachine = await startPlatform({
+      canonicalOrigin: "http://localhost:3101",
+    });
+    try {
+      // Reached across a network, so its own name for itself is no use here.
+      await expect(
+        readPlatformIdentity(onlyItsOwnMachine.url.replace("127.0.0.1", "[::1]")),
+      ).rejects.toThrow();
+
+      const refusal = await refusalFrom(
+        readPlatformIdentity("http://192.168.1.10:3101", async () =>
+          Response.json({
+            instance_id: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEA",
+            origin: "http://localhost:3101",
+          }),
+        ),
+      );
+
+      expect(refusal).toBeInstanceOf(PlatformOriginMismatchError);
+      expect(refusal.message).toContain("names only the platform's own machine");
+      expect(refusal.message).not.toContain("or use http://localhost:3101 here");
+
+      // One machine, two names for itself: the other name is worth offering.
+      const nearby = await refusalFrom(
+        readPlatformIdentity("http://127.0.0.1:3101", async () =>
+          Response.json({
+            instance_id: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEA",
+            origin: "http://localhost:3101",
+          }),
+        ),
+      );
+
+      expect(nearby.message).toContain("or use http://localhost:3101 here");
+      expect(nearby.message).not.toContain("names only the platform's own machine");
+    } finally {
+      await onlyItsOwnMachine.close();
+    }
+  });
+
+  /**
+   * Nobody typed egma's built-in default address, nobody runs what is at it,
+   * and nobody can fix it — so the refusal points at the one move that belongs
+   * to the developer, and never sends them off to inspect a website that is
+   * not theirs.
+   */
+  it("does not send a developer to inspect its own built-in default address", async () => {
+    const refusal = await refusalFrom(
+      resolvePlatformAccess({
+        env: workspace.env(),
+        flag: null,
+        cwd: workspace.dir,
+        fetchImpl: async () =>
+          new Response(null, { status: 307, headers: { location: "/login" } }),
+      }),
+    );
+
+    expect(refusal).toBeInstanceOf(DefaultPlatformUnusableError);
+    expect(refusal.message).toContain(DEFAULT_PLATFORM_URL);
+    expect(refusal.message).toContain("--url <address>");
+    expect(refusal.message).toContain("EGMA_URL");
+    // Not somebody's deployment, so not somebody's misconfiguration.
+    expect(refusal.message).not.toMatch(/sign-in page|proxy|this is where to look/u);
   });
 
   it("keeps the address it was given, whatever the platform calls itself", async () => {

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -107,6 +107,39 @@ describe("verifying an Egma platform", () => {
     }
   });
 
+  it("accepts an alias when it reports the bound instance and canonical origin", async () => {
+    const canonicalOrigin = "https://canonical.egma.example";
+    const alias = await startPlatform({ canonicalOrigin });
+    try {
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: canonicalOrigin, instance: alias.instanceId },
+          agent: null,
+          connection: null,
+          suite: null,
+        },
+      });
+
+      const access = await resolvePlatformAccess({
+        env: workspace.env(),
+        flag: alias.url,
+        cwd: workspace.dir,
+      });
+
+      expect(alias.url).not.toBe(canonicalOrigin);
+      expect(access).toMatchObject({
+        url: canonicalOrigin,
+        instanceId: alias.instanceId,
+      });
+      expect(alias.records.map((record) => `${record.method} ${record.path}`)).toEqual([
+        "GET /api/platform",
+      ]);
+    } finally {
+      await alias.close();
+    }
+  });
+
   it("uses Egma Cloud only when the repository is unbound", async () => {
     const requested: string[] = [];
     const access = await resolvePlatformAccess({

--- a/apps/cli/test/platform-onboarding-process.test.ts
+++ b/apps/cli/test/platform-onboarding-process.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 
@@ -139,6 +139,23 @@ it("verifies an explicitly selected platform and commits its identity on first o
     });
     expect(config.agent?.id).toMatch(/^agt_/u);
     expect(config.connection?.id).toMatch(/^con_/u);
+
+    // The binding is committed, so what is written beside it is read by
+    // everybody who clones this repository. It carries identity and no key:
+    // not the key this machine signs in to egma with, and not the provider key
+    // the wizard was handed on the way through.
+    const committed = await readFile(paths.config, "utf8");
+    for (const secret of [PLATFORM_KEY, PROVIDER_KEY]) {
+      expect(committed).not.toContain(secret);
+      expect(stdout).not.toContain(secret);
+      expect(stderr).not.toContain(secret);
+    }
+
+    // And the run address the developer is handed is on the platform this
+    // repository just bound itself to, with no key in it.
+    const runId = platform.running.runs[0]?.id ?? "";
+    expect(runId).not.toBe("");
+    expect(stdout).toContain(`${platform.url}/runs/${runId}`);
   } finally {
     await Promise.all([platform.close(), retell.close(), workspace.remove()]);
   }

--- a/apps/cli/test/platform-onboarding-process.test.ts
+++ b/apps/cli/test/platform-onboarding-process.test.ts
@@ -1,0 +1,145 @@
+/**
+ * First repository onboarding, through the built CLI rather than an injected
+ * access object: explicit address, public identity, then a committed binding.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { expect, it, vi } from "vitest";
+
+import {
+  folderPathsIn,
+  readConfig,
+  writeTestFile,
+} from "../src/folder/egma-folder.ts";
+import { DEFAULT_TEST_COUNT } from "../src/wizard/test-generation.ts";
+import { startFakeRetell } from "./support/fake-retell.ts";
+import { startPlatform } from "./support/fixture-platform/index.ts";
+import { gradeEveryRun } from "./support/grading.ts";
+import {
+  CLI_ENTRY,
+  FAKE_AGENT,
+  makeWorkspace,
+} from "./support/workspace.ts";
+
+const PLATFORM_KEY = "egma_sk_for-first-repository-onboarding";
+const PROVIDER_KEY = "synthetic-retell-key-for-first-onboarding";
+
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
+it("verifies an explicitly selected platform and commits its identity on first onboarding", async () => {
+  const [platform, retell, workspace] = await Promise.all([
+    startPlatform(),
+    startFakeRetell({
+      keys: [PROVIDER_KEY],
+      agents: [
+        {
+          agent_id: "synthetic-first-onboarding-agent",
+          agent_name: "First receptionist",
+          response_engine: { type: "retell-llm", llm_id: "synthetic-first-llm" },
+        },
+      ],
+      llms: [
+        {
+          llm_id: "synthetic-first-llm",
+          general_prompt: "Help each persona move an appointment.",
+        },
+      ],
+    }),
+    makeWorkspace(),
+  ]);
+
+  try {
+    platform.signedInWith(PLATFORM_KEY);
+    await workspace.signIn(platform.url, PLATFORM_KEY);
+
+    // Existing tests keep this proof about platform binding, not test
+    // generation. There is deliberately no config file and no binding yet.
+    const paths = folderPathsIn(workspace.dir);
+    await mkdir(paths.tests, { recursive: true });
+    for (let number = 1; number <= DEFAULT_TEST_COUNT; number += 1) {
+      const name = `first-onboarding-${number}`;
+      await writeTestFile(path.join(paths.tests, `${name}.md`), {
+        name,
+        personas: [],
+        version: null,
+        scenario: `The persona needs a different appointment time in case ${number}.`,
+        expectedBehaviors: ["The agent confirms the new time."],
+      });
+    }
+    await expect(readConfig(paths.config)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const script = await workspace.script({
+      steps: [
+        { kind: "say", text: "egma:found framework retell-sdk\n" },
+        { kind: "stop", reason: "end_turn" },
+      ],
+    });
+    const env = workspace.env({
+      EGMA_RETELL_URL: retell.url,
+      EGMA_RETELL_API_KEY: PROVIDER_KEY,
+    });
+    expect(env.EGMA_URL).toBeUndefined();
+
+    const grading = gradeEveryRun(platform);
+    let stdout = "";
+    let stderr = "";
+    let code = 1;
+    try {
+      const child = spawn(
+        process.execPath,
+        [
+          CLI_ENTRY,
+          "--headless",
+          "--url",
+          platform.url,
+          "--",
+          process.execPath,
+          FAKE_AGENT,
+          script,
+        ],
+        { cwd: workspace.dir, env },
+      );
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.stdin.end();
+      code = await new Promise<number>((resolve) => {
+        child.on("close", (value) => resolve(value ?? 1));
+      });
+    } finally {
+      grading.stop();
+    }
+
+    expect(code, stderr).toBe(0);
+    expect(stdout).toMatch(/^first-verdict: /mu);
+    expect(platform.records[0]).toMatchObject({
+      method: "GET",
+      path: "/api/platform",
+    });
+    for (const expectedPath of ["/api/agents", "/api/tests", "/api/runs"]) {
+      expect(
+        platform.records.some((request) => request.path === expectedPath),
+        expectedPath,
+      ).toBe(true);
+    }
+
+    const config = await readConfig(paths.config);
+    expect(config.platform).toEqual({
+      origin: platform.url,
+      instance: platform.instanceId,
+    });
+    expect(config.agent?.id).toMatch(/^agt_/u);
+    expect(config.connection?.id).toMatch(/^con_/u);
+  } finally {
+    await Promise.all([platform.close(), retell.close(), workspace.remove()]);
+  }
+});

--- a/apps/cli/test/platform-origin-agreement.test.ts
+++ b/apps/cli/test/platform-origin-agreement.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The API and CLI validate a platform origin at separate runtime boundaries.
+ * The CLI is published as a compiled standalone package, so sharing the API
+ * implementation would add a private package to its runtime dependencies.
+ * This agreement test makes that deliberate separation safe.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { loadConfig } from "../../api/src/config.ts";
+import { normalizePlatformOrigin } from "../src/platform/identity.ts";
+
+const startableApi = {
+  DATABASE_URL: "postgres://x/y",
+  CLICKHOUSE_URL: "http://x:8123/y",
+  EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
+  EGMA_ENCRYPTION_KEY: "0123456789abcdef".repeat(4),
+  EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
+};
+
+describe("the API and CLI platform-origin agreement", () => {
+  it.each([
+    [" HTTPS://Egma.Example:443/ ", "https://egma.example"],
+    ["http://127.0.0.1:3101/", "http://127.0.0.1:3101"],
+  ])("normalizes %s to %s at both boundaries", (candidate, expected) => {
+    expect(normalizePlatformOrigin(candidate)).toBe(expected);
+    expect(loadConfig({ ...startableApi, EGMA_BASE_URL: candidate }).baseUrl).toBe(
+      expected,
+    );
+  });
+
+  it.each([
+    "not a URL",
+    "ftp://egma.example",
+    "https://user:password@egma.example",
+    "https://egma.example/api",
+    "https://egma.example?one=two",
+    "https://egma.example#part",
+  ])("refuses %s at both boundaries", (candidate) => {
+    expect(() => normalizePlatformOrigin(candidate)).toThrow();
+    expect(() =>
+      loadConfig({ ...startableApi, EGMA_BASE_URL: candidate }),
+    ).toThrow();
+  });
+});

--- a/apps/cli/test/platform-origin-agreement.test.ts
+++ b/apps/cli/test/platform-origin-agreement.test.ts
@@ -5,10 +5,19 @@
  * This agreement test makes that deliberate separation safe.
  */
 
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { loadConfig } from "../../api/src/config.ts";
-import { normalizePlatformOrigin } from "../src/platform/identity.ts";
+import { PLATFORM_IDENTITY_PATH as API_PLATFORM_IDENTITY_PATH } from "../../api/src/routes/platform.ts";
+import {
+  normalizePlatformOrigin,
+  PLATFORM_IDENTITY_PATH,
+} from "../src/platform/identity.ts";
+
+const WEB = path.join(import.meta.dirname, "../../web");
 
 const startableApi = {
   DATABASE_URL: "postgres://x/y",
@@ -27,6 +36,21 @@ describe("the API and CLI platform-origin agreement", () => {
     expect(loadConfig({ ...startableApi, EGMA_BASE_URL: candidate }).baseUrl).toBe(
       expected,
     );
+  });
+
+  /**
+   * A self-hoster is given one origin, and in every deployment the pages answer
+   * there — so the identity read lands on the web process and is forwarded from
+   * it. A rewrite that did not carry this path would make the pages answer 404
+   * for it, and every command in a bound repository would refuse with "did not
+   * return a usable platform identity" on a platform that is running perfectly.
+   */
+  it("answers at the same path the API serves and the pages forward", async () => {
+    expect(PLATFORM_IDENTITY_PATH).toBe(API_PLATFORM_IDENTITY_PATH);
+
+    const rewrites = await readFile(path.join(WEB, "next.config.ts"), "utf8");
+    expect(rewrites).toContain(`source: "${PLATFORM_IDENTITY_PATH}"`);
+    expect(rewrites).toContain(`destination: \`\${api}${PLATFORM_IDENTITY_PATH}\``);
   });
 
   it.each([

--- a/apps/cli/test/pull-push.test.ts
+++ b/apps/cli/test/pull-push.test.ts
@@ -46,7 +46,7 @@ async function egma(args: readonly string[], env: NodeJS.ProcessEnv = {}): Promi
   try {
     const { stdout, stderr } = await run(process.execPath, [CLI_ENTRY, ...args], {
       cwd: workspace.dir,
-      env: workspace.env(env),
+      env: workspace.env({ EGMA_URL: platform.url, ...env }),
     });
     return { stdout, stderr, code: 0 };
   } catch (error) {
@@ -593,7 +593,7 @@ describe("both verbs, run with nobody watching", () => {
 
     const child = spawn(process.execPath, [CLI_ENTRY, "pull"], {
       cwd: workspace.dir,
-      env: workspace.env(),
+      env: workspace.env({ EGMA_URL: platform.url }),
       stdio: ["ignore", "pipe", "pipe"],
     });
 

--- a/apps/cli/test/run-command.test.ts
+++ b/apps/cli/test/run-command.test.ts
@@ -104,6 +104,7 @@ async function makeFolder(registered: Registered | null): Promise<void> {
   // never rewrites a config that is already there — and a check that changes
   // what the folder points at is exactly the thing that rule protects against.
   await writeConfig(made.paths.config, {
+    platform: null,
     agent: registered === null ? null : { name: "order-line", id: registered.agentId },
     connection: registered === null ? null : { name: "retell-1", id: registered.connectionId },
     suite: { name: "first-suite", id: null },

--- a/apps/cli/test/support/fixture-platform/index.ts
+++ b/apps/cli/test/support/fixture-platform/index.ts
@@ -10,6 +10,7 @@ import { newId } from "../../../../../packages/ids/src/index.ts";
 import { agentRoutes, type AgentControls } from "./agents.ts";
 import { controlRoutes } from "./controls.ts";
 import { deviceRoutes, type DeviceControls } from "./device.ts";
+import { platformRoutes, type PlatformIdentityControls } from "./platform.ts";
 import { runControlRoutes, runRoutes, type RunControls } from "./runs.ts";
 import { startFixturePlatform, type FixturePlatform } from "./server.ts";
 import { testRoutes, type TestControls } from "./tests.ts";
@@ -29,6 +30,8 @@ export type { FixturePlatform, Observation } from "./server.ts";
 export type { SeedTest, SeededTest, TestControls } from "./tests.ts";
 
 export type Platform = FixturePlatform & {
+  /** Stable identity returned before login. */
+  readonly instanceId: PlatformIdentityControls["instanceId"];
   /** What a person in a browser would do, done directly. */
   readonly device: DeviceControls;
   /** What was registered, and what the platform was handed to seal. */
@@ -49,8 +52,11 @@ export async function startPlatform(): Promise<Platform> {
   let registered!: AgentControls;
   let tests!: TestControls;
   let running!: RunControls;
+  let identity!: PlatformIdentityControls;
 
   const platform = await startFixturePlatform((origin) => {
+    const platformGroup = platformRoutes(origin);
+    identity = platformGroup.controls;
     const deviceGroup = deviceRoutes(origin);
     device = deviceGroup.controls;
 
@@ -79,6 +85,7 @@ export async function startPlatform(): Promise<Platform> {
     running = runGroup.controls;
 
     return [
+      platformGroup.group,
       deviceGroup.group,
       agentGroup.group,
       testGroup.group,
@@ -90,6 +97,7 @@ export async function startPlatform(): Promise<Platform> {
 
   return {
     ...platform,
+    instanceId: identity.instanceId,
     device,
     registered,
     tests,

--- a/apps/cli/test/support/fixture-platform/index.ts
+++ b/apps/cli/test/support/fixture-platform/index.ts
@@ -47,7 +47,12 @@ export type Platform = FixturePlatform & {
   signedInWith(key: string): void;
 };
 
-export async function startPlatform(): Promise<Platform> {
+export type StartPlatformOptions = {
+  /** What the identity route names when this socket is only an alias. */
+  readonly canonicalOrigin?: string;
+};
+
+export async function startPlatform(options: StartPlatformOptions = {}): Promise<Platform> {
   let device!: DeviceControls;
   let registered!: AgentControls;
   let tests!: TestControls;
@@ -55,7 +60,7 @@ export async function startPlatform(): Promise<Platform> {
   let identity!: PlatformIdentityControls;
 
   const platform = await startFixturePlatform((origin) => {
-    const platformGroup = platformRoutes(origin);
+    const platformGroup = platformRoutes(() => options.canonicalOrigin ?? origin());
     identity = platformGroup.controls;
     const deviceGroup = deviceRoutes(origin);
     device = deviceGroup.controls;

--- a/apps/cli/test/support/fixture-platform/platform.ts
+++ b/apps/cli/test/support/fixture-platform/platform.ts
@@ -1,0 +1,29 @@
+import { newId } from "@egma/ids";
+
+import type { RouteGroup } from "./server.ts";
+
+export type PlatformIdentityControls = {
+  readonly instanceId: string;
+};
+
+export function platformRoutes(
+  origin: () => string,
+): { readonly group: RouteGroup; readonly controls: PlatformIdentityControls } {
+  const instanceId = newId("pf");
+  return {
+    controls: { instanceId },
+    group: {
+      name: "platform",
+      routes: [
+        {
+          method: "GET",
+          path: "/api/platform",
+          handle: () => ({
+            status: 200,
+            body: { instance_id: instanceId, origin: origin() },
+          }),
+        },
+      ],
+    },
+  };
+}

--- a/apps/cli/test/support/workspace.ts
+++ b/apps/cli/test/support/workspace.ts
@@ -10,6 +10,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import type { DrivenAgentLaunch } from "../../src/acp/registry.ts";
+import { writeCredentials } from "../../src/platform/credentials.ts";
 import type { FakeScript } from "./fake-agent.ts";
 
 export const FAKE_AGENT = fileURLToPath(new URL("./fake-agent.ts", import.meta.url));
@@ -157,11 +158,7 @@ export async function makeWorkspace(
       return env;
     },
     async signIn(url, key = "egma_sk_already-held") {
-      await mkdir(egmaFolder, { recursive: true, mode: 0o700 });
-      await writeFile(credentialsFile, `${JSON.stringify({ url, key })}\n`, {
-        encoding: "utf8",
-        mode: 0o600,
-      });
+      await writeCredentials(credentialsFile, { url, key });
     },
     async browser() {
       // `BROWSER` names one command, exactly as it does for every other tool

--- a/apps/cli/test/teaching.test.ts
+++ b/apps/cli/test/teaching.test.ts
@@ -250,7 +250,11 @@ describe("the pane, while the files land", () => {
           launch: second.launch(await scriptFor(second)),
           cwd: second.dir,
           signal: new AbortController().signal,
-          platform: { url: elsewhere.url, credentialsFile: second.credentialsFile },
+          platform: {
+            url: elsewhere.url,
+            instanceId: elsewhere.instanceId,
+            credentialsFile: second.credentialsFile,
+          },
           retell: { url: retell.url },
           home: path.join(second.dir, "pretend-home"),
           runPollMs: 20,

--- a/apps/cli/test/tui.test.ts
+++ b/apps/cli/test/tui.test.ts
@@ -17,6 +17,7 @@ import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { runInTerminal, showing } from "./support/pty.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
 import { CLI_ENTRY, FAKE_AGENT, MANIFEST, makeWorkspace, type Workspace } from "./support/workspace.ts";
 
 // A real subprocess, a real terminal and a test run using every core: the
@@ -24,15 +25,18 @@ import { CLI_ENTRY, FAKE_AGENT, MANIFEST, makeWorkspace, type Workspace } from "
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 
 describe("the wizard on a real terminal", () => {
+  let platform: Platform;
   let workspace: Workspace;
 
   beforeEach(async () => {
+    platform = await startPlatform();
     workspace = await makeWorkspace({ "package.json": MANIFEST });
     // Login has its own checks; these are about what a real terminal draws.
-    await workspace.signIn("https://egma.invalid");
+    await workspace.signIn(platform.url);
   });
 
   afterEach(async () => {
+    await platform.close();
     await workspace.remove();
   });
 
@@ -52,7 +56,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
-      env: workspace.env(),
+      env: workspace.env({ EGMA_URL: platform.url }),
     });
 
     try {
@@ -107,7 +111,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
-      env: workspace.env(),
+      env: workspace.env({ EGMA_URL: platform.url }),
     });
 
     try {
@@ -145,7 +149,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
-      env: workspace.env(),
+      env: workspace.env({ EGMA_URL: platform.url }),
     });
 
     try {
@@ -169,7 +173,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
-      env: workspace.env(),
+      env: workspace.env({ EGMA_URL: platform.url }),
     });
 
     try {
@@ -198,7 +202,7 @@ describe("the wizard on a real terminal", () => {
       command: process.execPath,
       args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
       cwd: workspace.dir,
-      env: workspace.env(),
+      env: workspace.env({ EGMA_URL: platform.url }),
     });
 
     try {

--- a/apps/cli/test/unusable-keys.test.ts
+++ b/apps/cli/test/unusable-keys.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 
@@ -113,6 +113,48 @@ it("leaves the damaged file exactly as it was, on every one of them", async () =
   for (const verb of ["login", "connect", "push", "pull", "run"]) {
     await egma([verb, "--cwd", workspace.dir]);
   }
-  const { readFile } = await import("node:fs/promises");
   expect(await readFile(workspace.credentialsFile, "utf8")).toBe(DAMAGED);
 });
+
+/**
+ * The other way a keys file stops a command: it is there, it is perfectly
+ * well-formed, and this machine cannot open it.
+ *
+ * Told the same way as a damaged one, because it is the same fact about the
+ * same file — and proved through the real command rather than reasoned about,
+ * because the value of a refusal is entirely in whether it arrives.
+ *
+ * Skipped only for a user who can read anything, which cannot be staged for.
+ */
+it.skipIf(process.getuid?.() === 0)(
+  "says the same thing about a keys file it cannot open",
+  async () => {
+    const readable = `${JSON.stringify(
+      { version: 1, platforms: { "https://one.example": { key: "egma_sk_one" } } },
+      null,
+      2,
+    )}\n`;
+    await writeFile(workspace.credentialsFile, readable, "utf8");
+    await chmod(workspace.credentialsFile, 0o000);
+
+    try {
+      // `login` writes and `push` reads, so both doors are checked.
+      for (const verb of ["login", "push"]) {
+        const result = await egma([verb, "--cwd", workspace.dir]);
+        const shown = `${result.stdout}${result.stderr}`;
+
+        expect(result.code, verb).toBe(1);
+        expect(result.stdout, verb).toContain(`status: ${KEYS_UNUSABLE}`);
+        expect(result.stderr, verb).toContain(workspace.credentialsFile);
+        expect(shown, verb).not.toMatch(/^\s+at /mu);
+        expect(shown, verb).not.toContain("EACCES");
+        expect(shown, verb).not.toContain("[cause]");
+      }
+    } finally {
+      await chmod(workspace.credentialsFile, 0o600);
+    }
+
+    // And the key that was in there is still in there.
+    expect(await readFile(workspace.credentialsFile, "utf8")).toBe(readable);
+  },
+);

--- a/apps/cli/test/unusable-keys.test.ts
+++ b/apps/cli/test/unusable-keys.test.ts
@@ -1,0 +1,118 @@
+/**
+ * What every command does when this machine's keys file cannot be used.
+ *
+ * egma refuses to write over a keys file it cannot read, which is right — a
+ * damaged file can be repaired and one egma has overwritten cannot. But a
+ * refusal only counts as a refusal if it reaches the developer. Reaching them
+ * as an unhandled exception means a Node stack trace, a `[cause]` dump of the
+ * JSON parser's own words, and exit 1 in place of the verb's own answer, which
+ * is neither readable by a person nor branchable by a coding agent.
+ *
+ * So it is checked here through real processes, on every verb that reads the
+ * file, because only one of the five paths through `main` used to catch.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { createEgmaFolder, writeTestFile } from "../src/folder/egma-folder.ts";
+import { KEYS_UNUSABLE } from "../src/platform/credentials.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { CLI_ENTRY, makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+/** Truncated mid-key, which is what an interrupted write leaves behind. */
+const DAMAGED = '{\n  "version": 1,\n  "platforms": {\n    "https://one.example": {"ke';
+
+let platform: Platform;
+let workspace: Workspace;
+
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  workspace = await makeWorkspace();
+
+  await createEgmaFolder({
+    repository: workspace.dir,
+    config: {
+      platform: { origin: platform.url, instance: platform.instanceId },
+      agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+      connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+      suite: { name: "first-suite", id: null },
+    },
+  });
+  await writeTestFile(path.join(workspace.dir, "egma", "tests", "moves-a-booking.md"), {
+    name: "moves-a-booking",
+    personas: [],
+    version: null,
+    scenario: "The persona asks to move an appointment.",
+    expectedBehaviors: ["The agent confirms the new time."],
+  });
+
+  await mkdir(workspace.egmaFolder, { recursive: true });
+  await writeFile(workspace.credentialsFile, DAMAGED, "utf8");
+});
+
+afterEach(async () => {
+  await platform.close();
+  await workspace.remove();
+});
+
+async function egma(args: readonly string[]): Promise<{
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly code: number;
+}> {
+  const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+    cwd: workspace.dir,
+    env: workspace.env(),
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  child.stdin.end();
+  const code = await new Promise<number>((resolve) => {
+    child.on("close", (value) => resolve(value ?? 1));
+  });
+  return { stdout, stderr, code };
+}
+
+it.each([["login"], ["connect"], ["push"], ["pull"], ["run"]])(
+  "tells %s's caller what is wrong with the keys file instead of throwing at them",
+  async (verb) => {
+    const result = await egma([verb, "--cwd", workspace.dir]);
+    const shown = `${result.stdout}${result.stderr}`;
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain(`status: ${KEYS_UNUSABLE}`);
+    expect(result.stderr).toContain(workspace.credentialsFile);
+    expect(result.stderr).toContain("move it aside and sign in again");
+
+    // None of Node's own words: no stack frames, no parser complaint, no dump
+    // of the cause. A developer gets a sentence and a coding agent gets a
+    // status line, and neither has to read a trace to find out what happened.
+    expect(shown).not.toMatch(/^\s+at /mu);
+    expect(shown).not.toContain("SyntaxError");
+    expect(shown).not.toContain("[cause]");
+    expect(shown).not.toContain("node:internal");
+  },
+);
+
+it("leaves the damaged file exactly as it was, on every one of them", async () => {
+  for (const verb of ["login", "connect", "push", "pull", "run"]) {
+    await egma([verb, "--cwd", workspace.dir]);
+  }
+  const { readFile } = await import("node:fs/promises");
+  expect(await readFile(workspace.credentialsFile, "utf8")).toBe(DAMAGED);
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -25,6 +25,11 @@ const config: NextConfig = {
       // Ahead of this app's own files, so the API owns these paths outright.
       // `/api/health` is this process's own and is deliberately not among them.
       beforeFiles: [
+        // The platform's public identity, forwarded because the CLI reads it at
+        // the origin a self-hoster was given — which is this process, not the
+        // API's own port. Without this rule a bound repository could never
+        // verify the platform it is bound to.
+        { source: "/api/platform", destination: `${api}/api/platform` },
         { source: "/api/auth/:path*", destination: `${api}/api/auth/:path*` },
         { source: "/api/signup", destination: `${api}/api/signup` },
         {

--- a/packages/db/migrations/0020_platform_instance.sql
+++ b/packages/db/migrations/0020_platform_instance.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "platform_instance" (
+	"singleton" boolean PRIMARY KEY DEFAULT true NOT NULL,
+	"id" text COLLATE "C" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "platform_instance_id_format" CHECK ("platform_instance"."id" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "platform_instance_id_unique" ON "platform_instance" USING btree ("id");

--- a/packages/db/migrations/meta/0020_snapshot.json
+++ b/packages/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,4282 @@
+{
+  "id": "09ef7d1a-0aca-4e5f-af24-a1b4151f45fa",
+  "prevId": "a178e921-67e2-4bb6-8d82-e69a733b07b4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.platform_instance": {
+      "name": "platform_instance",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_instance_id_unique": {
+          "name": "platform_instance_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_instance_id_format": {
+          "name": "platform_instance_id_format",
+          "value": "\"platform_instance\".\"id\" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_rubric', 'metric_threshold', 'tool_calls', 'phrase_match')"
+        },
+        "grader_priority_allowed": {
+          "name": "grader_priority_allowed",
+          "value": "\"grader\".\"priority\" in ('P0', 'P1', 'P2')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_grader": {
+      "name": "test_grader",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_grader_grader_id_idx": {
+          "name": "test_grader_grader_id_idx",
+          "columns": [
+            {
+              "expression": "grader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_grader_test_version_id_test_version_id_fk": {
+          "name": "test_grader_test_version_id_test_version_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_grader_grader_id_grader_id_fk": {
+          "name": "test_grader_grader_id_grader_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_grader_pk": {
+          "name": "test_grader_pk",
+          "columns": [
+            "test_version_id",
+            "grader_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_grader_version_id_position_unique": {
+          "name": "test_grader_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_grader_test_version_id_prefix": {
+          "name": "test_grader_test_version_id_prefix",
+          "value": "\"test_grader\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0 and \"run\".\"canceled_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1786319406614,
       "tag": "0019_simulation_connection_type_leaves_the_row",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1786347823429,
+      "tag": "0020_platform_instance",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -30,10 +30,9 @@
  * this category is a deliberate act: a test names them all and fails when an
  * eighth appears.
  *
- * **Instance-scoped.** `instanceIsClaimed`, and only it. It takes nothing and
- * returns a boolean, so it can neither name a customer nor carry a row out. It
- * is asked by the one caller with no credential at all — somebody looking at a
- * signup form — and the same test names it.
+ * **Instance-scoped.** `instanceIsClaimed` and `platformInstanceId`. Both take
+ * nothing, so neither can name a customer. They return only one platform fact:
+ * whether signup has been claimed, or the platform's own non-secret identity.
  *
  * **Work-dispatching.** `claimGradingJobs`, `watchGradingWork`,
  * `claimSimulations`, `recordSimulationHeartbeat`, `sweepOrphanedSimulations`
@@ -164,7 +163,7 @@ export {
   type NewOrganization,
   type ProvisionedOrganization,
 } from "./provisioning.ts";
-export { instanceIsClaimed } from "./instance.ts";
+export { instanceIsClaimed, platformInstanceId } from "./instance.ts";
 
 export {
   readOrganization,

--- a/packages/db/src/access/instance.ts
+++ b/packages/db/src/access/instance.ts
@@ -1,5 +1,36 @@
+import { newId } from "@egma/ids";
+import { eq } from "drizzle-orm";
+
 import { db } from "../client.ts";
+import { platformInstance } from "../schema/platform.ts";
 import { organization } from "../schema/tenancy.ts";
+
+/**
+ * The stable, public identity of this whole Egma platform.
+ *
+ * It belongs to no organization and carries no customer data. The first read
+ * mints it. A concurrent first read can lose the insert race, then reads the
+ * winner, so every API process answers with one value.
+ */
+export async function platformInstanceId(): Promise<string> {
+  const minted = newId("pf");
+  const [inserted] = await db()
+    .insert(platformInstance)
+    .values({ singleton: true, id: minted })
+    .onConflictDoNothing({ target: platformInstance.singleton })
+    .returning({ id: platformInstance.id });
+  if (inserted !== undefined) return inserted.id;
+
+  const [held] = await db()
+    .select({ id: platformInstance.id })
+    .from(platformInstance)
+    .where(eq(platformInstance.singleton, true))
+    .limit(1);
+  if (held === undefined) {
+    throw new Error("the platform instance identity could not be read");
+  }
+  return held.id;
+}
 
 /**
  * Whether anybody has signed up here yet.

--- a/packages/db/src/access/instance.ts
+++ b/packages/db/src/access/instance.ts
@@ -1,35 +1,72 @@
 import { newId } from "@egma/ids";
 import { eq } from "drizzle-orm";
 
-import { db } from "../client.ts";
+import { db, type Database } from "../client.ts";
 import { platformInstance } from "../schema/platform.ts";
 import { organization } from "../schema/tenancy.ts";
+
+/**
+ * The answer, once this deployment has given it.
+ *
+ * It is held against the connection that answered rather than in a bare
+ * variable, because one process can serve two databases in a lifetime — a test
+ * closes an instance and starts another — and each of those is a different
+ * platform with a different identity. `connect` builds a new query interface,
+ * so a new connection is a new object here and the held answer is not reused
+ * across a platform boundary, which is the one mistake a cache like this could
+ * make that would matter.
+ */
+let held: { readonly connection: Database; readonly id: string } | undefined;
+
+async function storedInstanceId(): Promise<string | undefined> {
+  const [row] = await db()
+    .select({ id: platformInstance.id })
+    .from(platformInstance)
+    .where(eq(platformInstance.singleton, true))
+    .limit(1);
+  return row?.id;
+}
 
 /**
  * The stable, public identity of this whole Egma platform.
  *
  * It belongs to no organization and carries no customer data. The first read
- * mints it. A concurrent first read can lose the insert race, then reads the
- * winner, so every API process answers with one value.
+ * mints it, and every read after that is a read.
+ *
+ * **Reading before writing is the point, not an optimization.** This answers an
+ * unauthenticated route that anybody who can reach the platform may call as
+ * often as they like. An insert that conflicts is still an insert: Postgres
+ * writes the tuple, writes the index entry, writes it to the log, and only then
+ * discards it, so a speculative insert on every request lets a stranger grow
+ * dead rows on this table for free. The sibling public read on this deployment,
+ * `instanceIsClaimed`, is a plain select for the same reason.
+ *
+ * The insert stays for the one request that finds nothing, and it keeps
+ * `onConflictDoNothing` because two processes can arrive at that moment
+ * together — the loser reads the winner's row rather than failing.
  */
 export async function platformInstanceId(): Promise<string> {
-  const minted = newId("pf");
+  const connection = db();
+  if (held?.connection === connection) return held.id;
+
+  const found = await storedInstanceId();
+  if (found !== undefined) {
+    held = { connection, id: found };
+    return found;
+  }
+
   const [inserted] = await db()
     .insert(platformInstance)
-    .values({ singleton: true, id: minted })
+    .values({ singleton: true, id: newId("pf") })
     .onConflictDoNothing({ target: platformInstance.singleton })
     .returning({ id: platformInstance.id });
-  if (inserted !== undefined) return inserted.id;
 
-  const [held] = await db()
-    .select({ id: platformInstance.id })
-    .from(platformInstance)
-    .where(eq(platformInstance.singleton, true))
-    .limit(1);
-  if (held === undefined) {
+  const settled = inserted?.id ?? (await storedInstanceId());
+  if (settled === undefined) {
     throw new Error("the platform instance identity could not be read");
   }
-  return held.id;
+  held = { connection, id: settled };
+  return settled;
 }
 
 /**

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,4 +1,5 @@
 export * from "./columns.ts";
+export * from "./platform.ts";
 export * from "./identity.ts";
 export * from "./tenancy.ts";
 export * from "./device.ts";

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -1,0 +1,23 @@
+import { boolean, pgTable, uniqueIndex } from "drizzle-orm/pg-core";
+
+import { createdAt, idText, prefixCheck } from "./columns.ts";
+
+/**
+ * The identity of this Egma platform, not of any customer on it.
+ *
+ * One row lives with the platform database. It therefore survives API process
+ * restarts and moves with a restored platform backup. The singleton key makes
+ * two API processes racing on first read settle on the same identifier.
+ */
+export const platformInstance = pgTable(
+  "platform_instance",
+  {
+    singleton: boolean("singleton").primaryKey().default(true),
+    id: idText("id").notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    uniqueIndex("platform_instance_id_unique").on(table.id),
+    prefixCheck("platform_instance_id_format", table.id, "pf"),
+  ],
+);

--- a/packages/db/test/data-access-isolation.test.ts
+++ b/packages/db/test/data-access-isolation.test.ts
@@ -9,6 +9,7 @@ import {
   listMembers,
   listProjects,
   membershipsOf,
+  platformInstanceId,
   ProjectOutsideOrganizationError,
   projectsOf,
   provisionOrganization,
@@ -308,6 +309,16 @@ describe("which projects an organization has", () => {
 describe("whether anybody has signed up here yet", () => {
   it("is true once a customer exists, which is what closes open signup", async () => {
     expect(await instanceIsClaimed()).toBe(true);
+  });
+});
+
+describe("the platform instance identity", () => {
+  it("is stable and carries no customer identity", async () => {
+    const first = await platformInstanceId();
+    expect(first).toMatch(/^pf_[0-9A-HJKMNP-TV-Z]{26}$/u);
+    expect(await platformInstanceId()).toBe(first);
+    expect(first).not.toContain(acme.organizationId);
+    expect(first).not.toContain(globex.organizationId);
   });
 });
 

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -66,7 +66,7 @@ const CONTEXT_ESTABLISHING = [
  * It takes nothing and returns a boolean, which is what makes it safe without a
  * context; a build rule refuses it the moment it grows an argument.
  */
-const INSTANCE_SCOPED = ["instanceIsClaimed"];
+const INSTANCE_SCOPED = ["instanceIsClaimed", "platformInstanceId"];
 
 /**
  * What hands egma's own services their work, and what keeps a dispatch honest

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -63,8 +63,9 @@ const CONTEXT_ESTABLISHING = [
 
 /**
  * What answers a question about the deployment rather than about a customer.
- * It takes nothing and returns a boolean, which is what makes it safe without a
- * context; a build rule refuses it the moment it grows an argument.
+ * Neither takes an argument. One returns whether signup is claimed; the other
+ * returns the platform's own public, non-secret id. The build rule pins both
+ * exact return types and refuses either function if it grows an argument.
  */
 const INSTANCE_SCOPED = ["instanceIsClaimed", "platformInstanceId"];
 

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -31,6 +31,7 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   device_code: "dvc",
   organization: "org",
   organization_settings: "org",
+  platform_instance: "pf",
   project: "prj",
   membership: "mbr",
   invitation: "inv",

--- a/packages/ids/src/index.ts
+++ b/packages/ids/src/index.ts
@@ -32,6 +32,7 @@ export const ID_PREFIXES = [
   "acc",
   "vrf",
   "dvc",
+  "pf",
   "org",
   "prj",
   "mbr",

--- a/packages/lint/src/index.test.ts
+++ b/packages/lint/src/index.test.ts
@@ -286,6 +286,15 @@ describe("an exported call that could reach the database without a customer", ()
     expect(await check(root)).toEqual([]);
   });
 
+  it("allows the platform's public id as its one explicit instance fact", async () => {
+    await withSurface(
+      'export { platformInstanceId } from "./things.ts";\n',
+      "export async function platformInstanceId(): Promise<string> {\n  return 'pf_public';\n}\n",
+    );
+
+    expect(await check(root)).toEqual([]);
+  });
+
   it("refuses that exemption the moment it grows an argument", async () => {
     await withSurface(
       'export { instanceIsClaimed } from "./things.ts";\n',
@@ -297,6 +306,23 @@ describe("an exported call that could reach the database without a customer", ()
       "every-exported-call-carries-an-auth-context",
     ]);
     expect(violations[0]?.detail).toContain("wearing an exemption");
+  });
+
+  it("refuses either instance exception when its result grows wider", async () => {
+    await withSurface(
+      'export { instanceIsClaimed, platformInstanceId } from "./things.ts";\n',
+      "export async function instanceIsClaimed(): Promise<string> {\n  return 'all organizations';\n}\nexport async function platformInstanceId(): Promise<string[]> {\n  return ['pf_public'];\n}\n",
+    );
+
+    const violations = await check(root);
+    expect(rules(violations)).toEqual([
+      "every-exported-call-carries-an-auth-context",
+      "every-exported-call-carries-an-auth-context",
+    ]);
+    expect(violations.map((violation) => violation.detail)).toEqual([
+      expect.stringContaining("instanceIsClaimed"),
+      expect.stringContaining("platformInstanceId"),
+    ]);
   });
 
   /**

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -86,13 +86,17 @@ const CONTEXT_ESTABLISHING = [
  * who has no credential to build a context from and never will until they have
  * signed up.
  *
- * This category is narrower than the one above and the rule enforces the reason
- * it is safe: a function here **takes no arguments at all**. With nothing to
- * name, there is no customer to name wrongly, and a boolean carries no row out.
- * A function here that grew a parameter would be an ordinary read wearing an
- * exemption, so the rule refuses it.
+ * This category is narrower than the one above and the rule enforces both parts
+ * of each named exception: no function here takes an argument, and each returns
+ * only the platform fact written beside it. `instanceIsClaimed` returns a
+ * boolean. `platformInstanceId` returns the platform's public, non-secret id.
+ * A parameter or a wider return would make either an ordinary read wearing an
+ * exemption, so the rule refuses both changes.
  */
-const INSTANCE_SCOPED = ["instanceIsClaimed", "platformInstanceId"];
+const INSTANCE_SCOPED: ReadonlyMap<string, string> = new Map([
+  ["instanceIsClaimed", "Promise<boolean>"],
+  ["platformInstanceId", "Promise<string>"],
+]);
 
 /**
  * The exports that dispatch egma's own work across the whole deployment, and
@@ -517,9 +521,10 @@ async function checkExportedCallShapes(root: string): Promise<Violation[]> {
 
       const first = declaration.parameters[0];
       const firstType = first?.type?.getText(declaring);
+      const instanceScopedReturn = INSTANCE_SCOPED.get(name);
       const exempt =
         CONTEXT_ESTABLISHING.includes(name) ||
-        INSTANCE_SCOPED.includes(name) ||
+        instanceScopedReturn !== undefined ||
         WORK_DISPATCHING.includes(name);
       if (!exempt && firstType !== AUTH_CONTEXT) {
         violations.push({
@@ -533,7 +538,7 @@ async function checkExportedCallShapes(root: string): Promise<Violation[]> {
         });
       }
 
-      if (INSTANCE_SCOPED.includes(name) && declaration.parameters.length > 0) {
+      if (instanceScopedReturn !== undefined && declaration.parameters.length > 0) {
         violations.push({
           file,
           line: line(declaration),
@@ -543,6 +548,22 @@ async function checkExportedCallShapes(root: string): Promise<Violation[]> {
             `deployment rather than about a customer, and that only holds ` +
             `while it takes nothing. A parameter would give it a customer to ` +
             `name, and it would be an ordinary read wearing an exemption.`,
+        });
+      }
+
+      if (
+        instanceScopedReturn !== undefined &&
+        declaration.type?.getText(declaring) !== instanceScopedReturn
+      ) {
+        const declared = declaration.type?.getText(declaring) ?? "no declared return type";
+        violations.push({
+          file,
+          line: line(declaration),
+          rule: "every-exported-call-carries-an-auth-context",
+          detail:
+            `${name} skips the ${AUTH_CONTEXT} only because its public ` +
+            `instance fact is ${instanceScopedReturn}. It declares ${declared}; ` +
+            `a wider return would make this an ordinary read wearing an exemption.`,
         });
       }
 

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -92,7 +92,7 @@ const CONTEXT_ESTABLISHING = [
  * A function here that grew a parameter would be an ordinary read wearing an
  * exemption, so the rule refuses it.
  */
-const INSTANCE_SCOPED = ["instanceIsClaimed"];
+const INSTANCE_SCOPED = ["instanceIsClaimed", "platformInstanceId"];
 
 /**
  * The exports that dispatch egma's own work across the whole deployment, and


### PR DESCRIPTION
Ticket 01 of the self-hosted phone platform effort. Lands on the effort's integration branch, not on `main`.

## What this does

A developer selects an Egma platform once for an agent repository, and every later wizard or headless command uses that same platform. An unbound repository uses the built-in default. A bound repository refuses safely rather than sending its resource identifiers somewhere it did not choose.

- Every platform exposes a stable, non-secret instance identity and canonical origin through one public contract (`GET /api/platform`).
- Resolution is explicit `--url`, then `EGMA_URL`, then the committed repository binding, then the built-in default for an unbound repository. The machine's last login never selects a repository's platform.
- The committed binding lives in `egma/config.yaml` and holds no credential. Credentials live outside the repository, keyed by normalized platform origin, so signing in to one platform does not replace another's.
- A bound repository whose platform is unavailable refuses with a clear next action and never falls back.

## Two bugs found in review that would have broken the self-hosted path

**The web app did not forward `/api/platform`.** The address a self-hoster is handed is the web origin, so pointing the CLI at a healthy platform returned a 404 and a refusal that blamed the platform. The existing test hid this by starting the instance with the pages switched off.

**The platform could dictate its own address.** The CLI trusted the origin in the reply over the address the developer typed, and silently rewrote the committed binding to match. Running the stack on a LAN box would switch the CLI to `localhost`, and committing that binding would point every teammate's clone at their own machine. The CLI now keeps the address it was given, refuses a disagreement, and never rewrites a committed binding.

Also fixed: `/api/platform` attempted a database write on every unauthenticated request; a missing timeout meant a half-dead platform hung every command; a corrupt credentials file made the next write discard every platform's key; and a damaged credentials file crashed the CLI with a stack trace instead of its own message.

## Verification

- Full suite green: 2082 passed / 2 skipped across 132 files, plus 501 simulator tests.
- Three independent review rounds. Each fence proven by mutation — deleting the platform-mismatch check makes the CLI post identifiers to the wrong platform and the test fails.
- Real CLI child processes against two real platform instances on real Postgres, as the ticket requires. No fixture-only proof.

## Known and carried, not fixed here

- A wizard run ending at "no Retell key" leaves a folder holding only the binding. `connectStep` is rewritten by ticket 03; fixing it here means fixing it twice.
- The run address points at a page that does not exist yet — that page is ticket 06.
- The secret sweep covers config, terminal output, structured output and logs. Receipts do not exist until ticket 02, which carries that sweep.
- The test harness leaks a database when a test times out, which makes the suite intermittently red. Pre-existing; ticket 02 adds a sweep at `db:up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NniiSVBX5KKTveH1cY9FMw

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR binds each agent repository to a verified Egma platform and keeps credentials separately by normalized platform origin.
- Adds a public platform identity endpoint, persistent platform instance identity, and web proxy forwarding.
- Resolves explicit URL, environment URL, repository binding, and the built-in default in a fixed order.
- Refuses unavailable or mismatched bound platforms instead of falling back.
- Preserves credential entries across platforms and refuses unreadable stores without overwriting them.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/platform/credentials.ts | Implements repository-aware platform selection, identity verification, multi-platform credential storage, locking, and safe refusal for unreadable stores. |
| apps/cli/src/platform/identity.ts | Adds bounded platform identity retrieval and strict agreement between the requested and advertised origins. |
| apps/cli/src/main.ts | Resolves and verifies platform access centrally before dispatching wizard and headless commands. |
| apps/api/src/routes/platform.ts | Exposes the stable public platform identity and configured canonical origin. |
| packages/db/src/access/instance.ts | Persists and caches the singleton platform identity used by the public identity contract. |
| apps/web/next.config.ts | Forwards the platform identity route through the web origin used by self-hosted CLI clients. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI
    participant Repo as egma/config.yaml
    participant Platform as Selected Egma platform
    participant Keys as Machine credential store
    CLI->>Repo: Read committed platform binding
    CLI->>Platform: GET /api/platform
    Platform-->>CLI: instance_id and canonical origin
    CLI->>CLI: Verify address, origin, and bound instance
    alt identity matches binding
        CLI->>Keys: Read credential keyed by platform origin
        CLI->>Platform: Execute command
    else unavailable or mismatched
        CLI-->>CLI: Refuse without fallback or identifier upload
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Refuse a keys file egma cannot open, on ..."](https://github.com/egma-ai/egma/commit/ac4755cefb7f9343d95835045ee8aeaf75aee759) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51910196)</sub>

<!-- /greptile_comment -->