### PR TITLE
Onboard Remedy Phase One and create the selected connection

### DIFF
--- a/apps/api/test/runs-cli-verbs.test.ts
+++ b/apps/api/test/runs-cli-verbs.test.ts
@@ -6,6 +6,7 @@ import {
   startSimulation,
   type AuthContext,
 } from "@egma/db";
+import { newId } from "@egma/ids";
 import type { FastifyInstance } from "fastify";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -203,9 +204,9 @@ describe("starting a run from the terminal's own code", () => {
     expect(read).toEqual(answer.run);
   });
 
-  it("hands the platform's own refusal back as an answer, word for word", async () => {
+  it("starts a run over a phone connection, because the phone adapter has shipped", async () => {
     const { signedIn, fetchImpl, versions } = await readyToRun(
-      "runs_cli_no_adapter",
+      "runs_cli_over_phone",
     );
 
     const registered = await api.app.inject({
@@ -213,7 +214,7 @@ describe("starting a run from the terminal's own code", () => {
       url: "/api/agents",
       headers: { authorization: `Bearer ${signedIn.key}` },
       payload: {
-        name: "Old line",
+        name: "Front desk line",
         connection: {
           type: "phone",
           modality: "voice",
@@ -234,15 +235,35 @@ describe("starting a run from the terminal's own code", () => {
       fetchImpl,
     );
 
+    // This was the `no_adapter` refusal until the phone adapter shipped. The
+    // terminal's own code now gets a run back over a number, the same way it
+    // does over any other type egma conducts.
+    expect(answer.kind).toBe("started");
+    if (answer.kind !== "started") return;
+    expect(answer.run.connectionType).toBe("phone");
+    expect(answer.run.modality).toBe("voice");
+  });
+
+  it("hands the platform's own refusal back as an answer, word for word", async () => {
+    const { signedIn, fetchImpl, connectionId } = await readyToRun(
+      "runs_cli_refusal",
+    );
+
+    const missing = newId("tstv");
+    const answer = await startRun(
+      signedIn,
+      { agentId: "", connectionId, testVersionIds: [missing] },
+      fetchImpl,
+    );
+
     // A refusal, not an exception: the terminal prints the sentence as it
     // stands, because paraphrasing a decision it did not make would be egma
     // inventing an explanation.
     expect(answer).toEqual({
       kind: "refused",
       reason:
-        "egma has no simulator adapter for a phone connection yet, so it " +
-        "will not start a run it cannot conduct. Run these tests over a " +
-        "connection egma conducts today: retell, livekit.",
+        `there is no test version ${missing} on this egma. Push the test ` +
+        `first, or read the test and pin the version_id it names now.`,
     });
   });
 });

--- a/apps/api/test/runs-routes.test.ts
+++ b/apps/api/test/runs-routes.test.ts
@@ -107,7 +107,7 @@ const RETELL = {
   credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
 } as const;
 
-/** A number egma can be told to dial, and has no adapter to dial it with. */
+/** A number egma dials: the shipped phone adapter's own connection shape. */
 const PHONE = {
   type: "phone",
   modality: "voice",
@@ -492,28 +492,28 @@ describe("starting a run", () => {
     });
   });
 
-  it("refuses a connection type no simulator adapter has shipped for, at the door", async () => {
-    const { key, oneCaller } = await aCustomerReadyToRun("runs_no_adapter");
-    const dialled = await registerAgentThrough(key, "Old line", PHONE);
+  it("accepts a run over a phone connection, because the phone adapter has shipped", async () => {
+    const { key, oneCaller } = await aCustomerReadyToRun("runs_over_phone");
+    const dialled = await registerAgentThrough(key, "Front desk line", PHONE);
 
-    const refused = await request("POST", "/api/runs", key, {
+    const started = await request("POST", "/api/runs", key, {
       connection: dialled.connectionId,
       test_versions: [oneCaller],
     });
 
-    // The platform's own sentence, relayed word for word by whatever prints it.
-    expect(refused.statusCode).toBe(422);
-    expect(refused.body).toEqual({
-      error: "no_adapter",
-      message:
-        "egma has no simulator adapter for a phone connection yet, so it " +
-        "will not start a run it cannot conduct. Run these tests over a " +
-        "connection egma conducts today: retell, livekit.",
+    // This used to be the `no_adapter` refusal. The adapter is in the shipped
+    // simulator now, so the door opens — and the run is a real one, queued
+    // over the number the customer registered.
+    expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+    expect(started.body).toMatchObject({
+      status: "pending",
+      connection_id: dialled.connectionId,
+      connection_type: "phone",
+      modality: "voice",
     });
 
-    // And nothing is left queued for a conductor that does not exist.
     const { rows } = await api.database.sql("select id from run");
-    expect(rows).toEqual([]);
+    expect(rows).toEqual([{ id: String(started.body.id) }]);
   });
 
   it("is refused to a viewer, because a run spends money and creates data", async () => {

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -135,7 +135,8 @@ then egma asks the one question that decides what it creates:
 ```
 ◇ How should egma reach this agent?
   › Text — egma exchanges messages with the agent. No phone call, nothing dialled.
-    Phone — egma dials one of the agent's numbers and talks to it, as a customer would.
+    Phone — egma dials one of the agent's numbers and talks to it over the
+    telephone network, the way the people who call it do.
 
   egma creates the one you choose, and only that one.
 ```

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -129,10 +129,35 @@ take, and a key for an account with no agents on it, are told apart by name and
 each is worth one more try. One agent on the account is shown for confirmation
 with nothing to answer; several get a list to choose from.
 
-The agent's configuration — its prompt, its voice, its tools — is pulled and
-registered on egma, together with a connection for reaching it. **What Retell
-answered is kept exactly as it answered it**, beside what egma read out of it,
-so a field egma has no place for today is still there tomorrow.
+The agent's configuration — its prompt, its voice, its tools — is pulled, and
+then egma asks the one question that decides what it creates:
+
+```
+◇ How should egma reach this agent?
+  › Text — egma exchanges messages with the agent. No phone call, nothing dialled.
+    Phone — egma dials one of the agent's numbers and talks to it, as a customer would.
+
+  egma creates the one you choose, and only that one.
+```
+
+Both are real ways to test one voice agent, and they answer different
+questions. Text exercises the prompt, the reasoning and the tools. Phone
+exercises all of that plus the speech stack and the line it is carried on. The
+same test over both is the sharpest thing egma can tell you: passes on text and
+fails on phone means the prompt is fine and the speech stack is not.
+
+**egma creates the connection you chose and never both.** Choose the phone and
+it lists the numbers Retell routes to that agent, you pick one, and the
+connection it writes holds that number and nothing else — no Retell identifier
+and no credential of any kind, because the public telephone network neither
+knows nor cares what answers. Choose text and it writes one Retell chat
+connection for the voice agent you selected, with your key sealed on the
+platform.
+
+**What Retell answered is kept exactly as it answered it**, beside what egma
+read out of it, so a field egma has no place for today is still there tomorrow.
+Nothing in this step writes to your Retell account: every request egma makes to
+it is a read.
 
 If your repository keeps a prompt of its own and it differs from what Retell is
 running, egma says so in one line and carries on. It never blocks: being out of
@@ -155,12 +180,20 @@ EGMA_RETELL_API_KEY=… egma connect
 nothing new. With several agents on the account it lists them and refuses to
 guess; name one with `--retell-agent`.
 
-**Running it twice over the same Retell agent is safe.** egma answers the
-registration you already have rather than making a second one, stores the key
-you just gave, and says which of three things it did on the `registration:`
-line — `created`, `reused`, or `connection_added` when the same agent gained
-another way of being reached. The last two also print a `note:` line saying it
-in plain words.
+It refuses to guess the reach as well. Say `--reach text` or `--reach phone`
+(or set `EGMA_REACH`); with neither, it creates nothing at all and exits 5 —
+egma will not decide on your behalf whether to dial somebody's telephone. With
+`--reach phone` and several numbers routed to the agent, name one with
+`--phone-number` or `EGMA_PHONE_NUMBER`.
+
+**Running it twice over the same voice agent is safe.** egma answers the
+registration you already have rather than making a second one and says which of
+three things it did on the `registration:` line — `created`, `reused`, or
+`connection_added` when the same agent gained another way of being reached. The
+last two also print a `note:` line saying it in plain words. Coming back for the
+second reach lands on the same agent: one voice agent, two ways to reach it, one
+results history. `agent_registration:` and `connection_registration:` say the
+same thing for each half, as `created` or `reused`.
 
 ```
 url: https://app.egma.ai
@@ -169,20 +202,26 @@ retell_agent_id: agent_…
 retell_response_engine: retell-llm
 prompt_characters: 2140
 tools: 7
+reach: phone
+phone_number: +14155550111
 agent_id: agt_01K…
 agent_name: order-line
 connection_id: con_01K…
-connection_name: retell-1
-connection_type: retell
+connection_name: phone-1
+connection_type: phone
 connection_modality: voice
 registration: created
+agent_registration: created
+connection_registration: created
 drift: no
 grounded_in: retell
 status: connected
 
 0 connected   2 the key was refused   3 no agents on that account
-4 Retell or egma did not answer, or refused   5 several agents, none named
-6 no key given   7 not signed in to egma   130 stopped part way
+4 Retell or egma did not answer, or refused
+5 a choice only you can make was not made: which agent, text or phone, or
+  which number   6 no key given   7 not signed in to egma
+8 Retell routes no number to that agent   130 stopped part way
 ```
 
 ## Your tests are files in your repository
@@ -527,6 +566,12 @@ egma run [options]       Run this folder's tests, pinning the version of each.
                        waiting for a verdict. The run carries on on egma.
   --retell-agent <id>  With connect: which agent, when the Retell account
                        holds more than one.
+  --reach <text|phone> With connect and a headless wizard: how egma should
+                       reach the agent. egma creates the one you choose and
+                       never both, and creates nothing when neither is said.
+  --phone-number <e164>
+                       With --reach phone: which of the agent's numbers to
+                       dial, when Retell routes more than one to it.
   --repo-prompt <path> With connect: the prompt file in this repository, so
                        egma can say whether it and Retell have drifted apart.
   --existing-tests <path>
@@ -550,6 +595,8 @@ Environment:
                        read too, so an environment that already has one needs
                        nothing new.
   EGMA_RETELL_AGENT_ID Which Retell agent, same as --retell-agent.
+  EGMA_REACH           text or phone, same as --reach.
+  EGMA_PHONE_NUMBER    Which number to dial, same as --phone-number.
   EGMA_RETELL_URL      The Retell to talk to. Default: https://api.retellai.com
   EGMA_EXISTING_TESTS  Your existing test cases, same as --existing-tests.
   VISUAL, EDITOR       What e opens a generated test in, at the gate.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.65.0",
+    "@egma/db": "workspace:*",
+    "@egma/ids": "workspace:*",
     "@types/react": "^19.2.2",
     "@xterm/headless": "^6.0.0",
     "node-pty": "^1.1.0"

--- a/apps/cli/smoke/real-retell-connect.ts
+++ b/apps/cli/smoke/real-retell-connect.ts
@@ -368,11 +368,16 @@ async function main(): Promise<void> {
     /* the numbers, read the way the phone path reads them */
 
     // The other half of the flow, against the same real account: which numbers
-    // Retell routes to the agent egma just took. It is asked for here rather
-    // than walked through, because registering somebody's real telephone
-    // number against a fixture platform is not this check's business — what it
-    // proves is that the shapes the phone path reads are the shapes the real
-    // service answers with.
+    // Retell routes to the agent egma just took.
+    //
+    // What this proves is that the shapes the phone path reads are the shapes
+    // the real service answers with. Where it ends is the account's business
+    // rather than this check's: an agent with several numbers ends at "nobody
+    // said which", an agent with none ends there, and an agent with exactly one
+    // registers a phone connection for it. That last ending really does write
+    // somebody's telephone number down — on the fixture platform this check
+    // starts and throws away, which is nowhere and nobody's, and it is the only
+    // way the confirming read gets exercised at all.
     const numbered = await egma(
       ["connect", "--reach", "phone", "--retell-agent", result.retell_agent_id ?? ""],
       env,

--- a/apps/cli/smoke/real-retell-connect.ts
+++ b/apps/cli/smoke/real-retell-connect.ts
@@ -222,7 +222,11 @@ async function main(): Promise<void> {
     // First run with nothing said about which agent. One agent on the account
     // connects straight away; several are listed and refused, which is the
     // promptless surface behaving exactly as it should.
-    const first = await egma(["connect"], env, workdir);
+    //
+    // The reach is said, because egma will not choose between text and phone
+    // on anybody's behalf. Text here: this check has no platform to dial from
+    // and no business registering somebody's telephone number.
+    const first = await egma(["connect", "--reach", "text"], env, workdir);
     const listed = agentIdsIn(first.stdout);
 
     let connected = first;
@@ -236,7 +240,11 @@ async function main(): Promise<void> {
       // prompt to keep.
       for (const id of listed.slice(0, MOST_AGENTS_TRIED)) {
         chosen += 1;
-        connected = await egma(["connect", "--retell-agent", id], env, workdir);
+        connected = await egma(
+          ["connect", "--reach", "text", "--retell-agent", id],
+          env,
+          workdir,
+        );
         if (connected.code === 0 && Number(facts(connected.stdout).prompt_characters ?? 0) > 0) {
           break;
         }
@@ -308,13 +316,15 @@ async function main(): Promise<void> {
       "nothing egma stored holds a copy of what the provider is running",
     );
 
-    // Retell keeps voice agents and chat agents at two addresses, so the one
-    // this agent is at is the one that has to have answered.
-    const agentAddress =
-      result.connection_modality === "chat"
-        ? `/get-chat-agent/${result.retell_agent_id ?? ""}`
-        : `/get-agent/${result.retell_agent_id ?? ""}`;
-    const answeredWith = gate.answered(agentAddress) ?? "";
+    // Retell keeps voice agents and chat agents at two addresses, and one of
+    // them is where this agent is. Which one is a fact about the *agent* and
+    // not about the connection egma made for it: reaching a voice agent by
+    // text is an ordinary choice, so the connection's modality says which way
+    // egma will talk to it and never which door Retell keeps it behind.
+    const answeredWith =
+      gate.answered(`/get-agent/${result.retell_agent_id ?? ""}`) ??
+      gate.answered(`/get-chat-agent/${result.retell_agent_id ?? ""}`) ??
+      "";
     check(
       answeredWith.length > 0,
       `Retell answered for the agent egma took (${answeredWith.length} bytes)`,
@@ -354,6 +364,56 @@ async function main(): Promise<void> {
       connection?.credentialsHint === key.trim().slice(-4),
       "the key was sealed, and only its last characters came back",
     );
+
+    /* the numbers, read the way the phone path reads them */
+
+    // The other half of the flow, against the same real account: which numbers
+    // Retell routes to the agent egma just took. It is asked for here rather
+    // than walked through, because registering somebody's real telephone
+    // number against a fixture platform is not this check's business — what it
+    // proves is that the shapes the phone path reads are the shapes the real
+    // service answers with.
+    const numbered = await egma(
+      ["connect", "--reach", "phone", "--retell-agent", result.retell_agent_id ?? ""],
+      env,
+      workdir,
+    );
+    const dialling = facts(numbered.stdout);
+    const offered = numbered.stdout
+      .split("\n")
+      .filter((line) => line.startsWith("retell_number: "))
+      .map((line) => line.slice("retell_number: ".length).split(" ")[0] ?? "");
+    for (const number of offered) named.push(number);
+
+    say("");
+    say("── what the phone path read ──────────────────────────────");
+    say(`  status:  ${dialling.status ?? "none"}`);
+    say(`  numbers: ${offered.length}`);
+
+    // Three endings are all correct answers about a real account, and each says
+    // something different: one number was taken, several were offered and none
+    // named, or Retell routes none to this agent at all. What would not be
+    // correct is a fourth.
+    const dialled = dialling.phone_number ?? "";
+    check(
+      ["connected", "unchosen-number", "no-numbers"].includes(dialling.status ?? ""),
+      `the phone path ended in a way it has a word for (${dialling.status ?? "none"})`,
+    );
+    if (dialling.status === "connected") {
+      check(
+        /^\+[1-9]\d{1,14}$/u.test(dialled),
+        "the number egma took is E.164, read from the account",
+      );
+      check(
+        gate.forwarded.some((one) => one.includes("/get-phone-number")),
+        "the number egma took was confirmed at its own address before it was written",
+      );
+    }
+    check(
+      gate.forwarded.includes("GET /list-phone-numbers"),
+      "the account's numbers were listed, and only listed",
+    );
+    check(gate.refused.length === 0, "and nothing but reads was asked for them");
 
     // And the key is nowhere it should not be.
     const printed = `${connected.stdout}${connected.stderr}${first.stdout}${first.stderr}`;

--- a/apps/cli/smoke/real-whole-walk.ts
+++ b/apps/cli/smoke/real-whole-walk.ts
@@ -333,7 +333,14 @@ async function register(
   say("");
   say("── registering the voice agent ───────────────────────────");
 
-  let ran = await egma(["connect", "--cwd", repository], { env, stdin: `${vendor.key}\n` });
+  // Text, said in the command: egma creates the connection it is told to and
+  // never guesses between the two, so this walk says which one it means. The
+  // phone path is proven where a real number and a real carrier are, and this
+  // walk has neither.
+  let ran = await egma(["connect", "--cwd", repository, "--reach", "text"], {
+    env,
+    stdin: `${vendor.key}\n`,
+  });
 
   // A real account may hold several agents, and egma refuses to guess which
   // one. Any of them proves the same thing about the walk, so the first is
@@ -342,10 +349,10 @@ async function register(
     const listed = ran.said.get("retell_agent")?.[0]?.split(" ")[0] ?? "";
     secrets.push(listed);
     say(`  (the account holds several agents; the first was taken)`);
-    ran = await egma(["connect", "--cwd", repository, "--retell-agent", listed], {
-      env,
-      stdin: `${vendor.key}\n`,
-    });
+    ran = await egma(
+      ["connect", "--cwd", repository, "--reach", "text", "--retell-agent", listed],
+      { env, stdin: `${vendor.key}\n` },
+    );
   }
 
   // Everything that names the account, before a single line of this is printed.
@@ -358,8 +365,13 @@ async function register(
   check(first(ran.said, "registration") === "created", "the registration was a fresh one");
   check(first(ran.said, "connection_type") === "retell", "the connection is a retell one");
   check(
-    ["voice", "chat"].includes(first(ran.said, "connection_modality")),
-    `the connection names a modality (${first(ran.said, "connection_modality")})`,
+    first(ran.said, "connection_modality") === "chat",
+    `the text connection is a chat one (${first(ran.said, "connection_modality")})`,
+  );
+  check(first(ran.said, "reach") === "text", "egma made the connection it was told to");
+  check(
+    first(ran.said, "phone_number") === "none",
+    "a text connection dials nothing, and says so",
   );
 
   const agentId = first(ran.said, "agent_id");

--- a/apps/cli/smoke/real-wizard-e2e.ts
+++ b/apps/cli/smoke/real-wizard-e2e.ts
@@ -83,6 +83,7 @@ import { startInstance, type Instance } from "../../api/test/support/instance.ts
 import { DEFAULT_DRIVEN_AGENT_ID, launchForId } from "../src/acp/registry.ts";
 import { folderPathsIn, readConfig } from "../src/folder/egma-folder.ts";
 import { parseTestFile } from "../src/folder/test-file.ts";
+import { readCredentials } from "../src/platform/credentials.ts";
 import { skillPlacesFor } from "../src/skills/install.ts";
 import { runInTerminal, type TerminalRun } from "../test/support/pty.ts";
 import { NO_BROWSER, PASSWORD } from "./support/approving-person.ts";
@@ -371,10 +372,12 @@ async function showing(
  */
 async function rememberNames(origin: string, home: string): Promise<void> {
   try {
-    const held = JSON.parse(await readFile(path.join(home, "credentials"), "utf8")) as {
-      key?: unknown;
-    };
-    if (typeof held.key !== "string") return;
+    // Read through egma's own reader rather than by parsing the file here:
+    // keys are stored per platform origin, and a check that knew the file's
+    // shape for itself would go quietly wrong the day the shape moved — which
+    // is exactly what happened to this once.
+    const held = await readCredentials(path.join(home, "credentials"), origin);
+    if (held === null) return;
     const agents = await ask(origin, held.key, "/api/agents");
     const items = Array.isArray(agents.body.items)
       ? (agents.body.items as Record<string, unknown>[])
@@ -579,10 +582,11 @@ async function walkOnce(options: {
     const runId = /\brun_[0-9A-HJKMNP-TV-Z]{26}/u.exec(runScreen)?.[0] ?? "";
     if (runId === "") throw new Error("the run screen named no run");
 
-    const held = JSON.parse(await readFile(path.join(home, "credentials"), "utf8")) as {
-      url: string;
-      key: string;
-    };
+    const held = await readCredentials(
+      path.join(home, "credentials"),
+      options.instance.origin,
+    );
+    if (held === null) throw new Error("the walk stored no key for the platform it signed in to");
     secrets.push(held.key);
 
     // What arrives in place of a verdict, asked while the wizard is still
@@ -660,6 +664,9 @@ async function assertWhatLanded(options: {
   say(`── what walk ${options.walk} left on the platform ─────────────────`);
 
   check(outcome.exitCode === 0, `the wizard exited 0 (it exited ${outcome.exitCode})`);
+  // Read back for this origin and no other, which is the whole of what "stored
+  // per platform" means: a key filed under a different platform would not have
+  // come back at all.
   check(held.url === origin, "the key is stored against the egma it signed in to");
   check(held.key.startsWith("egma_sk_"), "the key is one the instance really minted");
 

--- a/apps/cli/smoke/real-wizard-e2e.ts
+++ b/apps/cli/smoke/real-wizard-e2e.ts
@@ -81,6 +81,7 @@ import { fileURLToPath } from "node:url";
 
 import { startInstance, type Instance } from "../../api/test/support/instance.ts";
 import { DEFAULT_DRIVEN_AGENT_ID, launchForId } from "../src/acp/registry.ts";
+import { folderPathsIn, readConfig } from "../src/folder/egma-folder.ts";
 import { parseTestFile } from "../src/folder/test-file.ts";
 import { skillPlacesFor } from "../src/skills/install.ts";
 import { runInTerminal, type TerminalRun } from "../test/support/pty.ts";
@@ -165,6 +166,47 @@ function nothingWasVerified(strict: boolean, missing: readonly string[]): void {
   say(RULE);
 }
 
+/** How far down a list this check will walk before giving up on a row. */
+const MOST_ROWS_WALKED = 200;
+
+/** How long a picker is given to catch up with one keystroke. */
+const SETTLES_IN = 600;
+
+/**
+ * Moves the highlight down a list until it is on the row this run wants.
+ *
+ * **One keystroke at a time, and each is waited out.** A terminal UI coalesces
+ * renders: press down twice before the first frame is drawn and the selection
+ * moves twice while the screen is painted once — so a loop reading the screen
+ * between presses walks straight past the row it was looking for without ever
+ * seeing it. That is not a hypothetical; it is what this did on a real account
+ * of 37 agents before the wait was put in. Waiting after every press is what
+ * makes one press worth one row on the screen as well as in the program.
+ *
+ * Answers whether it had to move at all, which is worth knowing: a run that
+ * walked to a row is a run whose first row was not the one it wanted.
+ */
+async function walkTo(
+  terminal: TerminalRun,
+  wanted: RegExp,
+  rows: number,
+  what: string,
+): Promise<boolean> {
+  let moved = false;
+  for (let step = 0; step <= Math.max(rows, 1); step += 1) {
+    // Waited for rather than looked at once: a frame can arrive half-drawn, and
+    // `waitFor` re-reads the screen on every chunk the terminal parses.
+    if (wanted.test(terminal.screen())) return moved;
+    if (await terminal.waitFor(() => wanted.test(terminal.screen()), SETTLES_IN)) {
+      return moved;
+    }
+    moved = true;
+    terminal.write("\u001B[B");
+  }
+  if (wanted.test(terminal.screen())) return moved;
+  throw new Error(`the list never showed ${what}\n\nlast screen:\n${redact(terminal.screen())}`);
+}
+
 /** A string with nothing in it a regular expression would read as syntax. */
 function escaped(text: string): string {
   return text.replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
@@ -232,8 +274,25 @@ async function approve(apiOrigin: string, cookie: string, userCode: string): Pro
 
 /* ── the repository the walk runs in ─────────────────────────────────── */
 
-/** What is never worth copying, and would make the copy enormous. */
-const NOT_COPIED = new Set([".git", "node_modules", "dist", ".next", ".turbo", "target"]);
+/**
+ * What is never worth copying, and would make the copy enormous.
+ *
+ * `egma` is in the list for a different reason: this check walks a repository
+ * *from nothing*, and a repository that has been walked before carries a
+ * committed binding to whichever platform walked it. egma refuses to move a
+ * committed binding — correctly — so a copy carrying one could never be walked
+ * against the instance this check just started. Leaving it out is what makes
+ * every walk here a first walk.
+ */
+const NOT_COPIED = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  ".next",
+  ".turbo",
+  "target",
+  "egma",
+]);
 
 /**
  * A copy of the developer's repository, so the walk writes into a copy.
@@ -435,17 +494,12 @@ async function walkOnce(options: {
       // walk walks past the rows until that name is the highlighted one; unnamed,
       // the first is taken and any of them proves the same thing about the walk.
       if (wantedAgent !== "") {
-        for (let moved = 0; moved < chosenFrom; moved += 1) {
-          if (new RegExp(`\u203a[^\n]*${escaped(wantedAgent)}`, "u").test(terminal.screen())) {
-            break;
-          }
-          agentCorrected = true;
-          terminal.write("\u001B[B");
-          await terminal.waitFor(() => true, 200);
-        }
-        if (!new RegExp(`\u203a[^\n]*${escaped(wantedAgent)}`, "u").test(terminal.screen())) {
-          throw new Error(`no agent on the account is called ${wantedAgent}`);
-        }
+        agentCorrected = await walkTo(
+          terminal,
+          new RegExp(`\u203a[^\n]*${escaped(wantedAgent)}`, "u"),
+          chosenFrom,
+          `an agent called ${wantedAgent}`,
+        );
       }
       terminal.write("\r");
     }
@@ -473,14 +527,12 @@ async function walkOnce(options: {
       }
       if (terminal.screen().includes("Which number should egma dial?")) {
         if (wantedNumber === "") throw new Error("several numbers reach that agent; name one");
-        for (let moved = 0; moved < 20; moved += 1) {
-          if (new RegExp(`\u203a\\s*${escaped(wantedNumber)}`, "u").test(terminal.screen())) break;
-          terminal.write("\u001B[B");
-          await terminal.waitFor(() => true, 200);
-        }
-        if (!new RegExp(`\u203a\\s*${escaped(wantedNumber)}`, "u").test(terminal.screen())) {
-          throw new Error(`Retell routes no ${wantedNumber} to that agent`);
-        }
+        await walkTo(
+          terminal,
+          new RegExp(`\u203a\\s*${escaped(wantedNumber)}`, "u"),
+          MOST_ROWS_WALKED,
+          `the number ${wantedNumber}`,
+        );
         terminal.write("\r");
       }
     }
@@ -585,6 +637,13 @@ async function walkOnce(options: {
   }
 }
 
+/** The instance's own identity, read the way the CLI reads it. */
+async function platformInstanceOf(origin: string): Promise<string> {
+  const answered = await fetch(`${origin}/api/platform`);
+  const body = (await answered.json().catch(() => ({}))) as { instance_id?: unknown };
+  return typeof body.instance_id === "string" ? body.instance_id : "";
+}
+
 /* ── what landed ─────────────────────────────────────────────────────── */
 
 async function assertWhatLanded(options: {
@@ -680,6 +739,27 @@ async function assertWhatLanded(options: {
       "the key was sealed on the platform, and only its last characters came back",
     );
   }
+
+  /* the committed file, which is the whole of what this repository points at */
+
+  const written = await readConfig(folderPathsIn(outcome.repository).config);
+  check(
+    written.platform?.origin === origin,
+    `the repository is bound to the platform it walked against (${String(written.platform?.origin)})`,
+  );
+  check(
+    written.platform?.instance === (await platformInstanceOf(origin)),
+    "and to that platform's own instance identity",
+  );
+  check(
+    written.agent?.id === agentId && written.connection?.id === String(connection?.id),
+    "the agent and the connection egma made are the ones the file names",
+  );
+  check(written.suite?.name !== undefined, `the file names a test suite (${String(written.suite?.name)})`);
+  check(
+    !JSON.stringify(written).includes(options.key),
+    "and no supplied secret is anywhere in it",
+  );
 
   const tests = await ask(origin, held.key, "/api/tests");
   const landed = Array.isArray(tests.body.items)

--- a/apps/cli/smoke/real-wizard-e2e.ts
+++ b/apps/cli/smoke/real-wizard-e2e.ts
@@ -57,6 +57,17 @@
  *                         what proves a second walk over the same provider
  *                         agent finds the registration the first one made
  *                         rather than minting a second identity for it.
+ *   --reach <text|phone>  Which way to take at the choice the wizard offers.
+ *                         Default: text. `phone` selects a destination number
+ *                         Retell routes to the chosen agent and asserts that
+ *                         the connection egma made holds that number and
+ *                         nothing else — no provider identifier, no credential.
+ *   --retell-agent-name <text>
+ *                         Take the agent whose name contains this, rather than
+ *                         the first on the account. What pins a walk to one
+ *                         agent on an account that holds several.
+ *   --phone-number <e164> With --reach phone: which number to dial, when Retell
+ *                         routes more than one to the chosen agent.
  *   --require-target      Turn a skip into a failure, for a machine that is
  *                         supposed to have all of this. `EGMA_SMOKE_REQUIRE_TARGET=1`
  *                         does the same.
@@ -108,11 +119,17 @@ const BUDGET = {
   login: 3 * 60_000,
   key: 15 * 60_000,
   agent: 2 * 60_000,
+  reach: 2 * 60_000,
   existing: 2 * 60_000,
   gate: 25 * 60_000,
   run: 5 * 60_000,
   exit: 5 * 60_000,
 };
+
+/** Which way this run takes at the choice the wizard offers. */
+function reachWanted(): "text" | "phone" {
+  return (argumentAfter("--reach") ?? "text").trim() === "phone" ? "phone" : "text";
+}
 
 function requiresTarget(): boolean {
   if (process.argv.includes(STRICT_FLAG)) return true;
@@ -146,6 +163,11 @@ function nothingWasVerified(strict: boolean, missing: readonly string[]): void {
     say("  with a failure instead.");
   }
   say(RULE);
+}
+
+/** A string with nothing in it a regular expression would read as syntax. */
+function escaped(text: string): string {
+  return text.replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 /** The value after a flag, or `null` when it was not given. */
@@ -244,6 +266,16 @@ type WalkOutcome = {
   readonly repository: string;
   /** Whether the account offered a choice of agents, and how many. */
   readonly chosenFrom: number;
+  /** Which way this walk took, and what it took it with. */
+  readonly reach: "text" | "phone";
+  /**
+   * Whether the wizard's coding-agent discovery pointed at the prompts this run
+   * was aimed at, or had to be corrected at the picker. Real information about
+   * the wizard, so it is recorded rather than smoothed over.
+   */
+  readonly promptsFound: string | null;
+  /** Whether the agent had to be picked out of several by name. */
+  readonly agentCorrected: boolean;
   /** The run the wizard started, as the run screen named it. */
   readonly runId: string;
 };
@@ -353,6 +385,11 @@ async function walkOnce(options: {
   });
 
   let chosenFrom = 1;
+  let promptsFound: string | null = null;
+  let agentCorrected = false;
+  const reach = reachWanted();
+  const wantedAgent = (argumentAfter("--retell-agent-name") ?? "").trim();
+  const wantedNumber = (argumentAfter("--phone-number") ?? "").trim();
 
   try {
     /* [human 1] the keystroke at the intro */
@@ -369,6 +406,13 @@ async function walkOnce(options: {
 
     /* [human 3] the provider key */
     await showing(terminal, "the key box", BUDGET.key, "Paste your Retell API key");
+    // What the coding agent said it found, before the key box covers it. It is
+    // recorded rather than acted on: whether discovery pointed at the right
+    // prompts is real information about the wizard, and correcting it at the
+    // picker is what a developer does.
+    promptsFound =
+      /Prompts\s{2,}(.+?)\s*$/mu.exec(terminal.scrollback() + terminal.screen())?.[1]?.trim() ??
+      null;
     took("login and finding the agent");
     terminal.write(`${options.key}\r`);
 
@@ -387,9 +431,58 @@ async function walkOnce(options: {
     if (terminal.screen().includes("Which one do you want tested?")) {
       const listed = /reaches (\d+) agents/u.exec(terminal.screen())?.[1] ?? "0";
       chosenFrom = Number(listed);
-      // The first of them. Which agent is the developer's choice on a real
-      // account, and any of them proves the same thing about the walk.
+      // Which agent is the developer's choice on a real account. Named, this
+      // walk walks past the rows until that name is the highlighted one; unnamed,
+      // the first is taken and any of them proves the same thing about the walk.
+      if (wantedAgent !== "") {
+        for (let moved = 0; moved < chosenFrom; moved += 1) {
+          if (new RegExp(`\u203a[^\n]*${escaped(wantedAgent)}`, "u").test(terminal.screen())) {
+            break;
+          }
+          agentCorrected = true;
+          terminal.write("\u001B[B");
+          await terminal.waitFor(() => true, 200);
+        }
+        if (!new RegExp(`\u203a[^\n]*${escaped(wantedAgent)}`, "u").test(terminal.screen())) {
+          throw new Error(`no agent on the account is called ${wantedAgent}`);
+        }
+      }
       terminal.write("\r");
+    }
+
+    /* [human 3c] text or phone, and for the phone the number to dial */
+    await showing(terminal, "the choice of reach", BUDGET.reach, "How should egma reach this agent?");
+    if (reach === "phone") {
+      terminal.write("\u001B[B");
+      await showing(terminal, "the phone row", BUDGET.reach, "\u203a Phone");
+    }
+    terminal.write("\r");
+
+    if (reach === "phone") {
+      // The number screen appears only when Retell routes several to the agent.
+      const picked = await terminal.waitFor(
+        () =>
+          terminal.screen().includes("Which number should egma dial?") ||
+          terminal.screen().includes("Do you already have test cases"),
+        BUDGET.reach,
+      );
+      if (!picked) {
+        throw new Error(
+          `the wizard never got past the choice of reach\n\nlast screen:\n${redact(terminal.screen())}`,
+        );
+      }
+      if (terminal.screen().includes("Which number should egma dial?")) {
+        if (wantedNumber === "") throw new Error("several numbers reach that agent; name one");
+        for (let moved = 0; moved < 20; moved += 1) {
+          if (new RegExp(`\u203a\\s*${escaped(wantedNumber)}`, "u").test(terminal.screen())) break;
+          terminal.write("\u001B[B");
+          await terminal.waitFor(() => true, 200);
+        }
+        if (!new RegExp(`\u203a\\s*${escaped(wantedNumber)}`, "u").test(terminal.screen())) {
+          throw new Error(`Retell routes no ${wantedNumber} to that agent`);
+        }
+        terminal.write("\r");
+      }
     }
     took("connecting");
 
@@ -481,6 +574,9 @@ async function walkOnce(options: {
       credentials: held,
       repository,
       chosenFrom,
+      reach,
+      promptsFound,
+      agentCorrected,
       runId,
     };
   } finally {
@@ -532,15 +628,58 @@ async function assertWhatLanded(options: {
     : [];
   const connection = connections.at(-1);
   check(connections.length >= 1, `a connection is attached to it (${connections.length})`);
-  check(connection?.type === "retell", `the connection is a retell one (${String(connection?.type)})`);
-  check(
-    connection?.modality === "voice" || connection?.modality === "chat",
-    `the connection names a modality (${String(connection?.modality)})`,
-  );
-  check(
-    connection?.credentials_hint === options.key.slice(-4),
-    "the key was sealed on the platform, and only its last characters came back",
-  );
+
+  if (outcome.reach === "phone") {
+    // **Only the connection that was chosen.** Creating both is the bug the
+    // choice exists to kill, so the count is asserted rather than the last row.
+    check(
+      connections.length === 1 && connection?.type === "phone",
+      `the walk created exactly one connection and it is the phone one (${connections
+        .map((one) => String(one.type))
+        .join(", ")})`,
+    );
+    check(
+      connection?.modality === "voice",
+      `the phone connection is a voice one (${String(connection?.modality)})`,
+    );
+
+    // The number, and nothing else at all. No Retell, Twilio, LiveKit, SIP or
+    // OpenAI credential, and no provider identifier — a phone connection is
+    // provider-blind, which is what makes it the same connection whoever
+    // answers.
+    const config = (connection?.config ?? {}) as Record<string, unknown>;
+    check(
+      Object.keys(config).length === 1 && typeof config.phoneNumber === "string",
+      `the phone connection holds only a number (${Object.keys(config).join(", ")})`,
+    );
+    check(
+      /^\+[1-9]\d{1,14}$/u.test(String(config.phoneNumber)),
+      `the number is E.164 (${String(config.phoneNumber)})`,
+    );
+    check(
+      connection?.credentials_hint === null || connection?.credentials_hint === undefined,
+      "no credential was sealed against the phone connection",
+    );
+    check(
+      !JSON.stringify(one.body).includes(options.key),
+      "the provider key is nowhere in what the platform holds for this agent",
+    );
+  } else {
+    check(
+      connections.length === 1 && connection?.type === "retell",
+      `the walk created exactly one connection and it is the retell one (${connections
+        .map((one) => String(one.type))
+        .join(", ")})`,
+    );
+    check(
+      connection?.modality === "chat",
+      `the text connection is a chat one (${String(connection?.modality)})`,
+    );
+    check(
+      connection?.credentials_hint === options.key.slice(-4),
+      "the key was sealed on the platform, and only its last characters came back",
+    );
+  }
 
   const tests = await ask(origin, held.key, "/api/tests");
   const landed = Array.isArray(tests.body.items)
@@ -699,6 +838,7 @@ async function main(): Promise<void> {
     `  its own env:   ${Object.keys(launch.env).length === 0 ? "nothing added" : Object.entries(launch.env).map(([name, value]) => `${name}=${value}`).join(", ")}`,
   );
   say(`  walks:         ${walks}`);
+  say(`  reach:         ${reachWanted()}`);
   say(`  Retell:        read-only, through a gate on this machine`);
   say("");
 
@@ -742,8 +882,19 @@ async function main(): Promise<void> {
         say(`  ${timing.phase.padEnd(28)} ${timing.seconds.padStart(7)}s`);
       }
       if (outcome.chosenFrom > 1) {
-        say(`  (the account listed ${outcome.chosenFrom} agents, and the first was taken)`);
+        say(
+          `  (the account listed ${outcome.chosenFrom} agents, and the one taken ${
+            outcome.agentCorrected ? "was picked out by name" : "was the first"
+          })`,
+        );
       }
+      say("");
+      say("── what the coding agent found, and which way was taken ──");
+      say(`  reach:    ${outcome.reach}`);
+      say(`  prompts:  ${redact(outcome.promptsFound ?? "nothing reported")}`);
+      say(
+        `  agent:    ${outcome.agentCorrected ? "corrected at the picker" : "taken as discovery left it"}`,
+      );
 
       registered.push(await assertWhatLanded({ instance, outcome, key, walk }));
     }

--- a/apps/cli/smoke/real-wizard-e2e.ts
+++ b/apps/cli/smoke/real-wizard-e2e.ts
@@ -468,12 +468,16 @@ async function walkOnce(options: {
 
     /* [human 3] the provider key */
     await showing(terminal, "the key box", BUDGET.key, "Paste your Retell API key");
-    // What the coding agent said it found, before the key box covers it. It is
-    // recorded rather than acted on: whether discovery pointed at the right
-    // prompts is real information about the wizard, and correcting it at the
-    // picker is what a developer does.
+    // What the coding agent said it found, before the key box covers it.
+    //
+    // Recorded rather than acted on: whether discovery pointed at the right
+    // prompts is real information about the wizard, and correcting the agent at
+    // the picker is what a developer does. It is read off the card the wizard
+    // draws, so a card that has already scrolled reads as "nothing reported" —
+    // which is a gap in this reading and never a claim about what was found.
+    // The whole of what the agent said is in the log the wizard names.
     promptsFound =
-      /Prompts\s{2,}(.+?)\s*$/mu.exec(terminal.scrollback() + terminal.screen())?.[1]?.trim() ??
+      /Prompts\s{2,}(.+?)\s*$/mu.exec(`${terminal.scrollback()}\n${terminal.screen()}`)?.[1]?.trim() ??
       null;
     took("login and finding the agent");
     terminal.write(`${options.key}\r`);

--- a/apps/cli/smoke/support/report.ts
+++ b/apps/cli/smoke/support/report.ts
@@ -31,10 +31,17 @@ export const secrets: string[] = [];
 /** Every check that did not hold, in the order they were found. */
 export const problems: string[] = [];
 
-/** The text with everything in `secrets` taken out of it. */
+/**
+ * The text with everything in `secrets` taken out of it.
+ *
+ * Nothing that is not a string is one, and the guard is not defensive tidying:
+ * a check that pushed `undefined` — a field that moved, an answer that was not
+ * the shape it used to be — would crash *here*, while printing the failure it
+ * was in the middle of reporting, and take the real reason down with it.
+ */
 export function redact(text: string): string {
   return [...new Set(secrets)]
-    .filter((one) => one.length > 3)
+    .filter((one) => typeof one === "string" && one.length > 3)
     .sort((left, right) => right.length - left.length)
     .reduce((held, one) => held.split(one).join("<redacted>"), text);
 }

--- a/apps/cli/smoke/support/report.ts
+++ b/apps/cli/smoke/support/report.ts
@@ -34,16 +34,23 @@ export const problems: string[] = [];
 /**
  * The text with everything in `secrets` taken out of it.
  *
- * Nothing that is not a string is one, and the guard is not defensive tidying:
- * a check that pushed `undefined` — a field that moved, an answer that was not
- * the shape it used to be — would crash *here*, while printing the failure it
- * was in the middle of reporting, and take the real reason down with it.
+ * **Neither side is trusted to be a string, and that is not defensive tidying.**
+ * This runs while a check is printing why it failed. A secret that arrived as
+ * `undefined` — a field that moved, an answer that was not the shape it used to
+ * be — used to crash the reduce; text that arrived as `undefined` crashes the
+ * same reduce from the other side. Either way the crash lands *inside* the
+ * error report and takes the real reason down with it, which is the one failure
+ * that costs a whole run of a check that takes twenty minutes.
+ *
+ * A value that is not text is described rather than dropped, because "the thing
+ * being printed was not a string" is itself the news at that moment.
  */
 export function redact(text: string): string {
+  const held = typeof text === "string" ? text : String(text);
   return [...new Set(secrets)]
     .filter((one) => typeof one === "string" && one.length > 3)
     .sort((left, right) => right.length - left.length)
-    .reduce((held, one) => held.split(one).join("<redacted>"), text);
+    .reduce((carried, one) => carried.split(one).join("<redacted>"), held);
 }
 
 export function say(message: string): void {

--- a/apps/cli/smoke/support/retell-gate.ts
+++ b/apps/cli/smoke/support/retell-gate.ts
@@ -22,6 +22,12 @@ export const ALLOWED: readonly { method: string; path: RegExp }[] = [
   { method: "GET", path: /^\/get-chat-agent\/[^/]+$/u },
   { method: "GET", path: /^\/get-retell-llm\/[^/]+$/u },
   { method: "GET", path: /^\/get-conversation-flow\/[^/]+$/u },
+  // The account's telephone numbers, and one number's own document. Both are
+  // reads, and both are what the phone path is built on: which numbers Retell
+  // routes to the agent under test, confirmed at the number's own address
+  // immediately before egma writes a connection it will really dial.
+  { method: "GET", path: /^\/list-phone-numbers$/u },
+  { method: "GET", path: /^\/get-phone-number\/[^/]+$/u },
 ];
 
 export type Gate = {

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -15,7 +15,9 @@
 
 import {
   bindRepositoryPlatform,
+  DEFAULT_SUITE_NAME,
   folderPathsIn,
+  readConfig,
   updateConfig,
 } from "../folder/egma-folder.ts";
 import { readCredentials, type VerifiedPlatformAccess } from "../platform/credentials.ts";
@@ -25,9 +27,13 @@ import {
   CUSTODY_LINE,
   KEY_ASK_LINE,
   keyAskLines,
+  NUMBER_ASK_LINE,
+  REACH_ASK_LINE,
+  REACH_LINES,
   registrationLine,
   type ConnectOptions,
   type ConnectOutcome,
+  type Reach,
 } from "../retell/connect.ts";
 import { DRIFT_LINE } from "../retell/prompt-drift.ts";
 
@@ -47,12 +53,22 @@ export const CONNECT_EXIT = {
    * look. The `reason:` line tells them apart for anything that reads.
    */
   unreachable: 4,
-  /** Several agents on the account and nothing said which one. */
+  /**
+   * Something the developer alone decides was not decided.
+   *
+   * One number for four questions — which agent, text or phone, which number,
+   * and a number that is not one of the ones offered — because they mean one
+   * thing to whoever ran the command: egma will not choose on their behalf, and
+   * the answer goes in the command. The `status:` line says which question it
+   * was, and the lines above it list what there was to choose from.
+   */
   unchosen: 5,
   /** No key was given at all. */
   noKey: 6,
   /** This machine holds no egma key, so there is nowhere to register. */
   notSignedIn: 7,
+  /** Retell routes no number to the chosen agent, so the phone reaches nothing. */
+  noNumbers: 8,
   /** Stopped part way through. */
   interrupted: 130,
 } as const;
@@ -62,6 +78,30 @@ export const KEY_VARIABLES = ["EGMA_RETELL_API_KEY", "RETELL_API_KEY"] as const;
 
 /** The environment variable that names which agent, when the account has several. */
 export const AGENT_VARIABLE = "EGMA_RETELL_AGENT_ID";
+
+/** The environment variable that says whether egma reaches the agent by text or phone. */
+export const REACH_VARIABLE = "EGMA_REACH";
+
+/** The environment variable that names the number to dial, when several reach the agent. */
+export const NUMBER_VARIABLE = "EGMA_PHONE_NUMBER";
+
+/** What a developer is told when what they said is not one of the two ways. */
+export function unknownReachRefusal(said: string): string {
+  return (
+    `"${said}" is not a way egma reaches an agent. Say --reach text or ` +
+    `--reach phone, or set ${REACH_VARIABLE}.`
+  );
+}
+
+/** The way that was named, `null` when none was, or the word that was not one. */
+export function reachIn(
+  named: string | null | undefined,
+): { readonly kind: "reach"; readonly reach: Reach } | { readonly kind: "unknown"; readonly said: string } | null {
+  const said = (named ?? "").trim().toLowerCase();
+  if (said === "") return null;
+  if (said === "text" || said === "phone") return { kind: "reach", reach: said };
+  return { kind: "unknown", said };
+}
 
 /** Argument names that would put a secret in the process table. */
 const REFUSED_ARGUMENTS = ["--key", "--api-key", "--retell-key", "--retell-api-key"];
@@ -86,6 +126,10 @@ export type ConnectCommandOptions = {
   readonly cwd: string;
   /** `--retell-agent`, when one was named. */
   readonly agentId: string | null;
+  /** `--reach`: text or phone. Nothing is created when neither was said. */
+  readonly reach: string | null;
+  /** `--phone-number`: which number to dial, when several reach the agent. */
+  readonly phoneNumber: string | null;
   /** `--repo-prompt`: the file to compare what the provider runs against. */
   readonly repoPrompt: string | null;
   readonly env: NodeJS.ProcessEnv;
@@ -136,7 +180,11 @@ function exitCodeFor(outcome: ConnectOutcome): number {
     case "no-agents":
       return CONNECT_EXIT.noAgents;
     case "unchosen":
+    case "unchosen-reach":
+    case "unchosen-number":
       return CONNECT_EXIT.unchosen;
+    case "no-numbers":
+      return CONNECT_EXIT.noNumbers;
     case "no-key":
       return CONNECT_EXIT.noKey;
     case "interrupted":
@@ -163,6 +211,16 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
   if (refused !== null) {
     options.fail(argumentRefusal(refused));
     return CONNECT_EXIT.noKey;
+  }
+
+  // Said before anything is read, because a word egma does not know is the
+  // developer's own typo and finding out after a key has been sent to Retell
+  // would cost them the round trip.
+  const named = reachIn(options.reach ?? options.env[REACH_VARIABLE]);
+  if (named !== null && named.kind === "unknown") {
+    options.out("status: unchosen");
+    options.fail(unknownReachRefusal(named.said));
+    return CONNECT_EXIT.unchosen;
   }
 
   options.out(`url: ${options.access.url}`);
@@ -226,8 +284,27 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
       for (const agent of agents) {
         options.out(`retell_agent: ${agent.id} ${agent.name}`.trimEnd());
       }
-      const named = (options.agentId ?? options.env[AGENT_VARIABLE] ?? "").trim();
-      return Promise.resolve(named === "" ? null : named);
+      const wanted = (options.agentId ?? options.env[AGENT_VARIABLE] ?? "").trim();
+      return Promise.resolve(wanted === "" ? null : wanted);
+    },
+    // The same question the wizard's screen asks, and the same two lines, so a
+    // coding agent reading this is told exactly what a person is told. There is
+    // nobody here to answer it, so it is answered in the command or not at all
+    // — and not at all creates nothing, which is the point.
+    chooseReach: () => {
+      options.out(`note: ${REACH_ASK_LINE}`);
+      for (const way of ["text", "phone"] as const) {
+        options.out(`reach_option: ${way} ${REACH_LINES[way]}`);
+      }
+      return Promise.resolve(named === null ? null : named.reach);
+    },
+    chooseNumber: (numbers) => {
+      options.out(`note: ${NUMBER_ASK_LINE}`);
+      for (const number of numbers) {
+        options.out(`retell_number: ${number.number} ${number.label}`.trimEnd());
+      }
+      const wanted = (options.phoneNumber ?? options.env[NUMBER_VARIABLE] ?? "").trim();
+      return Promise.resolve(wanted === "" ? null : wanted);
     },
   });
 
@@ -244,18 +321,32 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
   switch (outcome.kind) {
     case "connected": {
       const { registered, config } = outcome;
-      await updateConfig(folderPathsIn(options.cwd).config, {
+      // The same four things the wizard writes, from the same place, so a
+      // repository connected by the verb and one connected by the wizard hold
+      // the same file. A suite somebody has already named is left alone: it is
+      // their committed file, and this step learned nothing about it.
+      const paths = folderPathsIn(options.cwd);
+      const beforeThis = await readConfig(paths.config).catch(() => null);
+      await updateConfig(paths.config, {
         agent: { name: registered.agent.name, id: registered.agent.id },
         connection: {
           name: registered.connection.name,
           id: registered.connection.id,
         },
+        ...(beforeThis?.suite == null
+          ? { suite: { name: DEFAULT_SUITE_NAME, id: null } }
+          : {}),
       });
       options.out(`retell_agents: ${outcome.onTheAccount}`);
       options.out(`retell_agent_id: ${config.agentId}`);
       options.out(`retell_response_engine: ${config.engine}`);
       options.out(`prompt_characters: ${config.prompt === null ? 0 : config.prompt.length}`);
       options.out(`tools: ${config.tools.length}`);
+      options.out(`reach: ${outcome.reach}`);
+      // The number, or the word that there is none. Absent would read as an
+      // older egma that never printed it; `none` says a text connection dials
+      // nothing, which is a fact about the connection rather than a gap.
+      options.out(`phone_number: ${outcome.number ?? "none"}`);
       options.out(`agent_id: ${registered.agent.id}`);
       options.out(`agent_name: ${registered.agent.name}`);
       options.out(`connection_id: ${registered.connection.id}`);
@@ -266,6 +357,11 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
       // agent retrying this verb reads whether it made a second agent from
       // here rather than by counting what the platform holds.
       options.out(`registration: ${registered.result}`);
+      // And the same answer split in two, because a retry cares about each
+      // half: an agent that was already there with a connection that is new is
+      // a different fact from both of them being new.
+      options.out(`agent_registration: ${outcome.registration.agent}`);
+      options.out(`connection_registration: ${outcome.registration.connection}`);
       const already = registrationLine(registered);
       if (already !== null) options.out(`note: ${already}`);
       options.out(driftLine(outcome));
@@ -289,6 +385,28 @@ export async function runConnectCommand(options: ConnectCommandOptions): Promise
       options.out("status: unchosen");
       options.fail(
         `That key reaches ${outcome.agents.length} agents. Name one with --retell-agent, or with ${AGENT_VARIABLE}.`,
+      );
+      break;
+    case "unchosen-reach":
+      options.out("status: unchosen-reach");
+      options.fail(
+        "egma creates the one connection you choose and never both. Say " +
+          `--reach text or --reach phone, or set ${REACH_VARIABLE}. Nothing was written.`,
+      );
+      break;
+    case "unchosen-number":
+      options.out(`retell_numbers: ${outcome.numbers.length}`);
+      options.out("status: unchosen-number");
+      options.fail(
+        `Retell routes ${outcome.numbers.length} numbers to that agent. Name the one egma ` +
+          `should dial with --phone-number, or with ${NUMBER_VARIABLE}. Nothing was written.`,
+      );
+      break;
+    case "no-numbers":
+      options.out("status: no-numbers");
+      options.fail(
+        "Retell routes no phone number to that agent, so there is nothing for egma to " +
+          "dial. Assign one in the Retell dashboard, or connect over text with --reach text.",
       );
       break;
     case "no-key":

--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -33,6 +33,17 @@ export const TESTS_FOLDER_NAME = "tests";
 /** Reserved for per-agent memory files. Nothing creates it. */
 export const MEMORY_FOLDER_NAME = "memory";
 
+/**
+ * What this folder's first test suite is called when nobody has named one.
+ *
+ * Here rather than in the wizard, because both surfaces that fill this file in
+ * write it and they have to write the same word: a repository connected by the
+ * verb and a repository connected by the wizard are the same repository, and a
+ * suite name that differed between them would be a difference a developer would
+ * find later in a run label they did not choose.
+ */
+export const DEFAULT_SUITE_NAME = "first-suite";
+
 /** Where each part of the folder is, once a repository root is known. */
 export type FolderPaths = {
   readonly root: string;

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -21,6 +21,8 @@ import {
   AGENT_VARIABLE,
   argumentRefusal,
   KEY_VARIABLES,
+  NUMBER_VARIABLE,
+  REACH_VARIABLE,
   refusedArgumentIn,
   runConnectCommand,
 } from "./commands/connect.ts";
@@ -125,6 +127,10 @@ export type Invocation = {
   readonly noFollow: boolean;
   /** `--retell-agent`: which agent, when the account holds several. */
   readonly retellAgentId: string | null;
+  /** `--reach`: whether egma reaches the agent by text or by phone. */
+  readonly reach: string | null;
+  /** `--phone-number`: which number to dial, when several reach the agent. */
+  readonly phoneNumber: string | null;
   /** `--repo-prompt`: the repository's prompt, to compare the provider's with. */
   readonly repoPrompt: string | null;
   /** `--existing-tests`: the test cases the developer already had written down. */
@@ -157,6 +163,8 @@ export function parseArgs(argv: readonly string[]): Invocation {
   let force = false;
   let noFollow = false;
   let retellAgentId: string | null = null;
+  let reach: string | null = null;
+  let phoneNumber: string | null = null;
   let repoPrompt: string | null = null;
   let existingTests: string | null = null;
   let agentName: string | null = null;
@@ -186,6 +194,8 @@ export function parseArgs(argv: readonly string[]): Invocation {
     else if (argument === "--force") force = true;
     else if (argument === "--no-follow") noFollow = true;
     else if (argument === "--retell-agent") retellAgentId = argv[(index += 1)] ?? null;
+    else if (argument === "--reach") reach = argv[(index += 1)] ?? null;
+    else if (argument === "--phone-number") phoneNumber = argv[(index += 1)] ?? null;
     else if (argument === "--repo-prompt") repoPrompt = argv[(index += 1)] ?? null;
     else if (argument === "--existing-tests") existingTests = argv[(index += 1)] ?? null;
     else if (argument === "--agent") agentName = argv[(index += 1)] ?? null;
@@ -207,6 +217,8 @@ export function parseArgs(argv: readonly string[]): Invocation {
     force,
     noFollow,
     retellAgentId,
+    reach,
+    phoneNumber,
     repoPrompt,
     existingTests,
     agentName,
@@ -264,6 +276,14 @@ export function helpText(): string {
     "                       waiting for a verdict. The run carries on on egma.",
     "  --retell-agent <id>  With connect: which agent, when the Retell account",
     "                       holds more than one.",
+    "  --reach <text|phone> With connect and a headless wizard: how egma should",
+    "                       reach the agent. text exchanges messages with it;",
+    "                       phone dials one of its numbers. egma creates the one",
+    "                       you choose and never both, and creates nothing when",
+    "                       neither is said.",
+    "  --phone-number <e164>",
+    "                       With --reach phone: which of the agent's numbers to",
+    "                       dial, when Retell routes more than one to it.",
     "  --repo-prompt <path> With connect: the prompt file in this repository, so",
     "                       egma can say whether it and Retell have drifted apart.",
     "  --existing-tests <path>",
@@ -288,6 +308,8 @@ export function helpText(): string {
     "                       is read too, so an environment that already has one",
     "                       needs nothing new.",
     `  ${AGENT_VARIABLE} Which Retell agent, same as --retell-agent.`,
+    `  ${REACH_VARIABLE}            text or phone, same as --reach.`,
+    `  ${NUMBER_VARIABLE}     Which number to dial, same as --phone-number.`,
     `  ${RETELL_URL_VARIABLE}      The Retell to talk to. Default: ${RETELL_API}`,
     `  ${EXISTING_TESTS_VARIABLE}  Your existing test cases, same as --existing-tests.`,
     "  VISUAL, EDITOR       What e opens a generated test in, at the gate.",
@@ -305,19 +327,24 @@ export function helpText(): string {
     "",
     "What egma connect prints, one fact per line:",
     "  url, retell_agents, retell_agent, retell_agent_id, retell_response_engine,",
-    "  prompt_characters, tools, agent_id, agent_name, connection_id,",
-    "  connection_name, connection_type, connection_modality, registration,",
-    "  drift, grounded_in, status",
+    "  prompt_characters, tools, reach_option, retell_number, reach, phone_number,",
+    "  agent_id, agent_name, connection_id, connection_name, connection_type,",
+    "  connection_modality, registration, agent_registration,",
+    "  connection_registration, drift, grounded_in, status",
     "",
     "  registration says which of three things egma did: created, reused (this",
-    "  Retell agent was already registered, so nothing new was written), or",
-    "  connection_added (the same agent gained another way of being reached).",
-    "  The two that are not created also print a note: line saying so plainly.",
+    "  voice agent was already registered and already reached this way, so",
+    "  nothing was written), or connection_added (the same agent gained another",
+    "  way of being reached). The two that are not created also print a note:",
+    "  line saying so plainly. agent_registration and connection_registration",
+    "  say the same thing for each half, as created or reused.",
     "",
     "What egma connect answers with:",
     "  0 connected   2 the key was refused   3 no agents on that account",
-    "  4 Retell or egma did not answer, or refused   5 several agents, none named",
-    "  6 no key given   7 not signed in to egma   130 stopped part way",
+    "  4 Retell or egma did not answer, or refused",
+    "  5 a choice only you can make was not made: which agent, text or phone, or",
+    "    which number   6 no key given   7 not signed in to egma",
+    "  8 Retell routes no number to that agent   130 stopped part way",
     "",
     "What egma init, pull and push print, one fact per line:",
     "  url, folder, and then one line per test: what happened to it, the file,",
@@ -426,7 +453,7 @@ function retellReach(env: NodeJS.ProcessEnv): { readonly url: string } | undefin
  * not change where a secret comes from.
  */
 /** The answers a run with nobody watching can be given in advance. */
-type Held = "retell-key" | "retell-agent" | "existing-tests";
+type Held = "retell-key" | "retell-agent" | "reach" | "phone-number" | "existing-tests";
 
 function headlessAnswers(
   invocation: Invocation,
@@ -442,6 +469,15 @@ function headlessAnswers(
   }
   const named = (invocation.retellAgentId ?? env[AGENT_VARIABLE] ?? "").trim();
   if (named !== "") answers["retell-agent"] = named;
+
+  // Which way to reach the agent is knowledge, not consent: a run with nobody
+  // watching says it in the command or egma creates nothing at all. Left out
+  // deliberately means left out — egma never picks one of the two, because
+  // only one of them dials a real telephone.
+  const way = (invocation.reach ?? env[REACH_VARIABLE] ?? "").trim();
+  if (way !== "") answers["reach"] = way;
+  const dialling = (invocation.phoneNumber ?? env[NUMBER_VARIABLE] ?? "").trim();
+  if (dialling !== "") answers["phone-number"] = dialling;
 
   // Prior work is knowledge and not consent, so a run with nobody watching is
   // pointed at it in the command or it has none — exactly as the pointer to a
@@ -609,6 +645,8 @@ async function runConnect(
       access,
       cwd: path.resolve(invocation.cwd ?? process.cwd()),
       agentId: invocation.retellAgentId,
+      reach: invocation.reach,
+      phoneNumber: invocation.phoneNumber,
       repoPrompt: invocation.repoPrompt,
       env: process.env,
       signal: controller.signal,

--- a/apps/cli/src/platform/agents.ts
+++ b/apps/cli/src/platform/agents.ts
@@ -15,6 +15,13 @@
  * out of a stored copy that rots from the moment it is written. So this sends
  * no verbatim vendor payload, and a body that carried one would be refused by
  * name rather than quietly ignored.
+ *
+ * **Reads live here too, and they are here for one job.** Registering answers
+ * `name-taken` when a living agent in the project already holds the name, and
+ * what that means depends on which agent it is — the same voice agent being
+ * reached a second way, or a different one that happens to be called the same
+ * thing. Telling those apart takes a read, so the read is beside the write it
+ * belongs to rather than in a module of its own.
  */
 
 import type { RetellKey } from "../retell/key.ts";
@@ -23,7 +30,15 @@ import type { Fetch } from "./device-flow.ts";
 export type NewConnection = {
   /** Omit and the platform names it: `retell-1`, then `retell-2`. */
   readonly name?: string | undefined;
-  readonly type: "retell";
+  /**
+   * What kind of reach this is.
+   *
+   * `phone` carries no credential at all, and the platform refuses one on it by
+   * name: a destination number is public, and egma dials it with the telephony
+   * configuration its own deployment holds. That is what makes a phone
+   * connection provider-blind — nothing in it says who answers.
+   */
+  readonly type: "retell" | "phone";
   readonly modality: "voice" | "chat";
   readonly environment?: string | undefined;
   readonly config: Readonly<Record<string, string>>;
@@ -51,6 +66,14 @@ export type RegisteredConnection = {
   readonly modality: string;
   /** The last characters of the sealed secret, which is all that comes back. */
   readonly credentialsHint: string | null;
+  /**
+   * What to reach, as the platform stores it — the number for a phone
+   * connection, the vendor's agent id for a retell one. Never a secret: the
+   * config is the half of a connection that is public by construction, and it
+   * is what says whether a connection already on the platform is the one being
+   * asked for.
+   */
+  readonly config: Readonly<Record<string, string>>;
 };
 
 /**
@@ -108,10 +131,22 @@ function agentIn(body: Record<string, unknown>): RegisteredAgent | null {
   return id === "" ? null : { id, name: plain(agent["name"]) };
 }
 
-function connectionIn(body: Record<string, unknown>): RegisteredConnection | null {
-  const held = body["connection"];
-  if (typeof held !== "object" || held === null) return null;
-  const connection = held as Record<string, unknown>;
+/** The config a read answers with, as text values and nothing else. */
+function configIn(value: unknown): Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const held: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof entry === "string") held[key] = entry;
+  }
+  return held;
+}
+
+/** One connection out of whatever object holds it, or `null` when it is not one. */
+function connectionFrom(value: unknown): RegisteredConnection | null {
+  if (typeof value !== "object" || value === null) return null;
+  const connection = value as Record<string, unknown>;
   const id = plain(connection["id"]);
   if (id === "") return null;
   const hint = plain(connection["credentials_hint"]);
@@ -121,7 +156,12 @@ function connectionIn(body: Record<string, unknown>): RegisteredConnection | nul
     type: plain(connection["type"]),
     modality: plain(connection["modality"]),
     credentialsHint: hint === "" ? null : hint,
+    config: configIn(connection["config"]),
   };
+}
+
+function connectionIn(body: Record<string, unknown>): RegisteredConnection | null {
+  return connectionFrom(body["connection"]);
 }
 
 /**
@@ -145,6 +185,243 @@ function outcomeIn(body: Record<string, unknown>): RegisterOutcome | null {
   return OUTCOMES.includes(said) ? (said as RegisterOutcome) : null;
 }
 
+/** The body a connection travels in, on both doors that take one. */
+function connectionBody(connection: NewConnection): Record<string, unknown> {
+  return {
+    ...(connection.name === undefined ? {} : { name: connection.name }),
+    type: connection.type,
+    modality: connection.modality,
+    ...(connection.environment === undefined
+      ? {}
+      : { environment: connection.environment }),
+    config: connection.config,
+    // The one place the key is read on the way to egma. It is sealed there
+    // and never answered back — what comes back is its last characters.
+    ...(connection.credentials === undefined
+      ? {}
+      : { credentials: { apiKey: connection.credentials.reveal() } }),
+  };
+}
+
+/**
+ * One request to egma, with this machine's key on it, answered as a value.
+ *
+ * Every door here answers the same three ways when it is not the door's own
+ * business — the machine is not signed in, egma refused, egma never answered —
+ * so the shape is written once and each door reads its own success out of it.
+ */
+type Answered =
+  | { readonly kind: "ok"; readonly status: number; readonly body: Record<string, unknown> }
+  | { readonly kind: "not-authenticated" }
+  | { readonly kind: "refused"; readonly reason: string; readonly status: number; readonly body: Record<string, unknown> }
+  | { readonly kind: "unreachable"; readonly reason: string };
+
+async function askPlatform(
+  options: RegisterOptions,
+  request: {
+    readonly method: "GET" | "POST";
+    readonly path: string;
+    readonly body?: unknown;
+  },
+): Promise<Answered> {
+  const url = `${options.url.replace(/\/+$/u, "")}${request.path}`;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: request.method,
+      headers: {
+        authorization: `Bearer ${options.key}`,
+        ...(request.body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(request.body === undefined ? {} : { body: JSON.stringify(request.body) }),
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+    });
+  } catch {
+    return {
+      kind: "unreachable",
+      reason: `egma at ${options.url} did not answer. Check the address, and that the instance is running.`,
+    };
+  }
+
+  const held = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  if (response.status === 401) return { kind: "not-authenticated" };
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      kind: "refused",
+      reason: refusalIn(response.status, held),
+      status: response.status,
+      body: held,
+    };
+  }
+  return { kind: "ok", status: response.status, body: held };
+}
+
+/** An agent on the platform, as a listing or a read names it. */
+export type PlatformAgent = {
+  readonly id: string;
+  readonly name: string;
+};
+
+export type FoundAgent =
+  | { readonly kind: "found"; readonly agent: PlatformAgent }
+  /** No living agent of this credential's holds that name. */
+  | { readonly kind: "not-found" }
+  | { readonly kind: "not-authenticated" }
+  | { readonly kind: "refused"; readonly reason: string }
+  | { readonly kind: "unreachable"; readonly reason: string };
+
+/** How many pages of agents are walked before giving up on finding a name. */
+const MOST_PAGES = 20;
+
+/**
+ * The living agent holding one name, or the word that there is none.
+ *
+ * This exists for exactly one moment: egma asked the platform to register an
+ * agent, and the platform said a living agent already holds the name. What
+ * happens next depends on *which* agent that is — the same vendor agent being
+ * connected a second way, or a different one that happens to be called the same
+ * thing — and the only way to tell is to read it.
+ *
+ * Names are unique among a project's living agents, so at most one row can
+ * match and the walk stops at the first.
+ */
+export async function agentNamed(
+  name: string,
+  options: RegisterOptions,
+): Promise<FoundAgent> {
+  const wanted = name.trim();
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MOST_PAGES; page += 1) {
+    const answer = await askPlatform(options, {
+      method: "GET",
+      path:
+        cursor === undefined
+          ? "/api/agents"
+          : `/api/agents?cursor=${encodeURIComponent(cursor)}`,
+    });
+    if (answer.kind !== "ok") return answer;
+
+    const items = Array.isArray(answer.body["items"])
+      ? (answer.body["items"] as unknown[])
+      : [];
+    for (const row of items) {
+      if (typeof row !== "object" || row === null) continue;
+      const held = row as Record<string, unknown>;
+      const id = plain(held["id"]);
+      if (id !== "" && plain(held["name"]) === wanted) {
+        return { kind: "found", agent: { id, name: wanted } };
+      }
+    }
+
+    const next = plain(answer.body["next_cursor"]);
+    if (next === "") break;
+    cursor = next;
+  }
+
+  return { kind: "not-found" };
+}
+
+export type ReadAgent =
+  | {
+      readonly kind: "agent";
+      readonly agent: PlatformAgent;
+      /** Every living way of reaching it, oldest first. */
+      readonly connections: readonly RegisteredConnection[];
+    }
+  | { readonly kind: "not-found" }
+  | { readonly kind: "not-authenticated" }
+  | { readonly kind: "refused"; readonly reason: string }
+  | { readonly kind: "unreachable"; readonly reason: string };
+
+/** One agent and every living way of reaching it. */
+export async function readAgent(
+  agentId: string,
+  options: RegisterOptions,
+): Promise<ReadAgent> {
+  const answer = await askPlatform(options, {
+    method: "GET",
+    path: `/api/agents/${encodeURIComponent(agentId)}`,
+  });
+  if (answer.kind === "refused" && answer.status === 404) return { kind: "not-found" };
+  if (answer.kind !== "ok") return answer;
+
+  const held = answer.body["agent"];
+  if (typeof held !== "object" || held === null) {
+    return {
+      kind: "refused",
+      reason: "egma answered without saying what it holds. Check that this egma is up to date.",
+    };
+  }
+  const agent = held as Record<string, unknown>;
+  const id = plain(agent["id"]);
+  if (id === "") return { kind: "not-found" };
+
+  const rows = Array.isArray(answer.body["connections"])
+    ? (answer.body["connections"] as unknown[])
+    : [];
+  const connections: RegisteredConnection[] = [];
+  for (const row of rows) {
+    const connection = connectionFrom(row);
+    if (connection !== null) connections.push(connection);
+  }
+
+  return {
+    kind: "agent",
+    agent: { id, name: plain(agent["name"]) },
+    connections,
+  };
+}
+
+export type AddedConnection =
+  | { readonly kind: "added"; readonly connection: RegisteredConnection }
+  /** A living connection on this agent already holds the name. */
+  | { readonly kind: "name-taken"; readonly name: string }
+  | { readonly kind: "not-found" }
+  | { readonly kind: "not-authenticated" }
+  | { readonly kind: "refused"; readonly reason: string }
+  | { readonly kind: "unreachable"; readonly reason: string };
+
+/**
+ * Another way of reaching an agent that already exists.
+ *
+ * The same body an inline connection travels in, at the platform's own second
+ * door. It is what a developer who connected over text and came back for the
+ * phone goes through: one voice agent, two ways to reach it, and one results
+ * history.
+ */
+export async function addConnection(
+  agentId: string,
+  connection: NewConnection,
+  options: RegisterOptions,
+): Promise<AddedConnection> {
+  const answer = await askPlatform(options, {
+    method: "POST",
+    path: `/api/agents/${encodeURIComponent(agentId)}/connections`,
+    body: connectionBody(connection),
+  });
+
+  if (answer.kind === "refused") {
+    if (answer.status === 404) return { kind: "not-found" };
+    if (answer.status === 409 && plain(answer.body["error"]) === "name_taken") {
+      return { kind: "name-taken", name: connection.name ?? "" };
+    }
+    return { kind: "refused", reason: answer.reason };
+  }
+  if (answer.kind !== "ok") return answer;
+
+  const written = connectionFrom(answer.body["connection"]);
+  if (written === null) {
+    return {
+      kind: "refused",
+      reason: "egma answered without saying what it wrote. Check that this egma is up to date.",
+    };
+  }
+  return { kind: "added", connection: written };
+}
+
 /**
  * Writes the agent and its first connection, and answers what happened.
  *
@@ -157,56 +434,27 @@ export async function registerAgent(
   registration: Registration,
   options: RegisterOptions,
 ): Promise<RegisterResult> {
-  const url = `${options.url.replace(/\/+$/u, "")}/api/agents`;
-  const fetchImpl = options.fetchImpl ?? fetch;
-
-  const body = {
-    name: registration.name,
-    ...(registration.description === undefined ? {} : { description: registration.description }),
-    ...(registration.project === undefined ? {} : { project: registration.project }),
-    connection: {
-      ...(registration.connection.name === undefined ? {} : { name: registration.connection.name }),
-      type: registration.connection.type,
-      modality: registration.connection.modality,
-      ...(registration.connection.environment === undefined
+  const answer = await askPlatform(options, {
+    method: "POST",
+    path: "/api/agents",
+    body: {
+      name: registration.name,
+      ...(registration.description === undefined
         ? {}
-        : { environment: registration.connection.environment }),
-      config: registration.connection.config,
-      // The one place the key is read on the way to egma. It is sealed there
-      // and never answered back — what comes back is its last characters.
-      ...(registration.connection.credentials === undefined
-        ? {}
-        : { credentials: { apiKey: registration.connection.credentials.reveal() } }),
+        : { description: registration.description }),
+      ...(registration.project === undefined ? {} : { project: registration.project }),
+      connection: connectionBody(registration.connection),
     },
-  };
+  });
 
-  let response: Response;
-  try {
-    response = await fetchImpl(url, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${options.key}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify(body),
-      ...(options.signal === undefined ? {} : { signal: options.signal }),
-    });
-  } catch {
-    return {
-      kind: "unreachable",
-      reason: `egma at ${options.url} did not answer. Check the address, and that the instance is running.`,
-    };
+  if (answer.kind === "refused") {
+    if (answer.status === 409 && plain(answer.body["error"]) === "name_taken") {
+      return { kind: "name-taken", name: registration.name };
+    }
+    return { kind: "refused", reason: answer.reason };
   }
-
-  const held = (await response.json().catch(() => ({}))) as Record<string, unknown>;
-
-  if (response.status === 401) return { kind: "not-authenticated" };
-  if (response.status === 409 && plain(held["error"]) === "name_taken") {
-    return { kind: "name-taken", name: registration.name };
-  }
-  if (response.status < 200 || response.status >= 300) {
-    return { kind: "refused", reason: refusalIn(response.status, held) };
-  }
+  if (answer.kind !== "ok") return answer;
+  const held = answer.body;
 
   const agent = agentIn(held);
   const connection = connectionIn(held);

--- a/apps/cli/src/retell/client.ts
+++ b/apps/cli/src/retell/client.ts
@@ -11,6 +11,16 @@
  * — and one of the three shapes keeps its words in the customer's own service,
  * where there is nothing for egma to read. That is a real answer, not a failure.
  *
+ * **The account's telephone numbers are read here too, and only ever read.**
+ * Retell has no per-agent number listing, so the account's numbers are listed
+ * and the ones this agent answers are picked out of them — and the one a
+ * developer settles on is confirmed at its own address before egma writes a
+ * connection it will really dial. Which agent answers a number comes from
+ * `inbound_agents` and from nowhere else: Retell's older single-agent field was
+ * observed reporting nothing for a number that is in fact assigned, and a
+ * wizard that trusted it would tell a developer their agent has no numbers
+ * while their customers are dialling one.
+ *
  * **Every document is kept exactly as it arrived**, as text, beside whatever is
  * read out of it. It is the platform's rule for anything a provider sends, and
  * it is the reason a field egma has no place for today is still there tomorrow.
@@ -83,10 +93,47 @@ export type RetellConfig = {
   readonly tools: readonly unknown[];
 };
 
+/**
+ * One telephone number on the account, and which agents answer it.
+ *
+ * `answeredBy` is read from `inbound_agents` and from nothing else. Retell's
+ * older single-agent field is not read at all: it is absent from this account's
+ * answers and was observed reporting nothing for a number that is in fact
+ * assigned, so a wizard that trusted it would tell a developer their agent has
+ * no numbers while their customers are dialling one.
+ *
+ * A number may be answered by several agents under weighted routing, so this is
+ * a list. Which of them wins a given call is Retell's business and is
+ * deliberately not modelled — what egma needs to know is whether the agent the
+ * developer picked is among them.
+ */
+export type RetellNumber = {
+  /** E.164, exactly as Retell holds it. */
+  readonly number: string;
+  /** What the customer calls it, or `""` when they have never named it. */
+  readonly label: string;
+  /** Every agent Retell routes an inbound call on this number to. */
+  readonly answeredBy: readonly string[];
+};
+
 export type ListedAgents =
   | { readonly kind: "agents"; readonly agents: readonly RetellAgent[] }
   /** Retell would not take the key. */
   | { readonly kind: "invalid-key" }
+  | { readonly kind: "refused"; readonly reason: string }
+  | { readonly kind: "unreachable"; readonly reason: string };
+
+export type ListedNumbers =
+  | { readonly kind: "numbers"; readonly numbers: readonly RetellNumber[] }
+  | { readonly kind: "invalid-key" }
+  | { readonly kind: "refused"; readonly reason: string }
+  | { readonly kind: "unreachable"; readonly reason: string };
+
+export type ConfirmedNumber =
+  | { readonly kind: "number"; readonly number: RetellNumber }
+  | { readonly kind: "invalid-key" }
+  /** The number was listed a moment ago and is not there now. */
+  | { readonly kind: "gone" }
   | { readonly kind: "refused"; readonly reason: string }
   | { readonly kind: "unreachable"; readonly reason: string };
 
@@ -243,6 +290,124 @@ export async function listAgents(key: RetellKey, reach: RetellReach = {}): Promi
   }
 
   return { kind: "agents", agents };
+}
+
+/** A listed number, or `null` for a row that is not one. */
+function numberFrom(row: unknown): RetellNumber | null {
+  if (typeof row !== "object" || row === null) return null;
+  const held = row as Record<string, unknown>;
+  const number = plain(held["phone_number"]);
+  if (number === "") return null;
+
+  const routed = Array.isArray(held["inbound_agents"])
+    ? (held["inbound_agents"] as unknown[])
+    : [];
+  const answeredBy: string[] = [];
+  for (const entry of routed) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const id = plain((entry as Record<string, unknown>)["agent_id"]);
+    if (id !== "" && !answeredBy.includes(id)) answeredBy.push(id);
+  }
+
+  return { number, label: plain(held["nickname"]), answeredBy };
+}
+
+/**
+ * Every telephone number on the account the key belongs to.
+ *
+ * A read, and the only way to enumerate: Retell has no per-agent number
+ * listing, so the account's numbers are read and the ones this agent answers
+ * are picked out of them. The picking is `numbersAnswering` below, which is
+ * where the rule lives rather than here.
+ */
+export async function listNumbers(
+  key: RetellKey,
+  reach: RetellReach = {},
+): Promise<ListedNumbers> {
+  let answer: Answer;
+  try {
+    answer = await ask(key, reach, { method: "GET", path: "/list-phone-numbers" });
+  } catch (cause) {
+    if (cause instanceof RetellUnreachableError) {
+      return { kind: "unreachable", reason: cause.message };
+    }
+    throw cause;
+  }
+
+  if (answer.status === 401 || answer.status === 403) return { kind: "invalid-key" };
+  if (answer.status < 200 || answer.status >= 300) {
+    return { kind: "refused", reason: refusalIn(answer) };
+  }
+
+  let held: unknown;
+  try {
+    held = JSON.parse(answer.body);
+  } catch {
+    held = [];
+  }
+  const rows = Array.isArray(held) ? held : [];
+
+  const numbers: RetellNumber[] = [];
+  for (const row of rows) {
+    const number = numberFrom(row);
+    if (number !== null) numbers.push(number);
+  }
+  return { kind: "numbers", numbers };
+}
+
+/**
+ * One number's own document, which is where an assignment is settled.
+ *
+ * The listing is how the candidates are found; this is how the one the
+ * developer picked is confirmed, immediately before egma writes a connection
+ * that will be dialled for real. Both answers come from `inbound_agents`, so
+ * the two cannot disagree about *what* is read — what this buys is that the
+ * number egma is about to register still answers the agent under test at the
+ * moment it registers it, read at that number's own address rather than out of
+ * a list that was fetched a screen ago.
+ */
+export async function confirmNumber(
+  key: RetellKey,
+  number: string,
+  reach: RetellReach = {},
+): Promise<ConfirmedNumber> {
+  let answer: Answer;
+  try {
+    answer = await ask(key, reach, {
+      method: "GET",
+      path: `/get-phone-number/${encodeURIComponent(number)}`,
+    });
+  } catch (cause) {
+    if (cause instanceof RetellUnreachableError) {
+      return { kind: "unreachable", reason: cause.message };
+    }
+    throw cause;
+  }
+
+  if (answer.status === 401 || answer.status === 403) return { kind: "invalid-key" };
+  if (answer.status === 404) return { kind: "gone" };
+  if (answer.status < 200 || answer.status >= 300) {
+    return { kind: "refused", reason: refusalIn(answer) };
+  }
+
+  const held = numberFrom(parsed(answer));
+  if (held === null) return { kind: "gone" };
+  return { kind: "number", number: held };
+}
+
+/**
+ * The numbers one agent answers, out of the account's own.
+ *
+ * Written here rather than at the call site so that "assigned to this agent"
+ * means one thing everywhere, and so a surface that shows a developer a list of
+ * numbers to be dialled can never show one their agent does not answer.
+ */
+export function numbersAnswering(
+  numbers: readonly RetellNumber[],
+  agentId: string,
+): readonly RetellNumber[] {
+  const wanted = agentId.trim();
+  return numbers.filter((number) => number.answeredBy.includes(wanted));
 }
 
 /** Which second request an agent's response engine calls for, if any. */

--- a/apps/cli/src/retell/connect.ts
+++ b/apps/cli/src/retell/connect.ts
@@ -10,20 +10,41 @@
  * and everything the developer should see goes out through `say` — so the same
  * flow runs on a screen, in a pipe, and in a check with nobody watching.
  *
- * Four things happen in order and each one can end the flow honestly: the key
- * is taken, it is checked by listing the account's agents, one agent is settled
- * on, and its configuration is pulled and registered. A key that is wrong and
- * an account that is empty are told apart by name and each is worth one more
- * try — a typo should cost seconds, and a second wrong answer means the answer
- * is somewhere else.
+ * Six things happen in order and each one can end the flow honestly: the key is
+ * taken, it is checked by listing the account's agents, one agent is settled
+ * on, its configuration is pulled, the developer says whether egma should reach
+ * it by text or by phone — and, for the phone, which of the numbers Retell
+ * routes to that agent egma should dial. Then one connection is written: **the
+ * one that was chosen, and only that one.** A key that is wrong and an account
+ * that is empty are told apart by name and each is worth one more try — a typo
+ * should cost seconds, and a second wrong answer means the answer is somewhere
+ * else.
+ *
+ * **Nothing here writes to Retell.** Every request it makes is a read: the
+ * account's agents, one agent's own document, its response engine, the
+ * account's numbers, and one number's own document. egma reaches a customer's
+ * agent; it does not configure it.
  */
 
-import { registerAgent, type Registered, type RegisterOptions } from "../platform/agents.ts";
 import {
+  addConnection,
+  agentNamed,
+  readAgent,
+  registerAgent,
+  type NewConnection,
+  type Registered,
+  type RegisteredConnection,
+  type RegisterOptions,
+} from "../platform/agents.ts";
+import {
+  confirmNumber,
   listAgents,
+  listNumbers,
+  numbersAnswering,
   pullAgent,
   type RetellAgent,
   type RetellConfig,
+  type RetellNumber,
   type RetellReach,
 } from "./client.ts";
 import type { RetellKey } from "./key.ts";
@@ -54,6 +75,38 @@ export const NO_AGENTS_LINE =
 export const DEFAULT_AGENT_NAME = "voice-agent";
 
 /**
+ * How egma reaches the agent, chosen by the developer and never by egma.
+ *
+ * One voice agent can be reached both ways, and the two answer different
+ * questions: text exercises the prompt, the reasoning and the tools; phone
+ * exercises all of that plus the speech stack and the line it is carried on.
+ * The same test over both is the product's sharpest diagnostic — so both are
+ * offered, and **only the one that was chosen is created.** A wizard that made
+ * both would put a connection in somebody's project that they never asked for
+ * and would be billed for the day something ran over it.
+ */
+export type Reach = "text" | "phone";
+
+/** What the developer is choosing between, said the same way on every surface. */
+export const REACH_ASK_LINE = "How should egma reach this agent?";
+
+/** One line per way, said in what it tests rather than in what it is made of. */
+export const REACH_LINES: Readonly<Record<Reach, string>> = {
+  text: "Text — egma exchanges messages with the agent. No phone call, nothing dialled.",
+  phone: "Phone — egma dials one of the agent's numbers and talks to it, as a customer would.",
+};
+
+/** What the developer is asked when the phone was chosen. */
+export const NUMBER_ASK_LINE =
+  "Which number should egma dial? These are the numbers Retell routes to this agent.";
+
+/** The exact failure for an agent Retell routes no number to. */
+export const NO_NUMBERS_LINE =
+  "Retell routes no phone number to that agent, so there is nothing for egma to " +
+  "dial. Assign a number to it in the Retell dashboard, under Phone Numbers — " +
+  "or reach it over text instead.";
+
+/**
  * What egma says when connecting found something already there.
  *
  * Registering the same Retell agent twice is safe on purpose — a coding agent
@@ -73,12 +126,13 @@ export function registrationLine(registered: Registered): string | null {
       return null;
     case "reused":
       return (
-        `This Retell agent was already registered as ${registered.agent.name}, so egma ` +
-        `kept it and stored the key you just gave. Nothing new was registered.`
+        `This voice agent was already registered as ${registered.agent.name}, and ` +
+        `${registered.connection.name} was already the way egma reaches it. Nothing ` +
+        `new was registered.`
       );
     case "connection_added":
       return (
-        `This Retell agent was already registered as ${registered.agent.name}, so egma ` +
+        `This voice agent was already registered as ${registered.agent.name}, so egma ` +
         `added ${registered.connection.name} as another way of reaching it. No second ` +
         `agent was registered.`
       );
@@ -103,6 +157,22 @@ export function keyAskLines(ask: KeyAsk): readonly string[] {
 /** How many times a name already held is tried again with a number on the end. */
 const NAME_ATTEMPTS = 20;
 
+/**
+ * Which of the two things a write turned out to be, said for each half.
+ *
+ * The platform answers one word for the pair — created, reused, the same agent
+ * reached a new way — and that is one word too few for whoever is retrying.
+ * "The agent was already there and the connection is new" and "both are new"
+ * are different facts about somebody's project, and a coding agent deciding
+ * whether its retry worked needs both of them.
+ */
+export type WriteResult = "created" | "reused";
+
+export type Registration = {
+  readonly agent: WriteResult;
+  readonly connection: WriteResult;
+};
+
 export type ConnectOutcome =
   | {
       readonly kind: "connected";
@@ -111,6 +181,12 @@ export type ConnectOutcome =
       readonly drift: Drift;
       /** How many agents the account holds, which is why a picker appeared. */
       readonly onTheAccount: number;
+      /** Which way the developer chose, and the only one egma wrote. */
+      readonly reach: Reach;
+      /** The number egma will dial, or `null` for a text connection. */
+      readonly number: string | null;
+      /** Whether each half was written or found already there. */
+      readonly registration: Registration;
     }
   /** Nobody gave a key, so there is nothing to connect with. */
   | { readonly kind: "no-key" }
@@ -120,6 +196,12 @@ export type ConnectOutcome =
   | { readonly kind: "no-agents" }
   /** Several agents, and nobody said which. */
   | { readonly kind: "unchosen"; readonly agents: readonly RetellAgent[] }
+  /** Nobody said whether egma should reach the agent by text or by phone. */
+  | { readonly kind: "unchosen-reach" }
+  /** Retell routes no number to the chosen agent, so there is nothing to dial. */
+  | { readonly kind: "no-numbers" }
+  /** Several numbers reach the agent, and nobody said which to dial. */
+  | { readonly kind: "unchosen-number"; readonly numbers: readonly RetellNumber[] }
   | { readonly kind: "interrupted" }
   | { readonly kind: "failed"; readonly reason: string };
 
@@ -135,6 +217,22 @@ export type ConnectOptions = {
   readonly askForKey: () => Promise<RetellKey | null>;
   /** Which of several, by id, or `null` when nobody chose. */
   readonly chooseAgent: (agents: readonly RetellAgent[]) => Promise<string | null>;
+  /**
+   * Text or phone, or `null` when nobody chose.
+   *
+   * Asked once the agent is settled and never before it: which numbers exist
+   * is a fact about *that* agent, so there is nothing honest to offer until
+   * egma knows which one is under test.
+   */
+  readonly chooseReach: () => Promise<Reach | null>;
+  /**
+   * Which number to dial, in E.164, or `null` when nobody chose.
+   *
+   * Only ever called with more than one, exactly as the agent choice is: one
+   * number Retell routes to the agent is not a choice, and asking about it
+   * would be a question with one answer.
+   */
+  readonly chooseNumber: (numbers: readonly RetellNumber[]) => Promise<string | null>;
   /** One line about what is happening, for whoever is watching. */
   readonly say: (line: string) => void;
   /**
@@ -234,68 +332,341 @@ async function keyAndAgents(
 /** The key, carried between the two halves of the flow, never stored. */
 type KeyedOptions = ConnectOptions & { readonly key: RetellKey };
 
+/** What egma is being asked to write, once the reach has been chosen. */
+type Selected = {
+  readonly reach: Reach;
+  /** The connection body for the chosen reach, and no other. */
+  readonly connection: NewConnection;
+  /** The number egma will dial, or `null` for a text connection. */
+  readonly number: string | null;
+};
+
 /**
- * Writes the agent and its connection, taking the next free name when a living
- * agent already holds the one asked for.
+ * The one connection the chosen reach means.
  *
- * The platform names connections that way for the same reason, so a second run
- * in the same project lands beside the first instead of refusing.
+ * **Text is a chat connection over the selected voice agent**, not a second
+ * Retell agent: the identity is the voice agent's own, and what changes is how
+ * egma talks to it. **Phone carries the destination number and nothing else** —
+ * no Retell identifier and no credential — because the public telephone network
+ * neither knows nor cares what answers, and a phone connection that named a
+ * provider would be claiming knowledge egma does not use.
+ */
+function selectionFor(
+  reach: Reach,
+  config: RetellConfig,
+  key: RetellKey,
+  number: string | null,
+): Selected {
+  if (reach === "phone") {
+    return {
+      reach,
+      // No name: the platform's own default is the convention, and one
+      // convention in one place cannot drift from itself.
+      connection: {
+        type: "phone",
+        modality: "voice",
+        config: { phoneNumber: number ?? "" },
+      },
+      number,
+    };
+  }
+  return {
+    reach,
+    connection: {
+      type: "retell",
+      modality: "chat",
+      config: { retellAgentId: config.agentId },
+      credentials: key,
+    },
+    number: null,
+  };
+}
+
+/** Whether a connection already on the platform is the one being asked for. */
+function isTheSameReach(held: RegisteredConnection, wanted: NewConnection): boolean {
+  if (held.type !== wanted.type || held.modality !== wanted.modality) return false;
+  return Object.entries(wanted.config).every(([key, value]) => held.config[key] === value);
+}
+
+/** The Retell agent a connection already on the platform reaches, if it names one. */
+function retellAgentOf(held: RegisteredConnection): string | null {
+  if (held.type !== "retell") return null;
+  const named = held.config["retellAgentId"];
+  return named === undefined || named === "" ? null : named;
+}
+
+/** What a write turned out to be, for each half, out of the platform's one word. */
+function registrationOf(registered: Registered): Registration {
+  switch (registered.result) {
+    case "created":
+      return { agent: "created", connection: "created" };
+    case "reused":
+      return { agent: "reused", connection: "reused" };
+    case "connection_added":
+      return { agent: "reused", connection: "created" };
+  }
+}
+
+type Written = {
+  readonly kind: "registered";
+  readonly registered: Registered;
+  readonly registration: Registration;
+};
+
+/**
+ * Writes the selected connection, and the agent under it when there is not one
+ * already.
  *
- * **Connecting the same Retell agent twice is not a name clash.** egma settles
- * that inside its own write — the registration already there answers, with the
- * key rotated whole — and says which of the three things it did. So the name
- * loop below is for the other case only: a *different* Retell agent whose egma
- * name is already taken. Nothing here retries a reuse, because there is nothing
- * to retry.
+ * **A second walk over one voice agent must land on the first walk's agent**,
+ * whichever way it chose to reach it. Two egma agents for one Retell agent
+ * splits a team's results history in half, and that is the failure this whole
+ * function exists to prevent — a retry after a network failure nobody could
+ * read is the ordinary case, not a rare one.
+ *
+ * The platform settles the easy half itself: a retell connection carries the
+ * vendor's own agent id, so registering the same one twice answers what is
+ * already there with the key rotated whole. What it cannot settle is a **phone**
+ * connection, which carries a number and no vendor identity at all — the
+ * platform has nothing to match on, so it would write a second agent every
+ * time, and a developer who connected over text and came back for the phone
+ * would end up with two.
+ *
+ * So the refusal is read rather than worked around. `name-taken` means a living
+ * agent in this project already holds the name egma derives from the Retell
+ * agent's own, and exactly one of two things is true of it:
+ *
+ * - **It is this voice agent**, reached some other way. The chosen connection
+ *   joins it — or, when the same reach is already attached, that connection
+ *   answers and nothing is written at all.
+ * - **It is a different voice agent** wearing the same name, which a real
+ *   account does produce. Then the name is taken and the next one is tried,
+ *   exactly as before.
+ *
+ * **Two signals tell them apart, and a phone-only agent needs the second one.**
+ * A retell connection carries the vendor's own agent id, so it answers outright.
+ * A phone connection carries a number — and Retell knows which numbers it routes
+ * to the agent under test, so a number it routes here says "this is it" and a
+ * number it does not says "this is somebody else" just as clearly. Only an agent
+ * with no connections at all leaves nothing to read, and that is treated as this
+ * one: there is no history to split and nothing to be wrong about.
  */
 async function register(
   options: KeyedOptions,
   config: RetellConfig,
-): Promise<{ readonly kind: "registered"; readonly registered: Registered } | ConnectOutcome> {
+  selected: Selected,
+  /**
+   * The numbers Retell routes to the agent under test, read at most once and
+   * only when a name clash actually needs them. `null` when Retell would not
+   * say — which is not a reason to refuse a registration, so it reads as
+   * "nothing to go on" and the connection joins the agent that holds the name.
+   */
+  numbersOfTheAgent: () => Promise<readonly string[] | null>,
+): Promise<Written | ConnectOutcome> {
   const wanted = defaultAgentName(config.name);
+  const platform: RegisterOptions = {
+    url: options.platform.url,
+    key: options.platform.key,
+    fetchImpl: options.fetchImpl,
+    signal: options.signal,
+  };
+  const notSignedIn: ConnectOutcome = {
+    kind: "failed",
+    reason: "egma would not take this machine's key. Run egma login, then try again.",
+  };
 
   for (let attempt = 1; attempt <= NAME_ATTEMPTS; attempt += 1) {
     if (options.signal.aborted) return { kind: "interrupted" };
+    const name = attempt === 1 ? wanted : `${wanted}-${attempt}`;
 
     const result = await registerAgent(
-      {
-        name: attempt === 1 ? wanted : `${wanted}-${attempt}`,
-        connection: {
-          // No name: the platform's own default is the convention, and one
-          // convention in one place cannot drift from itself.
-          type: "retell",
-          modality: config.modality,
-          config: { retellAgentId: config.agentId },
-          credentials: options.key,
-        },
-      },
-      {
-        url: options.platform.url,
-        key: options.platform.key,
-        fetchImpl: options.fetchImpl,
-        signal: options.signal,
-      },
+      { name, connection: selected.connection },
+      platform,
     );
 
     switch (result.kind) {
       case "registered":
-        return { kind: "registered", registered: result.registered };
-      case "name-taken":
-        continue;
-      case "not-authenticated":
         return {
-          kind: "failed",
-          reason: "egma would not take this machine's key. Run egma login, then try again.",
+          kind: "registered",
+          registered: result.registered,
+          registration: registrationOf(result.registered),
         };
+      case "not-authenticated":
+        return notSignedIn;
       case "refused":
       case "unreachable":
         return { kind: "failed", reason: result.reason };
+      case "name-taken":
+        break;
+    }
+
+    // Somebody holds the name. Which somebody decides everything below.
+    const found = await agentNamed(name, platform);
+    if (options.signal.aborted) return { kind: "interrupted" };
+    if (found.kind === "not-authenticated") return notSignedIn;
+    if (found.kind === "refused" || found.kind === "unreachable") {
+      return { kind: "failed", reason: found.reason };
+    }
+    // Gone between the refusal and the read. Asking again is the whole answer.
+    if (found.kind === "not-found") continue;
+
+    const held = await readAgent(found.agent.id, platform);
+    if (options.signal.aborted) return { kind: "interrupted" };
+    if (held.kind === "not-authenticated") return notSignedIn;
+    if (held.kind === "refused" || held.kind === "unreachable") {
+      return { kind: "failed", reason: held.reason };
+    }
+    if (held.kind === "not-found") continue;
+
+    // A connection naming another Retell agent settles it: this is somebody
+    // else's agent under the same name, and the next name is tried.
+    const reaches = held.connections
+      .map(retellAgentOf)
+      .filter((named): named is string => named !== null);
+    if (reaches.length > 0 && !reaches.includes(config.agentId)) continue;
+
+    // Nothing here names a vendor, so the numbers do. An agent reached only by
+    // phone is this one exactly when Retell routes one of its numbers to the
+    // agent under test — and when it routes none of them, this is a different
+    // voice agent wearing the same name.
+    const dialled = held.connections
+      .filter((one) => one.type === "phone")
+      .map((one) => one.config["phoneNumber"] ?? "");
+    if (reaches.length === 0 && dialled.length > 0) {
+      const routed = await numbersOfTheAgent();
+      if (options.signal.aborted) return { kind: "interrupted" };
+      if (routed !== null && !dialled.some((number) => routed.includes(number))) continue;
+    }
+
+    // The same reach, already attached. Nothing is written and both halves
+    // answer as they stand — which is what makes running this twice free.
+    const already = held.connections.find((one) =>
+      isTheSameReach(one, selected.connection),
+    );
+    if (already !== undefined) {
+      return {
+        kind: "registered",
+        registered: { result: "reused", agent: held.agent, connection: already },
+        registration: { agent: "reused", connection: "reused" },
+      };
+    }
+
+    const added = await addConnection(found.agent.id, selected.connection, platform);
+    switch (added.kind) {
+      case "added":
+        return {
+          kind: "registered",
+          registered: {
+            result: "connection_added",
+            agent: held.agent,
+            connection: added.connection,
+          },
+          registration: { agent: "reused", connection: "created" },
+        };
+      case "not-authenticated":
+        return notSignedIn;
+      // The agent went away, or the connection name did, between the read and
+      // the write. Both are answered by going round again.
+      case "not-found":
+      case "name-taken":
+        continue;
+      case "refused":
+      case "unreachable":
+        return { kind: "failed", reason: added.reason };
     }
   }
 
   return {
     kind: "failed",
     reason: `every name from "${wanted}" onwards is already taken in this project. Rename one of them, or say which agent this is.`,
+  };
+}
+
+/**
+ * The number egma will dial, out of the ones Retell routes to this agent.
+ *
+ * Two reads, and both of them are reads. The account's numbers are listed
+ * because Retell has no per-agent listing, and the one the developer settles on
+ * is then read at its own address — immediately before egma writes a connection
+ * that will be dialled for real, and against the same field the listing was
+ * filtered on. A number that stopped answering this agent in between is an
+ * ending rather than a call to somebody else's telephone.
+ *
+ * A number the agent does not answer is never offered, so this cannot end with
+ * egma dialling a number for an agent that is not under test.
+ */
+async function pickNumber(
+  options: ConnectOptions,
+  key: RetellKey,
+  config: RetellConfig,
+): Promise<
+  | {
+      readonly kind: "number";
+      readonly number: string;
+      /** Every number Retell routes here, so nothing lists them twice. */
+      readonly routed: readonly string[];
+    }
+  | ConnectOutcome
+> {
+  const listed = await listNumbers(key, options.retell ?? {});
+  if (options.signal.aborted) return { kind: "interrupted" };
+
+  switch (listed.kind) {
+    case "numbers":
+      break;
+    case "invalid-key":
+      return { kind: "invalid-key" };
+    case "refused":
+    case "unreachable":
+      return { kind: "failed", reason: listed.reason };
+  }
+
+  const mine = numbersAnswering(listed.numbers, config.agentId);
+  if (mine.length === 0) {
+    options.say(NO_NUMBERS_LINE);
+    return { kind: "no-numbers" };
+  }
+
+  // One number is not a choice, exactly as one agent is not. The developer
+  // reads which one egma took, inside the flow, with nothing to answer.
+  let wanted = mine.length === 1 ? (mine[0] as RetellNumber).number : null;
+  if (wanted === null) {
+    wanted = (await options.chooseNumber(mine))?.trim() ?? null;
+    if (options.signal.aborted) return { kind: "interrupted" };
+    if (wanted === null || wanted === "") return { kind: "unchosen-number", numbers: mine };
+    if (!mine.some((one) => one.number === wanted)) {
+      return { kind: "unchosen-number", numbers: mine };
+    }
+  }
+
+  const confirmed = await confirmNumber(key, wanted, options.retell ?? {});
+  if (options.signal.aborted) return { kind: "interrupted" };
+
+  switch (confirmed.kind) {
+    case "number":
+      break;
+    case "invalid-key":
+      return { kind: "invalid-key" };
+    case "gone":
+      return {
+        kind: "failed",
+        reason: `${wanted} is no longer on the Retell account. Run egma again to see which numbers are.`,
+      };
+    case "refused":
+    case "unreachable":
+      return { kind: "failed", reason: confirmed.reason };
+  }
+
+  if (!confirmed.number.answeredBy.includes(config.agentId)) {
+    return {
+      kind: "failed",
+      reason: `Retell no longer routes ${wanted} to ${config.name}, so egma will not register it as the way to reach that agent. Run egma again to see which numbers it answers.`,
+    };
+  }
+
+  return {
+    kind: "number",
+    number: confirmed.number.number,
+    routed: mine.map((one) => one.number),
   };
 }
 
@@ -341,8 +712,36 @@ export async function connect(options: ConnectOptions): Promise<ConnectOutcome> 
   }
 
   const config = pulled.config;
+
+  // The agent is settled, so what egma may offer is settled with it. Asking
+  // before this point would be offering a phone the agent may have no number
+  // for.
+  const reach = await options.chooseReach();
+  if (options.signal.aborted) return { kind: "interrupted" };
+  if (reach === null) return { kind: "unchosen-reach" };
+
+  // Read once at most, and only where it is needed: by the phone branch, which
+  // needs it to offer anything at all, and by a name clash that has nothing
+  // else to go on. A text connect on an account nobody has clashed with never
+  // asks Retell about telephone numbers.
+  let routed: readonly string[] | null | undefined;
+  const numbersOfTheAgent = async (): Promise<readonly string[] | null> => {
+    if (routed !== undefined) return routed;
+    const listed = await listNumbers(key, options.retell ?? {});
+    routed =
+      listed.kind === "numbers"
+        ? numbersAnswering(listed.numbers, config.agentId).map((one) => one.number)
+        : null;
+    return routed;
+  };
+
+  const dialling = reach === "phone" ? await pickNumber(options, key, config) : null;
+  if (dialling !== null && dialling.kind !== "number") return dialling;
+  if (dialling !== null) routed = dialling.routed;
+  const selected = selectionFor(reach, config, key, dialling?.number ?? null);
+
   await options.beforeRegistering?.();
-  const written = await register(keyed, config);
+  const written = await register(keyed, config, selected, numbersOfTheAgent);
   if (written.kind !== "registered") return written;
 
   // Shown, never blocking: the drift is worked out after everything that
@@ -361,5 +760,8 @@ export async function connect(options: ConnectOptions): Promise<ConnectOutcome> 
     config,
     drift,
     onTheAccount: agents.length,
+    reach: selected.reach,
+    number: selected.number,
+    registration: written.registration,
   };
 }

--- a/apps/cli/src/retell/connect.ts
+++ b/apps/cli/src/retell/connect.ts
@@ -602,17 +602,53 @@ async function register(
       // is the whole answer: the next pass finds whatever is there now.
       case "not-found":
         continue;
-      // Nothing here names a connection, so the platform picks the first free
-      // `<type>-<n>` itself and cannot hand back a name already held. Reaching
-      // this means the platform's naming and this build's disagree, and going
-      // round again would register a *second agent* rather than fix it.
-      case "name-taken":
+      /**
+       * Nothing here names a connection, so the platform picks the first free
+       * `<type>-<n>` itself. There is exactly one ordinary way it can still
+       * answer that the name is held: **two connects adding the same reach at
+       * the same instant.** Both got past the check above while neither had
+       * written anything, then one lost the connection-name index.
+       *
+       * The loser's answer is a *reuse*, and it is read rather than assumed:
+       * the winner has committed by the time the index refused this write, so
+       * the agent is read again and the connection that is now there answers.
+       * That is exactly what the same race one level up already does — two
+       * simultaneous registrations settle to one agent because the loser waits
+       * on the index and then reads committed work — and doing it differently
+       * here would tell a developer their egma is out of date when the only
+       * thing that happened is that their other terminal got there first.
+       *
+       * The out-of-date sentence is kept for the case it was written for: the
+       * name really is held and nothing on the agent is the reach that was
+       * refused, which means the platform names connections in a way this
+       * build cannot predict.
+       */
+      case "name-taken": {
+        const now = await readAgent(found.agent.id, platform);
+        if (options.signal.aborted) return { kind: "interrupted" };
+        if (now.kind === "not-authenticated") return notSignedIn;
+        if (now.kind === "refused" || now.kind === "unreachable") {
+          return { kind: "failed", reason: now.reason };
+        }
+        if (now.kind === "not-found") continue;
+
+        const raced = now.connections.find((one) =>
+          isTheSameReach(one, selected.connection),
+        );
+        if (raced !== undefined) {
+          return {
+            kind: "registered",
+            registered: { result: "reused", agent: now.agent, connection: raced },
+            registration: { agent: "reused", connection: "reused" },
+          };
+        }
         return {
           kind: "failed",
           reason:
-            `egma would not name the new connection on ${held.agent.name}, ` +
+            `egma would not name the new connection on ${now.agent.name}, ` +
             "and nothing else was changed. Check that this egma is up to date.",
         };
+      }
       case "refused":
       case "unreachable":
         return { kind: "failed", reason: added.reason };

--- a/apps/cli/src/retell/connect.ts
+++ b/apps/cli/src/retell/connect.ts
@@ -93,7 +93,9 @@ export const REACH_ASK_LINE = "How should egma reach this agent?";
 /** One line per way, said in what it tests rather than in what it is made of. */
 export const REACH_LINES: Readonly<Record<Reach, string>> = {
   text: "Text — egma exchanges messages with the agent. No phone call, nothing dialled.",
-  phone: "Phone — egma dials one of the agent's numbers and talks to it, as a customer would.",
+  phone:
+    "Phone — egma dials one of the agent's numbers and talks to it over the " +
+    "telephone network, the way the people who call it do.",
 };
 
 /** What the developer is asked when the phone was chosen. */
@@ -374,6 +376,24 @@ function selectionFor(
     reach,
     connection: {
       type: "retell",
+      // Chat, whichever kind of agent this is: the modality says which layer is
+      // under test, and text exercises the prompt, the reasoning and the tools
+      // rather than the speech stack. It is *not* read off `config.modality`,
+      // which is the agent's own channel — reaching a voice agent by text is
+      // exactly what this choice is for.
+      //
+      // **A row written here is not conductable today, and that is not this
+      // step's to fix.** `spec.md` says text uses Retell's Agent Playground
+      // Completion — `POST /agent-playground-completion/{agent_id}`, which
+      // takes the whole message history per turn and works against an agent of
+      // either channel. The shipped plug
+      // (`apps/simulator/src/egma_simulator/plugs/retell.py`) speaks Retell's
+      // *chat-agent* API instead — `create-chat`, `create-chat-completion`,
+      // `end-chat` — and whether that accepts a voice agent's id is untested.
+      // Nothing in this ticket runs a text simulation, so nothing here can find
+      // out. Whoever ships the text path replaces that plug rather than
+      // pointing it somewhere else; the identity written down is already the
+      // right one.
       modality: "chat",
       config: { retellAgentId: config.agentId },
       credentials: key,
@@ -446,9 +466,17 @@ type Written = {
  * retell connection carries the vendor's own agent id and answers outright. A
  * phone connection carries a number, and Retell knows which numbers it routes to
  * the agent under test — so a number it routes here says "this is it", and a
- * number it does not says "this is somebody else" just as clearly. Only an agent
- * with no living connection at all leaves nothing to read, and that is taken as
- * this one: there is no history to split and nothing to be wrong about.
+ * number it does not says "this is somebody else" just as clearly.
+ *
+ * **Where neither signal answers, the next name is taken.** An agent reached
+ * only by phone, with Retell unable to say which numbers it routes, is an agent
+ * egma cannot identify — and the two ways of being wrong about it are not
+ * equally bad. Guess "this is it" and two voice agents share one egma agent and
+ * one results history, which nothing can unpick afterwards. Guess "somebody
+ * else" and there is a spare agent in the project, which a developer can delete
+ * in one command. So ambiguity goes to the next name, every time. An agent with
+ * no living connection at all is the one case with nothing to be wrong about —
+ * there is no history to split — and the chosen connection joins it.
  */
 async function register(
   options: KeyedOptions,
@@ -456,9 +484,14 @@ async function register(
   selected: Selected,
   /**
    * The numbers Retell routes to the agent under test, read at most once and
-   * only when a name clash actually needs them. `null` when Retell would not
-   * say — which is not a reason to refuse a registration, so it reads as
-   * "nothing to go on" and the connection joins the agent that holds the name.
+   * only when a name clash actually needs them.
+   *
+   * `null` when Retell would not say. That is not a reason to refuse the
+   * registration, and it is not a reason to guess either: it means this agent
+   * cannot be identified, so the next name is taken and the developer gets a
+   * spare agent rather than a merged history. Read once and no more, because a
+   * listing that failed on the first ask is not going to answer differently on
+   * the twentieth.
    */
   numbersOfTheAgent: () => Promise<readonly string[] | null>,
 ): Promise<Written | ConnectOutcome> {
@@ -526,15 +559,16 @@ async function register(
 
     // Nothing here names a vendor, so the numbers do. An agent reached only by
     // phone is this one exactly when Retell routes one of its numbers to the
-    // agent under test — and when it routes none of them, this is a different
-    // voice agent wearing the same name.
+    // agent under test. When it routes none of them — and when Retell would not
+    // say at all — this is somebody else's agent under the same name, and the
+    // next name is tried. Ambiguity goes that way on purpose: see above.
     const dialled = held.connections
       .filter((one) => one.type === "phone")
       .map((one) => one.config["phoneNumber"] ?? "");
     if (reaches.length === 0 && dialled.length > 0) {
       const routed = await numbersOfTheAgent();
       if (options.signal.aborted) return { kind: "interrupted" };
-      if (routed !== null && !dialled.some((number) => routed.includes(number))) continue;
+      if (routed === null || !dialled.some((number) => routed.includes(number))) continue;
     }
 
     // The same reach, already attached. Nothing is written and both halves

--- a/apps/cli/src/retell/connect.ts
+++ b/apps/cli/src/retell/connect.ts
@@ -442,13 +442,13 @@ type Written = {
  *   account does produce. Then the name is taken and the next one is tried,
  *   exactly as before.
  *
- * **Two signals tell them apart, and a phone-only agent needs the second one.**
- * A retell connection carries the vendor's own agent id, so it answers outright.
- * A phone connection carries a number — and Retell knows which numbers it routes
- * to the agent under test, so a number it routes here says "this is it" and a
+ * **Two signals tell those apart, and a phone-only agent needs the second.** A
+ * retell connection carries the vendor's own agent id and answers outright. A
+ * phone connection carries a number, and Retell knows which numbers it routes to
+ * the agent under test — so a number it routes here says "this is it", and a
  * number it does not says "this is somebody else" just as clearly. Only an agent
- * with no connections at all leaves nothing to read, and that is treated as this
- * one: there is no history to split and nothing to be wrong about.
+ * with no living connection at all leaves nothing to read, and that is taken as
+ * this one: there is no history to split and nothing to be wrong about.
  */
 async function register(
   options: KeyedOptions,
@@ -564,11 +564,21 @@ async function register(
         };
       case "not-authenticated":
         return notSignedIn;
-      // The agent went away, or the connection name did, between the read and
-      // the write. Both are answered by going round again.
+      // The agent went away between the read and the write. Going round again
+      // is the whole answer: the next pass finds whatever is there now.
       case "not-found":
-      case "name-taken":
         continue;
+      // Nothing here names a connection, so the platform picks the first free
+      // `<type>-<n>` itself and cannot hand back a name already held. Reaching
+      // this means the platform's naming and this build's disagree, and going
+      // round again would register a *second agent* rather than fix it.
+      case "name-taken":
+        return {
+          kind: "failed",
+          reason:
+            `egma would not name the new connection on ${held.agent.name}, ` +
+            "and nothing else was changed. Check that this egma is up to date.",
+        };
       case "refused":
       case "unreachable":
         return { kind: "failed", reason: added.reason };

--- a/apps/cli/src/ui/headless-ui.ts
+++ b/apps/cli/src/ui/headless-ui.ts
@@ -15,8 +15,14 @@
  */
 
 import { loginLines, type LoginPrompt } from "../platform/login.ts";
-import type { RetellAgent } from "../retell/client.ts";
-import { keyAskLines, type KeyAsk } from "../retell/connect.ts";
+import type { RetellAgent, RetellNumber } from "../retell/client.ts";
+import {
+  keyAskLines,
+  NUMBER_ASK_LINE,
+  REACH_ASK_LINE,
+  REACH_LINES,
+  type KeyAsk,
+} from "../retell/connect.ts";
 import { simulationLine } from "../run/lines.ts";
 import type { RunView } from "../run/view.ts";
 import type { SkillPlaces } from "../skills/install.ts";
@@ -36,6 +42,10 @@ export type HeadlessRecord = {
   keyAsks: KeyAsk[];
   /** The agents a choice was offered between, when one was. */
   agentChoices: RetellAgent[];
+  /** Whether the choice between text and phone was ever put to anybody. */
+  reachOffered: boolean;
+  /** The numbers a choice was offered between, when one was. */
+  numberChoices: RetellNumber[];
   statuses: string[];
   summary: string;
   /** Every test the coding agent said it had written, in the order it said so. */
@@ -66,6 +76,8 @@ export class HeadlessUI implements WizardUI {
     logins: [],
     keyAsks: [],
     agentChoices: [],
+    reachOffered: false,
+    numberChoices: [],
     statuses: [],
     summary: "",
     written: [],
@@ -136,6 +148,31 @@ export class HeadlessUI implements WizardUI {
     this.record.agentChoices = [...agents];
     for (const agent of agents) {
       this.write(`retell_agent: ${agent.id} ${agent.name}`.trimEnd());
+    }
+  }
+
+  /**
+   * The offer, printed the same way the screen draws it.
+   *
+   * It is printed even though nobody is here to answer it, because whoever
+   * reads this output afterwards has to be able to see that both ways were
+   * offered and that egma chose neither on their behalf.
+   */
+  setReachOffer(open: boolean): void {
+    if (!open) return;
+    this.record.reachOffered = true;
+    this.write(REACH_ASK_LINE);
+    for (const way of ["text", "phone"] as const) {
+      this.write(`reach_option: ${way} ${REACH_LINES[way]}`);
+    }
+  }
+
+  setNumberChoices(numbers: readonly RetellNumber[] | null): void {
+    if (numbers === null) return;
+    this.record.numberChoices = [...numbers];
+    this.write(NUMBER_ASK_LINE);
+    for (const number of numbers) {
+      this.write(`retell_number: ${number.number} ${number.label}`.trimEnd());
     }
   }
 

--- a/apps/cli/src/ui/tui/App.tsx
+++ b/apps/cli/src/ui/tui/App.tsx
@@ -15,7 +15,9 @@ import { GateScreen } from "./screens/GateScreen.tsx";
 import { GeneratingScreen } from "./screens/GeneratingScreen.tsx";
 import { IntroScreen } from "./screens/IntroScreen.tsx";
 import { LoginScreen } from "./screens/LoginScreen.tsx";
+import { PhoneNumberScreen } from "./screens/PhoneNumberScreen.tsx";
 import { PromptsPointerScreen } from "./screens/PromptsPointerScreen.tsx";
+import { ReachScreen } from "./screens/ReachScreen.tsx";
 import { RetellAgentScreen } from "./screens/RetellAgentScreen.tsx";
 import { RetellKeyScreen } from "./screens/RetellKeyScreen.tsx";
 import { RunScreen } from "./screens/RunScreen.tsx";
@@ -78,6 +80,17 @@ export function App({ store, onQuit, onInterrupt }: AppProps) {
   if (screen === "retell-agent") {
     return (
       <RetellAgentScreen state={state} onAnswer={(id) => store.answer("retell-agent", id)} />
+    );
+  }
+  if (screen === "reach") {
+    return <ReachScreen onAnswer={(reach) => store.answer("reach", reach)} />;
+  }
+  if (screen === "phone-number") {
+    return (
+      <PhoneNumberScreen
+        state={state}
+        onAnswer={(number) => store.answer("phone-number", number)}
+      />
     );
   }
   if (screen === "existing-tests") {

--- a/apps/cli/src/ui/tui/ink-ui.ts
+++ b/apps/cli/src/ui/tui/ink-ui.ts
@@ -6,7 +6,7 @@
  */
 
 import type { LoginPrompt } from "../../platform/login.ts";
-import type { RetellAgent } from "../../retell/client.ts";
+import type { RetellAgent, RetellNumber } from "../../retell/client.ts";
 import type { KeyAsk } from "../../retell/connect.ts";
 import type { RunView } from "../../run/view.ts";
 import type { SkillPlaces } from "../../skills/install.ts";
@@ -53,6 +53,14 @@ export class InkUI implements WizardUI {
 
   setAgentChoices(agents: readonly RetellAgent[] | null): void {
     this.store.setAgentChoices(agents);
+  }
+
+  setReachOffer(open: boolean): void {
+    this.store.setReachOffer(open);
+  }
+
+  setNumberChoices(numbers: readonly RetellNumber[] | null): void {
+    this.store.setNumberChoices(numbers);
   }
 
   setGeneration(progress: GenerationProgress | null): void {

--- a/apps/cli/src/ui/tui/router.ts
+++ b/apps/cli/src/ui/tui/router.ts
@@ -21,6 +21,8 @@ export type ScreenId =
   | "prompts-pointer"
   | "retell-key"
   | "retell-agent"
+  | "reach"
+  | "phone-number"
   | "existing-tests"
   | "generating"
   | "gate"

--- a/apps/cli/src/ui/tui/screens/PhoneNumberScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/PhoneNumberScreen.tsx
@@ -1,0 +1,99 @@
+/**
+ * Which number egma should dial, when Retell routes more than one to the agent.
+ *
+ * This screen exists only when there is a real choice. One number is not a
+ * choice, so the flow never opens the question and the router never reaches
+ * here — the same rule the choice of agent follows.
+ *
+ * Every number on it is one Retell already routes to the agent the developer
+ * picked, so there is no way through this screen to a telephone that somebody
+ * else answers. The customer's own nickname for each is shown beside it,
+ * because two numbers on a real account are very often nearly the same digits.
+ */
+
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+import { NUMBER_ASK_LINE } from "../../../retell/connect.ts";
+import { dispatchKey, hintBar, type KeyBinding } from "../keybindings.ts";
+import type { WizardState } from "../state.ts";
+
+export type PhoneNumberScreenProps = {
+  readonly state: WizardState;
+  /** The chosen number in E.164, or `null` when the developer chose none. */
+  readonly onAnswer: (number: string | null) => void;
+};
+
+/** How many rows are on screen at once, so a long account still fits. */
+const VISIBLE = 8;
+
+export function PhoneNumberScreen({ state, onAnswer }: PhoneNumberScreenProps) {
+  const numbers = state.numberChoices ?? [];
+  const [at, setAt] = useState(0);
+
+  const bindings: KeyBinding[] = [
+    {
+      match: "upArrow",
+      label: "↑↓",
+      action: "choose",
+      handler: () => setAt((held) => (held === 0 ? numbers.length - 1 : held - 1)),
+    },
+    {
+      match: "downArrow",
+      label: "↑↓",
+      action: "choose",
+      handler: () => setAt((held) => (held + 1) % Math.max(numbers.length, 1)),
+    },
+    {
+      match: "return",
+      label: "enter",
+      action: "dial this one",
+      handler: () => onAnswer(numbers[at]?.number ?? null),
+    },
+    {
+      match: "escape",
+      label: "esc",
+      action: "none of these",
+      handler: () => onAnswer(null),
+    },
+  ];
+
+  useInput((input, key) => {
+    dispatchKey(bindings, input, key);
+  });
+
+  // The window follows the cursor rather than the cursor following the window,
+  // so the chosen row is always on screen however many numbers there are.
+  const from = Math.min(
+    Math.max(0, at - Math.floor(VISIBLE / 2)),
+    Math.max(0, numbers.length - VISIBLE),
+  );
+  const shown = numbers.slice(from, from + VISIBLE);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={2} paddingY={1}>
+      <Text bold>egma</Text>
+      <Box height={1} />
+      <Text>{NUMBER_ASK_LINE}</Text>
+      <Box height={1} />
+      <Box flexDirection="column">
+        {shown.map((number, index) => {
+          const chosen = from + index === at;
+          return (
+            <Text key={number.number} bold={chosen}>
+              {`${chosen ? "›" : " "} ${number.number}`}
+              {number.label === "" ? "" : <Text dimColor>{`  ${number.label}`}</Text>}
+            </Text>
+          );
+        })}
+      </Box>
+      {numbers.length > VISIBLE ? (
+        <Box marginTop={1}>
+          <Text dimColor>{`${numbers.length - shown.length} more`}</Text>
+        </Box>
+      ) : null}
+      <Box height={1} />
+      <Text dimColor>{hintBar(bindings)}</Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/ui/tui/screens/ReachScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/ReachScreen.tsx
@@ -6,9 +6,12 @@
  * never both** — a second connection nobody asked for is a second thing in
  * somebody's project that they would find later and have to work out.
  *
- * There is no default and there is no highlighted safe option, because one of
- * the two dials a real telephone and costs real money. A developer who closes
- * the wizard here has answered too, and nothing is created.
+ * **The highlight starts on text, and the keystroke is still required.** One of
+ * the two dials a real telephone and costs real money, so the row the cursor
+ * rests on before anybody has touched it is the one that does not — but resting
+ * there is not choosing, and nothing at all is created until enter is pressed.
+ * A developer who closes the wizard here has answered too, and nothing is
+ * created then either.
  */
 
 import { useState } from "react";

--- a/apps/cli/src/ui/tui/screens/ReachScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/ReachScreen.tsx
@@ -1,0 +1,83 @@
+/**
+ * Text or phone: how egma should reach the agent under test.
+ *
+ * The one question in the walk whose answer decides what egma writes. Both ways
+ * are real and both are supported, and **egma creates the one that is chosen and
+ * never both** — a second connection nobody asked for is a second thing in
+ * somebody's project that they would find later and have to work out.
+ *
+ * There is no default and there is no highlighted safe option, because one of
+ * the two dials a real telephone and costs real money. A developer who closes
+ * the wizard here has answered too, and nothing is created.
+ */
+
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+import { REACH_ASK_LINE, REACH_LINES, type Reach } from "../../../retell/connect.ts";
+import { dispatchKey, hintBar, type KeyBinding } from "../keybindings.ts";
+
+export type ReachScreenProps = {
+  /** The chosen way, or `null` when the developer chose neither. */
+  readonly onAnswer: (reach: Reach | null) => void;
+};
+
+const WAYS: readonly Reach[] = ["text", "phone"];
+
+export function ReachScreen({ onAnswer }: ReachScreenProps) {
+  const [at, setAt] = useState(0);
+
+  const bindings: KeyBinding[] = [
+    {
+      match: "upArrow",
+      label: "↑↓",
+      action: "choose",
+      handler: () => setAt((held) => (held === 0 ? WAYS.length - 1 : held - 1)),
+    },
+    {
+      match: "downArrow",
+      label: "↑↓",
+      action: "choose",
+      handler: () => setAt((held) => (held + 1) % WAYS.length),
+    },
+    {
+      match: "return",
+      label: "enter",
+      action: "reach it this way",
+      handler: () => onAnswer(WAYS[at] ?? null),
+    },
+    {
+      match: "escape",
+      label: "esc",
+      action: "neither",
+      handler: () => onAnswer(null),
+    },
+  ];
+
+  useInput((input, key) => {
+    dispatchKey(bindings, input, key);
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={2} paddingY={1}>
+      <Text bold>egma</Text>
+      <Box height={1} />
+      <Text>{REACH_ASK_LINE}</Text>
+      <Box height={1} />
+      <Box flexDirection="column">
+        {WAYS.map((way, index) => {
+          const chosen = index === at;
+          return (
+            <Text key={way} bold={chosen}>
+              {`${chosen ? "›" : " "} ${REACH_LINES[way]}`}
+            </Text>
+          );
+        })}
+      </Box>
+      <Box height={1} />
+      <Text dimColor>egma creates the one you choose, and only that one.</Text>
+      <Box height={1} />
+      <Text dimColor>{hintBar(bindings)}</Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/ui/tui/state.ts
+++ b/apps/cli/src/ui/tui/state.ts
@@ -7,7 +7,7 @@
  */
 
 import type { LoginPrompt } from "../../platform/login.ts";
-import type { RetellAgent } from "../../retell/client.ts";
+import type { RetellAgent, RetellNumber } from "../../retell/client.ts";
 import type { KeyAsk } from "../../retell/connect.ts";
 import type { RunView } from "../../run/view.ts";
 import type { SkillPlaces } from "../../skills/install.ts";
@@ -39,6 +39,10 @@ export type WizardState = {
   readonly keyAsk: KeyAsk | null;
   /** The agents a choice is open between, or `null` when none is. */
   readonly agentChoices: readonly RetellAgent[] | null;
+  /** True while the choice between text and phone is open. */
+  readonly reachOffered: boolean;
+  /** The numbers a choice is open between, or `null` when none is. */
+  readonly numberChoices: readonly RetellNumber[] | null;
   /** The developer has read the intro and said go. */
   readonly begun: boolean;
   /** The developer has read the test list and said run them. */
@@ -74,6 +78,8 @@ export function emptyState(): WizardState {
     loginCopied: false,
     keyAsk: null,
     agentChoices: null,
+    reachOffered: false,
+    numberChoices: null,
     begun: false,
     agreedToRun: false,
     running: false,

--- a/apps/cli/src/ui/tui/store.ts
+++ b/apps/cli/src/ui/tui/store.ts
@@ -18,7 +18,7 @@
 import { WizardRouter, type ScreenName, type Sequence } from "./router.ts";
 import { emptyState, type WizardState } from "./state.ts";
 import type { LoginPrompt } from "../../platform/login.ts";
-import type { RetellAgent } from "../../retell/client.ts";
+import type { RetellAgent, RetellNumber } from "../../retell/client.ts";
 import type { KeyAsk } from "../../retell/connect.ts";
 import type { RunView } from "../../run/view.ts";
 import type { SkillPlaces } from "../../skills/install.ts";
@@ -42,6 +42,12 @@ export const WALK_SCREENS: Sequence = [
   // Never reached with one agent on the account, because the flow only opens
   // this question when there is a choice to make.
   { id: "retell-agent", show: (state) => state.asking === "retell-agent" },
+  // The one question that decides what egma creates. Never skipped and never
+  // answered for the developer.
+  { id: "reach", show: (state) => state.asking === "reach" },
+  // Never reached when Retell routes one number to the agent, because the flow
+  // only opens this question when there is a choice to make.
+  { id: "phone-number", show: (state) => state.asking === "phone-number" },
   { id: "existing-tests", show: (state) => state.asking === "existing-tests" },
   // The last question the wizard asks, over the run screen it interrupts: the
   // run keeps moving underneath while the developer decides.
@@ -188,6 +194,14 @@ export class WizardStore {
 
   setAgentChoices(agentChoices: readonly RetellAgent[] | null): void {
     this.change({ agentChoices });
+  }
+
+  setReachOffer(reachOffered: boolean): void {
+    this.change({ reachOffered });
+  }
+
+  setNumberChoices(numberChoices: readonly RetellNumber[] | null): void {
+    this.change({ numberChoices });
   }
 
   setGeneration(generation: GenerationProgress | null): void {

--- a/apps/cli/src/ui/wizard-ui.ts
+++ b/apps/cli/src/ui/wizard-ui.ts
@@ -11,7 +11,7 @@
  */
 
 import type { LoginPrompt } from "../platform/login.ts";
-import type { RetellAgent } from "../retell/client.ts";
+import type { RetellAgent, RetellNumber } from "../retell/client.ts";
 import type { KeyAsk } from "../retell/connect.ts";
 import type { RunView } from "../run/view.ts";
 import type { SkillPlaces } from "../skills/install.ts";
@@ -41,6 +41,16 @@ export type AskId =
   | "prompts-pointer"
   | "retell-key"
   | "retell-agent"
+  /**
+   * Text or phone: the one question whose answer decides what egma creates.
+   *
+   * A question and never a gate, and one egma never answers on the developer's
+   * behalf. Only one of the two dials a real telephone, and egma choosing that
+   * for somebody would be egma spending their money.
+   */
+  | "reach"
+  /** Which of the agent's numbers to dial, when Retell routes it more than one. */
+  | "phone-number"
   | "existing-tests"
   /**
    * Whether to install the egma skill, and where.
@@ -110,6 +120,24 @@ export interface WizardUI {
    * screen that never appears is how a flow asks nothing.
    */
   setAgentChoices(agents: readonly RetellAgent[] | null): void;
+
+  /**
+   * That the two ways of reaching the agent are on offer, or `null` when they
+   * are not.
+   *
+   * A write and not a question, exactly as the agent choices are: the flow says
+   * the offer is open and the screen collects the word.
+   */
+  setReachOffer(open: boolean): void;
+
+  /**
+   * The numbers Retell routes to the chosen agent, while a choice among them is
+   * open, or `null` when there is no choice to make.
+   *
+   * Set only when there is more than one: one number is not a choice, and a
+   * screen that never appears is how a flow asks nothing.
+   */
+  setNumberChoices(numbers: readonly RetellNumber[] | null): void;
 
   /**
    * Park until the developer has let the flow past this point. A gate that the

--- a/apps/cli/src/ui/wizard-ui.ts
+++ b/apps/cli/src/ui/wizard-ui.ts
@@ -122,11 +122,14 @@ export interface WizardUI {
   setAgentChoices(agents: readonly RetellAgent[] | null): void;
 
   /**
-   * That the two ways of reaching the agent are on offer, or `null` when they
-   * are not.
+   * Whether the two ways of reaching the agent are on offer right now.
    *
    * A write and not a question, exactly as the agent choices are: the flow says
-   * the offer is open and the screen collects the word.
+   * the offer is open and the screen collects the word. It is a plain `true`
+   * and `false` rather than a value-or-`null` because there is nothing to
+   * carry — the two ways egma offers are the same two every time, and a screen
+   * that had to be told them could show a different pair from the one the flow
+   * would act on.
    */
   setReachOffer(open: boolean): void;
 

--- a/apps/cli/src/wizard/connect-step.ts
+++ b/apps/cli/src/wizard/connect-step.ts
@@ -11,6 +11,7 @@
  * provider, once for a body to egma. Nothing here writes it anywhere.
  */
 
+import { bindRepositoryPlatform } from "../folder/egma-folder.ts";
 import type { Registered } from "../platform/agents.ts";
 import { readCredentials } from "../platform/credentials.ts";
 import type { RetellConfig } from "../retell/client.ts";
@@ -19,9 +20,12 @@ import {
   connect,
   CUSTODY_LINE,
   KEY_ASK_LINE,
+  NO_NUMBERS_LINE,
   registrationLine,
   type ConnectOptions,
   type ConnectOutcome,
+  type Reach,
+  type Registration,
 } from "../retell/connect.ts";
 import { DRIFT_LINE } from "../retell/prompt-drift.ts";
 import type { WizardUI } from "../ui/wizard-ui.ts";
@@ -43,6 +47,11 @@ export type ConnectStepOptions = {
   readonly fetchImpl?: ConnectOptions["fetchImpl"];
 };
 
+/** The two words a reach screen may answer with, and nothing else. */
+function reachFrom(answer: string | null): Reach | null {
+  return answer === "text" || answer === "phone" ? answer : null;
+}
+
 /** The line the wizard closes on, for every way this step can end. */
 function reportFor(outcome: ConnectOutcome, signal: AbortSignal): ExitReport {
   switch (outcome.kind) {
@@ -60,6 +69,17 @@ function reportFor(outcome: ConnectOutcome, signal: AbortSignal): ExitReport {
       return { kind: "failed", reason: "there are no agents on that Retell account." };
     case "unchosen":
       return { kind: "failed", reason: "nobody said which Retell agent to test." };
+    case "unchosen-reach":
+      return {
+        kind: "failed",
+        reason:
+          "nobody said whether egma should reach this agent by text or by phone, " +
+          "so nothing was created.",
+      };
+    case "no-numbers":
+      return { kind: "failed", reason: NO_NUMBERS_LINE };
+    case "unchosen-number":
+      return { kind: "failed", reason: "nobody said which number egma should dial." };
     case "interrupted":
       return stopReport(signal, null);
     case "failed":
@@ -80,6 +100,12 @@ export type Connected = {
   readonly connected: {
     readonly registered: Registered;
     readonly config: RetellConfig;
+    /** Which way the developer chose, and the only one egma created. */
+    readonly reach: Reach;
+    /** The number egma will dial, or `null` for a text connection. */
+    readonly number: string | null;
+    /** Whether the agent and the connection were written or found. */
+    readonly registration: Registration;
   } | null;
 };
 
@@ -110,6 +136,10 @@ export async function connectStep(options: ConnectStepOptions): Promise<Connecte
   // the box rather than leaving the developer to guess what changed.
   let problem: string | null = null;
 
+  // A repository this platform may not write into, carried out of the hook
+  // below because the flow has no ending of its own for it.
+  const binding: { refused: Error | null } = { refused: null };
+
   const outcome = await connect({
     platform: { url: held.url, key: held.key },
     cwd: options.cwd,
@@ -138,6 +168,45 @@ export async function connectStep(options: ConnectStepOptions): Promise<Connecte
       ui.setAgentChoices(null);
       return chosen ?? null;
     },
+    chooseReach: async () => {
+      ui.setReachOffer(true);
+      const chosen = await untilAborted(ui.waitForAnswer("reach"), signal);
+      ui.setReachOffer(false);
+      return reachFrom(chosen ?? null);
+    },
+    chooseNumber: async (numbers) => {
+      ui.setNumberChoices(numbers);
+      const chosen = await untilAborted(ui.waitForAnswer("phone-number"), signal);
+      ui.setNumberChoices(null);
+      return chosen ?? null;
+    },
+    // The last moment before this repository owns anything that only one
+    // platform can resolve, and the reason this hook exists at all: every
+    // ending above it — no key, a key Retell will not take, an empty account,
+    // an unanswered choice of agent, reach or number — must leave the
+    // repository exactly as the walk found it. Bound any earlier and a wizard
+    // closed at the key box would leave an egma folder behind holding nothing
+    // but a binding.
+    beforeRegistering: async () => {
+      try {
+        await bindRepositoryPlatform(options.cwd, {
+          origin: options.platform.url,
+          instance: options.platform.instanceId,
+        });
+      } catch (cause) {
+        // Carried out rather than answered from in here: the flow has no
+        // ending for this, and an agent must not be registered on a platform
+        // this repository has already refused.
+        binding.refused = cause instanceof Error ? cause : new Error(String(cause));
+        throw cause;
+      }
+      ui.pushStatus(
+        `${ACTION_MARK} Bound this repository to Egma platform ${options.platform.instanceId}.`,
+      );
+    },
+  }).catch((cause: unknown) => {
+    if (binding.refused === null) throw cause;
+    return { kind: "failed", reason: binding.refused.message } as const;
   });
 
   if (outcome.kind !== "connected") {
@@ -151,8 +220,16 @@ export async function connectStep(options: ConnectStepOptions): Promise<Connecte
     // answer.
     ui.pushStatus(`${ACTION_MARK} Retell agent ${config.name}`);
     ui.pushStatus(`${DETAIL_MARK} ${config.agentId}`);
+    // The number, said on its own line and before the connection line, because
+    // it is the one fact on this screen that will cost somebody money.
+    if (outcome.number !== null) {
+      ui.pushStatus(`${ACTION_MARK} egma will dial ${outcome.number}.`);
+    }
     ui.pushStatus(
-      `${ACTION_MARK} ${registered.agent.name} is on egma, reachable over ${registered.connection.name} (retell ${registered.connection.modality}).`,
+      `${ACTION_MARK} ${registered.agent.name} is on egma, reachable over ${registered.connection.name} (${registered.connection.type} ${registered.connection.modality}).`,
+    );
+    ui.pushStatus(
+      `${DETAIL_MARK} agent ${outcome.registration.agent}, connection ${outcome.registration.connection}`,
     );
     // A second walk over the same Retell agent finds what the first one wrote.
     // egma says so rather than drawing a line that reads like a fresh
@@ -164,7 +241,13 @@ export async function connectStep(options: ConnectStepOptions): Promise<Connecte
 
     return {
       report: reportFor(outcome, signal),
-      connected: { registered, config },
+      connected: {
+        registered,
+        config,
+        reach: outcome.reach,
+        number: outcome.number,
+        registration: outcome.registration,
+      },
     };
   }
 }

--- a/apps/cli/src/wizard/generate-step.ts
+++ b/apps/cli/src/wizard/generate-step.ts
@@ -37,6 +37,7 @@ import { readdir } from "node:fs/promises";
 
 import {
   createEgmaFolder,
+  DEFAULT_SUITE_NAME,
   readConfig,
   readFolder,
   updateConfig,
@@ -65,9 +66,6 @@ import {
   GenerationTally,
   type GenerationContext,
 } from "./test-generation.ts";
-
-/** What this folder's first test suite is called when nobody has named one. */
-export const DEFAULT_SUITE_NAME = "first-suite";
 
 /**
  * How the step ended, and what it left behind for the step after it.

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -17,7 +17,6 @@
 import process from "node:process";
 
 import type { DrivenAgentLaunch } from "../acp/registry.ts";
-import { bindRepositoryPlatform } from "../folder/egma-folder.ts";
 import { signedInAt } from "../platform/signed-in.ts";
 import type { ConnectOptions } from "../retell/connect.ts";
 import { homeIn } from "../skills/install.ts";
@@ -131,17 +130,11 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
     return found.report;
   }
 
-  // The last moment before this repository owns anything that only one platform
-  // can resolve. Committed here rather than earlier so a walk that found no
-  // agent leaves the repository exactly as it was, and rather than later so no
-  // identifier can ever exist in this folder without the platform that issued
-  // it written down beside it.
-  await bindRepositoryPlatform(cwd, {
-    origin: options.platform.url,
-    instance: options.platform.instanceId,
-  });
-  ui.pushStatus(`Bound this repository to Egma platform ${options.platform.instanceId}.`);
-
+  // The binding is written inside the connect step, at the last moment before
+  // egma asks the platform to create anything — not here. Bound at this line, a
+  // walk that ended at the key box, at an unanswered choice of agent, or at
+  // "text or phone?" would leave an egma folder behind holding nothing but a
+  // binding, in a repository the developer had decided not to connect.
   const connected = await connectStep({
     ui,
     platform: options.platform,

--- a/apps/cli/test/assembly.test.ts
+++ b/apps/cli/test/assembly.test.ts
@@ -198,7 +198,7 @@ describe("the whole walk, offline", () => {
     // and the one thing nobody can answer in advance is answered here. The
     // skill offer is left unanswered, which is skip — the answer that has to
     // leave the machine exactly as it was.
-    const ui = new HeadlessUI({ answers: { "retell-key": KEY } });
+    const ui = new HeadlessUI({ answers: { "retell-key": KEY, reach: "text" } });
 
     // One verdict, and one only: the wizard leaves at the first, and a sweep
     // that judged the whole suite would put a number in the exit line that
@@ -274,10 +274,13 @@ describe("the whole walk, offline", () => {
     expect(platform.registered.agents.map((agent) => agent.name)).toEqual(["order-line"]);
     const connection = platform.registered.connections[0];
     expect(platform.registered.connections).toHaveLength(1);
+    // One connection, and it is the one the walk chose: text, which is a chat
+    // connection over the selected voice agent. Creating both is the bug the
+    // choice exists to kill.
     expect(connection).toMatchObject({
       agentId: platform.registered.agents[0]?.id,
       type: "retell",
-      modality: "voice",
+      modality: "chat",
       name: "retell-1",
       config: { retellAgentId: RETELL_AGENT_ID },
     });

--- a/apps/cli/test/connect-command.test.ts
+++ b/apps/cli/test/connect-command.test.ts
@@ -27,6 +27,8 @@ import { CLI_ENTRY, MANIFEST, makeWorkspace, type Workspace } from "./support/wo
 const KEY = "key_1f4c9b7e2a6d0538c1e7";
 const PROMPT = "You answer the order line.\nNever quote a price.\n";
 
+const DIALLED = "+14155550111";
+
 const ONE_AGENT: FakeRetellScript = {
   keys: [KEY],
   agents: [
@@ -38,6 +40,13 @@ const ONE_AGENT: FakeRetellScript = {
     },
   ],
   llms: [{ llm_id: "llm_0001", general_prompt: PROMPT, general_tools: [{ type: "end_call" }] }],
+  numbers: [
+    {
+      phone_number: DIALLED,
+      nickname: "order line",
+      inbound_agents: [{ agent_id: "agent_0001" }],
+    },
+  ],
 };
 
 const TWO_AGENTS: FakeRetellScript = {
@@ -82,6 +91,10 @@ function egma(
   const env = workspace.env({
     EGMA_URL: platform.url,
     ...(retell === undefined ? {} : { EGMA_RETELL_URL: retell.url }),
+    // Every check written before there was a choice is about the connection
+    // egma made then, and that is the text one. The checks that are about the
+    // choice itself say so in their own arguments, which win over this.
+    EGMA_REACH: "text",
     ...options.env,
   });
 
@@ -135,7 +148,11 @@ describe("egma connect", () => {
     expect(said.connection_id).toMatch(/^con_/u);
     expect(said.connection_name).toBe("retell-1");
     expect(said.connection_type).toBe("retell");
-    expect(said.connection_modality).toBe("voice");
+    expect(said.connection_modality).toBe("chat");
+    expect(said.reach).toBe("text");
+    expect(said.phone_number).toBe("none");
+    expect(said.agent_registration).toBe("created");
+    expect(said.connection_registration).toBe("created");
     expect(said.grounded_in).toBe("retell");
     expect(said.status).toBe("connected");
 
@@ -147,11 +164,13 @@ describe("egma connect", () => {
 
     expect(platform.registered.agents).toHaveLength(1);
     expect(platform.registered.sealed).toEqual([KEY]);
+    // The same four things the wizard's own walk writes, so a repository
+    // connected by the verb and one connected by the wizard hold one file.
     expect(await readConfig(path.join(workspace.dir, "egma", "config.yaml"))).toEqual({
       platform: { origin: platform.url, instance: platform.instanceId },
       agent: { name: said.agent_name, id: said.agent_id },
       connection: { name: said.connection_name, id: said.connection_id },
-      suite: null,
+      suite: { name: "first-suite", id: null },
     });
   });
 
@@ -171,9 +190,11 @@ describe("egma connect", () => {
     expect(facts(theirs.stdout).agent_name).toBe("order-line");
     expect(facts(theirs.stdout).registration).toBe("reused");
     expect(facts(ours.stdout).registration).toBe("created");
+    expect(facts(theirs.stdout).agent_registration).toBe("reused");
+    expect(facts(theirs.stdout).connection_registration).toBe("reused");
     expect(theirs.stdout).toContain(
-      "note: This Retell agent was already registered as order-line, so egma kept it " +
-        "and stored the key you just gave. Nothing new was registered.",
+      "note: This voice agent was already registered as order-line, and retell-1 was " +
+        "already the way egma reaches it. Nothing new was registered.",
     );
     expect(platform.registered.agents).toHaveLength(1);
     expect(platform.registered.connections).toHaveLength(1);
@@ -342,6 +363,123 @@ describe("egma connect", () => {
     expect(help.stdout).toContain("egma connect [options]");
     expect(help.stdout).toContain("0 connected   2 the key was refused");
     expect(help.stdout).toContain("EGMA_RETELL_API_KEY");
+    expect(help.stdout).toContain("--reach <text|phone>");
+  });
+});
+
+/**
+ * The choice, on the surface a coding agent drives.
+ *
+ * The wizard has a screen for it; this has a flag, an environment variable, and
+ * an exit code for the case nobody said. What must not exist on either surface
+ * is a default — egma picking one of the two would be egma deciding whether to
+ * dial somebody's telephone.
+ */
+describe("which connection egma creates", () => {
+  it("creates only the phone connection, holding the number and nothing else", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+
+    const result = await egma(["connect", "--reach", "phone"], { stdin: KEY });
+
+    expect(result.code).toBe(CONNECT_EXIT.connected);
+    const said = facts(result.stdout);
+    expect(said.reach).toBe("phone");
+    expect(said.phone_number).toBe(DIALLED);
+    expect(said.connection_type).toBe("phone");
+    expect(said.connection_modality).toBe("voice");
+    expect(said.connection_name).toBe("phone-1");
+
+    expect(platform.registered.connections).toHaveLength(1);
+    expect(platform.registered.connections[0]?.config).toEqual({ phoneNumber: DIALLED });
+    // No Retell, Twilio, LiveKit, SIP or OpenAI credential is anywhere near it.
+    expect(platform.registered.sealed).toEqual([]);
+    expect(JSON.stringify(platform.registered)).not.toContain(KEY);
+
+    // And the committed file names the connection egma really made.
+    const written = await readConfig(folderPathsIn(workspace.dir).config);
+    expect(written.connection).toEqual({ name: "phone-1", id: said.connection_id });
+    expect(JSON.stringify(written)).not.toContain(KEY);
+  });
+
+  it("creates nothing at all when neither way was chosen", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+
+    const result = await egma(["connect"], { stdin: KEY, env: { EGMA_REACH: "" } });
+
+    expect(result.code).toBe(CONNECT_EXIT.unchosen);
+    expect(facts(result.stdout).status).toBe("unchosen-reach");
+    // Both ways were put on the screen, and neither was taken.
+    expect(result.stdout).toContain("reach_option: text");
+    expect(result.stdout).toContain("reach_option: phone");
+    expect(platform.registered.agents).toHaveLength(0);
+    expect(platform.registered.connections).toHaveLength(0);
+    await expect(readConfig(folderPathsIn(workspace.dir).config)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("refuses a word that is not one of the two, before it reads anything", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+
+    const result = await egma(["connect", "--reach", "carrier-pigeon"], { stdin: KEY });
+
+    expect(result.code).toBe(CONNECT_EXIT.unchosen);
+    expect(result.stderr).toContain("is not a way egma reaches an agent");
+    expect(retell.requests).toHaveLength(0);
+  });
+
+  it("says which numbers reach the agent when it will not guess between them", async () => {
+    retell = await startFakeRetell({
+      ...ONE_AGENT,
+      numbers: [
+        ...(ONE_AGENT.numbers ?? []),
+        {
+          phone_number: "+14155550999",
+          nickname: "overflow",
+          inbound_agents: [{ agent_id: "agent_0001" }],
+        },
+      ],
+    });
+
+    const unchosen = await egma(["connect", "--reach", "phone"], { stdin: KEY });
+    expect(unchosen.code).toBe(CONNECT_EXIT.unchosen);
+    expect(facts(unchosen.stdout).status).toBe("unchosen-number");
+    expect(unchosen.stdout).toContain(`retell_number: ${DIALLED} order line`);
+    expect(platform.registered.agents).toHaveLength(0);
+
+    const named = await egma(["connect", "--reach", "phone", "--phone-number", "+14155550999"], {
+      stdin: KEY,
+    });
+    expect(named.code).toBe(CONNECT_EXIT.connected);
+    expect(facts(named.stdout).phone_number).toBe("+14155550999");
+  });
+
+  it("says plainly when Retell routes no number to the agent", async () => {
+    retell = await startFakeRetell({ ...ONE_AGENT, numbers: [] });
+
+    const result = await egma(["connect", "--reach", "phone"], { stdin: KEY });
+
+    expect(result.code).toBe(CONNECT_EXIT.noNumbers);
+    expect(facts(result.stdout).status).toBe("no-numbers");
+    expect(result.stderr).toContain("Retell routes no phone number to that agent");
+    expect(platform.registered.agents).toHaveLength(0);
+  });
+
+  it("is deterministic under retry, and says which half it wrote each time", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+
+    const first = await egma(["connect", "--reach", "phone"], { stdin: KEY });
+    const again = await egma(["connect", "--reach", "phone"], { stdin: KEY });
+
+    expect(facts(first.stdout).agent_registration).toBe("created");
+    expect(facts(first.stdout).connection_registration).toBe("created");
+    expect(facts(again.stdout).agent_registration).toBe("reused");
+    expect(facts(again.stdout).connection_registration).toBe("reused");
+    expect(facts(again.stdout).agent_id).toBe(facts(first.stdout).agent_id);
+    expect(facts(again.stdout).connection_id).toBe(facts(first.stdout).connection_id);
+
+    expect(platform.registered.agents).toHaveLength(1);
+    expect(platform.registered.connections).toHaveLength(1);
   });
 });
 

--- a/apps/cli/test/connect-screen.test.ts
+++ b/apps/cli/test/connect-screen.test.ts
@@ -3,9 +3,10 @@
  *
  * A pseudo-terminal runs the built command and a headless terminal emulator
  * reads its screen and everything it wrote. That is the only way to check the
- * two promises this step makes to a person rather than to a machine: that the
- * key is drawn as dots while it is typed, and that one agent on the account
- * costs no keystrokes while several get a list to choose from.
+ * promises this step makes to a person rather than to a machine: that the key
+ * is drawn as dots while it is typed, that one agent on the account costs no
+ * keystrokes while several get a list to choose from, and that the choice
+ * between text and phone is really put to the person at the keyboard.
  *
  * The key typed here is invented and reaches a fake Retell on this machine.
  */
@@ -33,6 +34,8 @@ vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 
 const KEY = "key_h4j7d2s9f5g8k1l3m6n0";
 
+const DIALLED = "+14155550111";
+
 const ONE_AGENT: FakeRetellScript = {
   keys: [KEY],
   agents: [
@@ -43,6 +46,13 @@ const ONE_AGENT: FakeRetellScript = {
     },
   ],
   llms: [{ llm_id: "llm_0001", general_prompt: "You answer the order line.\n" }],
+  numbers: [
+    {
+      phone_number: DIALLED,
+      nickname: "order line",
+      inbound_agents: [{ agent_id: "agent_0001" }],
+    },
+  ],
 };
 
 const TWO_AGENTS: FakeRetellScript = {
@@ -160,6 +170,11 @@ describe("the key screen", () => {
 
     run.write("\r");
 
+    // Text or phone, put to the person at the keyboard. Text is taken here;
+    // the phone has a check of its own below.
+    await showing(run, "How should egma reach this agent?", "[enter] reach it this way");
+    run.write("\r");
+
     // The walk carries on to the one question the generate step asks. It is
     // answered here so the run reaches its own ending rather than the
     // teardown's.
@@ -248,6 +263,9 @@ describe("the picker", () => {
     await showing(run, "\u203a after-hours");
     run.write("\r");
 
+    await showing(run, "How should egma reach this agent?");
+    run.write("\r");
+
     // Past the one question the generate step asks, and past its gate.
     await showing(run, "Do you already have test cases", "[n] none");
     run.write("n");
@@ -263,5 +281,68 @@ describe("the picker", () => {
 
     // The one that was highlighted is the one that was registered.
     expect(platform.registered.connections[0]?.config).toEqual({ retellAgentId: "agent_0002" });
+  });
+});
+
+describe("the choice between text and phone", () => {
+  it("is a screen, and taking the phone creates the phone connection and no other", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+    const run = await wizard();
+
+    await showing(run, "Paste your Retell API key");
+    run.write(`${KEY}\n`);
+
+    const offered = await showing(
+      run,
+      "How should egma reach this agent?",
+      "Text — egma exchanges messages with the agent.",
+      "Phone — egma dials one of the agent's numbers",
+      "egma creates the one you choose, and only that one.",
+    );
+    // Nothing is chosen for the developer: the phone is the second row, and
+    // reaching it takes a keystroke.
+    expect(offered).toContain("\u203a Text");
+
+    run.write("\u001B[B");
+    await showing(run, "\u203a Phone");
+    run.write("\r");
+
+    await showing(run, "Do you already have test cases", "[n] none");
+    run.write("n");
+    await showing(run, "price-question", "[enter] run");
+    const grading = gradeEveryRun(platform);
+    run.write("\r");
+
+    const exited = await run.exited;
+    grading.stop();
+    expect(exited).toBe(0);
+
+    // One number reaches this agent, so there was nothing to choose between —
+    // and the number egma was about to dial was said all the same, because it
+    // is the one fact in the walk that costs somebody money.
+    expect(run.raw()).toContain(`egma will dial ${DIALLED}.`);
+
+    // The phone connection, and nothing else. No retell connection was made
+    // alongside it, and the key never reached egma at all.
+    expect(platform.registered.connections).toHaveLength(1);
+    expect(platform.registered.connections[0]?.type).toBe("phone");
+    expect(platform.registered.connections[0]?.config).toEqual({ phoneNumber: DIALLED });
+    expect(platform.registered.sealed).toEqual([]);
+    expect(run.raw()).not.toContain(KEY);
+  });
+
+  it("creates nothing when the developer takes neither way", async () => {
+    retell = await startFakeRetell(ONE_AGENT);
+    const run = await wizard();
+
+    await showing(run, "Paste your Retell API key");
+    run.write(`${KEY}\n`);
+    await showing(run, "How should egma reach this agent?", "[esc] neither");
+    run.write("\u001B");
+
+    expect(await run.exited).toBe(1);
+    expect(run.scrollback()).toContain("text or by phone");
+    expect(platform.registered.agents).toHaveLength(0);
+    expect(platform.registered.connections).toHaveLength(0);
   });
 });

--- a/apps/cli/test/connect-screen.test.ts
+++ b/apps/cli/test/connect-screen.test.ts
@@ -35,6 +35,7 @@ vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 const KEY = "key_h4j7d2s9f5g8k1l3m6n0";
 
 const DIALLED = "+14155550111";
+const ALSO_DIALLED = "+14155550999";
 
 const ONE_AGENT: FakeRetellScript = {
   keys: [KEY],
@@ -329,6 +330,61 @@ describe("the choice between text and phone", () => {
     expect(platform.registered.connections[0]?.config).toEqual({ phoneNumber: DIALLED });
     expect(platform.registered.sealed).toEqual([]);
     expect(run.raw()).not.toContain(KEY);
+  });
+
+  it("asks which number to dial when Retell routes the agent more than one", async () => {
+    retell = await startFakeRetell({
+      ...ONE_AGENT,
+      numbers: [
+        ...(ONE_AGENT.numbers ?? []),
+        {
+          phone_number: ALSO_DIALLED,
+          nickname: "overflow",
+          inbound_agents: [{ agent_id: "agent_0001" }],
+        },
+      ],
+    });
+    const run = await wizard();
+
+    await showing(run, "Paste your Retell API key");
+    run.write(`${KEY}\n`);
+    await showing(run, "How should egma reach this agent?");
+    run.write("\u001B[B");
+    await showing(run, "\u203a Phone");
+    run.write("\r");
+
+    // Two numbers reach this agent, so there is a real choice and the wizard
+    // makes it. Both are numbers Retell routes here; a number somebody else
+    // answers is never on this screen at all.
+    const listed = await showing(
+      run,
+      "Which number should egma dial?",
+      DIALLED,
+      ALSO_DIALLED,
+      "[enter] dial this one",
+    );
+    expect(listed).toContain("order line");
+
+    run.write("\u001B[B");
+    await showing(run, `\u203a ${ALSO_DIALLED}`);
+    run.write("\r");
+
+    await showing(run, "Do you already have test cases", "[n] none");
+    run.write("n");
+    await showing(run, "price-question", "[enter] run");
+    const grading = gradeEveryRun(platform);
+    run.write("\r");
+
+    const exited = await run.exited;
+    grading.stop();
+    expect(exited).toBe(0);
+
+    // The one that was highlighted is the one egma will dial, and it is the
+    // whole of what the connection holds.
+    expect(platform.registered.connections).toHaveLength(1);
+    expect(platform.registered.connections[0]?.config).toEqual({
+      phoneNumber: ALSO_DIALLED,
+    });
   });
 
   it("creates nothing when the developer takes neither way", async () => {

--- a/apps/cli/test/connect.test.ts
+++ b/apps/cli/test/connect.test.ts
@@ -22,9 +22,11 @@ import {
   KEY_ASK_LINE,
   CUSTODY_LINE,
   NO_AGENTS_LINE,
+  NO_NUMBERS_LINE,
 } from "../src/retell/connect.ts";
 import { DRIFT_LINE } from "../src/retell/prompt-drift.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import type { AskId } from "../src/ui/wizard-ui.ts";
 import { connectStep } from "../src/wizard/connect-step.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
@@ -56,6 +58,12 @@ const ONE_AGENT: FakeRetellScript = {
     },
   ],
 };
+
+/** Two numbers on the account, one of them answered by the order line. */
+const NUMBERS = [
+  { phone_number: "+15551110000", nickname: "order line", inbound_agents: [{ agent_id: "agent_0001" }] },
+  { phone_number: "+15552220000", nickname: "somebody else", inbound_agents: [{ agent_id: "agent_9999" }] },
+] as const;
 
 const THREE_AGENTS: FakeRetellScript = {
   keys: [KEY],
@@ -92,6 +100,14 @@ type RunOptions = {
   readonly keys: readonly (string | null)[];
   /** Which agent they pick, when they are asked. */
   readonly agent?: string | null;
+  /**
+   * Which way they say egma should reach it. `text` unless a check is about
+   * the phone: every check written before there was a choice is about the
+   * connection egma made then, and text is that connection.
+   */
+  readonly reach?: string | null;
+  /** Which number they pick, when Retell routes the agent more than one. */
+  readonly number?: string | null;
   /** Where the coding agent said the repository keeps its prompt. */
   readonly repoPrompts?: string | null;
 };
@@ -105,17 +121,23 @@ type RunOptions = {
 class ScriptedUI extends HeadlessUI {
   private readonly keys: (string | null)[];
   private readonly agent: string | null;
+  private readonly reach: string | null;
+  private readonly number: string | null;
 
   constructor(options: RunOptions) {
     super();
     this.keys = [...options.keys];
     this.agent = options.agent ?? null;
+    this.reach = options.reach === undefined ? "text" : options.reach;
+    this.number = options.number ?? null;
   }
 
-  override waitForAnswer(ask: "prompts-pointer" | "retell-key" | "retell-agent") {
+  override waitForAnswer(ask: AskId) {
     this.record.asked.push(ask);
     if (ask === "retell-key") return Promise.resolve(this.keys.shift() ?? null);
     if (ask === "retell-agent") return Promise.resolve(this.agent);
+    if (ask === "reach") return Promise.resolve(this.reach);
+    if (ask === "phone-number") return Promise.resolve(this.number);
     return Promise.resolve(null);
   }
 }
@@ -282,15 +304,24 @@ describe("one agent, and several", () => {
     expect(platform.registered.agents).toHaveLength(0);
   });
 
-  it("carries the agent's own modality, so a chat agent is not called a voice one", async () => {
+  it("makes a text connection a chat one, whichever kind of agent it reaches", async () => {
     retell = await startFakeRetell(THREE_AGENTS);
 
+    // agent_0003 is a chat agent and agent_0002 is a voice one. Text is what
+    // egma is doing over the connection, not what the agent is: reaching a
+    // voice agent by text is exactly the point of the choice, and the modality
+    // says which layer is under test rather than which kind of agent answered.
     const { connected } = await run({ keys: [KEY], agent: "agent_0003" });
-
-    const [connection] = platform.registered.connections;
-    expect(connection?.modality).toBe("chat");
+    expect(platform.registered.connections[0]?.modality).toBe("chat");
     // A custom model is the customer's own service, so Retell holds no prompt.
     expect(connected?.config.prompt).toBeNull();
+
+    const voice = await run({ keys: [KEY], agent: "agent_0002" });
+    expect(voice.connected?.config.modality).toBe("voice");
+    expect(platform.registered.connections[1]?.modality).toBe("chat");
+    expect(platform.registered.connections[1]?.config).toEqual({
+      retellAgentId: "agent_0002",
+    });
   });
 
   it("reads a chat agent at the address Retell keeps chat agents at", async () => {
@@ -405,7 +436,7 @@ describe("what lands on the platform", () => {
     expect(connection?.id).toMatch(/^con_[0-9A-HJKMNP-TV-Z]{26}$/u);
     expect(connection?.name).toBe("retell-1");
     expect(connection?.type).toBe("retell");
-    expect(connection?.modality).toBe("voice");
+    expect(connection?.modality).toBe("chat");
     expect(connection?.topology).toBe("hosted-broker");
     expect(connection?.agentId).toBe(agent?.id);
   });
@@ -461,9 +492,18 @@ describe("what lands on the platform", () => {
 
     // Said in plain words, on the screen, and never as a failure.
     expect(second.ui.record.statuses.join("\n")).toContain(
-      "This Retell agent was already registered as order-line, so egma kept it and " +
-        "stored the key you just gave. Nothing new was registered.",
+      "This voice agent was already registered as order-line, and retell-1 was " +
+        "already the way egma reaches it. Nothing new was registered.",
     );
+    // And each half is reported on its own, because a retry cares about both.
+    expect(second.connected?.registration).toEqual({
+      agent: "reused",
+      connection: "reused",
+    });
+    expect(first.connected?.registration).toEqual({
+      agent: "created",
+      connection: "created",
+    });
   });
 });
 
@@ -786,6 +826,7 @@ describe("a registration answer this build cannot read", () => {
           type: "retell",
           modality: "voice",
           credentialsHint: "WXYZ",
+          config: {},
         },
       },
     });

--- a/apps/cli/test/failure-branches.test.ts
+++ b/apps/cli/test/failure-branches.test.ts
@@ -100,9 +100,11 @@ afterEach(async () => {
 /** The walk, with whatever the developer would have answered written down. */
 async function walkWith(options: {
   readonly script: string;
-  readonly answers?: Partial<Record<"prompts-pointer" | "retell-key", string>>;
+  readonly answers?: Partial<Record<"prompts-pointer" | "retell-key" | "reach", string>>;
 }) {
-  const ui = new HeadlessUI({ answers: options.answers ?? {} });
+  // Text unless a check says otherwise: every branch here is about a way the
+  // walk can fail before or after the choice, not about the choice itself.
+  const ui = new HeadlessUI({ answers: { reach: "text", ...(options.answers ?? {}) } });
 
   // A walk that gets as far as a suite ends in a run, and a run ends when
   // verdicts arrive. Nothing here conducts a simulation, so the fixture is

--- a/apps/cli/test/fixture-agreement.test.ts
+++ b/apps/cli/test/fixture-agreement.test.ts
@@ -1321,26 +1321,24 @@ describe("starting a run", () => {
     }
   });
 
-  it("refuses a connection type no simulator adapter has shipped for, at the door", async () => {
+  it("starts a run over a phone connection, because the phone adapter has shipped", async () => {
     const { connectionId, oneCaller } = await readyToRun("phone");
 
-    const refused = await ask("POST", "/api/runs", {
+    const started = await ask("POST", "/api/runs", {
       connection: connectionId,
       test_versions: [oneCaller],
     });
 
-    // The platform's own sentence, relayed word for word by whatever prints it.
-    expect(refused.status).toBe(422);
-    expect(refused.body).toEqual({
-      error: "no_adapter",
-      message:
-        "egma has no simulator adapter for a phone connection yet, so it " +
-        "will not start a run it cannot conduct. Run these tests over a " +
-        "connection egma conducts today: retell, livekit.",
+    // This was the `no_adapter` refusal until the phone plug shipped. Both
+    // ends of the agreement had to move together: a fixture still refusing
+    // here would let a client pass its checks and fail on a real platform.
+    expect(started.status, JSON.stringify(started.body)).toBe(201);
+    expect(started.body).toMatchObject({
+      connection_id: connectionId,
+      connection_type: "phone",
+      modality: "voice",
     });
-
-    // And nothing is left queued for a conductor that does not exist.
-    expect(platform.running.runs).toEqual([]);
+    expect(platform.running.runs).toHaveLength(1);
   });
 
   /**

--- a/apps/cli/test/gate-screen.test.ts
+++ b/apps/cli/test/gate-screen.test.ts
@@ -156,6 +156,11 @@ async function toTheGate(
   await showing(run, "Paste your Retell API key");
   run.write(`${KEY}\r`);
 
+  // Text or phone. Not this check's subject, and not skippable
+  // either: egma never picks one of the two for a developer.
+  await showing(run, "How should egma reach this agent?");
+  run.write("\r");
+
   await showing(run, "Do you already have test cases", "[n] none");
   run.write("n");
 
@@ -272,6 +277,11 @@ describe("the files arriving", () => {
     run.write("\r");
     await showing(run, "Paste your Retell API key");
     run.write(`${KEY}\r`);
+
+    // Text or phone. Not this check's subject, and not skippable
+    // either: egma never picks one of the two for a developer.
+    await showing(run, "How should egma reach this agent?");
+    run.write("\r");
     await showing(run, "Do you already have test cases", "[n] none");
 
     run.write("");
@@ -351,7 +361,7 @@ describe("the gate", () => {
       IN_ORDER[0] as string,
       "default persona",
       "more (↑↓ browse · e opens in $EDITOR)",
-      "Run these against order-line over retell-1 (voice)?",
+      "Run these against order-line over retell-1 (chat)?",
       ...GATE_HINTS,
     );
 
@@ -534,7 +544,7 @@ describe("the gate", () => {
       "5 tests generated",
       'suite "first-suite"',
       IN_ORDER[0] as string,
-      "Run these against order-line over retell-1 (voice)?",
+      "Run these against order-line over retell-1 (chat)?",
       ...GATE_HINTS,
     );
     expect(back).not.toContain("STAND-IN EDITOR HAS THE SCREEN");

--- a/apps/cli/test/generate.test.ts
+++ b/apps/cli/test/generate.test.ts
@@ -153,6 +153,9 @@ async function runWalk(options: {
     write: (line) => lines.push(line),
     answers: {
       "retell-key": KEY,
+      // Text. These checks are about writing and pushing tests, and a walk
+      // that stops at "text or phone?" never reaches either.
+      reach: "text",
       ...(options.existingTests === undefined
         ? {}
         : { "existing-tests": options.existingTests }),
@@ -607,6 +610,7 @@ async function withNobodyWatching(
             EGMA_URL: platform.url,
             EGMA_RETELL_URL: retell.url,
             EGMA_RETELL_API_KEY: KEY,
+            EGMA_REACH: "text",
             // Nowhere near the home of whoever is running this.
             HOME: path.join(workspace.dir, "pretend-home"),
           }),

--- a/apps/cli/test/interrupt.test.ts
+++ b/apps/cli/test/interrupt.test.ts
@@ -244,6 +244,11 @@ describe("Ctrl-C at the gate, with the files already written", () => {
       await showing(terminal, "Paste your Retell API key");
       terminal.write(`${KEY}\r`);
 
+      // Text or phone. Not this check's subject, and not skippable
+      // either: egma never picks one of the two for a developer.
+      await showing(terminal, "How should egma reach this agent?");
+      terminal.write("\r");
+
       await showing(terminal, "Do you already have test cases");
       terminal.write("n");
 
@@ -318,6 +323,11 @@ describe("Ctrl-C at the run screen, with the suite already going", () => {
 
       await showing(terminal, "Paste your Retell API key");
       terminal.write(`${KEY}\r`);
+
+      // Text or phone. Not this check's subject, and not skippable
+      // either: egma never picks one of the two for a developer.
+      await showing(terminal, "How should egma reach this agent?");
+      terminal.write("\r");
 
       await showing(terminal, "Do you already have test cases");
       terminal.write("n");

--- a/apps/cli/test/key-custody.test.ts
+++ b/apps/cli/test/key-custody.test.ts
@@ -132,7 +132,7 @@ describe("a whole run, swept afterwards", () => {
     const printed: string[] = [];
     const ui = new HeadlessUI({
       write: (line) => printed.push(line),
-      answers: { "retell-key": KEY },
+      answers: { "retell-key": KEY, reach: "text" },
     });
 
     // The walk ends in a run, and a run ends when verdicts arrive. The sweep
@@ -229,6 +229,7 @@ describe("a whole run, swept afterwards", () => {
         EGMA_URL: platform.url,
         EGMA_RETELL_URL: retell.url,
         EGMA_RETELL_API_KEY: KEY,
+        EGMA_REACH: "text",
       }),
     });
     child.stdin.end("");

--- a/apps/cli/test/platform-binding-process.test.ts
+++ b/apps/cli/test/platform-binding-process.test.ts
@@ -134,7 +134,7 @@ describe("commands after a repository is bound", () => {
     const connected = await reachesBound(
       ["connect"],
       "/api/agents",
-      { EGMA_RETELL_API_KEY: PROVIDER_KEY },
+      { EGMA_RETELL_API_KEY: PROVIDER_KEY, EGMA_REACH: "text" },
     );
     expect(connected.code).toBe(0);
     expect(connected.stdout).toContain("status: connected");
@@ -193,7 +193,7 @@ describe("commands after a repository is bound", () => {
       // consent only so a real terminal is not needed in CI.
       wizard = await command(
         ["--headless", "--", process.execPath, FAKE_AGENT, script],
-        { EGMA_RETELL_API_KEY: PROVIDER_KEY },
+        { EGMA_RETELL_API_KEY: PROVIDER_KEY, EGMA_REACH: "text" },
       );
     } finally {
       grading.stop();

--- a/apps/cli/test/platform-onboarding-process.test.ts
+++ b/apps/cli/test/platform-onboarding-process.test.ts
@@ -81,6 +81,7 @@ it("verifies an explicitly selected platform and commits its identity on first o
     const env = workspace.env({
       EGMA_RETELL_URL: retell.url,
       EGMA_RETELL_API_KEY: PROVIDER_KEY,
+      EGMA_REACH: "text",
     });
     expect(env.EGMA_URL).toBeUndefined();
 

--- a/apps/cli/test/reach-choice.test.ts
+++ b/apps/cli/test/reach-choice.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Text or phone: the choice that decides what egma creates.
+ *
+ * A fake Retell speaking the shapes the real service answers with, the fixture
+ * platform speaking egma's public API, and the headless UI in between. What is
+ * asserted is what a developer could check afterwards in their own project: how
+ * many connections are on it, what each one holds, and — the whole reason this
+ * exists — that the one they did not choose was never created.
+ *
+ * The rule under all of it: **egma creates the selected connection and nothing
+ * else.** A wizard that made both would put a connection in somebody's project
+ * that they never asked for, and on the phone side that is a connection egma
+ * would dial a real telephone over.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NO_NUMBERS_LINE } from "../src/retell/connect.ts";
+import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import type { AskId } from "../src/ui/wizard-ui.ts";
+import { connectStep } from "../src/wizard/connect-step.ts";
+import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { filesUnder, makeWorkspace, type Workspace } from "./support/workspace.ts";
+
+const KEY = "key_1f4c9b7e2a6d0538c1e7";
+
+/** The one number the agent under test answers, and one it does not. */
+const DIALLED = "+14155550111";
+const SOMEBODY_ELSE = "+14155550222";
+
+const ACCOUNT: FakeRetellScript = {
+  keys: [KEY],
+  agents: [
+    {
+      agent_id: "agent_0001",
+      agent_name: "front-desk",
+      response_engine: { type: "retell-llm", llm_id: "llm_0001" },
+    },
+  ],
+  llms: [{ llm_id: "llm_0001", general_prompt: "You answer the front desk.\n" }],
+  numbers: [
+    {
+      phone_number: DIALLED,
+      nickname: "front desk",
+      inbound_agents: [{ agent_id: "agent_0001", weight: 1 }],
+    },
+    {
+      phone_number: SOMEBODY_ELSE,
+      nickname: "another team",
+      inbound_agents: [{ agent_id: "agent_9999" }],
+    },
+  ],
+};
+
+/** The same account, with two numbers routed to the agent under test. */
+const TWO_NUMBERS: FakeRetellScript = {
+  ...ACCOUNT,
+  numbers: [
+    ...(ACCOUNT.numbers ?? []),
+    {
+      phone_number: "+14155550333",
+      nickname: "overflow",
+      inbound_agents: [{ agent_id: "agent_0001" }],
+    },
+  ],
+};
+
+let platform: Platform;
+let workspace: Workspace;
+let retell: FakeRetell | undefined;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  workspace = await makeWorkspace();
+  await workspace.signIn(platform.url, platform.device.mint());
+});
+
+afterEach(async () => {
+  await retell?.close();
+  retell = undefined;
+  await platform.close();
+  await workspace.remove();
+});
+
+type Answers = {
+  readonly reach?: string | null;
+  readonly number?: string | null;
+  /** Which agent, when the account holds more than one. */
+  readonly agent?: string | null;
+};
+
+/** Whether the walk left an egma folder behind in the repository. */
+async function wroteAnEgmaFolder(): Promise<boolean> {
+  return (await filesUnder(workspace.dir)).some((file) => file.startsWith("egma/"));
+}
+
+class ScriptedUI extends HeadlessUI {
+  private readonly said: Answers;
+
+  constructor(answers: Answers) {
+    super();
+    this.said = answers;
+  }
+
+  override waitForAnswer(ask: AskId) {
+    this.record.asked.push(ask);
+    if (ask === "retell-key") return Promise.resolve<string | null>(KEY);
+    if (ask === "retell-agent") return Promise.resolve(this.said.agent ?? null);
+    if (ask === "reach") return Promise.resolve(this.said.reach ?? null);
+    if (ask === "phone-number") return Promise.resolve(this.said.number ?? null);
+    return Promise.resolve(null);
+  }
+}
+
+async function run(answers: Answers) {
+  const ui = new ScriptedUI(answers);
+  const { report, connected } = await connectStep({
+    ui,
+    platform: {
+      url: platform.url,
+      instanceId: platform.instanceId,
+      credentialsFile: workspace.credentialsFile,
+    },
+    cwd: workspace.dir,
+    repoPrompts: null,
+    signal: new AbortController().signal,
+    retell: { url: retell?.url ?? "http://127.0.0.1:1" },
+  });
+  return { ui, report, connected };
+}
+
+describe("choosing the phone", () => {
+  it("creates one phone connection holding the number and nothing else", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const { connected } = await run({ reach: "phone" });
+
+    expect(connected?.reach).toBe("phone");
+    expect(connected?.number).toBe(DIALLED);
+
+    // One connection, and it is the phone one. The retell connection egma used
+    // to create whatever was chosen is the bug this whole ticket exists for.
+    expect(platform.registered.connections).toHaveLength(1);
+    const [connection] = platform.registered.connections;
+    expect(connection?.type).toBe("phone");
+    expect(connection?.modality).toBe("voice");
+    expect(connection?.name).toBe("phone-1");
+
+    // The number, and not one other thing. A phone connection is
+    // provider-blind: nothing in it says who answers, and nothing in it opens
+    // anything.
+    expect(connection?.config).toEqual({ phoneNumber: DIALLED });
+    expect(connection?.credentialsHint).toBeNull();
+    expect(platform.registered.sealed).toEqual([]);
+
+    // And the key never reached egma at all — it went to Retell, and stayed
+    // there, because a phone connection has nowhere to put one.
+    const written = JSON.stringify(platform.registered);
+    expect(written).not.toContain(KEY);
+    expect(written).not.toContain("agent_0001");
+  });
+
+  it("offers only the numbers Retell routes to the chosen agent", async () => {
+    retell = await startFakeRetell(TWO_NUMBERS);
+
+    const { ui } = await run({ reach: "phone", number: "+14155550333" });
+
+    expect(ui.record.numberChoices.map((one) => one.number)).toEqual([
+      DIALLED,
+      "+14155550333",
+    ]);
+    // Somebody else's number is never on the screen, so there is no way through
+    // it to a telephone the agent under test does not answer.
+    expect(ui.record.numberChoices.map((one) => one.number)).not.toContain(
+      SOMEBODY_ELSE,
+    );
+    expect(platform.registered.connections[0]?.config).toEqual({
+      phoneNumber: "+14155550333",
+    });
+  });
+
+  it("asks nothing when Retell routes one number to the agent, and says which", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const { ui } = await run({ reach: "phone" });
+
+    expect(ui.record.asked).not.toContain("phone-number");
+    expect(ui.record.statuses).toContain(`◆ egma will dial ${DIALLED}.`);
+  });
+
+  it("reads the chosen number's own document before it registers it", async () => {
+    const account = await startFakeRetell(ACCOUNT);
+    retell = account;
+
+    await run({ reach: "phone" });
+
+    const asked = account.requests.map((one) => `${one.method} ${one.path}`);
+    expect(asked).toContain("GET /list-phone-numbers");
+    expect(asked).toContain(`GET /get-phone-number/${encodeURIComponent(DIALLED)}`);
+    // Reads only. Nothing in this flow writes to somebody's Retell account.
+    expect(
+      account.requests.filter(
+        (one) => one.method !== "GET" && one.path !== "/v2/list-agents",
+      ),
+    ).toEqual([]);
+  });
+
+  it("ends plainly when Retell routes no number to the agent, and creates nothing", async () => {
+    retell = await startFakeRetell({ ...ACCOUNT, numbers: [] });
+
+    const { ui, report } = await run({ reach: "phone" });
+
+    expect(ui.record.statuses).toContain(NO_NUMBERS_LINE);
+    expect(report).toEqual({ kind: "failed", reason: NO_NUMBERS_LINE });
+    expect(platform.registered.agents).toHaveLength(0);
+    expect(platform.registered.connections).toHaveLength(0);
+    // And the repository is exactly as the walk found it.
+    expect(await wroteAnEgmaFolder()).toBe(false);
+  });
+
+  it("ends plainly when several numbers reach the agent and none is chosen", async () => {
+    retell = await startFakeRetell(TWO_NUMBERS);
+
+    const { report } = await run({ reach: "phone", number: null });
+
+    expect(report).toEqual({
+      kind: "failed",
+      reason: "nobody said which number egma should dial.",
+    });
+    expect(platform.registered.agents).toHaveLength(0);
+  });
+});
+
+describe("choosing text", () => {
+  it("creates one Retell chat connection over the selected voice agent", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const { connected } = await run({ reach: "text" });
+
+    expect(connected?.reach).toBe("text");
+    expect(connected?.number).toBeNull();
+
+    expect(platform.registered.connections).toHaveLength(1);
+    const [connection] = platform.registered.connections;
+    expect(connection?.type).toBe("retell");
+    expect(connection?.modality).toBe("chat");
+    // The selected *voice* agent's own identity, which is the point: text is a
+    // way of reaching that agent, not a second agent to reach.
+    expect(connection?.config).toEqual({ retellAgentId: "agent_0001" });
+    expect(connection?.credentialsHint).toBe(KEY.slice(-4));
+    expect(platform.registered.sealed).toEqual([KEY]);
+  });
+
+  it("reads no phone number at all, because nothing is going to be dialled", async () => {
+    const account = await startFakeRetell(ACCOUNT);
+    retell = account;
+
+    await run({ reach: "text" });
+
+    const asked = account.requests.map((one) => one.path);
+    expect(asked).not.toContain("/list-phone-numbers");
+  });
+});
+
+describe("choosing neither", () => {
+  it("creates nothing, and leaves the repository exactly as it was", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const { ui, report } = await run({ reach: null });
+
+    expect(ui.record.reachOffered).toBe(true);
+    expect(report).toEqual({
+      kind: "failed",
+      reason:
+        "nobody said whether egma should reach this agent by text or by phone, " +
+        "so nothing was created.",
+    });
+    expect(platform.registered.agents).toHaveLength(0);
+    expect(platform.registered.connections).toHaveLength(0);
+    // The wart this ticket inherited: a walk that ends before anything is
+    // created used to leave an egma folder behind holding nothing but a
+    // platform binding, in a repository the developer had decided not to
+    // connect.
+    expect(await wroteAnEgmaFolder()).toBe(false);
+  });
+
+  it("binds the repository at the moment egma is asked to create something", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const { ui } = await run({ reach: "phone" });
+
+    expect(await wroteAnEgmaFolder()).toBe(true);
+    expect(ui.record.statuses).toContain(
+      `◆ Bound this repository to Egma platform ${platform.instanceId}.`,
+    );
+  });
+});
+
+describe("running it twice", () => {
+  it("finds the phone connection it made the first time, and writes nothing", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const first = await run({ reach: "phone" });
+    const second = await run({ reach: "phone" });
+
+    expect(first.connected?.registration).toEqual({
+      agent: "created",
+      connection: "created",
+    });
+    expect(second.connected?.registration).toEqual({
+      agent: "reused",
+      connection: "reused",
+    });
+    expect(second.connected?.registered.agent.id).toBe(first.connected?.registered.agent.id);
+    expect(second.connected?.registered.connection.id).toBe(
+      first.connected?.registered.connection.id,
+    );
+
+    // One agent, one way of reaching it, however many times this ran. Two
+    // identities for one voice agent would split a team's results history in
+    // half, and a retry after a network failure nobody could read is ordinary.
+    expect(platform.registered.agents).toHaveLength(1);
+    expect(platform.registered.connections).toHaveLength(1);
+  });
+
+  it("adds the phone to the agent text already reached, rather than a second agent", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const text = await run({ reach: "text" });
+    const phone = await run({ reach: "phone" });
+
+    expect(phone.connected?.registration).toEqual({
+      agent: "reused",
+      connection: "created",
+    });
+    expect(phone.connected?.registered.agent.id).toBe(text.connected?.registered.agent.id);
+
+    expect(platform.registered.agents).toHaveLength(1);
+    expect(platform.registered.connections.map((one) => one.type)).toEqual([
+      "retell",
+      "phone",
+    ]);
+  });
+
+  it("still takes the next name for a different voice agent called the same thing", async () => {
+    // Two agents on the account with one name between them, which a real
+    // account does produce. The second is a different agent and gets its own
+    // egma agent — the name loop this replaced was there for exactly this, and
+    // reading the refusal rather than working around it must not lose it.
+    retell = await startFakeRetell({
+      ...ACCOUNT,
+      agents: [
+        ...ACCOUNT.agents,
+        {
+          agent_id: "agent_0002",
+          agent_name: "front-desk",
+          response_engine: { type: "retell-llm", llm_id: "llm_0001" },
+        },
+      ],
+    });
+
+    // The first walk leaves an agent reached only by phone, so nothing on it
+    // names a vendor at all. What tells the second walk that this is somebody
+    // else's agent is the number: Retell routes it to agent_0001 and not to
+    // agent_0002, and that is as good an answer as a vendor id would be.
+    const first = await run({ reach: "phone", agent: "agent_0001" });
+    const second = await run({ reach: "text", agent: "agent_0002" });
+
+    expect(first.connected?.registered.agent.name).toBe("front-desk");
+    expect(second.connected?.registered.agent.name).toBe("front-desk-2");
+    expect(second.connected?.registration).toEqual({
+      agent: "created",
+      connection: "created",
+    });
+    expect(platform.registered.agents).toHaveLength(2);
+    expect(platform.registered.connections).toHaveLength(2);
+  });
+
+  it("joins a phone-only agent when the number is one Retell routes to this agent", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const phone = await run({ reach: "phone" });
+    const text = await run({ reach: "text" });
+
+    // Nothing on the agent named a vendor, and the number said this was it.
+    expect(text.connected?.registered.agent.id).toBe(phone.connected?.registered.agent.id);
+    expect(text.connected?.registration).toEqual({
+      agent: "reused",
+      connection: "created",
+    });
+    expect(platform.registered.agents).toHaveLength(1);
+  });
+});

--- a/apps/cli/test/reach-choice.test.ts
+++ b/apps/cli/test/reach-choice.test.ts
@@ -377,6 +377,42 @@ describe("running it twice", () => {
     expect(platform.registered.connections).toHaveLength(2);
   });
 
+  /**
+   * The one case where neither signal answers, and the direction it goes.
+   *
+   * A phone-only agent names no vendor, so the numbers are the only way to tell
+   * whose it is — and here Retell will not list them. egma cannot identify the
+   * agent, and the two ways of being wrong are not equally bad: a merged
+   * results history cannot be unpicked, and a spare agent is one delete. So it
+   * takes the next name.
+   */
+  it("takes the next name when Retell will not say which numbers reach the agent", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+    const phone = await run({ reach: "phone" });
+    await retell.close();
+
+    // The same account, with the number listing broken and nothing else.
+    retell = await startFakeRetell({
+      ...ACCOUNT,
+      refusing: [{ path: "/list-phone-numbers", status: 500 }],
+    });
+    const text = await run({ reach: "text" });
+
+    expect(text.connected?.registered.agent.name).toBe("front-desk-2");
+    expect(text.connected?.registration).toEqual({
+      agent: "created",
+      connection: "created",
+    });
+    // Two agents, and neither of them holds a connection it cannot account for.
+    expect(platform.registered.agents.map((one) => one.name)).toEqual([
+      "front-desk",
+      "front-desk-2",
+    ]);
+    expect(text.connected?.registered.agent.id).not.toBe(
+      phone.connected?.registered.agent.id,
+    );
+  });
+
   it("joins a phone-only agent when the number is one Retell routes to this agent", async () => {
     retell = await startFakeRetell(ACCOUNT);
 

--- a/apps/cli/test/reach-choice.test.ts
+++ b/apps/cli/test/reach-choice.test.ts
@@ -113,7 +113,7 @@ class ScriptedUI extends HeadlessUI {
   }
 }
 
-async function run(answers: Answers) {
+async function run(answers: Answers, fetchImpl?: typeof fetch) {
   const ui = new ScriptedUI(answers);
   const { report, connected } = await connectStep({
     ui,
@@ -126,8 +126,37 @@ async function run(answers: Answers) {
     repoPrompts: null,
     signal: new AbortController().signal,
     retell: { url: retell?.url ?? "http://127.0.0.1:1" },
+    ...(fetchImpl === undefined ? {} : { fetchImpl }),
   });
   return { ui, report, connected };
+}
+
+/**
+ * The other terminal, getting there first.
+ *
+ * The first attempt to attach a connection is really made — so the platform
+ * really holds it, exactly as it would if a second `connect` had won — and then
+ * this run is told the name is taken, which is what the loser of that race is
+ * told. Nothing is faked but the timing.
+ */
+function losingTheRace(): typeof fetch {
+  let raced = false;
+  return (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const where = typeof input === "string" ? input : String(input);
+    if (raced || init?.method !== "POST" || !where.endsWith("/connections")) {
+      return fetch(input, init);
+    }
+    raced = true;
+    // The winner's write, made through the same door and committed.
+    await fetch(input, init);
+    return new Response(
+      JSON.stringify({
+        error: "name_taken",
+        message: 'a connection named "phone-1" already exists on this agent',
+      }),
+      { status: 409, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
 }
 
 describe("choosing the phone", () => {
@@ -411,6 +440,41 @@ describe("running it twice", () => {
     expect(text.connected?.registered.agent.id).not.toBe(
       phone.connected?.registered.agent.id,
     );
+  });
+
+  /**
+   * Two terminals attaching the same reach at the same instant.
+   *
+   * Both get past the check that says the reach is not there yet, because
+   * neither has written anything when either looks. One then loses the
+   * connection-name index — and the right answer for the loser is the
+   * connection the winner just wrote, because that is what it was going to
+   * create. Telling them their egma is out of date would send a developer to
+   * check a version when the only thing that happened is that their other
+   * terminal got there first.
+   */
+  it("reads the winner's connection as a reuse when it loses the race to attach", async () => {
+    retell = await startFakeRetell(ACCOUNT);
+
+    const text = await run({ reach: "text" });
+    const phone = await run({ reach: "phone" }, losingTheRace());
+
+    expect(phone.report.kind).toBe("connected");
+    expect(phone.connected?.registration).toEqual({
+      agent: "reused",
+      connection: "reused",
+    });
+    expect(phone.connected?.registered.agent.id).toBe(text.connected?.registered.agent.id);
+    expect(phone.connected?.registered.connection.name).toBe("phone-1");
+    expect(phone.connected?.number).toBe(DIALLED);
+
+    // One agent, one connection each way, and no second phone connection left
+    // behind by the write that lost.
+    expect(platform.registered.agents).toHaveLength(1);
+    expect(platform.registered.connections.map((one) => one.name)).toEqual([
+      "retell-1",
+      "phone-1",
+    ]);
   });
 
   it("joins a phone-only agent when the number is one Retell routes to this agent", async () => {

--- a/apps/cli/test/run-screen.test.ts
+++ b/apps/cli/test/run-screen.test.ts
@@ -173,6 +173,11 @@ async function toTheRun(cols = 100): Promise<TerminalRun> {
   await showing(run, "Paste your Retell API key");
   run.write(`${KEY}\r`);
 
+  // Text or phone. Not this check's subject, and not skippable
+  // either: egma never picks one of the two for a developer.
+  await showing(run, "How should egma reach this agent?");
+  run.write("\r");
+
   await showing(run, "Do you already have test cases", "[n] none");
   run.write("n");
 

--- a/apps/cli/test/support/fake-retell.ts
+++ b/apps/cli/test/support/fake-retell.ts
@@ -3,9 +3,15 @@
  *
  * The CLI talks to Retell over plain HTTP, so that is the seam a check stands
  * in at: a server on this machine answering `/v2/list-agents`, `/get-agent/…`,
- * `/get-chat-agent/…`, `/get-retell-llm/…` and `/get-conversation-flow/…` with
- * the fields the SDK's own types name. Nothing in CI ever reaches the real
- * Retell, and no real key exists anywhere near these checks.
+ * `/get-chat-agent/…`, `/get-retell-llm/…`, `/get-conversation-flow/…`,
+ * `/list-phone-numbers` and `/get-phone-number/…` with the fields the SDK's own
+ * types name. Nothing in CI ever reaches the real Retell, and no real key
+ * exists anywhere near these checks.
+ *
+ * **The number rows carry `inbound_agents` and nothing else about routing**,
+ * which is the shape the real service answers with — every number on the
+ * account this effort ran against reports its assignment there and carries no
+ * single-agent field at all.
  *
  * It is exactly as strict as Retell is, and never kinder. An agent is served
  * only at the address for its own kind, a required field is always sent, and a
@@ -45,6 +51,15 @@ export type FakeLlm = {
   readonly extra?: Record<string, unknown>;
 };
 
+/** One telephone number on the account, as Retell answers it. */
+export type FakeNumber = {
+  readonly phone_number: string;
+  readonly nickname?: string;
+  /** Every agent Retell routes an inbound call on it to, with its weight. */
+  readonly inbound_agents?: readonly { readonly agent_id: string; readonly weight?: number }[];
+  readonly extra?: Record<string, unknown>;
+};
+
 /** A conversation flow, the other engine Retell holds the words for. */
 export type FakeFlow = {
   readonly conversation_flow_id: string;
@@ -59,6 +74,8 @@ export type FakeRetellScript = {
   readonly agents: readonly FakeAgent[];
   readonly llms?: readonly FakeLlm[];
   readonly flows?: readonly FakeFlow[];
+  /** The account's telephone numbers. None when omitted. */
+  readonly numbers?: readonly FakeNumber[];
   /**
    * How many agents one listing answers with, so following pages can be
    * checked. The whole account in one answer when omitted.
@@ -120,6 +137,21 @@ function flowBody(flow: FakeFlow): Record<string, unknown> {
     nodes: [],
     last_modification_timestamp: 1_700_000_000_000,
     ...(flow.extra ?? {}),
+  };
+}
+
+function numberBody(number: FakeNumber): Record<string, unknown> {
+  return {
+    phone_number: number.phone_number,
+    phone_number_type: "retell-telnyx",
+    phone_number_pretty: number.phone_number,
+    ...(number.nickname === undefined ? {} : { nickname: number.nickname }),
+    inbound_agents: (number.inbound_agents ?? []).map((held) => ({
+      weight: held.weight ?? 1,
+      agent_id: held.agent_id,
+    })),
+    last_modification_timestamp: 1_700_000_000_000,
+    ...(number.extra ?? {}),
   };
 }
 
@@ -202,6 +234,26 @@ export async function startFakeRetell(script: FakeRetellScript): Promise<FakeRet
             return;
           }
           send(200, agentBody(agent));
+          return;
+        }
+
+        if (incoming.method === "GET" && at.pathname === "/list-phone-numbers") {
+          // A bare array, which is what Retell answers here — not the paged
+          // envelope the agent listing uses.
+          send(200, (script.numbers ?? []).map(numberBody));
+          return;
+        }
+
+        if (incoming.method === "GET" && at.pathname.startsWith("/get-phone-number/")) {
+          const wanted = decodeURIComponent(at.pathname.slice("/get-phone-number/".length));
+          const number = (script.numbers ?? []).find(
+            (held) => held.phone_number === wanted,
+          );
+          if (number === undefined) {
+            send(404, { error_message: "phone number not found" });
+            return;
+          }
+          send(200, numberBody(number));
           return;
         }
 

--- a/apps/cli/test/support/fake-retell.ts
+++ b/apps/cli/test/support/fake-retell.ts
@@ -83,6 +83,19 @@ export type FakeRetellScript = {
   readonly pageSize?: number;
   /** Answer every request with this status and body instead. */
   readonly refuseWith?: { readonly status: number; readonly body: unknown };
+  /**
+   * Answer these paths with this status instead, and everything else normally.
+   *
+   * For the half-broken account, which is a real thing and not a contrived one:
+   * a listing that works and a second one that does not. What egma does when
+   * one read fails is a different question from what it does when the whole
+   * service is down, and a fake that could only do the second could not ask it.
+   */
+  readonly refusing?: readonly {
+    readonly path: string;
+    readonly status: number;
+    readonly body?: unknown;
+  }[];
 };
 
 /** One request, as the fake saw it. */
@@ -186,6 +199,14 @@ export async function startFakeRetell(script: FakeRetellScript): Promise<FakeRet
 
         if (script.refuseWith !== undefined) {
           send(script.refuseWith.status, script.refuseWith.body);
+          return;
+        }
+
+        const refused = (script.refusing ?? []).find(
+          (one) => one.path === at.pathname,
+        );
+        if (refused !== undefined) {
+          send(refused.status, refused.body ?? { error_message: "not today" });
           return;
         }
 

--- a/apps/cli/test/support/fixture-platform/agents.ts
+++ b/apps/cli/test/support/fixture-platform/agents.ts
@@ -308,7 +308,9 @@ const REGISTRY: Readonly<Record<string, Descriptor>> = {
         },
       },
     ],
-    simulatorAdapter: false,
+    // The simulator dials: the phone plug is in the shipped build. Whether one
+    // deployment's carrier is set up is a separate fact, answered elsewhere.
+    simulatorAdapter: true,
   },
   livekit: {
     // Voice only, because voice is the lane that exists.

--- a/apps/cli/test/support/workspace.ts
+++ b/apps/cli/test/support/workspace.ts
@@ -155,6 +155,11 @@ export async function makeWorkspace(
       if (extra.EGMA_RETELL_API_KEY === undefined) delete env.EGMA_RETELL_API_KEY;
       if (extra.RETELL_API_KEY === undefined) delete env.RETELL_API_KEY;
       if (extra.EGMA_RETELL_AGENT_ID === undefined) delete env.EGMA_RETELL_AGENT_ID;
+      // And a way to reach an agent that the person running the suite happens
+      // to have set is not a way any check may take: which connection egma
+      // creates is what several of them are about.
+      if (extra.EGMA_REACH === undefined) delete env.EGMA_REACH;
+      if (extra.EGMA_PHONE_NUMBER === undefined) delete env.EGMA_PHONE_NUMBER;
       return env;
     },
     async signIn(url, key = "egma_sk_already-held") {

--- a/apps/cli/test/teaching.test.ts
+++ b/apps/cli/test/teaching.test.ts
@@ -213,6 +213,11 @@ describe("the pane, while the files land", () => {
       await showing(terminal, "Paste your Retell API key");
       terminal.write(`${KEY}\r`);
 
+      // Text or phone. Not this check's subject, and not skippable
+      // either: egma never picks one of the two for a developer.
+      await showing(terminal, "How should egma reach this agent?");
+      terminal.write("\r");
+
       await showing(terminal, "Do you already have test cases");
       terminal.write("n");
 
@@ -244,7 +249,7 @@ describe("the pane, while the files land", () => {
       const gradingElsewhere = gradeEveryRun(elsewhere, { atMost: 1 });
       try {
         await second.signIn(elsewhere.url, elsewhere.device.mint());
-        const ui = new HeadlessUI({ answers: { "retell-key": KEY } });
+        const ui = new HeadlessUI({ answers: { "retell-key": KEY, reach: "text" } });
         const report = await walk({
           ui,
           launch: second.launch(await scriptFor(second)),
@@ -302,6 +307,11 @@ describe("the pane, while the files land", () => {
       terminal.write("\r");
       await showing(terminal, "Paste your Retell API key");
       terminal.write(`${KEY}\r`);
+
+      // Text or phone. Not this check's subject, and not skippable
+      // either: egma never picks one of the two for a developer.
+      await showing(terminal, "How should egma reach this agent?");
+      terminal.write("\r");
       await showing(terminal, "Do you already have test cases");
       terminal.write("n");
 

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -481,12 +481,14 @@ export const CONNECTION_REGISTRY: Readonly<
     // readiness, and it is a separate question that has to be asked where a
     // deployment's configuration is known — this package cannot see it.
     //
-    // **Nothing asks it today.** `phoneReadiness` and
-    // `phoneSetupRequiredMessage` exist in `apps/api` and no route calls
-    // either, so a platform whose phone half has never been set up accepts a
-    // phone run here and fails it later at the simulator. Closing that is
-    // ticket 04's second acceptance criterion: refuse at run creation, before
-    // any paid provider action, when phone readiness is not `ready`.
+    // **Nothing on the way to a run asks it today.** `phoneReadiness` is read
+    // once at API startup and served by `GET /api/platform`, so a developer can
+    // *see* that a platform's phone half is unset — but no run-creation path
+    // consults it, and `phoneSetupRequiredMessage` is called from nowhere at
+    // all. So a platform that has never been given a carrier accepts a phone
+    // run here and fails it later at the simulator. Closing that is ticket 04's
+    // second acceptance criterion: refuse at run creation, before any paid
+    // provider action, when phone readiness is not `ready`.
     simulatorAdapter: true,
   },
   livekit: {

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -476,11 +476,17 @@ export const CONNECTION_REGISTRY: Readonly<
     // for this type and places the call over the deployment's own carrier
     // trunk, so a run over a phone connection is one egma can conduct.
     //
-    // **Whether this deployment can dial is a second question, and it is not
-    // asked here.** A platform whose carrier has never been set up will refuse
-    // a phone run at the API, where phone readiness is known — this registry
-    // says only what the shipped simulator holds an adapter for, which is a
-    // fact about the build rather than about one deployment's configuration.
+    // **What this says is a fact about the build, never about one deployment's
+    // carrier.** Whether *this* platform has been given a trunk is phone
+    // readiness, and it is a separate question that has to be asked where a
+    // deployment's configuration is known — this package cannot see it.
+    //
+    // **Nothing asks it today.** `phoneReadiness` and
+    // `phoneSetupRequiredMessage` exist in `apps/api` and no route calls
+    // either, so a platform whose phone half has never been set up accepts a
+    // phone run here and fails it later at the simulator. Closing that is
+    // ticket 04's second acceptance criterion: refuse at run creation, before
+    // any paid provider action, when phone readiness is not `ready`.
     simulatorAdapter: true,
   },
   livekit: {

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -472,9 +472,16 @@ export const CONNECTION_REGISTRY: Readonly<
         },
       },
     ],
-    // Nothing dials yet: a customer may register the number they want called,
-    // and a run over it is refused at creation until the adapter lands.
-    simulatorAdapter: false,
+    // The simulator dials. `egma_simulator.plugs.phone.PhoneCall` is registered
+    // for this type and places the call over the deployment's own carrier
+    // trunk, so a run over a phone connection is one egma can conduct.
+    //
+    // **Whether this deployment can dial is a second question, and it is not
+    // asked here.** A platform whose carrier has never been set up will refuse
+    // a phone run at the API, where phone readiness is known — this registry
+    // says only what the shipped simulator holds an adapter for, which is a
+    // fact about the build rather than about one deployment's configuration.
+    simulatorAdapter: true,
   },
   livekit: {
     // Voice only, and only because voice is the lane that exists. The registry

--- a/packages/db/test/connection-registry.test.ts
+++ b/packages/db/test/connection-registry.test.ts
@@ -2,8 +2,10 @@ import { AgentWriteRefusedError } from "@egma/db";
 import { describe, expect, it } from "vitest";
 
 import {
+  conductableConnectionTypes,
   descriptorOf,
   gatedConfig,
+  noSimulatorAdapterMessage,
   optional,
   shapeChosen,
   shapeOf,
@@ -532,5 +534,34 @@ describe("a livekit connection that is half of each shape", () => {
     expect(() =>
       validCredentials("livekit", { url: A_URL }, { ...KEYS, apiToken: "x" }),
     ).toThrow(/have no key "apiToken"/);
+  });
+});
+
+/**
+ * Which types egma can conduct a run over, which is the whole of what the
+ * capability registry publishes about the simulator.
+ *
+ * It is a fact about the shipped build and never about one deployment: a
+ * platform whose carrier has never been configured still holds the phone
+ * adapter, and what it does about that is phone readiness' business, asked at
+ * the API where a deployment's configuration is known.
+ */
+describe("what the shipped simulator can conduct", () => {
+  it("counts phone among them, because the phone plug ships", () => {
+    expect(descriptorOf("phone").simulatorAdapter).toBe(true);
+    expect(conductableConnectionTypes()).toContain("phone");
+  });
+
+  it("names every shipped type in the refusal, and takes the list from the registry", () => {
+    // The sentence exists for a type egma has not shipped an adapter for.
+    // Every type in `CONNECTION_TYPES` has one today, so the rule is exercised
+    // on a name the registry does not hold — which is exactly the case the
+    // refusal is kept for.
+    expect(noSimulatorAdapterMessage("vapi")).toBe(
+      "egma has no simulator adapter for a vapi connection yet, so it will " +
+        "not start a run it cannot conduct. Run these tests over a " +
+        `connection egma conducts today: ${conductableConnectionTypes().join(", ")}.`,
+    );
+    expect(conductableConnectionTypes()).toEqual(["retell", "phone", "livekit"]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,12 @@ importers:
       '@agentclientprotocol/claude-agent-acp':
         specifier: ^0.65.0
         version: 0.65.0(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))
+      '@egma/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@egma/ids':
+        specifier: workspace:*
+        version: link:../../packages/ids
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.18


### PR DESCRIPTION
Ticket 03 of the self-hosted phone platform effort. Lands on the effort's integration branch, not on `main`.

## What this does

The wizard confirms a Retell voice agent against the live account, then asks how Egma should reach it — text or phone — and creates **only** the connection chosen. Choosing phone lists the numbers Retell routes to that agent, confirms the selected one immediately before writing, and registers a provider-blind connection holding the destination number and nothing else.

Phone is now a shipped connection type in the capability registry, so run creation accepts it and the old phone `no_adapter` expectations became positive phone tests.

## Proven live, not with fixtures

A real wizard process against the real Retell read API and a real local Egma platform produced:

- agent `agt_01KZPWZ4NCE62SVXDH4AG0D4KS` — "Prod Remedy Cameron phase 1"
- connection `con_01KZPWZ4NGE85AX0Y97GSDBN4A` — `phone` / `voice`, config exactly `{"phoneNumber": "+14156882612"}`, `credentials_hint: null`
- 12 tests pushed, run created, all 12 simulations stayed `queued` — nothing dialled

The connection holding no credential is also true by construction: the registry gates a phone config to `{phoneNumber}` and refuses any credential block by name.

The read-only Retell gate forwarded five read shapes and refused zero writes. No Retell update, no publish, no dial.

## Also here

- **Ticket 01's leftover wart is fixed.** A wizard run ending at the key box, at an unanswered agent choice, or at "text or phone?" now leaves no `egma/` folder. The binding moved into `connectStep`'s `beforeRegistering` hook, which fires immediately before the platform is asked to create anything.
- **Ambiguity now takes the next name instead of merging.** When the number listing fails and a same-named agent is reached only by phone, the old code attached the new connection to whatever held the name — merging two vendor agents into one results history. A merged history cannot be unpicked; a spare agent is one delete. Mutation-proven.
- **`apps/cli` now declares `@egma/db` and `@egma/ids`.** They were resolved only by a test alias, so `pnpm smoke:retell` and `smoke:e2e` — the scripts that carry this effort's live proof — could not run from a clean install.

## Known and carried

- **AC5 is not met.** The text connection is created with the right identity, but it is **not conductable today**. The spec names `POST /agent-playground-completion/{agent_id}`; the shipped plug speaks `create-chat` / `create-chat-completion` / `end-chat`, which is Retell's chat-agent API — something the spec itself lists as out of scope. Whoever ships the text path replaces the plug. Text is not on this effort's proof path.
- **No readiness gate on run creation yet.** An unconfigured platform accepts a phone run and fails it later at the simulator instead of refusing before any paid action. Ticket 04 AC2 owns that refusal, which must live at the API route because `packages/db` cannot import from `apps/api`. A comment that wrongly claimed this fence already existed has been corrected to say what is true.
- **Renaming an agent on Retell breaks phone reuse.** A phone connection carries no vendor identity by design, so the live name is the only lookup key. Rename it and the next connect mints a second Egma agent with a second phone connection to the same number. A rename is not a retry, so create-or-reuse still holds.

## Two product decisions surfaced, deliberately not made here

**One agent per repository.** `egma/config.yaml` holds one agent, one connection, one suite — but a customer repository holding several agents is normal. The platform already handles this (a project has many agents; tests belong to the project). The limitation is that `egma run` reads `config.agent.id` with no per-run override, so the file is a single "current target" pointer. Either it grows a list with one marked current, or `egma run` grows `--agent`.

**Agent selection has nothing to narrow it.** The live account listed 37 agents; a developer must recognise theirs by name. `compareWithRepo` already computes prompt drift between the repository and each live agent — exactly the evidence that would rank 37 down to 1 — but it runs *after* registration. Moving it before the picker uses code that already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NniiSVBX5KKTveH1cY9FMw

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Retell phone onboarding and registers only the text or phone connection selected by the user, while making phone connections eligible for run creation.

- Adds reach and phone-number selection to interactive and headless connect flows.
- Confirms the selected Retell number immediately before registration and adds mixed-reach reuse and name-conflict handling.
- Delays repository binding until immediately before registration.
- Updates the phone connection registry, CLI dependencies, tests, smoke checks, and documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/retell/connect.ts | Implements reach selection, number confirmation, mixed-reach identity resolution, conservative name-conflict handling, and concurrent attachment recovery. |
| apps/cli/src/retell/client.ts | Adds sanitized Retell phone-number listing and confirmation reads using inbound-agent routing. |
| apps/cli/src/platform/agents.ts | Adds platform agent reads and connection attachment APIs used to reuse an existing agent safely. |
| apps/cli/src/wizard/connect-step.ts | Integrates reach and number choices and moves repository binding to the pre-registration hook. |
| apps/cli/src/commands/connect.ts | Adds headless reach and number options, outcomes, registration reporting, and delayed repository binding. |
| apps/cli/src/ui/tui/screens/PhoneNumberScreen.tsx | Adds an interactive selector for sanitized Retell phone-number metadata. |
| packages/db/src/access/connection-registry.ts | Marks the existing phone adapter as shipped so phone run creation is accepted. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Retell
    participant Egma
    User->>CLI: Select Retell agent and reach
    alt Phone selected
        CLI->>Retell: List phone numbers
        Retell-->>CLI: Numbers and inbound agents
        User->>CLI: Select number
        CLI->>Retell: Confirm selected number
        Retell-->>CLI: Current routing
        CLI->>Egma: Register phone connection
    else Text selected
        CLI->>Egma: Register Retell text connection
    end
    Egma-->>CLI: Created or reused registration
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Answer the loser of a connection race wi..."](https://github.com/egma-ai/egma/commit/d51a51ff7b7172b44dbc81afaab37a4402aea88b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52013361)</sub>

<!-- /greptile_comment -->