### PR TITLE
Publish the CLI as @egma/cli, and release it from a tag

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -26,12 +26,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to a commit, not a tag. A tag can be moved; this job
+      # holds npm publishing authority, so what it runs must not change under
+      # it. The trailing comment is the human-readable version each SHA is.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         # Version comes from "packageManager" in the root package.json.
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,95 @@
+name: Release CLI
+
+# Releasing is one deliberate act: push a tag that names the version.
+#
+#   pnpm --filter @egma/cli exec npm version minor   # bumps apps/cli/package.json
+#   git commit -am "cli: 0.2.0" && git push
+#   git tag cli-v0.2.0 && git push origin cli-v0.2.0
+#
+# Nothing else publishes. Merging to main does not publish.
+#
+# There is no npm token in this repository. npm is told, once, on the package
+# settings page, that this workflow in this repository may publish @egma/cli.
+# GitHub proves that per run with a short-lived OIDC token, which is what
+# `id-token: write` below allows. Provenance is attached automatically.
+
+on:
+  push:
+    tags:
+      - "cli-v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        # Version comes from "packageManager" in the root package.json.
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Report toolchain
+        # Trusted publishing needs npm >= 11.5.1. Printed so a failure here is
+        # readable rather than a bare 404 from the registry.
+        run: node --version && npm --version && pnpm --version
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Check the tag matches the version
+        # Catches the classic slip: tagged cli-v0.2.0, shipped 0.1.0.
+        run: |
+          tagged="${GITHUB_REF_NAME#cli-v}"
+          packaged="$(node -p "require('./apps/cli/package.json').version")"
+          if [ "$tagged" != "$packaged" ]; then
+            echo "Tag says $tagged, apps/cli/package.json says $packaged." >&2
+            exit 1
+          fi
+          echo "Releasing @egma/cli $packaged."
+
+      - name: Build
+        # Root build is lint + tsc -b over every project the CLI is built from.
+        run: pnpm build
+
+      - name: Prove the tarball runs
+        # The same check a person would do by hand: pack it, install it
+        # somewhere clean, and run the command. Catches a missing runtime
+        # dependency or a broken bin entry before it reaches anyone.
+        run: |
+          set -e
+          dir="$(mktemp -d)"
+          (cd apps/cli && npm pack --pack-destination "$dir")
+          tarball="$(ls "$dir"/*.tgz)"
+          cd "$dir"
+          npm init -y > /dev/null
+          npm install "$tarball" --no-audit --no-fund
+          ./node_modules/.bin/egma --version
+
+      - name: Refuse a manifest npm would silently rewrite
+        # npm quietly "corrects" a manifest on publish and ships the corrected
+        # one. A bin path written "./dist/bin.js" gets dropped entirely, so the
+        # package installs with no command — and the tarball check above still
+        # passes, because a local tarball reads bin from its own package.json.
+        # The dry run is the only place this shows up. Treat it as fatal.
+        run: |
+          set -e
+          out="$(npm publish --dry-run 2>&1)"
+          echo "$out"
+          if echo "$out" | grep -qi "auto-corrected some errors"; then
+            echo "::error::npm would rewrite apps/cli/package.json before publishing. Fix it rather than shipping the rewrite." >&2
+            exit 1
+          fi
+        working-directory: apps/cli
+
+      - name: Publish to npm
+        # npm, not pnpm: OIDC trusted publishing lives in the npm CLI.
+        # No NODE_AUTH_TOKEN — the OIDC exchange is the credential.
+        run: npm publish
+        working-directory: apps/cli

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ laptop that is often the same person, and the two directories are still
 separate, because one platform serves many repositories.
 
 ```bash
-npx egma-cli self-host up
+npx @egma/cli self-host up
 ```
 
 That starts the whole platform and prints the address an agent repository
@@ -61,7 +61,7 @@ perfectly well, so `self-host up` brings one up *ready* and says phone is `setup
 required`. One more command in this directory makes it able to place calls:
 
 ```bash
-npx egma-cli self-host phone setup
+npx @egma/cli self-host phone setup
 ```
 
 It asks for a Twilio account, a voice number that account **already owns**, and
@@ -132,14 +132,14 @@ With an instance up and an account on it, the walk is one command:
 
 ```bash
 cd ~/your-voice-agent
-EGMA_URL=http://localhost:3101 npx egma-cli
+EGMA_URL=http://localhost:3101 npx @egma/cli
 ```
 
 To run it from this checkout instead — for development, or ahead of a release:
 
 ```bash
 pnpm install                    # once
-pnpm --filter egma-cli build    # builds it into apps/cli/dist
+pnpm --filter @egma/cli build    # builds it into apps/cli/dist
 ```
 
 Then run it in the repository that holds your voice agent, naming the instance
@@ -150,7 +150,7 @@ cd ~/your-voice-agent
 EGMA_URL=http://localhost:3101 node ~/egma/apps/cli/dist/bin.js
 ```
 
-`~/egma` is this checkout. The published package is `egma-cli`; the command it installs is `egma`.
+`~/egma` is this checkout. The published package is `@egma/cli`; the command it installs is `egma`.
 
 It signs that machine in — a short code, approved in the browser you signed up
 in — registers your voice agent together with the way egma reaches it, writes a
@@ -177,7 +177,7 @@ commands:
 
 ```bash
 pnpm db:up
-pnpm --filter egma-cli smoke:walk
+pnpm --filter @egma/cli smoke:walk
 ```
 
 They start a whole egma of its own, sign in through a real browser, register,
@@ -356,7 +356,7 @@ You should not have to hand-build SIP paperwork in somebody's console, and you
 do not:
 
 ```bash
-npx egma-cli self-host phone setup
+npx @egma/cli self-host phone setup
 ```
 
 It reads your account first and shows you a plan — what it would create and what

--- a/apps/cli/NOTICE
+++ b/apps/cli/NOTICE
@@ -1,4 +1,4 @@
-egma-cli
+@egma/cli
 Copyright (c) egma contributors
 Licensed under the Apache License, Version 2.0 (see ../../LICENSE).
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -3,16 +3,14 @@
 The egma wizard and client, in one command.
 
 ```
-npx egma
+npx @egma/cli
 ```
 
-**Not yet, though: that package is not published.** The name on npm is a
-placeholder that holds it and runs nothing, so today the command is built from
-a checkout — see [Trying it on an instance of your
+The package is `@egma/cli`; the command it installs is `egma`. Running it from
+a checkout instead — for development, or ahead of a release — is
+`node …/apps/cli/dist/bin.js`, the same command with every option and every
+verb the same. See [Trying it on an instance of your
 own](#trying-it-on-an-instance-of-your-own) for the two lines that do it.
-Everywhere below, `npx egma` is the shape the command takes when it ships;
-`node …/apps/cli/dist/bin.js` is the same command today, and every option and
-every verb is the same.
 
 Run it in your repository. It opens a terminal wizard, tells you what it is
 about to do, and starts on one keystroke. When it closes, your terminal has one
@@ -27,7 +25,7 @@ is how CI runs it.
 
 <!-- The facts are FACTS in src/wizard/facts.ts, which is the source of truth; keep this sentence in step. -->
 
-`npx egma` signs this machine in to egma, then finds your voice agent. It starts
+`npx @egma/cli` signs this machine in to egma, then finds your voice agent. It starts
 the coding agent you already have, hands it egma's own notes on how voice agents
 are built, and has it read this folder and report which framework runs it, where
 its prompts live, where its tools are defined, how it reaches production, and
@@ -658,7 +656,7 @@ Clone the repository, then, from your checkout of it:
 
 ```
 pnpm install
-npx egma-cli self-host up
+npx @egma/cli self-host up
 ```
 
 That starts a whole egma — Postgres, ClickHouse, the API, the pages, the
@@ -671,7 +669,7 @@ because a platform with no carrier runs text simulations perfectly well. To make
 it able to place calls, one more command in the same directory:
 
 ```
-npx egma-cli self-host phone setup
+npx @egma/cli self-host phone setup
 ```
 
 It asks for a Twilio account, a voice number that account **already owns**, and
@@ -681,10 +679,10 @@ or registers a number. The Twilio Auth Token is used once and kept nowhere: what
 runs afterwards holds a SIP credential for one trunk and nothing else on that
 account.
 
-The command itself is not on npm yet, so build it from the same checkout:
+To run the command from this same checkout rather than from npm, build it:
 
 ```
-pnpm --filter egma-cli build
+pnpm --filter @egma/cli build
 ```
 
 Then run it from the repository that holds your voice agent, naming the
@@ -695,8 +693,8 @@ cd ~/your-voice-agent
 EGMA_URL=http://localhost:3101 node ~/egma/apps/cli/dist/bin.js
 ```
 
-(`~/egma` is wherever you cloned this. When the package ships, that whole line
-becomes `npx egma`.)
+(`~/egma` is wherever you cloned this. From npm, that whole line is
+`EGMA_URL=http://localhost:3101 npx @egma/cli`.)
 
 The wizard signs this machine in against that instance, registers your agent
 and a way to reach it, writes a first suite of tests with your coding agent,
@@ -715,7 +713,7 @@ approval really happens in a browser — it is two commands:
 
 ```
 pnpm db:up
-pnpm --filter egma-cli smoke:walk
+pnpm --filter @egma/cli smoke:walk
 ```
 
 The second builds everything it needs, starts an egma of its own, signs in,

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "The egma wizard and client: npx @egma/cli walks a developer to their first run.",
   "license": "Apache-2.0",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,14 +1,30 @@
 {
-  "name": "egma-cli",
-  "version": "0.0.0",
+  "name": "@egma/cli",
+  "version": "0.1.0",
   "type": "module",
-  "description": "The egma wizard and client: npx egma walks a developer to their first run.",
+  "description": "The egma wizard and client: npx @egma/cli walks a developer to their first run.",
   "license": "Apache-2.0",
+  "homepage": "https://github.com/egma-ai/egma",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/egma-ai/egma.git",
+    "directory": "apps/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/egma-ai/egma/issues"
+  },
+  "keywords": [
+    "voice-agents",
+    "testing",
+    "simulation",
+    "open-source"
+  ],
   "bin": {
-    "egma": "./dist/bin.js"
+    "egma": "dist/bin.js"
   },
   "files": [
     "dist",
+    "!dist/.tsbuildinfo",
     "skills",
     "NOTICE",
     "README.md"
@@ -21,6 +37,7 @@
   },
   "scripts": {
     "build": "tsc -b",
+    "prepublishOnly": "pnpm -w build",
     "smoke": "node smoke/real-claude-code.ts && node smoke/real-claude-code-fence.ts && node smoke/real-claude-code-discovery.ts && node smoke/real-claude-code-generation.ts",
     "smoke:platform": "node smoke/real-platform-login.ts",
     "smoke:retell": "node smoke/real-retell-connect.ts",

--- a/apps/cli/smoke/real-whole-walk.ts
+++ b/apps/cli/smoke/real-whole-walk.ts
@@ -38,7 +38,7 @@
  * had `pnpm install`:
  *
  *   pnpm db:up
- *   pnpm --filter egma-cli smoke:walk
+ *   pnpm --filter @egma/cli smoke:walk
  *
  * The first starts the Postgres and the ClickHouse; the second builds
  * everything this needs and walks. Set `RETELL_API_KEY` in the environment of
@@ -647,7 +647,7 @@ function proven(): void {
 
 async function main(): Promise<void> {
   if (!(await stat(CLI_ENTRY).then((found) => found.isFile(), () => false))) {
-    say(`FAILED: ${CLI_ENTRY} is not built. Run pnpm --filter egma-cli smoke:walk.`);
+    say(`FAILED: ${CLI_ENTRY} is not built. Run pnpm --filter @egma/cli smoke:walk.`);
     process.exitCode = 1;
     return;
   }

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -371,7 +371,7 @@ async function runUp(
     options.out(`phone_missing: ${platform.phoneMissing.join(", ")}`);
   }
   options.out("status: ready");
-  options.out(`connect: npx egma --url ${address}`);
+  options.out(`connect: npx @egma/cli --url ${address}`);
 
   options.fail("");
   options.fail(`egma is running at ${address}`);
@@ -382,7 +382,7 @@ async function runUp(
   );
   options.fail("");
   options.fail("In your agent repository, once:");
-  options.fail(`  npx egma --url ${address}`);
+  options.fail(`  npx @egma/cli --url ${address}`);
   return SELF_HOST_EXIT.ok;
 }
 

--- a/apps/cli/test/self-host-up.test.ts
+++ b/apps/cli/test/self-host-up.test.ts
@@ -110,7 +110,9 @@ describe("egma self-host up", () => {
       expect(run.stdout).toContain("status: ready");
       // Phone readiness is reported separately, and honestly.
       expect(run.stdout).toContain("phone: setup_required");
-      expect(run.stdout).toContain(`connect: npx egma --url ${platform.url}`);
+      expect(run.stdout).toContain(
+        `connect: npx @egma/cli --url ${platform.url}`,
+      );
 
       // Every service it started, named. Four of them — the simulator, the
       // grader, the SIP gateway and its Redis — publish nothing and have no


### PR DESCRIPTION
The CLI has never shipped. The name on npm was a placeholder that ran nothing, and `apps/cli` was still at `0.0.0`. This makes it publishable and gives it one way to release.

## Making it publishable

- Renames the package `egma-cli` → **`@egma/cli`**, version `0.1.0`.
- Adds `repository`, `homepage`, `bugs`, `keywords`. npm provenance needs `repository`.
- Adds `prepublishOnly` so a publish can never ship a stale `dist/`.
- Keeps `dist/.tsbuildinfo` out of the tarball — 124 kB of build cache nobody installs.
- Updates every doc reference, including the "not yet published" note in `apps/cli/README.md`, which stops being true.

`DEVICE_CLIENT_ID` stays `"egma-cli"`. It is the client id the CLI and the API agree on, not the package name; renaming it would break login until both sides ship together.

## The bug this caught

The `bin` path was `"./dist/bin.js"`. **npm deletes a bin entry written with a leading `./`** when it builds the manifest it publishes — and then publishes the deleted version. The package installs with no `egma` command.

It is close to invisible. A tarball installed from disk works fine, because that reads `bin` from its own `package.json`. Only `npm publish --dry-run` shows it, as one `warn` line in a 400-line log. Isolated it directly:

| `bin` value | npm's response |
|---|---|
| `"./dist/bin.js"` | strips the entry |
| `"dist/bin.js"` | accepted |

Fixed, and the release workflow now **fails on any manifest npm would rewrite**, because the tarball smoke test cannot catch this class of problem.

## How releasing works

`.github/workflows/release-cli.yml` runs on tags matching `cli-v*`. Nothing else publishes — merging this PR does not publish.

```
git tag cli-v0.2.0 && git push origin cli-v0.2.0
```

The workflow checks the tag matches `package.json`, builds, packs the tarball and installs it somewhere clean to prove the command runs, refuses a rewritten manifest, then publishes.

**There is no npm token in this repository.** npm is told once, on the package settings page, that this workflow in this repo may publish `@egma/cli`. GitHub proves that per run with a short-lived OIDC token — that is the `id-token: write` permission. Provenance is attached automatically, so npm shows a verified link from the tarball back to the commit that built it.

## Verified

- Root build passes (lint + `tsc -b`).
- All 582 CLI tests pass.
- Packed, installed into an empty directory, ran the binary: `egma --version` → `0.1.0`, help renders, `bin` links correctly.
- `npm publish --dry-run` is clean, no warnings.

## Not done here

The first publish of `0.1.0` cannot come from CI — npm will not let you register a trusted publisher for a package with no versions, so the settings page does not exist yet. It has to be published once by hand, then the trusted publisher is registered, and every release after that is a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789027303&installation_model_id=431960&pr_number=71&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F71&signature=d3a6a9f8f733eac729ddac4374490d8fed0844a81de7842683e057dbf2c3babd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the scoped CLI package publishable and adds a tag-driven, OIDC-authenticated npm release workflow.
- Renames the package to `@egma/cli`, supplies npm metadata, and ensures publishing rebuilds the workspace.
- Corrects the executable manifest and excludes TypeScript build cache data from published tarballs.
- Adds version validation, build, package smoke testing, manifest-rewrite detection, and npm publishing for `cli-v*` tags.
- Updates documentation and self-host follow-up output to use the scoped package name.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the scoped follow-up command is corrected on both output paths, and all third-party actions in the publishing job are pinned to immutable commit SHAs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-cli.yml | Adds the tag-triggered CLI release pipeline and now pins every third-party action to an immutable commit SHA. |
| apps/cli/package.json | Renames and versions the package, adds publishing metadata and safeguards, and corrects the npm executable path. |
| apps/cli/src/commands/self-host.ts | Correctly updates both machine-readable and human-readable follow-up commands to invoke `@egma/cli`. |
| apps/cli/test/self-host-up.test.ts | Updates the self-host success-output assertion for the scoped npm package invocation. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Maintainer
    participant GitHub as GitHub Actions
    participant npm
    Maintainer->>GitHub: "Push cli-v* tag"
    GitHub->>GitHub: Verify tag matches package version
    GitHub->>GitHub: Install, build, and pack CLI
    GitHub->>GitHub: Install tarball and run egma --version
    GitHub->>npm: Run publish dry-run
    npm-->>GitHub: Return normalized-manifest diagnostics
    GitHub->>npm: "Publish @egma/cli using OIDC"
    npm-->>GitHub: Publish package with provenance
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Address review: fix the connect line, pi..."](https://github.com/egma-ai/egma/commit/eec9f6fe98513bb5e1a54211409a9e01bc044765) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52119492)</sub>

<!-- /greptile_comment -->