### PR TITLE
The deployment generates its own media-server credential

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,12 +338,22 @@ EGMA_SIMULATOR_SIP_TRUNK_PASSWORD=
 # variable — point EGMA_SIMULATOR_LIVEKIT_URL at it and leave these alone.
 
 # What the three containers authenticate each other with, and what the simulator
-# is given when EGMA_SIMULATOR_LIVEKIT_API_KEY and _SECRET above are left empty. The defaults are
-# development ones, and they are safe as they stand because the server's ports
-# are published to this machine's loopback and nowhere else. Change both before
-# changing EGMA_LIVEKIT_BIND.
-EGMA_LIVEKIT_API_KEY=egma-devkey
-EGMA_LIVEKIT_API_SECRET=egma-development-only-livekit-secret-change-it
+# is given when EGMA_SIMULATOR_LIVEKIT_API_KEY and _SECRET above are left empty.
+#
+# Leave both empty. `egma self-host up` generates a random pair for this
+# workspace, writes it to .egma-platform/platform.env, and hands the same one to
+# the media server, the simulator and the SIP gateway. It is a password between
+# egma's own parts, like the Postgres password: you never choose it and never
+# type it, and a pair that already exists is left alone so that preparing the
+# workspace again does not lock out a running deployment.
+#
+# There is deliberately no default here and none in docker-compose.yml. There
+# used to be one, written into a public repository, which nothing ever replaced
+# — so any deployment that widened EGMA_LIVEKIT_BIND was accepting anyone who
+# had read that repository. Set these two by hand only if you drive the compose
+# file without the egma CLI, and then treat them as secrets.
+EGMA_LIVEKIT_API_KEY=
+EGMA_LIVEKIT_API_SECRET=
 
 # Where the LiveKit server's own ports are published. Loopback by default: the
 # simulator reaches it across the compose network, so this is for a person at

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
-# Everything here has a working default in docker-compose.yml. Copy this file
-# to .env only if you want to change one.
+# Nearly everything here has a working default in docker-compose.yml. Copy this
+# file to .env only if you want to change one.
+#
+# The exception is the media server's key and secret, which have no default
+# anywhere — a deployment must not run on a credential published in this
+# repository. `egma self-host up` generates that pair for you and writes it
+# where the deployment reads it back, so there is nothing to copy for it. See
+# EGMA_LIVEKIT_API_KEY below.
 
 # Postgres. The published port is 5433 so it does not collide with a Postgres
 # already running on the machine.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ That starts the whole platform and prints the address an agent repository
 points at. Nobody runs a migration step, because there isn't one — the API
 applies its migrations while it boots.
 
+The first `up` in a workspace also **generates the credential egma's media
+server, its simulator and its SIP gateway authenticate each other with**, and
+writes it to `.egma-platform/platform.env`. You never choose it and never type
+it: it is a password between egma's own parts, in the same class as the
+Postgres password. A pair that is already there is left exactly as it is, so
+starting the platform again never locks a running deployment out of itself.
+There is deliberately no default for it anywhere in this repository — a
+deployment must not run on a credential every reader of this repository holds.
+
 `docker compose up` starts the same containers, and is not the same thing.
 
 **Once you have run `egma self-host phone setup`, use `egma self-host up` to
@@ -32,8 +41,10 @@ nothing points compose at it — the self-host commands read it back and hand it
 to the containers themselves. A bare `docker compose up` therefore brings the
 platform back with its carrier, speech and judge configuration empty: the
 containers are recreated, phone readiness goes back to `setup required`, and
-the simulator has no trunk to dial through. Nothing is lost and nothing has to
-be set up again; `egma self-host up` restores it.
+the simulator has no trunk to dial through. Its media server refuses to start
+at all, because that pair has no default and a bare compose run does not read
+the file holding yours. Nothing is lost and nothing has to be set up again;
+`egma self-host up` restores it.
 
 There is a second, smaller difference. `egma self-host up` waits for the
 platform to answer for itself, tells you what to type next, and tries once more

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ platform back with its carrier, speech and judge configuration empty: the
 containers are recreated, phone readiness goes back to `setup required`, and
 the simulator has no trunk to dial through. Its media server refuses to start
 at all, because that pair has no default and a bare compose run does not read
-the file holding yours. Nothing is lost and nothing has to be set up again;
-`egma self-host up` restores it.
+the file holding yours. **That takes the simulator with it** — the simulator
+waits for a healthy media server, so a bare `docker compose up` leaves you with
+no simulator at all, not merely no phone. Nothing is lost and nothing has to be
+set up again; `egma self-host up` restores it.
 
 There is a second, smaller difference. `egma self-host up` waits for the
 platform to answer for itself, tells you what to type next, and tries once more

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -453,7 +453,7 @@ async function runUp(
 const MEDIA_CREDENTIAL_NOTICE = [
   "A media-server credential was generated for this workspace and written to " +
     ".egma-platform/platform.env. It is egma's own password between its media " +
-    "server, its simulator and its SIP bridge: you never choose it and never " +
+    "server, its simulator and its SIP gateway: you never choose it and never " +
     "type it, and a pair that exists is never replaced. Keep that file wherever " +
     "the rest of this deployment's secrets live.",
   "Until this, all three fell back to a pair published in egma's own repository. " +

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -37,9 +37,9 @@ import path from "node:path";
 
 import { compose, DockerMissingError, type ComposeOptions } from "../self-host/compose.ts";
 import {
-  mediaCredential,
-  recorded,
+  recordMediaCredential,
   MEDIA_SECRET_VARIABLE,
+  type MediaCredential,
 } from "../self-host/media-credential.ts";
 import {
   askPlainly,
@@ -332,26 +332,20 @@ async function runUp(
   options.out(`url: ${address}`);
 
   // The media credential: whatever this workspace or its operator already has,
-  // and a fresh one where neither has any.
-  //
-  // **Written down whenever the file does not already say it**, which covers
-  // one more case than generating does. A pair only exported into a shell is a
-  // pair the next start cannot find, and the start after that would mint a
-  // third one and lock the deployment out of itself. The file is the record of
-  // what this deployment runs on, however the value first arrived.
-  const media = mediaCredential(options.env, stored);
-  if (!recorded(media, stored)) {
-    try {
-      writePlatformConfig(workspace, { ...stored, ...media.values });
-    } catch (cause) {
-      options.out("status: failed");
-      options.out(
-        `reason: this workspace has no media-server credential and egma could not write one: ${
-          (cause as Error).message
-        }`,
-      );
-      return SELF_HOST_EXIT.refused;
-    }
+  // and a fresh one where neither has any. Recorded before anything is started,
+  // and read back off the disk, so what the containers are handed below is what
+  // the next start will find.
+  let media: MediaCredential;
+  try {
+    media = await recordMediaCredential(workspace, options.env);
+  } catch (cause) {
+    options.out("status: failed");
+    options.out(
+      `reason: this workspace has no media-server credential and egma could not write one: ${
+        (cause as Error).message
+      }`,
+    );
+    return SELF_HOST_EXIT.refused;
   }
   options.out(`media_credential: ${media.generated ? "generated" : "existing"}`);
   if (media.generated) for (const line of MEDIA_CREDENTIAL_NOTICE) options.fail(line);
@@ -637,8 +631,12 @@ async function runPhoneSetup(
   // made it: this command waits on a running platform, and a running platform
   // was started by `up`. What this covers is a deployment brought up before
   // egma generated the pair at all, whose first act after upgrading is carrier
-  // setup. The write below records it either way.
-  const media = mediaCredential(options.env, stored);
+  // setup.
+  //
+  // It goes through the same one-winner step `up` does, so a setup racing a
+  // start cannot leave the two of them running on different pairs. The write
+  // further down then re-states the same pair beside the carrier settings.
+  const media = await recordMediaCredential(workspace, options.env);
 
   const configuration: Record<string, string> = {
     ...stored,

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -15,7 +15,10 @@
  * - **`up`** starts the whole platform and prints the address an agent
  *   repository points at. Everything: the API, the web application, both
  *   stores, the simulator, the grader, LiveKit, its SIP gateway and their
- *   Redis. There is no phone overlay to ask for by name any more.
+ *   Redis. There is no phone overlay to ask for by name any more. It also
+ *   prepares the workspace: a workspace with no media-server credential is
+ *   given one, generated here and written beside the other bootstrap
+ *   variables, so that no deployment runs on a pair anyone can read.
  * - **`phone setup`** makes that deployment able to place a call. It asks for a
  *   Twilio account, a number that account already owns, and one OpenAI key;
  *   shows a plan; and on approval does the carrier paperwork, activates the
@@ -33,6 +36,11 @@
 import path from "node:path";
 
 import { compose, DockerMissingError, type ComposeOptions } from "../self-host/compose.ts";
+import {
+  mediaCredential,
+  recorded,
+  MEDIA_SECRET_VARIABLE,
+} from "../self-host/media-credential.ts";
 import {
   askPlainly,
   askSecret,
@@ -127,6 +135,17 @@ const STARTED = [
 
 /** Which services phone configuration reaches, and therefore what is recreated. */
 const PHONE_SERVICES = ["api", "simulator", "grader"] as const;
+
+/**
+ * The three that authenticate each other with the media credential.
+ *
+ * Recreated together whenever that pair is minted, because a container keeps
+ * the environment it was created with: replacing one of the three and not the
+ * others leaves a deployment where two halves of one password disagree, and
+ * every phone simulation fails to authenticate with nothing on screen to say
+ * why.
+ */
+const MEDIA_SERVICES = ["livekit", "livekit-sip", "simulator"] as const;
 
 export type SelfHostOptions = {
   readonly cwd: string;
@@ -309,16 +328,45 @@ async function runUp(
     stored.EGMA_BASE_URL?.trim() ||
     DEFAULT_PLATFORM_ADDRESS;
 
-  const environment: Record<string, string> = { ...stored, EGMA_BASE_URL: address };
+  options.out(`workspace: ${workspace}`);
+  options.out(`url: ${address}`);
+
+  // The media credential: whatever this workspace or its operator already has,
+  // and a fresh one where neither has any.
+  //
+  // **Written down whenever the file does not already say it**, which covers
+  // one more case than generating does. A pair only exported into a shell is a
+  // pair the next start cannot find, and the start after that would mint a
+  // third one and lock the deployment out of itself. The file is the record of
+  // what this deployment runs on, however the value first arrived.
+  const media = mediaCredential(options.env, stored);
+  if (!recorded(media, stored)) {
+    try {
+      writePlatformConfig(workspace, { ...stored, ...media.values });
+    } catch (cause) {
+      options.out("status: failed");
+      options.out(
+        `reason: this workspace has no media-server credential and egma could not write one: ${
+          (cause as Error).message
+        }`,
+      );
+      return SELF_HOST_EXIT.refused;
+    }
+  }
+  options.out(`media_credential: ${media.generated ? "generated" : "existing"}`);
+  if (media.generated) for (const line of MEDIA_CREDENTIAL_NOTICE) options.fail(line);
+
+  const environment: Record<string, string> = {
+    ...stored,
+    ...media.values,
+    EGMA_BASE_URL: address,
+  };
   const composeOptions: ComposeOptions = {
     workspace,
     environment,
     signal: options.signal,
     onLine: (line) => options.fail(line),
   };
-
-  options.out(`workspace: ${workspace}`);
-  options.out(`url: ${address}`);
 
   // Twice, on a workspace that has never been started. ClickHouse's own
   // entrypoint starts a server, creates the database, stops it and starts the
@@ -390,6 +438,28 @@ async function runUp(
   options.fail(`  npx @egma/cli --url ${address}`);
   return SELF_HOST_EXIT.ok;
 }
+
+/**
+ * What the operator is told when a media credential was minted for them.
+ *
+ * **The second half is the part that has to be said.** A deployment that was
+ * already running was running on a pair published in egma's own repository,
+ * and this start replaces its media containers. That is a security fact its
+ * operator is entitled to hear plainly rather than infer from containers
+ * restarting — and it is written as a condition the reader resolves rather
+ * than as a guess made here, because nothing in this workspace reliably says
+ * whether a deployment has been up before.
+ */
+const MEDIA_CREDENTIAL_NOTICE = [
+  "A media-server credential was generated for this workspace and written to " +
+    ".egma-platform/platform.env. It is egma's own password between its media " +
+    "server, its simulator and its SIP bridge: you never choose it and never " +
+    "type it, and a pair that exists is never replaced. Keep that file wherever " +
+    "the rest of this deployment's secrets live.",
+  "Until this, all three fell back to a pair published in egma's own repository. " +
+    "If this deployment was already running, that is what it was using, and its " +
+    "media containers are replaced by this start.",
+] as const;
 
 type PlatformFacts = {
   readonly instanceId: string;
@@ -562,8 +632,17 @@ async function runPhoneSetup(
     stored.EGMA_BASE_URL?.trim() ||
     DEFAULT_PLATFORM_ADDRESS;
 
+  // The media credential, made here only if neither this command's environment
+  // nor the workspace already has one. In the ordinary order `up` has already
+  // made it: this command waits on a running platform, and a running platform
+  // was started by `up`. What this covers is a deployment brought up before
+  // egma generated the pair at all, whose first act after upgrading is carrier
+  // setup. The write below records it either way.
+  const media = mediaCredential(options.env, stored);
+
   const configuration: Record<string, string> = {
     ...stored,
+    ...media.values,
     EGMA_BASE_URL: address,
 
     // What the API knows about the carrier: three non-secret facts, and it
@@ -612,19 +691,7 @@ async function runPhoneSetup(
   // together, which is the whole repair.
   let configFile: string;
   try {
-    configFile = writePlatformConfig(workspace, configuration, {
-    header: [
-      "egma platform configuration — written by `egma self-host phone setup`.",
-      "",
-      "This file holds credentials. It is created readable by you and nobody",
-      "else, it belongs wherever the rest of this deployment's secrets do, and",
-      "it belongs in no repository.",
-      "",
-      "The Twilio Auth Token is deliberately not here. It was used once, to do",
-      "the carrier paperwork, and never kept: what a running egma holds is the",
-      "SIP credential below, which can authenticate one trunk and nothing else.",
-      ],
-    });
+    configFile = writePlatformConfig(workspace, configuration);
   } catch (cause) {
     throw new CarrierError(
       `Twilio accepted a new SIP password for ${applied.sipUsername}, and this machine could not write it down: ${(cause as Error).message}. The carrier now accepts only a password that is not saved here, so calls would fail to authenticate. Run \`egma self-host phone setup\` again — it mints another password and writes both ends together. Nothing was charged and no call was placed.`,
@@ -641,8 +708,16 @@ async function runPhoneSetup(
   // Activate it. Recreating rather than restarting, because a container keeps
   // the environment it was created with and a restart would come back with the
   // configuration it did not have.
+  //
+  // The media three join the phone three when this run minted the media
+  // credential, for exactly the same reason one step down: recreating the
+  // simulator on a new pair while the media server keeps the old one is a
+  // deployment whose parts no longer authenticate each other.
+  const recreating = media.generated
+    ? [...new Set([...PHONE_SERVICES, ...MEDIA_SERVICES])]
+    : [...PHONE_SERVICES];
   const recreated = await compose(
-    ["up", "-d", "--wait", "--wait-timeout", "300", "--force-recreate", ...PHONE_SERVICES],
+    ["up", "-d", "--wait", "--wait-timeout", "300", "--force-recreate", ...recreating],
     composeOptions,
   );
 
@@ -667,10 +742,19 @@ async function runPhoneSetup(
       configuration_file: path.relative(workspace, configFile),
       platform_url: address,
       phone_state: readiness ?? "unknown",
+      // Said and never shown, exactly like the SIP password above.
+      media_credential: media.generated ? "generated" : "existing",
     },
     steps: applied.steps.map((step) => `${step.action}: ${step.detail}`),
   };
-  const allSecrets = [...secrets, applied.sipPassword];
+  // The media secret joins the swept set even though nothing prints it. The
+  // sweep is a guard rather than a review habit, and a guard that covers only
+  // the secrets somebody remembered is the wrong half of one.
+  const allSecrets = [
+    ...secrets,
+    applied.sipPassword,
+    media.values[MEDIA_SECRET_VARIABLE] as string,
+  ];
   const receiptFile = fileReceipt(workspace, receipt, allSecrets);
 
   const done = {
@@ -683,6 +767,7 @@ async function runPhoneSetup(
     receipt: path.relative(workspace, receiptFile),
     platform_url: address,
     phone: readiness ?? "unknown",
+    media_credential: media.generated ? "generated" : "existing",
   } as const;
 
   if (readiness !== "ready") {
@@ -704,6 +789,7 @@ async function runPhoneSetup(
 
   answer(options, mode, { ...done, status: "ready" }, allSecrets);
   options.fail("");
+  if (media.generated) for (const line of MEDIA_CREDENTIAL_NOTICE) options.fail(line);
   options.fail("This egma can place phone calls.");
   options.fail(
     `The Twilio Auth Token was used once and kept nowhere. What is running holds a SIP credential for the trunk ${applied.trunkSid} and nothing else on that account.`,

--- a/apps/cli/src/self-host/media-credential.ts
+++ b/apps/cli/src/self-host/media-credential.ts
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { rmSync, statSync, writeFileSync } from "node:fs";
+import { readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import {
@@ -112,7 +112,7 @@ function recorded(
 }
 
 /** What holds the workspace while one command decides its media credential. */
-const MINTING_LOCK_FILE = ".media-credential.lock";
+export const MINTING_LOCK_FILE = ".media-credential.lock";
 
 /** Owner read and write, like everything else in the platform directory. */
 const PRIVATE_FILE_MODE = 0o600;
@@ -128,6 +128,16 @@ const PRIVATE_FILE_MODE = 0o600;
  */
 const LOCK_IS_ABANDONED_AFTER_MS = 30_000;
 const LOCK_POLL_MS = 25;
+
+/**
+ * How many times a displaced holder starts over.
+ *
+ * Displacement takes a stall longer than the window above, so a second one in
+ * the same command is already beyond anything this can reason about. The
+ * attempts are bounded rather than unbounded because a loop that cannot end is
+ * worse than a refusal that says what happened.
+ */
+const ATTEMPTS = 3;
 
 /**
  * The pair this workspace uses, written down if it was not already, with
@@ -152,61 +162,135 @@ const LOCK_POLL_MS = 25;
  * that file legitimately already exists on the deployment this most matters to
  * — one upgraded from a release that wrote carrier settings and no media pair
  * — so creating it exclusively would decide nothing there.
+ *
+ * **A holder that was displaced starts over rather than trusting itself.** A
+ * lock old enough to look abandoned is taken from whoever left it, and a
+ * process that stalled past that window — a closed lid, a machine deep in swap
+ * — wakes to find its turn was given away, possibly after it had already
+ * written a pair. What it decided is then worth nothing, so it goes back to
+ * the top and reads the disk again like any other latecomer.
  */
 export async function recordMediaCredential(
   workspace: string,
   environment: Readonly<Record<string, string | undefined>>,
 ): Promise<MediaCredential> {
-  // The ordinary path, and the only one on every start after the first: what
-  // is on disk is already what this command would use. Nothing is written and
-  // no lock is taken, so a plain start neither creates a lock file nor
-  // contends for one.
-  const held = readPlatformConfig(workspace);
-  if (recorded(mediaCredential(environment, held), held)) {
-    return mediaCredential(environment, held);
+  for (let attempt = 0; attempt < ATTEMPTS; attempt += 1) {
+    // The ordinary path, and the only one on every start after the first: what
+    // is on disk is already what this command would use. Nothing is written and
+    // no lock is taken, so a plain start neither creates a lock file nor
+    // contends for one.
+    const held = readPlatformConfig(workspace);
+    const already = mediaCredential(environment, held);
+    if (recorded(already, held)) return already;
+
+    const lock = await takeMintingLock(workspace);
+    let landed: MediaCredential;
+    try {
+      // Read again inside the lock. Whoever held it before us may have been
+      // recording the very pair we were about to generate, and this is the read
+      // that sees it.
+      const stored = readPlatformConfig(workspace);
+      const decided = mediaCredential(environment, stored);
+      if (!recorded(decided, stored)) {
+        writePlatformConfig(workspace, { ...stored, ...decided.values });
+      }
+      // What actually landed, rather than what was decided in memory.
+      landed = {
+        ...mediaCredential(readPlatformConfig(workspace)),
+        generated: decided.generated,
+      };
+    } catch (cause) {
+      lock.release();
+      throw cause;
+    }
+    // Only now is the answer worth anything: a holder still holding its own
+    // lock did this step alone, and a displaced one did not.
+    if (lock.release()) return landed;
   }
 
-  const release = await takeMintingLock(workspace);
-  try {
-    // Read again inside the lock. Whoever held it before us may have been
-    // recording the very pair we were about to generate, and this is the read
-    // that sees it.
-    const stored = readPlatformConfig(workspace);
-    const decided = mediaCredential(environment, stored);
-    if (!recorded(decided, stored)) {
-      writePlatformConfig(workspace, { ...stored, ...decided.values });
-    }
-    // What actually landed, rather than what was decided in memory.
-    return { ...mediaCredential(readPlatformConfig(workspace)), generated: decided.generated };
-  } finally {
-    release();
+  // Displaced every time. Nothing more is written — whatever is on the disk is
+  // what the deployment runs on, and this command uses that or says it cannot.
+  const settled = readPlatformConfig(workspace);
+  const onDisk = mediaCredential(settled);
+  if (onDisk.generated) {
+    throw new Error(
+      "another command held this workspace's media-server credential for the whole of " +
+        `${ATTEMPTS} attempts and left none behind. Run this again.`,
+    );
   }
+  return onDisk;
 }
 
+/** A held minting lock, and the only thing that may give it back. */
+export type MintingLock = {
+  /**
+   * Give the lock back, and say whether it was still ours to give.
+   *
+   * `false` means this holder was displaced while it worked: the file now
+   * carries somebody else's token, and **it is not removed**. Removing it
+   * would put the displacer and the next command inside the step together,
+   * which is the state the lock exists to prevent.
+   */
+  release(): boolean;
+};
+
 /**
- * Hold the workspace until the returned function gives it back.
+ * Hold the workspace until the returned lock is released.
  *
  * `wx` is the whole mechanism: creating a file that must not already exist is
  * one atomic operation, so of any number of commands asking at once exactly
  * one succeeds and the rest see `EEXIST`.
+ *
+ * **The file carries a token naming this holder**, because a lock file's
+ * existence does not say whose it is. Without one, a holder that stalled past
+ * the takeover window would come back and delete its successor's lock, and a
+ * third command would then walk straight into the step beside that successor.
+ * So every removal — a release, and a takeover — first reads the token and
+ * acts only on the lock it meant to act on.
+ *
+ * Exported so the ownership contract can be checked directly. The alternative
+ * is a test that stalls a real process for longer than the takeover window,
+ * which is half a minute of waiting to assert one comparison.
  */
-async function takeMintingLock(workspace: string): Promise<() => void> {
+export async function takeMintingLock(workspace: string): Promise<MintingLock> {
   const file = path.join(platformDirectory(workspace), MINTING_LOCK_FILE);
+  const ours = `${process.pid}:${randomBytes(12).toString("base64url")}\n`;
   for (;;) {
     try {
-      writeFileSync(file, `${process.pid}\n`, { mode: PRIVATE_FILE_MODE, flag: "wx" });
-      return () => rmSync(file, { force: true });
+      writeFileSync(file, ours, { mode: PRIVATE_FILE_MODE, flag: "wx" });
+      return {
+        release: () => {
+          if (lockToken(file) !== ours) return false;
+          rmSync(file, { force: true });
+          return true;
+        },
+      };
     } catch (cause) {
       if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
     }
+
+    const holder = lockToken(file);
     const heldSince = statSync(file, { throwIfNoEntry: false })?.mtimeMs;
-    // Either it was released between the failed create and this look, or it
-    // was left behind by a process that is not coming back. Both end the same
-    // way: try again, and this time there is nothing in the way.
-    if (heldSince === undefined || Date.now() - heldSince > LOCK_IS_ABANDONED_AFTER_MS) {
-      rmSync(file, { force: true });
+    // Released between the failed create and this look. Go straight round.
+    if (holder === null || heldSince === undefined) continue;
+
+    if (Date.now() - heldSince > LOCK_IS_ABANDONED_AFTER_MS) {
+      // Displace that holder, and only that one. Reading the token again
+      // before removing keeps a lock somebody took in the meantime — after
+      // the old one was released — from being thrown away by this branch.
+      if (lockToken(file) === holder) rmSync(file, { force: true });
       continue;
     }
     await new Promise((wake) => setTimeout(wake, LOCK_POLL_MS));
+  }
+}
+
+/** Whose lock this is, or `null` where there is no lock to read. */
+function lockToken(file: string): string | null {
+  try {
+    return readFileSync(file, "utf8");
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw cause;
   }
 }

--- a/apps/cli/src/self-host/media-credential.ts
+++ b/apps/cli/src/self-host/media-credential.ts
@@ -22,6 +22,14 @@
  */
 
 import { randomBytes } from "node:crypto";
+import { rmSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  platformDirectory,
+  readPlatformConfig,
+  writePlatformConfig,
+} from "./workspace.ts";
 
 /** What the compose file reads the pair from, and therefore what is written. */
 export const MEDIA_KEY_VARIABLE = "EGMA_LIVEKIT_API_KEY";
@@ -87,13 +95,13 @@ export function mediaCredential(
 /**
  * Whether a workspace's configuration already says exactly this pair.
  *
- * The question a caller asks before writing, and it is not the same question as
+ * The question asked before writing, and it is not the same question as
  * `generated`. A pair that arrived from the environment was made by nobody
  * here, and still has to be written down: one that lives only in a shell is one
  * the next start cannot find, and that start would mint a third pair and lock
  * the deployment out of itself.
  */
-export function recorded(
+function recorded(
   credential: MediaCredential,
   stored: Readonly<Record<string, string>>,
 ): boolean {
@@ -101,4 +109,104 @@ export function recorded(
     stored[MEDIA_KEY_VARIABLE] === credential.values[MEDIA_KEY_VARIABLE] &&
     stored[MEDIA_SECRET_VARIABLE] === credential.values[MEDIA_SECRET_VARIABLE]
   );
+}
+
+/** What holds the workspace while one command decides its media credential. */
+const MINTING_LOCK_FILE = ".media-credential.lock";
+
+/** Owner read and write, like everything else in the platform directory. */
+const PRIVATE_FILE_MODE = 0o600;
+
+/**
+ * How long a lock may exist before whoever left it is treated as gone.
+ *
+ * Generous by two orders of magnitude. What the lock is held across is reading
+ * a small file, making 41 random bytes and writing that file back, so a lock
+ * this old belongs to a process that died holding it rather than to one still
+ * working — and a lock nobody will ever release must not stop a deployment
+ * from starting for ever.
+ */
+const LOCK_IS_ABANDONED_AFTER_MS = 30_000;
+const LOCK_POLL_MS = 25;
+
+/**
+ * The pair this workspace uses, written down if it was not already, with
+ * exactly one winner when two commands ask at the same moment.
+ *
+ * **Two commands mint.** `egma self-host up` and `egma self-host phone setup`
+ * both reach here, so the two racers need not even be the same command. Left
+ * unguarded, each would generate its own pair, each would write the file, and
+ * each would then hand *its* pair to Compose — leaving the recorded pair and
+ * the running containers' pair different. That failure passes every health
+ * check and surfaces minutes later as a carrier or media refusal that names
+ * nothing about configuration, which is the exact failure this whole effort
+ * exists to remove. Shipping a new one of those inside it would be a poor
+ * trade.
+ *
+ * So the read-decide-write step has one winner. The loser waits, re-reads, and
+ * **adopts** what the winner recorded rather than overwriting it. The value
+ * returned is read back off the disk after the step, so the pair handed to
+ * Compose is the pair in the file by construction rather than by argument.
+ *
+ * A file lock rather than an exclusive create of the configuration itself:
+ * that file legitimately already exists on the deployment this most matters to
+ * — one upgraded from a release that wrote carrier settings and no media pair
+ * — so creating it exclusively would decide nothing there.
+ */
+export async function recordMediaCredential(
+  workspace: string,
+  environment: Readonly<Record<string, string | undefined>>,
+): Promise<MediaCredential> {
+  // The ordinary path, and the only one on every start after the first: what
+  // is on disk is already what this command would use. Nothing is written and
+  // no lock is taken, so a plain start neither creates a lock file nor
+  // contends for one.
+  const held = readPlatformConfig(workspace);
+  if (recorded(mediaCredential(environment, held), held)) {
+    return mediaCredential(environment, held);
+  }
+
+  const release = await takeMintingLock(workspace);
+  try {
+    // Read again inside the lock. Whoever held it before us may have been
+    // recording the very pair we were about to generate, and this is the read
+    // that sees it.
+    const stored = readPlatformConfig(workspace);
+    const decided = mediaCredential(environment, stored);
+    if (!recorded(decided, stored)) {
+      writePlatformConfig(workspace, { ...stored, ...decided.values });
+    }
+    // What actually landed, rather than what was decided in memory.
+    return { ...mediaCredential(readPlatformConfig(workspace)), generated: decided.generated };
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Hold the workspace until the returned function gives it back.
+ *
+ * `wx` is the whole mechanism: creating a file that must not already exist is
+ * one atomic operation, so of any number of commands asking at once exactly
+ * one succeeds and the rest see `EEXIST`.
+ */
+async function takeMintingLock(workspace: string): Promise<() => void> {
+  const file = path.join(platformDirectory(workspace), MINTING_LOCK_FILE);
+  for (;;) {
+    try {
+      writeFileSync(file, `${process.pid}\n`, { mode: PRIVATE_FILE_MODE, flag: "wx" });
+      return () => rmSync(file, { force: true });
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+    }
+    const heldSince = statSync(file, { throwIfNoEntry: false })?.mtimeMs;
+    // Either it was released between the failed create and this look, or it
+    // was left behind by a process that is not coming back. Both end the same
+    // way: try again, and this time there is nothing in the way.
+    if (heldSince === undefined || Date.now() - heldSince > LOCK_IS_ABANDONED_AFTER_MS) {
+      rmSync(file, { force: true });
+      continue;
+    }
+    await new Promise((wake) => setTimeout(wake, LOCK_POLL_MS));
+  }
 }

--- a/apps/cli/src/self-host/media-credential.ts
+++ b/apps/cli/src/self-host/media-credential.ts
@@ -1,5 +1,5 @@
 /**
- * The credential the media server, the simulator and the SIP bridge
+ * The credential the media server, the simulator and the SIP gateway
  * authenticate each other with.
  *
  * **It is a password between egma's own parts**, in the same class as the

--- a/apps/cli/src/self-host/media-credential.ts
+++ b/apps/cli/src/self-host/media-credential.ts
@@ -1,0 +1,104 @@
+/**
+ * The credential the media server, the simulator and the SIP bridge
+ * authenticate each other with.
+ *
+ * **It is a password between egma's own parts**, in the same class as the
+ * Postgres password: generated when a workspace is prepared, written beside the
+ * other bootstrap variables, and never seen, chosen or typed by the operator.
+ *
+ * It exists because the alternative was live. All three containers used to fall
+ * back to a key and a secret written into the compose file in the public
+ * repository, and nothing in the CLI, the skills or the documentation ever
+ * replaced them. Published to loopback the exposure is small — but the compose
+ * file invites a wider bind for testing from another machine, and at that
+ * moment the media server accepts anyone who read the repository.
+ *
+ * **A pair that already exists is left exactly as it is.** The three containers
+ * hold whatever they were created with, so a preparation that minted a fresh
+ * pair would leave a running deployment whose parts no longer agree — and the
+ * symptom is every phone simulation failing to authenticate, a long way from
+ * the command that caused it. Regenerating is therefore the one thing this must
+ * never do on its own.
+ */
+
+import { randomBytes } from "node:crypto";
+
+/** What the compose file reads the pair from, and therefore what is written. */
+export const MEDIA_KEY_VARIABLE = "EGMA_LIVEKIT_API_KEY";
+export const MEDIA_SECRET_VARIABLE = "EGMA_LIVEKIT_API_SECRET";
+
+/**
+ * The pair a workspace is to use, and whether this call is what made it.
+ *
+ * `generated` is not a detail: it is the difference between a start that leaves
+ * a deployment alone and one that replaces its media containers, and the
+ * operator is told which of the two happened.
+ */
+export type MediaCredential = {
+  readonly values: Readonly<Record<string, string>>;
+  readonly generated: boolean;
+};
+
+/**
+ * The first pair any of these sources carries, or a fresh one where none does.
+ *
+ * Sources are given in order of precedence, and the caller's order is the same
+ * one `up` already uses for the platform's address: the environment first,
+ * because a self-hoster who exported this pair meant it, then the workspace's
+ * own configuration. A pair egma is handed is a pair egma keeps.
+ *
+ * **Half a pair counts as none, one source at a time.** A key with no secret
+ * authenticates nothing, and a key from one source beside a secret from another
+ * is two halves of two different passwords — worse than either. So a source
+ * carrying one of the two is passed over whole, and the two are always minted
+ * together.
+ *
+ * Both generated values are drawn from `A-Za-z0-9_-` alone. They travel through
+ * a `NAME=value` file with no quoting, a child process environment, and a YAML
+ * scalar in the compose file, and a character that needed escaping in any one
+ * of those would break a deployment in a way that reads as a wrong password.
+ */
+export function mediaCredential(
+  ...sources: readonly Readonly<Record<string, string | undefined>>[]
+): MediaCredential {
+  for (const source of sources) {
+    const key = source[MEDIA_KEY_VARIABLE]?.trim() ?? "";
+    const secret = source[MEDIA_SECRET_VARIABLE]?.trim() ?? "";
+    if (key !== "" && secret !== "") {
+      return {
+        values: { [MEDIA_KEY_VARIABLE]: key, [MEDIA_SECRET_VARIABLE]: secret },
+        generated: false,
+      };
+    }
+  }
+  return {
+    values: {
+      // Named so that a person reading the media server's logs can tell egma's
+      // own credential from one they brought themselves.
+      [MEDIA_KEY_VARIABLE]: `egma${randomBytes(9).toString("base64url")}`,
+      // 32 bytes. The media server refuses a secret shorter than 32
+      // characters, and this is well past that in any encoding.
+      [MEDIA_SECRET_VARIABLE]: randomBytes(32).toString("base64url"),
+    },
+    generated: true,
+  };
+}
+
+/**
+ * Whether a workspace's configuration already says exactly this pair.
+ *
+ * The question a caller asks before writing, and it is not the same question as
+ * `generated`. A pair that arrived from the environment was made by nobody
+ * here, and still has to be written down: one that lives only in a shell is one
+ * the next start cannot find, and that start would mint a third pair and lock
+ * the deployment out of itself.
+ */
+export function recorded(
+  credential: MediaCredential,
+  stored: Readonly<Record<string, string>>,
+): boolean {
+  return (
+    stored[MEDIA_KEY_VARIABLE] === credential.values[MEDIA_KEY_VARIABLE] &&
+    stored[MEDIA_SECRET_VARIABLE] === credential.values[MEDIA_SECRET_VARIABLE]
+  );
+}

--- a/apps/cli/src/self-host/workspace.ts
+++ b/apps/cli/src/self-host/workspace.ts
@@ -43,6 +43,31 @@ export const PLATFORM_DIRECTORY = ".egma-platform";
  */
 export const PLATFORM_CONFIG_FILE = "platform.env";
 
+/**
+ * What is written at the top of that file, whichever command wrote it.
+ *
+ * One header rather than one per writer: the file is the same file, read by
+ * every `self-host` command and rewritten by more than one of them, and a
+ * header that changed depending on which command last touched it would tell a
+ * person the wrong story about what is in it.
+ */
+export const PLATFORM_CONFIG_HEADER = [
+  "egma platform configuration — written by `egma self-host`.",
+  "",
+  "This file holds credentials. It is created readable by you and nobody",
+  "else, it belongs wherever the rest of this deployment's secrets do, and",
+  "it belongs in no repository.",
+  "",
+  "The media server's key and secret are egma's own. They are generated when",
+  "this workspace is prepared and never regenerated, because the three",
+  "containers that authenticate each other with them hold whatever they were",
+  "created with. Nobody chooses them and nobody types them.",
+  "",
+  "The Twilio Auth Token is deliberately not here. It was used once, to do",
+  "the carrier paperwork, and never kept: what a running egma holds is the",
+  "SIP credential, which can authenticate one trunk and nothing else.",
+] as const;
+
 /** Owner read and write, and nothing for anybody else. */
 const PRIVATE_FILE_MODE = 0o600;
 const PRIVATE_DIRECTORY_MODE = 0o700;
@@ -127,12 +152,11 @@ export function platformDirectory(workspace: string): string {
 export function writePlatformConfig(
   workspace: string,
   values: Record<string, string>,
-  { header }: { readonly header: readonly string[] },
 ): string {
   platformDirectory(workspace);
   const file = platformConfigPath(workspace);
   const body = [
-    ...header.map((line) => (line === "" ? "#" : `# ${line}`)),
+    ...PLATFORM_CONFIG_HEADER.map((line) => (line === "" ? "#" : `# ${line}`)),
     "",
     ...Object.entries(values).map(([name, value]) => `${name}=${value}`),
     "",

--- a/apps/cli/test/self-host-media-credential.test.ts
+++ b/apps/cli/test/self-host-media-credential.test.ts
@@ -2,8 +2,8 @@
  * The media server's credential, which a deployment now makes for itself.
  *
  * **This closes a hole that was open in a running deployment**, not a
- * hypothetical one. The media server, the simulator and the SIP bridge all fell
- * back to a key and a secret written into the compose file in the public
+ * hypothetical one. The media server, the simulator and the SIP gateway all
+ * fell back to a key and a secret written into the compose file in the public
  * repository, and nothing in the CLI, the skills or the documentation ever
  * replaced them. Bound to loopback the exposure is small; the compose file
  * invites a wider bind for testing from another machine, and at that moment the
@@ -17,22 +17,26 @@
  *    symptom is every phone simulation failing to authenticate.
  * 2. **The pair reaches compose**, because a credential written to a file no
  *    container reads is the same as no credential at all.
- * 3. **The secret is never printed.** It is a password between egma's own
- *    parts, and the operator never sees it, chooses it or types it.
+ * 3. **The secret is never printed, and the file it lands in is private.** It
+ *    is a password between egma's own parts, and the operator never sees it,
+ *    chooses it or types it.
  * 4. **A workspace prepared before this change is told** what happened, because
  *    its containers are recreated underneath it.
  */
 
-import { spawn } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
-import { tmpdir } from "node:os";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { CLI_ENTRY } from "./support/workspace.ts";
+import {
+  makePlatformWorkspace,
+  runSelfHost,
+  startPlatform,
+  type FakePlatform,
+  type PlatformWorkspace,
+  type SelfHostRun,
+} from "./support/platform-workspace.ts";
 
 /** The pair that was published in this repository, and must never come back. */
 const PUBLISHED_KEY = "egma-devkey";
@@ -41,114 +45,20 @@ const PUBLISHED_SECRET = "egma-development-only-livekit-secret-change-it";
 const KEY_VARIABLE = "EGMA_LIVEKIT_API_KEY";
 const SECRET_VARIABLE = "EGMA_LIVEKIT_API_SECRET";
 
-type FakePlatform = { readonly url: string; close(): Promise<void> };
+const WORKSPACE_PREFIX = "egma-media-credential-";
 
-/** A stand-in for the running platform, answering only what `up` reads. */
-async function startPlatform(): Promise<FakePlatform> {
-  const server: Server = createServer((_request, answer) => {
-    answer.writeHead(200, { "content-type": "application/json" });
-    answer.end(
-      JSON.stringify({
-        instance_id: "pf_00000000000000000000000001",
-        origin: url,
-        phone: { state: "setup_required", missing: ["the carrier trunk"] },
-      }),
-    );
-  });
-  await new Promise<void>((listening) => server.listen(0, "127.0.0.1", listening));
-  const { port } = server.address() as AddressInfo;
-  const url = `http://127.0.0.1:${port}`;
-  return {
-    url,
-    close: () =>
-      new Promise<void>((closed) => {
-        server.close(() => closed());
-      }),
-  };
-}
-
-type Workspace = {
-  readonly dir: string;
-  readonly binDir: string;
-  /** What compose was asked for, and what it was asked for it with. */
-  dockerCalls(): Promise<string>;
-  /** What egma wrote down, as names and values. */
-  storedConfig(): Promise<Record<string, string>>;
-};
-
-/**
- * A workspace with a `docker` on its PATH that succeeds and writes down the two
- * media variables it was handed.
- *
- * The environment matters more than the arguments here: the whole claim is that
- * the three media containers are handed one pair, and a compose invocation that
- * carried neither variable would leave every one of them to its own default.
- */
-async function makeWorkspace(): Promise<Workspace> {
-  const dir = await mkdtemp(path.join(tmpdir(), "egma-media-credential-"));
-  await writeFile(path.join(dir, "docker-compose.yml"), "name: egma\nservices: {}\n");
-  const binDir = path.join(dir, "bin");
-  await mkdir(binDir, { recursive: true });
-  const calls = path.join(dir, "docker-calls.txt");
-  await writeFile(calls, "");
-  const shim = path.join(binDir, "docker");
-  await writeFile(
-    shim,
-    `#!/bin/sh\necho "ARGS $@" >> "${calls}"\n` +
-      `echo "${KEY_VARIABLE}=\${${KEY_VARIABLE}}" >> "${calls}"\n` +
-      `echo "${SECRET_VARIABLE}=\${${SECRET_VARIABLE}}" >> "${calls}"\nexit 0\n`,
-  );
-  await chmod(shim, 0o755);
-  return {
-    dir,
-    binDir,
-    dockerCalls: () => readFile(calls, "utf8"),
-    storedConfig: async () => {
-      const file = path.join(dir, ".egma-platform", "platform.env");
-      const found: Record<string, string> = {};
-      for (const line of (await readFile(file, "utf8")).split("\n")) {
-        const text = line.trim();
-        if (text === "" || text.startsWith("#")) continue;
-        const split = text.indexOf("=");
-        if (split <= 0) continue;
-        found[text.slice(0, split)] = text.slice(split + 1);
-      }
-      return found;
-    },
-  };
-}
-
-type Run = { readonly code: number; readonly stdout: string; readonly stderr: string };
-
-async function runUp(
-  workspace: Workspace,
+function runUp(
+  workspace: PlatformWorkspace,
   platform: FakePlatform,
   extraEnv: NodeJS.ProcessEnv = {},
-): Promise<Run> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [CLI_ENTRY, "self-host", "up"], {
-      cwd: workspace.dir,
-      env: {
-        ...process.env,
-        PATH: `${workspace.binDir}:${process.env.PATH ?? ""}`,
-        EGMA_BASE_URL: platform.url,
-        ...extraEnv,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString("utf8")));
-    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString("utf8")));
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
-  });
+): Promise<SelfHostRun> {
+  return runSelfHost(workspace, ["up"], { EGMA_BASE_URL: platform.url, ...extraEnv });
 }
 
 describe("the media server's credential", () => {
   it("is generated when a workspace is prepared, and is not the published one", async () => {
     const platform = await startPlatform();
-    const workspace = await makeWorkspace();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
       const run = await runUp(workspace, platform);
 
@@ -175,6 +85,15 @@ describe("the media server's credential", () => {
 
       // It is a password between egma's own parts. The operator never sees it.
       expect(`${run.stdout}\n${run.stderr}`).not.toContain(secret);
+
+      // And `up` is now the *first* writer of this file, so the mode it creates
+      // it with is this command's to get right. It holds a generated secret
+      // from the moment it exists, and a file the rest of the machine can read
+      // is a password the rest of the machine has.
+      expect((await stat(workspace.configFile)).mode & 0o777).toBe(0o600);
+      expect(
+        (await stat(path.dirname(workspace.configFile))).mode & 0o777,
+      ).toBe(0o700);
     } finally {
       await platform.close();
     }
@@ -182,7 +101,7 @@ describe("the media server's credential", () => {
 
   it("hands that one pair to compose, so the three media containers agree", async () => {
     const platform = await startPlatform();
-    const workspace = await makeWorkspace();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
       await runUp(workspace, platform);
 
@@ -199,7 +118,7 @@ describe("the media server's credential", () => {
 
   it("leaves a pair that already exists alone, so a second start breaks nothing", async () => {
     const platform = await startPlatform();
-    const workspace = await makeWorkspace();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
       await runUp(workspace, platform);
       const first = await workspace.storedConfig();
@@ -221,13 +140,13 @@ describe("the media server's credential", () => {
 
   it("gives a workspace prepared before this change a pair, and says so", async () => {
     const platform = await startPlatform();
-    const workspace = await makeWorkspace();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
       // What an upgrading deployment's workspace holds: everything phone setup
       // wrote, and no media credential, because there was nothing to write it.
-      await mkdir(path.join(workspace.dir, ".egma-platform"), { recursive: true });
+      await mkdir(path.dirname(workspace.configFile), { recursive: true });
       await writeFile(
-        path.join(workspace.dir, ".egma-platform", "platform.env"),
+        workspace.configFile,
         "EGMA_PHONE_SOURCE_NUMBER=+15550100100\nEGMA_SIMULATOR_MEDIA_BACKEND=livekit\n",
       );
 
@@ -240,6 +159,9 @@ describe("the media server's credential", () => {
       // Everything the carrier paperwork left behind survives the rewrite.
       expect(stored.EGMA_PHONE_SOURCE_NUMBER).toBe("+15550100100");
       expect(stored.EGMA_SIMULATOR_MEDIA_BACKEND).toBe("livekit");
+      // A file somebody loosened is tightened again by the write, rather than
+      // keeping whatever mode it happened to have.
+      expect((await stat(workspace.configFile)).mode & 0o777).toBe(0o600);
       // And the operator is told, in sentences, because their media containers
       // are being replaced by this run — and because what those containers held
       // until this moment is a security fact they are entitled to hear plainly.
@@ -259,7 +181,7 @@ describe("the media server's credential", () => {
     // cannot find, and that start would mint a third and lock the deployment
     // out of itself.
     const platform = await startPlatform();
-    const workspace = await makeWorkspace();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
       const run = await runUp(workspace, platform, {
         [KEY_VARIABLE]: "a-key-the-operator-chose",
@@ -277,13 +199,10 @@ describe("the media server's credential", () => {
 
   it("replaces half a pair, because half a credential authenticates nothing", async () => {
     const platform = await startPlatform();
-    const workspace = await makeWorkspace();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
-      await mkdir(path.join(workspace.dir, ".egma-platform"), { recursive: true });
-      await writeFile(
-        path.join(workspace.dir, ".egma-platform", "platform.env"),
-        `${KEY_VARIABLE}=a-key-with-no-secret\n`,
-      );
+      await mkdir(path.dirname(workspace.configFile), { recursive: true });
+      await writeFile(workspace.configFile, `${KEY_VARIABLE}=a-key-with-no-secret\n`);
 
       const run = await runUp(workspace, platform);
 

--- a/apps/cli/test/self-host-media-credential.test.ts
+++ b/apps/cli/test/self-host-media-credential.test.ts
@@ -24,12 +24,17 @@
  *    its containers are recreated underneath it.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import { mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  MINTING_LOCK_FILE,
+  recordMediaCredential,
+  takeMintingLock,
+} from "../src/self-host/media-credential.ts";
 import {
   makePlatformWorkspace,
   runSelfHost,
@@ -264,5 +269,70 @@ describe("the media server's credential", () => {
     } finally {
       await platform.close();
     }
+  });
+});
+
+/**
+ * Who owns the lock that decides the pair.
+ *
+ * A lock old enough to look abandoned is taken from whoever left it, which is
+ * right — a process that died holding it must not stop every later start. But
+ * it makes a second failure possible, and it is the one this describes: a
+ * holder that merely *stalled* past the window, on a closed lid or a machine
+ * deep in swap, wakes up and finishes. If releasing means "delete the lock
+ * file", it deletes its successor's lock, and the next command then walks into
+ * the step beside that successor. Two commands inside the section is the exact
+ * state the lock exists to prevent.
+ *
+ * These run against the lock rather than against two stalled processes,
+ * because reproducing the stall honestly means waiting out the takeover window
+ * to assert one comparison.
+ */
+describe("the minting lock", () => {
+  function lockPath(workspace: PlatformWorkspace): string {
+    return path.join(path.dirname(workspace.configFile), MINTING_LOCK_FILE);
+  }
+
+  it("removes its own lock, and says it did", async () => {
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
+    const lock = await takeMintingLock(workspace.dir);
+
+    expect(existsSync(lockPath(workspace))).toBe(true);
+    expect(lock.release()).toBe(true);
+    expect(existsSync(lockPath(workspace))).toBe(false);
+  });
+
+  it("leaves a lock that was taken over from it alone", async () => {
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
+    const stalled = await takeMintingLock(workspace.dir);
+
+    // What a displaced holder wakes up to: its turn was given away, and the
+    // file now carries the token of whoever is inside the step right now.
+    const successor = "12345:a-token-that-is-not-ours\n";
+    writeFileSync(lockPath(workspace), successor);
+
+    expect(stalled.release()).toBe(false);
+    expect(existsSync(lockPath(workspace))).toBe(true);
+    expect(readFileSync(lockPath(workspace), "utf8")).toBe(successor);
+  });
+
+  it("takes over a lock nobody is coming back for, and mints under it", async () => {
+    // The other half of the same decision. A crashed holder must not stop a
+    // deployment from ever starting again, so a lock older than the window is
+    // displaced and the work goes ahead.
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
+    await mkdir(path.dirname(workspace.configFile), { recursive: true });
+    writeFileSync(lockPath(workspace), "999999:left-behind-by-a-dead-process\n");
+    const longAgo = new Date(Date.now() - 10 * 60_000);
+    utimesSync(lockPath(workspace), longAgo, longAgo);
+
+    const credential = await recordMediaCredential(workspace.dir, {});
+
+    expect(credential.generated).toBe(true);
+    expect(credential.values[KEY_VARIABLE]).not.toBe("");
+    // The pair is on disk, and the abandoned lock is gone rather than
+    // inherited.
+    expect(await workspace.storedConfig()).toMatchObject(credential.values);
+    expect(existsSync(lockPath(workspace))).toBe(false);
   });
 });

--- a/apps/cli/test/self-host-media-credential.test.ts
+++ b/apps/cli/test/self-host-media-credential.test.ts
@@ -24,6 +24,7 @@
  *    its containers are recreated underneath it.
  */
 
+import { existsSync } from "node:fs";
 import { mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -192,6 +193,56 @@ describe("the media server's credential", () => {
       const stored = await workspace.storedConfig();
       expect(stored[KEY_VARIABLE]).toBe("a-key-the-operator-chose");
       expect(stored[SECRET_VARIABLE]).toBe("a-secret-the-operator-chose-that-is-long-enough");
+    } finally {
+      await platform.close();
+    }
+  });
+
+  it("mints one pair when two commands prepare the same workspace at once", async () => {
+    // Two preparations racing on a workspace with no pair is reachable without
+    // anybody doing anything strange: `up` and `phone setup` both mint, so the
+    // racers need not even be the same command. Unguarded, each generates its
+    // own pair, each writes the file, and each hands *its* pair to Compose — so
+    // the recorded pair and the running containers' pair differ. That passes
+    // every health check and surfaces minutes later as an authentication
+    // refusal naming nothing about configuration, which is the exact failure
+    // this whole effort exists to remove.
+    const platform = await startPlatform();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
+    try {
+      const [first, second] = await Promise.all([
+        runUp(workspace, platform),
+        runUp(workspace, platform),
+      ]);
+
+      expect(first.code).toBe(0);
+      expect(second.code).toBe(0);
+
+      // Exactly one winner. The loser adopted what the winner recorded rather
+      // than writing over it, which is the whole property.
+      const runs = [first, second];
+      expect(runs.filter((run) => run.stdout.includes("media_credential: generated"))).toHaveLength(1);
+      expect(runs.filter((run) => run.stdout.includes("media_credential: existing"))).toHaveLength(1);
+
+      // One pair on disk, and every pair either command handed to Compose is
+      // that pair. Read from what the docker stand-in wrote down, so this is
+      // what the containers would really have been created with.
+      const stored = await workspace.storedConfig();
+      const calls = await workspace.dockerCalls();
+      for (const variable of [KEY_VARIABLE, SECRET_VARIABLE]) {
+        const onDisk = stored[variable] ?? "";
+        expect(onDisk).not.toBe("");
+        const handed = [...calls.matchAll(new RegExp(`^${variable}=(.*)$`, "gmu"))].map(
+          (line) => line[1] as string,
+        );
+        expect(handed).toHaveLength(2);
+        expect(new Set(handed)).toEqual(new Set([onDisk]));
+      }
+
+      // And nothing is left holding the workspace once both have finished.
+      expect(
+        existsSync(path.join(path.dirname(workspace.configFile), ".media-credential.lock")),
+      ).toBe(false);
     } finally {
       await platform.close();
     }

--- a/apps/cli/test/self-host-media-credential.test.ts
+++ b/apps/cli/test/self-host-media-credential.test.ts
@@ -1,0 +1,298 @@
+/**
+ * The media server's credential, which a deployment now makes for itself.
+ *
+ * **This closes a hole that was open in a running deployment**, not a
+ * hypothetical one. The media server, the simulator and the SIP bridge all fell
+ * back to a key and a secret written into the compose file in the public
+ * repository, and nothing in the CLI, the skills or the documentation ever
+ * replaced them. Bound to loopback the exposure is small; the compose file
+ * invites a wider bind for testing from another machine, and at that moment the
+ * media server accepts anyone who read the repository.
+ *
+ * So preparing a workspace mints a random pair. What is worth proving, in the
+ * order it would cost to get wrong:
+ *
+ * 1. **A second preparation does not replace it.** A regenerated pair is a
+ *    running deployment whose three media containers stop agreeing, and the
+ *    symptom is every phone simulation failing to authenticate.
+ * 2. **The pair reaches compose**, because a credential written to a file no
+ *    container reads is the same as no credential at all.
+ * 3. **The secret is never printed.** It is a password between egma's own
+ *    parts, and the operator never sees it, chooses it or types it.
+ * 4. **A workspace prepared before this change is told** what happened, because
+ *    its containers are recreated underneath it.
+ */
+
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { CLI_ENTRY } from "./support/workspace.ts";
+
+/** The pair that was published in this repository, and must never come back. */
+const PUBLISHED_KEY = "egma-devkey";
+const PUBLISHED_SECRET = "egma-development-only-livekit-secret-change-it";
+
+const KEY_VARIABLE = "EGMA_LIVEKIT_API_KEY";
+const SECRET_VARIABLE = "EGMA_LIVEKIT_API_SECRET";
+
+type FakePlatform = { readonly url: string; close(): Promise<void> };
+
+/** A stand-in for the running platform, answering only what `up` reads. */
+async function startPlatform(): Promise<FakePlatform> {
+  const server: Server = createServer((_request, answer) => {
+    answer.writeHead(200, { "content-type": "application/json" });
+    answer.end(
+      JSON.stringify({
+        instance_id: "pf_00000000000000000000000001",
+        origin: url,
+        phone: { state: "setup_required", missing: ["the carrier trunk"] },
+      }),
+    );
+  });
+  await new Promise<void>((listening) => server.listen(0, "127.0.0.1", listening));
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}`;
+  return {
+    url,
+    close: () =>
+      new Promise<void>((closed) => {
+        server.close(() => closed());
+      }),
+  };
+}
+
+type Workspace = {
+  readonly dir: string;
+  readonly binDir: string;
+  /** What compose was asked for, and what it was asked for it with. */
+  dockerCalls(): Promise<string>;
+  /** What egma wrote down, as names and values. */
+  storedConfig(): Promise<Record<string, string>>;
+};
+
+/**
+ * A workspace with a `docker` on its PATH that succeeds and writes down the two
+ * media variables it was handed.
+ *
+ * The environment matters more than the arguments here: the whole claim is that
+ * the three media containers are handed one pair, and a compose invocation that
+ * carried neither variable would leave every one of them to its own default.
+ */
+async function makeWorkspace(): Promise<Workspace> {
+  const dir = await mkdtemp(path.join(tmpdir(), "egma-media-credential-"));
+  await writeFile(path.join(dir, "docker-compose.yml"), "name: egma\nservices: {}\n");
+  const binDir = path.join(dir, "bin");
+  await mkdir(binDir, { recursive: true });
+  const calls = path.join(dir, "docker-calls.txt");
+  await writeFile(calls, "");
+  const shim = path.join(binDir, "docker");
+  await writeFile(
+    shim,
+    `#!/bin/sh\necho "ARGS $@" >> "${calls}"\n` +
+      `echo "${KEY_VARIABLE}=\${${KEY_VARIABLE}}" >> "${calls}"\n` +
+      `echo "${SECRET_VARIABLE}=\${${SECRET_VARIABLE}}" >> "${calls}"\nexit 0\n`,
+  );
+  await chmod(shim, 0o755);
+  return {
+    dir,
+    binDir,
+    dockerCalls: () => readFile(calls, "utf8"),
+    storedConfig: async () => {
+      const file = path.join(dir, ".egma-platform", "platform.env");
+      const found: Record<string, string> = {};
+      for (const line of (await readFile(file, "utf8")).split("\n")) {
+        const text = line.trim();
+        if (text === "" || text.startsWith("#")) continue;
+        const split = text.indexOf("=");
+        if (split <= 0) continue;
+        found[text.slice(0, split)] = text.slice(split + 1);
+      }
+      return found;
+    },
+  };
+}
+
+type Run = { readonly code: number; readonly stdout: string; readonly stderr: string };
+
+async function runUp(
+  workspace: Workspace,
+  platform: FakePlatform,
+  extraEnv: NodeJS.ProcessEnv = {},
+): Promise<Run> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_ENTRY, "self-host", "up"], {
+      cwd: workspace.dir,
+      env: {
+        ...process.env,
+        PATH: `${workspace.binDir}:${process.env.PATH ?? ""}`,
+        EGMA_BASE_URL: platform.url,
+        ...extraEnv,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString("utf8")));
+    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString("utf8")));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+describe("the media server's credential", () => {
+  it("is generated when a workspace is prepared, and is not the published one", async () => {
+    const platform = await startPlatform();
+    const workspace = await makeWorkspace();
+    try {
+      const run = await runUp(workspace, platform);
+
+      expect(run.code).toBe(0);
+      expect(run.stdout).toContain("media_credential: generated");
+
+      const stored = await workspace.storedConfig();
+      const key = stored[KEY_VARIABLE] ?? "";
+      const secret = stored[SECRET_VARIABLE] ?? "";
+
+      expect(key).not.toBe("");
+      expect(secret).not.toBe("");
+      expect(key).not.toBe(PUBLISHED_KEY);
+      expect(secret).not.toBe(PUBLISHED_SECRET);
+      // LiveKit refuses a secret shorter than 32 characters, and a short one is
+      // guessable besides. Asserted rather than trusted, because the length is
+      // one edit away from being trimmed to something tidy-looking.
+      expect(secret.length).toBeGreaterThanOrEqual(32);
+      // Nothing in either value may need quoting: they travel through a
+      // `NAME=value` file egma parses itself, a child process environment, and
+      // a YAML scalar in the compose file.
+      expect(key).toMatch(/^[A-Za-z0-9_-]+$/u);
+      expect(secret).toMatch(/^[A-Za-z0-9_-]+$/u);
+
+      // It is a password between egma's own parts. The operator never sees it.
+      expect(`${run.stdout}\n${run.stderr}`).not.toContain(secret);
+    } finally {
+      await platform.close();
+    }
+  });
+
+  it("hands that one pair to compose, so the three media containers agree", async () => {
+    const platform = await startPlatform();
+    const workspace = await makeWorkspace();
+    try {
+      await runUp(workspace, platform);
+
+      const stored = await workspace.storedConfig();
+      const calls = await workspace.dockerCalls();
+      // A credential written to a file no container reads is no credential at
+      // all: what proves this works is compose being handed the same pair.
+      expect(calls).toContain(`${KEY_VARIABLE}=${stored[KEY_VARIABLE] as string}`);
+      expect(calls).toContain(`${SECRET_VARIABLE}=${stored[SECRET_VARIABLE] as string}`);
+    } finally {
+      await platform.close();
+    }
+  });
+
+  it("leaves a pair that already exists alone, so a second start breaks nothing", async () => {
+    const platform = await startPlatform();
+    const workspace = await makeWorkspace();
+    try {
+      await runUp(workspace, platform);
+      const first = await workspace.storedConfig();
+
+      const second = await runUp(workspace, platform);
+      const after = await workspace.storedConfig();
+
+      expect(second.code).toBe(0);
+      expect(after[KEY_VARIABLE]).toBe(first[KEY_VARIABLE]);
+      expect(after[SECRET_VARIABLE]).toBe(first[SECRET_VARIABLE]);
+      // And it says which of the two happened, because "generated" on a running
+      // deployment is the line that explains why its containers were replaced.
+      expect(second.stdout).toContain("media_credential: existing");
+      expect(second.stdout).not.toContain("media_credential: generated");
+    } finally {
+      await platform.close();
+    }
+  });
+
+  it("gives a workspace prepared before this change a pair, and says so", async () => {
+    const platform = await startPlatform();
+    const workspace = await makeWorkspace();
+    try {
+      // What an upgrading deployment's workspace holds: everything phone setup
+      // wrote, and no media credential, because there was nothing to write it.
+      await mkdir(path.join(workspace.dir, ".egma-platform"), { recursive: true });
+      await writeFile(
+        path.join(workspace.dir, ".egma-platform", "platform.env"),
+        "EGMA_PHONE_SOURCE_NUMBER=+15550100100\nEGMA_SIMULATOR_MEDIA_BACKEND=livekit\n",
+      );
+
+      const run = await runUp(workspace, platform);
+
+      expect(run.code).toBe(0);
+      const stored = await workspace.storedConfig();
+      expect(stored[KEY_VARIABLE]).not.toBe(undefined);
+      expect(stored[SECRET_VARIABLE]).not.toBe(undefined);
+      // Everything the carrier paperwork left behind survives the rewrite.
+      expect(stored.EGMA_PHONE_SOURCE_NUMBER).toBe("+15550100100");
+      expect(stored.EGMA_SIMULATOR_MEDIA_BACKEND).toBe("livekit");
+      // And the operator is told, in sentences, because their media containers
+      // are being replaced by this run — and because what those containers held
+      // until this moment is a security fact they are entitled to hear plainly.
+      expect(run.stderr).toContain("media-server credential was generated");
+      expect(run.stderr).toContain("published in egma's own repository");
+      expect(run.stderr).toContain("media containers are replaced by this start");
+    } finally {
+      await platform.close();
+    }
+  });
+
+  it("keeps a pair the operator brought, and writes it down rather than replacing it", async () => {
+    // `.env.example` names these two variables, so somebody exporting them
+    // meant it — and a CLI that quietly minted its own over the top would be
+    // ignoring a setting it told them to make. Recording it matters as much as
+    // honouring it: a pair that lives only in one shell is one the next start
+    // cannot find, and that start would mint a third and lock the deployment
+    // out of itself.
+    const platform = await startPlatform();
+    const workspace = await makeWorkspace();
+    try {
+      const run = await runUp(workspace, platform, {
+        [KEY_VARIABLE]: "a-key-the-operator-chose",
+        [SECRET_VARIABLE]: "a-secret-the-operator-chose-that-is-long-enough",
+      });
+
+      expect(run.stdout).toContain("media_credential: existing");
+      const stored = await workspace.storedConfig();
+      expect(stored[KEY_VARIABLE]).toBe("a-key-the-operator-chose");
+      expect(stored[SECRET_VARIABLE]).toBe("a-secret-the-operator-chose-that-is-long-enough");
+    } finally {
+      await platform.close();
+    }
+  });
+
+  it("replaces half a pair, because half a credential authenticates nothing", async () => {
+    const platform = await startPlatform();
+    const workspace = await makeWorkspace();
+    try {
+      await mkdir(path.join(workspace.dir, ".egma-platform"), { recursive: true });
+      await writeFile(
+        path.join(workspace.dir, ".egma-platform", "platform.env"),
+        `${KEY_VARIABLE}=a-key-with-no-secret\n`,
+      );
+
+      const run = await runUp(workspace, platform);
+
+      expect(run.stdout).toContain("media_credential: generated");
+      const stored = await workspace.storedConfig();
+      expect(stored[KEY_VARIABLE]).not.toBe("a-key-with-no-secret");
+      expect(stored[SECRET_VARIABLE] ?? "").not.toBe("");
+    } finally {
+      await platform.close();
+    }
+  });
+});

--- a/apps/cli/test/self-host-up.test.ts
+++ b/apps/cli/test/self-host-up.test.ts
@@ -13,97 +13,32 @@
  *
  * So this file proves the two are one value: what is printed is what was set,
  * and a platform that disagrees is a failure here rather than a mystery later.
+ *
+ * The platform and the container runtime this runs against are the shared
+ * stand-ins in `support/platform-workspace.ts`; what it drives is the real CLI
+ * process.
  */
 
-import { spawn } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { CLI_ENTRY } from "./support/workspace.ts";
+import {
+  makePlatformWorkspace,
+  runSelfHost,
+  startPlatform,
+} from "./support/platform-workspace.ts";
 
-type FakePlatform = {
-  readonly url: string;
-  /** Every path asked for, so a test can prove what `up` did *not* do. */
-  readonly asked: readonly string[];
-  close(): Promise<void>;
-};
-
-/** A platform that reports whichever origin it was told to report. */
-async function startPlatform(reports: (own: string) => string): Promise<FakePlatform> {
-  const asked: string[] = [];
-  const server: Server = createServer((request, answer) => {
-    asked.push(`${request.method} ${request.url ?? ""}`);
-    answer.writeHead(200, { "content-type": "application/json" });
-    answer.end(
-      JSON.stringify({
-        instance_id: "pf_00000000000000000000000001",
-        origin: reports(url),
-        phone: { state: "setup_required", missing: ["the carrier trunk"] },
-      }),
-    );
-  });
-  await new Promise<void>((listening) => server.listen(0, "127.0.0.1", listening));
-  const { port } = server.address() as AddressInfo;
-  const url = `http://127.0.0.1:${port}`;
-  return {
-    url,
-    asked,
-    close: () =>
-      new Promise<void>((closed) => {
-        server.close(() => closed());
-      }),
-  };
-}
-
-async function makeWorkspace(): Promise<{ dir: string; binDir: string; dockerCalls(): Promise<string> }> {
-  const dir = await mkdtemp(path.join(tmpdir(), "egma-platform-up-"));
-  await writeFile(path.join(dir, "docker-compose.yml"), "name: egma\nservices: {}\n");
-  const binDir = path.join(dir, "bin");
-  await mkdir(binDir, { recursive: true });
-  const calls = path.join(dir, "docker-calls.txt");
-  await writeFile(calls, "");
-  const shim = path.join(binDir, "docker");
-  // Records the environment it was given as well as the arguments, because
-  // what `up` really has to get right is what compose is told, not what the
-  // command printed about it.
-  await writeFile(
-    shim,
-    `#!/bin/sh\necho "ARGS $@" >> "${calls}"\necho "EGMA_BASE_URL=\${EGMA_BASE_URL}" >> "${calls}"\nexit 0\n`,
-  );
-  await chmod(shim, 0o755);
-  return { dir, binDir, dockerCalls: () => readFile(calls, "utf8") };
-}
-
-async function runUp(
-  workspace: { dir: string; binDir: string },
-  env: NodeJS.ProcessEnv,
-): Promise<{ code: number; stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [CLI_ENTRY, "self-host", "up"], {
-      cwd: workspace.dir,
-      env: { ...process.env, PATH: `${workspace.binDir}:${process.env.PATH ?? ""}`, ...env },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString("utf8")));
-    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString("utf8")));
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
-  });
-}
+const WORKSPACE_PREFIX = "egma-platform-up-";
 
 describe("egma self-host up", () => {
   it("starts the platform, and the address it prints is the one the platform reports", async () => {
-    const platform = await startPlatform((own) => own);
-    const workspace = await makeWorkspace();
+    const platform = await startPlatform();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
-      const run = await runUp(workspace, { EGMA_BASE_URL: platform.url });
+      const run = await runSelfHost(workspace, ["up"], { EGMA_BASE_URL: platform.url });
 
       expect(run.code).toBe(0);
       expect(run.stdout).toContain(`url: ${platform.url}`);
@@ -153,10 +88,10 @@ describe("egma self-host up", () => {
     // started on a LAN address whose API still reports localhost. Every later
     // command in every agent repository would be refused, a directory away
     // from anything that could explain it.
-    const platform = await startPlatform(() => "http://localhost:3101");
-    const workspace = await makeWorkspace();
+    const platform = await startPlatform({ reports: () => "http://localhost:3101" });
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     try {
-      const run = await runUp(workspace, { EGMA_BASE_URL: platform.url });
+      const run = await runSelfHost(workspace, ["up"], { EGMA_BASE_URL: platform.url });
 
       expect(run.code).toBe(4);
       expect(run.stdout).toContain("status: failed");
@@ -176,20 +111,18 @@ describe("egma self-host up", () => {
     // second `up` works. A first run that fails once and works when you type
     // the same thing again is a product that taught its first user to distrust
     // it, so the command types it again itself.
-    const platform = await startPlatform((own) => own);
-    const workspace = await makeWorkspace();
-    const failFirst = path.join(workspace.binDir, "docker");
-    const calls = path.join(workspace.dir, "docker-calls.txt");
+    const platform = await startPlatform();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
     await writeFile(
-      failFirst,
-      `#!/bin/sh\necho "ARGS $@" >> "${calls}"\n` +
-        `n=$(grep -c "^ARGS compose up" "${calls}")\n` +
+      workspace.dockerShim,
+      `#!/bin/sh\necho "ARGS $@" >> "${workspace.callsFile}"\n` +
+        `n=$(grep -c "^ARGS compose up" "${workspace.callsFile}")\n` +
         `if [ "$n" -le 1 ]; then exit 1; fi\nexit 0\n`,
     );
-    await chmod(failFirst, 0o755);
+    await chmod(workspace.dockerShim, 0o755);
 
     try {
-      const run = await runUp(workspace, { EGMA_BASE_URL: platform.url });
+      const run = await runSelfHost(workspace, ["up"], { EGMA_BASE_URL: platform.url });
 
       expect(run.code).toBe(0);
       expect(run.stdout).toContain("status: ready");
@@ -203,11 +136,10 @@ describe("egma self-host up", () => {
 
   it("refuses in a directory that is not a platform workspace", async () => {
     const notAWorkspace = await mkdtemp(path.join(tmpdir(), "egma-not-platform-"));
-    const workspace = await makeWorkspace();
-    const run = await runUp(
-      { dir: notAWorkspace, binDir: workspace.binDir },
-      { EGMA_BASE_URL: "http://127.0.0.1:1" },
-    );
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
+    const run = await runSelfHost({ dir: notAWorkspace, binDir: workspace.binDir }, ["up"], {
+      EGMA_BASE_URL: "http://127.0.0.1:1",
+    });
 
     expect(run.code).toBe(1);
     expect(run.stderr).toContain("this is not a platform workspace");

--- a/apps/cli/test/support/platform-workspace.ts
+++ b/apps/cli/test/support/platform-workspace.ts
@@ -1,0 +1,183 @@
+/**
+ * The two stand-ins every `egma self-host` check needs, in one place.
+ *
+ * A self-host command talks to exactly two things it cannot have in a test: a
+ * running platform, and a container runtime. Everything above those is the real
+ * CLI process and the real command modules, which is the point — a suite that
+ * started Docker would take minutes and a suite that mocked the command would
+ * prove nothing.
+ *
+ * These lived twice, copied between the files that drive `up`. Two copies of a
+ * harness drift, and a drifted harness is two tests that believe they check the
+ * same command and do not, so there is one copy and it lives here.
+ */
+
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { CLI_ENTRY } from "./workspace.ts";
+
+export type FakePlatform = {
+  readonly url: string;
+  /** Every path asked for, so a test can prove what a command did *not* do. */
+  readonly asked: readonly string[];
+  close(): Promise<void>;
+};
+
+export type FakePlatformOptions = {
+  /**
+   * What origin the platform reports about itself, given its own address.
+   *
+   * Its own by default. A test overrides it to build the one disaster `up`
+   * exists to catch: a deployment started on one address whose API reports
+   * another, which makes every later command in every agent repository fail a
+   * directory away from anything that could explain it.
+   */
+  readonly reports?: (own: string) => string;
+  /** Phone readiness, which is reported separately from platform readiness. */
+  readonly phone?: { readonly state: string; readonly missing: readonly string[] };
+};
+
+/** A stand-in for a running platform, answering only what `self-host` reads. */
+export async function startPlatform(
+  options: FakePlatformOptions = {},
+): Promise<FakePlatform> {
+  const phone = options.phone ?? { state: "setup_required", missing: ["the carrier trunk"] };
+  const asked: string[] = [];
+  const server: Server = createServer((request, answer) => {
+    asked.push(`${request.method ?? ""} ${request.url ?? ""}`);
+    answer.writeHead(200, { "content-type": "application/json" });
+    answer.end(
+      JSON.stringify({
+        instance_id: "pf_00000000000000000000000001",
+        origin: options.reports === undefined ? url : options.reports(url),
+        phone: { state: phone.state, missing: phone.missing },
+      }),
+    );
+  });
+  await new Promise<void>((listening) => server.listen(0, "127.0.0.1", listening));
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}`;
+  return {
+    url,
+    asked,
+    close: () =>
+      new Promise<void>((closed) => {
+        server.close(() => closed());
+      }),
+  };
+}
+
+/**
+ * The variables the `docker` stand-in writes down beside the arguments it was
+ * given.
+ *
+ * The environment matters more than the arguments for most of what these
+ * commands promise: what a self-host command really has to get right is what
+ * compose is *told*, not what the command printed about it. A variable a
+ * compose invocation does not carry never reaches a container however it is
+ * set.
+ */
+const RECORDED_VARIABLES = [
+  "EGMA_BASE_URL",
+  "EGMA_LIVEKIT_API_KEY",
+  "EGMA_LIVEKIT_API_SECRET",
+] as const;
+
+export type PlatformWorkspace = {
+  readonly dir: string;
+  readonly binDir: string;
+  /** The `docker` stand-in, for a test that needs one that behaves otherwise. */
+  readonly dockerShim: string;
+  /** Where that stand-in appends what it was asked for. */
+  readonly callsFile: string;
+  dockerCalls(): Promise<string>;
+  /** The platform's own configuration file, whether or not it exists yet. */
+  readonly configFile: string;
+  /** What egma wrote there, as names and values. */
+  storedConfig(): Promise<Record<string, string>>;
+};
+
+/**
+ * A directory shaped like a platform workspace, with a `docker` on its PATH
+ * that succeeds and writes down what it was asked for.
+ *
+ * Standing in for the container runtime rather than for egma: everything the
+ * command does above `docker compose` is the real thing.
+ */
+export async function makePlatformWorkspace(prefix: string): Promise<PlatformWorkspace> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  await writeFile(path.join(dir, "docker-compose.yml"), "name: egma\nservices: {}\n");
+  const binDir = path.join(dir, "bin");
+  await mkdir(binDir, { recursive: true });
+  const callsFile = path.join(dir, "docker-calls.txt");
+  await writeFile(callsFile, "");
+  const dockerShim = path.join(binDir, "docker");
+  await writeFile(
+    dockerShim,
+    `#!/bin/sh\necho "ARGS $@" >> "${callsFile}"\n` +
+      RECORDED_VARIABLES.map(
+        (name) => `echo "${name}=\${${name}}" >> "${callsFile}"\n`,
+      ).join("") +
+      "exit 0\n",
+  );
+  await chmod(dockerShim, 0o755);
+
+  const configFile = path.join(dir, ".egma-platform", "platform.env");
+  return {
+    dir,
+    binDir,
+    dockerShim,
+    callsFile,
+    configFile,
+    dockerCalls: () => readFile(callsFile, "utf8"),
+    storedConfig: async () => {
+      const found: Record<string, string> = {};
+      for (const line of (await readFile(configFile, "utf8")).split("\n")) {
+        const text = line.trim();
+        if (text === "" || text.startsWith("#")) continue;
+        const split = text.indexOf("=");
+        if (split <= 0) continue;
+        found[text.slice(0, split)] = text.slice(split + 1);
+      }
+      return found;
+    },
+  };
+}
+
+export type SelfHostRun = {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+/**
+ * One `egma self-host …` run, as a person would type it.
+ *
+ * The workspace is taken structurally — a directory and a `bin` to find
+ * `docker` in — so that a check can run the command from somewhere that is
+ * deliberately *not* a platform workspace.
+ */
+export async function runSelfHost(
+  workspace: { readonly dir: string; readonly binDir: string },
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv = {},
+): Promise<SelfHostRun> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_ENTRY, "self-host", ...argv], {
+      cwd: workspace.dir,
+      env: { ...process.env, PATH: `${workspace.binDir}:${process.env.PATH ?? ""}`, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString("utf8")));
+    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString("utf8")));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}

--- a/apps/simulator/tests/test_deployment.py
+++ b/apps/simulator/tests/test_deployment.py
@@ -217,6 +217,64 @@ def test_the_default_stack_dials_nothing_until_phone_setup_has_run():
     )
 
 
+MEDIA_CREDENTIAL = ("EGMA_LIVEKIT_API_KEY", "EGMA_LIVEKIT_API_SECRET")
+"""The pair the media server, the simulator and the SIP gateway
+authenticate each other with."""
+
+PUBLISHED_MEDIA_CREDENTIAL = (
+    "egma-devkey",
+    "egma-development-only-livekit-secret-change-it",
+)
+"""What that pair used to fall back to, in this file, in a public
+repository. Named here so the test can say *these exact values* are gone
+rather than merely that some default is absent."""
+
+
+def test_no_development_media_credential_is_left_in_the_deployment_description():
+    """The media server does not run on a credential anyone can read.
+
+    This is a finding rather than a precaution. A running deployment was
+    checked and found using the pair below: all three containers fell back
+    to it, and nothing in the CLI, the skills or the documentation ever
+    replaced them. Published to loopback the exposure is small — and the
+    deployment description invites a wider bind for testing from another
+    machine, at which point the media server accepts anyone who read the
+    repository.
+
+    `egma self-host` generates a pair for the workspace instead. What is
+    asserted here is the half a behavioural test cannot reach: that no
+    default is left in the files a self-hoster copies, and that all three
+    containers read the same two variables, so no two of them can end up
+    holding different halves of one password.
+    """
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    example = (ROOT / ".env.example").read_text(encoding="utf-8")
+
+    for published in PUBLISHED_MEDIA_CREDENTIAL:
+        assert published not in compose, (
+            f"docker-compose.yml still carries {published!r}; a deployment "
+            "started from this file authenticates its media server with a "
+            "value every reader of this repository holds"
+        )
+        assert published not in example, (
+            f".env.example still carries {published!r}; a self-hoster who "
+            "copies it to .env is back on the published pair"
+        )
+
+    for name in MEDIA_CREDENTIAL:
+        read = re.findall(rf"\$\{{{name}(:-[^}}]*)?\}}", compose)
+        assert len(read) == 3, (
+            f"docker-compose.yml reads {name} {len(read)} time(s); the media "
+            "server, the simulator and the SIP gateway all read it, and one "
+            "of them left out is one container holding a different password"
+        )
+        assert set(read) == {":-"}, (
+            f"{name} has a default in docker-compose.yml: {sorted(set(read))}. "
+            "This pair is generated per workspace and has no default; any "
+            "value written here is a credential the whole world already has"
+        )
+
+
 OVERLAY_VARIABLE = re.compile(r"\$\{(EGMA_(?:LIVEKIT|WORKBENCH)_[A-Z0-9_]+)")
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -453,14 +453,17 @@ services:
       #
       # The LiveKit beside it is the default, filled in from the same pair
       # the two containers below authenticate each other with, so the
-      # three halves can never disagree. The backend itself stays unset
-      # until `egma self-host phone setup` has run: a simulator told to
-      # dial with no trunk refuses to start, and platform readiness must
-      # not wait on carrier setup.
+      # three halves can never disagree. That pair has no default here:
+      # `egma self-host` generates one for the workspace and hands it to
+      # all three, so a deployment never runs on a credential published in
+      # this repository. The backend itself stays unset until
+      # `egma self-host phone setup` has run: a simulator told to dial
+      # with no trunk refuses to start, and platform readiness must not
+      # wait on carrier setup.
       EGMA_SIMULATOR_MEDIA_BACKEND: ${EGMA_SIMULATOR_MEDIA_BACKEND:-}
       EGMA_SIMULATOR_LIVEKIT_URL: ${EGMA_SIMULATOR_LIVEKIT_URL:-ws://livekit:7880}
-      EGMA_SIMULATOR_LIVEKIT_API_KEY: ${EGMA_SIMULATOR_LIVEKIT_API_KEY:-${EGMA_LIVEKIT_API_KEY:-egma-devkey}}
-      EGMA_SIMULATOR_LIVEKIT_API_SECRET: ${EGMA_SIMULATOR_LIVEKIT_API_SECRET:-${EGMA_LIVEKIT_API_SECRET:-egma-development-only-livekit-secret-change-it}}
+      EGMA_SIMULATOR_LIVEKIT_API_KEY: ${EGMA_SIMULATOR_LIVEKIT_API_KEY:-${EGMA_LIVEKIT_API_KEY:-}}
+      EGMA_SIMULATOR_LIVEKIT_API_SECRET: ${EGMA_SIMULATOR_LIVEKIT_API_SECRET:-${EGMA_LIVEKIT_API_SECRET:-}}
       EGMA_SIMULATOR_SIP_TRUNK_ID: ${EGMA_SIMULATOR_SIP_TRUNK_ID:-}
       EGMA_SIMULATOR_SIP_TRUNK_ADDRESS: ${EGMA_SIMULATOR_SIP_TRUNK_ADDRESS:-}
       EGMA_SIMULATOR_SIP_TRUNK_NUMBER: ${EGMA_SIMULATOR_SIP_TRUNK_NUMBER:-}
@@ -684,15 +687,19 @@ services:
   # Its ports are published to this machine's loopback and no further —
   # the workbench's idiom, for the same reason: a person at this machine
   # may want to reach it, and nobody else has any business doing so. The
-  # simulator does not come through here; it uses the compose network. That
-  # is also what makes the development key below harmless — it
-  # authenticates traffic that cannot arrive from off this host. Change
-  # `EGMA_LIVEKIT_BIND` and it stops being harmless, so if you ever do,
-  # change the key pair first.
+  # simulator does not come through here; it uses the compose network.
+  #
+  # The pair below has **no default**, and that is a fix rather than an
+  # omission. It used to fall back to a key and a secret written in this
+  # file, in a public repository, and nothing ever replaced them — so a
+  # deployment that widened `EGMA_LIVEKIT_BIND` for testing from another
+  # machine was accepting anyone who had read the repository. `egma
+  # self-host` now generates a pair for the workspace and hands the same
+  # one to this server, the simulator and the gateway below.
   livekit:
     image: livekit/livekit-server:v1.13.5
     environment:
-      LIVEKIT_KEYS: "${EGMA_LIVEKIT_API_KEY:-egma-devkey}: ${EGMA_LIVEKIT_API_SECRET:-egma-development-only-livekit-secret-change-it}"
+      LIVEKIT_KEYS: "${EGMA_LIVEKIT_API_KEY:-}: ${EGMA_LIVEKIT_API_SECRET:-}"
       LIVEKIT_CONFIG: |
         port: 7880
         rtc:
@@ -746,8 +753,10 @@ services:
     entrypoint: ["livekit-sip"]
     environment:
       SIP_CONFIG_BODY: |
-        api_key: ${EGMA_LIVEKIT_API_KEY:-egma-devkey}
-        api_secret: ${EGMA_LIVEKIT_API_SECRET:-egma-development-only-livekit-secret-change-it}
+        # The generated pair, the same one the media server and the
+        # simulator hold. No default, for the reason stated above it.
+        api_key: ${EGMA_LIVEKIT_API_KEY:-}
+        api_secret: ${EGMA_LIVEKIT_API_SECRET:-}
         ws_url: ws://livekit:7880
         redis:
           address: livekit-redis:6379


### PR DESCRIPTION
Closes ticket 01 of the platform-settings effort.

## The problem

The media server, the simulator and the SIP gateway all fell back to a key and secret written into `docker-compose.yml` in this public repository. Nothing in the CLI, the skills or the documentation ever replaced them. A deployment checked while the ticket was written was running on that published pair. On a laptop bound to the local machine the exposure is small — but the deployment description invites a wider binding for testing from another machine, and at that moment the media server accepts anyone who read this repository.

## What changed

- `egma self-host up` generates a random key and secret when the workspace has none, and writes them beside the other bootstrap variables in `.egma-platform/platform.env` (0600, in a 0700 directory). `egma self-host phone setup --apply` does the same, as a fallback for a deployment whose first act after upgrading is carrier setup.
- A pair that already exists is left alone, so preparing again does not invalidate a running deployment.
- The media server, the simulator and the SIP gateway all read the same two variables, so no two of them can disagree.
- The published development pair is gone from `docker-compose.yml` and `.env.example`. It survives only as a test constant.
- An operator upgrading from a deployment that used the published pair is told, in two sentences, that this happened and why.

The operator never sees, chooses or types this pair. It is a password between egma's own parts, in the same class as the Postgres password.

## Notes for the reviewer

- The variables lose their default rather than taking the `${VAR:?}` required form. Ticket 05 of this spec owns converting the whole bootstrap set, and `:?` today would break `pnpm db:up` for everyone. The practical effect is already the one we want: `livekit-server` with an empty pair refuses to start with `Could not parse keys`, and the simulator waits on a healthy media server, so a bare `docker compose up` fails loudly instead of running on a published key. The README says so.
- `writePlatformConfig` lost its `header` parameter. Two commands write that file now, so a header naming only one of them would be wrong; it is a constant in `workspace.ts`.
- `apps/cli/test/support/platform-workspace.ts` is new. It is the shared harness for `self-host-up.test.ts` and `self-host-media-credential.test.ts`, which had grown about 110 duplicated lines between them.

## Tests

`apps/cli/test/self-host-media-credential.test.ts` covers that preparation generates a pair and that a second preparation does not replace it, and asserts the file permissions. `apps/simulator/tests/test_deployment.py` covers that no development default for the pair remains reachable from the deployment description.

`pnpm typecheck` passes. The full suite has two failures, both in `apps/api/test/default-judge-on-signup.test.ts`; both fail identically on the base commit and this branch changes no file under `apps/api` or `packages/`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789333109&installation_model_id=431960&pr_number=76&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F76&signature=bde683526f88005a79efa2e9c0df1107cdcb6d6828962a321b3adcdc61474dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the repository-published media-server credential with a workspace-specific generated pair shared by LiveKit, its SIP gateway, and the simulator.
- Generates and privately persists credentials during self-host preparation.
- Preserves an existing complete pair across subsequent runs.
- Removes development defaults from deployment configuration and documents bare-Compose behavior.
- Adds shared CLI test infrastructure and credential lifecycle coverage.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a displaced credential writer can still overwrite its successor's persisted pair and leave running media components using a different credential.

The previously reported stale-takeover failure remains reachable: ownership is checked only after the configuration write, so an old holder can resume after takeover, replace the successor's credential, and return the replacement on retry while the successor has already supplied its own pair to Compose.

**Files Needing Attention:** apps/cli/src/self-host/media-credential.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/self-host/media-credential.ts | Adds media credential generation, persistence, and token-based coordination between concurrent preparation commands. |
| apps/cli/src/commands/self-host.ts | Integrates the persisted media credential into self-host startup and phone setup Compose environments. |
| apps/cli/src/self-host/workspace.ts | Centralizes the private platform configuration header while retaining atomic configuration writes. |
| docker-compose.yml | Removes the published media credential defaults and routes all media components through deployment-provided variables. |
| apps/cli/test/self-host-media-credential.test.ts | Covers generation, persistence, environment propagation, ordinary concurrency, file permissions, and lock ownership behavior. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as self-host command
    participant Lock as workspace lock
    participant Config as platform.env
    participant Compose
    CLI->>Lock: acquire exclusive token
    CLI->>Config: read existing credential
    alt credential absent
        CLI->>Config: persist generated pair
    end
    CLI->>Lock: release owned token
    CLI->>Compose: start services with returned pair
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Let a lock holder remove only the lock i..."](https://github.com/egma-ai/egma/commit/0320ac195b0228d1ebab914c20deabd07dc58ff2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53480263)</sub>

<!-- /greptile_comment -->