### PR TITLE
The platform stores, seeds and reports its own settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -469,6 +469,26 @@ EGMA_JUDGE_PROVIDER=
 EGMA_JUDGE_MODEL=
 EGMA_JUDGE_API_KEY=
 
+# --- The persona's model, as the platform holds it ----------------------------
+# What the persona thinks with when it calls an agent. These are the platform's
+# own settings: it keeps them in its own store, sealed with EGMA_ENCRYPTION_KEY,
+# rather than only in this file. That is the whole point — a setting the
+# platform holds survives a restart, an upgrade and a move to another machine,
+# and a second simulator on another host needs nothing copied to it.
+#
+# There are two ways to put a setting in and the choice is yours. Setting them
+# here is the one for a deployment that answers no questions: on start the API
+# writes any of them the platform does not already hold. It never replaces one
+# that is already set, so a redeploy carrying an old key cannot undo a new one.
+# The other way is `egma self-host setup`, which asks.
+#
+# Leave them empty and nothing breaks at start: the platform reports
+# `setup required` and names each one that is missing, rather than starting
+# hollow and failing on the first simulation.
+EGMA_PERSONA_MODEL_PROVIDER=
+EGMA_PERSONA_MODEL=
+EGMA_PERSONA_MODEL_API_KEY=
+
 # --- The grader ------------------------------------------------------------
 # The service that judges finished conversations. It claims its work, so it
 # publishes no port and needs no inbound networking.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,3 +1,5 @@
+import type { PlatformSettingValues } from "@egma/db";
+
 import { SERVICE_TOKEN_PREFIX } from "./auth/service-token.ts";
 import type { SmtpSettings } from "./auth/email.ts";
 import type { PhoneSettings } from "./phone-readiness.ts";
@@ -100,6 +102,26 @@ export type Config = {
    * verdicts and says so, exactly as before.
    */
   readonly defaultJudge: DefaultJudge | undefined;
+  /**
+   * The settings this environment offers the platform on start, for anything
+   * the platform does not already hold.
+   *
+   * **This is the second of the two ways a setting gets in, and the operator
+   * chooses which.** One is an interview — `egma self-host setup` asks for each
+   * setting and writes it through the API. The other is this: an automated
+   * deployment answers no questions, so it puts the settings in its environment
+   * and the platform seeds itself from them at start. It is the behaviour the
+   * default judge already has, extended rather than reinvented.
+   *
+   * Empty is the ordinary case and is never an error. A setting absent here is
+   * one somebody supplies through the interface or the setup command, and the
+   * platform says so in its readiness answer until they do.
+   *
+   * Nothing here is ever *replaced* from the environment. See
+   * `seedPlatformSettings`: a redeploy carrying a script's copy of the old key
+   * must not undo a key the operator changed.
+   */
+  readonly platformSettings: PlatformSettingValues;
   /**
    * The object store voice simulations' recordings live in, or `undefined` on a
    * deployment that has named none.
@@ -331,8 +353,47 @@ export function loadConfig(
       speechProvider: environment.EGMA_PHONE_SPEECH_PROVIDER?.trim() || null,
     },
     defaultJudge: defaultJudge(environment),
+    platformSettings: platformSettings(environment),
     blob: blobStore(environment, parsedBaseUrl),
   };
+}
+
+/**
+ * The settings this environment offers the platform, by the name the platform
+ * stores each one under.
+ *
+ * **Each variable is read here, literally and by name, on purpose.** A loop
+ * over the settings catalog would be shorter and would defeat the check that
+ * every variable the API reads is passed to the api container and documented
+ * in `.env.example` — which is a check that exists because that exact gap
+ * happened once already: phone readiness was written, documented and tested,
+ * and then reported `setup required` against a real carrier because the compose
+ * entry never passed the variables through.
+ *
+ * **Unlike the judge's three, these are not all-or-nothing.** Half a judge is a
+ * judge that errors every verdict it is given, so half is refused at startup.
+ * Half of these is an ordinary platform mid-setup: a deployment that supplied
+ * the provider and the model from a script and means to type the key into the
+ * settings form is exactly the case the readiness answer is for, and refusing
+ * to start on it would make seeding an all-or-nothing act rather than a
+ * gap-filling one.
+ */
+function platformSettings(
+  environment: NodeJS.ProcessEnv,
+): PlatformSettingValues {
+  const offered = {
+    persona_model_provider: environment.EGMA_PERSONA_MODEL_PROVIDER?.trim(),
+    persona_model: environment.EGMA_PERSONA_MODEL?.trim(),
+    persona_model_key: environment.EGMA_PERSONA_MODEL_API_KEY?.trim(),
+  };
+
+  // Compose passes an unset optional through as an empty string rather than
+  // leaving it out, so "" and "never set" have to mean the same thing: a blank
+  // model name seeded as a model name would be a platform reporting itself
+  // configured with nothing to ask.
+  return Object.fromEntries(
+    Object.entries(offered).filter(([, value]) => (value ?? "") !== ""),
+  ) as PlatformSettingValues;
 }
 
 /**

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import {
   runClickHouseMigrations,
   runMigrations,
   seedDefaultJudge,
+  seedPlatformSettings,
 } from "@egma/db";
 
 import { loadConfig } from "./config.ts";
@@ -35,7 +36,21 @@ connectClickHouse({ clickhouseUrl: config.clickhouseUrl });
 const judged =
   config.defaultJudge === undefined ? [] : await seedDefaultJudge(config.defaultJudge);
 
+// The settings this environment offers, written for anything the platform does
+// not already hold. This is how an automated deployment configures itself with
+// no interview — and it never replaces a setting somebody has changed, so a
+// redeploy carrying a script's copy of an old key cannot undo a new one.
+const seeded = await seedPlatformSettings(config.platformSettings);
+
 const { app } = buildApi({ config });
+if (seeded.length > 0) {
+  // The names, never the values and never their hints: what is worth saying is
+  // that this platform just gained settings it did not have, and which ones.
+  app.log.info(
+    { settings: seeded },
+    "the environment supplied platform settings this deployment was missing",
+  );
+}
 if (judged.length > 0) {
   // The project ids, never the key and never its hint: what is worth saying is
   // that somebody's grading just started working, and which projects it is

--- a/apps/api/src/platform-readiness.ts
+++ b/apps/api/src/platform-readiness.ts
@@ -1,0 +1,65 @@
+import { PLATFORM_SETTINGS, type PlatformFacts } from "@egma/db";
+
+import type { PhoneReadiness } from "./phone-readiness.ts";
+
+/**
+ * Whether this platform has been set up, and what it is still missing.
+ *
+ * **Readiness stopped being a fact about the phone alone.** The settings a
+ * deployment needs used to live in a file beside it that only the CLI read, and
+ * a platform started any other way had none of them — the phone, the persona's
+ * model, the speech providers, all absent at once, and each absence surfacing
+ * minutes later as a failure naming nothing about configuration. So the
+ * platform answers for its whole configuration here, reading what it holds from
+ * its own store rather than from this process's environment.
+ *
+ * **Everything in the answer is non-secret, and that is what lets it be
+ * answered at the one door that asks for no credential.** It names which
+ * settings are absent, in the words a person would use — "the persona's model
+ * key" rather than a column name — and it never carries a value that any
+ * setting marked secret holds. The one door to a stored secret is the work
+ * order a simulator claims, and it is nowhere near this.
+ *
+ * **This and phone readiness are two facts, not one.** A platform with no
+ * carrier still runs chat and text simulations perfectly well, so `phone` keeps
+ * answering separately and the run door keeps gating on it alone. What this
+ * adds is the whole-platform answer beside it: `setup required` while anything
+ * at all is missing, the carrier included.
+ */
+
+export type PlatformSetupState = "ready" | "setup_required";
+
+export type PlatformReadiness = {
+  readonly state: PlatformSetupState;
+  /**
+   * What setup has not supplied yet, by the name a person would use. Empty when
+   * the state is `ready`. Named rather than counted, because "setup required"
+   * with nothing after it sends a self-hoster to read source.
+   */
+  readonly missing: readonly string[];
+};
+
+/**
+ * The platform's answer, from what its store holds and what its carrier facts
+ * say.
+ *
+ * The phone half is still read from this process's configuration rather than
+ * from the store; moving it is the next ticket's, and this composes the two so
+ * that the answer is already whole while that move happens underneath it.
+ */
+export function platformReadiness(
+  held: PlatformFacts,
+  phone: PhoneReadiness,
+): PlatformReadiness {
+  const missing = [
+    ...PLATFORM_SETTINGS.filter(
+      (setting) => !Object.hasOwn(held, setting.name),
+    ).map((setting) => setting.label),
+    ...phone.missing,
+  ];
+
+  return {
+    state: missing.length === 0 ? "ready" : "setup_required",
+    missing,
+  };
+}

--- a/apps/api/src/routes/platform-settings.ts
+++ b/apps/api/src/routes/platform-settings.ts
@@ -1,7 +1,6 @@
 import {
   authorize,
   NotPermittedError,
-  PLATFORM_SETTINGS,
   readPlatformSettings,
   UnprocessableInputError,
   writePlatformSettings,
@@ -12,7 +11,7 @@ import type { FastifyInstance } from "fastify";
 
 import type { SessionIdentityProvider } from "../auth/seam.ts";
 import { credentialed, requesterOf } from "../http/credentialed.ts";
-import { invalid, notPermitted, unprocessable } from "../http/refusals.ts";
+import { notPermitted, unprocessable } from "../http/refusals.ts";
 import type { RateLimit } from "../http/rate-limit.ts";
 
 /**
@@ -35,16 +34,19 @@ import type { RateLimit } from "../http/rate-limit.ts";
  * shape in which one could be edited in place, because the envelope is sealed
  * over the whole value.
  *
- * **Only an owner may knock, on both doors.** These are the deployment's own
- * provider credentials, which is the row of the permission table that already
- * names provider credentials. A `member` and a `viewer` are refused the read as
- * firmly as the write: reading is how you learn whose account this platform
- * spends from.
+ * **Only a single organization's owner may knock, on both doors.** These are
+ * the deployment's own provider credentials, which is the row of the permission
+ * table that already names provider credentials — so a `member` and a `viewer`
+ * are refused the read as firmly as the write, because reading is how you learn
+ * whose account this platform spends from. And the whole group is refused on a
+ * deployment serving more than one organization, where these settings belong to
+ * none of them; the factory holds both halves and says why.
  *
- * **Unknown keys are refused by name.** The body is small and every key in it
- * changes what the platform will speak with, so a typo quietly ignored would be
- * an operator believing they had set something they had not. The agent group's
- * gate, for the agent group's reason.
+ * **Unknown keys are refused by name, once.** The body is small and every key
+ * in it changes what the platform will speak with, so a typo quietly ignored
+ * would be an operator believing they had set something they had not. That
+ * refusal is the factory's — this door does not check the same thing a second
+ * time, because one condition answered two ways is a contract with two faces.
  *
  * The address follows the standing rule: nothing is rooted at a project and the
  * organization is never in a path. Neither appears here at all, because these
@@ -54,6 +56,12 @@ import type { RateLimit } from "../http/rate-limit.ts";
 export type PlatformSettingsRoutesOptions = {
   readonly provider: SessionIdentityProvider;
   readonly rateLimit: RateLimit;
+  /**
+   * Whether this deployment serves one organization. Handed to the factory on
+   * every call: it is what decides whether anybody at all may be here, and the
+   * flag lives in this process's configuration rather than in the store.
+   */
+  readonly singleOrganization: boolean;
 };
 
 export const PLATFORM_SETTINGS_PATH = "/api/platform/settings";
@@ -78,24 +86,6 @@ function answer(held: readonly PlatformSetting[]): Record<string, unknown> {
   return { settings: held.map(described) };
 }
 
-/**
- * The unknown-key gate. Refusing by name rather than ignoring is what turns a
- * typo into an answer a person can act on: a misspelled setting that was
- * silently dropped would leave the platform reporting `setup required` for
- * something its operator is certain they supplied.
- */
-function unknownKeyIn(body: Body): string | undefined {
-  const known = PLATFORM_SETTINGS.map((setting) => setting.name);
-  for (const key of Object.keys(body)) {
-    if ((known as readonly string[]).includes(key)) continue;
-    return (
-      `this egma has no platform setting "${key}"; it holds ` +
-      `${known.join(", ")}`
-    );
-  }
-  return undefined;
-}
-
 export async function platformSettingsRoutes(
   app: FastifyInstance,
   options: PlatformSettingsRoutesOptions,
@@ -115,17 +105,21 @@ export async function platformSettingsRoutes(
    */
   app.get(PLATFORM_SETTINGS_PATH, async (request, reply) => {
     const { auth } = requesterOf(request);
-    return reply.send(answer(await readPlatformSettings(auth)));
+    const held = await readPlatformSettings(auth, {
+      singleOrganization: options.singleOrganization,
+    });
+    return reply.send(answer(held));
   });
 
   /**
    * A setting written, or several.
    *
    * The role is checked before anything in the body is looked at, which is the
-   * stance every write in this API takes and which matters here for a reason of
-   * its own: the unknown-key refusal below names every setting this platform
-   * holds, and somebody who may not read the settings must not learn their
-   * names by misspelling one.
+   * stance every write in this API takes: somebody who may not do this is
+   * refused for who they are, rather than after a refusal that has read what
+   * they sent. The factory checks it again — and checks the deployment's mode
+   * with it — because a factory that trusted its callers would be one route
+   * away from not being checked at all.
    */
   app.patch(PLATFORM_SETTINGS_PATH, async (request, reply) => {
     const { auth } = requesterOf(request);
@@ -136,11 +130,9 @@ export async function platformSettingsRoutes(
       projectId: auth.projectId,
     });
 
-    const unknown = unknownKeyIn(body);
-    if (unknown !== undefined) return invalid(reply, unknown);
-
     const written = await writePlatformSettings(
       auth,
+      { singleOrganization: options.singleOrganization },
       body as PlatformSettingValues,
     );
     return reply.send(answer(written));
@@ -155,9 +147,10 @@ export async function platformSettingsRoutes(
    * other group relays `NotPermittedError`'s own message, which reads "a member
    * may not manage_organization" — the name of a row in the permission table,
    * written for whoever is reading the code rather than for the colleague who
-   * just tried to look at the platform's settings. There is one action behind
-   * this whole group, so there is exactly one thing that sentence could ever be
-   * about, and it is worth saying in words.
+   * just tried to look at the platform's settings. One action stands behind
+   * this whole group, so the sentence names both of the ways a caller can meet
+   * it — the role they hold, and the kind of deployment this is — and lets them
+   * see which of the two is theirs.
    */
   app.setErrorHandler(async (error, _request, reply) => {
     if (error instanceof UnprocessableInputError) {
@@ -168,10 +161,13 @@ export async function platformSettingsRoutes(
       return notPermitted(
         reply,
         "the settings of this platform are read and changed by an " +
-          "organization owner. They are the deployment's own provider " +
-          "credentials — whose account every simulation is conducted on — " +
-          "which is a decision of the same kind as billing rather than of the " +
-          "same kind as writing a test.",
+          "organization owner, and only while this egma serves one " +
+          "organization. They are the deployment's own provider credentials — " +
+          "whose account every simulation is conducted on — which is a " +
+          "decision of the same kind as billing rather than of the same kind " +
+          "as writing a test; and where several organizations share a platform " +
+          "they belong to none of them, so egma refuses everybody rather than " +
+          "picking one.",
       );
     }
 

--- a/apps/api/src/routes/platform-settings.ts
+++ b/apps/api/src/routes/platform-settings.ts
@@ -1,0 +1,180 @@
+import {
+  authorize,
+  NotPermittedError,
+  PLATFORM_SETTINGS,
+  readPlatformSettings,
+  UnprocessableInputError,
+  writePlatformSettings,
+  type PlatformSetting,
+  type PlatformSettingValues,
+} from "@egma/db";
+import type { FastifyInstance } from "fastify";
+
+import type { SessionIdentityProvider } from "../auth/seam.ts";
+import { credentialed, requesterOf } from "../http/credentialed.ts";
+import { invalid, notPermitted, unprocessable } from "../http/refusals.ts";
+import type { RateLimit } from "../http/rate-limit.ts";
+
+/**
+ * The settings this deployment holds, as an organization owner reads and
+ * changes them.
+ *
+ * Four things about this group are contract rather than convenience.
+ *
+ * **No read ever answers a stored secret.** What comes back for a setting is a
+ * *hint*: the whole value where the setting is not a secret — a provider's
+ * name, a model's name — and the last four characters where it is, so that two
+ * keys can be told apart without either being handed to a browser. There is no
+ * query, no header and no role that widens that, because the sealed column is
+ * not among the ones the read selects at all. A stolen browser record is
+ * therefore not a stolen provider account.
+ *
+ * **An edit changes what it names and nothing else.** One row per setting is
+ * what makes that structural: changing the model on a settings form cannot drop
+ * the key beside it, and a value is replaced whole or left alone — there is no
+ * shape in which one could be edited in place, because the envelope is sealed
+ * over the whole value.
+ *
+ * **Only an owner may knock, on both doors.** These are the deployment's own
+ * provider credentials, which is the row of the permission table that already
+ * names provider credentials. A `member` and a `viewer` are refused the read as
+ * firmly as the write: reading is how you learn whose account this platform
+ * spends from.
+ *
+ * **Unknown keys are refused by name.** The body is small and every key in it
+ * changes what the platform will speak with, so a typo quietly ignored would be
+ * an operator believing they had set something they had not. The agent group's
+ * gate, for the agent group's reason.
+ *
+ * The address follows the standing rule: nothing is rooted at a project and the
+ * organization is never in a path. Neither appears here at all, because these
+ * settings belong to the deployment rather than to any customer on it.
+ */
+
+export type PlatformSettingsRoutesOptions = {
+  readonly provider: SessionIdentityProvider;
+  readonly rateLimit: RateLimit;
+};
+
+export const PLATFORM_SETTINGS_PATH = "/api/platform/settings";
+
+type Body = Record<string, unknown>;
+
+/** One setting as every read of one describes it. */
+function described(setting: PlatformSetting): Record<string, unknown> {
+  return {
+    name: setting.name,
+    label: setting.label,
+    secret: setting.secret,
+    // Null rather than absent, so a client can tell "the platform holds none of
+    // this" from "this answer is an older shape that never carried one" — and
+    // so a setup interview knows exactly what is left to ask for.
+    hint: setting.hint,
+    updated_at: setting.updatedAt?.toISOString() ?? null,
+  };
+}
+
+function answer(held: readonly PlatformSetting[]): Record<string, unknown> {
+  return { settings: held.map(described) };
+}
+
+/**
+ * The unknown-key gate. Refusing by name rather than ignoring is what turns a
+ * typo into an answer a person can act on: a misspelled setting that was
+ * silently dropped would leave the platform reporting `setup required` for
+ * something its operator is certain they supplied.
+ */
+function unknownKeyIn(body: Body): string | undefined {
+  const known = PLATFORM_SETTINGS.map((setting) => setting.name);
+  for (const key of Object.keys(body)) {
+    if ((known as readonly string[]).includes(key)) continue;
+    return (
+      `this egma has no platform setting "${key}"; it holds ` +
+      `${known.join(", ")}`
+    );
+  }
+  return undefined;
+}
+
+export async function platformSettingsRoutes(
+  app: FastifyInstance,
+  options: PlatformSettingsRoutesOptions,
+): Promise<void> {
+  credentialed(app, {
+    provider: options.provider,
+    rateLimit: options.rateLimit,
+  });
+
+  /**
+   * Every setting this platform knows about, held or not.
+   *
+   * The ones it does not hold are answered too, with a null hint, because the
+   * question anybody asks here is *what is still missing* — a list of only what
+   * is present would answer it by omission, which is how a setting gets
+   * forgotten.
+   */
+  app.get(PLATFORM_SETTINGS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    return reply.send(answer(await readPlatformSettings(auth)));
+  });
+
+  /**
+   * A setting written, or several.
+   *
+   * The role is checked before anything in the body is looked at, which is the
+   * stance every write in this API takes and which matters here for a reason of
+   * its own: the unknown-key refusal below names every setting this platform
+   * holds, and somebody who may not read the settings must not learn their
+   * names by misspelling one.
+   */
+  app.patch(PLATFORM_SETTINGS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const body = (request.body ?? {}) as Body;
+
+    authorize(auth, "manage_organization", {
+      organizationId: auth.organizationId,
+      projectId: auth.projectId,
+    });
+
+    const unknown = unknownKeyIn(body);
+    if (unknown !== undefined) return invalid(reply, unknown);
+
+    const written = await writePlatformSettings(
+      auth,
+      body as PlatformSettingValues,
+    );
+    return reply.send(answer(written));
+  });
+
+  /**
+   * The refusals this group owns, each answered as an answer rather than as a
+   * fault. A factory's sentence is relayed word for word — a client puts it in
+   * front of whoever is holding the terminal, so the wording is the contract.
+   *
+   * **The permission refusal is the one exception, and deliberately.** Every
+   * other group relays `NotPermittedError`'s own message, which reads "a member
+   * may not manage_organization" — the name of a row in the permission table,
+   * written for whoever is reading the code rather than for the colleague who
+   * just tried to look at the platform's settings. There is one action behind
+   * this whole group, so there is exactly one thing that sentence could ever be
+   * about, and it is worth saying in words.
+   */
+  app.setErrorHandler(async (error, _request, reply) => {
+    if (error instanceof UnprocessableInputError) {
+      return unprocessable(reply, error.message);
+    }
+
+    if (error instanceof NotPermittedError) {
+      return notPermitted(
+        reply,
+        "the settings of this platform are read and changed by an " +
+          "organization owner. They are the deployment's own provider " +
+          "credentials — whose account every simulation is conducted on — " +
+          "which is a decision of the same kind as billing rather than of the " +
+          "same kind as writing a test.",
+      );
+    }
+
+    throw error;
+  });
+}

--- a/apps/api/src/routes/platform.ts
+++ b/apps/api/src/routes/platform.ts
@@ -1,7 +1,8 @@
-import { platformInstanceId } from "@egma/db";
+import { platformFacts, platformInstanceId } from "@egma/db";
 import type { FastifyPluginAsync } from "fastify";
 
 import type { PhoneReadiness } from "../phone-readiness.ts";
+import { platformReadiness } from "../platform-readiness.ts";
 
 export type PlatformRouteOptions = {
   /** The one browser/API origin configured for this platform. */
@@ -29,10 +30,21 @@ export const platformRoutes: FastifyPluginAsync<PlatformRouteOptions> = async (
   app,
   options,
 ) => {
-  app.get(PLATFORM_IDENTITY_PATH, async (_request, reply) =>
-    reply.send({
+  app.get(PLATFORM_IDENTITY_PATH, async (_request, reply) => {
+    // Read from the store on every request rather than held from start, which
+    // is the whole point of the settings living there: an operator who supplies
+    // a missing key stops being `setup required` at once, without a restart.
+    // It is a select and never an insert, on the identity read's own reasoning
+    // — this door is public and anybody who can reach the platform may knock as
+    // often as they like.
+    const setup = platformReadiness(await platformFacts(), options.phone);
+
+    return reply.send({
       instance_id: await platformInstanceId(),
       origin: options.origin,
+      // What the whole platform is still missing, in the words a person would
+      // use, and never a secret — see `platform-readiness.ts`.
+      setup: { state: setup.state, missing: setup.missing },
       // Two facts, never one: a platform is ready for text work long before
       // anybody has given it a carrier, and a single "ready" that waited for
       // the carrier would make the first-run story impossible to tell.
@@ -40,6 +52,6 @@ export const platformRoutes: FastifyPluginAsync<PlatformRouteOptions> = async (
         state: options.phone.state,
         missing: options.phone.missing,
       },
-    }),
-  );
+    });
+  });
 };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -19,6 +19,7 @@ import { memberRoutes } from "./routes/members.ts";
 import { mockToolRoutes } from "./routes/mock-tools.ts";
 import { phoneReadiness } from "./phone-readiness.ts";
 import { platformRoutes } from "./routes/platform.ts";
+import { platformSettingsRoutes } from "./routes/platform-settings.ts";
 import { recordingRoutes } from "./routes/recordings.ts";
 import { reportRoutes } from "./routes/reports.ts";
 import { runRoutes } from "./routes/runs.ts";
@@ -227,6 +228,18 @@ export function buildApi(options: ServerOptions): Api {
     rateLimit,
     emailSender,
     baseUrl: config.baseUrl,
+  });
+
+  // What this deployment has been configured with, as an owner reads and
+  // changes it. Its own credentialed scope, like every other group, so its one
+  // refusal — the settings of a platform are not everybody's to see — never
+  // reaches another group's error handler. It sits beside the public platform
+  // route rather than inside it: they answer at addresses that share a prefix
+  // and share nothing else, one asking for no credential and one refusing
+  // anybody but an owner.
+  void app.register(platformSettingsRoutes, {
+    provider: identity.provider,
+    rateLimit,
   });
 
   // What a developer's folder syncs against. Its own scope, like every other

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -240,6 +240,12 @@ export function buildApi(options: ServerOptions): Api {
   void app.register(platformSettingsRoutes, {
     provider: identity.provider,
     rateLimit,
+    // The same flag the platform's own judge is gated on a few lines above, and
+    // for the same reason: what a deployment holds for itself is an owner's to
+    // read and to change only while that owner is the whole deployment. On one
+    // serving several customers these settings belong to none of them, and the
+    // question of whose they are is not answered yet.
+    singleOrganization: config.singleOrganization,
   });
 
   // What a developer's folder syncs against. Its own scope, like every other

--- a/apps/api/test/platform-info.test.ts
+++ b/apps/api/test/platform-info.test.ts
@@ -11,6 +11,22 @@ import {
 import { testConfig } from "./support/api.ts";
 
 /**
+ * What a platform nobody has configured answers about its own setup: every
+ * setting it needs, named in the words a person would use, and nothing else.
+ */
+const NOTHING_SET_UP = {
+  state: "setup_required",
+  missing: [
+    "the persona's model provider",
+    "the persona's model",
+    "the persona's model key",
+    "the carrier trunk",
+    "the source number",
+    "the speech provider",
+  ],
+};
+
+/**
  * The public identity survives the API object that first read it.
  *
  * Both objects use the same real Postgres database. Closing the first object
@@ -33,10 +49,19 @@ it("keeps one public platform identity across an API restart", async () => {
     const first = await app.inject({ method: "GET", url: "/api/platform" });
     expect(first.statusCode).toBe(200);
     const identity = first.json<Record<string, unknown>>();
-    expect(Object.keys(identity).sort()).toEqual(["instance_id", "origin", "phone"]);
+    expect(Object.keys(identity).sort()).toEqual([
+      "instance_id",
+      "origin",
+      "phone",
+      "setup",
+    ]);
     expect(identity).toEqual({
       instance_id: expect.stringMatching(/^pf_[0-9A-HJKMNP-TV-Z]{26}$/u),
       origin: config.baseUrl,
+      // What the whole platform is still missing, read from the platform's own
+      // store rather than from this process's environment — which is why it
+      // survives a restart with nothing carried across but the database.
+      setup: NOTHING_SET_UP,
       // Phone readiness is a second fact and never a component of the first.
       // A platform with no carrier is ready — it runs text simulations
       // perfectly well — and saying otherwise would make the first-run story
@@ -98,6 +123,7 @@ it("reads its identity rather than writing on every public request", async () =>
       expect(again.json()).toEqual({
         instance_id: minted.instance_id,
         origin: config.baseUrl,
+        setup: NOTHING_SET_UP,
         // A platform nobody has set a carrier up on says so here rather than
         // anywhere a developer has to go looking, and says it separately from
         // being ready — it runs text simulations perfectly well.
@@ -141,6 +167,7 @@ it("reads its identity rather than writing on every public request", async () =>
     expect(cold.json()).toEqual({
       instance_id: minted.instance_id,
       origin: config.baseUrl,
+      setup: NOTHING_SET_UP,
       phone: {
       state: "setup_required",
       missing: ["the carrier trunk", "the source number", "the speech provider"],

--- a/apps/api/test/platform-settings-routes.test.ts
+++ b/apps/api/test/platform-settings-routes.test.ts
@@ -1,0 +1,448 @@
+import { seedPlatformSettings } from "@egma/db";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  colleagueOf,
+  request as ask,
+  signUp,
+  type Answer,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The platform's own settings, over real HTTP against real Postgres.
+ *
+ * **What this file is about.** A self-hoster configures their platform once.
+ * Every one of those settings used to live in a single file beside the
+ * deployment that only the egma CLI read, so starting the platform any other
+ * way lost all of them at once — and absent did not fail, because each variable
+ * had an empty default. Every container started, every health check passed, the
+ * platform reported itself ready, and the failure arrived minutes later as a
+ * provider refusal naming nothing about configuration.
+ *
+ * So the platform owns its settings now, in its own store. What is asserted
+ * here is what somebody outside the module can observe: a setting written is a
+ * setting the platform holds, what lands in storage is not the plain value, a
+ * setting read back has no key in it, and the readiness answer names what is
+ * still missing in words a person reads. Nothing below knows the name of a
+ * column or the shape of a sealed string.
+ *
+ * Refusal wording is contract — it is read in a terminal and acted on — so a
+ * sentence that changed without somebody deciding to change it fails here.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const A_REAL_KEY = "sk-the-operator-pasted-this-one-QRST";
+const A_SECOND_KEY = "sk-and-then-replaced-it-with-this-WXYZ";
+
+/** What a fully configured phone half looks like, for the `ready` case. */
+const A_CARRIER = {
+  trunkAddress: "acme.pstn.twilio.com",
+  sourceNumber: "+15550100",
+  speechProvider: "openai",
+} as const;
+
+function request(
+  method: "GET" | "PATCH",
+  key: string,
+  payload?: Record<string, unknown>,
+): Promise<Answer> {
+  return ask(api.app, method, "/api/platform/settings", key, payload);
+}
+
+/** One setting as the wire describes it, by name. */
+function settingsIn(body: Record<string, unknown>): Record<string, unknown> {
+  const listed = body.settings as { name: string }[];
+  return Object.fromEntries(listed.map((setting) => [setting.name, setting]));
+}
+
+/** What the platform says about its own setup, at the door that asks for nothing. */
+async function readiness(): Promise<{
+  state: string;
+  missing: readonly string[];
+}> {
+  const answered = await api.app.inject({ method: "GET", url: "/api/platform" });
+  expect(answered.statusCode).toBe(200);
+  return (answered.json() as { setup: { state: string; missing: string[] } })
+    .setup;
+}
+
+/** An owner, which is what a self-hoster is on the platform they run. */
+async function owner(label: string): Promise<Customer> {
+  api = await createApi(label);
+  return signUp(api.app, "ada@acme.example", "Acme");
+}
+
+describe("writing the platform's settings", () => {
+  it("answers every setting it knows about, with a hint and never a key", async () => {
+    const ada = await owner("platform_settings_write");
+
+    const written = await request("PATCH", ada.secret, {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: A_REAL_KEY,
+    });
+
+    expect(written.statusCode, JSON.stringify(written.body)).toBe(200);
+    const held = settingsIn(written.body);
+    expect(held.persona_model_provider).toEqual({
+      name: "persona_model_provider",
+      label: "the persona's model provider",
+      secret: false,
+      hint: "openai",
+      updated_at: expect.any(String),
+    });
+    // Enough to tell two keys apart, and nothing anybody could spend with.
+    expect(held.persona_model_key).toMatchObject({
+      label: "the persona's model key",
+      secret: true,
+      hint: "QRST",
+    });
+    expect(JSON.stringify(written.body)).not.toContain(A_REAL_KEY);
+  });
+
+  it("seals what it stores, so a copy of the database is not a copy of the account", async () => {
+    const ada = await owner("platform_settings_sealed");
+    await request("PATCH", ada.secret, { persona_model_key: A_REAL_KEY });
+
+    // The one read in this file that goes around the API, on purpose: the claim
+    // is that what is stored is ciphertext, and only a read the API cannot
+    // dress up can say so.
+    const { rows } = await api.database.sql<{ value: string }>(
+      "select value from platform_setting where name = $1",
+      ["persona_model_key"],
+    );
+    expect(rows[0]?.value).not.toContain(A_REAL_KEY);
+    expect(rows[0]?.value.startsWith("v1.")).toBe(true);
+  });
+
+  it("changes what it names and leaves the rest alone", async () => {
+    const ada = await owner("platform_settings_partial");
+    await request("PATCH", ada.secret, {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: A_REAL_KEY,
+    });
+
+    // A settings form changes one field at a time, which is the whole reason
+    // there is a row for each setting rather than one sealed document.
+    const edited = await request("PATCH", ada.secret, {
+      persona_model_key: A_SECOND_KEY,
+    });
+
+    const held = settingsIn(edited.body);
+    expect(held.persona_model_key).toMatchObject({ hint: "WXYZ" });
+    expect(held.persona_model).toMatchObject({ hint: "gpt-4o" });
+  });
+
+  it("reads back what a restart would read, because the platform holds it", async () => {
+    const ada = await owner("platform_settings_read");
+    await request("PATCH", ada.secret, {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: A_REAL_KEY,
+    });
+
+    const read = await request("GET", ada.secret);
+
+    expect(read.statusCode).toBe(200);
+    expect(settingsIn(read.body).persona_model).toMatchObject({
+      hint: "gpt-4o",
+    });
+    expect(JSON.stringify(read.body)).not.toContain(A_REAL_KEY);
+  });
+
+  it("belongs to the deployment, so the stored row names no customer", async () => {
+    const ada = await owner("platform_settings_deployment_scoped");
+    await request("PATCH", ada.secret, { persona_model: "gpt-4o" });
+
+    const { rows } = await api.database.sql<{ column_name: string }>(
+      `select column_name from information_schema.columns
+        where table_name = 'platform_setting'`,
+    );
+    const columns = rows.map((row) => row.column_name);
+
+    expect(columns).not.toContain("organization_id");
+    expect(columns).not.toContain("project_id");
+  });
+});
+
+describe("who may read and change them", () => {
+  it("refuses a member both, and says why in a sentence", async () => {
+    const ada = await owner("platform_settings_member");
+    const bruno = await colleagueOf(
+      api.app,
+      ada,
+      "bruno@acme.example",
+      "member",
+    );
+
+    const read = await request("GET", bruno.secret);
+    const write = await request("PATCH", bruno.secret, {
+      persona_model: "gpt-4o",
+    });
+
+    for (const refused of [read, write]) {
+      expect(refused.statusCode).toBe(403);
+      expect(refused.body.message).toBe(
+        "the settings of this platform are read and changed by an " +
+          "organization owner. They are the deployment's own provider " +
+          "credentials — whose account every simulation is conducted on — " +
+          "which is a decision of the same kind as billing rather than of the " +
+          "same kind as writing a test.",
+      );
+    }
+  });
+
+  it("refuses a viewer the same two", async () => {
+    const ada = await owner("platform_settings_viewer");
+    const cleo = await colleagueOf(api.app, ada, "cleo@acme.example", "viewer");
+
+    expect((await request("GET", cleo.secret)).statusCode).toBe(403);
+    expect(
+      (await request("PATCH", cleo.secret, { persona_model: "gpt-4o" }))
+        .statusCode,
+    ).toBe(403);
+  });
+
+  it("tells a refused member nothing about what the platform holds", async () => {
+    const ada = await owner("platform_settings_refusal_says_nothing");
+    await request("PATCH", ada.secret, { persona_model_key: A_REAL_KEY });
+    const bruno = await colleagueOf(
+      api.app,
+      ada,
+      "bruno@acme.example",
+      "member",
+    );
+
+    const refused = await request("GET", bruno.secret);
+
+    expect(JSON.stringify(refused.body)).not.toContain("QRST");
+    expect(JSON.stringify(refused.body)).not.toContain(A_REAL_KEY);
+
+    // Not the names of the settings either, which the unknown-key refusal
+    // recites: somebody who may not read them must not learn what they are by
+    // misspelling one, so the role is answered before the body is looked at.
+    const guessed = await request("PATCH", bruno.secret, {
+      persona_moddel: "gpt-4o",
+    });
+    expect(guessed.statusCode).toBe(403);
+    expect(JSON.stringify(guessed.body)).not.toContain("persona_model_key");
+  });
+});
+
+describe("a write that cannot be acted on", () => {
+  it("refuses a key this platform has no setting for, by name", async () => {
+    const ada = await owner("platform_settings_unknown_key");
+
+    const refused = await request("PATCH", ada.secret, {
+      persona_moddel: "gpt-4o",
+    });
+
+    expect(refused.statusCode).toBe(400);
+    expect(refused.body.message).toBe(
+      'this egma has no platform setting "persona_moddel"; it holds ' +
+        "persona_model_provider, persona_model, persona_model_key",
+    );
+  });
+
+  it("refuses a secret too short for any provider to have issued it", async () => {
+    const ada = await owner("platform_settings_short_key");
+
+    const refused = await request("PATCH", ada.secret, {
+      persona_model_key: "sk-abc",
+    });
+
+    expect(refused.statusCode).toBe(422);
+    expect(refused.body.message).toBe(
+      "the persona's model key is at least 8 characters, and this one is " +
+        "shorter than any provider issues",
+    );
+  });
+
+  it("refuses an empty value, because clearing a setting is not writing one", async () => {
+    const ada = await owner("platform_settings_empty_value");
+
+    const refused = await request("PATCH", ada.secret, { persona_model: "  " });
+
+    expect(refused.statusCode).toBe(422);
+    expect(refused.body.message).toContain("the persona's model needs a value");
+  });
+});
+
+describe("what the platform says about its own setup", () => {
+  it("names every absent setting while any are absent", async () => {
+    api = await createApi("platform_settings_readiness_missing");
+
+    expect(await readiness()).toEqual({
+      state: "setup_required",
+      missing: [
+        "the persona's model provider",
+        "the persona's model",
+        "the persona's model key",
+        "the carrier trunk",
+        "the source number",
+        "the speech provider",
+      ],
+    });
+  });
+
+  it("stops naming a setting the moment somebody supplies it", async () => {
+    api = await createApi("platform_settings_readiness_narrows", {
+      phone: { ...A_CARRIER },
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+    await request("PATCH", ada.secret, {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+    });
+
+    // No restart between the write and this read: the answer is built from the
+    // store on every request, which is the whole point of the store.
+    expect(await readiness()).toEqual({
+      state: "setup_required",
+      missing: ["the persona's model key"],
+    });
+  });
+
+  it("answers ready once nothing is missing", async () => {
+    api = await createApi("platform_settings_readiness_ready", {
+      phone: { ...A_CARRIER },
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+    await request("PATCH", ada.secret, {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: A_REAL_KEY,
+    });
+
+    expect(await readiness()).toEqual({ state: "ready", missing: [] });
+  });
+
+  it("carries no secret, at a door that asks for no credential", async () => {
+    api = await createApi("platform_settings_readiness_is_public", {
+      phone: { ...A_CARRIER },
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    await request("PATCH", ada.secret, {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: A_REAL_KEY,
+    });
+
+    const answered = await api.app.inject({
+      method: "GET",
+      url: "/api/platform",
+    });
+
+    // Not the key, and not the hint of one either: this answer is read by
+    // anybody who can reach the platform, before login and before a repository
+    // identifier is ever sent.
+    expect(answered.body).not.toContain(A_REAL_KEY);
+    expect(answered.body).not.toContain("QRST");
+  });
+});
+
+/** The variables a container must have whatever else it was started with. */
+const A_CONTAINERS_ENVIRONMENT = {
+  DATABASE_URL: "postgres://unused/unused",
+  CLICKHOUSE_URL: "http://unused/unused",
+  EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
+  EGMA_ENCRYPTION_KEY: "0123456789abcdef".repeat(4),
+  EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
+  EGMA_BASE_URL: "http://localhost:3101",
+} as const;
+
+describe("a deployment that answers no questions", () => {
+  it("reads what its environment named as the settings to seed", async () => {
+    const config = loadConfig({
+      ...A_CONTAINERS_ENVIRONMENT,
+      EGMA_PERSONA_MODEL_PROVIDER: "openai",
+      EGMA_PERSONA_MODEL: "gpt-4o",
+      EGMA_PERSONA_MODEL_API_KEY: A_REAL_KEY,
+    });
+
+    expect(config.platformSettings).toEqual({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: A_REAL_KEY,
+    });
+  });
+
+  it("treats an empty variable as one nobody set", async () => {
+    // This is the original failure's own shape, met at the door it used to come
+    // through: compose passes an unset optional as an empty string, and a blank
+    // seeded as a value would be a platform reporting itself configured with
+    // nothing to speak to.
+    const config = loadConfig({
+      ...A_CONTAINERS_ENVIRONMENT,
+      EGMA_PERSONA_MODEL_PROVIDER: "openai",
+      EGMA_PERSONA_MODEL: "",
+      EGMA_PERSONA_MODEL_API_KEY: "   ",
+    });
+
+    expect(config.platformSettings).toEqual({ persona_model_provider: "openai" });
+  });
+
+  it("holds nothing to seed on a deployment that named none", async () => {
+    expect(loadConfig({ ...A_CONTAINERS_ENVIRONMENT }).platformSettings).toEqual(
+      {},
+    );
+  });
+
+  it("writes what its environment named, and reads it back through the API", async () => {
+    // What `index.ts` does at start, with the values `loadConfig` read out of
+    // the environment: an automated deployment configures itself and nobody
+    // types anything.
+    api = await createApi("platform_settings_seeded_from_environment");
+    const written = await seedPlatformSettings(
+      loadConfig({
+        ...A_CONTAINERS_ENVIRONMENT,
+        EGMA_PERSONA_MODEL_PROVIDER: "openai",
+        EGMA_PERSONA_MODEL: "gpt-4o",
+        EGMA_PERSONA_MODEL_API_KEY: A_REAL_KEY,
+      }).platformSettings,
+    );
+    expect([...written].sort()).toEqual([
+      "persona_model",
+      "persona_model_key",
+      "persona_model_provider",
+    ]);
+
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const read = await request("GET", ada.secret);
+
+    expect(settingsIn(read.body).persona_model_key).toMatchObject({
+      hint: "QRST",
+    });
+    expect(JSON.stringify(read.body)).not.toContain(A_REAL_KEY);
+  });
+
+  it("leaves a setting somebody changed exactly as they left it", async () => {
+    api = await createApi("platform_settings_seed_never_replaces");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    await request("PATCH", ada.secret, { persona_model_key: A_SECOND_KEY });
+
+    // The next start, with the old key still in the deployment script.
+    expect(
+      await seedPlatformSettings({
+        persona_model: "gpt-4o",
+        persona_model_key: A_REAL_KEY,
+      }),
+    ).toEqual(["persona_model"]);
+
+    const read = await request("GET", ada.secret);
+    expect(settingsIn(read.body).persona_model_key).toMatchObject({
+      hint: "WXYZ",
+    });
+  });
+});

--- a/apps/api/test/platform-settings-routes.test.ts
+++ b/apps/api/test/platform-settings-routes.test.ts
@@ -74,9 +74,17 @@ async function readiness(): Promise<{
     .setup;
 }
 
-/** An owner, which is what a self-hoster is on the platform they run. */
+/**
+ * An owner, which is what a self-hoster is on the platform they run.
+ *
+ * **Single-organization, always, and that is a precondition rather than a
+ * convenience.** These settings are the deployment's own provider credentials,
+ * so they are only anybody's to read or change while that anybody is the whole
+ * deployment; on a platform serving several customers the whole group is
+ * refused, which the last block in this file is about.
+ */
 async function owner(label: string): Promise<Customer> {
-  api = await createApi(label);
+  api = await createApi(label, { singleOrganization: true });
   return signUp(api.app, "ada@acme.example", "Acme");
 }
 
@@ -193,10 +201,13 @@ describe("who may read and change them", () => {
       expect(refused.statusCode).toBe(403);
       expect(refused.body.message).toBe(
         "the settings of this platform are read and changed by an " +
-          "organization owner. They are the deployment's own provider " +
-          "credentials — whose account every simulation is conducted on — " +
-          "which is a decision of the same kind as billing rather than of the " +
-          "same kind as writing a test.",
+          "organization owner, and only while this egma serves one " +
+          "organization. They are the deployment's own provider credentials — " +
+          "whose account every simulation is conducted on — which is a " +
+          "decision of the same kind as billing rather than of the same kind " +
+          "as writing a test; and where several organizations share a platform " +
+          "they belong to none of them, so egma refuses everybody rather than " +
+          "picking one.",
       );
     }
   });
@@ -246,9 +257,12 @@ describe("a write that cannot be acted on", () => {
       persona_moddel: "gpt-4o",
     });
 
-    expect(refused.statusCode).toBe(400);
+    // One condition, one answer. The factory owns this refusal and the door
+    // does not check the same thing a second time — two answers for one
+    // condition would be a contract with two faces.
+    expect(refused.statusCode).toBe(422);
     expect(refused.body.message).toBe(
-      'this egma has no platform setting "persona_moddel"; it holds ' +
+      '"persona_moddel" is not a platform setting egma knows; it holds ' +
         "persona_model_provider, persona_model, persona_model_key",
     );
   });
@@ -296,6 +310,7 @@ describe("what the platform says about its own setup", () => {
 
   it("stops naming a setting the moment somebody supplies it", async () => {
     api = await createApi("platform_settings_readiness_narrows", {
+      singleOrganization: true,
       phone: { ...A_CARRIER },
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
@@ -315,6 +330,7 @@ describe("what the platform says about its own setup", () => {
 
   it("answers ready once nothing is missing", async () => {
     api = await createApi("platform_settings_readiness_ready", {
+      singleOrganization: true,
       phone: { ...A_CARRIER },
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
@@ -330,6 +346,7 @@ describe("what the platform says about its own setup", () => {
 
   it("carries no secret, at a door that asks for no credential", async () => {
     api = await createApi("platform_settings_readiness_is_public", {
+      singleOrganization: true,
       phone: { ...A_CARRIER },
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
@@ -403,7 +420,9 @@ describe("a deployment that answers no questions", () => {
     // What `index.ts` does at start, with the values `loadConfig` read out of
     // the environment: an automated deployment configures itself and nobody
     // types anything.
-    api = await createApi("platform_settings_seeded_from_environment");
+    api = await createApi("platform_settings_seeded_from_environment", {
+      singleOrganization: true,
+    });
     const written = await seedPlatformSettings(
       loadConfig({
         ...A_CONTAINERS_ENVIRONMENT,
@@ -428,7 +447,9 @@ describe("a deployment that answers no questions", () => {
   });
 
   it("leaves a setting somebody changed exactly as they left it", async () => {
-    api = await createApi("platform_settings_seed_never_replaces");
+    api = await createApi("platform_settings_seed_never_replaces", {
+      singleOrganization: true,
+    });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
     await request("PATCH", ada.secret, { persona_model_key: A_SECOND_KEY });
 
@@ -444,5 +465,50 @@ describe("a deployment that answers no questions", () => {
     expect(settingsIn(read.body).persona_model_key).toMatchObject({
       hint: "WXYZ",
     });
+  });
+});
+
+describe("a platform that serves more than one organization", () => {
+  /**
+   * **Nobody's, rather than everybody's.** These settings are the deployment's
+   * own provider credentials. On a platform holding several customers, one
+   * organization's owner reading them would be reading the hints of a key the
+   * others depend on, and writing them would point everybody else's simulations
+   * at an account nobody else agreed to. Whose they are there is a real
+   * question and is deliberately unanswered, so egma refuses everybody rather
+   * than picking one — the guard the platform's own judge already stands
+   * behind, which is only ever given away on a single-organization deployment.
+   */
+  it("refuses every owner both doors", async () => {
+    api = await createApi("platform_settings_several_customers", {
+      singleOrganization: false,
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const grace = await signUp(api.app, "grace@globex.example", "Globex");
+
+    for (const person of [ada, grace]) {
+      const read = await request("GET", person.secret);
+      const write = await request("PATCH", person.secret, {
+        persona_model: "gpt-4o",
+      });
+
+      expect(read.statusCode).toBe(403);
+      expect(write.statusCode).toBe(403);
+      expect(read.body.message).toContain(
+        "only while this egma serves one organization",
+      );
+    }
+  });
+
+  it("still says what it is missing, because that answer carries nothing", async () => {
+    api = await createApi("platform_settings_several_customers_readiness", {
+      singleOrganization: false,
+    });
+
+    // Readiness is not a permission question: it names absent settings in the
+    // words a person would use and carries no value that any secret holds, so
+    // the door that asks for no credential answers here exactly as it does on
+    // a deployment that is one team.
+    expect((await readiness()).state).toBe("setup_required");
   });
 });

--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -113,6 +113,7 @@ describe("the provider's footprint on the schema", () => {
     "persona",
     "persona_version",
     "platform_instance",
+    "platform_setting",
     "project",
     "run",
     "run_event",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -30,6 +30,18 @@ const config: NextConfig = {
         // API's own port. Without this rule a bound repository could never
         // verify the platform it is bound to.
         { source: "/api/platform", destination: `${api}/api/platform` },
+        // What this deployment has been configured with, as its owner reads and
+        // changes it. Forwarded because the point of holding these on the
+        // platform is that nobody needs shell access to change one: the person
+        // who does it is signed in to this origin, and this is the only origin
+        // their session is valid for. It is its own rule rather than a
+        // `:path*` under the identity above, because that identity is public
+        // and this refuses anybody but an owner — two different doors that
+        // happen to share a prefix.
+        {
+          source: "/api/platform/settings",
+          destination: `${api}/api/platform/settings`,
+        },
         { source: "/api/auth/:path*", destination: `${api}/api/auth/:path*` },
         { source: "/api/signup", destination: `${api}/api/signup` },
         {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,6 +325,17 @@ services:
       EGMA_JUDGE_PROVIDER: ${EGMA_JUDGE_PROVIDER:-}
       EGMA_JUDGE_MODEL: ${EGMA_JUDGE_MODEL:-}
       EGMA_JUDGE_API_KEY: ${EGMA_JUDGE_API_KEY:-}
+      # What the persona thinks with, and the platform's own setting rather
+      # than the simulator's. It is written into the platform's store on boot,
+      # sealed, for anything the store does not already hold — and never over a
+      # value somebody changed, so a redeploy carrying an old key in a script
+      # cannot undo a new one. Setting these is one of the two ways in and is
+      # for a deployment that answers no questions; the other is
+      # `egma self-host setup`, which asks. Leave them empty and the platform
+      # reports `setup required` naming each one until somebody supplies it.
+      EGMA_PERSONA_MODEL_PROVIDER: ${EGMA_PERSONA_MODEL_PROVIDER:-}
+      EGMA_PERSONA_MODEL: ${EGMA_PERSONA_MODEL:-}
+      EGMA_PERSONA_MODEL_API_KEY: ${EGMA_PERSONA_MODEL_API_KEY:-}
     ports:
       # Published on the host, so that a self-hoster who already runs
       # something on these can move egma rather than move the other thing —

--- a/packages/db/migrations/0023_platform_settings.sql
+++ b/packages/db/migrations/0023_platform_settings.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "platform_setting" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"value" text NOT NULL,
+	"hint" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "platform_setting_name_unique" UNIQUE("name"),
+	CONSTRAINT "platform_setting_id_prefix" CHECK ("platform_setting"."id" ~ '^pfs_[0-9A-HJKMNP-TV-Z]{26}$')
+);

--- a/packages/db/migrations/meta/0023_snapshot.json
+++ b/packages/db/migrations/meta/0023_snapshot.json
@@ -1,0 +1,4675 @@
+{
+  "id": "831abe2d-7970-4ad5-94eb-032b2019c330",
+  "prevId": "d9c691b6-c0f6-4674-a9af-bb89363e3a7d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.platform_instance": {
+      "name": "platform_instance",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_instance_id_unique": {
+          "name": "platform_instance_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_instance_id_format": {
+          "name": "platform_instance_id_format",
+          "value": "\"platform_instance\".\"id\" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_setting": {
+      "name": "platform_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_setting_name_unique": {
+          "name": "platform_setting_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "platform_setting_id_prefix": {
+          "name": "platform_setting_id_prefix",
+          "value": "\"platform_setting\".\"id\" ~ '^pfs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_rubric', 'metric_threshold', 'tool_calls', 'phrase_match')"
+        },
+        "grader_priority_allowed": {
+          "name": "grader_priority_allowed",
+          "value": "\"grader\".\"priority\" in ('P0', 'P1', 'P2')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool": {
+      "name": "mock_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_milliseconds": {
+          "name": "delay_milliseconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_tool_project_id_tool_name_unique": {
+          "name": "mock_tool_project_id_tool_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_tool_organization_id_project_id_idx": {
+          "name": "mock_tool_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_organization_id_organization_id_fk": {
+          "name": "mock_tool_organization_id_organization_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_created_by_user_id_fk": {
+          "name": "mock_tool_created_by_user_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_tool_project_organization_fk": {
+          "name": "mock_tool_project_organization_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mock_tool_id_project_id_unique": {
+          "name": "mock_tool_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_id_prefix": {
+          "name": "mock_tool_id_prefix",
+          "value": "\"mock_tool\".\"id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "mock_tool_delay_within_budget": {
+          "name": "mock_tool_delay_within_budget",
+          "value": "\"mock_tool\".\"delay_milliseconds\" between 0 and 30000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool_agent": {
+      "name": "mock_tool_agent",
+      "schema": "",
+      "columns": {
+        "mock_tool_id": {
+          "name": "mock_tool_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mock_tool_agent_agent_id_idx": {
+          "name": "mock_tool_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_agent_mock_tool_id_mock_tool_id_fk": {
+          "name": "mock_tool_agent_mock_tool_id_mock_tool_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_id_agent_id_fk": {
+          "name": "mock_tool_agent_agent_id_agent_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_mock_tool_project_fk": {
+          "name": "mock_tool_agent_mock_tool_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_project_fk": {
+          "name": "mock_tool_agent_agent_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mock_tool_agent_pk": {
+          "name": "mock_tool_agent_pk",
+          "columns": [
+            "mock_tool_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "mock_tool_agent_mock_tool_id_position_unique": {
+          "name": "mock_tool_agent_mock_tool_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mock_tool_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_agent_mock_tool_id_prefix": {
+          "name": "mock_tool_agent_mock_tool_id_prefix",
+          "value": "\"mock_tool_agent\".\"mock_tool_id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_grader": {
+      "name": "test_grader",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_grader_grader_id_idx": {
+          "name": "test_grader_grader_id_idx",
+          "columns": [
+            {
+              "expression": "grader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_grader_test_version_id_test_version_id_fk": {
+          "name": "test_grader_test_version_id_test_version_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_grader_grader_id_grader_id_fk": {
+          "name": "test_grader_grader_id_grader_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_grader_pk": {
+          "name": "test_grader_pk",
+          "columns": [
+            "test_version_id",
+            "grader_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_grader_version_id_position_unique": {
+          "name": "test_grader_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_grader_test_version_id_prefix": {
+          "name": "test_grader_test_version_id_prefix",
+          "value": "\"test_grader\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tool_snapshot": {
+          "name": "mock_tool_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0 and \"run\".\"canceled_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_coverage": {
+          "name": "mock_tool_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_mock_tool_coverage_only_when_ended": {
+          "name": "simulation_mock_tool_coverage_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null or \"simulation\".\"mock_tool_coverage\" is null"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1786416089352,
       "tag": "0022_quick_silver_samurai",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1786739000389,
+      "tag": "0023_platform_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -174,12 +174,17 @@ export { instanceIsClaimed, platformInstanceId } from "./instance.ts";
  * chose. `platformFacts` is the third instance-scoped export: it takes nothing,
  * so there is no customer to name, and it answers only what is not secret,
  * because the readiness answer it feeds is read before anybody has logged in.
+ *
+ * The read and the write take the deployment's own tenancy beside the context,
+ * because who may be here depends on it: an organization owner may, and only
+ * while this deployment serves one organization.
  */
 export {
   platformFacts,
   readPlatformSettings,
   seedPlatformSettings,
   writePlatformSettings,
+  type DeploymentTenancy,
   type PlatformFacts,
   type PlatformSetting,
 } from "./platform-settings.ts";

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -167,6 +167,29 @@ export {
 } from "./provisioning.ts";
 export { instanceIsClaimed, platformInstanceId } from "./instance.ts";
 
+/**
+ * The settings this deployment holds — the judge configuration's idiom, one
+ * scope up. Sealed with the deployment's own key, hinted rather than handed
+ * back, seeded from the environment at start and never over a value somebody
+ * chose. `platformFacts` is the third instance-scoped export: it takes nothing,
+ * so there is no customer to name, and it answers only what is not secret,
+ * because the readiness answer it feeds is read before anybody has logged in.
+ */
+export {
+  platformFacts,
+  readPlatformSettings,
+  seedPlatformSettings,
+  writePlatformSettings,
+  type PlatformFacts,
+  type PlatformSetting,
+} from "./platform-settings.ts";
+export {
+  PLATFORM_SETTINGS,
+  type PlatformSettingDefinition,
+  type PlatformSettingName,
+  type PlatformSettingValues,
+} from "../schema/platform.ts";
+
 export {
   readOrganization,
   readOrganizationSettings,

--- a/packages/db/src/access/platform-settings.ts
+++ b/packages/db/src/access/platform-settings.ts
@@ -11,7 +11,7 @@ import {
 } from "../schema/platform.ts";
 import { sealCredentials } from "../sealing.ts";
 import type { AuthContext } from "./context.ts";
-import { UnprocessableInputError } from "./errors.ts";
+import { NotPermittedError, UnprocessableInputError } from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
 
 /**
@@ -80,13 +80,61 @@ export type PlatformSetting = {
  * entirely. That is the whole of what the unauthenticated readiness answer is
  * built from, which is why a secret's *hint* is not in it either — enough to
  * say a key is there, and never any part of the key.
+ *
+ * Written on one line and keyed by the settings egma knows, both deliberately:
+ * the build rule pins this alias's whole body as the text of what
+ * `platformFacts` may answer, so widening it to carry a hint or a secret stops
+ * the build rather than quietly widening an exemption.
  */
-export type PlatformFacts = Readonly<Record<string, string | null>>;
+export type PlatformFacts = Readonly<Partial<Record<PlatformSettingName, string | null>>>;
+
+/**
+ * What kind of deployment this is, for the one decision that turns on it.
+ *
+ * It is the existing `EGMA_SINGLE_ORGANIZATION` flag, which already means "this
+ * deployment is one team", handed in rather than read here: the flag belongs to
+ * the process's configuration and this module reads no environment. The judge
+ * gates on the same flag in the same way, one scope down.
+ */
+export type DeploymentTenancy = {
+  /** Whether this deployment serves exactly one organization. */
+  readonly singleOrganization: boolean;
+};
+
+/**
+ * Who may read and change the settings of this whole platform.
+ *
+ * **Two conditions, and both are refusals of the same kind.** An organization
+ * owner may, on the row of the permission table that already names provider
+ * credentials — these are the deployment's own accounts, and which provider it
+ * speaks with and whose key it spends is the same kind of decision as retention
+ * and billing rather than the same kind as writing a test.
+ *
+ * **And only while this deployment serves one organization.** That mode is what
+ * makes an owner and the platform's operator the same person; without it, every
+ * organization's owner would read the hints of a key the others depend on and
+ * could point the platform at an account nobody else agreed to. When a
+ * deployment serves several customers this becomes a real permission question —
+ * whose settings these are, and who is allowed to answer for the deployment —
+ * and that question is deliberately not answered here. Until it is, egma
+ * refuses everybody rather than picking one of them.
+ *
+ * The judge's guard is the same guard: the platform's own model credential is
+ * given away only on a single-organization deployment, and for the same reason.
+ */
+function onlyASingleOrganizationsOwner(
+  auth: AuthContext,
+  deployment: DeploymentTenancy,
+): void {
+  authorize(auth, "manage_organization", here(auth));
+  if (deployment.singleOrganization) return;
+  throw new NotPermittedError(auth, "manage_organization", here(auth));
+}
 
 function definitionOf(name: string): PlatformSettingDefinition {
   const known = PLATFORM_SETTINGS.find(
     (candidate) => candidate.name === name,
-  ) as PlatformSettingDefinition | undefined;
+  );
   if (known === undefined) {
     throw new UnprocessableInputError(
       `"${name}" is not a platform setting egma knows; it holds ${PLATFORM_SETTINGS.map(
@@ -200,24 +248,15 @@ async function heldSettings(): Promise<
 }
 
 /**
- * What this platform holds, and what it is missing.
- *
- * **Only an organization owner may ask**, on the row of the permission table
- * that already names provider credentials. These are the deployment's own
- * accounts: which provider it speaks with and whose key it spends is the same
- * kind of decision as retention and billing, rather than the same kind as
- * writing a test — and a `viewer` who could read them would be reading the
- * hints of the platform's secrets.
- *
- * While a deployment serves one organization, which it does by default and does
- * on every self-host, its owner and the platform's operator are the same
- * person. A deployment serving several organizations makes this a real
- * permission question, and that question is deliberately not answered here.
+ * What this platform holds, and what it is missing. Refused to anybody but a
+ * single organization's owner — see `onlyASingleOrganizationsOwner`, which is
+ * the whole of who may be here and why.
  */
 export async function readPlatformSettings(
   auth: AuthContext,
+  deployment: DeploymentTenancy,
 ): Promise<readonly PlatformSetting[]> {
-  authorize(auth, "manage_organization", here(auth));
+  onlyASingleOrganizationsOwner(auth, deployment);
   return answer(await heldSettings());
 }
 
@@ -233,9 +272,10 @@ export async function readPlatformSettings(
  */
 export async function writePlatformSettings(
   auth: AuthContext,
+  deployment: DeploymentTenancy,
   values: PlatformSettingValues,
 ): Promise<readonly PlatformSetting[]> {
-  authorize(auth, "manage_organization", here(auth));
+  onlyASingleOrganizationsOwner(auth, deployment);
 
   // One statement for however many settings were named, so a form that changes
   // three of them cannot land one and then fail: each row carries its own new
@@ -270,7 +310,7 @@ export async function writePlatformSettings(
  */
 export async function platformFacts(): Promise<PlatformFacts> {
   const held = await heldSettings();
-  const facts: Record<string, string | null> = {};
+  const facts: Partial<Record<PlatformSettingName, string | null>> = {};
   for (const definition of PLATFORM_SETTINGS) {
     const row = held.find((candidate) => candidate.name === definition.name);
     if (row === undefined) continue;

--- a/packages/db/src/access/platform-settings.ts
+++ b/packages/db/src/access/platform-settings.ts
@@ -1,0 +1,326 @@
+import { newId } from "@egma/ids";
+import { inArray, sql } from "drizzle-orm";
+
+import { db } from "../client.ts";
+import {
+  platformSetting,
+  PLATFORM_SETTINGS,
+  type PlatformSettingDefinition,
+  type PlatformSettingName,
+  type PlatformSettingValues,
+} from "../schema/platform.ts";
+import { sealCredentials } from "../sealing.ts";
+import type { AuthContext } from "./context.ts";
+import { UnprocessableInputError } from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+
+/**
+ * The settings this deployment holds: what it was configured with, sealed, and
+ * owned by the platform rather than by any customer on it.
+ *
+ * **This is the judge configuration's idiom, one scope up.** A judge's
+ * provider, model and key live in a table owned by a project, sealed with the
+ * deployment's encryption key, with a hint kept for display; environment
+ * variables seed it once at start and never replace a judge a project has
+ * chosen. Everything here is that arrangement applied to the settings that
+ * belong to the whole deployment, and nothing about it is new — which is the
+ * point. A second idiom for the same job is the thing worth avoiding.
+ *
+ * Three doors, and the split between them is the design:
+ *
+ * - **Writing** takes each value in the clear, seals it, and keeps a hint
+ *   beside it — the whole value for a setting that is not a secret, the last
+ *   four characters for one that is.
+ * - **Reading** answers every setting the platform knows about, held or not,
+ *   with its label and its hint. It never answers a stored secret, and there is
+ *   no argument by which it could be asked to: the sealed column is not among
+ *   the ones it selects.
+ * - **Seeding** is the deployment configuring itself at start, from its own
+ *   environment. It writes only where the platform holds nothing.
+ *
+ * There is deliberately **no door to the plaintext here yet**. The one caller
+ * that needs it is the work order a simulator claims, and opening that door
+ * before something goes through it would be a way out with nothing watching it.
+ */
+
+/**
+ * The floor under a secret, so the stored last-four stays a hint rather than
+ * most of the secret it hints at. Real provider keys are tens of characters, so
+ * anything this short is a paste gone wrong. The judge's floor, for the judge's
+ * reason.
+ */
+const SHORTEST_SECRET = 8;
+
+/** How much of a secret a hint may be. */
+const HINT_CHARACTERS = 4;
+
+/** One setting as anybody but the deployment's own machinery sees it. */
+export type PlatformSetting = {
+  readonly name: PlatformSettingName;
+  /** The words a person calls it by, and the words a refusal names it in. */
+  readonly label: string;
+  /** Whether the stored value may ever be shown back. */
+  readonly secret: boolean;
+  /**
+   * What may be shown: the whole value where this is not a secret, its last
+   * four characters where it is, and `null` where the platform holds no such
+   * setting at all. Absent is an ordinary state rather than a fault — it is
+   * what every platform is before anybody has set it up.
+   */
+  readonly hint: string | null;
+  /** When it was last changed, or `null` while the platform holds none. */
+  readonly updatedAt: Date | null;
+};
+
+/**
+ * What this deployment has been configured with, as anybody may see it.
+ *
+ * A setting the platform holds appears here: its value where that value is not
+ * a secret, and `null` where it is. A setting it does not hold is absent
+ * entirely. That is the whole of what the unauthenticated readiness answer is
+ * built from, which is why a secret's *hint* is not in it either — enough to
+ * say a key is there, and never any part of the key.
+ */
+export type PlatformFacts = Readonly<Record<string, string | null>>;
+
+function definitionOf(name: string): PlatformSettingDefinition {
+  const known = PLATFORM_SETTINGS.find(
+    (candidate) => candidate.name === name,
+  ) as PlatformSettingDefinition | undefined;
+  if (known === undefined) {
+    throw new UnprocessableInputError(
+      `"${name}" is not a platform setting egma knows; it holds ${PLATFORM_SETTINGS.map(
+        (setting) => setting.name,
+      ).join(", ")}`,
+    );
+  }
+  return known;
+}
+
+/**
+ * Trimmed before it is sealed, like every credential this codebase stores: a
+ * key pasted with whitespace would pass every check, seal the padding, and fail
+ * at the provider with nothing to say the stored value was the problem.
+ */
+function validValue(
+  definition: PlatformSettingDefinition,
+  value: unknown,
+): string {
+  if (typeof value !== "string") {
+    throw new UnprocessableInputError(
+      `${definition.label} is written as text, and this request sent ${typeof value}`,
+    );
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    throw new UnprocessableInputError(
+      `${definition.label} needs a value. Clearing a setting is not something ` +
+        "egma does here: a platform that held one and then held none would " +
+        "report itself as never having been set up.",
+    );
+  }
+  if (definition.secret && trimmed.length < SHORTEST_SECRET) {
+    throw new UnprocessableInputError(
+      `${definition.label} is at least ${SHORTEST_SECRET} characters, and ` +
+        "this one is shorter than any provider issues",
+    );
+  }
+  return trimmed;
+}
+
+/** What a person may be shown of a stored value. See `PlatformSetting.hint`. */
+function hintOf(definition: PlatformSettingDefinition, value: string): string {
+  return definition.secret ? value.slice(-HINT_CHARACTERS) : value;
+}
+
+/** One row, validated and sealed, ready to insert. Shared by both writers. */
+function rowFor(name: PlatformSettingName, value: unknown, now: Date) {
+  const definition = definitionOf(name);
+  const settled = validValue(definition, value);
+  return {
+    id: newId("pfs"),
+    name,
+    // Sealed per row rather than once for many: the envelope carries its own
+    // initialisation vector, and reusing one across rows is the mistake this
+    // repeats a cheap operation to avoid.
+    value: sealCredentials(settled),
+    hint: hintOf(definition, settled),
+    updatedAt: now,
+  };
+}
+
+/** Every setting named, validated and sealed, in the order they were named. */
+function rowsFor(values: PlatformSettingValues, now: Date) {
+  const named = Object.keys(values) as PlatformSettingName[];
+  if (named.length === 0) {
+    throw new UnprocessableInputError(
+      `a write names at least one setting to change; egma holds ${PLATFORM_SETTINGS.map(
+        (setting) => setting.name,
+      ).join(", ")}`,
+    );
+  }
+  return named.map((name) => rowFor(name, values[name], now));
+}
+
+/** The columns a read answers from. The sealed value is not among them. */
+const SHOWN = {
+  name: platformSetting.name,
+  hint: platformSetting.hint,
+  updatedAt: platformSetting.updatedAt,
+} as const;
+
+/** Every setting egma knows about, against what this platform actually holds. */
+function answer(
+  held: readonly { name: string; hint: string; updatedAt: Date }[],
+): readonly PlatformSetting[] {
+  return PLATFORM_SETTINGS.map((definition) => {
+    const row = held.find((candidate) => candidate.name === definition.name);
+    return {
+      name: definition.name,
+      label: definition.label,
+      secret: definition.secret,
+      hint: row?.hint ?? null,
+      updatedAt: row?.updatedAt ?? null,
+    };
+  });
+}
+
+async function heldSettings(): Promise<
+  readonly { name: string; hint: string; updatedAt: Date }[]
+> {
+  return db()
+    .select(SHOWN)
+    .from(platformSetting)
+    .where(
+      inArray(
+        platformSetting.name,
+        PLATFORM_SETTINGS.map((setting) => setting.name),
+      ),
+    );
+}
+
+/**
+ * What this platform holds, and what it is missing.
+ *
+ * **Only an organization owner may ask**, on the row of the permission table
+ * that already names provider credentials. These are the deployment's own
+ * accounts: which provider it speaks with and whose key it spends is the same
+ * kind of decision as retention and billing, rather than the same kind as
+ * writing a test — and a `viewer` who could read them would be reading the
+ * hints of the platform's secrets.
+ *
+ * While a deployment serves one organization, which it does by default and does
+ * on every self-host, its owner and the platform's operator are the same
+ * person. A deployment serving several organizations makes this a real
+ * permission question, and that question is deliberately not answered here.
+ */
+export async function readPlatformSettings(
+  auth: AuthContext,
+): Promise<readonly PlatformSetting[]> {
+  authorize(auth, "manage_organization", here(auth));
+  return answer(await heldSettings());
+}
+
+/**
+ * A setting written, or several. What a write does not name, the platform
+ * keeps.
+ *
+ * One row per setting is what makes that true without an argument for it: a
+ * write touches the rows it names and no others, so changing the model on a
+ * settings form cannot drop the key beside it. A value replaces whole or is
+ * left alone; there is no shape in which one could be edited in place, because
+ * the envelope is sealed over the whole value.
+ */
+export async function writePlatformSettings(
+  auth: AuthContext,
+  values: PlatformSettingValues,
+): Promise<readonly PlatformSetting[]> {
+  authorize(auth, "manage_organization", here(auth));
+
+  // One statement for however many settings were named, so a form that changes
+  // three of them cannot land one and then fail: each row carries its own new
+  // value, and `excluded` is how the conflicting row's own values are taken
+  // rather than the same value being written to every one of them.
+  await db()
+    .insert(platformSetting)
+    .values(rowsFor(values, new Date()))
+    .onConflictDoUpdate({
+      target: platformSetting.name,
+      set: {
+        value: sql`excluded.value`,
+        hint: sql`excluded.hint`,
+        updatedAt: sql`excluded.updated_at`,
+      },
+    });
+
+  return answer(await heldSettings());
+}
+
+/**
+ * What this deployment has been configured with, for the answer it gives before
+ * anybody has logged in.
+ *
+ * It takes nothing, so there is no customer it could be asked about, and it
+ * returns non-secret facts only — a provider's name, a model's name, and `null`
+ * standing in for every secret it holds. That is what lets it skip the
+ * `AuthContext` every read of a customer's data requires: the readiness answer
+ * is read by the CLI in front of every command, before login and before a
+ * repository identifier is ever sent, exactly as the platform's own identity
+ * is.
+ */
+export async function platformFacts(): Promise<PlatformFacts> {
+  const held = await heldSettings();
+  const facts: Record<string, string | null> = {};
+  for (const definition of PLATFORM_SETTINGS) {
+    const row = held.find((candidate) => candidate.name === definition.name);
+    if (row === undefined) continue;
+    facts[definition.name] = definition.secret ? null : row.hint;
+  }
+  return facts;
+}
+
+/**
+ * Give the platform every setting its environment names and it does not
+ * already hold.
+ *
+ * **This is the second way in, and the operator chooses which.** One is an
+ * interview: `egma self-host setup` asks for each setting in turn and writes it
+ * through the API. The other is this — an automated deployment answers no
+ * questions, so it puts the settings in its environment and the platform reads
+ * them on start.
+ *
+ * **It never overwrites.** A setting somebody has changed has been changed, and
+ * a restart is not an occasion to put a script's copy of the old key back. So
+ * this is safe to run on every boot, and running it on every boot is what makes
+ * a setting added to the environment later arrive at the next start rather than
+ * never.
+ *
+ * Not authorized against an `AuthContext` on purpose, exactly as the default
+ * judge's seeding is not: there is no user here. This is the deployment acting
+ * on its own configuration, in the same breath as applying its migrations, and
+ * there is no session it could be doing it under.
+ */
+export async function seedPlatformSettings(
+  values: PlatformSettingValues,
+): Promise<readonly PlatformSettingName[]> {
+  const named = Object.keys(values) as PlatformSettingName[];
+  if (named.length === 0) return [];
+
+  const now = new Date();
+  const rows = named
+    .filter((name) => values[name] !== undefined)
+    .map((name) => rowFor(name, values[name], now));
+  if (rows.length === 0) return [];
+
+  const written = await db()
+    .insert(platformSetting)
+    .values(rows)
+    // The setting a person had already written stays exactly as they wrote it,
+    // and this is the whole safety of running on every boot. Nothing here is a
+    // race worth locking for either: the losing side is the environment's copy,
+    // which is exactly the side that should lose.
+    .onConflictDoNothing({ target: platformSetting.name })
+    .returning({ name: platformSetting.name });
+
+  return written.map((row) => row.name as PlatformSettingName);
+}

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -1,6 +1,6 @@
-import { boolean, pgTable, uniqueIndex } from "drizzle-orm/pg-core";
+import { boolean, pgTable, text, unique, uniqueIndex } from "drizzle-orm/pg-core";
 
-import { createdAt, idText, prefixCheck } from "./columns.ts";
+import { createdAt, idText, prefixCheck, updatedAt } from "./columns.ts";
 
 /**
  * The identity of this Egma platform, not of any customer on it.
@@ -21,3 +21,127 @@ export const platformInstance = pgTable(
     prefixCheck("platform_instance_id_format", table.id, "pf"),
   ],
 );
+
+/**
+ * What this deployment has been configured with: one row for each setting,
+ * sealed, and owned by the whole platform rather than by any customer on it.
+ *
+ * **Why the platform owns these at all.** They used to live in a file beside
+ * the deployment that only the egma CLI read. Start the platform any other way
+ * — the plain `docker compose up` the documentation shows, a machine restart in
+ * a different directory, a colleague who cloned the repository — and every
+ * setting was absent; and absent did not fail, because each variable had an
+ * empty default. Every container started, every health check passed, and the
+ * failure arrived minutes later as a carrier refusal naming nothing about
+ * configuration. Postgres has a volume, so a setting written here survives a
+ * restart, an upgrade and a move to another machine.
+ *
+ * **It carries no organization and no project**, and that is the whole point of
+ * the table: these belong to the deployment. `platform_instance` above is the
+ * precedent — a row that belongs to the whole platform and to no customer. The
+ * judge is the other half of the same decision and is deliberately *not* here:
+ * a judge is owned by the project that chose it, because a judge configured per
+ * container would spend from an account nobody in that project agreed to. The
+ * persona's own providers were argued the same way and decided the other way,
+ * at the founder's direction: on a self-hosted deployment the operator and the
+ * only project's admin are the same person, and asking twice for one key buys
+ * nothing. The trigger to revisit is the first hosted tenant.
+ *
+ * **One row per setting rather than one sealed document.** The interface that
+ * reads and writes these is a settings form that changes one field at a time;
+ * each setting carries its own hint the way the judge configuration already
+ * does; and adding a setting later is an insert rather than a schema change.
+ *
+ * That last property is why `name` carries **no allowed-value check**, which is
+ * the one place this table departs from the schema's usual habit of pinning an
+ * enumerated column. A check here would mean a migration for every setting the
+ * platform grows, which is exactly the cost the row-per-setting shape was
+ * chosen to avoid. What a name may be is `PLATFORM_SETTINGS` below, and the
+ * access module refuses a write that names anything else — a name nobody wrote
+ * is a row nothing ever reads, which is a very different kind of wrong from a
+ * connection whose type no adapter has shipped for.
+ */
+export const platformSetting = pgTable(
+  "platform_setting",
+  {
+    id: idText("id").primaryKey(),
+    /** Which setting this is, from `PLATFORM_SETTINGS`. */
+    name: text("name").notNull(),
+    /**
+     * The value, sealed with the deployment's own encryption key — the same
+     * module and the same key a connection's credentials and a judge's key are
+     * sealed with, keeping its version prefix so a later re-sealing is a data
+     * migration rather than a guess at what an old row was encrypted with.
+     *
+     * Everything is sealed, including the settings that are not secret. One
+     * rule for the column means there is no second shape a reader has to know
+     * about, and no row whose secrecy depends on which writer wrote it.
+     */
+    value: text("value").notNull(),
+    /**
+     * What may be shown: the whole value for a setting that is not a secret,
+     * and the last few characters for one that is. It is the only thing any
+     * read of these answers with, which is what makes "never returns a key" a
+     * property of the column rather than a promise each caller keeps.
+     */
+    hint: text("hint").notNull(),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("platform_setting_id_prefix", table.id, "pfs"),
+    // The setting's name is what a caller names and what a write conflicts on;
+    // the identifier is the row's own, on the schema's standing rule that every
+    // table has one.
+    unique("platform_setting_name_unique").on(table.name),
+  ],
+);
+
+/**
+ * A setting this platform can hold, as a person meets it.
+ *
+ * The label is the words a readiness answer names it in — "the persona's model
+ * key" rather than `persona_model_key` — because "setup required" with a column
+ * name after it sends a self-hoster to read source.
+ */
+export type PlatformSettingDefinition = {
+  readonly name: PlatformSettingName;
+  /** What a person calls it, in a refusal and in a setup interview alike. */
+  readonly label: string;
+  /**
+   * Whether the stored value may ever be shown back. A secret's hint is its
+   * last few characters, so two keys can be told apart without either being
+   * handed out; anything else hints with itself.
+   */
+  readonly secret: boolean;
+};
+
+/**
+ * Every setting this platform knows about, in the order a person is asked for
+ * them.
+ *
+ * The list grows as the effort moves the rest of the deployment's settings in:
+ * the carrier trunk and the media backend, the speech providers and their keys.
+ * Adding one here is an insert at run time and nothing else — no migration, and
+ * no check constraint to widen.
+ */
+export const PLATFORM_SETTINGS = [
+  {
+    name: "persona_model_provider",
+    label: "the persona's model provider",
+    secret: false,
+  },
+  { name: "persona_model", label: "the persona's model", secret: false },
+  { name: "persona_model_key", label: "the persona's model key", secret: true },
+] as const satisfies readonly PlatformSettingDefinition[];
+
+/** The name of one setting. A write that names anything else is refused. */
+export type PlatformSettingName =
+  | "persona_model_provider"
+  | "persona_model"
+  | "persona_model_key";
+
+/** The settings a caller is changing or seeding, by name. */
+export type PlatformSettingValues = Readonly<
+  Partial<Record<PlatformSettingName, string>>
+>;

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -98,32 +98,17 @@ export const platformSetting = pgTable(
 );
 
 /**
- * A setting this platform can hold, as a person meets it.
- *
- * The label is the words a readiness answer names it in — "the persona's model
- * key" rather than `persona_model_key` — because "setup required" with a column
- * name after it sends a self-hoster to read source.
- */
-export type PlatformSettingDefinition = {
-  readonly name: PlatformSettingName;
-  /** What a person calls it, in a refusal and in a setup interview alike. */
-  readonly label: string;
-  /**
-   * Whether the stored value may ever be shown back. A secret's hint is its
-   * last few characters, so two keys can be told apart without either being
-   * handed out; anything else hints with itself.
-   */
-  readonly secret: boolean;
-};
-
-/**
  * Every setting this platform knows about, in the order a person is asked for
- * them.
+ * them. **This list is the only place a setting's name is written.**
  *
  * The list grows as the effort moves the rest of the deployment's settings in:
  * the carrier trunk and the media backend, the speech providers and their keys.
- * Adding one here is an insert at run time and nothing else — no migration, and
- * no check constraint to widen.
+ * Adding one here is an insert at run time and nothing else — no migration, no
+ * check constraint to widen, and no second list to remember.
+ *
+ * A label is the words a readiness answer names the setting in — "the persona's
+ * model key" rather than `persona_model_key` — because "setup required" with a
+ * column name after it sends a self-hoster to read source.
  */
 export const PLATFORM_SETTINGS = [
   {
@@ -133,13 +118,27 @@ export const PLATFORM_SETTINGS = [
   },
   { name: "persona_model", label: "the persona's model", secret: false },
   { name: "persona_model_key", label: "the persona's model key", secret: true },
-] as const satisfies readonly PlatformSettingDefinition[];
+] as const satisfies readonly {
+  readonly name: string;
+  /** What a person calls it, in a refusal and in a setup interview alike. */
+  readonly label: string;
+  /**
+   * Whether the stored value may ever be shown back. A secret's hint is its
+   * last few characters, so two keys can be told apart without either being
+   * handed out; anything else hints with itself.
+   */
+  readonly secret: boolean;
+}[];
+
+/**
+ * A setting this platform can hold, as a person meets it — one entry of the
+ * catalog above, read off it rather than restated. `graders.ts`'s shape for
+ * every closed vocabulary in this schema, applied to a list of records.
+ */
+export type PlatformSettingDefinition = (typeof PLATFORM_SETTINGS)[number];
 
 /** The name of one setting. A write that names anything else is refused. */
-export type PlatformSettingName =
-  | "persona_model_provider"
-  | "persona_model"
-  | "persona_model_key";
+export type PlatformSettingName = PlatformSettingDefinition["name"];
 
 /** The settings a caller is changing or seeding, by name. */
 export type PlatformSettingValues = Readonly<

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -63,11 +63,17 @@ const CONTEXT_ESTABLISHING = [
 
 /**
  * What answers a question about the deployment rather than about a customer.
- * Neither takes an argument. One returns whether signup is claimed; the other
- * returns the platform's own public, non-secret id. The build rule pins both
- * exact return types and refuses either function if it grows an argument.
+ * None takes an argument. One returns whether signup is claimed; one returns
+ * the platform's own public, non-secret id; and the third returns what this
+ * deployment has been configured with, with every secret in it reduced to
+ * `null`. The build rule pins all three exact return types and refuses any of
+ * them if it grows an argument.
  */
-const INSTANCE_SCOPED = ["instanceIsClaimed", "platformInstanceId"];
+const INSTANCE_SCOPED = [
+  "instanceIsClaimed",
+  "platformFacts",
+  "platformInstanceId",
+];
 
 /**
  * What hands egma's own services their work, and what keeps a dispatch honest
@@ -213,6 +219,10 @@ const CONTEXT_REQUIRING = [
   "markSimulationCanceled",
   "readOrganization",
   "readOrganizationSettings",
+  // The deployment's own settings, on the judge configuration's exact terms:
+  // an owner writes them, a read answers a hint and never a stored secret, and
+  // the environment seeds what the platform does not already hold.
+  "readPlatformSettings",
   "readProject",
   "readRunVerdicts",
   "readTrace",
@@ -243,12 +253,14 @@ const CONTEXT_REQUIRING = [
   "resolveSimulationConnection",
   "revokeApiKey",
   "seedDefaultJudge",
+  "seedPlatformSettings",
   "setJudgeConfiguration",
   "startRun",
   "startSimulation",
   "updateAgent",
   "updateConnection",
   "updateOrganizationSettings",
+  "writePlatformSettings",
 ];
 
 /**
@@ -263,6 +275,14 @@ const PERMISSION = [
   "permits",
   "permitsApiKeyMintedBy",
 ];
+
+/**
+ * Every setting this deployment can hold, and the words a person meets each one
+ * by. Exported because a readiness answer and a setup interview both have to
+ * name them, and a list written in two places is a list that will one day
+ * disagree with itself.
+ */
+const THE_PLATFORMS_SETTINGS = ["PLATFORM_SETTINGS"];
 
 /** Vocabulary: the table definitions, how a caller proved who they are, and the refusals. */
 const VALUES = [
@@ -380,6 +400,7 @@ describe("the data-access module's surface", () => {
         ...READ_LIMITS,
         ...THE_FOLD,
         ...THE_MOCKED_WORLD,
+        ...THE_PLATFORMS_SETTINGS,
       ].sort(),
     );
   });

--- a/packages/db/test/platform-settings.test.ts
+++ b/packages/db/test/platform-settings.test.ts
@@ -1,0 +1,348 @@
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  NotPermittedError,
+  platformFacts,
+  readPlatformSettings,
+  seedPlatformSettings,
+  writePlatformSettings,
+  type AuthContext,
+  type PlatformSettingValues,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * The settings this deployment holds, in the platform's own store.
+ *
+ * **What this file is about.** Every one of these used to live in a file beside
+ * the deployment that only the CLI read, so starting the platform any other way
+ * lost all of them — silently, because each variable had an empty default. So
+ * the claims here are about survival and about secrecy: what lands in the table
+ * is sealed rather than plain, what comes back out is a hint rather than a key,
+ * and what the environment seeds is written once and never over the top of a
+ * value somebody chose.
+ *
+ * The judge is the model this follows, one scope up: sealed with the
+ * deployment's own key, a hint kept for display, and a boot-time seed that
+ * never replaces a choice. What is different is only who owns the row — these
+ * belong to the deployment and to no customer, which is why no organization or
+ * project appears anywhere below.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const globex = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+const bruno = newId("usr");
+
+const THEIR_OWN_KEY = "sk-the-operator-typed-this-one-QRST";
+const FROM_THE_ENVIRONMENT = "sk-a-deployment-script-supplied-this-WXYZ";
+
+function owner(): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role: "admin",
+    via: "session",
+  };
+}
+
+function member(role: "member" | "viewer"): AuthContext {
+  return {
+    userId: bruno,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+/** One setting as it stands, by name — the shape every read here asserts on. */
+async function settingsByName(
+  auth: AuthContext = owner(),
+): Promise<Record<string, { hint: string | null; secret: boolean }>> {
+  const held = await readPlatformSettings(auth);
+  return Object.fromEntries(
+    held.map((setting) => [
+      setting.name,
+      { hint: setting.hint, secret: setting.secret },
+    ]),
+  );
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("platform_settings");
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedUser(database, bruno, "bruno@acme.example");
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("a platform that has been given no settings", () => {
+  it("answers every setting it knows about, holding none of them", async () => {
+    // Naming the settings it does not have is the whole readiness answer: a
+    // platform that said only "setup required" would send whoever runs it to
+    // read source to find out what is missing.
+    expect(await settingsByName()).toEqual({
+      persona_model_provider: { hint: null, secret: false },
+      persona_model: { hint: null, secret: false },
+      persona_model_key: { hint: null, secret: true },
+    });
+  });
+
+  it("holds nothing anybody could be shown", async () => {
+    expect(await platformFacts()).toEqual({});
+  });
+});
+
+describe("writing a platform setting", () => {
+  it("seals the value rather than storing it", async () => {
+    await writePlatformSettings(owner(), {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: THEIR_OWN_KEY,
+    });
+
+    // The one read in this file that goes around the module, on purpose: the
+    // claim is that what is stored is ciphertext, and only a read the module
+    // cannot dress up can say so.
+    const stored = await database.sql<{ value: string; hint: string }>(
+      "select value, hint from platform_setting where name = $1",
+      ["persona_model_key"],
+    );
+    expect(stored.rows[0]?.value).not.toContain(THEIR_OWN_KEY);
+    expect(stored.rows[0]?.value.startsWith("v1.")).toBe(true);
+    expect(stored.rows[0]?.hint).not.toContain(THEIR_OWN_KEY);
+  });
+
+  it("answers the provider, the model and a hint, and never the key", async () => {
+    const held = await settingsByName();
+
+    expect(held.persona_model_provider).toEqual({
+      hint: "openai",
+      secret: false,
+    });
+    expect(held.persona_model).toEqual({ hint: "gpt-4o", secret: false });
+    // Enough to tell two keys apart, and nothing anybody could spend with.
+    expect(held.persona_model_key).toEqual({ hint: "QRST", secret: true });
+
+    expect(JSON.stringify(await readPlatformSettings(owner()))).not.toContain(
+      THEIR_OWN_KEY,
+    );
+  });
+
+  it("shows what is not a secret and withholds what is", async () => {
+    // The public readiness answer reads this, so a secret must never have a
+    // value here — not even a hint of one.
+    expect(await platformFacts()).toEqual({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: null,
+    });
+  });
+
+  it("changes one setting and leaves the rest alone", async () => {
+    await writePlatformSettings(owner(), { persona_model: "gpt-4.1-mini" });
+
+    const held = await settingsByName();
+    expect(held.persona_model?.hint).toBe("gpt-4.1-mini");
+    expect(held.persona_model_key?.hint).toBe("QRST");
+  });
+
+  it("seals a replacement afresh, so two writes of one value are two rows apart", async () => {
+    const before = await database.sql<{ value: string }>(
+      "select value from platform_setting where name = $1",
+      ["persona_model_key"],
+    );
+    await writePlatformSettings(owner(), { persona_model_key: THEIR_OWN_KEY });
+    const after = await database.sql<{ value: string }>(
+      "select value from platform_setting where name = $1",
+      ["persona_model_key"],
+    );
+
+    // A fresh initialisation vector every time, exactly as a connection's
+    // credentials are resealed: the column tells nobody that nothing changed.
+    expect(after.rows[0]?.value).not.toBe(before.rows[0]?.value);
+  });
+
+  it("belongs to the deployment, so the row names no customer", async () => {
+    const { rows } = await database.sql<{ column_name: string }>(
+      `select column_name from information_schema.columns
+        where table_name = 'platform_setting'`,
+    );
+    const columns = rows.map((row) => row.column_name).sort();
+
+    expect(columns).toEqual([
+      "created_at",
+      "hint",
+      "id",
+      "name",
+      "updated_at",
+      "value",
+    ]);
+  });
+
+  it("is one deployment's answer, whichever customer asked", async () => {
+    // There is one platform and one set of settings on it. An owner in another
+    // organization reads the same answer, because there is no other answer to
+    // read — which is what "owned by the deployment" means when it is written
+    // down as behaviour rather than as a column that is absent.
+    const elsewhere = await readPlatformSettings({
+      userId: newId("usr"),
+      organizationId: globex.organization,
+      projectId: globex.project,
+      role: "admin",
+      via: "session",
+    });
+
+    expect(
+      elsewhere.find((setting) => setting.name === "persona_model")?.hint,
+    ).toBe("gpt-4.1-mini");
+  });
+});
+
+describe("who may read and change them", () => {
+  it("refuses a member the read and the write alike", async () => {
+    // These are the deployment's own provider credentials. Everybody in the
+    // organization can start a run with them; being able to see whose account
+    // is spent, or point it at another, is the organization-settings decision
+    // rather than the authoring one.
+    await expect(readPlatformSettings(member("member"))).rejects.toThrow(
+      NotPermittedError,
+    );
+    await expect(
+      writePlatformSettings(member("member"), { persona_model: "gpt-4o" }),
+    ).rejects.toThrow(NotPermittedError);
+  });
+
+  it("refuses a viewer the same two", async () => {
+    await expect(readPlatformSettings(member("viewer"))).rejects.toThrow(
+      NotPermittedError,
+    );
+    await expect(
+      writePlatformSettings(member("viewer"), { persona_model: "gpt-4o" }),
+    ).rejects.toThrow(NotPermittedError);
+  });
+
+  it("leaves the settings as they were", async () => {
+    expect((await settingsByName()).persona_model?.hint).toBe("gpt-4.1-mini");
+  });
+});
+
+describe("a write that cannot be acted on", () => {
+  it("refuses a setting the platform does not know", async () => {
+    await expect(
+      writePlatformSettings(
+        owner(),
+        // A name nobody reads is a row nothing ever uses, so it is refused
+        // here rather than written and forgotten.
+        { not_a_setting: "anything" } as unknown as PlatformSettingValues,
+      ),
+    ).rejects.toThrow(/not a platform setting egma knows/u);
+  });
+
+  it("refuses an empty value, because clearing a setting is not writing one", async () => {
+    await expect(
+      writePlatformSettings(owner(), { persona_model: "   " }),
+    ).rejects.toThrow(/needs a value/u);
+  });
+
+  it("refuses a secret too short for any provider to have issued it", async () => {
+    await expect(
+      writePlatformSettings(owner(), { persona_model_key: "sk-abc" }),
+    ).rejects.toThrow(/shorter than any provider issues/u);
+  });
+});
+
+describe("seeding from the environment", () => {
+  it("never replaces a setting somebody has already chosen", async () => {
+    // The property that makes seeding safe on every boot: a redeploy carrying
+    // the old key in a script must not undo a key the operator changed.
+    const written = await seedPlatformSettings({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o-mini",
+      persona_model_key: FROM_THE_ENVIRONMENT,
+    });
+
+    expect(written).toEqual([]);
+    const held = await settingsByName();
+    expect(held.persona_model?.hint).toBe("gpt-4.1-mini");
+    expect(held.persona_model_key?.hint).toBe("QRST");
+  });
+});
+
+describe("seeding a platform that holds nothing", () => {
+  beforeAll(async () => {
+    // Back to a platform nobody has configured, which is what every deployment
+    // is on the morning somebody first starts it.
+    await database.sql("delete from platform_setting");
+  });
+
+  it("writes what the environment names", async () => {
+    const written = await seedPlatformSettings({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o-mini",
+      persona_model_key: FROM_THE_ENVIRONMENT,
+    });
+
+    expect([...written].sort()).toEqual([
+      "persona_model",
+      "persona_model_key",
+      "persona_model_provider",
+    ]);
+    expect(await settingsByName()).toEqual({
+      persona_model_provider: { hint: "openai", secret: false },
+      persona_model: { hint: "gpt-4o-mini", secret: false },
+      persona_model_key: { hint: "WXYZ", secret: true },
+    });
+  });
+
+  it("seals what it wrote, exactly as a person's own write is sealed", async () => {
+    const stored = await database.sql<{ value: string }>(
+      "select value from platform_setting where name = $1",
+      ["persona_model_key"],
+    );
+    expect(stored.rows[0]?.value).not.toContain(FROM_THE_ENVIRONMENT);
+    expect(stored.rows[0]?.value.startsWith("v1.")).toBe(true);
+  });
+
+  it("writes nothing on the next boot, so every start is safe", async () => {
+    expect(
+      await seedPlatformSettings({
+        persona_model_provider: "openai",
+        persona_model: "gpt-4o-mini",
+        persona_model_key: FROM_THE_ENVIRONMENT,
+      }),
+    ).toEqual([]);
+  });
+
+  it("fills only the gap when the environment names more than the platform holds", async () => {
+    await database.sql("delete from platform_setting where name = $1", [
+      "persona_model",
+    ]);
+
+    expect(
+      await seedPlatformSettings({
+        persona_model_provider: "openai",
+        persona_model: "gpt-4o-mini",
+        persona_model_key: FROM_THE_ENVIRONMENT,
+      }),
+    ).toEqual(["persona_model"]);
+  });
+});

--- a/packages/db/test/platform-settings.test.ts
+++ b/packages/db/test/platform-settings.test.ts
@@ -65,11 +65,21 @@ function member(role: "member" | "viewer"): AuthContext {
   };
 }
 
+/**
+ * A deployment that is one team, which is what every self-host is and what the
+ * default flag says. It is the precondition on being here at all, so it is
+ * written out at every call rather than hidden in a helper's default.
+ */
+const ONE_TEAM = { singleOrganization: true } as const;
+
+/** And a platform serving several customers, where these settings are nobody's. */
+const SEVERAL_CUSTOMERS = { singleOrganization: false } as const;
+
 /** One setting as it stands, by name — the shape every read here asserts on. */
 async function settingsByName(
   auth: AuthContext = owner(),
 ): Promise<Record<string, { hint: string | null; secret: boolean }>> {
-  const held = await readPlatformSettings(auth);
+  const held = await readPlatformSettings(auth, ONE_TEAM);
   return Object.fromEntries(
     held.map((setting) => [
       setting.name,
@@ -113,7 +123,7 @@ describe("a platform that has been given no settings", () => {
 
 describe("writing a platform setting", () => {
   it("seals the value rather than storing it", async () => {
-    await writePlatformSettings(owner(), {
+    await writePlatformSettings(owner(), ONE_TEAM, {
       persona_model_provider: "openai",
       persona_model: "gpt-4o",
       persona_model_key: THEIR_OWN_KEY,
@@ -142,7 +152,7 @@ describe("writing a platform setting", () => {
     // Enough to tell two keys apart, and nothing anybody could spend with.
     expect(held.persona_model_key).toEqual({ hint: "QRST", secret: true });
 
-    expect(JSON.stringify(await readPlatformSettings(owner()))).not.toContain(
+    expect(JSON.stringify(await readPlatformSettings(owner(), ONE_TEAM))).not.toContain(
       THEIR_OWN_KEY,
     );
   });
@@ -158,7 +168,7 @@ describe("writing a platform setting", () => {
   });
 
   it("changes one setting and leaves the rest alone", async () => {
-    await writePlatformSettings(owner(), { persona_model: "gpt-4.1-mini" });
+    await writePlatformSettings(owner(), ONE_TEAM, { persona_model: "gpt-4.1-mini" });
 
     const held = await settingsByName();
     expect(held.persona_model?.hint).toBe("gpt-4.1-mini");
@@ -170,7 +180,7 @@ describe("writing a platform setting", () => {
       "select value from platform_setting where name = $1",
       ["persona_model_key"],
     );
-    await writePlatformSettings(owner(), { persona_model_key: THEIR_OWN_KEY });
+    await writePlatformSettings(owner(), ONE_TEAM, { persona_model_key: THEIR_OWN_KEY });
     const after = await database.sql<{ value: string }>(
       "select value from platform_setting where name = $1",
       ["persona_model_key"],
@@ -198,45 +208,86 @@ describe("writing a platform setting", () => {
     ]);
   });
 
-  it("is one deployment's answer, whichever customer asked", async () => {
-    // There is one platform and one set of settings on it. An owner in another
-    // organization reads the same answer, because there is no other answer to
-    // read — which is what "owned by the deployment" means when it is written
-    // down as behaviour rather than as a column that is absent.
-    const elsewhere = await readPlatformSettings({
+});
+
+describe("a deployment that serves more than one organization", () => {
+  /** An owner, and of a second organization on the same platform. */
+  function ownerAtGlobex(): AuthContext {
+    return {
       userId: newId("usr"),
       organizationId: globex.organization,
       projectId: globex.project,
       role: "admin",
       via: "session",
-    });
+    };
+  }
 
-    expect(
-      elsewhere.find((setting) => setting.name === "persona_model")?.hint,
-    ).toBe("gpt-4.1-mini");
+  /**
+   * **There is one platform and one set of settings on it, and that is exactly
+   * why nobody may have them here.** These are the deployment's own provider
+   * credentials: on a platform holding several customers, letting one
+   * organization's owner read them would show them the hints of a key the
+   * others depend on, and letting them write would point everybody else's
+   * simulations at an account nobody else agreed to.
+   *
+   * Whose settings these are on such a deployment is a real question and it is
+   * deliberately not answered yet. Until it is, egma refuses everybody rather
+   * than picking one of them — the same guard the platform's own judge is
+   * behind, which is only ever given away on a single-organization deployment.
+   */
+  it("refuses an owner of a second organization both the read and the write", async () => {
+    await expect(
+      readPlatformSettings(ownerAtGlobex(), SEVERAL_CUSTOMERS),
+    ).rejects.toThrow(NotPermittedError);
+    await expect(
+      writePlatformSettings(ownerAtGlobex(), SEVERAL_CUSTOMERS, {
+        persona_model: "gpt-4o",
+      }),
+    ).rejects.toThrow(NotPermittedError);
+  });
+
+  it("refuses the first organization's owner too, so it is the deployment and not the customer", async () => {
+    await expect(
+      readPlatformSettings(owner(), SEVERAL_CUSTOMERS),
+    ).rejects.toThrow(NotPermittedError);
+  });
+
+  it("changed nothing: the settings are as the single-organization owner left them", async () => {
+    expect((await settingsByName()).persona_model?.hint).toBe("gpt-4.1-mini");
   });
 });
 
 describe("who may read and change them", () => {
+  it("lets an owner read them while this deployment is one team", async () => {
+    // The passing side of the precondition above, kept beside it: the default
+    // deployment, and the self-hoster who is both its operator and its only
+    // organization's admin.
+    const held = await readPlatformSettings(owner(), ONE_TEAM);
+
+    expect(held.find((setting) => setting.name === "persona_model")?.hint).toBe(
+      "gpt-4.1-mini",
+    );
+  });
+
   it("refuses a member the read and the write alike", async () => {
     // These are the deployment's own provider credentials. Everybody in the
     // organization can start a run with them; being able to see whose account
     // is spent, or point it at another, is the organization-settings decision
     // rather than the authoring one.
-    await expect(readPlatformSettings(member("member"))).rejects.toThrow(
+    await expect(readPlatformSettings(member("member"), ONE_TEAM)).rejects.toThrow(
       NotPermittedError,
     );
     await expect(
-      writePlatformSettings(member("member"), { persona_model: "gpt-4o" }),
+      writePlatformSettings(member("member"), ONE_TEAM, { persona_model: "gpt-4o" }),
     ).rejects.toThrow(NotPermittedError);
   });
 
   it("refuses a viewer the same two", async () => {
-    await expect(readPlatformSettings(member("viewer"))).rejects.toThrow(
+    await expect(readPlatformSettings(member("viewer"), ONE_TEAM)).rejects.toThrow(
       NotPermittedError,
     );
     await expect(
-      writePlatformSettings(member("viewer"), { persona_model: "gpt-4o" }),
+      writePlatformSettings(member("viewer"), ONE_TEAM, { persona_model: "gpt-4o" }),
     ).rejects.toThrow(NotPermittedError);
   });
 
@@ -250,6 +301,7 @@ describe("a write that cannot be acted on", () => {
     await expect(
       writePlatformSettings(
         owner(),
+        ONE_TEAM,
         // A name nobody reads is a row nothing ever uses, so it is refused
         // here rather than written and forgotten.
         { not_a_setting: "anything" } as unknown as PlatformSettingValues,
@@ -259,13 +311,13 @@ describe("a write that cannot be acted on", () => {
 
   it("refuses an empty value, because clearing a setting is not writing one", async () => {
     await expect(
-      writePlatformSettings(owner(), { persona_model: "   " }),
+      writePlatformSettings(owner(), ONE_TEAM, { persona_model: "   " }),
     ).rejects.toThrow(/needs a value/u);
   });
 
   it("refuses a secret too short for any provider to have issued it", async () => {
     await expect(
-      writePlatformSettings(owner(), { persona_model_key: "sk-abc" }),
+      writePlatformSettings(owner(), ONE_TEAM, { persona_model_key: "sk-abc" }),
     ).rejects.toThrow(/shorter than any provider issues/u);
   });
 });

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -32,6 +32,11 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   organization: "org",
   organization_settings: "org",
   platform_instance: "pf",
+  // One row for each setting the deployment holds. Its identity is its own
+  // rather than somebody's key, because it belongs to the platform and to no
+  // customer — the one table below the tenancy tables that names neither an
+  // organization nor a project.
+  platform_setting: "pfs",
   project: "prj",
   membership: "mbr",
   invitation: "inv",

--- a/packages/ids/src/index.ts
+++ b/packages/ids/src/index.ts
@@ -33,6 +33,7 @@ export const ID_PREFIXES = [
   "vrf",
   "dvc",
   "pf",
+  "pfs",
   "org",
   "prj",
   "mbr",

--- a/packages/lint/src/index.test.ts
+++ b/packages/lint/src/index.test.ts
@@ -326,6 +326,47 @@ describe("an exported call that could reach the database without a customer", ()
   });
 
   /**
+   * The widening that a pin on the *name* would have missed, which is the whole
+   * reason the pin carries the alias's body.
+   *
+   * `platformFacts` answers what this deployment was configured with, at the
+   * one door that asks for no credential, and what keeps that safe is the shape
+   * behind the name: non-secret values, with every secret reduced to null. A
+   * rule comparing `Promise<PlatformFacts>` as text would stay green while
+   * somebody put a key's hint — or a key — inside it, so the alias declared
+   * beside the function is pinned with it.
+   */
+  it("refuses an instance exception whose answer is widened behind its own name", async () => {
+    const widened =
+      "export type PlatformFacts = Readonly<Record<string, string>>;\n" +
+      "export async function platformFacts(): Promise<PlatformFacts> {\n  return {};\n}\n";
+    await withSurface(
+      'export { platformFacts } from "./things.ts";\n',
+      widened,
+    );
+
+    const violations = await check(root);
+    expect(rules(violations)).toEqual([
+      "every-exported-call-carries-an-auth-context",
+    ]);
+    expect(violations[0]?.detail).toContain("PlatformFacts");
+    expect(violations[0]?.detail).toContain("wearing an exemption");
+  });
+
+  it("passes the same exception while its answer is the shape that was pinned", async () => {
+    const pinned =
+      "export type PlatformSettingName = 'persona_model';\n" +
+      "export type PlatformFacts = Readonly<Partial<Record<PlatformSettingName, string | null>>>;\n" +
+      "export async function platformFacts(): Promise<PlatformFacts> {\n  return {};\n}\n";
+    await withSurface('export { platformFacts } from "./things.ts";\n', pinned);
+
+    // One level of alias, and one file: `PlatformSettingName` is followed here
+    // because it is declared beside it, and the settings this platform holds
+    // may grow — what may never grow is the value beside them.
+    expect(await check(root)).toEqual([]);
+  });
+
+  /**
    * The engine's own work, which is the one thing on this surface that
    * legitimately spans customers: the grader service holds no credential
    * because there is nobody for it to be, so it is handed work instead. What

--- a/packages/lint/src/index.test.ts
+++ b/packages/lint/src/index.test.ts
@@ -337,8 +337,13 @@ describe("an exported call that could reach the database without a customer", ()
    * beside the function is pinned with it.
    */
   it("refuses an instance exception whose answer is widened behind its own name", async () => {
+    // Only the *value* is widened, and the keys beside it are left exactly as
+    // they were. That is the leak this pin exists to catch, isolated: the
+    // secret a caller may be handed lives in the value, and it is written
+    // inside the pinned alias's own body.
     const widened =
-      "export type PlatformFacts = Readonly<Record<string, string>>;\n" +
+      "export type PlatformSettingName = 'persona_model';\n" +
+      "export type PlatformFacts = Readonly<Partial<Record<PlatformSettingName, { value: string | null; hint: string }>>>;\n" +
       "export async function platformFacts(): Promise<PlatformFacts> {\n  return {};\n}\n";
     await withSurface(
       'export { platformFacts } from "./things.ts";\n',
@@ -360,9 +365,15 @@ describe("an exported call that could reach the database without a customer", ()
       "export async function platformFacts(): Promise<PlatformFacts> {\n  return {};\n}\n";
     await withSurface('export { platformFacts } from "./things.ts";\n', pinned);
 
-    // One level of alias, and one file: `PlatformSettingName` is followed here
-    // because it is declared beside it, and the settings this platform holds
-    // may grow — what may never grow is the value beside them.
+    // **One level, and `PlatformSettingName` is deliberately not one of them.**
+    // The walk collects the aliases named in the *signature* — here
+    // `PlatformFacts` — and appends their declarations; it does not recurse
+    // into what those declarations then name. That is the point rather than a
+    // gap: the settings this platform holds are meant to grow, one per ticket
+    // of this effort, and a pin that followed their names would stop the build
+    // on every setting added. What may never grow is the *value* beside them,
+    // and that is written inside the body this pin does carry — the test above
+    // widens exactly that and is refused.
     expect(await check(root)).toEqual([]);
   });
 

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -534,16 +534,26 @@ function aliasBody(tree: ts.SourceFile, named: string): string | undefined {
 /**
  * An answer as a reader of the call sees it: what is written after the
  * signature, plus the body of every type alias declared in the same file that
- * it names — including one nested inside `Promise<…>`, which is where every
- * answer on this surface lives.
+ * the signature names — including one nested inside `Promise<…>`, which is
+ * where every answer on this surface lives.
  *
  * **This is `asWritten`'s rule applied to the answer, and it is what makes the
  * instance-scoped pin a pin.** Comparing `Promise<Something>` as text pins only
  * the spelling of a name: the alias behind it could be widened to hand out a
  * secret with the rule still green, which is the one thing that exemption
- * exists to prevent. One level, same file, exactly as the parameter rule —
- * a name from another module is somebody else's vocabulary, and following it
- * would pin a file this one does not own.
+ * exists to prevent.
+ *
+ * **One level, and the level is the signature's.** What the *alias body* then
+ * names is not followed, and that is the design rather than a gap. Two reasons,
+ * and they point the same way. A name from another module is somebody else's
+ * vocabulary, and following it would pin a file this one does not own — the
+ * parameter rule's reasoning, unchanged. And the one such name in practice is
+ * a key type that is *meant* to grow: `PlatformFacts` is keyed by the settings
+ * this platform holds, a list that gains an entry with every ticket of the
+ * settings effort, and a pin that followed it would stop the build on each one.
+ * What may never grow is the value beside the key, and that is written inside
+ * the body this does carry — so the widening that would leak a secret is caught
+ * and the widening that adds a setting is not.
  */
 function answerAsWritten(
   tree: ts.SourceFile,

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -92,10 +92,19 @@ const CONTEXT_ESTABLISHING = [
  * boolean. `platformInstanceId` returns the platform's public, non-secret id.
  * A parameter or a wider return would make either an ordinary read wearing an
  * exemption, so the rule refuses both changes.
+ *
+ * `platformFacts` was added on 2026-08-14 with the platform's own settings,
+ * deliberately and on the same two terms. It is asked by the readiness answer
+ * the CLI reads in front of every command — before login and before any
+ * repository identifier is sent, exactly as the platform's identity is — so
+ * there is no credential to build a context from. It takes nothing, and its
+ * `PlatformFacts` is a map of non-secret values in which every secret the
+ * platform holds is `null`: enough to say a key is there, and no part of one.
  */
 const INSTANCE_SCOPED: ReadonlyMap<string, string> = new Map([
   ["instanceIsClaimed", "Promise<boolean>"],
   ["platformInstanceId", "Promise<string>"],
+  ["platformFacts", "Promise<PlatformFacts>"],
 ]);
 
 /**
@@ -170,14 +179,21 @@ const WORK_DISPATCHING = [
  * the same breath as applying migrations, on the deployment's own
  * configuration, and it names no customer.
  *
+ * `seedPlatformSettings` was added on 2026-08-14 and is the same act one scope
+ * up: the settings the deployment itself owns — the persona's model provider,
+ * its model and its key to begin with — written from the environment on start
+ * for anything the platform does not already hold, and never over a value
+ * somebody chose. It names no customer because there is none to name: these
+ * belong to the platform and to nobody on it.
+ *
  * The rule enforces the second half of that the same way it does for work
  * dispatch: nothing here may be handed an `organizationId` or a `projectId`. A
  * function here that grew one would be an ordinary cross-tenant *write* wearing
  * an exemption, which is worse than the read work dispatch guards against.
  *
- * A second name here is a decision somebody has to make on purpose.
+ * A third name here is a decision somebody has to make on purpose.
  */
-const DEPLOYMENT_CONFIGURING = ["seedDefaultJudge"];
+const DEPLOYMENT_CONFIGURING = ["seedDefaultJudge", "seedPlatformSettings"];
 
 /**
  * What a work-dispatching or deployment-configuring export may not be handed,

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -93,6 +93,13 @@ const CONTEXT_ESTABLISHING = [
  * A parameter or a wider return would make either an ordinary read wearing an
  * exemption, so the rule refuses both changes.
  *
+ * **The answer is pinned as a reader sees it, alias body and all.** Where the
+ * declared type names an alias from the same file, the pin carries that alias's
+ * whole declaration — otherwise the pin would hold only the spelling of a name,
+ * and a shape behind it could be widened to hand out a secret with this rule
+ * still green. That is `asWritten`'s rule for parameters, applied to the answer
+ * by `answerAsWritten`.
+ *
  * `platformFacts` was added on 2026-08-14 with the platform's own settings,
  * deliberately and on the same two terms. It is asked by the readiness answer
  * the CLI reads in front of every command — before login and before any
@@ -100,11 +107,18 @@ const CONTEXT_ESTABLISHING = [
  * there is no credential to build a context from. It takes nothing, and its
  * `PlatformFacts` is a map of non-secret values in which every secret the
  * platform holds is `null`: enough to say a key is there, and no part of one.
+ * The settings behind it are the whole effort's — the carrier trunk and the
+ * speech keys arrive there next — so the pin holds the value type it may
+ * answer, and a hint added to it stops the build.
  */
 const INSTANCE_SCOPED: ReadonlyMap<string, string> = new Map([
   ["instanceIsClaimed", "Promise<boolean>"],
   ["platformInstanceId", "Promise<string>"],
-  ["platformFacts", "Promise<PlatformFacts>"],
+  [
+    "platformFacts",
+    "Promise<PlatformFacts> export type PlatformFacts = " +
+      "Readonly<Partial<Record<PlatformSettingName, string | null>>>;",
+  ],
 ]);
 
 /**
@@ -507,6 +521,51 @@ function asWritten(tree: ts.SourceFile, parameter: ts.ParameterDeclaration): str
   return written;
 }
 
+/** The body of a type alias declared in this file, or nothing. */
+function aliasBody(tree: ts.SourceFile, named: string): string | undefined {
+  for (const statement of tree.statements) {
+    if (ts.isTypeAliasDeclaration(statement) && statement.name.text === named) {
+      return statement.getText(tree);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * An answer as a reader of the call sees it: what is written after the
+ * signature, plus the body of every type alias declared in the same file that
+ * it names — including one nested inside `Promise<…>`, which is where every
+ * answer on this surface lives.
+ *
+ * **This is `asWritten`'s rule applied to the answer, and it is what makes the
+ * instance-scoped pin a pin.** Comparing `Promise<Something>` as text pins only
+ * the spelling of a name: the alias behind it could be widened to hand out a
+ * secret with the rule still green, which is the one thing that exemption
+ * exists to prevent. One level, same file, exactly as the parameter rule —
+ * a name from another module is somebody else's vocabulary, and following it
+ * would pin a file this one does not own.
+ */
+function answerAsWritten(
+  tree: ts.SourceFile,
+  declaration: ts.FunctionDeclaration,
+): string {
+  const type = declaration.type;
+  if (type === undefined) return "no declared return type";
+
+  const named: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isTypeReferenceNode(node)) named.push(node.typeName.getText(tree));
+    ts.forEachChild(node, visit);
+  };
+  visit(type);
+
+  const bodies = [...new Set(named)]
+    .map((name) => aliasBody(tree, name))
+    .filter((body): body is string => body !== undefined);
+
+  return [type.getText(tree), ...bodies].join(" ");
+}
+
 /**
  * Every function the module exports either takes an `AuthContext` first, or is
  * one of the named exceptions: the seven that produce a context, the one that
@@ -594,20 +653,21 @@ async function checkExportedCallShapes(root: string): Promise<Violation[]> {
         });
       }
 
-      if (
-        instanceScopedReturn !== undefined &&
-        declaration.type?.getText(declaring) !== instanceScopedReturn
-      ) {
-        const declared = declaration.type?.getText(declaring) ?? "no declared return type";
-        violations.push({
-          file,
-          line: line(declaration),
-          rule: "every-exported-call-carries-an-auth-context",
-          detail:
-            `${name} skips the ${AUTH_CONTEXT} only because its public ` +
-            `instance fact is ${instanceScopedReturn}. It declares ${declared}; ` +
-            `a wider return would make this an ordinary read wearing an exemption.`,
-        });
+      if (instanceScopedReturn !== undefined) {
+        // The answer *and* the body of any alias it names, so widening the
+        // shape behind a name is as loud as widening the name.
+        const declared = answerAsWritten(declaring, declaration);
+        if (declared !== instanceScopedReturn) {
+          violations.push({
+            file,
+            line: line(declaration),
+            rule: "every-exported-call-carries-an-auth-context",
+            detail:
+              `${name} skips the ${AUTH_CONTEXT} only because its public ` +
+              `instance fact is ${instanceScopedReturn}. It declares ${declared}; ` +
+              `a wider return would make this an ordinary read wearing an exemption.`,
+          });
+        }
       }
 
       if (


### PR DESCRIPTION
Closes ticket 02 of the platform-settings effort. This is the tracer bullet: the table, the sealing, the routes, the permission and the readiness answer, proven end to end with one group of settings — the persona's model provider, model name and key. Tickets 03, 04 and 05 ride on this shape.

## The problem

Settings that belong to the whole deployment lived in one file beside it, which only the egma CLI read. Start the platform any other way and every setting was absent — and absent did not fail, because each variable had an empty default. Every container started, every health check passed, and the failure arrived minutes later as a carrier refusal that named nothing about configuration.

## What changed

- A new `platform_setting` table holds **one row for each setting**, keyed by name, sealed with the encryption key the platform already holds, with a short hint kept for display. The table is deployment-scoped and carries no organization or project identifier.
- `GET` and `PATCH /api/platform/settings` read and write them. A read returns the provider, the model and a hint. **It never returns a key.**
- On start, the API writes any setting it finds in the environment that the platform does not already hold, and never replaces one it does.
- `GET /api/platform` gains `setup: { state, missing }`. The platform answers `ready` or `setup required` for its whole configuration and names each absent setting in the words a person would use. No readiness answer carries a secret.

**The judge is the model this follows, not a second idiom.** Same `sealCredentials`, same `v1.` version prefix, same last-four hint, same minimum key length, same `onConflictDoNothing` seeding. No new key and no new sealing code.

## Permission

Any organization owner may read and change these settings **while the deployment is in single-organization mode**, which is the existing flag meaning "this deployment is one team". When the deployment serves more than one organization, every owner is refused — including the first organization's. Whose these settings are is the question the spec puts out of scope, and answering it by letting the oldest organization win would answer it by accident. Seeding and the non-secret facts stay ungated: one is the deployment configuring itself, the other carries no secret.

## Notes for the reviewer

- `packages/lint/src/index.ts` changed. The rule that pins a data-access function's return type compared the declared type as literal **text**, so pinning `Promise<PlatformFacts>` pinned only an alias spelling — the alias body could be widened to carry a secret with the rule still green. The rule now also appends the body of any type alias declared in the same file that the return type names, including inside `Promise<…>`. This was verified by widening the alias and watching the build fail.
- One refusal for an unknown setting name, not two. The route's duplicate is gone; the access layer's 422 is the only one.
- The setting names are written once. `PlatformSettingName` derives from the `PLATFORM_SETTINGS` catalog, following `schema/graders.ts`.
- Documentation added here names `egma self-host setup`, which ticket 04 builds on this same integration branch.
- The readiness answer's phone half still reads process configuration. Ticket 03 moves it.

## Tests

`packages/db/test/platform-settings.test.ts` and `apps/api/test/platform-settings-routes.test.ts` cover every ticket criterion, including a raw Postgres read proving what lands in storage is ciphertext with the version prefix, an `information_schema` assertion that the table carries no organization or project column, and a public-door test asserting neither a key nor its hint appears.

`pnpm typecheck` passes. The full suite has two failures, both in `apps/api/test/default-judge-on-signup.test.ts`; both fail identically on the base commit, off this diff — `test/support/api.ts` defaults `singleOrganization: false` while `server.ts` gates the default judge on that flag.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789334051&installation_model_id=431960&pr_number=77&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F77&signature=ebdb2bb9ed611a24b7824d59b2d8a8097b4071eaef6393a6f476525b2723cc39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves deployment-wide persona model settings into sealed database storage and exposes readiness and owner-managed settings APIs.
- Adds the platform settings schema, migration, encrypted persistence, environment seeding, and access functions.
- Adds authenticated settings read/write routes and incorporates stored settings into public platform readiness.
- Extends configuration, deployment wiring, tests, and lint enforcement for the new settings contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/access/platform-settings.ts | Implements sealed platform-setting persistence, environment seeding, permission checks, and non-secret platform facts. |
| apps/api/src/routes/platform-settings.ts | Adds owner-gated JSON endpoints for reading descriptions and updating deployment settings without returning stored secrets. |
| apps/api/src/platform-readiness.ts | Combines stored platform-setting facts with phone readiness into the public setup state. |
| packages/lint/src/index.ts | Extends return-shape pinning to include directly referenced same-file alias bodies; the previously questioned nested alias controls keys rather than secret-bearing values. |
| packages/db/migrations/0023_platform_settings.sql | Adds the deployment-scoped platform settings table and its update-time trigger. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  ENV[Environment settings] -->|seed missing values| DB[(platform_setting)]
  OWNER[Single-organization owner] -->|PATCH /api/platform/settings| API[Settings route]
  API -->|seal and persist| DB
  DB -->|non-secret descriptions| API
  DB -->|platform facts| READY[GET /api/platform]
  PHONE[Phone readiness] --> READY
  READY -->|ready or setup_required| CLIENT[CLI or browser]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Say what the answer pin actually follows..."](https://github.com/egma-ai/egma/commit/4fd235a4fd9aae7ab317e43009c023cf81bced0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53484775)</sub>

<!-- /greptile_comment -->