### PR TITLE
Hand the platform's own settings to the simulator on the work order

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -444,16 +444,6 @@ EGMA_SIMULATOR_LOG_LEVEL=INFO
 # whatever port you pick: the workbench authenticates nobody.
 EGMA_WORKBENCH_PORT=8085
 
-# --- Phone readiness, as the API reports it -----------------------------------
-# Three non-secret facts, written by `egma self-host phone setup`, and the whole
-# of what the API process knows about the carrier. It reports the platform's
-# phone state from them: all three present is `ready`, and anything less is
-# `setup required` naming what is missing. There is no token, no password and no
-# provider key here on purpose — the API neither dials nor speaks.
-EGMA_PHONE_TRUNK_ADDRESS=
-EGMA_PHONE_SOURCE_NUMBER=
-EGMA_PHONE_SPEECH_PROVIDER=
-
 # --- The default judge --------------------------------------------------------
 # The judge a project is given when it has configured none, from the one OpenAI
 # key phone setup asked for. All three or none: half a judge is a judge that
@@ -469,12 +459,14 @@ EGMA_JUDGE_PROVIDER=
 EGMA_JUDGE_MODEL=
 EGMA_JUDGE_API_KEY=
 
-# --- The persona's model, as the platform holds it ----------------------------
-# What the persona thinks with when it calls an agent. These are the platform's
-# own settings: it keeps them in its own store, sealed with EGMA_ENCRYPTION_KEY,
-# rather than only in this file. That is the whole point — a setting the
-# platform holds survives a restart, an upgrade and a move to another machine,
-# and a second simulator on another host needs nothing copied to it.
+# --- What this platform is configured with ------------------------------------
+# The persona's model, the legs it speaks and hears with, and the carrier a
+# phone call goes over. These are the platform's own settings: it keeps them in
+# its own store, sealed with EGMA_ENCRYPTION_KEY, rather than only in this file.
+# That is the whole point — a setting the platform holds survives a restart, an
+# upgrade and a move to another machine, and a second simulator on another host
+# needs nothing copied to it. They reach each simulator on the work order it
+# claims, which is why no EGMA_SIMULATOR_* variable below repeats any of them.
 #
 # There are two ways to put a setting in and the choice is yours. Setting them
 # here is the one for a deployment that answers no questions: on start the API
@@ -485,9 +477,34 @@ EGMA_JUDGE_API_KEY=
 # Leave them empty and nothing breaks at start: the platform reports
 # `setup required` and names each one that is missing, rather than starting
 # hollow and failing on the first simulation.
+
+# What the persona thinks with when it calls an agent.
 EGMA_PERSONA_MODEL_PROVIDER=
 EGMA_PERSONA_MODEL=
 EGMA_PERSONA_MODEL_API_KEY=
+
+# What it hears with and speaks with on a voice simulation, and what tells it
+# the agent has started and stopped speaking. A key per leg: one account often
+# serves both, and then the same key goes in both — but two companies is an
+# ordinary deployment and each needs its own.
+EGMA_PERSONA_STT_PROVIDER=
+EGMA_PERSONA_STT_API_KEY=
+EGMA_PERSONA_TTS_PROVIDER=
+EGMA_PERSONA_TTS_API_KEY=
+EGMA_PERSONA_TTS_MODEL=
+EGMA_PERSONA_TTS_VOICE=
+EGMA_PERSONA_VAD_PROVIDER=
+
+# How a call reaches the telephone network: which bridge places it, and the
+# trunk the carrier authenticates. Written by `egma self-host phone setup`
+# under these same names. The media server's own key and secret are *not*
+# here — they belong to a container that reads them when it is created, so
+# they stay with EGMA_LIVEKIT_API_KEY and EGMA_LIVEKIT_API_SECRET above.
+EGMA_MEDIA_BACKEND=
+EGMA_PHONE_TRUNK_ADDRESS=
+EGMA_PHONE_SOURCE_NUMBER=
+EGMA_PHONE_TRUNK_USERNAME=
+EGMA_PHONE_TRUNK_PASSWORD=
 
 # --- The grader ------------------------------------------------------------
 # The service that judges finished conversations. It claims its work, so it

--- a/.env.example
+++ b/.env.example
@@ -231,107 +231,46 @@ EGMA_SIMULATOR_SERVICE_TOKEN=
 # has room for, so more work than this queues instead of overloading.
 EGMA_SIMULATOR_CAPACITY=4
 
-# Where the persona's words come from: `scripted` or `openai`. `scripted` walks
-# the scenario deterministically and needs no account, which is why it is the
-# default. `openai` speaks the OpenAI chat-completions shape to any provider
-# using it, and makes the model name and key required.
-EGMA_SIMULATOR_MODEL_PROVIDER=scripted
-EGMA_SIMULATOR_MODEL_NAME=
-EGMA_SIMULATOR_MODEL_API_KEY=
-
-# Which endpoint the `openai` provider speaks to. Defaults to OpenAI's own.
+# **Which providers this simulator uses is not set here.** The persona's model
+# and key, what it speaks and hears with, what tells it the agent has stopped
+# talking, which bridge places a call and which carrier trunk it goes over are
+# all the *platform's* settings. Set them under "What this platform is
+# configured with" further down, or through `egma self-host setup`. The API
+# seals them into its own store and hands them to every simulator on the work
+# order it claims, so nothing about a provider is written on a container again
+# and a second simulator is started with nothing copied to it.
+#
+# Which endpoint the `openai` model provider speaks to. This one stays here
+# because it is a property of the network this container is on rather than of
+# the deployment's account. Defaults to OpenAI's own.
 EGMA_SIMULATOR_MODEL_BASE_URL=https://api.openai.com/v1
 
-# What the persona hears with, in a voice simulation: `scripted`, `deepgram` or
-# `openai`. `scripted` reads a deterministic test tone back into words — no
-# account, no network — which is why it is the default and what CI runs on. The
-# other two transcribe real speech and make their key below required.
-EGMA_SIMULATOR_STT_PROVIDER=scripted
-EGMA_SIMULATOR_DEEPGRAM_API_KEY=
-
-# What the persona speaks with: `scripted`, `elevenlabs` or `openai`. Chosen
-# apart from the ears above, so a real voice with scripted ears is one variable.
-# Naming a provider makes its key required. Which voice it speaks with comes
-# from the persona's own traits; a persona naming none gets the default below
-# for `openai`, and a default English voice for `elevenlabs`.
-EGMA_SIMULATOR_TTS_PROVIDER=scripted
-EGMA_SIMULATOR_ELEVENLABS_API_KEY=
-
-# One key for both legs when either names `openai`, because one account speaks
-# and listens. `egma self-host phone setup` asks for it once and writes it here
-# and into the persona's own key above — the same key, four jobs: the persona's
-# words, its voice, its ears, and the judge a project is given when it has
-# configured none.
-EGMA_SIMULATOR_OPENAI_API_KEY=
-
-# Which models the two `openai` legs ask for, and which voice the persona speaks
-# with when its own traits name none. Empty means egma's own defaults:
-# gpt-4o-transcribe, gpt-4o-mini-tts and alloy. They are configuration rather
-# than a constant of the product, because the provider retires and adds models on
-# its own schedule and a deployment must be able to move without waiting for an
-# egma release.
-#
-# The speaking leg is worth one more sentence. OpenAI returns 24 kHz audio
-# whatever is asked of it, and a phone line is 8 kHz — so egma converts what it
-# receives down to the band the line really carries rather than relabelling it,
-# which is what an unconverted stream would be: a voice three times too deep and
-# three times too slow, with every measurement taken off it wrong by the same
-# factor.
+# Which model the listening leg asks for. Empty means egma's own default,
+# gpt-4o-transcribe. It is configuration rather than a constant of the product,
+# because the provider retires and adds models on its own schedule, and it stays
+# a per-container variable because the platform's settings do not carry it.
 EGMA_SIMULATOR_STT_MODEL=
-EGMA_SIMULATOR_TTS_MODEL=
-EGMA_SIMULATOR_TTS_VOICE=
-
-# What tells the persona that the agent has started or stopped speaking:
-# `scripted` or `silero`. Chosen apart from the two above and needing no key
-# either way — `silero` is the production voice detector and it ships inside
-# the pinned pipecat wheel, so choosing it downloads nothing. `scripted` reads
-# the test tone exactly, which is what makes CI's timings the same every run;
-# it hears no real speech, so a deployment with real ears and a real voice
-# wants `silero` here too.
-EGMA_SIMULATOR_VAD_PROVIDER=scripted
 
 # --- Phone calls -------------------------------------------------------------
 # Only for a simulation whose connection names a phone number. Nothing below is
 # read until one does, and a simulator that never dials needs none of it.
 #
-# **You should not have to fill any of this in by hand.** `egma self-host phone
-# setup` asks for a Twilio account, a number that account already owns and one
-# OpenAI key, does the carrier paperwork, and writes what came out of it into
-# .egma-platform/platform.env — a private file it creates and the self-host
-# commands read back. What is below is the same set of names, for a deployment
-# that configures its own environment instead. Everything here arrives from your
-# environment and from nowhere else: a spec never carries a trunk.
+# **Which bridge places the call, and the carrier trunk it goes over, are the
+# platform's settings and are not here.** Set them under "What this platform is
+# configured with" further down, or let `egma self-host phone setup` do the
+# Twilio paperwork and write them for you. They reach every simulator on the
+# work order it claims, so the carrier work you did once is done once, and a
+# second simulator on another machine needs nothing copied to it.
 #
-# Which bridge places the call. `livekit` is the one this ships with;
-# `scripted` is the local stand-in CI and the demo run on, which places no call
-# at all. Naming one is what makes the variables below required, and what makes
-# this simulator able to dial: leave it unset and startup is silent, and a
-# simulation naming a phone number is refused with the variable to set.
-EGMA_SIMULATOR_MEDIA_BACKEND=
-
-# The LiveKit server and its API credentials. The same three variables point at
+# What is left here is the media server this container talks to. It is a
+# third-party binary that reads its own key and secret when it is *created*, so
+# it can never come from the platform's store. The same three variables point at
 # a self-hosted LiveKit and at LiveKit Cloud — only the URL differs. Left empty,
 # they are filled in from the LiveKit beside the simulator and the EGMA_LIVEKIT_*
 # pair further down; set them here only to point at a LiveKit you run elsewhere.
 EGMA_SIMULATOR_LIVEKIT_URL=
 EGMA_SIMULATOR_LIVEKIT_API_KEY=
 EGMA_SIMULATOR_LIVEKIT_API_SECRET=
-
-# The SIP trunk that carries the call to the phone network. Bring your own,
-# from any carrier: either a trunk already stored in LiveKit, named here by its
-# id...
-EGMA_SIMULATOR_SIP_TRUNK_ID=
-# ...or one given inline — the carrier's termination hostname, the number calls
-# appear to come from, and the username and password LiveKit documents for
-# outbound credential auth. The password is a secret and is never logged. The
-# username and password go together: one without the other is refused at
-# startup, because a carrier answers half a credential the same 403 it answers
-# a wrong one. Leave both empty for a trunk your carrier authenticates by
-# address instead.
-EGMA_SIMULATOR_SIP_TRUNK_ADDRESS=
-EGMA_SIMULATOR_SIP_TRUNK_NUMBER=
-EGMA_SIMULATOR_SIP_TRUNK_USERNAME=
-EGMA_SIMULATOR_SIP_TRUNK_PASSWORD=
 
 # --- The phone stack ----------------------------------------------------------
 # The LiveKit server, its SIP gateway and their Redis. They are part of the
@@ -482,7 +421,7 @@ EGMA_JUDGE_API_KEY=
 # That is the whole point — a setting the platform holds survives a restart, an
 # upgrade and a move to another machine, and a second simulator on another host
 # needs nothing copied to it. They reach each simulator on the work order it
-# claims, which is why no EGMA_SIMULATOR_* variable below repeats any of them.
+# claims, which is why the EGMA_SIMULATOR_* block above names none of them.
 #
 # There are two ways to put a setting in and the choice is yours. Setting them
 # here is the one for a deployment that answers no questions: on start the API

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -2,7 +2,6 @@ import type { PlatformSettingValues } from "@egma/db";
 
 import { SERVICE_TOKEN_PREFIX } from "./auth/service-token.ts";
 import type { SmtpSettings } from "./auth/email.ts";
-import type { PhoneSettings } from "./phone-readiness.ts";
 import type { BlobStore } from "./recordings/signed-link.ts";
 
 /** A judge the platform hands to projects that have configured none. */
@@ -80,14 +79,6 @@ export type Config = {
    * pattern, so `docker compose up` still works with zero setup.
    */
   readonly simulatorServiceToken: string;
-  /**
-   * The non-secret facts `egma self-host phone setup` leaves behind, and the
-   * whole of what this process knows about the carrier. It never holds the
-   * Twilio Auth Token, the SIP password or the OpenAI key that the simulator
-   * dials and speaks with — the platform's phone authority lives in the
-   * container that uses it, and this side only says whether it exists.
-   */
-  readonly phone: PhoneSettings;
   /**
    * The judge a project is given when it has configured none, from the one
    * OpenAI key a self-hoster supplied at phone setup.
@@ -347,11 +338,6 @@ export function loadConfig(
     trustProxy: flag(environment, "EGMA_TRUST_PROXY", false),
     rateLimitPerMinute,
     simulatorServiceToken,
-    phone: {
-      trunkAddress: environment.EGMA_PHONE_TRUNK_ADDRESS?.trim() || null,
-      sourceNumber: environment.EGMA_PHONE_SOURCE_NUMBER?.trim() || null,
-      speechProvider: environment.EGMA_PHONE_SPEECH_PROVIDER?.trim() || null,
-    },
     defaultJudge: defaultJudge(environment),
     platformSettings: platformSettings(environment),
     blob: blobStore(environment, parsedBaseUrl),
@@ -361,6 +347,17 @@ export function loadConfig(
 /**
  * The settings this environment offers the platform, by the name the platform
  * stores each one under.
+ *
+ * **The carrier is in here now, and that is the point of the whole effort.**
+ * This process used to hold three non-secret phone facts as its own
+ * configuration and hold nothing else about the deployment, so a platform
+ * started without them reported `setup required` with no way to fix it but a
+ * restart. They are settings like the rest now: seeded from here once, stored
+ * sealed, changed through the settings form, and read from the store on every
+ * answer that depends on them. This process therefore does hold the trunk
+ * password long enough to seal it — the same way it already holds a judge's key
+ * and a connection's credentials long enough to seal those — and it never
+ * dials, speaks or listens with any of them.
  *
  * **Each variable is read here, literally and by name, on purpose.** A loop
  * over the settings catalog would be shorter and would defeat the check that
@@ -385,6 +382,20 @@ function platformSettings(
     persona_model_provider: environment.EGMA_PERSONA_MODEL_PROVIDER?.trim(),
     persona_model: environment.EGMA_PERSONA_MODEL?.trim(),
     persona_model_key: environment.EGMA_PERSONA_MODEL_API_KEY?.trim(),
+    speech_to_text_provider: environment.EGMA_PERSONA_STT_PROVIDER?.trim(),
+    speech_to_text_key: environment.EGMA_PERSONA_STT_API_KEY?.trim(),
+    text_to_speech_provider: environment.EGMA_PERSONA_TTS_PROVIDER?.trim(),
+    text_to_speech_key: environment.EGMA_PERSONA_TTS_API_KEY?.trim(),
+    text_to_speech_model: environment.EGMA_PERSONA_TTS_MODEL?.trim(),
+    text_to_speech_voice: environment.EGMA_PERSONA_TTS_VOICE?.trim(),
+    voice_activity_provider: environment.EGMA_PERSONA_VAD_PROVIDER?.trim(),
+    media_backend: environment.EGMA_MEDIA_BACKEND?.trim(),
+    // The carrier keeps the variable names phone setup already wrote, so an
+    // operator upgrading meets the same three words they were given before.
+    carrier_trunk_address: environment.EGMA_PHONE_TRUNK_ADDRESS?.trim(),
+    carrier_trunk_number: environment.EGMA_PHONE_SOURCE_NUMBER?.trim(),
+    carrier_trunk_username: environment.EGMA_PHONE_TRUNK_USERNAME?.trim(),
+    carrier_trunk_password: environment.EGMA_PHONE_TRUNK_PASSWORD?.trim(),
   };
 
   // Compose passes an unset optional through as an empty string rather than

--- a/apps/api/src/phone-readiness.ts
+++ b/apps/api/src/phone-readiness.ts
@@ -1,6 +1,6 @@
 import type { PlatformFacts, PlatformSettingName } from "@egma/db";
 
-import { labelOf } from "./platform-readiness.ts";
+import { holds, labelOf } from "./platform-readiness.ts";
 
 /**
  * Whether this platform can place a phone call, and what is missing when it
@@ -77,10 +77,14 @@ export function phoneReadiness(held: PlatformFacts): PhoneReadiness {
     which: keyof typeof PHONE_SETUP_FACTS,
   ): string | null => held[PHONE_SETUP_FACTS[which]] ?? null;
 
+  // Asked with the same predicate the whole-platform answer asks, and never
+  // of the value: `platformFacts` answers `null` for every setting the catalog
+  // marks secret, so the day one of these three becomes a secret a value test
+  // would read it as absent forever. See `holds`.
   const missing = (
     Object.keys(PHONE_SETUP_FACTS) as (keyof typeof PHONE_SETUP_FACTS)[]
   )
-    .filter((which) => fact(which) === null)
+    .filter((which) => !holds(held, PHONE_SETUP_FACTS[which]))
     .map((which) => labelOf(PHONE_SETUP_FACTS[which]));
 
   return {

--- a/apps/api/src/phone-readiness.ts
+++ b/apps/api/src/phone-readiness.ts
@@ -1,3 +1,7 @@
+import type { PlatformFacts, PlatformSettingName } from "@egma/db";
+
+import { labelOf } from "./platform-readiness.ts";
+
 /**
  * Whether this platform can place a phone call, and what is missing when it
  * cannot.
@@ -8,12 +12,21 @@
  * lie that stops a first-run story dead. So `self-host up` brings a platform up
  * *ready*, and this says separately whether the phone half has been set up.
  *
+ * **It is read from the platform's own store rather than from this process's
+ * environment**, and that move is what makes the answer recoverable. The three
+ * facts used to arrive as environment variables of this container, so a
+ * platform started any other way than through the CLI reported `setup required`
+ * with the carrier paperwork already done — and the only way back was to find
+ * the file and restart. They are ordinary settings now: an operator who supplies
+ * a missing one is ready on the next request, with nothing restarted.
+ *
  * **Everything here is non-secret, and that is deliberate.** The facts are the
  * carrier's own hostname, the number a call appears to come from, and which
  * speech provider was configured — three things a caller sees on their handset
- * or an invoice, and none of which opens anything. The Twilio Auth Token, the
- * SIP password and the OpenAI key reach the containers that need them and
- * never this module, so no answer built here can leak one.
+ * or an invoice, and none of which opens anything. The trunk password and the
+ * provider keys are sealed in the same store and reach only the work order a
+ * simulator claims; `platformFacts` answers `null` for every one of them, so no
+ * answer built here can carry one even by accident.
  */
 
 /** What a platform's phone half can be. */
@@ -36,40 +49,46 @@ export type PhoneReadiness = {
 };
 
 /**
- * The three things phone setup leaves behind on the platform, and the names a
- * refusal uses for them.
+ * The three things the phone half stands on, as the platform stores them and
+ * as a refusal names them.
  *
  * A trunk with no source number places a call the carrier refuses; a carrier
  * with no speech provider places a call nobody can talk on. Neither is *nearly*
  * ready, so a partial answer is still `setup_required` — and it says which
  * half, because the one thing worse than "not ready" is "not ready" with no
  * indication of what to do.
+ *
+ * The label is not restated here: the settings catalog already carries the
+ * words each setting is named in, and a second copy of them is a second copy to
+ * disagree. What this holds is only which settings the phone half needs, and
+ * which reported fact each one fills.
  */
 export const PHONE_SETUP_FACTS = {
-  trunkAddress: "the carrier trunk",
-  sourceNumber: "the source number",
-  speechProvider: "the speech provider",
-} as const;
+  trunkAddress: "carrier_trunk_address",
+  sourceNumber: "carrier_trunk_number",
+  // The persona's mouth, which is also its ears on every deployment that
+  // configured one account for both. It is the one of the two legs a caller
+  // would notice, which is what makes it the fact worth reporting.
+  speechProvider: "text_to_speech_provider",
+} as const satisfies Record<string, PlatformSettingName>;
 
-export type PhoneSettings = {
-  readonly trunkAddress: string | null;
-  readonly sourceNumber: string | null;
-  readonly speechProvider: string | null;
-};
+export function phoneReadiness(held: PlatformFacts): PhoneReadiness {
+  const fact = (
+    which: keyof typeof PHONE_SETUP_FACTS,
+  ): string | null => held[PHONE_SETUP_FACTS[which]] ?? null;
 
-export function phoneReadiness(settings: PhoneSettings): PhoneReadiness {
   const missing = (
     Object.keys(PHONE_SETUP_FACTS) as (keyof typeof PHONE_SETUP_FACTS)[]
   )
-    .filter((fact) => settings[fact] === null)
-    .map((fact) => PHONE_SETUP_FACTS[fact]);
+    .filter((which) => fact(which) === null)
+    .map((which) => labelOf(PHONE_SETUP_FACTS[which]));
 
   return {
     state: missing.length === 0 ? "ready" : "setup_required",
     missing,
-    trunkAddress: settings.trunkAddress,
-    sourceNumber: settings.sourceNumber,
-    speechProvider: settings.speechProvider,
+    trunkAddress: fact("trunkAddress"),
+    sourceNumber: fact("sourceNumber"),
+    speechProvider: fact("speechProvider"),
   };
 }
 

--- a/apps/api/src/platform-readiness.ts
+++ b/apps/api/src/platform-readiness.ts
@@ -1,6 +1,8 @@
-import { PLATFORM_SETTINGS, type PlatformFacts } from "@egma/db";
-
-import type { PhoneReadiness } from "./phone-readiness.ts";
+import {
+  PLATFORM_SETTINGS,
+  type PlatformFacts,
+  type PlatformSettingName,
+} from "@egma/db";
 
 /**
  * Whether this platform has been set up, and what it is still missing.
@@ -24,7 +26,9 @@ import type { PhoneReadiness } from "./phone-readiness.ts";
  * carrier still runs chat and text simulations perfectly well, so `phone` keeps
  * answering separately and the run door keeps gating on it alone. What this
  * adds is the whole-platform answer beside it: `setup required` while anything
- * at all is missing, the carrier included.
+ * at all is missing, the carrier included. Both now read the same store, so
+ * they can no longer be a fact about the deployment and a fact about one
+ * container that quietly disagree.
  */
 
 export type PlatformSetupState = "ready" | "setup_required";
@@ -40,23 +44,32 @@ export type PlatformReadiness = {
 };
 
 /**
- * The platform's answer, from what its store holds and what its carrier facts
- * say.
+ * The words one setting is named in, read off the catalog rather than restated.
  *
- * The phone half is still read from this process's configuration rather than
- * from the store; moving it is the next ticket's, and this composes the two so
- * that the answer is already whole while that move happens underneath it.
+ * One place, because two readiness answers name the same settings and a second
+ * copy of the words is a second copy to drift.
  */
-export function platformReadiness(
-  held: PlatformFacts,
-  phone: PhoneReadiness,
-): PlatformReadiness {
-  const missing = [
-    ...PLATFORM_SETTINGS.filter(
-      (setting) => !Object.hasOwn(held, setting.name),
-    ).map((setting) => setting.label),
-    ...phone.missing,
-  ];
+export function labelOf(name: PlatformSettingName): string {
+  const definition = PLATFORM_SETTINGS.find(
+    (setting) => setting.name === name,
+  );
+  // Unreachable while the argument is a `PlatformSettingName`, and kept because
+  // the alternative is a readiness answer naming `undefined` to a self-hoster.
+  return definition?.label ?? name;
+}
+
+/**
+ * The platform's answer, from what its store holds.
+ *
+ * The carrier is among the settings now, so this is one list over one source
+ * rather than a composition of two. That is what closes the gap the effort
+ * started from: there is no half of this answer left that a container could
+ * hold and lose.
+ */
+export function platformReadiness(held: PlatformFacts): PlatformReadiness {
+  const missing = PLATFORM_SETTINGS.filter(
+    (setting) => !Object.hasOwn(held, setting.name),
+  ).map((setting) => setting.label);
 
   return {
     state: missing.length === 0 ? "ready" : "setup_required",

--- a/apps/api/src/platform-readiness.ts
+++ b/apps/api/src/platform-readiness.ts
@@ -59,16 +59,37 @@ export function labelOf(name: PlatformSettingName): string {
 }
 
 /**
+ * Whether this platform holds a setting at all.
+ *
+ * **One predicate, and both readiness answers ask it.** The question is
+ * *presence*, and `platformFacts` answers `null` for every setting the catalog
+ * marks secret — so a reader that tested the value instead would read every
+ * secret as absent forever, and would start doing it to a phone fact the day
+ * one of those three becomes a secret. Asking about the key rather than the
+ * value is what makes that impossible rather than merely unlikely.
+ */
+export function holds(held: PlatformFacts, name: PlatformSettingName): boolean {
+  return Object.hasOwn(held, name);
+}
+
+/**
  * The platform's answer, from what its store holds.
  *
  * The carrier is among the settings now, so this is one list over one source
  * rather than a composition of two. That is what closes the gap the effort
  * started from: there is no half of this answer left that a container could
  * hold and lose.
+ *
+ * **Only the settings setup has to supply are waited for.** The catalog says
+ * which, and two of them are not: the simulator has a working default for the
+ * text-to-speech model and voice, so a platform that has never named one still
+ * speaks. Demanding them would tell an operator who finished the whole
+ * documented setup that they had not, which is this effort's own failure
+ * wearing the opposite face.
  */
 export function platformReadiness(held: PlatformFacts): PlatformReadiness {
   const missing = PLATFORM_SETTINGS.filter(
-    (setting) => !Object.hasOwn(held, setting.name),
+    (setting) => setting.required && !holds(held, setting.name),
   ).map((setting) => setting.label);
 
   return {

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -7,7 +7,9 @@ import {
   getRun,
   getSimulationTestVersion,
   resolveMockTools,
+  resolvePlatformSettings,
   resolveSimulationConnection,
+  type PlatformSettingValues,
   type Run,
   type SimulationClaim,
 } from "@egma/db";
@@ -52,10 +54,21 @@ import { invalid, notTheService } from "../http/refusals.ts";
  * What goes back is the whole work order: for each claimed simulation, a
  * fully assembled spec — persona traits as the pinned version saved them,
  * the pinned test version's scenario, the connection's config with its
- * credentials unsealed, the answers this simulation's mock tools serve, and
- * the platform's limits — validated against the contract schema before a
- * byte of it is sent. This is the only place credential material ever
- * travels; the report direction structurally has nowhere to put it.
+ * credentials unsealed, the answers this simulation's mock tools serve, the
+ * deployment's own settings unsealed beside them, and the platform's limits
+ * — validated against the contract schema before a byte of it is sent. This
+ * is the only place credential material ever travels; the report direction
+ * structurally has nowhere to put it.
+ *
+ * **The platform's settings ride this same answer on purpose.** They used to
+ * live in each simulator's environment, which meant a second simulator on
+ * another machine needed a file copied to it and a container started
+ * without one dialled nothing while reporting itself healthy. Sending them
+ * here opens no new door: it is the door a connection's credentials already
+ * come through, with the same authority behind it and the same protection
+ * over it — and it keeps the property that every arrow points outward from
+ * the simulator, which talks to this API and to nothing else, and never to
+ * Postgres.
  */
 
 export type ClaimRoutesOptions = {
@@ -105,6 +118,74 @@ const SIMULATION_LIMITS = {
 const CONTRACT_VERSION = 1;
 
 type Body = Record<string, unknown>;
+
+/**
+ * The deployment's own settings, in the three groups the contract carries
+ * them in and the simulator already has seams for: what the persona thinks
+ * with, what it speaks and hears with, and how a call reaches the telephone
+ * network.
+ *
+ * **Grouped rather than flat, because the groups are what can be absent.** A
+ * deployment that has never been given a carrier is the ordinary deployment,
+ * and it is exactly the one the fixtures cover — so "the phone half is
+ * absent" has to be one missing object rather than five missing keys that
+ * nothing holds together. The three groups also land one-for-one on the
+ * simulator's own records, which is what makes taking a value from here a
+ * substitution rather than a translation.
+ *
+ * A field the platform does not hold is left out entirely rather than sent
+ * as `null` or `""`. The contract's rule is that what is here replaces what
+ * the simulator has and what is absent leaves it standing, and an empty
+ * string sent as a model name would be a name the simulator was told to use.
+ */
+function platformBlock(
+  held: PlatformSettingValues,
+): Record<string, unknown> | undefined {
+  // Written out setting by setting rather than folded over the catalog, for
+  // the reason `config.ts` reads each variable by name: this is where a
+  // stored setting becomes a field the simulator reads, and a loop would
+  // make an unread setting look exactly like a read one.
+  const model = onlyWhatIsHeld({
+    provider: held.persona_model_provider,
+    model: held.persona_model,
+    key: held.persona_model_key,
+  });
+  const speech = onlyWhatIsHeld({
+    stt_provider: held.speech_to_text_provider,
+    stt_key: held.speech_to_text_key,
+    tts_provider: held.text_to_speech_provider,
+    tts_key: held.text_to_speech_key,
+    tts_model: held.text_to_speech_model,
+    tts_voice: held.text_to_speech_voice,
+    vad_provider: held.voice_activity_provider,
+  });
+  const carrier = onlyWhatIsHeld({
+    media_backend: held.media_backend,
+    trunk_address: held.carrier_trunk_address,
+    trunk_number: held.carrier_trunk_number,
+    trunk_username: held.carrier_trunk_username,
+    trunk_password: held.carrier_trunk_password,
+  });
+
+  const platform = onlyWhatIsHeld({ model, speech, carrier });
+  // A platform that has configured nothing sends no block at all, so a spec
+  // it assembles is byte for byte the spec it was before these settings
+  // existed — which is what makes every fixture written before today still
+  // the document this door really produces.
+  return platform === undefined ? undefined : platform;
+}
+
+/** One block with its absent fields dropped, or nothing where none is held. */
+function onlyWhatIsHeld<T>(
+  fields: Record<string, T | undefined>,
+): Record<string, T> | undefined {
+  const present = Object.entries(fields).filter(
+    ([, value]) => value !== undefined,
+  );
+  return present.length === 0
+    ? undefined
+    : (Object.fromEntries(present) as Record<string, T>);
+}
 
 /** What a claim request said, once every field has been read and refused for itself. */
 type ClaimAsk = {
@@ -220,6 +301,14 @@ async function assembledSpec(
     };
   }
 
+  // Read for **each** simulation and never cached, which is the whole point
+  // of the settings living in the store: an operator who replaces a spent key
+  // has it in effect on the next simulation, with no container restarted and
+  // nothing to remember to do. One more small select is nothing beside
+  // conducting a conversation over a telephone connection, and a measurement
+  // may ask for caching later — nothing has yet.
+  const platform = platformBlock(await resolvePlatformSettings(claim.auth));
+
   if (!runs.has(claim.runId)) {
     runs.set(claim.runId, await getRun(claim.auth, claim.runId));
   }
@@ -261,6 +350,10 @@ async function assembledSpec(
     // work order it was before mock tools existed, and an empty list
     // would be a claim about tools where there is nothing to claim.
     ...(mockTools.length === 0 ? {} : { mock_tools: mockTools }),
+    // And left out entirely where the platform holds nothing, on the same
+    // reasoning one line up: a deployment that has configured no settings of
+    // its own hands the simulator the document it always handed it.
+    ...(platform === undefined ? {} : { platform }),
   };
   // `mockToolId` is deliberately not among the fields sent. The simulator
   // records which mock tool answered by its tool name, which is the whole

--- a/apps/api/src/routes/platform.ts
+++ b/apps/api/src/routes/platform.ts
@@ -1,18 +1,12 @@
 import { platformFacts, platformInstanceId } from "@egma/db";
 import type { FastifyPluginAsync } from "fastify";
 
-import type { PhoneReadiness } from "../phone-readiness.ts";
+import { phoneReadiness } from "../phone-readiness.ts";
 import { platformReadiness } from "../platform-readiness.ts";
 
 export type PlatformRouteOptions = {
   /** The one browser/API origin configured for this platform. */
   readonly origin: string;
-  /**
-   * Whether this platform can place a phone call, and what is missing when it
-   * cannot. Everything in it is non-secret — see `phone-readiness.ts` — which
-   * is what lets it answer here, at the one door that asks for no credential.
-   */
-  readonly phone: PhoneReadiness;
 };
 
 /**
@@ -37,7 +31,12 @@ export const platformRoutes: FastifyPluginAsync<PlatformRouteOptions> = async (
     // It is a select and never an insert, on the identity read's own reasoning
     // — this door is public and anybody who can reach the platform may knock as
     // often as they like.
-    const setup = platformReadiness(await platformFacts(), options.phone);
+    //
+    // One read for both answers. They are two facts about one deployment, and
+    // reading twice would let them be two facts about two moments.
+    const held = await platformFacts();
+    const setup = platformReadiness(held);
+    const phone = phoneReadiness(held);
 
     return reply.send({
       instance_id: await platformInstanceId(),
@@ -48,10 +47,7 @@ export const platformRoutes: FastifyPluginAsync<PlatformRouteOptions> = async (
       // Two facts, never one: a platform is ready for text work long before
       // anybody has given it a carrier, and a single "ready" that waited for
       // the carrier would make the first-run story impossible to tell.
-      phone: {
-        state: options.phone.state,
-        missing: options.phone.missing,
-      },
+      phone: { state: phone.state, missing: phone.missing },
     });
   });
 };

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -6,6 +6,7 @@ import {
   listRunEvents,
   listSimulations,
   NotPermittedError,
+  platformFacts,
   ProjectOutsideOrganizationError,
   readRunVerdicts,
   readVerdicts,
@@ -39,8 +40,8 @@ import {
   unprocessable,
 } from "../http/refusals.ts";
 import {
+  phoneReadiness,
   phoneSetupRequiredMessage,
-  type PhoneReadiness,
 } from "../phone-readiness.ts";
 
 /**
@@ -92,16 +93,6 @@ export type RunRoutesOptions = {
   readonly rateLimit: RateLimit;
   /** Where this instance is, for the address a person opens results at. */
   readonly baseUrl: string;
-  /**
-   * Whether this deployment has been set up to place phone calls.
-   *
-   * Read here rather than in `@egma/db` because it is not a fact about the
-   * product at all — it is a fact about one installation's carrier, and it
-   * arrives as this process's configuration. The data-access package cannot
-   * see it and must not learn to: it would mean a package every test and every
-   * worker imports carrying a deployment's environment around.
-   */
-  readonly phone: PhoneReadiness;
 };
 
 /**
@@ -471,22 +462,24 @@ export async function runRoutes(
      * Nothing is dialled from a platform that has no carrier, and the refusal
      * lands before the run exists.
      *
-     * **Only asked on a platform that is not ready**, so the ordinary case —
-     * a set-up deployment, which is every deployment that has ever placed a
-     * call — costs nothing at all. A read here would otherwise sit in front of
-     * every run creation to answer a question that has one answer.
+     * **Asked of the store on every run creation**, rather than of this
+     * process's configuration once at start. The carrier is one of the
+     * platform's own settings now, so an operator who finishes setup has their
+     * next run accepted with no container restarted — and, the other way
+     * round, a run started against a carrier somebody has since cleared is
+     * refused rather than dispatched at a trunk that is gone. It is one small
+     * select in front of an act that creates a whole run; the answer it used
+     * to be was fast and could be a day out of date.
      *
      * A connection this caller cannot see reads as `undefined` and falls
      * through untouched: `startRun` owns that sentence, and answering it here
      * would confirm somebody else's connection exists by refusing about it.
      */
-    if (options.phone.state !== "ready") {
+    const carrier = phoneReadiness(await platformFacts());
+    if (carrier.state !== "ready") {
       const type = await connectionTypeOf(acting.auth, text(body.connection));
       if (type !== undefined && NEEDS_THE_PLATFORMS_CARRIER.includes(type)) {
-        return phoneSetupRequired(
-          reply,
-          phoneSetupRequiredMessage(options.phone),
-        );
+        return phoneSetupRequired(reply, phoneSetupRequiredMessage(carrier));
       }
     }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -17,7 +17,6 @@ import { invitationRoutes } from "./routes/invitations.ts";
 import { meRoutes } from "./routes/me.ts";
 import { memberRoutes } from "./routes/members.ts";
 import { mockToolRoutes } from "./routes/mock-tools.ts";
-import { phoneReadiness } from "./phone-readiness.ts";
 import { platformRoutes } from "./routes/platform.ts";
 import { platformSettingsRoutes } from "./routes/platform-settings.ts";
 import { recordingRoutes } from "./routes/recordings.ts";
@@ -174,15 +173,16 @@ export function buildApi(options: ServerOptions): Api {
       .send({ status: healthy ? "ok" : "unavailable", postgres, clickhouse });
   });
 
-  // Whether this deployment can dial, worked out once and handed to both the
-  // door that reports it and the door that enforces it. One value rather than
-  // two calls, so what `GET /api/platform` tells a developer and what run
-  // creation does to them can never be two different answers.
-  const phone = phoneReadiness(config.phone);
-
   // Read before login and before any repository identifier is sent. It is
   // public because the CLI uses it to decide whether login is safe to start.
-  void app.register(platformRoutes, { origin: config.baseUrl, phone });
+  //
+  // Whether this deployment can dial is no longer worked out here and handed
+  // down: the carrier is one of the platform's own settings now, so the door
+  // that reports it and the door that enforces it each read the store when
+  // they are asked. That is what stops them being one answer from start-up
+  // that an operator finishing setup cannot change without a restart, and they
+  // still cannot disagree — one store, one `phoneReadiness`, two callers.
+  void app.register(platformRoutes, { origin: config.baseUrl });
 
   // Registered without `fastify-plugin` on purpose: the adapter replaces every
   // body parser inside its own scope so the provider sees the bytes that were
@@ -269,7 +269,6 @@ export function buildApi(options: ServerOptions): Api {
     provider: identity.provider,
     rateLimit,
     baseUrl: config.baseUrl,
-    phone,
   });
 
   // Where a recording's reference becomes something a browser can play. Its own

--- a/apps/api/test/claims-routes.test.ts
+++ b/apps/api/test/claims-routes.test.ts
@@ -12,7 +12,11 @@ import {
 } from "../src/auth/service-token.ts";
 import { CLAIMS_PATH } from "../src/routes/claims.ts";
 import { fixedWindowRateLimit } from "../src/http/rate-limit.ts";
-import { createApi, type TestApi } from "./support/api.ts";
+import {
+  createApi,
+  type TestApi,
+  type TestApiOptions,
+} from "./support/api.ts";
 import {
   contextFor,
   NEUTRAL_TRAITS,
@@ -74,14 +78,17 @@ async function claim(
 }
 
 /** A customer with an agent, a persona, and a test — everything a run needs. */
-async function aCustomerReadyToRun(label: string): Promise<{
+async function aCustomerReadyToRun(
+  label: string,
+  options: TestApiOptions = {},
+): Promise<{
   ada: Customer;
   key: string;
   agentId: string;
   connectionId: string;
   versionId: string;
 }> {
-  api = await createApi(label);
+  api = await createApi(label, options);
   const ada = await signUp(api.app, "ada@acme.example", "Acme");
   const key = await projectKeyFor(api.app, ada);
 
@@ -215,6 +222,10 @@ describe("claiming work", () => {
     // An empty list would be a claim about tools where this project has
     // made none, and most projects have made none.
     expect("mock_tools" in spec).toBe(false);
+    // And so does a platform nobody has configured: no block at all, which
+    // is byte for byte the document this door produced before the settings
+    // existed. Every fixture written before today is still what it sends.
+    expect("platform" in spec).toBe(false);
 
     // The row carries the claim, and the run has started.
     const row = await getSimulation(contextFor(ada, "member"), simulationId);
@@ -609,5 +620,160 @@ describe("a simulation the platform cannot hand over", () => {
     );
     expect(row?.status).toBe("failed");
     expect(row?.endingReason).toBe("dispatch_failed");
+  });
+});
+
+describe("the platform's own settings, on the work order", () => {
+  /**
+   * What a configured deployment holds, seeded the way an automated one
+   * seeds it — through the real door, sealed into the real table. Every
+   * value here is distinct and recognisable, so what comes back on the work
+   * order can be told from what any other setting holds.
+   */
+  const A_CONFIGURED_PLATFORM = {
+    persona_model_provider: "openai",
+    persona_model: "gpt-4o",
+    persona_model_key: "sk-the-persona-thinks-with-this-one",
+    speech_to_text_provider: "deepgram",
+    speech_to_text_key: "the-listening-leg-uses-this-one",
+    text_to_speech_provider: "elevenlabs",
+    text_to_speech_key: "the-speaking-leg-uses-this-one",
+    text_to_speech_model: "eleven_turbo_v2_5",
+    text_to_speech_voice: "brisk-tenor-7",
+    voice_activity_provider: "silero",
+    media_backend: "livekit",
+    carrier_trunk_address: "acme.pstn.twilio.com",
+    carrier_trunk_number: "+15550100",
+    carrier_trunk_username: "acme-trunk",
+    carrier_trunk_password: "the-carrier-issued-this-one",
+  } as const;
+
+  /** The one claimed spec of a run, whatever this platform holds. */
+  async function theWorkOrderFor(label: string, settings: object) {
+    const { key, connectionId, versionId } = await aCustomerReadyToRun(label, {
+      platformSettings: settings,
+    });
+    await aQueuedRun(key, connectionId, versionId);
+
+    const answered = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 0,
+    });
+    expect(answered.statusCode, JSON.stringify(answered.body)).toBe(200);
+    const specs = answered.body.specs as Record<string, unknown>[];
+    const spec = specs[0];
+    if (spec === undefined) throw new Error("no spec came back");
+    return spec;
+  }
+
+  it("carries the unsealed values, grouped the way the simulator reads them", async () => {
+    const spec = await theWorkOrderFor(
+      "claims_platform_settings",
+      A_CONFIGURED_PLATFORM,
+    );
+
+    // Held to the contract on the way out, like everything else this door
+    // sends: what leaves here is what the simulator's own check accepts.
+    expect(specComplaints(spec)).toEqual([]);
+
+    expect(spec.platform).toEqual({
+      model: {
+        provider: "openai",
+        model: "gpt-4o",
+        key: "sk-the-persona-thinks-with-this-one",
+      },
+      speech: {
+        stt_provider: "deepgram",
+        stt_key: "the-listening-leg-uses-this-one",
+        tts_provider: "elevenlabs",
+        tts_key: "the-speaking-leg-uses-this-one",
+        tts_model: "eleven_turbo_v2_5",
+        tts_voice: "brisk-tenor-7",
+        vad_provider: "silero",
+      },
+      carrier: {
+        media_backend: "livekit",
+        trunk_address: "acme.pstn.twilio.com",
+        trunk_number: "+15550100",
+        trunk_username: "acme-trunk",
+        trunk_password: "the-carrier-issued-this-one",
+      },
+    });
+
+    // In the clear, and never the sealed envelope or the hint kept for
+    // display: a simulator handed either would speak to a provider with
+    // four characters of a key.
+    const stored = await api.database.sql<{ value: string; hint: string }>(
+      "select value, hint from platform_setting where name = 'persona_model_key'",
+    );
+    expect(stored.rows[0]?.value).not.toContain(
+      "sk-the-persona-thinks-with-this-one",
+    );
+    expect(stored.rows[0]?.hint).toBe("-one");
+  });
+
+  it("leaves out the half of the platform that has no carrier", async () => {
+    // Every deployment before somebody does the Twilio paperwork, which is
+    // most of them and all of them on a first morning. The block is absent
+    // rather than empty, because an empty one would be a claim that this
+    // deployment has a carrier made of nothing.
+    const spec = await theWorkOrderFor("claims_platform_no_carrier", {
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o",
+      persona_model_key: "sk-the-persona-thinks-with-this-one",
+    });
+
+    expect(specComplaints(spec)).toEqual([]);
+    expect(spec.platform).toEqual({
+      model: {
+        provider: "openai",
+        model: "gpt-4o",
+        key: "sk-the-persona-thinks-with-this-one",
+      },
+    });
+  });
+
+  it("hands the next simulation a changed setting, with nothing restarted", async () => {
+    // The freshness promise, and the reason there is no cache here: the
+    // settings are read for each simulation, so replacing a spent key is
+    // a write and then the next conversation, rather than a write and a
+    // deploy.
+    const { ada, key, connectionId, versionId } = await aCustomerReadyToRun(
+      "claims_platform_settings_change",
+      { singleOrganization: true, platformSettings: A_CONFIGURED_PLATFORM },
+    );
+
+    await aQueuedRun(key, connectionId, versionId);
+    const before = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 0,
+    });
+    const first = (before.body.specs as Record<string, unknown>[])[0];
+    expect((first?.platform as { model: { key: string } }).model.key).toBe(
+      "sk-the-persona-thinks-with-this-one",
+    );
+
+    // Written the way an owner writes one, through the API, on the running
+    // instance. No restart, no redeploy, no second process.
+    const changed = await api.app.inject({
+      method: "PATCH",
+      url: "/api/platform/settings",
+      headers: { authorization: `Bearer ${ada.secret}` },
+      payload: { persona_model_key: "sk-and-the-operator-replaced-it-WXYZ" },
+    });
+    expect(changed.statusCode, changed.body).toBe(200);
+
+    await aQueuedRun(key, connectionId, versionId);
+    const after = await claim(api.config.simulatorServiceToken, {
+      claimant: "sim-under-test",
+      capacity: 4,
+      wait_seconds: 0,
+    });
+    const second = (after.body.specs as Record<string, unknown>[])[0];
+    expect((second?.platform as { model: { key: string } }).model.key).toBe(
+      "sk-and-the-operator-replaced-it-WXYZ",
+    );
   });
 });

--- a/apps/api/test/deployment.test.ts
+++ b/apps/api/test/deployment.test.ts
@@ -112,9 +112,9 @@ describe("the API's deployment story", () => {
     ).toEqual([]);
   });
 
-  it("keeps the judge's key off the grader, and the carrier's secrets off the API", () => {
-    // The two halves of one decision, held here because each is one line away
-    // from being undone and neither would fail anything else.
+  it("keeps the judge's key off the grader, and every setting off the simulator", () => {
+    // Three halves of one decision, held here because each is one line away
+    // from being undone and none would fail anything else.
     //
     // A judge configured per container is a judge no project chose, spent on
     // conversations belonging to customers who agreed to neither — so the key
@@ -122,15 +122,36 @@ describe("the API's deployment story", () => {
     // never the grader, which opens that row.
     expect(serviceBlock("grader")).not.toContain("EGMA_JUDGE_API_KEY");
 
-    // And the API holds nothing it would dial or speak with. Its whole
-    // knowledge of the carrier is three non-secret facts.
+    // The API *does* hold the carrier's secrets now, and that is the effort's
+    // whole point: it seals them into the platform's own store, exactly as it
+    // already seals a judge's key and a connection's credentials, and it
+    // neither dials nor speaks with any of them. What it must still never
+    // hold is the one credential that opens the whole Twilio account.
     const api = serviceBlock("api");
-    for (const secret of [
-      "TWILIO_AUTH_TOKEN",
-      "EGMA_SIMULATOR_SIP_TRUNK_PASSWORD",
-      "EGMA_SIMULATOR_OPENAI_API_KEY",
+    expect(api).not.toContain("TWILIO_AUTH_TOKEN");
+    expect(api).toContain("EGMA_PHONE_TRUNK_PASSWORD");
+
+    // And the variables the platform's settings are *seeded from* reach the
+    // API and no simulator. They are what the API seals into the store, and
+    // every simulator is then handed the values on the work order it claims;
+    // a compose entry for one of them on the simulator would be a second
+    // place the same setting is written down, and the two would disagree the
+    // first time somebody changed one. Which is this effort's own failure,
+    // arriving by a new route.
+    //
+    // The simulator's own `EGMA_SIMULATOR_*` provider variables are a
+    // different thing and stay: they are what a bare simulator falls back to
+    // when the platform holds nothing — the workbench story and every
+    // contributor's checkout — and a work-order value replaces each of them.
+    const simulator = serviceBlock("simulator");
+    for (const owned of [
+      "EGMA_PERSONA_MODEL_API_KEY",
+      "EGMA_PERSONA_STT_API_KEY",
+      "EGMA_PERSONA_TTS_API_KEY",
+      "EGMA_PHONE_TRUNK_PASSWORD",
+      "EGMA_MEDIA_BACKEND:",
     ]) {
-      expect(api).not.toContain(secret);
+      expect(simulator, `the simulator is handed ${owned}`).not.toContain(owned);
     }
   });
 

--- a/apps/api/test/phone-readiness.test.ts
+++ b/apps/api/test/phone-readiness.test.ts
@@ -2,6 +2,11 @@
  * Phone readiness: a second fact about a platform, never a component of the
  * first.
  *
+ * Read from the platform's own store now, rather than from this container's
+ * environment. That is the whole recoverability of it: the facts survive a
+ * restart, a rebuild and a move to another machine, and an operator who
+ * supplies a missing one is ready on the next request with nothing restarted.
+ *
  * A deployment with no carrier runs text and chat simulations perfectly well.
  * Folding that into one `ready` would either call a working platform broken or
  * call a platform that cannot dial ready — and the first makes the first-run
@@ -31,17 +36,13 @@ const BASE = {
 
 describe("phone readiness", () => {
   it("is setup_required on a platform nobody has given a carrier, and names all three", () => {
-    const readiness = phoneReadiness({
-      trunkAddress: null,
-      sourceNumber: null,
-      speechProvider: null,
-    });
+    const readiness = phoneReadiness({});
 
     expect(readiness.state).toBe("setup_required");
     expect(readiness.missing).toEqual([
       "the carrier trunk",
       "the source number",
-      "the speech provider",
+      "the text-to-speech provider",
     ]);
   });
 
@@ -50,14 +51,15 @@ describe("phone readiness", () => {
     // can talk on, and charges for it — so half a setup is a refusal, and the
     // refusal has to say which half so somebody can act on it.
     const readiness = phoneReadiness({
-      trunkAddress: "egma-simulator-abc.pstn.twilio.com",
-      sourceNumber: "+15550100100",
-      speechProvider: null,
+      carrier_trunk_address: "egma-simulator-abc.pstn.twilio.com",
+      carrier_trunk_number: "+15550100100",
     });
 
     expect(readiness.state).toBe("setup_required");
-    expect(readiness.missing).toEqual(["the speech provider"]);
-    expect(phoneSetupRequiredMessage(readiness)).toContain("the speech provider");
+    expect(readiness.missing).toEqual(["the text-to-speech provider"]);
+    expect(phoneSetupRequiredMessage(readiness)).toContain(
+      "the text-to-speech provider",
+    );
     expect(phoneSetupRequiredMessage(readiness)).toContain("egma self-host phone setup");
     // Said plainly, because a developer reading it is not the person who runs
     // the platform on a hosted deployment and needs to know nothing was spent.
@@ -66,31 +68,65 @@ describe("phone readiness", () => {
 
   it("is ready once all three are there", () => {
     const readiness = phoneReadiness({
-      trunkAddress: "egma-simulator-abc.pstn.twilio.com",
-      sourceNumber: "+15550100100",
-      speechProvider: "openai",
+      carrier_trunk_address: "egma-simulator-abc.pstn.twilio.com",
+      carrier_trunk_number: "+15550100100",
+      text_to_speech_provider: "openai",
     });
 
     expect(readiness.state).toBe("ready");
     expect(readiness.missing).toEqual([]);
+    expect(readiness.trunkAddress).toBe("egma-simulator-abc.pstn.twilio.com");
+    expect(readiness.sourceNumber).toBe("+15550100100");
+    expect(readiness.speechProvider).toBe("openai");
   });
 
-  it("reads the three non-secret facts from the environment, and holds no credential", () => {
+  it("answers from what a secret-free view of the store can say, and no more", () => {
+    // `platformFacts` is the only thing this reads, and it answers `null` for
+    // every setting the catalog marks secret. So a carrier that is fully
+    // configured — trunk password and all — still reports itself missing
+    // nothing more than these three, and there is no argument by which a key
+    // could reach this answer.
+    const readiness = phoneReadiness({
+      carrier_trunk_address: "egma-simulator-abc.pstn.twilio.com",
+      carrier_trunk_number: "+15550100100",
+      carrier_trunk_username: "egma-trunk",
+      carrier_trunk_password: null,
+      text_to_speech_provider: "openai",
+      text_to_speech_key: null,
+    });
+
+    expect(readiness.state).toBe("ready");
+    expect(JSON.stringify(readiness)).not.toContain("null,");
+    expect(Object.keys(readiness).sort()).toEqual([
+      "missing",
+      "sourceNumber",
+      "speechProvider",
+      "state",
+      "trunkAddress",
+    ]);
+  });
+
+  it("seeds the carrier out of the environment, and never holds it after", () => {
+    // The variables phone setup already wrote, read once at start as settings
+    // to seed rather than as this process's own configuration. What the API
+    // then holds about the carrier is nothing at all: the store holds it.
     const config = loadConfig({
       ...BASE,
       EGMA_PHONE_TRUNK_ADDRESS: "egma-simulator-abc.pstn.twilio.com",
       EGMA_PHONE_SOURCE_NUMBER: "+15550100100",
-      EGMA_PHONE_SPEECH_PROVIDER: "openai",
+      EGMA_PHONE_TRUNK_USERNAME: "egma-trunk",
+      EGMA_PHONE_TRUNK_PASSWORD: "the-carrier-issued-this-one",
+      EGMA_PERSONA_TTS_PROVIDER: "openai",
     });
 
-    expect(phoneReadiness(config.phone).state).toBe("ready");
-    // Everything the API holds about the carrier, written out, so that a field
-    // carrying a credential could not be added without this line changing.
-    expect(Object.keys(config.phone).sort()).toEqual([
-      "sourceNumber",
-      "speechProvider",
-      "trunkAddress",
-    ]);
+    expect(config.platformSettings).toEqual({
+      carrier_trunk_address: "egma-simulator-abc.pstn.twilio.com",
+      carrier_trunk_number: "+15550100100",
+      carrier_trunk_username: "egma-trunk",
+      carrier_trunk_password: "the-carrier-issued-this-one",
+      text_to_speech_provider: "openai",
+    });
+    expect(Object.keys(config)).not.toContain("phone");
   });
 });
 

--- a/apps/api/test/platform-info.test.ts
+++ b/apps/api/test/platform-info.test.ts
@@ -20,9 +20,32 @@ const NOTHING_SET_UP = {
     "the persona's model provider",
     "the persona's model",
     "the persona's model key",
+    "the speech-to-text provider",
+    "the speech-to-text key",
+    "the text-to-speech provider",
+    "the text-to-speech key",
+    "the text-to-speech model",
+    "the text-to-speech voice",
+    "the voice-activity provider",
+    "the media backend",
     "the carrier trunk",
     "the source number",
-    "the speech provider",
+    "the carrier trunk username",
+    "the carrier trunk password",
+  ],
+};
+
+/**
+ * And what its phone half answers: the three non-secret facts the carrier
+ * stands on, named separately because a platform with no carrier still runs
+ * text and chat simulations perfectly well.
+ */
+const NO_CARRIER = {
+  state: "setup_required",
+  missing: [
+    "the carrier trunk",
+    "the source number",
+    "the text-to-speech provider",
   ],
 };
 
@@ -66,10 +89,7 @@ it("keeps one public platform identity across an API restart", async () => {
       // A platform with no carrier is ready — it runs text simulations
       // perfectly well — and saying otherwise would make the first-run story
       // impossible to tell. What it says instead is what setup still needs.
-      phone: {
-      state: "setup_required",
-      missing: ["the carrier trunk", "the source number", "the speech provider"],
-    },
+      phone: NO_CARRIER,
     });
 
     await app.close();
@@ -127,10 +147,7 @@ it("reads its identity rather than writing on every public request", async () =>
         // A platform nobody has set a carrier up on says so here rather than
         // anywhere a developer has to go looking, and says it separately from
         // being ready — it runs text simulations perfectly well.
-        phone: {
-          state: "setup_required",
-          missing: ["the carrier trunk", "the source number", "the speech provider"],
-        },
+        phone: NO_CARRIER,
       });
     }
     expect(
@@ -168,10 +185,7 @@ it("reads its identity rather than writing on every public request", async () =>
       instance_id: minted.instance_id,
       origin: config.baseUrl,
       setup: NOTHING_SET_UP,
-      phone: {
-      state: "setup_required",
-      missing: ["the carrier trunk", "the source number", "the speech provider"],
-    },
+      phone: NO_CARRIER,
     });
   } finally {
     await app?.close();

--- a/apps/api/test/platform-info.test.ts
+++ b/apps/api/test/platform-info.test.ts
@@ -24,8 +24,6 @@ const NOTHING_SET_UP = {
     "the speech-to-text key",
     "the text-to-speech provider",
     "the text-to-speech key",
-    "the text-to-speech model",
-    "the text-to-speech voice",
     "the voice-activity provider",
     "the media backend",
     "the carrier trunk",

--- a/apps/api/test/platform-info.test.ts
+++ b/apps/api/test/platform-info.test.ts
@@ -28,8 +28,6 @@ const NOTHING_SET_UP = {
     "the media backend",
     "the carrier trunk",
     "the source number",
-    "the carrier trunk username",
-    "the carrier trunk password",
   ],
 };
 

--- a/apps/api/test/platform-settings-routes.test.ts
+++ b/apps/api/test/platform-settings-routes.test.ts
@@ -324,8 +324,6 @@ describe("what the platform says about its own setup", () => {
         "the speech-to-text key",
         "the text-to-speech provider",
         "the text-to-speech key",
-        "the text-to-speech model",
-        "the text-to-speech voice",
         "the voice-activity provider",
         "the media backend",
         "the carrier trunk",
@@ -354,6 +352,44 @@ describe("what the platform says about its own setup", () => {
       state: "setup_required",
       missing: ["the persona's model key"],
     });
+  });
+
+  it("answers ready to a platform holding exactly what setup writes", async () => {
+    // **The two have to agree, and this is where they are held together.**
+    // Membership of the catalog with `required` means "setup is incomplete
+    // without it", so a setting marked required that the setup command never
+    // writes would leave an operator who followed the documentation to the end
+    // still reading `setup required`, with nothing sensible to type. These are
+    // the settings `egma self-host phone setup` really writes, and the two the
+    // simulator defaults for are deliberately not among them.
+    api = await createApi("platform_settings_ready_after_setup", {
+      singleOrganization: true,
+      platformSettings: {
+        persona_model_provider: "openai",
+        persona_model: "gpt-4o",
+        persona_model_key: A_REAL_KEY,
+        speech_to_text_provider: "openai",
+        speech_to_text_key: A_REAL_KEY,
+        text_to_speech_provider: "openai",
+        text_to_speech_key: A_REAL_KEY,
+        voice_activity_provider: "silero",
+        media_backend: "livekit",
+        carrier_trunk_address: "acme.pstn.twilio.com",
+        carrier_trunk_number: "+15550100",
+        carrier_trunk_username: "acme-trunk",
+        carrier_trunk_password: "the-carrier-issued-this-one",
+      },
+    });
+
+    expect(await readiness()).toEqual({ state: "ready", missing: [] });
+
+    // And the two it did not write are still settings the platform can hold
+    // and hand over — optional is not absent from the catalog.
+    expect(
+      PLATFORM_SETTINGS.filter((setting) => !setting.required).map(
+        (setting) => setting.name,
+      ),
+    ).toEqual(["text_to_speech_model", "text_to_speech_voice"]);
   });
 
   it("answers ready once nothing is missing", async () => {

--- a/apps/api/test/platform-settings-routes.test.ts
+++ b/apps/api/test/platform-settings-routes.test.ts
@@ -328,8 +328,6 @@ describe("what the platform says about its own setup", () => {
         "the media backend",
         "the carrier trunk",
         "the source number",
-        "the carrier trunk username",
-        "the carrier trunk password",
       ],
     });
   });
@@ -383,13 +381,50 @@ describe("what the platform says about its own setup", () => {
 
     expect(await readiness()).toEqual({ state: "ready", missing: [] });
 
+
     // And the two it did not write are still settings the platform can hold
     // and hand over — optional is not absent from the catalog.
     expect(
       PLATFORM_SETTINGS.filter((setting) => !setting.required).map(
         (setting) => setting.name,
       ),
-    ).toEqual(["text_to_speech_model", "text_to_speech_voice"]);
+    ).toEqual([
+      "text_to_speech_model",
+      "text_to_speech_voice",
+      // A trunk the carrier authenticates by the address it came from is a
+      // real deployment and needs neither of these — which is what the
+      // simulator's own carrier check says too, so readiness must not call
+      // such a platform unconfigured forever.
+      "carrier_trunk_username",
+      "carrier_trunk_password",
+    ]);
+  });
+
+  it("answers ready to a carrier that authenticates its trunk by address", async () => {
+    // A trunk a carrier authenticates by the address it came from needs
+    // neither a username nor a password, and that is a real deployment — the
+    // simulator's own carrier check says so in as many words, and refuses
+    // *half* a credential precisely because neither half is the honest shape.
+    // Readiness demanding a username a carrier does not use would call a
+    // working platform unconfigured with no way out of it.
+    api = await createApi("platform_settings_ready_trunk_by_address", {
+      singleOrganization: true,
+      platformSettings: {
+        persona_model_provider: "openai",
+        persona_model: "gpt-4o",
+        persona_model_key: A_REAL_KEY,
+        speech_to_text_provider: "openai",
+        speech_to_text_key: A_REAL_KEY,
+        text_to_speech_provider: "openai",
+        text_to_speech_key: A_REAL_KEY,
+        voice_activity_provider: "silero",
+        media_backend: "livekit",
+        carrier_trunk_address: "acme.pstn.twilio.com",
+        carrier_trunk_number: "+15550100",
+      },
+    });
+
+    expect(await readiness()).toEqual({ state: "ready", missing: [] });
   });
 
   it("answers ready once nothing is missing", async () => {

--- a/apps/api/test/platform-settings-routes.test.ts
+++ b/apps/api/test/platform-settings-routes.test.ts
@@ -1,4 +1,4 @@
-import { seedPlatformSettings } from "@egma/db";
+import { PLATFORM_SETTINGS, seedPlatformSettings } from "@egma/db";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { loadConfig } from "../src/config.ts";
@@ -42,11 +42,26 @@ afterEach(async () => {
 const A_REAL_KEY = "sk-the-operator-pasted-this-one-QRST";
 const A_SECOND_KEY = "sk-and-then-replaced-it-with-this-WXYZ";
 
-/** What a fully configured phone half looks like, for the `ready` case. */
-const A_CARRIER = {
-  trunkAddress: "acme.pstn.twilio.com",
-  sourceNumber: "+15550100",
-  speechProvider: "openai",
+/**
+ * Everything but the persona's model, so a test about one group of settings can
+ * reach `ready` without typing the other fourteen.
+ *
+ * Seeded the way an automated deployment seeds them, sealed like every other
+ * row — there is no shortcut into this table and this suite does not invent one.
+ */
+const EVERYTHING_ELSE = {
+  speech_to_text_provider: "openai",
+  speech_to_text_key: "sk-the-listening-leg-uses-this-one",
+  text_to_speech_provider: "openai",
+  text_to_speech_key: "sk-the-speaking-leg-uses-this-one",
+  text_to_speech_model: "gpt-4o-mini-tts",
+  text_to_speech_voice: "alloy",
+  voice_activity_provider: "silero",
+  media_backend: "livekit",
+  carrier_trunk_address: "acme.pstn.twilio.com",
+  carrier_trunk_number: "+15550100",
+  carrier_trunk_username: "acme-trunk",
+  carrier_trunk_password: "the-carrier-issued-this-one",
 } as const;
 
 function request(
@@ -261,10 +276,14 @@ describe("a write that cannot be acted on", () => {
     // does not check the same thing a second time — two answers for one
     // condition would be a contract with two faces.
     expect(refused.statusCode).toBe(422);
+    // The names read off the catalog rather than listed again: the list grows
+    // as settings move in, and what has to hold is that the refusal names the
+    // typo and then every setting the platform really has.
     expect(refused.body.message).toBe(
       '"persona_moddel" is not a platform setting egma knows; it holds ' +
-        "persona_model_provider, persona_model, persona_model_key",
+        PLATFORM_SETTINGS.map((setting) => setting.name).join(", "),
     );
+    expect(String(refused.body.message)).toContain("carrier_trunk_address");
   });
 
   it("refuses a secret too short for any provider to have issued it", async () => {
@@ -301,9 +320,18 @@ describe("what the platform says about its own setup", () => {
         "the persona's model provider",
         "the persona's model",
         "the persona's model key",
+        "the speech-to-text provider",
+        "the speech-to-text key",
+        "the text-to-speech provider",
+        "the text-to-speech key",
+        "the text-to-speech model",
+        "the text-to-speech voice",
+        "the voice-activity provider",
+        "the media backend",
         "the carrier trunk",
         "the source number",
-        "the speech provider",
+        "the carrier trunk username",
+        "the carrier trunk password",
       ],
     });
   });
@@ -311,7 +339,7 @@ describe("what the platform says about its own setup", () => {
   it("stops naming a setting the moment somebody supplies it", async () => {
     api = await createApi("platform_settings_readiness_narrows", {
       singleOrganization: true,
-      phone: { ...A_CARRIER },
+      platformSettings: { ...EVERYTHING_ELSE },
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
 
@@ -331,7 +359,7 @@ describe("what the platform says about its own setup", () => {
   it("answers ready once nothing is missing", async () => {
     api = await createApi("platform_settings_readiness_ready", {
       singleOrganization: true,
-      phone: { ...A_CARRIER },
+      platformSettings: { ...EVERYTHING_ELSE },
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
 
@@ -347,7 +375,7 @@ describe("what the platform says about its own setup", () => {
   it("carries no secret, at a door that asks for no credential", async () => {
     api = await createApi("platform_settings_readiness_is_public", {
       singleOrganization: true,
-      phone: { ...A_CARRIER },
+      platformSettings: { ...EVERYTHING_ELSE },
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
     await request("PATCH", ada.secret, {

--- a/apps/api/test/runs-cli-verbs.test.ts
+++ b/apps/api/test/runs-cli-verbs.test.ts
@@ -102,9 +102,9 @@ async function signedInAs(person: Customer): Promise<SignedIn> {
  * all three — see `phone-readiness.ts`.
  */
 const PHONE_IS_SET_UP = {
-  trunkAddress: "egma-simulator-106e37f8.pstn.twilio.com",
-  sourceNumber: "+18885550123",
-  speechProvider: "openai",
+  carrier_trunk_address: "egma-simulator-106e37f8.pstn.twilio.com",
+  carrier_trunk_number: "+18885550123",
+  text_to_speech_provider: "openai",
 } as const;
 
 /** A number egma dials, registered the way the wizard registers one. */
@@ -130,7 +130,9 @@ async function readyToRun(
 }> {
   api = await createApi(
     label,
-    options.phoneIsSetUp === true ? { phone: PHONE_IS_SET_UP } : {},
+    options.phoneIsSetUp === true
+      ? { platformSettings: PHONE_IS_SET_UP }
+      : {},
   );
   const ada = await signUp(api.app, "ada@acme.example", "Acme");
   const signedIn = await signedInAs(ada);
@@ -308,8 +310,9 @@ describe("starting a run from the terminal's own code", () => {
     expect(answer.reason).toBe(
       "this egma has not been set up to place phone calls, so nothing was " +
         "dialled and nothing was charged. It is missing the carrier trunk " +
-        "and the source number and the speech provider. Whoever runs this " +
-        "platform makes it ready with one command in the platform workspace: " +
+        "and the source number and the text-to-speech provider. Whoever runs " +
+        "this platform makes it ready with one command in the platform " +
+        "workspace: " +
         "egma self-host phone setup.",
     );
   });

--- a/apps/api/test/runs-routes.test.ts
+++ b/apps/api/test/runs-routes.test.ts
@@ -123,9 +123,9 @@ const PHONE = {
  * been given a carrier, which is the only thing the run door asks about.
  */
 const PHONE_IS_SET_UP = {
-  trunkAddress: "egma-simulator-106e37f8.pstn.twilio.com",
-  sourceNumber: "+18885550123",
-  speechProvider: "openai",
+  carrier_trunk_address: "egma-simulator-106e37f8.pstn.twilio.com",
+  carrier_trunk_number: "+18885550123",
+  text_to_speech_provider: "openai",
 } as const;
 
 /** Somebody with a key, an agent to check, and a test to check it against. */
@@ -142,7 +142,9 @@ async function aCustomerReadyToRun(
 }> {
   api = await createApi(
     label,
-    options.phoneIsSetUp === true ? { phone: PHONE_IS_SET_UP } : {},
+    options.phoneIsSetUp === true
+      ? { platformSettings: PHONE_IS_SET_UP }
+      : {},
   );
   const ada = await signUp(api.app, "ada@acme.example", "Acme");
   const key = await projectKeyFor(api.app, ada);
@@ -565,8 +567,9 @@ describe("starting a run", () => {
       message:
         "this egma has not been set up to place phone calls, so nothing was " +
         "dialled and nothing was charged. It is missing the carrier trunk " +
-        "and the source number and the speech provider. Whoever runs this " +
-        "platform makes it ready with one command in the platform workspace: " +
+        "and the source number and the text-to-speech provider. Whoever runs " +
+        "this platform makes it ready with one command in the platform " +
+        "workspace: " +
         "egma self-host phone setup.",
     });
 
@@ -581,7 +584,10 @@ describe("starting a run", () => {
 
   it("says which half of phone setup is missing, so a partly-configured platform is not told to start again", async () => {
     api = await createApi("runs_phone_half_set", {
-      phone: { ...PHONE_IS_SET_UP, sourceNumber: null },
+      platformSettings: {
+        carrier_trunk_address: PHONE_IS_SET_UP.carrier_trunk_address,
+        text_to_speech_provider: PHONE_IS_SET_UP.text_to_speech_provider,
+      },
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
     const key = await projectKeyFor(api.app, ada);

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -3,6 +3,7 @@ import {
   connectClickHouse,
   disconnect,
   disconnectClickHouse,
+  seedPlatformSettings,
 } from "@egma/db";
 import type { FastifyInstance } from "fastify";
 
@@ -57,13 +58,22 @@ export type TestApiOptions = {
    */
   readonly defaultJudge?: Config["defaultJudge"];
   /**
-   * What `egma self-host phone setup` left behind, for a test about a platform
-   * that can dial. Absent by default, and absent is the honest default: a
-   * deployment nobody has given a carrier is what every egma is on its first
-   * morning, and a suite that quietly started every instance phone-ready would
-   * never have noticed the run door letting a phone run through.
+   * Settings this instance starts holding, seeded exactly as a deployment's own
+   * environment seeds them — through `seedPlatformSettings`, sealed, into the
+   * real table.
+   *
+   * Absent by default, and absent is the honest default: a deployment nobody
+   * has configured is what every egma is on its first morning, and a suite that
+   * quietly started every instance phone-ready would never have noticed the run
+   * door letting a phone run through.
+   *
+   * This replaced a `phone` block handed straight to the configuration. The
+   * carrier is one of the platform's own settings now, so a test that wants a
+   * platform able to dial has to put the settings where the platform keeps
+   * them — which is the same path the product takes and no longer a shortcut
+   * around it.
    */
-  readonly phone?: Config["phone"];
+  readonly platformSettings?: Config["platformSettings"];
   /**
    * The object store recordings are resolved against. Absent by default, and
    * absent is the honest default: an egma nobody has pointed at a store is
@@ -139,12 +149,19 @@ export async function createApi(
     ...(traceStore === undefined ? {} : { clickhouseUrl: traceStore.url }),
     singleOrganization: options.singleOrganization ?? false,
     trustProxy: options.trustProxy ?? false,
-    ...(options.phone === undefined ? {} : { phone: options.phone }),
     ...(options.blob === undefined ? {} : { blob: options.blob }),
     ...(options.defaultJudge === undefined
       ? {}
       : { defaultJudge: options.defaultJudge }),
   });
+
+  // Through the deployment's own seeding door rather than written straight
+  // into the table: what a test then reads back has been sealed and hinted the
+  // way the product seals and hints it, and a suite that inserted rows itself
+  // would be proving something about rows nothing produces.
+  if (options.platformSettings !== undefined) {
+    await seedPlatformSettings(options.platformSettings);
+  }
 
   const { app, identity } = buildApi({
     config,

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -566,32 +566,34 @@ async function runPhoneSetup(
     ...stored,
     EGMA_BASE_URL: address,
 
-    // What the API knows about the carrier: three non-secret facts, and it
-    // reports readiness from them. No token, no password, no key.
+    // The carrier, written under the names the API seeds the platform's own
+    // settings from. **These reach no simulator container.** The API seals
+    // them into the platform's store on start, and each simulator is handed
+    // them on the work order it claims — which is why the SIP credential is
+    // here once rather than twice, and why a second simulator on another
+    // machine needs nothing copied to it. The SIP credential authenticates
+    // one trunk and can do nothing else on the account; that is the whole
+    // reason the Auth Token is a setup-time input rather than anybody's
+    // variable at all.
+    EGMA_MEDIA_BACKEND: "livekit",
     EGMA_PHONE_TRUNK_ADDRESS: applied.trunkAddress,
     EGMA_PHONE_SOURCE_NUMBER: applied.sourceNumber,
-    EGMA_PHONE_SPEECH_PROVIDER: "openai",
-
-    // What the simulator dials with. The SIP credential authenticates one
-    // trunk and can do nothing else on the account — that is the whole reason
-    // the Auth Token is a setup-time input rather than a container's variable.
-    EGMA_SIMULATOR_MEDIA_BACKEND: "livekit",
-    EGMA_SIMULATOR_SIP_TRUNK_ADDRESS: applied.trunkAddress,
-    EGMA_SIMULATOR_SIP_TRUNK_NUMBER: applied.sourceNumber,
-    EGMA_SIMULATOR_SIP_TRUNK_USERNAME: applied.sipUsername,
-    EGMA_SIMULATOR_SIP_TRUNK_PASSWORD: applied.sipPassword,
+    EGMA_PHONE_TRUNK_USERNAME: applied.sipUsername,
+    EGMA_PHONE_TRUNK_PASSWORD: applied.sipPassword,
 
     // One key, four jobs: the persona's words, its voice, its ears, and the
     // judge a project is given when it has configured none. Pipecat's own
     // OpenAI integrations and its Silero detector; egma configures them and
-    // implements no speech provider of its own.
-    EGMA_SIMULATOR_MODEL_PROVIDER: "openai",
-    EGMA_SIMULATOR_MODEL_NAME: options.env.EGMA_PERSONA_MODEL?.trim() || "gpt-4o",
-    EGMA_SIMULATOR_MODEL_API_KEY: openaiKey,
-    EGMA_SIMULATOR_STT_PROVIDER: "openai",
-    EGMA_SIMULATOR_TTS_PROVIDER: "openai",
-    EGMA_SIMULATOR_VAD_PROVIDER: "silero",
-    EGMA_SIMULATOR_OPENAI_API_KEY: openaiKey,
+    // implements no speech provider of its own. The first three are the
+    // platform's settings too, and travel the same way the carrier does.
+    EGMA_PERSONA_MODEL_PROVIDER: "openai",
+    EGMA_PERSONA_MODEL: options.env.EGMA_PERSONA_MODEL?.trim() || "gpt-4o",
+    EGMA_PERSONA_MODEL_API_KEY: openaiKey,
+    EGMA_PERSONA_STT_PROVIDER: "openai",
+    EGMA_PERSONA_STT_API_KEY: openaiKey,
+    EGMA_PERSONA_TTS_PROVIDER: "openai",
+    EGMA_PERSONA_TTS_API_KEY: openaiKey,
+    EGMA_PERSONA_VAD_PROVIDER: "silero",
     EGMA_JUDGE_PROVIDER: "openai",
     EGMA_JUDGE_MODEL: options.env.EGMA_JUDGE_MODEL?.trim() || "gpt-4o",
     EGMA_JUDGE_API_KEY: openaiKey,

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -304,6 +304,17 @@ one.
 
 Everything arrives as environment variables.
 
+**The provider settings in this table are a fallback, and a deployment does
+not use them.** Which model the persona thinks with, what it speaks and hears
+with, which bridge places a call and which carrier trunk it goes over are the
+*platform's* settings: the control plane stores them sealed and hands them to
+this process on the work order it claims, read afresh for every simulation. A
+work-order value replaces whatever this environment said, and no compose file
+passes any of them — so on a real deployment there is nothing here to set and
+nothing to keep in step. They stay readable for the one reader who has no
+platform behind them: a bare `egma-simulator` process, which is what the
+workbench story and every contributor's checkout run.
+
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `EGMA_SIMULATOR_CONTROL_PLANE_URL` | (required) | Where to claim, heartbeat, and report. |

--- a/apps/simulator/src/egma_simulator/config.py
+++ b/apps/simulator/src/egma_simulator/config.py
@@ -362,11 +362,23 @@ class MediaSettings:
         neither names a backend, which is every deployment that has never
         been given a carrier and is the ordinary case.
 
+        **It never refuses.** This runs for every simulation, and most
+        simulations never dial: a platform whose carrier is half configured
+        still runs chat and text work perfectly well, and failing that work
+        over a trunk it was never going to use would be a broken phone
+        breaking the telephone-free half of the product. So what is
+        assembled here is whatever the two sides between them have, and
+        every refusal lives in :meth:`checked`, which the phone plug calls
+        when a call is really about to be placed.
+
         **The platform's inline trunk replaces the container's whole
         trunk, stored reference and all.** A container that still held
         ``EGMA_SIMULATOR_SIP_TRUNK_ID`` would otherwise keep dialling its
         own trunk while the platform's settings page showed another — the
-        exact shape of silent disagreement this effort exists to end.
+        exact shape of silent disagreement this effort exists to end. The
+        replacement is whole for the same reason: address, number,
+        username and password move together, so a platform trunk can never
+        be dialled with a leftover caller identity from this container.
         """
         backend = carrier.media_backend or (
             None if standing is None else standing.backend
@@ -381,44 +393,86 @@ class MediaSettings:
             # bridge it needs has not been read yet. Reading it here rather
             # than at startup is what lets a simulator be given a carrier
             # after it was started, which is the whole of "adding capacity
-            # is starting a container and nothing else".
-            else cls.for_backend(
-                backend, because="the platform's media backend is " + backend
-            )
+            # is starting a container and nothing else". Read without
+            # demanding: a missing one is the phone's problem to report,
+            # and it is reported by `checked` at the moment of dialling.
+            else cls._bridge_this_container_offers(backend)
         )
         if backend != "livekit":
             return cls(backend=backend)
 
         platform_named_a_trunk = carrier.trunk_address is not None
+        trunk = carrier if platform_named_a_trunk else bridge
         return cls(
             backend=backend,
             livekit_url=bridge.livekit_url,
             livekit_api_key=bridge.livekit_api_key,
             livekit_api_secret=bridge.livekit_api_secret,
             trunk_id=None if platform_named_a_trunk else bridge.trunk_id,
-            trunk_address=carrier.trunk_address or bridge.trunk_address,
-            trunk_number=carrier.trunk_number or bridge.trunk_number,
-            trunk_username=(
-                carrier.trunk_username
-                if platform_named_a_trunk
-                else bridge.trunk_username
-            ),
-            trunk_password=(
-                carrier.trunk_password
-                if platform_named_a_trunk
-                else bridge.trunk_password
-            ),
-        ).checked()
+            trunk_address=trunk.trunk_address,
+            trunk_number=trunk.trunk_number,
+            trunk_username=trunk.trunk_username,
+            trunk_password=trunk.trunk_password,
+        )
+
+    @classmethod
+    def _bridge_this_container_offers(cls, backend: str) -> MediaSettings:
+        """The media server this container reaches, read without demanding.
+
+        The bridge is bootstrap configuration — a third-party binary reads
+        its own key and secret when it is created — so it is this
+        container's whatever the platform says. What is different from
+        :meth:`for_backend` is only the silence: an absent variable is left
+        absent rather than refused, because this is read for every
+        simulation and most of them never dial.
+        """
+        return cls(
+            backend=backend,
+            livekit_url=_text("EGMA_SIMULATOR_LIVEKIT_URL"),
+            livekit_api_key=_text("EGMA_SIMULATOR_LIVEKIT_API_KEY"),
+            livekit_api_secret=_text("EGMA_SIMULATOR_LIVEKIT_API_SECRET"),
+            trunk_id=_text("EGMA_SIMULATOR_SIP_TRUNK_ID"),
+            trunk_address=_text("EGMA_SIMULATOR_SIP_TRUNK_ADDRESS"),
+            trunk_number=_text("EGMA_SIMULATOR_SIP_TRUNK_NUMBER"),
+            trunk_username=_text("EGMA_SIMULATOR_SIP_TRUNK_USERNAME"),
+            trunk_password=_text("EGMA_SIMULATOR_SIP_TRUNK_PASSWORD"),
+        )
 
     def checked(self) -> MediaSettings:
         """These settings, or the refusal a deployment that cannot dial earns.
 
-        Run where both halves are in hand — the container's bridge and the
-        platform's trunk — because until then "there is no trunk" is not
-        yet true of anything.
+        **Every carrier refusal is here, and here is the moment a call is
+        about to be placed.** That is the whole of why it is a step of its
+        own: the same facts are assembled for every simulation, and only a
+        simulation that dials has any business failing over them.
         """
+        if self.backend not in MEDIA_BACKENDS:
+            raise ValueError(
+                f"this deployment's media backend is {self.backend!r}, which "
+                "is not a bridge this simulator has; it places calls through "
+                f"{', '.join(MEDIA_BACKENDS)}"
+            )
         if self.backend != "livekit":
             return self
+        absent = [
+            variable
+            for variable, value in (
+                ("EGMA_SIMULATOR_LIVEKIT_URL", self.livekit_url),
+                ("EGMA_SIMULATOR_LIVEKIT_API_KEY", self.livekit_api_key),
+                ("EGMA_SIMULATOR_LIVEKIT_API_SECRET", self.livekit_api_secret),
+            )
+            if value is None
+        ]
+        if absent:
+            # Named as variables rather than as settings, because that is
+            # what they are: the media server is a container of its own that
+            # reads its key and secret when it is created, so these can never
+            # come from the platform's store and this container is where they
+            # are missing from.
+            raise ValueError(
+                f"this deployment dials through livekit and this container is "
+                f"missing {' and '.join(absent)}"
+            )
         if self.trunk_id is None and self.trunk_address is None:
             raise ValueError(
                 "a phone call needs a trunk, and this deployment has none. "

--- a/apps/simulator/src/egma_simulator/config.py
+++ b/apps/simulator/src/egma_simulator/config.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from .reporting import DELIVERY_DEADLINE_SECONDS
+from .spec import PlatformCarrier
 
 MODEL_PROVIDERS = ("scripted", "openai")
 DEFAULT_MODEL_BASE_URL = "https://api.openai.com/v1"
@@ -225,17 +226,23 @@ def _writable_directory(name: str, path: Path) -> Path:
 
 @dataclass(frozen=True)
 class MediaSettings:
-    """How this deployment places a phone call, read once at startup.
+    """How this deployment places a phone call.
 
     A phone call needs a bridge and — for a real one — a SIP trunk, and
-    both belong to the deployment rather than to any one simulation. So
-    they arrive here, are checked here, and a simulator that cannot place
-    calls says so on its first line naming the variable rather than
-    failing one claimed simulation after another with the same sentence.
+    both belong to the deployment rather than to any one simulation.
 
-    A deployment that names no backend gets no settings at all and starts
-    in silence: dialling is opt-in, and a simulator that never dials
-    should not have to explain a trunk it does not want.
+    **The two halves now arrive from two places, and that is the point.**
+    The bridge is the media server this container talks to: a third-party
+    binary that reads its own key and secret when it is created, so those
+    stay in this environment and are checked at startup as they always
+    were. The trunk is the carrier paperwork somebody did once with
+    Twilio, which belongs to the whole platform — so it rides each work
+    order, and a second simulator on another machine needs no file copied
+    to it. :meth:`for_simulation` is where the two meet.
+
+    A deployment that names no backend and is handed none gets no settings
+    at all and places no calls: dialling is opt-in, and a simulator that
+    never dials should not have to explain a trunk it does not want.
     """
 
     backend: str
@@ -265,27 +272,51 @@ class MediaSettings:
 
     @classmethod
     def from_env(cls) -> MediaSettings | None:
-        """This deployment's bridge, or ``None`` where it names none."""
+        """This deployment's bridge, or ``None`` where it names none.
+
+        **The trunk is read here and no longer required here.** It used to
+        be: a simulator that named a backend and no trunk refused to start,
+        because the trunk was this container's to have and half a
+        deployment was nobody's. It is the platform's now, and a simulator
+        waiting for a work order to bring it one is an ordinary and
+        supported deployment — so the sentence that used to stop the
+        container has moved to :meth:`checked`, which runs when a call is
+        actually about to be placed and can see both halves at once. What
+        a self-hoster with no carrier reads instead is the platform's own
+        readiness answer, which names the carrier as a setting it is
+        missing. That answer is the whole reason this effort exists.
+        """
         named = _text("EGMA_SIMULATOR_MEDIA_BACKEND")
         if named is None:
             return None
+        return cls.for_backend(named, because=f"EGMA_SIMULATOR_MEDIA_BACKEND={named}")
+
+    @classmethod
+    def for_backend(cls, named: str, *, because: str) -> MediaSettings:
+        """One backend's settings out of this container's environment.
+
+        ``because`` is what made the backend required, said the way a
+        refusal says it — the variable that named it, or the platform
+        setting that did. Which one it was is the whole of the difference,
+        and a self-hoster reading the refusal needs to know which of the
+        two to go and change.
+        """
         if named not in MEDIA_BACKENDS:
             raise ValueError(
-                "EGMA_SIMULATOR_MEDIA_BACKEND must be one of "
-                f"{', '.join(MEDIA_BACKENDS)}; got {named!r}"
+                f"{because} names a media backend this simulator does not "
+                f"have; it places calls through {', '.join(MEDIA_BACKENDS)}"
             )
         if named != "livekit":
             return cls(backend=named)
 
-        chosen = f"EGMA_SIMULATOR_MEDIA_BACKEND={named}"
         settings = cls(
             backend=named,
-            livekit_url=_needed("EGMA_SIMULATOR_LIVEKIT_URL", because=chosen),
+            livekit_url=_needed("EGMA_SIMULATOR_LIVEKIT_URL", because=because),
             livekit_api_key=_needed(
-                "EGMA_SIMULATOR_LIVEKIT_API_KEY", because=chosen
+                "EGMA_SIMULATOR_LIVEKIT_API_KEY", because=because
             ),
             livekit_api_secret=_needed(
-                "EGMA_SIMULATOR_LIVEKIT_API_SECRET", because=chosen
+                "EGMA_SIMULATOR_LIVEKIT_API_SECRET", because=because
             ),
             trunk_id=_text("EGMA_SIMULATOR_SIP_TRUNK_ID"),
             trunk_address=_text("EGMA_SIMULATOR_SIP_TRUNK_ADDRESS"),
@@ -293,23 +324,12 @@ class MediaSettings:
             trunk_username=_text("EGMA_SIMULATOR_SIP_TRUNK_USERNAME"),
             trunk_password=_text("EGMA_SIMULATOR_SIP_TRUNK_PASSWORD"),
         )
-        if settings.trunk_id is None and settings.trunk_address is None:
-            raise ValueError(
-                "a phone call needs a trunk: set EGMA_SIMULATOR_SIP_TRUNK_ID "
-                "for a trunk already stored in LiveKit, or "
-                "EGMA_SIMULATOR_SIP_TRUNK_ADDRESS with "
-                "EGMA_SIMULATOR_SIP_TRUNK_USERNAME and "
-                "EGMA_SIMULATOR_SIP_TRUNK_PASSWORD for an inline one"
-            )
-        # Credential auth is a pair. Neither half is a trunk the carrier
-        # authenticates some other way — by the address it came from — and
-        # that is a real deployment. One half is nobody's deployment: every
-        # call it places comes back 403, which reads as *wrong* credentials
-        # rather than as half of one, and it reads that way once per
-        # simulation until somebody looks here. The rule binds the inline
-        # trunk only: with a stored trunk selected the inline fields are
-        # never read, and refusing a working deployment over a leftover
-        # half would be the louder wrong.
+        # Half a trunk *in this environment* is still refused here, by name
+        # and at startup, even though the whole trunk is no longer required
+        # here. Which trunk a call goes over may now come from the platform,
+        # but a container holding one of these two variables and not the
+        # other is a mistake somebody made in this file, and the sentence
+        # that fixes it is the one naming both variables.
         if settings.trunk_id is None and (settings.trunk_username is None) != (
             settings.trunk_password is None
         ):
@@ -330,6 +350,107 @@ class MediaSettings:
                 "wrong one"
             )
         return settings
+
+    @classmethod
+    def for_simulation(
+        cls, standing: MediaSettings | None, carrier: PlatformCarrier
+    ) -> MediaSettings | None:
+        """The bridge and trunk one simulation is dialled over.
+
+        This container's own settings with the platform's carrier laid
+        over them, and it is the one place the two meet. ``None`` where
+        neither names a backend, which is every deployment that has never
+        been given a carrier and is the ordinary case.
+
+        **The platform's inline trunk replaces the container's whole
+        trunk, stored reference and all.** A container that still held
+        ``EGMA_SIMULATOR_SIP_TRUNK_ID`` would otherwise keep dialling its
+        own trunk while the platform's settings page showed another — the
+        exact shape of silent disagreement this effort exists to end.
+        """
+        backend = carrier.media_backend or (
+            None if standing is None else standing.backend
+        )
+        if backend is None:
+            return None
+
+        bridge = (
+            standing
+            if standing is not None and standing.backend == backend
+            # The platform names a backend this container did not, so the
+            # bridge it needs has not been read yet. Reading it here rather
+            # than at startup is what lets a simulator be given a carrier
+            # after it was started, which is the whole of "adding capacity
+            # is starting a container and nothing else".
+            else cls.for_backend(
+                backend, because="the platform's media backend is " + backend
+            )
+        )
+        if backend != "livekit":
+            return cls(backend=backend)
+
+        platform_named_a_trunk = carrier.trunk_address is not None
+        return cls(
+            backend=backend,
+            livekit_url=bridge.livekit_url,
+            livekit_api_key=bridge.livekit_api_key,
+            livekit_api_secret=bridge.livekit_api_secret,
+            trunk_id=None if platform_named_a_trunk else bridge.trunk_id,
+            trunk_address=carrier.trunk_address or bridge.trunk_address,
+            trunk_number=carrier.trunk_number or bridge.trunk_number,
+            trunk_username=(
+                carrier.trunk_username
+                if platform_named_a_trunk
+                else bridge.trunk_username
+            ),
+            trunk_password=(
+                carrier.trunk_password
+                if platform_named_a_trunk
+                else bridge.trunk_password
+            ),
+        ).checked()
+
+    def checked(self) -> MediaSettings:
+        """These settings, or the refusal a deployment that cannot dial earns.
+
+        Run where both halves are in hand — the container's bridge and the
+        platform's trunk — because until then "there is no trunk" is not
+        yet true of anything.
+        """
+        if self.backend != "livekit":
+            return self
+        if self.trunk_id is None and self.trunk_address is None:
+            raise ValueError(
+                "a phone call needs a trunk, and this deployment has none. "
+                "Give the platform a carrier trunk — the setting is on its "
+                "settings page and `egma self-host phone setup` writes it — "
+                "or set EGMA_SIMULATOR_SIP_TRUNK_ID on this container for a "
+                "trunk already stored in LiveKit"
+            )
+        # Credential auth is a pair. Neither half is a trunk the carrier
+        # authenticates some other way — by the address it came from — and
+        # that is a real deployment. One half is nobody's deployment: every
+        # call it places comes back 403, which reads as *wrong* credentials
+        # rather than as half of one, and it reads that way once per
+        # simulation until somebody looks here. The rule binds the inline
+        # trunk only: with a stored trunk selected the inline fields are
+        # never read, and refusing a working deployment over a leftover
+        # half would be the louder wrong.
+        if self.trunk_id is None and (self.trunk_username is None) != (
+            self.trunk_password is None
+        ):
+            missing, given = (
+                ("password", "username")
+                if self.trunk_password is None
+                else ("username", "password")
+            )
+            raise ValueError(
+                f"this deployment's carrier trunk has a {given} and no "
+                f"{missing}: a trunk authenticated by credentials needs both "
+                "halves, and a carrier refuses half of one exactly the way it "
+                "refuses a wrong one"
+            )
+        return self
 
 
 def _needed(variable: str, *, because: str) -> str:
@@ -583,6 +704,21 @@ class SimulatorConfig:
             )
             if key is not None
         )
+
+    def key_for(self, provider: str) -> str | None:
+        """The key this container holds for one speech provider, if any.
+
+        The environment names its speech keys after providers — one openai
+        key for both legs, because one account really does serve both — and
+        the legs are what a work order names its keys after. This is the
+        one translation between the two, so a reader of either shape never
+        has to know about the other.
+        """
+        return {
+            "deepgram": self.deepgram_api_key,
+            "elevenlabs": self.elevenlabs_api_key,
+            "openai": self.openai_api_key,
+        }.get(provider)
 
     @property
     def media_secrets(self) -> tuple[str, ...]:

--- a/apps/simulator/src/egma_simulator/model.py
+++ b/apps/simulator/src/egma_simulator/model.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Protocol
 import aiohttp
 
 from .client import UNREACHABLE
+from .config import MODEL_PROVIDERS
 
 if TYPE_CHECKING:
     from .config import SimulatorConfig
@@ -186,6 +187,18 @@ def build_model_client(
     """
     said = spec.platform.model
     provider = said.provider or config.model_provider
+    if provider not in MODEL_PROVIDERS:
+        # **Refused rather than quietly downgraded to the stand-in.** This
+        # container's own provider name is checked when it starts, so a
+        # name that gets here is one the platform holds — and a typo on a
+        # settings page must not produce a completed, green simulation
+        # conducted by a canned robot. That is worse than a failure,
+        # because a failure tells the truth about what happened.
+        raise ModelFailure(
+            f"the platform's persona_model_provider is {provider!r}, which is "
+            "not a model client this simulator has; it thinks with "
+            f"{', '.join(MODEL_PROVIDERS)}"
+        )
     if provider != "openai":
         return ScriptedModel(spec.scenario_instructions)
 

--- a/apps/simulator/src/egma_simulator/model.py
+++ b/apps/simulator/src/egma_simulator/model.py
@@ -174,15 +174,33 @@ def build_model_client(
     The scripted client derives its script from the spec, which is what
     makes two different specs conduct two different exchanges with no code
     change; the OpenAI-compatible client is configuration alone.
+
+    **The platform's own settings win over this container's.** They arrive
+    on the work order, they are read afresh for every simulation, and each
+    of the three replaces this container's answer on its own — so a
+    deployment that has configured the persona's model centrally needs no
+    model variables on any simulator, and a replaced key applies to the
+    next simulation with no restart. A setting the platform does not hold
+    leaves this container's own value standing, which is what makes a
+    deployment that has configured nothing behave exactly as it did.
     """
-    if config.model_provider == "openai":
-        if config.model_name is None or config.model_api_key is None:
-            raise ModelFailure(
-                "the openai model provider needs both a model name and a key"
-            )
-        return OpenAICompatibleModel(
-            base_url=config.model_base_url,
-            api_key=config.model_api_key,
-            model_name=config.model_name,
+    said = spec.platform.model
+    provider = said.provider or config.model_provider
+    if provider != "openai":
+        return ScriptedModel(spec.scenario_instructions)
+
+    model_name = said.model or config.model_name
+    api_key = said.key or config.model_api_key
+    if model_name is None or api_key is None:
+        raise ModelFailure(
+            "the openai model provider needs both a model name and a key"
         )
-    return ScriptedModel(spec.scenario_instructions)
+    return OpenAICompatibleModel(
+        # The base URL stays this container's. It is not one of the
+        # platform's settings: it says which address this simulator reaches
+        # a provider at, which is a property of the network it is on rather
+        # than of the deployment's account.
+        base_url=config.model_base_url,
+        api_key=api_key,
+        model_name=model_name,
+    )

--- a/apps/simulator/src/egma_simulator/pipeline.py
+++ b/apps/simulator/src/egma_simulator/pipeline.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 
 from .blob import BlobStore
 from .conductor import DEFAULT_CONDUCT, ConductParameters, VoiceConductor
+from .config import MediaSettings
 from .mock_tools import ExchangedToolCall, MockToolSeam
 from .plugs import DuplexLine, PlatformPlug, PlugError, plug_for
 from .recording import RECORDING_NAME
@@ -80,6 +81,7 @@ def assemble(
     *,
     blobs: BlobStore,
     speech: SpeechProviders = SCRIPTED_PAIR,
+    media: MediaSettings | None = None,
     parameters: ConductParameters | None = None,
 ) -> Assembled:
     """Build one simulation's pipeline from its spec.
@@ -93,6 +95,12 @@ def assemble(
     configuration says what carries it. Left alone it is the scripted
     pair, so a deployment with nothing to say about providers gets
     exactly the pipeline it always got.
+
+    ``media`` is the same for the telephone network — this container's
+    bridge with the platform's own carrier already laid over it, resolved
+    once by whoever built these arguments and handed whole to the plug.
+    ``None`` is a deployment that places no calls, and a spec that then
+    names a phone number is refused by the plug with a sentence saying so.
     """
     factory = plug_for(spec.connection_type)
     if factory is None:
@@ -110,6 +118,7 @@ def assemble(
         credentials=spec.credentials,
         simulation_id=spec.simulation_id,
         mock_tools=mock_tools,
+        media=media,
     )
     if spec.modality != "voice":
         return Assembled(plug=plug, mock_tools=mock_tools)

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -14,7 +14,7 @@ requires reading anything beyond this file, that is a bug in this file.
 ## What a plug receives
 
 A plug is constructed once per simulation, from the claimed spec, with
-five keyword arguments:
+six keyword arguments:
 
 - ``modality`` — ``"chat"`` or ``"voice"``. A plug that cannot speak the
   requested modality must refuse at construction (raise ``PlugError``).
@@ -42,6 +42,13 @@ five keyword arguments:
   that saying-so is what puts a coverage stamp on the record. Every other
   plug takes it and drops it, and its record honestly claims nothing about
   tools, because egma was never in the path to learn anything.
+- ``media`` — how a call reaches the telephone network for this
+  simulation (:class:`egma_simulator.config.MediaSettings`), or ``None``
+  on a deployment that places no calls. Already resolved: this
+  container's bridge with the platform's own carrier laid over it, worked
+  out once by assembly so that no plug reaches for an environment
+  variable of its own. Only a plug that dials has any use for it, which
+  today is the phone; every other plug takes it and drops it.
 
 Constructors validate and hold; they never do I/O. A constructor that
 raises means the simulation fails with an honest reason before the
@@ -298,9 +305,9 @@ class DuplexLine(Protocol):
 
 PlugFactory = Callable[..., PlatformPlug | DuplexLine]
 """What the registry hands back: called with ``modality=``, ``config=``,
-``credentials=``, ``simulation_id=`` and ``mock_tools=`` keywords, it
-returns one plug for one simulation — in practice, the plug class
-itself."""
+``credentials=``, ``simulation_id=``, ``mock_tools=`` and ``media=``
+keywords, it returns one plug for one simulation — in practice, the plug
+class itself."""
 
 
 def plug_for(connection_type: str) -> PlugFactory | None:

--- a/apps/simulator/src/egma_simulator/plugs/livekit.py
+++ b/apps/simulator/src/egma_simulator/plugs/livekit.py
@@ -112,8 +112,15 @@ class LiveKitRoom:
         credentials: object,
         simulation_id: str,
         mock_tools: MockToolSeam | None = None,
+        media: object = None,
         driver: Any = None,
     ) -> None:
+        # A room is reached over the deployment's own media server, whose
+        # address and credential are this container's bootstrap
+        # configuration rather than a platform setting — so the carrier
+        # resolved for this simulation is nothing to this plug.
+        del media
+
         if modality != "voice":
             raise PlugError(
                 f"the livekit plug speaks voice only; a {modality!r} "

--- a/apps/simulator/src/egma_simulator/plugs/loopback.py
+++ b/apps/simulator/src/egma_simulator/plugs/loopback.py
@@ -111,12 +111,13 @@ class LoopbackCounterpart:
         credentials: object,
         simulation_id: str | None = None,
         mock_tools: object = None,
+        media: object = None,
     ) -> None:
         # The loopback counterpart takes no credentials; anything handed
         # over is ignored unread, the way a sentinel-planting test expects.
-        # It has nobody to tell which simulation this is, either, and
-        # nobody's tools to stand in front of.
-        del credentials, simulation_id, mock_tools
+        # It has nobody to tell which simulation this is, either, nobody's
+        # tools to stand in front of, and no telephone network to reach.
+        del credentials, simulation_id, mock_tools, media
 
         if modality != "voice":
             raise PlugError(

--- a/apps/simulator/src/egma_simulator/plugs/phone.py
+++ b/apps/simulator/src/egma_simulator/plugs/phone.py
@@ -108,11 +108,13 @@ class PhoneCall:
         # stand in front of its tools.
         del simulation_id, mock_tools
 
-        # Which bridge and which trunk were checked at startup; this reads
-        # the result rather than the environment, so nothing here can be
-        # the first to discover a deployment cannot dial. The keyword is
-        # for tests, which build settings rather than an environment.
-        settings = media if media is not None else MediaSettings.from_env()
+        # Which bridge and which trunk this call goes over, resolved by
+        # assembly from this container's own configuration and the
+        # platform's carrier on the work order. Read here rather than
+        # worked out here: a plug that reached for an environment variable
+        # would be a second answer to a question the deployment already
+        # answered, and the two could disagree.
+        settings = media
 
         if modality != "voice":
             raise PlugError(
@@ -133,9 +135,10 @@ class PhoneCall:
 
         if settings is None:
             raise PlugError(
-                "this simulator places no phone calls: set "
-                f"{BACKEND_VARIABLE} to one of {sorted(BACKENDS)}, with the "
-                "server and trunk that backend needs"
+                "this deployment places no phone calls: give the platform a "
+                f"media backend — one of {sorted(BACKENDS)} — with the carrier "
+                f"trunk that backend needs, or set {BACKEND_VARIABLE} on this "
+                "container"
             )
         backend_name = settings.backend
         factory = backend_for(backend_name)

--- a/apps/simulator/src/egma_simulator/plugs/phone.py
+++ b/apps/simulator/src/egma_simulator/plugs/phone.py
@@ -140,6 +140,16 @@ class PhoneCall:
                 f"trunk that backend needs, or set {BACKEND_VARIABLE} on this "
                 "container"
             )
+        # **The moment a carrier's own refusals belong.** The settings are
+        # assembled for every simulation and most of them never dial, so a
+        # half-configured phone must not fail the chat work beside it. Here
+        # a call is about to be placed, so here is where a missing trunk or
+        # a missing bridge is the honest reason this one cannot happen.
+        try:
+            settings = settings.checked()
+        except ValueError as cannot_dial:
+            raise PlugError(str(cannot_dial)) from cannot_dial
+
         backend_name = settings.backend
         factory = backend_for(backend_name)
         if factory is None:

--- a/apps/simulator/src/egma_simulator/plugs/retell.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell.py
@@ -84,13 +84,15 @@ class RetellChat:
         credentials: object,
         simulation_id: str | None = None,
         mock_tools: object = None,
+        media: object = None,
     ) -> None:
         # Retell mints its own chat id and that is what a report joins on,
         # so this plug has nothing to tell it about the simulation. egma
         # is not in this agent's tool path either — a chat over somebody
         # else's platform has no room to stand in — so its record honestly
-        # claims nothing about tools.
-        del simulation_id, mock_tools
+        # claims nothing about tools. Retell carries its own audio, so the
+        # deployment's carrier is nothing to it either.
+        del simulation_id, mock_tools, media
 
         if modality != "chat":
             raise PlugError(

--- a/apps/simulator/src/egma_simulator/plugs/scripted.py
+++ b/apps/simulator/src/egma_simulator/plugs/scripted.py
@@ -62,12 +62,13 @@ class ScriptedCounterpart:
         credentials: object,
         simulation_id: str | None = None,
         mock_tools: object = None,
+        media: object = None,
     ) -> None:
         # The scripted counterpart takes no credentials; anything handed
         # over is ignored unread, the way a sentinel-planting test expects.
-        # It has nobody to tell which simulation this is, either, and
-        # nobody's tools to stand in front of.
-        del credentials, simulation_id, mock_tools
+        # It has nobody to tell which simulation this is, either, nobody's
+        # tools to stand in front of, and no telephone network to reach.
+        del credentials, simulation_id, mock_tools, media
 
         if modality != "chat":
             raise PlugError(

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -37,7 +37,7 @@ from typing import Protocol
 
 from .blob import BlobStore, FilesystemBlobStore, S3BlobStore
 from .client import ClaimFailure, ControlPlaneClient, HeartbeatFailure
-from .config import SimulatorConfig
+from .config import MediaSettings, SimulatorConfig
 from .contract import ContractViolation
 from .model import build_model_client
 from .persona import Persona
@@ -258,7 +258,18 @@ class RunningSimulation:
             assembled = assemble(
                 self._spec,
                 blobs=self._blobs,
-                speech=SpeechProviders.from_config(self._config),
+                # This container's configuration with the platform's own
+                # settings laid over it, resolved here — once, for this
+                # simulation, from the work order that claimed it. Which is
+                # what makes a key an operator replaced apply to the next
+                # simulation with nothing restarted, and what lets a second
+                # simulator on another machine hold no settings at all.
+                speech=SpeechProviders.for_simulation(
+                    self._config, self._spec.platform.speech
+                ),
+                media=MediaSettings.for_simulation(
+                    self._config.media, self._spec.platform.carrier
+                ),
             )
             self._assembled = assembled
             persona = Persona(
@@ -634,7 +645,13 @@ class SimulatorService:
                 )
                 continue
 
+            # The connection's credentials and the platform's own keys, both
+            # registered before anything is conducted with either. A key that
+            # arrived on a work order is exactly as much a secret as one that
+            # arrived in this container's environment, and the filter that
+            # keeps it out of the log has to know about it either way.
             self._secrets.register(spec.credentials)
+            self._secrets.register(list(spec.platform.secrets))
             executor.submit(spec)
 
     async def _conduct_one(

--- a/apps/simulator/src/egma_simulator/spec.py
+++ b/apps/simulator/src/egma_simulator/spec.py
@@ -13,7 +13,7 @@ the fields at face value.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from .contract import ContractViolation, validate_spec
@@ -47,6 +47,140 @@ class MockTool:
     def fails(self) -> bool:
         """Whether this answer is the failure branch."""
         return "error" in self.answer
+
+
+@dataclass(frozen=True)
+class PlatformModel:
+    """What the persona thinks with, as the platform has it configured.
+
+    Every field is optional, because a platform mid-setup holds some of
+    them and not others, and one that holds none is every platform before
+    anybody set it up. ``None`` here always means *the platform said
+    nothing about this*, never *the platform said nothing* — so a reader
+    leaves its own value standing rather than clearing it.
+    """
+
+    provider: str | None = None
+    model: str | None = None
+    key: str | None = field(default=None, repr=False)
+    """Kept out of the dataclass repr, like every other key in this
+    process: a log line carrying one is a log line that should not have."""
+
+
+@dataclass(frozen=True)
+class PlatformSpeech:
+    """What the persona speaks and hears with, as the platform has it.
+
+    A key per leg rather than one per provider, which is the shape the
+    contract carries and the shape :class:`~egma_simulator.speech.SpeechProviders`
+    holds: the two legs are two accounts as often as they are one, and a
+    shape that could not say so would make the second one unreachable.
+    """
+
+    stt_provider: str | None = None
+    stt_key: str | None = field(default=None, repr=False)
+    tts_provider: str | None = None
+    tts_key: str | None = field(default=None, repr=False)
+    tts_model: str | None = None
+    tts_voice: str | None = None
+    vad_provider: str | None = None
+
+
+@dataclass(frozen=True)
+class PlatformCarrier:
+    """How a call reaches the telephone network, as the platform has it.
+
+    The media server's own key and secret are deliberately not here: they
+    are read by a third-party container when it is created and cannot come
+    from the platform's store, so they stay in each simulator's
+    environment. What is here is the choice of bridge and the trunk the
+    carrier authenticates — the paperwork somebody did once with Twilio,
+    which is exactly the thing this effort exists to stop losing.
+    """
+
+    media_backend: str | None = None
+    trunk_address: str | None = None
+    trunk_number: str | None = None
+    trunk_username: str | None = None
+    trunk_password: str | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True)
+class PlatformSettings:
+    """What the deployment has been configured with, off the work order.
+
+    **These arrive per simulation and replace this container's own.** They
+    used to be each simulator's environment, which meant a second
+    simulator on another machine needed a file copied to it, and a
+    container started without one dialled nothing while reporting itself
+    healthy. They belong to the whole deployment, so the deployment holds
+    them and hands them down with the work.
+
+    Three groups, because the groups are what can be absent: a deployment
+    with no carrier is the ordinary deployment, and the whole phone half
+    then simply is not here. Absent everywhere is also ordinary and is
+    what every spec written before these existed carries — which is why
+    every field is optional and every reader treats ``None`` as *say
+    nothing*.
+    """
+
+    model: PlatformModel = field(default_factory=PlatformModel)
+    speech: PlatformSpeech = field(default_factory=PlatformSpeech)
+    carrier: PlatformCarrier = field(default_factory=PlatformCarrier)
+
+    @property
+    def secrets(self) -> tuple[str, ...]:
+        """Every secret these settings hold, for redaction.
+
+        One place to ask, exactly as the configuration's own secrets have
+        one, so a fourth key arriving cannot fall out of the scrubbing.
+        """
+        return tuple(
+            secret
+            for secret in (
+                self.model.key,
+                self.speech.stt_key,
+                self.speech.tts_key,
+                self.carrier.trunk_password,
+            )
+            if secret is not None
+        )
+
+    @classmethod
+    def from_document(cls, written: Any) -> PlatformSettings:
+        """The platform block of a validated spec, or the empty settings.
+
+        The schema has already refused a field nobody writes, so the reads
+        below take what is there at face value — the same bargain the rest
+        of this module makes.
+        """
+        block = written or {}
+        model = block.get("model") or {}
+        speech = block.get("speech") or {}
+        carrier = block.get("carrier") or {}
+        return cls(
+            model=PlatformModel(
+                provider=model.get("provider"),
+                model=model.get("model"),
+                key=model.get("key"),
+            ),
+            speech=PlatformSpeech(
+                stt_provider=speech.get("stt_provider"),
+                stt_key=speech.get("stt_key"),
+                tts_provider=speech.get("tts_provider"),
+                tts_key=speech.get("tts_key"),
+                tts_model=speech.get("tts_model"),
+                tts_voice=speech.get("tts_voice"),
+                vad_provider=speech.get("vad_provider"),
+            ),
+            carrier=PlatformCarrier(
+                media_backend=carrier.get("media_backend"),
+                trunk_address=carrier.get("trunk_address"),
+                trunk_number=carrier.get("trunk_number"),
+                trunk_username=carrier.get("trunk_username"),
+                trunk_password=carrier.get("trunk_password"),
+            ),
+        )
 
 
 @dataclass(frozen=True)
@@ -101,6 +235,16 @@ class SimulationSpec:
     unobserved.
     """
 
+    platform: PlatformSettings = field(default_factory=PlatformSettings)
+    """What the deployment has been configured with — its persona's model,
+    its speech legs, its carrier — read afresh for this simulation.
+
+    Empty is an ordinary state and means the platform said nothing, so
+    this container's own configuration stands exactly as it did. It is
+    never *this simulation asked for nothing*: the settings belong to the
+    deployment, and a simulation has no opinion about them.
+    """
+
     @classmethod
     def from_document(cls, document: Any) -> SimulationSpec:
         """Hold a claimed document to the contract, then read it.
@@ -114,6 +258,7 @@ class SimulationSpec:
         limits = document["limits"]
         return cls(
             mock_tools=_mock_tools(document.get("mock_tools") or []),
+            platform=PlatformSettings.from_document(document.get("platform")),
             simulation_id=document["simulation_id"],
             modality=document["modality"],
             scenario_instructions=document["scenario"]["instructions"],

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -66,7 +66,14 @@ from pipecat.services.settings import STTSettings
 from pipecat.services.stt_service import SegmentedSTTService
 from pipecat.utils.time import time_now_iso8601
 
-from .config import DEFAULT_STT_MODEL, DEFAULT_TTS_MODEL, DEFAULT_TTS_VOICE
+from .config import (
+    DEFAULT_STT_MODEL,
+    DEFAULT_TTS_MODEL,
+    DEFAULT_TTS_VOICE,
+    STT_PROVIDERS,
+    TTS_PROVIDERS,
+    VAD_PROVIDERS,
+)
 from .spec import PlatformSpeech
 
 if TYPE_CHECKING:
@@ -477,6 +484,40 @@ class SpeechProviders:
         )
 
 
+    def checked(self) -> SpeechProviders:
+        """These legs, or the refusal an unrecognised provider earns.
+
+        **Refused rather than quietly downgraded to the stand-in.** Every
+        builder below falls through to the scripted leg for a provider it
+        does not implement, which is exactly right when the choice was
+        `scripted` and exactly wrong when the choice was `elevenlabss`: a
+        typo on a settings page would otherwise produce a completed, green
+        simulation conducted by a canned robot, which is worse than a
+        failure because a failure tells the truth about what happened.
+
+        This container's own three names are checked when it starts, so a
+        name that reaches here is one the platform holds — and the refusal
+        names the platform's setting, the value, and what this simulator
+        really has.
+
+        Called where the legs are *built*, not where they are resolved: a
+        chat simulation has no mouth and no ears, and must not fail over a
+        speech provider it was never going to use.
+        """
+        for setting, chosen, allowed in (
+            ("speech_to_text_provider", self.stt, STT_PROVIDERS),
+            ("text_to_speech_provider", self.tts, TTS_PROVIDERS),
+            ("voice_activity_provider", self.vad, VAD_PROVIDERS),
+        ):
+            if chosen not in allowed:
+                raise SpeechFault(
+                    f"the platform's {setting} is {chosen!r}, which is not a "
+                    "speech leg this simulator has; it speaks and listens "
+                    f"with {', '.join(allowed)}"
+                )
+        return self
+
+
 SCRIPTED_PAIR = SpeechProviders()
 """The pair a pipeline is assembled with when nothing is configured."""
 
@@ -531,6 +572,7 @@ def build_legs(
     reaches the provider only once the exchange opens, so assembling a
     pipeline stays the validation step it has always been.
     """
+    providers = providers.checked()
     speaking, spoken_with, closers = _mouth(providers, voice, sample_rate_hz)
     listening_leg, listening = _ears(providers, sample_rate_hz)
     return SpeechLegs(
@@ -584,6 +626,7 @@ def build_vad(
     for by name because loading a model is a cost only a deployment that
     wants it should pay.
     """
+    providers = providers.checked()
     if providers.vad != "silero":
         return ScriptedVAD(
             sample_rate_hz=sample_rate_hz, window_samples=window_samples

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -67,6 +67,7 @@ from pipecat.services.stt_service import SegmentedSTTService
 from pipecat.utils.time import time_now_iso8601
 
 from .config import DEFAULT_STT_MODEL, DEFAULT_TTS_MODEL, DEFAULT_TTS_VOICE
+from .spec import PlatformSpeech
 
 if TYPE_CHECKING:
     from .config import SimulatorConfig
@@ -426,27 +427,53 @@ class SpeechProviders:
     production detector, and it ships inside the pinned pipecat wheel, so
     choosing it downloads nothing."""
 
-    deepgram_api_key: str | None = field(default=None, repr=False)
-    elevenlabs_api_key: str | None = field(default=None, repr=False)
-    openai_api_key: str | None = field(default=None, repr=False)
-    """One key for both openai legs, because one account serves both."""
+    stt_key: str | None = field(default=None, repr=False)
+    tts_key: str | None = field(default=None, repr=False)
+    """A key per leg, not per provider.
+
+    The environment names its keys after providers, because one account
+    there really does serve both openai legs. The platform's own settings
+    name them after legs, because on a deployment that listens with one
+    company and speaks with another they are two accounts — and a shape
+    that could not say so would make the second key unreachable. So the
+    legs are what these are keyed by, and translating the environment's
+    provider-shaped names into them happens once, in
+    :meth:`for_simulation`.
+    """
 
     stt_model: str = DEFAULT_STT_MODEL
     tts_model: str = DEFAULT_TTS_MODEL
     tts_voice: str = DEFAULT_TTS_VOICE
 
     @classmethod
-    def from_config(cls, config: SimulatorConfig) -> SpeechProviders:
+    def for_simulation(
+        cls, config: SimulatorConfig, platform: PlatformSpeech | None = None
+    ) -> SpeechProviders:
+        """The pair one simulation is assembled with.
+
+        This container's own configuration, with the platform's settings
+        laid over it leg by leg — which is what makes a second simulator on
+        another machine need no speech variables at all, and what makes a
+        replaced key apply to the next simulation with no restart.
+
+        **A leg's key follows its leg's provider.** Naming a provider and
+        no key is a deployment saying "use this company, with the key you
+        already have", which is what a self-hoster who set one key for both
+        openai legs means. Naming a key and no provider is that key for
+        whichever leg the container already chose.
+        """
+        said = platform or PlatformSpeech()
+        stt = said.stt_provider or config.stt_provider
+        tts = said.tts_provider or config.tts_provider
         return cls(
-            stt=config.stt_provider,
-            tts=config.tts_provider,
-            vad=config.vad_provider,
-            deepgram_api_key=config.deepgram_api_key,
-            elevenlabs_api_key=config.elevenlabs_api_key,
-            openai_api_key=config.openai_api_key,
+            stt=stt,
+            tts=tts,
+            vad=said.vad_provider or config.vad_provider,
+            stt_key=said.stt_key or config.key_for(stt),
+            tts_key=said.tts_key or config.key_for(tts),
             stt_model=config.stt_model,
-            tts_model=config.tts_model,
-            tts_voice=config.tts_voice,
+            tts_model=said.tts_model or config.tts_model,
+            tts_voice=said.tts_voice or config.tts_voice,
         )
 
 
@@ -586,7 +613,7 @@ def _mouth(
     from pipecat.services.elevenlabs.tts import ElevenLabsHttpTTSService
     from pipecat.services.tts_service import TextAggregationMode
 
-    if not providers.elevenlabs_api_key:
+    if not providers.tts_key:
         raise SpeechFault("the elevenlabs speaking leg was chosen without a key")
 
     spoken_with = _voice_from(
@@ -597,7 +624,7 @@ def _mouth(
         settings.speed = spoken_with.speed
     session = aiohttp.ClientSession()
     leg = ElevenLabsHttpTTSService(
-        api_key=providers.elevenlabs_api_key,
+        api_key=providers.tts_key,
         aiohttp_session=session,
         sample_rate=sample_rate_hz,
         settings=settings,
@@ -626,12 +653,10 @@ def _ears(
 
     from pipecat.services.deepgram.stt import DeepgramSTTService
 
-    if not providers.deepgram_api_key:
+    if not providers.stt_key:
         raise SpeechFault("the deepgram listening leg was chosen without a key")
 
-    leg = DeepgramSTTService(
-        api_key=providers.deepgram_api_key, sample_rate=sample_rate_hz
-    )
+    leg = DeepgramSTTService(api_key=providers.stt_key, sample_rate=sample_rate_hz)
 
     async def connected() -> None:
         # The service opens its websocket in a background task and drops
@@ -683,7 +708,7 @@ def _openai_mouth(
     """
     from pipecat.services.openai.tts import OpenAITTSService
 
-    if not providers.openai_api_key:
+    if not providers.tts_key:
         raise SpeechFault("the openai speaking leg was chosen without a key")
 
     spoken_with = _voice_from(
@@ -699,7 +724,7 @@ def _openai_mouth(
     leg = Pipeline(
         [
             OpenAITTSService(
-                api_key=providers.openai_api_key,
+                api_key=providers.tts_key,
                 # Built at the provider's own band. Handing it the line's
                 # band is what makes it mislabel, so it is never told one.
                 sample_rate=OPENAI_TTS_BAND_HZ,
@@ -725,11 +750,11 @@ def _openai_ears(
     """
     from pipecat.services.openai.stt import OpenAISTTService
 
-    if not providers.openai_api_key:
+    if not providers.stt_key:
         raise SpeechFault("the openai listening leg was chosen without a key")
 
     return OpenAISTTService(
-        api_key=providers.openai_api_key,
+        api_key=providers.stt_key,
         sample_rate=sample_rate_hz,
         settings=OpenAISTTService.Settings(model=providers.stt_model),
     )

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -105,6 +105,26 @@ async def _serve_workbench(state: WorkbenchState) -> AsyncIterator[Workbench]:
 
 
 @pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """A clean environment, and somewhere harmless for the two directories.
+
+    Whatever this machine has set is cleared first, so a developer with
+    their own ``EGMA_SIMULATOR_*`` exported cannot make these pass or fail
+    differently from anybody else's.
+
+    Here rather than in one suite because two of them configure a simulator
+    in process now: the one about reading the environment, and the one
+    about the platform's settings replacing what it read.
+    """
+    for name in list(os.environ):
+        if name.startswith("EGMA_SIMULATOR_"):
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("EGMA_SIMULATOR_WAL_DIR", str(tmp_path / "wal"))
+    monkeypatch.setenv("EGMA_SIMULATOR_BLOB_DIR", str(tmp_path / "blobs"))
+    return monkeypatch
+
+
+@pytest.fixture
 async def workbench() -> AsyncIterator[Workbench]:
     async for running in _serve_workbench(
         WorkbenchState(hold_seconds=CLAIM_HOLD_SECONDS)
@@ -525,6 +545,7 @@ def a_spec(
     max_duration_seconds: int,
     modality: str = "chat",
     mock_tools: list[dict] | None = None,
+    platform: dict | None = None,
 ) -> dict:
     """The envelope every spec shares: one persona, one scenario, one set of
     walls, one exchange. What differs between two specs is the connection
@@ -549,6 +570,13 @@ def a_spec(
     }
     if mock_tools:
         spec["mock_tools"] = mock_tools
+    if platform:
+        # Left off the document entirely when the platform holds nothing,
+        # for the reason `mock_tools` is: that is what the control plane
+        # really sends for a deployment nobody has configured, and a spec
+        # carrying an empty block would be exercising a shape nothing
+        # produces.
+        spec["platform"] = platform
     return spec
 
 
@@ -566,6 +594,7 @@ def scripted_spec(
     max_turns: int = 60,
     max_duration_seconds: int = 600,
     credentials: dict | None = None,
+    platform: dict | None = None,
 ) -> dict:
     """One spec against the scripted counterpart, the whole suite's staple.
 
@@ -590,6 +619,7 @@ def scripted_spec(
             "config": config,
             "credentials": credentials,
         },
+        platform=platform,
         scenario=scenario,
         personality=personality,
         max_turns=max_turns,
@@ -729,16 +759,18 @@ def phone_spec(
     max_turns: int = 60,
     max_duration_seconds: int = 600,
     credentials: dict | None = None,
+    platform: dict | None = None,
 ) -> dict:
     """One voice spec that dials a number.
 
     Deliberately the same shape as :func:`loopback_spec`: a phone
     simulation differs from every other voice one by its connection block
-    and by nothing else. Which bridge places the call is the simulator's
-    own configuration rather than the spec's, so ``backend`` here only
-    decides whether the scripted backend's script is written into the
-    spec — what the far end says, whether it hangs up, what the carrier
-    answers — which only that backend reads.
+    and by nothing else. ``backend`` here only decides whether the
+    scripted backend's script is written into the spec — what the far end
+    says, whether it hangs up, what the carrier answers — which only that
+    backend reads. Which bridge really places the call is the deployment's:
+    this container's own configuration with the platform's carrier, which
+    ``platform`` is how a test supplies.
     """
     config: dict = {"phoneNumber": number}
     if caller_id is not None:
@@ -760,6 +792,7 @@ def phone_spec(
         simulation_id,
         modality="voice",
         connection={"type": "phone", "config": config, "credentials": credentials},
+        platform=platform,
         scenario=scenario,
         personality=personality,
         max_turns=max_turns,

--- a/apps/simulator/tests/test_config.py
+++ b/apps/simulator/tests/test_config.py
@@ -453,9 +453,9 @@ def test_a_bridge_with_no_trunk_anywhere_starts_and_refuses_when_asked_to_dial(
     container waiting for one is an ordinary deployment — the whole
     of what "a second simulator on another host needs no settings" means.
 
-    What is *not* given up is the refusal. It moves to where both halves
-    are in hand, and it names both ways a trunk can be given, because
-    picking one for somebody is what a refusal must not do.
+    What is *not* given up is the refusal. It moves to the moment a call is
+    about to be placed, and it names both ways a trunk can be given,
+    because picking one for somebody is what a refusal must not do.
     """
     a_deployment_that_dials(env, EGMA_SIMULATOR_SIP_TRUNK_ADDRESS=None)
 
@@ -463,11 +463,58 @@ def test_a_bridge_with_no_trunk_anywhere_starts_and_refuses_when_asked_to_dial(
     assert standing is not None
     assert standing.trunk_address is None
 
+    # Assembling never refuses: this runs for every simulation, and a
+    # simulation that never dials must not fail over a trunk it was never
+    # going to use.
+    settled = MediaSettings.for_simulation(standing, PlatformCarrier())
+    assert settled is not None
+
     with pytest.raises(ValueError) as refusal:
-        MediaSettings.for_simulation(standing, PlatformCarrier())
+        settled.checked()
     told = str(refusal.value)
     assert "carrier trunk" in told
     assert "EGMA_SIMULATOR_SIP_TRUNK_ID" in told
+
+
+def test_a_half_configured_phone_does_not_break_the_work_that_never_dials(env):
+    """The rule the refusal's new home exists for.
+
+    A platform holding a media backend and no trunk, or a container with no
+    media server behind the backend the platform named, are both real
+    states somebody is in mid-setup. Neither may fail a chat simulation:
+    the telephone-free half of the product goes on working, and the phone
+    says what is wrong when somebody asks it to dial.
+    """
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+
+    for carrier in (
+        PlatformCarrier(media_backend="livekit"),
+        PlatformCarrier(media_backend="livekit", trunk_address="a.example.com"),
+        PlatformCarrier(media_backend="a-bridge-nobody-wrote"),
+    ):
+        settled = MediaSettings.for_simulation(None, carrier)
+        assert settled is not None, carrier
+        # And each of them still refuses at the moment of dialling.
+        with pytest.raises(ValueError):
+            settled.checked()
+
+
+def test_a_bridge_this_container_cannot_reach_is_named_when_a_call_is_placed(env):
+    """The media server is bootstrap configuration and can never come from
+    the store, so a container missing it is where the refusal points."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+
+    settled = MediaSettings.for_simulation(
+        None,
+        PlatformCarrier(media_backend="livekit", trunk_address="a.example.com"),
+    )
+    assert settled is not None
+
+    with pytest.raises(ValueError) as refusal:
+        settled.checked()
+    told = str(refusal.value)
+    assert "EGMA_SIMULATOR_LIVEKIT_URL" in told
+    assert "EGMA_SIMULATOR_LIVEKIT_API_SECRET" in told
 
 
 def test_the_platforms_trunk_is_what_a_simulator_holding_none_dials_over(env):

--- a/apps/simulator/tests/test_config.py
+++ b/apps/simulator/tests/test_config.py
@@ -14,30 +14,16 @@ no network at all.
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
 import pytest
 
-from egma_simulator.config import ObjectStoreSettings, SimulatorConfig
+from egma_simulator.config import (
+    MediaSettings,
+    ObjectStoreSettings,
+    SimulatorConfig,
+)
+from egma_simulator.spec import PlatformCarrier
 
 A_URL = "http://control-plane.internal:3100"
-
-
-@pytest.fixture
-def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    """A clean environment, and somewhere harmless for the two directories.
-
-    Whatever this machine has set is cleared first, so a developer with
-    their own ``EGMA_SIMULATOR_*`` exported cannot make these pass or fail
-    differently from anybody else's.
-    """
-    for name in list(os.environ):
-        if name.startswith("EGMA_SIMULATOR_"):
-            monkeypatch.delenv(name, raising=False)
-    monkeypatch.setenv("EGMA_SIMULATOR_WAL_DIR", str(tmp_path / "wal"))
-    monkeypatch.setenv("EGMA_SIMULATOR_BLOB_DIR", str(tmp_path / "blobs"))
-    return monkeypatch
 
 
 def test_one_variable_is_enough(env, tmp_path):
@@ -457,15 +443,125 @@ def test_a_livekit_deployment_missing_a_variable_is_refused_by_name(env, missing
     assert missing in str(refusal.value)
 
 
-def test_a_deployment_with_no_trunk_at_all_is_refused_naming_both_ways(env):
-    """A call needs a trunk, and there are two ways to give one — so the
-    refusal names both rather than picking one for somebody."""
+def test_a_bridge_with_no_trunk_anywhere_starts_and_refuses_when_asked_to_dial(
+    env,
+):
+    """The trunk is the platform's now, so its absence is not a startup fault.
+
+    A simulator that names a bridge and holds no trunk used to refuse to
+    start. It cannot any more: the trunk arrives on each work order, so a
+    container waiting for one is an ordinary deployment — the whole
+    of what "a second simulator on another host needs no settings" means.
+
+    What is *not* given up is the refusal. It moves to where both halves
+    are in hand, and it names both ways a trunk can be given, because
+    picking one for somebody is what a refusal must not do.
+    """
     a_deployment_that_dials(env, EGMA_SIMULATOR_SIP_TRUNK_ADDRESS=None)
+
+    standing = SimulatorConfig.from_env().media
+    assert standing is not None
+    assert standing.trunk_address is None
+
     with pytest.raises(ValueError) as refusal:
-        SimulatorConfig.from_env()
+        MediaSettings.for_simulation(standing, PlatformCarrier())
     told = str(refusal.value)
+    assert "carrier trunk" in told
     assert "EGMA_SIMULATOR_SIP_TRUNK_ID" in told
-    assert "EGMA_SIMULATOR_SIP_TRUNK_ADDRESS" in told
+
+
+def test_the_platforms_trunk_is_what_a_simulator_holding_none_dials_over(env):
+    """The proof of the whole ticket, at the seam the carrier passes through.
+
+    This container knows a bridge and nothing else — no trunk address, no
+    number, no credential. Everything a call is authenticated with rides
+    the work order, and what comes out is a deployment able to dial.
+    """
+    a_deployment_that_dials(
+        env,
+        EGMA_SIMULATOR_SIP_TRUNK_ADDRESS=None,
+        EGMA_SIMULATOR_SIP_TRUNK_NUMBER=None,
+        EGMA_SIMULATOR_SIP_TRUNK_USERNAME=None,
+        EGMA_SIMULATOR_SIP_TRUNK_PASSWORD=None,
+    )
+
+    settled = MediaSettings.for_simulation(
+        SimulatorConfig.from_env().media,
+        PlatformCarrier(
+            trunk_address="the-platform-holds-this.pstn.twilio.com",
+            trunk_number="+15551110000",
+            trunk_username="platform-trunk-user",
+            trunk_password="SENTINEL-platform-trunk-password",
+        ),
+    )
+
+    assert settled is not None
+    assert settled.trunk_address == "the-platform-holds-this.pstn.twilio.com"
+    assert settled.trunk_number == "+15551110000"
+    assert settled.trunk_username == "platform-trunk-user"
+    assert settled.trunk_password == "SENTINEL-platform-trunk-password"
+    # And the bridge is still this container's, which is the other half of
+    # the split: the media server's key and secret are read by a
+    # third-party binary at creation and can never come from the store.
+    assert settled.livekit_url == "wss://livekit.internal"
+    assert settled.livekit_api_secret == "SENTINEL-livekit-secret-4c81"
+
+
+def test_the_platforms_trunk_wins_over_the_one_in_this_environment(env):
+    """One value here, a different value for the same setting on the work
+    order, and the call goes over the second. The stored reference goes
+    with it: a container quietly dialling its own trunk while the
+    platform's settings page showed another is the disagreement this
+    whole effort exists to end."""
+    a_deployment_that_dials(env, EGMA_SIMULATOR_SIP_TRUNK_ID="ST_left_behind")
+
+    settled = MediaSettings.for_simulation(
+        SimulatorConfig.from_env().media,
+        PlatformCarrier(
+            trunk_address="the-platform-holds-this.pstn.twilio.com",
+            trunk_number="+15551110000",
+            trunk_username="platform-trunk-user",
+            trunk_password="SENTINEL-platform-trunk-password",
+        ),
+    )
+
+    assert settled is not None
+    assert settled.trunk_id is None
+    assert settled.trunk_address == "the-platform-holds-this.pstn.twilio.com"
+    assert settled.trunk_username == "platform-trunk-user"
+
+
+def test_a_container_that_names_no_bridge_dials_over_the_platforms(env):
+    """Adding capacity is starting a container and nothing else.
+
+    Nothing here says this simulator may dial; the platform's own media
+    backend does. What the container still supplies is the media server it
+    reaches — bootstrap configuration, never a setting.
+    """
+    a_deployment_that_dials(env, EGMA_SIMULATOR_MEDIA_BACKEND=None)
+    assert SimulatorConfig.from_env().media is None
+
+    settled = MediaSettings.for_simulation(
+        None,
+        PlatformCarrier(
+            media_backend="livekit",
+            trunk_address="the-platform-holds-this.pstn.twilio.com",
+            trunk_number="+15551110000",
+        ),
+    )
+
+    assert settled is not None
+    assert settled.backend == "livekit"
+    assert settled.livekit_url == "wss://livekit.internal"
+    assert settled.trunk_address == "the-platform-holds-this.pstn.twilio.com"
+
+
+def test_a_deployment_nobody_gave_a_carrier_dials_nothing_and_says_nothing(env):
+    """Neither side names a backend, which is every platform before
+    somebody has done the carrier paperwork. It is an ordinary state, not
+    a fault, and a simulator in it simply places no calls."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    assert MediaSettings.for_simulation(None, PlatformCarrier()) is None
 
 
 def test_a_bring_your_own_trunk_arrives_whole(env):

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -56,6 +56,14 @@ EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
     ),
     "spec/modality-unknown.json": ("/modality", "enum", None),
     "spec/unknown-field.json": ("", "additionalProperties", "agent_id"),
+    # The platform's own settings are a closed list on both sides — the
+    # catalog the control plane stores them under, and the block this
+    # process reads. A field nobody writes is a setting nobody reads.
+    "spec/platform-setting-unknown.json": (
+        "/platform/model",
+        "additionalProperties",
+        "base_url",
+    ),
     "spec/wrong-contract-version.json": ("/contract_version", "const", None),
     "report/completed-claiming-never-ran.json": (
         "/events/0/facts/ending",

--- a/apps/simulator/tests/test_deployment.py
+++ b/apps/simulator/tests/test_deployment.py
@@ -53,6 +53,44 @@ DOCUMENTED_ELSEWHERE = {
 stated reason. Everything else must reach the container, because a
 variable a compose entry leaves out never arrives however it is set."""
 
+OWNED_BY_THE_PLATFORM = {
+    "EGMA_SIMULATOR_MODEL_PROVIDER",
+    "EGMA_SIMULATOR_MODEL_NAME",
+    "EGMA_SIMULATOR_MODEL_API_KEY",
+    "EGMA_SIMULATOR_STT_PROVIDER",
+    "EGMA_SIMULATOR_TTS_PROVIDER",
+    "EGMA_SIMULATOR_VAD_PROVIDER",
+    "EGMA_SIMULATOR_DEEPGRAM_API_KEY",
+    "EGMA_SIMULATOR_ELEVENLABS_API_KEY",
+    "EGMA_SIMULATOR_OPENAI_API_KEY",
+    "EGMA_SIMULATOR_TTS_MODEL",
+    "EGMA_SIMULATOR_TTS_VOICE",
+    "EGMA_SIMULATOR_MEDIA_BACKEND",
+    "EGMA_SIMULATOR_SIP_TRUNK_ID",
+    "EGMA_SIMULATOR_SIP_TRUNK_ADDRESS",
+    "EGMA_SIMULATOR_SIP_TRUNK_NUMBER",
+    "EGMA_SIMULATOR_SIP_TRUNK_USERNAME",
+    "EGMA_SIMULATOR_SIP_TRUNK_PASSWORD",
+}
+"""Settings that belong to the platform, not to any container.
+
+Each of these is stored by the API, sealed, and handed to every simulator
+on the work order it claims — so no compose file passes one and
+`.env.example` names none of them. A compose entry for any of them would be
+a **second place the same setting is written down**, and the two would
+disagree the first time somebody changed one: the whole failure this effort
+exists to remove, arriving by a new route. It would also leave every one of
+them in the silent-empty `${VAR:-}` form that the bootstrap work has to be
+able to say no deployment variable uses.
+
+The code still reads them, and that is deliberate rather than left over: a
+bare `egma-simulator` process — the workbench story and every contributor's
+checkout — has no platform behind it and configures itself from its own
+environment. A work-order value replaces whatever it found. They stay in
+this app's README table for that reader, which is the reason
+`EGMA_SIMULATOR_BLOB_DIR` above is there too.
+"""
+
 
 def repository_root() -> Path:
     """The checkout this app lives in, found by what is at its top."""
@@ -82,7 +120,12 @@ def test_every_variable_the_code_reads_is_in_the_env_example():
     documented = set(
         VARIABLE.findall((ROOT / ".env.example").read_text(encoding="utf-8"))
     )
-    missing = variables_read_by_the_code() - documented - DOCUMENTED_ELSEWHERE
+    missing = (
+        variables_read_by_the_code()
+        - documented
+        - DOCUMENTED_ELSEWHERE
+        - OWNED_BY_THE_PLATFORM
+    )
     assert not missing, (
         f".env.example does not name {sorted(missing)}, which the simulator "
         "reads — a self-hoster cannot set a variable nobody told them about"
@@ -96,7 +139,12 @@ def test_every_variable_the_code_reads_is_passed_through_by_compose():
     passed: set[str] = set()
     for compose in COMPOSE_FILES:
         passed |= set(VARIABLE.findall(compose.read_text(encoding="utf-8")))
-    missing = variables_read_by_the_code() - passed - DOCUMENTED_ELSEWHERE
+    missing = (
+        variables_read_by_the_code()
+        - passed
+        - DOCUMENTED_ELSEWHERE
+        - OWNED_BY_THE_PLATFORM
+    )
     assert not missing, (
         f"no compose file passes {sorted(missing)} to the simulator, so a "
         "container never sees it however it is set"
@@ -200,20 +248,26 @@ def test_no_phone_overlay_is_left_to_ask_for_by_name():
     )
 
 
-def test_the_default_stack_dials_nothing_until_phone_setup_has_run():
-    """Platform readiness does not wait on carrier setup.
+@pytest.mark.parametrize("compose", COMPOSE_FILES, ids=lambda path: path.name)
+def test_no_compose_file_hands_a_simulator_a_setting_the_platform_owns(compose):
+    """Platform readiness does not wait on carrier setup, and a setting has
+    exactly one home.
 
-    A simulator whose media backend is named starts checking for a trunk
-    at startup and refuses to run without one — so a default that named a
-    backend would make `docker compose up` fail on a machine that has
-    never seen a carrier, which is every machine on its first run.
+    Both properties fall out of the same absence. Nothing in any compose file
+    tells a simulator which providers to use or whether it may dial: the
+    platform holds all of it and hands it over on the work order, so
+    `docker compose up` on a machine that has never seen a carrier starts
+    exactly as it always did, and there is no second copy of a setting for
+    the store's copy to disagree with.
     """
-    default = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
-    named = "EGMA_SIMULATOR_MEDIA_BACKEND: ${EGMA_SIMULATOR_MEDIA_BACKEND:-}"
-    assert named in default, (
-        "docker-compose.yml gives the simulator a media backend by default; a "
-        "simulator told to dial with no trunk refuses to start, so a first "
-        "`up` on a machine with no carrier would fail"
+    block = service_block(compose, "simulator")
+    if block is None:
+        return
+    handed = sorted(name for name in OWNED_BY_THE_PLATFORM if name in block)
+    assert not handed, (
+        f"{compose.name} hands the simulator {handed}, which the platform "
+        "stores and delivers on the work order — a second home for a setting "
+        "is two answers that disagree the first time one of them changes"
     )
 
 

--- a/apps/simulator/tests/test_live_deepgram.py
+++ b/apps/simulator/tests/test_live_deepgram.py
@@ -129,7 +129,7 @@ async def test_a_real_transcriber_reads_a_real_sentence(tmp_path: Path):
         blobs=FilesystemBlobStore(tmp_path),
         recording_key="sim-live-deepgram/dual-channel.wav",
         speech=SpeechProviders(
-            stt="deepgram", vad="silero", deepgram_api_key=DEEPGRAM_API_KEY
+            stt="deepgram", vad="silero", stt_key=DEEPGRAM_API_KEY
         ),
     )
     heard: list[tuple[str, str]] = []

--- a/apps/simulator/tests/test_phone_band.py
+++ b/apps/simulator/tests/test_phone_band.py
@@ -160,7 +160,7 @@ def test_the_openai_mouth_is_built_at_the_provider_band_and_converted_after():
     conversion to the line's band sits after it.
     """
     leg, spoken_with, closers = _mouth(
-        SpeechProviders(tts="openai", openai_api_key=A_KEY),
+        SpeechProviders(tts="openai", tts_key=A_KEY),
         voice_from_traits({}),
         TELEPHONY_BAND_HZ,
     )

--- a/apps/simulator/tests/test_platform_settings.py
+++ b/apps/simulator/tests/test_platform_settings.py
@@ -379,3 +379,101 @@ def test_the_media_server_stays_this_containers_and_the_trunk_the_platforms():
     assert settled.livekit_url == "wss://this-containers-media-server"
     assert settled.livekit_api_secret == "this-containers-media-secret"
     assert settled.trunk_address == "the-platforms-trunk.pstn.twilio.com"
+
+
+# -- A typo must refuse, never conduct ----------------------------------------
+#
+# The worst failure this effort could ship: a platform whose provider name
+# has one letter wrong, and a simulation that completes green anyway because
+# every builder falls through to its scripted stand-in. On a product whose
+# whole purpose is trust in the agent somebody ships, a canned robot
+# reporting a pass is worse than any refusal — a refusal tells the truth.
+#
+# The container's own names are refused when it starts, by `_one_of`. These
+# are the platform's, and they had no equivalent until now.
+
+
+def test_a_model_provider_nobody_wrote_refuses_rather_than_conducting(
+    a_container, env
+):
+    from egma_simulator.model import ModelFailure
+
+    env.setenv("EGMA_SIMULATOR_MODEL_PROVIDER", "scripted")
+    config = SimulatorConfig.from_env()
+
+    with pytest.raises(ModelFailure) as refusal:
+        build_model_client(
+            config,
+            a_spec_with(
+                PlatformSettings(model=PlatformModel(provider="openaii"))
+            ),
+        )
+
+    told = str(refusal.value)
+    assert "persona_model_provider" in told
+    assert "openaii" in told
+    assert "scripted, openai" in told
+
+
+@pytest.mark.parametrize(
+    ("setting", "block", "wrong"),
+    [
+        ("speech_to_text_provider", "stt_provider", "deepgramm"),
+        ("text_to_speech_provider", "tts_provider", "elevenlabss"),
+        ("voice_activity_provider", "vad_provider", "silerro"),
+    ],
+)
+def test_a_speech_provider_nobody_wrote_refuses_rather_than_conducting(
+    a_container, setting, block, wrong
+):
+    from egma_simulator.speech import (
+        SpeechFault,
+        build_legs,
+        build_vad,
+        voice_from_traits,
+    )
+
+    providers = SpeechProviders.for_simulation(
+        SimulatorConfig.from_env(), PlatformSpeech(**{block: wrong})
+    )
+
+    # Both entry points, because a voice simulation goes through both and a
+    # refusal only one of them held would be a leg silently standing in.
+    for build in (
+        lambda: build_legs(
+            providers, voice=voice_from_traits({}), sample_rate_hz=8000
+        ),
+        lambda: build_vad(providers, sample_rate_hz=8000, window_samples=160),
+    ):
+        with pytest.raises(SpeechFault) as refusal:
+            build()
+        told = str(refusal.value)
+        assert setting in told
+        assert wrong in told
+
+
+def test_a_chat_simulation_is_not_broken_by_a_speech_provider_it_never_uses(
+    a_container, env
+):
+    """The refusal is where the leg is *built*, and a chat simulation builds
+    none. A platform mid-setup with a typo in its speaking leg still runs
+    every chat and text simulation it always did."""
+    config = SimulatorConfig.from_env()
+    client = build_model_client(
+        config,
+        a_spec_with(
+            PlatformSettings(speech=PlatformSpeech(tts_provider="elevenlabss"))
+        ),
+    )
+    assert client is not None
+
+
+def test_a_media_backend_nobody_wrote_refuses_at_the_moment_of_dialling():
+    settled = MediaSettings.for_simulation(
+        None, PlatformCarrier(media_backend="livekitt")
+    )
+    assert settled is not None
+
+    with pytest.raises(ValueError) as refusal:
+        settled.checked()
+    assert "livekitt" in str(refusal.value)

--- a/apps/simulator/tests/test_platform_settings.py
+++ b/apps/simulator/tests/test_platform_settings.py
@@ -1,0 +1,381 @@
+"""The platform's own settings, arriving on the work order.
+
+**This file holds the proof of the whole change.** A setting used to be a
+variable in each simulator's environment, which meant a second simulator on
+another machine needed a file copied to it, and a container started without
+one dialled nothing while reporting itself healthy. The settings belong to
+the deployment now: it holds them, it seals them, and it hands them down on
+the work order a simulator already claims.
+
+The claim under test is therefore a *precedence* claim, and it is only worth
+anything when both sides are set at once. So the tests below put one value
+in the simulator's environment and a different value for the same setting on
+the work order, and then observe which one was used. A test that set only one
+side would pass against a simulator that read neither.
+
+The acceptance tests here are black-box like the rest of that suite: a real
+child process, configured only through its environment, claiming real
+documents over real HTTP from the workbench, and every assertion read back
+out of the workbench's records or the process's own output.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import (
+    SENTINEL_TRUNK_ENV,
+    assert_kept_secret,
+    has_terminal,
+    phone_spec,
+    scripted_spec,
+    terminal_event_for,
+    turns_for,
+)
+
+from egma_simulator.config import MediaSettings, SimulatorConfig
+from egma_simulator.model import GOODBYE, OpenAICompatibleModel, build_model_client
+from egma_simulator.spec import (
+    Limits,
+    PlatformCarrier,
+    PlatformModel,
+    PlatformSettings,
+    PlatformSpeech,
+    SimulationSpec,
+)
+from egma_simulator.speech import SpeechProviders
+
+# -- The proof, conducted -----------------------------------------------------
+
+A_MODEL_THIS_CONTAINER_WOULD_HAVE_USED = {
+    "EGMA_SIMULATOR_MODEL_PROVIDER": "openai",
+    "EGMA_SIMULATOR_MODEL_NAME": "the-model-this-container-was-told-about",
+    "EGMA_SIMULATOR_MODEL_API_KEY": "SENTINEL-container-model-key-4f19",
+    # A port nothing answers on. If this container's own configuration were
+    # what conducted the exchange, every persona turn would fail against it —
+    # which is exactly what makes the assertion below a real observation
+    # rather than two settings that happen to agree.
+    "EGMA_SIMULATOR_MODEL_BASE_URL": "http://127.0.0.1:1/v1",
+}
+
+
+async def test_the_work_orders_model_is_what_conducts_not_this_containers(
+    workbench, start_simulator
+):
+    """One value here, a different value for the same setting there.
+
+    The container is told to think with a real provider at an address
+    nothing answers on. The work order says `scripted`. The exchange
+    happens, turn for turn — which it could not have if this container's
+    own configuration had been what was read.
+    """
+    spec = scripted_spec(
+        "sim-platform-model-001",
+        scenario="State the first point. State the second point.",
+        greeting="Lakeside Dental, how can I help?",
+        replies=["Noted.", "Noted again."],
+        platform={"model": {"provider": "scripted"}},
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(
+        workbench, extra_env=A_MODEL_THIS_CONTAINER_WOULD_HAVE_USED
+    )
+
+    records = await workbench.wait_for(has_terminal("sim-platform-model-001"))
+
+    assert turns_for(records, "sim-platform-model-001") == [
+        ("agent", "Lakeside Dental, how can I help?"),
+        ("human", "State the first point."),
+        ("agent", "Noted."),
+        ("human", "State the second point."),
+        ("agent", "Noted again."),
+        ("human", GOODBYE),
+    ]
+    terminal = terminal_event_for(records, "sim-platform-model-001")
+    assert terminal["facts"]["ending"] == "persona_concluded"
+
+    # And the key this container was started with never left it, which is
+    # the standing promise about every credential in this process.
+    assert_kept_secret(
+        "SENTINEL-container-model-key-4f19",
+        records=records,
+        simulator=simulator,
+    )
+
+
+A_CARRIER_ONLY_THE_PLATFORM_HOLDS = {
+    "media_backend": "scripted",
+    "trunk_address": "the-platform-holds-this.pstn.twilio.com",
+    "trunk_number": "+15551110000",
+    "trunk_username": "platform-trunk-user",
+    "trunk_password": "SENTINEL-platform-trunk-password-8c02",
+}
+
+
+async def test_a_phone_simulation_dials_with_a_trunk_no_container_holds(
+    workbench, start_simulator
+):
+    """The carrier lives only in the platform, and a call still happens.
+
+    Nothing in this container's environment says it may dial or what it
+    would dial with — no backend, no trunk address, no number, no
+    credential. Everything arrives on the work order, and the conversation
+    completes over the telephone connection.
+
+    This is the self-hoster's story the effort was written for: the Twilio
+    paperwork is done once, it lives in the platform's own store, and
+    adding a second simulator is starting a container and nothing else.
+    """
+    spec = phone_spec(
+        "sim-platform-carrier-001",
+        greeting="Lakeside Dental.",
+        replies=["Noted."],
+        provider_reference="platform-carrier-1",
+        platform={"carrier": A_CARRIER_ONLY_THE_PLATFORM_HOLDS},
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench)
+
+    records = await workbench.wait_for(
+        has_terminal("sim-platform-carrier-001"), within_seconds=60.0
+    )
+
+    terminal = terminal_event_for(records, "sim-platform-carrier-001")
+    assert terminal["status"] == "completed", terminal
+    assert terminal["facts"]["provider_reference"] == "platform-carrier-1"
+
+    # A trunk password that arrived on a work order is exactly as much a
+    # secret as one that arrived in this container's environment, and the
+    # filter that keeps it out of the log has to know about it either way.
+    assert_kept_secret(
+        "SENTINEL-platform-trunk-password-8c02",
+        records=records,
+        simulator=simulator,
+    )
+
+
+async def test_the_work_orders_trunk_is_what_is_dialled_not_this_containers(
+    workbench, start_simulator
+):
+    """And when both sides hold a carrier, the platform's is the one used.
+
+    The container is given a whole LiveKit deployment pointed at a port
+    nothing answers on — a real bridge, a real trunk, every secret a
+    sentinel. The work order names the scripted bridge and its own trunk.
+    The call completes, which it could not have done over the bridge in
+    this container's environment.
+    """
+    spec = phone_spec(
+        "sim-platform-carrier-002",
+        greeting="Lakeside Dental.",
+        replies=["Noted."],
+        platform={"carrier": A_CARRIER_ONLY_THE_PLATFORM_HOLDS},
+    )
+    await workbench.offer(spec)
+    simulator = start_simulator(workbench, extra_env=SENTINEL_TRUNK_ENV)
+
+    records = await workbench.wait_for(
+        has_terminal("sim-platform-carrier-002"), within_seconds=60.0
+    )
+
+    terminal = terminal_event_for(records, "sim-platform-carrier-002")
+    assert terminal["status"] == "completed", terminal
+    assert_kept_secret(
+        SENTINEL_TRUNK_ENV["EGMA_SIMULATOR_SIP_TRUNK_PASSWORD"],
+        records=records,
+        simulator=simulator,
+    )
+
+
+async def test_a_deployment_that_configured_nothing_conducts_exactly_as_before(
+    workbench, start_simulator
+):
+    """The other direction, and the one that must never regress.
+
+    A work order with no platform block at all is what every spec written
+    before these settings existed looks like, and what the control plane
+    really sends for a deployment nobody has configured. This container's
+    own values stand, and the exchange is the one it always was.
+    """
+    spec = scripted_spec(
+        "sim-platform-absent-001",
+        greeting="Lakeside Dental.",
+        replies=["Noted.", "Noted again."],
+    )
+    assert "platform" not in spec
+
+    await workbench.offer(spec)
+    start_simulator(workbench)
+
+    records = await workbench.wait_for(has_terminal("sim-platform-absent-001"))
+    terminal = terminal_event_for(records, "sim-platform-absent-001")
+    assert terminal["facts"]["ending"] == "persona_concluded"
+
+
+# -- The same claim at each seam, read directly -------------------------------
+#
+# The acceptance tests above prove the whole path and are slow. These prove
+# the same precedence rule at each of the three seams the settings enter
+# through, which is where a reader goes to find out what wins and why.
+
+
+A_URL = "http://control-plane.internal"
+
+
+@pytest.fixture
+def a_container(env) -> None:
+    """A simulator configured the way one with no platform behind it is."""
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+
+
+def a_spec_with(platform: PlatformSettings) -> SimulationSpec:
+    """One claimed spec, carrying whatever settings a test is about."""
+    return SimulationSpec(
+        simulation_id="sim-under-test",
+        modality="chat",
+        scenario_instructions="State the first point.",
+        limits=Limits(max_duration_seconds=600, max_turns=60),
+        persona_traits={},
+        connection_type="scripted",
+        connection_config={},
+        credentials=None,
+        platform=platform,
+    )
+
+
+def test_the_work_orders_model_replaces_this_containers_field_by_field(
+    a_container, env
+):
+    """Each of the three stands on its own.
+
+    A platform that holds the provider and the model but not the key yet is
+    an ordinary platform mid-setup, and what it says about the two it holds
+    has to apply without the third.
+    """
+    env.setenv("EGMA_SIMULATOR_MODEL_PROVIDER", "openai")
+    env.setenv("EGMA_SIMULATOR_MODEL_NAME", "this-containers-model")
+    env.setenv("EGMA_SIMULATOR_MODEL_API_KEY", "this-containers-key")
+    config = SimulatorConfig.from_env()
+
+    client = build_model_client(
+        config,
+        a_spec_with(
+            PlatformSettings(
+                model=PlatformModel(provider="openai", model="the-platforms-model")
+            )
+        ),
+    )
+
+    assert isinstance(client, OpenAICompatibleModel)
+    assert client._model_name == "the-platforms-model"
+    # The key the platform said nothing about is this container's, still.
+    assert client._api_key == "this-containers-key"
+
+
+def test_the_work_orders_speech_legs_replace_this_containers(a_container, env):
+    """One leg at a time, and each leg's key follows its leg's provider."""
+    env.setenv("EGMA_SIMULATOR_STT_PROVIDER", "scripted")
+    env.setenv("EGMA_SIMULATOR_TTS_PROVIDER", "scripted")
+    config = SimulatorConfig.from_env()
+
+    providers = SpeechProviders.for_simulation(
+        config,
+        PlatformSpeech(
+            stt_provider="deepgram",
+            stt_key="the-platforms-listening-key",
+            tts_provider="elevenlabs",
+            tts_key="the-platforms-speaking-key",
+            tts_voice="a-voice-the-platform-chose",
+            vad_provider="silero",
+        ),
+    )
+
+    assert providers.stt == "deepgram"
+    assert providers.stt_key == "the-platforms-listening-key"
+    assert providers.tts == "elevenlabs"
+    assert providers.tts_key == "the-platforms-speaking-key"
+    assert providers.tts_voice == "a-voice-the-platform-chose"
+    assert providers.vad == "silero"
+
+
+def test_a_platform_that_names_a_provider_and_no_key_uses_this_containers(
+    a_container, env
+):
+    """Which is what a self-hoster who set one openai key for both legs
+    means: use this company, with the key you already have."""
+    env.setenv("EGMA_SIMULATOR_STT_PROVIDER", "openai")
+    env.setenv("EGMA_SIMULATOR_TTS_PROVIDER", "openai")
+    env.setenv("EGMA_SIMULATOR_OPENAI_API_KEY", "one-account-for-both-legs")
+    config = SimulatorConfig.from_env()
+
+    providers = SpeechProviders.for_simulation(config, PlatformSpeech())
+
+    assert providers.stt_key == "one-account-for-both-legs"
+    assert providers.tts_key == "one-account-for-both-legs"
+
+
+def test_a_platform_that_says_nothing_leaves_every_leg_where_it_was(
+    a_container, env
+):
+    env.setenv("EGMA_SIMULATOR_STT_PROVIDER", "deepgram")
+    env.setenv("EGMA_SIMULATOR_DEEPGRAM_API_KEY", "this-containers-key")
+    config = SimulatorConfig.from_env()
+
+    providers = SpeechProviders.for_simulation(config)
+
+    assert providers.stt == "deepgram"
+    assert providers.stt_key == "this-containers-key"
+    assert providers.tts == "scripted"
+    assert providers.tts_key is None
+
+
+def test_the_settings_a_work_order_carries_are_all_registered_for_redaction():
+    """Every secret in the block, in one place to ask.
+
+    The registry is what keeps a credential out of the log, and it can only
+    scrub what it was told about. A fourth key arriving in this block and
+    not in this tuple would be a key the filter has never heard of.
+    """
+    settings = PlatformSettings(
+        model=PlatformModel(key="a-model-key"),
+        speech=PlatformSpeech(stt_key="a-listening-key", tts_key="a-speaking-key"),
+        carrier=PlatformCarrier(trunk_password="a-trunk-password"),
+    )
+
+    assert set(settings.secrets) == {
+        "a-model-key",
+        "a-listening-key",
+        "a-speaking-key",
+        "a-trunk-password",
+    }
+    # And a platform holding none of them offers none, rather than a tuple
+    # of empties the filter would then try to scrub every line against.
+    assert PlatformSettings().secrets == ()
+
+
+def test_the_media_server_stays_this_containers_and_the_trunk_the_platforms():
+    """The split the spec drew, held at the one seam it passes through.
+
+    A third-party binary reads its own key and secret when it is created and
+    cannot reach the platform's database, so the bridge is bootstrap
+    configuration forever. The trunk is paperwork somebody did once with a
+    carrier, so it is the platform's.
+    """
+    bridge = MediaSettings(
+        backend="livekit",
+        livekit_url="wss://this-containers-media-server",
+        livekit_api_key="this-containers-media-key",
+        livekit_api_secret="this-containers-media-secret",
+    )
+
+    settled = MediaSettings.for_simulation(
+        bridge,
+        PlatformCarrier(
+            trunk_address="the-platforms-trunk.pstn.twilio.com",
+            trunk_number="+15551110000",
+        ),
+    )
+
+    assert settled is not None
+    assert settled.livekit_url == "wss://this-containers-media-server"
+    assert settled.livekit_api_secret == "this-containers-media-secret"
+    assert settled.trunk_address == "the-platforms-trunk.pstn.twilio.com"

--- a/apps/simulator/tests/test_plug_phone.py
+++ b/apps/simulator/tests/test_plug_phone.py
@@ -466,16 +466,39 @@ def test_the_plug_speaks_voice_only():
     assert "chat" in str(refusal.value)
 
 
-def test_the_deployment_the_simulator_started_with_is_what_places_the_call(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """A spec names a number and nothing else about how it travels; which
-    bridge this simulator dials through was settled at startup."""
-    monkeypatch.setenv("EGMA_SIMULATOR_MEDIA_BACKEND", "scripted")
+def test_the_deployment_is_what_places_the_call_and_the_plug_never_asks_again():
+    """A spec names a number and nothing else about how it travels.
+
+    Which bridge and which trunk was settled once, by the deployment — this
+    container's media server with the platform's own carrier laid over it —
+    and handed here whole. The plug reads it and reaches for nothing: an
+    environment variable read here would be a second answer to a question
+    already answered, and two answers can disagree.
+    """
     plug = PhoneCall(
-        modality="voice", config={"phoneNumber": A_NUMBER}, credentials=None
+        modality="voice",
+        config={"phoneNumber": A_NUMBER},
+        credentials=None,
+        media=SCRIPTED,
     )
     assert isinstance(plug.backend, ScriptedBackend)
+
+
+def test_a_deployment_that_was_handed_no_bridge_says_so_rather_than_dialling(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """And it says so whatever this container's environment holds: the
+    resolved settings are the whole answer, so a leftover variable cannot
+    quietly turn dialling back on."""
+    monkeypatch.setenv("EGMA_SIMULATOR_MEDIA_BACKEND", "scripted")
+    with pytest.raises(PlugError) as refusal:
+        PhoneCall(
+            modality="voice",
+            config={"phoneNumber": A_NUMBER},
+            credentials=None,
+            media=None,
+        )
+    assert "places no phone calls" in str(refusal.value)
 
 
 # -- Hearing the far end -----------------------------------------------------

--- a/apps/simulator/tests/test_quarantine.py
+++ b/apps/simulator/tests/test_quarantine.py
@@ -236,10 +236,12 @@ def test_an_unconfigured_simulator_loads_no_provider_library():
         from pathlib import Path
 
         # A deployment that dials through the scripted bridge — which is
-        # still a deployment that never wants LiveKit's library.
-        os.environ["EGMA_SIMULATOR_MEDIA_BACKEND"] = "scripted"
-
+        # still a deployment that never wants LiveKit's library. Named on
+        # the work order, the way a real one names it now, rather than in
+        # this process's environment.
         from egma_simulator.blob import FilesystemBlobStore
+        from egma_simulator.config import MediaSettings
+        from egma_simulator.spec import PlatformCarrier
         from egma_simulator.model import ScriptedModel
         from egma_simulator.persona import Persona
         from egma_simulator.pipeline import assemble
@@ -280,7 +282,13 @@ def test_an_unconfigured_simulator_loads_no_provider_library():
 
         async def conduct(spec):
             with tempfile.TemporaryDirectory() as blobs:
-                assembled = assemble(spec, blobs=FilesystemBlobStore(Path(blobs)))
+                assembled = assemble(
+                    spec,
+                    blobs=FilesystemBlobStore(Path(blobs)),
+                    media=MediaSettings.for_simulation(
+                        None, PlatformCarrier(media_backend="scripted")
+                    ),
+                )
                 heard = []
                 if assembled.conductor is not None:
                     async def on_utterance(speaker, text, began, ended):

--- a/apps/simulator/tests/test_voice.py
+++ b/apps/simulator/tests/test_voice.py
@@ -1265,8 +1265,8 @@ def test_a_counterpart_cannot_both_echo_and_read_a_script(tmp_path: Path):
 REAL_PAIR = SpeechProviders(
     stt="deepgram",
     tts="elevenlabs",
-    deepgram_api_key="deepgram-key-for-assembly-only",
-    elevenlabs_api_key="elevenlabs-key-for-assembly-only",
+    stt_key="deepgram-key-for-assembly-only",
+    tts_key="elevenlabs-key-for-assembly-only",
 )
 """Both providers named. Building legs is not connecting to them, so an
 assembled pipeline can be inspected here without a network or an account."""
@@ -1338,7 +1338,7 @@ async def test_each_leg_is_chosen_on_its_own(tmp_path: Path):
     from pipecat.services.elevenlabs.tts import ElevenLabsHttpTTSService
 
     providers = SpeechProviders(
-        tts="elevenlabs", elevenlabs_api_key="elevenlabs-key-for-assembly-only"
+        tts="elevenlabs", tts_key="elevenlabs-key-for-assembly-only"
     )
     async with assembled_with(providers, tmp_path) as assembled:
         legs = assembled.conductor.legs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,14 +308,6 @@ services:
       # prerequisite for anything, including adding a second person.
       EGMA_SMTP_URL: ${EGMA_SMTP_URL:-}
       EGMA_MAIL_FROM: ${EGMA_MAIL_FROM:-}
-      # What this process knows about the carrier: three non-secret facts,
-      # written by `egma self-host phone setup`, from which it reports the
-      # platform's phone state. No token, no password, no provider key — the
-      # API neither dials nor speaks, and phone authority lives in the
-      # container that uses it.
-      EGMA_PHONE_TRUNK_ADDRESS: ${EGMA_PHONE_TRUNK_ADDRESS:-}
-      EGMA_PHONE_SOURCE_NUMBER: ${EGMA_PHONE_SOURCE_NUMBER:-}
-      EGMA_PHONE_SPEECH_PROVIDER: ${EGMA_PHONE_SPEECH_PROVIDER:-}
       # The judge a project is given when it has configured none, from the one
       # OpenAI key phone setup asked for. Written into each project's own
       # sealed row on boot and never over one that is already there. It is here
@@ -325,17 +317,41 @@ services:
       EGMA_JUDGE_PROVIDER: ${EGMA_JUDGE_PROVIDER:-}
       EGMA_JUDGE_MODEL: ${EGMA_JUDGE_MODEL:-}
       EGMA_JUDGE_API_KEY: ${EGMA_JUDGE_API_KEY:-}
-      # What the persona thinks with, and the platform's own setting rather
-      # than the simulator's. It is written into the platform's store on boot,
-      # sealed, for anything the store does not already hold — and never over a
-      # value somebody changed, so a redeploy carrying an old key in a script
-      # cannot undo a new one. Setting these is one of the two ways in and is
-      # for a deployment that answers no questions; the other is
+      # What this deployment has been configured with — the persona's model,
+      # its speech legs, and the carrier a phone call goes over. The
+      # platform's own settings rather than any one container's: they are
+      # written into the platform's store on boot, sealed, for anything the
+      # store does not already hold — and never over a value somebody
+      # changed, so a redeploy carrying an old key in a script cannot undo a
+      # new one. They then reach the simulator on the work order it claims,
+      # which is why no simulator container names any of them.
+      #
+      # Setting them here is one of the two ways in, and it is for a
+      # deployment that answers no questions; the other is
       # `egma self-host setup`, which asks. Leave them empty and the platform
-      # reports `setup required` naming each one until somebody supplies it.
+      # reports `setup required` naming each one until somebody supplies it —
+      # which is the whole difference from the file this replaced, where an
+      # absent setting was an empty setting and nothing said so.
       EGMA_PERSONA_MODEL_PROVIDER: ${EGMA_PERSONA_MODEL_PROVIDER:-}
       EGMA_PERSONA_MODEL: ${EGMA_PERSONA_MODEL:-}
       EGMA_PERSONA_MODEL_API_KEY: ${EGMA_PERSONA_MODEL_API_KEY:-}
+      EGMA_PERSONA_STT_PROVIDER: ${EGMA_PERSONA_STT_PROVIDER:-}
+      EGMA_PERSONA_STT_API_KEY: ${EGMA_PERSONA_STT_API_KEY:-}
+      EGMA_PERSONA_TTS_PROVIDER: ${EGMA_PERSONA_TTS_PROVIDER:-}
+      EGMA_PERSONA_TTS_API_KEY: ${EGMA_PERSONA_TTS_API_KEY:-}
+      EGMA_PERSONA_TTS_MODEL: ${EGMA_PERSONA_TTS_MODEL:-}
+      EGMA_PERSONA_TTS_VOICE: ${EGMA_PERSONA_TTS_VOICE:-}
+      EGMA_PERSONA_VAD_PROVIDER: ${EGMA_PERSONA_VAD_PROVIDER:-}
+      # The carrier, under the names phone setup already wrote, so an
+      # operator upgrading meets the words they were given before. The API
+      # holds the trunk password only long enough to seal it — exactly as it
+      # already holds a judge's key and a connection's credentials — and it
+      # neither dials nor speaks with any of it.
+      EGMA_MEDIA_BACKEND: ${EGMA_MEDIA_BACKEND:-}
+      EGMA_PHONE_TRUNK_ADDRESS: ${EGMA_PHONE_TRUNK_ADDRESS:-}
+      EGMA_PHONE_SOURCE_NUMBER: ${EGMA_PHONE_SOURCE_NUMBER:-}
+      EGMA_PHONE_TRUNK_USERNAME: ${EGMA_PHONE_TRUNK_USERNAME:-}
+      EGMA_PHONE_TRUNK_PASSWORD: ${EGMA_PHONE_TRUNK_PASSWORD:-}
     ports:
       # Published on the host, so that a self-hoster who already runs
       # something on these can move egma rather than move the other thing —

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -432,70 +432,43 @@ services:
       # to overload — raise this, or start a second simulator, and they
       # distribute between themselves with nothing in front of them.
       EGMA_SIMULATOR_CAPACITY: ${EGMA_SIMULATOR_CAPACITY:-4}
-      # Where the persona's words come from. `scripted` walks the scenario
-      # deterministically and needs no account, which is why it is the
-      # default; `openai` speaks to any provider using that shape and makes
-      # the next two required.
-      EGMA_SIMULATOR_MODEL_PROVIDER: ${EGMA_SIMULATOR_MODEL_PROVIDER:-scripted}
-      EGMA_SIMULATOR_MODEL_NAME: ${EGMA_SIMULATOR_MODEL_NAME:-}
-      EGMA_SIMULATOR_MODEL_API_KEY: ${EGMA_SIMULATOR_MODEL_API_KEY:-}
-      EGMA_SIMULATOR_MODEL_BASE_URL: ${EGMA_SIMULATOR_MODEL_BASE_URL:-}
-      # What the persona hears and speaks with in a voice simulation. Both
-      # default to `scripted`, which needs no account and no network — a
-      # first voice simulation costs nothing — and each is chosen on its
-      # own. Naming `deepgram` or `elevenlabs` makes that provider's key
-      # required, and the simulator says so at startup rather than failing
-      # every voice simulation it later claims.
-      EGMA_SIMULATOR_STT_PROVIDER: ${EGMA_SIMULATOR_STT_PROVIDER:-scripted}
-      EGMA_SIMULATOR_DEEPGRAM_API_KEY: ${EGMA_SIMULATOR_DEEPGRAM_API_KEY:-}
-      EGMA_SIMULATOR_TTS_PROVIDER: ${EGMA_SIMULATOR_TTS_PROVIDER:-scripted}
-      EGMA_SIMULATOR_ELEVENLABS_API_KEY: ${EGMA_SIMULATOR_ELEVENLABS_API_KEY:-}
-      # One key for both legs when either names `openai`, because one
-      # account speaks and listens. It is what `egma self-host phone
-      # setup` asks for once, and the same key the persona's brain reads
-      # through EGMA_SIMULATOR_MODEL_API_KEY above.
-      EGMA_SIMULATOR_OPENAI_API_KEY: ${EGMA_SIMULATOR_OPENAI_API_KEY:-}
-      # Which models those legs ask for, and which voice the persona
-      # speaks with when its own traits name none. Models are the
-      # provider's to retire and add, so they are configuration rather
-      # than a constant of the product.
-      EGMA_SIMULATOR_STT_MODEL: ${EGMA_SIMULATOR_STT_MODEL:-}
-      EGMA_SIMULATOR_TTS_MODEL: ${EGMA_SIMULATOR_TTS_MODEL:-}
-      EGMA_SIMULATOR_TTS_VOICE: ${EGMA_SIMULATOR_TTS_VOICE:-}
-      # What hears the agent start and stop speaking. Bundled in the image
-      # either way, so this downloads nothing at run time.
-      EGMA_SIMULATOR_VAD_PROVIDER: ${EGMA_SIMULATOR_VAD_PROVIDER:-scripted}
-      # How a phone call's audio travels, for a simulation whose connection
-      # names a number. Naming a backend is what makes the rest required
-      # and what makes this simulator able to dial at all; unset, it starts
-      # in silence and refuses such a simulation with the variable to set.
-      # The simulator's own posture is unchanged either way: it joins a
-      # LiveKit room outbound and is never dialled into. `scripted` places
-      # no call at all and is what the local story and CI use. A LiveKit
-      # and a SIP trunk are what make a real call possible; the trunk is
-      # yours, from any carrier, either one already stored in LiveKit or
-      # the inline fields below. Standing the LiveKit and SIP containers up
-      # beside this one is a separate, opt-in overlay: those need a public
-      # IP, which this file never assumes.
+      # **No provider setting reaches this container.** Which model the
+      # persona thinks with, what it speaks and hears with, what tells it
+      # the agent has stopped talking, which bridge places a call and which
+      # carrier trunk it goes over are all the *platform's* settings now:
+      # the API seals them into its own store and hands them to this
+      # container on the work order it claims, read afresh for every
+      # simulation. So there is nothing here to set, nothing to keep in
+      # step with the api service above, and nothing that can go missing
+      # when this container is recreated. A second simulator is started and
+      # nothing is copied to it.
       #
-      # The LiveKit beside it is the default, filled in from the same pair
-      # the two containers below authenticate each other with, so the
-      # three halves can never disagree. That pair has no default here:
-      # `egma self-host` generates one for the workspace and hands it to
-      # all three, so a deployment never runs on a credential published in
-      # this repository. The backend itself stays unset until
-      # `egma self-host phone setup` has run: a simulator told to dial
-      # with no trunk refuses to start, and platform readiness must not
-      # wait on carrier setup.
-      EGMA_SIMULATOR_MEDIA_BACKEND: ${EGMA_SIMULATOR_MEDIA_BACKEND:-}
+      # Two per-container exceptions stay, and each is here because it
+      # cannot be anywhere else. This is the address this container reaches
+      # a model provider at — a property of the network it is on rather
+      # than of the deployment's account:
+      EGMA_SIMULATOR_MODEL_BASE_URL: ${EGMA_SIMULATOR_MODEL_BASE_URL:-}
+      # And this is which model the listening leg asks for, which the
+      # platform's settings do not carry:
+      EGMA_SIMULATOR_STT_MODEL: ${EGMA_SIMULATOR_STT_MODEL:-}
+      # The media server this container talks to. It is a third-party
+      # binary that reads its own key and secret when it is *created*, so
+      # it can never reach the platform's database and its address and
+      # credential stay bootstrap configuration on both sides. The default
+      # is the LiveKit beside it, filled in from the same pair the two
+      # containers below authenticate each other with, so the three halves
+      # can never disagree. That pair has no default here: `egma self-host`
+      # generates one for the workspace and hands it to all three, so a
+      # deployment never runs on a credential published in this repository.
+      #
+      # Nothing here makes this simulator dial. Whether it may, and what
+      # trunk it goes over, is the platform's `media_backend` and carrier
+      # trunk — so `docker compose up` on a machine that has never seen a
+      # carrier starts exactly as it always did, and platform readiness
+      # never waits on carrier setup.
       EGMA_SIMULATOR_LIVEKIT_URL: ${EGMA_SIMULATOR_LIVEKIT_URL:-ws://livekit:7880}
       EGMA_SIMULATOR_LIVEKIT_API_KEY: ${EGMA_SIMULATOR_LIVEKIT_API_KEY:-${EGMA_LIVEKIT_API_KEY:-}}
       EGMA_SIMULATOR_LIVEKIT_API_SECRET: ${EGMA_SIMULATOR_LIVEKIT_API_SECRET:-${EGMA_LIVEKIT_API_SECRET:-}}
-      EGMA_SIMULATOR_SIP_TRUNK_ID: ${EGMA_SIMULATOR_SIP_TRUNK_ID:-}
-      EGMA_SIMULATOR_SIP_TRUNK_ADDRESS: ${EGMA_SIMULATOR_SIP_TRUNK_ADDRESS:-}
-      EGMA_SIMULATOR_SIP_TRUNK_NUMBER: ${EGMA_SIMULATOR_SIP_TRUNK_NUMBER:-}
-      EGMA_SIMULATOR_SIP_TRUNK_USERNAME: ${EGMA_SIMULATOR_SIP_TRUNK_USERNAME:-}
-      EGMA_SIMULATOR_SIP_TRUNK_PASSWORD: ${EGMA_SIMULATOR_SIP_TRUNK_PASSWORD:-}
       # Where recordings go. Naming an endpoint is the whole of what sends
       # them to object storage; naming none keeps them in a directory on
       # whatever disk the process is running on, which is what a bare

--- a/packages/db/src/access/connection-registry.ts
+++ b/packages/db/src/access/connection-registry.ts
@@ -482,7 +482,7 @@ export const CONNECTION_REGISTRY: Readonly<
     // deployment's configuration is known — this package cannot see it.
     //
     // That second question is asked, and it is asked in front of this one.
-    // `POST /api/runs` reads `phoneReadiness` off its own configuration and
+    // `POST /api/runs` reads `phoneReadiness` off the platform's own store and
     // refuses a run over a phone connection with `phone_setup_required` before
     // a row is written, so a platform nobody has given a carrier says so
     // instead of queueing a call it cannot place. The two refusals sit in two

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -178,10 +178,17 @@ export { instanceIsClaimed, platformInstanceId } from "./instance.ts";
  * The read and the write take the deployment's own tenancy beside the context,
  * because who may be here depends on it: an organization owner may, and only
  * while this deployment serves one organization.
+ *
+ * `resolvePlatformSettings` is the one door to the plaintext, and it takes the
+ * context like everything else — and then refuses every context that did not
+ * come from a simulation claim, because conducting is the only thing egma does
+ * with these. It is `resolveSimulationConnection`'s guard, word for word, over
+ * the settings that ride the same work order.
  */
 export {
   platformFacts,
   readPlatformSettings,
+  resolvePlatformSettings,
   seedPlatformSettings,
   writePlatformSettings,
   type DeploymentTenancy,

--- a/packages/db/src/access/platform-settings.ts
+++ b/packages/db/src/access/platform-settings.ts
@@ -9,7 +9,7 @@ import {
   type PlatformSettingName,
   type PlatformSettingValues,
 } from "../schema/platform.ts";
-import { sealCredentials } from "../sealing.ts";
+import { openCredentials, sealCredentials } from "../sealing.ts";
 import type { AuthContext } from "./context.ts";
 import { NotPermittedError, UnprocessableInputError } from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
@@ -37,10 +37,9 @@ import { authorize, here } from "./permissions.ts";
  *   the ones it selects.
  * - **Seeding** is the deployment configuring itself at start, from its own
  *   environment. It writes only where the platform holds nothing.
- *
- * There is deliberately **no door to the plaintext here yet**. The one caller
- * that needs it is the work order a simulator claims, and opening that door
- * before something goes through it would be a way out with nothing watching it.
+ * - **Resolving** is the one door to the plaintext, and it opens for the work
+ *   order a simulator claims and for nothing else. See
+ *   `resolvePlatformSettings`, which is where that argument is written out.
  */
 
 /**
@@ -294,6 +293,69 @@ export async function writePlatformSettings(
     });
 
   return answer(await heldSettings());
+}
+
+/**
+ * What this deployment has been configured with, in the clear, for the work
+ * order a simulator claims.
+ *
+ * **This is the same door a connection's credentials come through, and it is
+ * guarded the same way.** `resolveSimulationConnection` unseals for egma's own
+ * simulator and refuses every other kind of context; so does this, on the same
+ * sentence and for the same reason. The settings and the connection's
+ * credentials then ride one answer, with one authority behind it, which is what
+ * keeps the simulator's arrows all pointing outward: it talks to the API and to
+ * nothing else, and never to Postgres.
+ *
+ * **A claim's context is the only one that can be here**, and a claim mints it
+ * — `auth.via` is `simulator` on a context nothing but `claimSimulations`
+ * produces. There is no argument by which a person's session, an API key or a
+ * grading claim could reach these values, because the refusal is on the kind of
+ * context rather than on anything a caller passes.
+ *
+ * **It takes the context and reads nothing from it**, which is not the loophole
+ * it looks like: these settings belong to the deployment and to no customer, so
+ * there is no tenancy to narrow by and no row here a narrowing could hide. The
+ * context is what says *who is asking*, and that is the whole question this door
+ * has to answer.
+ *
+ * Read for each simulation, deliberately, and not cached. A key an operator
+ * changes applies to the next simulation with no restart, and one more small
+ * select is nothing beside conducting a conversation over a telephone
+ * connection. A measurement may ask for caching later; nothing has yet.
+ */
+export async function resolvePlatformSettings(
+  auth: AuthContext,
+): Promise<PlatformSettingValues> {
+  authorize(auth, "read", here(auth));
+
+  if (auth.via !== "simulator") {
+    throw new Error(
+      "the platform's settings are unsealed for egma's own simulator and for nothing else, because conducting is the only thing egma does with them",
+    );
+  }
+
+  const held = await db()
+    .select({ name: platformSetting.name, value: platformSetting.value })
+    .from(platformSetting)
+    .where(
+      inArray(
+        platformSetting.name,
+        PLATFORM_SETTINGS.map((setting) => setting.name),
+      ),
+    );
+
+  const resolved: Partial<Record<PlatformSettingName, string>> = {};
+  for (const row of held) {
+    const opened = openCredentials(row.value);
+    if (typeof opened !== "string" || opened === "") {
+      throw new Error(
+        `the platform setting ${row.name} holds a value in a shape egma never writes; the row needs repairing before anybody can conduct with it`,
+      );
+    }
+    resolved[row.name as PlatformSettingName] = opened;
+  }
+  return resolved;
 }
 
 /**

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -119,14 +119,29 @@ export const platformSetting = pgTable(
  * that can disagree with that one, and the disagreement would be a setting an
  * operator could store and never use.
  *
- * **`required` is what setup has to supply and what readiness waits for.** Two
- * entries are not: the simulator has a working default for the text-to-speech
- * model and voice, so a platform that never names one still speaks. Marking
- * them required would leave an operator who finished the whole documented setup
- * still reading `setup required` with nothing sensible to type — which is the
- * same silent-mismatch failure this effort exists to remove, wearing the
- * opposite face. They are settings somebody may change, not settings they must
- * supply, and the interview treats them the same way.
+ * **`required` is what setup has to supply and what readiness waits for.** Four
+ * entries are not, and each is not for a stated reason.
+ *
+ * The text-to-speech model and voice have a working default in the simulator,
+ * so a platform that never names one still speaks. The carrier trunk's username
+ * and password are a pair a carrier may not use at all: a trunk authenticated
+ * by the address it came from is a real deployment, which is what the
+ * simulator's own carrier check says in as many words, so demanding them would
+ * be readiness calling a working platform unconfigured forever.
+ *
+ * Marking any of the four required would leave an operator who finished the
+ * whole documented setup still reading `setup required` with nothing sensible
+ * to type — the same silent-mismatch failure this effort exists to remove,
+ * wearing the opposite face. They are settings somebody may supply, not
+ * settings they must, and the interview treats them the same way.
+ *
+ * **The keys, by contrast, are required and stay required.** A platform holding
+ * a provider and a model and no key is precisely the hollow start this whole
+ * effort removes: it would report `ready` and then fail every simulation at the
+ * provider, minutes later, with a refusal naming nothing about configuration.
+ * The `scripted` providers need no key, but a platform running scripted is not
+ * a platform anybody configured — it is what a simulator with no settings at
+ * all already does.
  */
 export const PLATFORM_SETTINGS = [
   {
@@ -211,13 +226,13 @@ export const PLATFORM_SETTINGS = [
     name: "carrier_trunk_username",
     label: "the carrier trunk username",
     secret: false,
-    required: true,
+    required: false,
   },
   {
     name: "carrier_trunk_password",
     label: "the carrier trunk password",
     secret: true,
-    required: true,
+    required: false,
   },
 ] as const satisfies readonly {
   readonly name: string;

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -118,70 +118,106 @@ export const platformSetting = pgTable(
  * with a sentence naming the ones it has. A second list here would be a list
  * that can disagree with that one, and the disagreement would be a setting an
  * operator could store and never use.
+ *
+ * **`required` is what setup has to supply and what readiness waits for.** Two
+ * entries are not: the simulator has a working default for the text-to-speech
+ * model and voice, so a platform that never names one still speaks. Marking
+ * them required would leave an operator who finished the whole documented setup
+ * still reading `setup required` with nothing sensible to type — which is the
+ * same silent-mismatch failure this effort exists to remove, wearing the
+ * opposite face. They are settings somebody may change, not settings they must
+ * supply, and the interview treats them the same way.
  */
 export const PLATFORM_SETTINGS = [
   {
     name: "persona_model_provider",
     label: "the persona's model provider",
     secret: false,
+    required: true,
   },
-  { name: "persona_model", label: "the persona's model", secret: false },
-  { name: "persona_model_key", label: "the persona's model key", secret: true },
+  {
+    name: "persona_model",
+    label: "the persona's model",
+    secret: false,
+    required: true,
+  },
+  {
+    name: "persona_model_key",
+    label: "the persona's model key",
+    secret: true,
+    required: true,
+  },
   {
     name: "speech_to_text_provider",
     label: "the speech-to-text provider",
     secret: false,
+    required: true,
   },
   {
     name: "speech_to_text_key",
     label: "the speech-to-text key",
     secret: true,
+    required: true,
   },
   {
     name: "text_to_speech_provider",
     label: "the text-to-speech provider",
     secret: false,
+    required: true,
   },
   {
     name: "text_to_speech_key",
     label: "the text-to-speech key",
     secret: true,
+    required: true,
   },
   {
     name: "text_to_speech_model",
     label: "the text-to-speech model",
     secret: false,
+    required: false,
   },
   {
     name: "text_to_speech_voice",
     label: "the text-to-speech voice",
     secret: false,
+    required: false,
   },
   {
     name: "voice_activity_provider",
     label: "the voice-activity provider",
     secret: false,
+    required: true,
   },
-  { name: "media_backend", label: "the media backend", secret: false },
+  {
+    name: "media_backend",
+    label: "the media backend",
+    secret: false,
+    required: true,
+  },
   {
     name: "carrier_trunk_address",
     label: "the carrier trunk",
     secret: false,
+    required: true,
   },
   {
     name: "carrier_trunk_number",
     label: "the source number",
     secret: false,
+    required: true,
   },
   {
     name: "carrier_trunk_username",
     label: "the carrier trunk username",
     secret: false,
+    required: true,
   },
   {
     name: "carrier_trunk_password",
     label: "the carrier trunk password",
     secret: true,
+    required: true,
   },
 ] as const satisfies readonly {
   readonly name: string;
@@ -193,6 +229,14 @@ export const PLATFORM_SETTINGS = [
    * handed out; anything else hints with itself.
    */
   readonly secret: boolean;
+  /**
+   * Whether setup is incomplete without it, and therefore whether readiness
+   * waits for it. `false` where the simulator has a default that works, so a
+   * platform that never names one still conducts a simulation — see the
+   * catalog's own note above for why that difference has to be written down
+   * rather than left to whoever writes the interview.
+   */
+  readonly required: boolean;
 }[];
 
 /**

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -101,14 +101,23 @@ export const platformSetting = pgTable(
  * Every setting this platform knows about, in the order a person is asked for
  * them. **This list is the only place a setting's name is written.**
  *
- * The list grows as the effort moves the rest of the deployment's settings in:
- * the carrier trunk and the media backend, the speech providers and their keys.
  * Adding one here is an insert at run time and nothing else — no migration, no
- * check constraint to widen, and no second list to remember.
+ * check constraint to widen, and no second list to remember. The order is the
+ * order a setup interview walks: who the persona thinks with, then what it
+ * speaks and hears with, then how a call reaches the telephone network — so
+ * that an operator gathers one provider's paperwork at a time rather than
+ * jumping between accounts.
  *
  * A label is the words a readiness answer names the setting in — "the persona's
  * model key" rather than `persona_model_key` — because "setup required" with a
  * column name after it sends a self-hoster to read source.
+ *
+ * **Nothing here is checked against a closed list of providers.** Which model a
+ * deployment thinks with and which company transcribes for it are the
+ * simulator's vocabulary, and it already refuses a provider it holds no leg for
+ * with a sentence naming the ones it has. A second list here would be a list
+ * that can disagree with that one, and the disagreement would be a setting an
+ * operator could store and never use.
  */
 export const PLATFORM_SETTINGS = [
   {
@@ -118,6 +127,62 @@ export const PLATFORM_SETTINGS = [
   },
   { name: "persona_model", label: "the persona's model", secret: false },
   { name: "persona_model_key", label: "the persona's model key", secret: true },
+  {
+    name: "speech_to_text_provider",
+    label: "the speech-to-text provider",
+    secret: false,
+  },
+  {
+    name: "speech_to_text_key",
+    label: "the speech-to-text key",
+    secret: true,
+  },
+  {
+    name: "text_to_speech_provider",
+    label: "the text-to-speech provider",
+    secret: false,
+  },
+  {
+    name: "text_to_speech_key",
+    label: "the text-to-speech key",
+    secret: true,
+  },
+  {
+    name: "text_to_speech_model",
+    label: "the text-to-speech model",
+    secret: false,
+  },
+  {
+    name: "text_to_speech_voice",
+    label: "the text-to-speech voice",
+    secret: false,
+  },
+  {
+    name: "voice_activity_provider",
+    label: "the voice-activity provider",
+    secret: false,
+  },
+  { name: "media_backend", label: "the media backend", secret: false },
+  {
+    name: "carrier_trunk_address",
+    label: "the carrier trunk",
+    secret: false,
+  },
+  {
+    name: "carrier_trunk_number",
+    label: "the source number",
+    secret: false,
+  },
+  {
+    name: "carrier_trunk_username",
+    label: "the carrier trunk username",
+    secret: false,
+  },
+  {
+    name: "carrier_trunk_password",
+    label: "the carrier trunk password",
+    secret: true,
+  },
 ] as const satisfies readonly {
   readonly name: string;
   /** What a person calls it, in a refusal and in a setup interview alike. */
@@ -140,7 +205,14 @@ export type PlatformSettingDefinition = (typeof PLATFORM_SETTINGS)[number];
 /** The name of one setting. A write that names anything else is refused. */
 export type PlatformSettingName = PlatformSettingDefinition["name"];
 
-/** The settings a caller is changing or seeding, by name. */
+/**
+ * Settings by name, in the clear.
+ *
+ * One shape for the three journeys a plain value makes: what a caller is
+ * changing, what an environment is seeding, and what the platform hands the
+ * simulator on a work order. They are the same thing said three times, and a
+ * second alias for the third would be a second vocabulary for one map.
+ */
 export type PlatformSettingValues = Readonly<
   Partial<Record<PlatformSettingName, string>>
 >;

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -246,6 +246,12 @@ const CONTEXT_REQUIRING = [
   // Names off a reviewed file turned into the identity a version names. It
   // reads personas and nothing else, and only ones the context already reaches.
   "resolvePersonaNames",
+  // The dispatch path's door to the deployment's own settings in the clear —
+  // the third secret egma holds, and the same door the connection's
+  // credentials below come through. It takes the context like everything else
+  // and then refuses every one that did not come from a simulation claim,
+  // because conducting is the only thing egma does with these.
+  "resolvePlatformSettings",
   // The dispatch path's door to a connection's plaintext. It takes the context
   // like everything else — and then refuses every one that did not come from a
   // simulation claim, because conducting is the only thing egma does with a

--- a/packages/db/test/platform-settings.test.ts
+++ b/packages/db/test/platform-settings.test.ts
@@ -4,7 +4,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   NotPermittedError,
   platformFacts,
+  PLATFORM_SETTINGS,
   readPlatformSettings,
+  resolvePlatformSettings,
   seedPlatformSettings,
   writePlatformSettings,
   type AuthContext,
@@ -109,11 +111,47 @@ describe("a platform that has been given no settings", () => {
     // Naming the settings it does not have is the whole readiness answer: a
     // platform that said only "setup required" would send whoever runs it to
     // read source to find out what is missing.
-    expect(await settingsByName()).toEqual({
-      persona_model_provider: { hint: null, secret: false },
-      persona_model: { hint: null, secret: false },
-      persona_model_key: { hint: null, secret: true },
-    });
+    //
+    // Every name in the catalog, read off the catalog rather than listed
+    // again: the list grows as settings move in, and a second copy of it here
+    // would be a copy that goes stale rather than a claim that goes wrong.
+    // What is asserted is the property — one answer per setting, and every
+    // one of them absent.
+    const held = await settingsByName();
+    expect(Object.keys(held)).toEqual(
+      PLATFORM_SETTINGS.map((setting) => setting.name),
+    );
+    for (const setting of PLATFORM_SETTINGS) {
+      expect(held[setting.name]).toEqual({
+        hint: null,
+        secret: setting.secret,
+      });
+    }
+  });
+
+  it("knows the persona's model, its speech legs and its carrier", async () => {
+    // The catalog written out once, because the loop above proves a shape and
+    // this proves the contents — that the settings this effort moved really
+    // are the ones the platform holds, and which of them may be shown back.
+    expect(
+      PLATFORM_SETTINGS.map((setting) => [setting.name, setting.secret]),
+    ).toEqual([
+      ["persona_model_provider", false],
+      ["persona_model", false],
+      ["persona_model_key", true],
+      ["speech_to_text_provider", false],
+      ["speech_to_text_key", true],
+      ["text_to_speech_provider", false],
+      ["text_to_speech_key", true],
+      ["text_to_speech_model", false],
+      ["text_to_speech_voice", false],
+      ["voice_activity_provider", false],
+      ["media_backend", false],
+      ["carrier_trunk_address", false],
+      ["carrier_trunk_number", false],
+      ["carrier_trunk_username", false],
+      ["carrier_trunk_password", true],
+    ]);
   });
 
   it("holds nothing anybody could be shown", async () => {
@@ -358,11 +396,16 @@ describe("seeding a platform that holds nothing", () => {
       "persona_model_key",
       "persona_model_provider",
     ]);
-    expect(await settingsByName()).toEqual({
-      persona_model_provider: { hint: "openai", secret: false },
-      persona_model: { hint: "gpt-4o-mini", secret: false },
-      persona_model_key: { hint: "WXYZ", secret: true },
+    const held = await settingsByName();
+    expect(held.persona_model_provider).toEqual({
+      hint: "openai",
+      secret: false,
     });
+    expect(held.persona_model).toEqual({ hint: "gpt-4o-mini", secret: false });
+    expect(held.persona_model_key).toEqual({ hint: "WXYZ", secret: true });
+    // And nothing this environment did not name: a seed writes what it was
+    // given and never fills a gap with a guess.
+    expect(held.carrier_trunk_address).toEqual({ hint: null, secret: false });
   });
 
   it("seals what it wrote, exactly as a person's own write is sealed", async () => {
@@ -396,5 +439,84 @@ describe("seeding a platform that holds nothing", () => {
         persona_model_key: FROM_THE_ENVIRONMENT,
       }),
     ).toEqual(["persona_model"]);
+  });
+});
+
+describe("the one door to the plaintext", () => {
+  /**
+   * The context a simulation claim mints, and the only kind that may be here.
+   *
+   * A claim carries no user: the simulator stands behind every organization at
+   * once and holds no credential, so the context arrives narrowed to the row it
+   * was handed rather than resolved from anybody's key. `via` is what says
+   * where it came from, and it is what this door reads.
+   */
+  function claimed(): AuthContext {
+    return {
+      // Not an identifier and deliberately not shaped like one: the claim
+      // machinery writes the same word, because the conversations a simulator
+      // conducts were asked for by whoever started the run rather than by it.
+      userId: "simulator",
+      organizationId: acme.organization,
+      projectId: acme.project,
+      role: "member",
+      via: "simulator",
+    };
+  }
+
+  it("answers a claim with the values in the clear, and nothing it does not hold", async () => {
+    await database.sql("delete from platform_setting");
+    await seedPlatformSettings({
+      persona_model_provider: "openai",
+      persona_model_key: THEIR_OWN_KEY,
+      carrier_trunk_password: "the-carrier-issued-this-one",
+    });
+
+    // In the clear: this is the one caller that has to replay a key to a
+    // provider, so a hint would be four characters of a credential and the
+    // sealed envelope would be an envelope.
+    expect(await resolvePlatformSettings(claimed())).toEqual({
+      persona_model_provider: "openai",
+      persona_model_key: THEIR_OWN_KEY,
+      carrier_trunk_password: "the-carrier-issued-this-one",
+    });
+  });
+
+  it("refuses every context a claim did not mint", async () => {
+    // The guard is on the kind of context rather than on anything a caller
+    // passes, so there is no argument by which a person's session, an API key
+    // or the grading engine could reach a stored key. It is
+    // `resolveSimulationConnection`'s guard word for word, over the settings
+    // that ride the same work order.
+    for (const auth of [
+      owner(),
+      member("member"),
+      { ...claimed(), via: "api_key" } as AuthContext,
+      { ...claimed(), via: "engine" } as AuthContext,
+    ]) {
+      await expect(resolvePlatformSettings(auth)).rejects.toThrow(
+        /egma's own simulator/u,
+      );
+    }
+  });
+
+  it("answers nothing at all on a platform nobody has configured", async () => {
+    await database.sql("delete from platform_setting");
+    expect(await resolvePlatformSettings(claimed())).toEqual({});
+  });
+
+  it("refuses a row that will not unseal rather than conducting with it", async () => {
+    await database.sql("delete from platform_setting");
+    await seedPlatformSettings({ persona_model_provider: "openai" });
+    // What a lost encryption key or a hand-edited row leaves behind. Handing
+    // the simulator whatever came out would be a provider call with garbage
+    // in the authorization header; the row is named instead, so whoever reads
+    // the log knows which one needs repairing.
+    await database.sql(
+      "update platform_setting set value = 'not-an-envelope-at-all' where name = $1",
+      ["persona_model_provider"],
+    );
+
+    await expect(resolvePlatformSettings(claimed())).rejects.toThrow();
   });
 });

--- a/packages/simulation-contract/fixtures/spec/invalid/platform-setting-unknown.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/platform-setting-unknown.json
@@ -1,0 +1,35 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K4QW7M4E8YB2FVN0H9TZQWEU",
+  "modality": "chat",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Margaret, 68, retired schoolteacher.",
+      "language": "en-US"
+    }
+  },
+  "scenario": {
+    "instructions": "Move a dental cleaning from Tuesday to Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "platform": {
+    "model": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "fixture-not-a-real-secret-persona-model-0001",
+      "base_url": "https://api.openai.example/v1"
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/valid/chat-platform-without-a-carrier.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-platform-without-a-carrier.json
@@ -1,0 +1,43 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K4QW7M4E8YB2FVN0H9TZQWET",
+  "modality": "chat",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+      "language": "en-US"
+    }
+  },
+  "scenario": {
+    "instructions": "Move a dental cleaning from Tuesday to Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "platform": {
+    "model": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "fixture-not-a-real-secret-persona-model-0001"
+    },
+    "speech": {
+      "stt_provider": "openai",
+      "stt_key": "fixture-not-a-real-secret-listening-0002",
+      "tts_provider": "openai",
+      "tts_key": "fixture-not-a-real-secret-speaking-0003",
+      "tts_model": "gpt-4o-mini-tts",
+      "tts_voice": "alloy",
+      "vad_provider": "silero"
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/valid/voice-phone-platform-configured.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-phone-platform-configured.json
@@ -1,0 +1,53 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K4QW7M4E8YB2FVN0H9TZQWES",
+  "modality": "voice",
+  "connection": {
+    "type": "phone",
+    "config": {
+      "phoneNumber": "+15551234567"
+    },
+    "credentials": null
+  },
+  "persona": {
+    "traits": {
+      "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "brisk-tenor-7",
+        "speed": 1.15
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your card was charged twice for the same order this morning. You want the duplicate charge reversed and a confirmation number before you hang up."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "platform": {
+    "model": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "fixture-not-a-real-secret-persona-model-0001"
+    },
+    "speech": {
+      "stt_provider": "deepgram",
+      "stt_key": "fixture-not-a-real-secret-listening-0002",
+      "tts_provider": "elevenlabs",
+      "tts_key": "fixture-not-a-real-secret-speaking-0003",
+      "tts_model": "eleven_turbo_v2_5",
+      "tts_voice": "brisk-tenor-7",
+      "vad_provider": "silero"
+    },
+    "carrier": {
+      "media_backend": "livekit",
+      "trunk_address": "egma-fixture.pstn.twilio.com",
+      "trunk_number": "+15550000000",
+      "trunk_username": "egma-fixture-trunk",
+      "trunk_password": "fixture-not-a-real-secret-trunk-0004"
+    }
+  }
+}

--- a/packages/simulation-contract/schemas/simulation-spec.v1.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v1.schema.json
@@ -98,9 +98,115 @@
       "description": "The answers this simulation serves for the agent's tools, already resolved: one entry per tool name, the project's default or the test's override, whichever applies — worked out once by the control plane so that every simulation in one run sees one world and nothing downstream can reach a second answer. Absent, which is the ordinary case, means egma answers for nothing: every tool the agent has runs its own implementation, untouched and unobserved. Order is the order the answers were authored, and it is stable so that two runs of one project read alike.",
       "type": "array",
       "items": { "$ref": "#/$defs/mock_tool" }
+    },
+    "platform": {
+      "description": "What this deployment has been configured with, unsealed for exactly this hand-off: who the persona thinks with, what it speaks and hears with, and how a call reaches the telephone network. These belong to the whole deployment rather than to any customer on it, and they used to live in each simulator's own environment — which meant a second simulator on another machine needed a file copied to it, and a container started without one dialled nothing while reporting itself healthy. They ride this document instead, through the same door and with the same authority as the connection's credentials beside them, and are read afresh for each simulation so a changed key applies to the next one with no restart. Every block is optional and so is every field inside it: a setting the platform does not hold leaves the simulator's own value standing, and a setting it does hold replaces it. A platform that has configured nothing sends nothing, and a simulator conducts exactly as it did before this block existed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model": { "$ref": "#/$defs/platform_model" },
+        "speech": { "$ref": "#/$defs/platform_speech" },
+        "carrier": { "$ref": "#/$defs/platform_carrier" }
+      }
     }
   },
   "$defs": {
+    "platform_model": {
+      "description": "What the persona thinks with. Every field is optional, because a platform mid-setup holds some of them and not others, and one that holds none of them is every platform before anybody set it up.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "description": "Which client speaks to the model — the simulator's own open vocabulary, not an enum here: a simulator holding no client for a provider refuses at runtime with the ones it has, rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "description": "Which model to ask for, verbatim as the provider names it. Configuration rather than a constant of the product: providers retire and add models on their own schedule.",
+          "type": "string",
+          "minLength": 1
+        },
+        "key": {
+          "description": "The provider key, in the clear for exactly this hand-off. Held in memory for the simulation, registered for redaction, and never logged, persisted or reported. No report document has anywhere to put it.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "platform_speech": {
+      "description": "What the persona speaks and hears with on a voice simulation, and what tells it the agent has started and stopped speaking. A key per leg rather than one per provider: the two legs are two accounts as often as they are one, and a shape that could not say so would make the second one unreachable.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "stt_provider": {
+          "description": "The persona's ears. An open vocabulary, refused at runtime by the simulator holding no such leg.",
+          "type": "string",
+          "minLength": 1
+        },
+        "stt_key": {
+          "description": "The listening leg's provider key, on the same terms as the model key above.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_provider": {
+          "description": "The persona's mouth. Chosen apart from the ears on purpose — a real mouth with scripted ears is a configuration somebody will want.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_key": {
+          "description": "The speaking leg's provider key, on the same terms as the model key above.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_model": {
+          "description": "Which model the speaking leg asks for, where its provider has more than one.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_voice": {
+          "description": "Which voice the speaking leg asks for when the persona's own traits name none.",
+          "type": "string",
+          "minLength": 1
+        },
+        "vad_provider": {
+          "description": "What tells the persona the agent has started or stopped speaking. Needs no key either way.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "platform_carrier": {
+      "description": "How a call reaches the telephone network: which bridge places it, and the trunk the carrier authenticates. Absent on every deployment that has never been given a carrier — which still runs chat and voice simulations perfectly well — and that absence is an ordinary state rather than a fault. The media server's own key and secret are deliberately not here: they are read by a third-party container when it is created and cannot come from the platform's store, so they stay in each simulator's environment.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "media_backend": {
+          "description": "Which driver places the call. An open vocabulary, refused at runtime by a simulator holding no such backend.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_address": {
+          "description": "The carrier hostname a call is routed through. Non-secret: it is a fact the readiness answer already reports.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_number": {
+          "description": "The number a call appears to come from, E.164. Non-secret, for the same reason.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_username": {
+          "description": "The username the carrier authenticates the trunk by.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_password": {
+          "description": "The password beside it, in the clear for exactly this hand-off and on the same terms as every other secret in this document.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "mock_tool": {
       "description": "One tool name, and what egma answers when the agent calls it. Matching is by the name and strictly by it: a mock tool never reads a call's arguments, so there is no matcher here and nowhere for one to go.",
       "type": "object",

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -119,6 +119,16 @@ const EXPECTED_REJECTION: Record<string, Rejection> = {
     keyword: "additionalProperties",
     property: "agent_id",
   },
+  // The platform's own settings are a closed list on both sides — the catalog
+  // the control plane stores them under, and the block the simulator reads. A
+  // field nobody writes is a setting nobody reads, and a spec carrying one has
+  // a deployment believing something is configured that is not, so it is
+  // refused rather than carried and dropped.
+  "spec/platform-setting-unknown.json": {
+    at: "/platform/model",
+    keyword: "additionalProperties",
+    property: "base_url",
+  },
   "spec/wrong-contract-version.json": {
     at: "/contract_version",
     keyword: "const",


### PR DESCRIPTION
## The problem

A self-hosted egma kept its provider settings — the persona's model and key, what it speaks and hears with, and the carrier trunk somebody did paperwork with Twilio for — in a file beside the deployment that only the egma CLI read. Start the platform any other way (the plain `docker compose up` the documentation shows, a machine restart in a different directory, a colleague who cloned the repository) and every setting was absent.

Absent did not fail. Each variable was written with an empty default, so an absent setting became an empty setting: every container started, every health check passed, the platform reported itself ready, and the failure arrived minutes later as a carrier refusal naming nothing about configuration. The settings were also unrecoverable — upgrade Docker, move machines, or lose the file, and you did the carrier work again.

## What moves

The settings belong to the deployment, so the deployment holds them. Ticket 02 built the table, the sealing, the routes and the permission gate. This one delivers them.

- **The catalog grows from three entries to fifteen**: the speech-to-text leg and its key, the text-to-speech leg with its key, model and voice, the voice-activity provider, the media backend, and the carrier trunk's address, number, username and password. Adding a setting is an insert — no migration, no check constraint (`pnpm db:generate` confirms none).
- **They ride the work order a simulator already claims.** `resolvePlatformSettings` is the one door to the plaintext. It takes the `AuthContext` like everything else and then refuses every context a simulation claim did not mint — `resolveSimulationConnection`'s guard, over the settings that ride the same answer. Nothing new is opened, and the simulator keeps the property that every arrow points outward from it: it talks to the API and to nothing else, and never to Postgres.
- **Read for each simulation, never cached.** A replaced key applies to the next conversation with nothing restarted.
- **Readiness reads the store, phone half included.** `phoneReadiness` stopped reading this process's configuration, which is what makes it recoverable: the three facts survive a restart, a rebuild and a move to another machine. The run door asks the store on each run creation for the same reason.
- **No simulator container is handed a setting the platform owns.** No compose file passes one and `.env.example` names none.

## The test that proves it

`apps/simulator/tests/test_platform_settings.py::test_the_work_orders_model_is_what_conducts_not_this_containers`.

A real simulator child process is started told to think with a real provider at `http://127.0.0.1:1/v1` — a port nothing answers on. The work order says `scripted`. The exchange then happens turn for turn, which it could not have done if the container's own configuration had been what was read. That is what makes it an observation rather than two settings that happen to agree, and removing the fold in `model.py` makes it fail.

The same claim is proved twice more for the carrier — a phone simulation conducted with no carrier variable anywhere in the container's environment, and one where both sides hold a carrier and the platform's wins — and at each seam directly in the same file.

## Decisions worth knowing

**The contract stayed at v1.** `platform` is an optional property added to the existing spec schema, exactly as `mock_tools` was. Both halves ship in one compose file and `docker compose up` upgrades every image together, so an older simulator meeting a newer API carries the risk that precedent already carries. Fixtures cover a fully configured platform, one whose phone half is absent, and an unknown field being refused.

**A provider name nobody wrote refuses, rather than falling through to the stand-in.** Every builder previously fell back to its scripted leg for a provider it did not implement — right for `scripted`, wrong for `elevenlabss`, and one letter on a settings page produced a completed, green simulation conducted by a canned robot. On a product about trust in the agent somebody ships, that is worse than a failure. The model client, both speech legs, the turn detector and the media backend each refuse a name they do not have, naming the setting, the value, and what this simulator really has.

**The carrier's refusals moved to the moment of dialling.** A trunk used to be required when the container started. It is the platform's now, so a simulator waiting for a work order to bring it one is an ordinary deployment. Every carrier refusal lives in `MediaSettings.checked()`, which the phone plug calls when a call is really about to be placed — so a half-configured phone costs the phone simulation that asked and never the chat work beside it.

**Speech keys are per leg, not per provider.** The environment names keys after providers because one OpenAI account really does serve both legs. The work order names them after legs, because listening with one company and speaking with another is an ordinary deployment and a provider-keyed shape could not express the second key.

**The media server's key and secret stay in the environment.** It is a third-party binary that reads its own configuration when it is created and cannot reach the platform's store. The trunk is paperwork somebody did once with a carrier, so it is the platform's.

**Two settings are marked not-required.** The simulator has a working default for the text-to-speech model and voice, and setup has never written them — so demanding them would tell an operator who finished the documented path that they had not.

## Test result, honestly

`pnpm typecheck` clean. `pnpm lint` clean. Simulator: 590 passed, 7 skipped, ruff clean. SDK 66 passed, fixture 8 passed.

TypeScript suite: **2401 passed, 2 failed.** Both failures are in `apps/api/test/default-judge-on-signup.test.ts` and are pre-existing on the base commit — the test helper defaults `singleOrganization: false` while `server.ts` gates the default judge on that flag. They are off this diff and out of this spec's scope.

One CLI test (`run-screen.test.ts`, "leaves the machine untouched on [s]") failed once under full-suite load at 63s and passed in isolation at 6s and on a second full run; it is a timing flake against the shared database, not a behaviour change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789340015&installation_model_id=431960&pr_number=79&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F79&signature=71d3e3601393dbf0ad79435d182b274cc52e21e6d318a3a8e874706a98b5e1fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves platform-owned model, speech, media, and carrier settings into persistent storage and delivers them to simulators through claimed work orders.
- Expands the platform settings catalog and readiness checks.
- Adds platform settings to the simulation contract and simulator configuration.
- Reads carrier readiness dynamically from stored settings.
- Allows address-authenticated trunks without username or password.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/schema/platform.ts | Expands the settings catalog and now correctly permits carrier trunks authenticated solely by source address. |
| apps/api/src/routes/claims.ts | Adds stored platform settings to claimed simulation work orders using optional grouped contract fields. |
| apps/api/src/platform-readiness.ts | Computes setup readiness from catalog-required settings held in persistent storage. |
| apps/api/src/phone-readiness.ts | Derives phone readiness from persistent carrier and speech facts rather than process configuration. |
| apps/simulator/src/egma_simulator/config.py | Folds work-order platform settings into per-simulation provider and carrier configuration. |
| packages/simulation-contract/schemas/simulation-spec.v1.schema.json | Extends the v1 work-order schema with optional platform model, speech, and carrier groups. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  ENV[Deployment settings] --> API[API seeds sealed platform store]
  UI[Settings API] --> STORE[(Platform settings store)]
  API --> STORE
  STORE --> READY[Platform and phone readiness]
  STORE --> CLAIM[Simulation claim assembly]
  CLAIM --> ORDER[Work order with platform settings]
  ORDER --> SIM[Simulator]
  SIM --> PROVIDERS[Model, speech, media, and carrier providers]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Let a trunk the carrier authenticates by..."](https://github.com/egma-ai/egma/commit/371c0addcf55bb8c215dc7a9ec26a428b7b9fec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53513947)</sub>

<!-- /greptile_comment -->