### PR TITLE
The bootstrap variables refuse to start when absent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,12 @@ TEST_CLICKHOUSE_URL=http://egma:egma@localhost:8124/egma
 # store's admin surface — rights to list, replace and delete every recording you
 # hold — and the store publishes a port, because a browser has to be able to
 # fetch a recording. MinIO refuses a password under eight characters.
+#
+# **A deployment pointed at somebody else's S3 still needs this pair.** The
+# MinIO in docker-compose.yml is part of the default deployment and the
+# simulator waits on the job that creates its bucket, so it is a container that
+# starts whether or not your recordings go to it — and a store that starts needs
+# a root credential. Give it a throwaway one: nothing of yours is in there.
 EGMA_S3_ACCESS_KEY_ID=
 EGMA_S3_SECRET_ACCESS_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,19 @@
 
 # Postgres. The published port is 5433 so it does not collide with a Postgres
 # already running on the machine.
+#
+# **The bind is loopback by default and that is a security decision.** The user
+# and password just below are printed in this repository, and what answers on
+# this port is every row your platform holds — your organizations, your keys,
+# and the settings it seals. On 0.0.0.0 that is `docker compose up` on a shared
+# network offering all of it to whoever can route to the machine. Widen it only
+# when something off this machine really must reach the database, and change
+# POSTGRES_PASSWORD in the same breath.
 POSTGRES_USER=egma
 POSTGRES_PASSWORD=egma
 POSTGRES_DB=egma
 POSTGRES_PORT=5433
+POSTGRES_BIND=127.0.0.1
 
 # Where the tests look for Postgres. They create and drop a database per test
 # file, so this user needs permission to do that.
@@ -35,11 +44,14 @@ TEST_DATABASE_URL=postgres://egma:egma@localhost:5433/egma
 
 # ClickHouse, which holds the traces. The published port is 8124 for the same
 # reason Postgres publishes 5433 — so it does not collide with a ClickHouse
-# already running on the machine.
+# already running on the machine. Loopback by default for the reason Postgres
+# is: this credential is printed here too, and what it opens is every
+# conversation your platform has recorded.
 CLICKHOUSE_USER=egma
 CLICKHOUSE_PASSWORD=egma
 CLICKHOUSE_DB=egma
 CLICKHOUSE_PORT=8124
+CLICKHOUSE_BIND=127.0.0.1
 
 # Where the tests look for ClickHouse. A database per test file here too, so
 # this user needs permission to create and drop them.
@@ -103,14 +115,18 @@ EGMA_S3_REGION=
 # **The bind is loopback by default and that is a security decision, not a
 # default nobody thought about.** What answers on this port is the store's admin
 # surface and its root credential, which can list, replace and delete every
-# recording you hold — and the development default for that credential is
-# printed above, in a public repository. On 0.0.0.0 that is `docker compose up`
-# on a shared network handing every recording to the room, to read and to
-# overwrite.
+# recording you hold. On 0.0.0.0 that is `docker compose up` on a shared network
+# offering every recording to the room, to read and to overwrite.
+#
+# That credential used to have a development default printed above, in a public
+# repository, which made the sentence above true on your own network too. It has
+# none now — you chose it, and the deployment refuses to start until you have.
+# The loopback bind stays all the same: a password is one mistake away from a
+# wide port, and closing the port by default is the half that costs nothing.
 #
 # Open it when the browsers that need recordings are not on this machine: set
 # EGMA_S3_BIND=0.0.0.0 and set EGMA_BLOB_PUBLIC_URL to the address those
-# browsers use. Change EGMA_S3_SECRET_ACCESS_KEY *first*.
+# browsers use.
 EGMA_S3_PORT=9000
 EGMA_S3_BIND=127.0.0.1
 
@@ -192,14 +208,21 @@ EGMA_ENCRYPTION_KEY=
 # port. An agent repository reads this instance's identity here before it sends
 # anything, and it will not follow an instance to an address the developer did
 # not give it — so an instance that others reach at 192.168.1.10 or at
-# egma.example must say so here rather than leave the localhost default, or
-# their first command refuses and says which of the two addresses to fix.
+# egma.example must say exactly that, or their first command refuses and says
+# which of the two addresses to fix.
+#
+# **This line is left empty on purpose, and it is the one value in this file
+# where a helpful-looking default would be the most expensive.** A copied
+# `http://localhost:3101` is correct on a laptop and wrong on every deployment
+# anybody else reaches — and wrong in the quiet way, because the platform starts
+# and answers perfectly while every agent repository is refused at a directory's
+# distance from the cause. `http://localhost:3101` is what a laptop writes here.
 #
 # Changed in the self-hosted release: a value carrying a path, query, fragment
 # or credentials is now refused at startup instead of being trimmed. Serving
 # egma under a subpath was never supported; if yours is set that way, drop
 # everything after the port. The startup message names the part to remove.
-EGMA_BASE_URL=http://localhost:3101
+EGMA_BASE_URL=
 
 # One organization on this deployment, and the first person to sign up claims
 # it and becomes its admin. Everyone after them arrives by invitation. Turn it

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,26 @@
-# Nearly everything here has a working default in docker-compose.yml. Copy this
-# file to .env only if you want to change one.
+# Copy this file to .env. Ports, the stores' own users and every piece of
+# per-container tuning have working defaults in docker-compose.yml, so you can
+# leave those alone — but **ten variables have no default anywhere and the
+# deployment refuses to start without them**, naming the one it is missing.
 #
-# The exception is the media server's key and secret, which have no default
-# anywhere — a deployment must not run on a credential published in this
-# repository. `egma self-host up` generates that pair for you and writes it
-# where the deployment reads it back, so there is nothing to copy for it. See
-# EGMA_LIVEKIT_API_KEY below.
+# They are this deployment's own secrets and its own address, and each one is
+# marked REQUIRED below. A default for any of them would be a value every
+# reader of this repository holds: the key that seals your provider keys, the
+# secret that signs your sessions, the token that hands a claim answer your
+# customers' live credentials, the credential that can replace any recording
+# you hold. A platform running on those looks perfectly healthy, which is why
+# it is refused instead.
+#
+#   EGMA_ENCRYPTION_KEY  EGMA_AUTH_SECRET  EGMA_SIMULATOR_SERVICE_TOKEN
+#   EGMA_S3_ACCESS_KEY_ID  EGMA_S3_SECRET_ACCESS_KEY
+#   EGMA_S3_READ_ACCESS_KEY_ID  EGMA_S3_READ_SECRET_ACCESS_KEY
+#   EGMA_BASE_URL
+#   EGMA_LIVEKIT_API_KEY  EGMA_LIVEKIT_API_SECRET
+#
+# The last three of those you do not type. `egma self-host up` generates the
+# media pair for your workspace, writes it where the deployment reads it back,
+# and sets EGMA_BASE_URL to the address it prints — so a workspace started
+# through the CLI needs the first seven here and nothing more.
 
 # Postgres. The published port is 5433 so it does not collide with a Postgres
 # already running on the machine.
@@ -41,12 +56,16 @@ TEST_CLICKHOUSE_URL=http://egma:egma@localhost:8124/egma
 # somebody else's S3 sets the EGMA_S3_* side.
 #
 # One credential reaches both halves here: the store is stood up with it, and
-# the simulator writes with it, so the two can never disagree. Change the secret
-# before anybody else can reach your instance — the store now publishes a port,
-# because a browser has to be able to fetch a recording — and note that MinIO
-# refuses a password under eight characters.
-EGMA_S3_ACCESS_KEY_ID=egma
-EGMA_S3_SECRET_ACCESS_KEY=egma-development-only-object-storage-secret-change-it
+# the simulator writes with it, so the two can never disagree.
+#
+# **REQUIRED, both of them.** There is no default here and none in
+# docker-compose.yml, and the deployment refuses to start without them rather
+# than running on a pair printed in a public repository. What they open is the
+# store's admin surface — rights to list, replace and delete every recording you
+# hold — and the store publishes a port, because a browser has to be able to
+# fetch a recording. MinIO refuses a password under eight characters.
+EGMA_S3_ACCESS_KEY_ID=
+EGMA_S3_SECRET_ACCESS_KEY=
 
 # The bucket recordings land in, created on the deployment's first start. There
 # is no reason to change it unless you are pointing the platform at a bucket
@@ -59,8 +78,12 @@ EGMA_S3_BUCKET=egma-recordings
 # replacing one. That is why it is a separate pair from the write credential
 # above: a recording is evidence, and evidence somebody else can overwrite is
 # not evidence. The deployment creates this user on first start.
-EGMA_S3_READ_ACCESS_KEY_ID=egma-read
-EGMA_S3_READ_SECRET_ACCESS_KEY=egma-development-only-read-only-secret-change-it
+#
+# **REQUIRED, both of them**, for the reason the pair above is: reading every
+# recording a deployment holds is not a right this repository may hand out with
+# its source.
+EGMA_S3_READ_ACCESS_KEY_ID=
+EGMA_S3_READ_SECRET_ACCESS_KEY=
 
 # Which region the store's signatures carry. Both halves read it — the
 # simulator signs its uploads with it and the API signs playback links with it —
@@ -138,23 +161,30 @@ EGMA_BLOB_PUBLIC_URL=http://localhost:9000
 # refuses to start on half of one.
 EGMA_BLOB_BUCKET=egma-recordings
 EGMA_BLOB_REGION=
-EGMA_BLOB_ACCESS_KEY_ID=egma-read
-EGMA_BLOB_SECRET_ACCESS_KEY=egma-development-only-read-only-secret-change-it
+EGMA_BLOB_ACCESS_KEY_ID=
+EGMA_BLOB_SECRET_ACCESS_KEY=
 
-# What session cookies are signed with. The API refuses to start without one.
-# The compose file has a development default; change it before anybody else can
-# reach your instance. `openssl rand -base64 32` is a fine way to make one.
+# What session cookies are signed with. **REQUIRED** — there is no default in
+# the compose file any more, and the deployment refuses to start without one
+# rather than signing your sessions with a secret published in this repository.
+# `openssl rand -base64 32` is a fine way to make one.
 EGMA_AUTH_SECRET=
 
-# What connection credentials are encrypted with before they are stored: 32
-# random bytes written as 64 hex characters. `openssl rand -hex 32` makes one.
-# The compose file has a development default; change it before anybody else
-# can reach your instance. Back it up alongside the database — the stored
-# credentials are unrecoverable without it, and a backup of one without the
-# other is half a backup.
+# What connection credentials and this platform's own settings are sealed with
+# before they are stored: 32 random bytes written as 64 hex characters.
+# `openssl rand -hex 32` makes one.
+#
+# **REQUIRED**, and this is the one that most needed to be. It used to have a
+# development default in the compose file, which meant a deployment could seal
+# every provider key it holds with a key printed in a public repository and
+# nothing anywhere would say so. Back it up alongside the database — the stored
+# credentials and settings are unrecoverable without it, and a backup of one
+# without the other is half a backup.
 EGMA_ENCRYPTION_KEY=
 
-# Where a browser reaches this instance. The pages and the API answer on one
+# Where a browser reaches this instance. **REQUIRED**, and `egma self-host up`
+# sets it to the address it prints, so only a deployment driven by plain
+# `docker compose` has to state it here. The pages and the API answer on one
 # origin, so this is both of them, and it is always your own — nothing about
 # logging in reaches a domain egma runs.
 #
@@ -220,10 +250,12 @@ EGMA_SIMULATOR_CONTROL_PLANE_URL=http://api:3100
 # What the simulator shows the API to be allowed to claim work, sent as
 # `Authorization: Bearer`. One value, read by both containers, and the API
 # checks it on every claim — the answers carry your customers' live provider
-# credentials, so this door is never open. The compose file has a development
-# default; CHANGE IT before anybody else can reach your instance, because
-# port 3100 is published on the host and whoever holds this token is handed
-# those credentials. It must start with egma_st_ so scanners recognise a leak;
+# credentials, so this door is never open.
+#
+# **REQUIRED.** No default in the compose file: port 3100 is published on the
+# host, and whoever holds this token is handed those credentials, so a token
+# every reader of this repository knows is a door standing open. It must start
+# with egma_st_ so scanners recognise a leak;
 # `echo "egma_st_$(openssl rand -hex 32)"` makes one.
 EGMA_SIMULATOR_SERVICE_TOKEN=
 
@@ -292,11 +324,15 @@ EGMA_SIMULATOR_LIVEKIT_API_SECRET=
 # type it, and a pair that already exists is left alone so that preparing the
 # workspace again does not lock out a running deployment.
 #
-# There is deliberately no default here and none in docker-compose.yml. There
-# used to be one, written into a public repository, which nothing ever replaced
-# — so any deployment that widened EGMA_LIVEKIT_BIND was accepting anyone who
-# had read that repository. Set these two by hand only if you drive the compose
-# file without the egma CLI, and then treat them as secrets.
+# **REQUIRED**, and there is deliberately no default here and none in
+# docker-compose.yml. There used to be one, written into a public repository,
+# which nothing ever replaced — so any deployment that widened
+# EGMA_LIVEKIT_BIND was accepting anyone who had read that repository. Empty is
+# no longer quietly accepted either: `docker compose up` with neither of these
+# set refuses and names them, rather than starting a media server with no
+# password and a simulator that waits on it for ever. Set these two by hand
+# only if you drive the compose file without the egma CLI, and then treat them
+# as secrets.
 EGMA_LIVEKIT_API_KEY=
 EGMA_LIVEKIT_API_SECRET=
 

--- a/README.md
+++ b/README.md
@@ -637,12 +637,19 @@ both; point `TEST_DATABASE_URL` and `TEST_CLICKHOUSE_URL` somewhere else if you
 would rather use your own.
 
 **Contributing costs you no `.env`.** The stores' own users, databases and
-ports keep their defaults, so a fresh checkout runs `pnpm db:up` and then
-`pnpm test`. The deployment's REQUIRED secrets are a different matter — running
-the platform needs them, and starting two stores does not — so `pnpm db:up`
-hands Compose a placeholder for each and neither container ever reads one. See
-`packages/db/test/support/start-stores.ts`, which explains why that wrapper
-exists at all.
+ports keep their defaults, so a fresh checkout runs `pnpm db:up`, then
+`pnpm test`, then `pnpm db:down`. The deployment's REQUIRED secrets are a
+different matter — running the platform needs them, and operating two stores
+does not — so both of those scripts hand Compose a placeholder for each, and
+neither container ever reads one. See `packages/db/test/support/compose.ts`,
+which explains why the wrapper exists at all.
+
+**Plain `docker compose` in a checkout is a different story, and it should be.**
+Compose reads the whole file before it does anything — `ps` and `down` included
+— so every subcommand refuses until this deployment's ten REQUIRED values are
+set, which is right for a deployment and merely inconvenient in a checkout
+nobody runs the platform from. Use the two scripts above, or fill in `.env` and
+drive Compose directly the way a self-hoster does.
 
 The object store is real for the same reason and asks you for nothing. The
 handful of tests that need one start their own MinIO container, on a port of

--- a/README.md
+++ b/README.md
@@ -17,12 +17,30 @@ laptop that is often the same person, and the two directories are still
 separate, because one platform serves many repositories.
 
 ```bash
+cp .env.example .env      # then fill in the seven this command cannot make for you
 npx @egma/cli self-host up
 ```
 
 That starts the whole platform and prints the address an agent repository
 points at. Nobody runs a migration step, because there isn't one — the API
 applies its migrations while it boots.
+
+**The first step is not optional, and the deployment says so rather than
+guessing.** Ten values have no default anywhere, and `.env.example` marks every
+one REQUIRED. Three of them you never type — `egma self-host up` generates the
+media server's key and secret, and sets `EGMA_BASE_URL` to the address it
+prints. The other seven are yours: the key that seals every credential and
+setting you store, the secret that signs your sessions, the token a simulator
+claims work with, and the object store's two credential pairs. `openssl` makes
+each in a line, and `.env.example` gives the line.
+
+They lost their defaults because a default was the wrong answer. Each used to
+fall back to a value written in this repository, which every reader of it
+holds — so a deployment could seal its provider keys with a published key, sign
+its sessions with a published secret, and answer a claim for anybody who had
+read the source, and nothing anywhere said so. A start missing one now stops
+with that variable's name and how to make one, before a single container is
+created.
 
 The first `up` in a workspace also **generates the credential egma's media
 server, its simulator and its SIP gateway authenticate each other with**, and
@@ -42,14 +60,18 @@ platform's own database rather than in a file beside it, so a plain
 clone all bring the platform back configured. Nothing has to be set up again.
 
 **What a bare `docker compose up` does still lose is the media server's key and
-secret.** They are in `.egma-platform/platform.env`, nothing points compose at
-that file, and a container reads that pair when it is *created* — so it cannot
-come from the platform's database. The pair has no default anywhere, deliberately,
-so the media server refuses to start rather than run on a credential published in
-this repository. **That takes the simulator with it**, because the simulator
-waits for a healthy media server, and you are left with no simulator at all
-rather than merely no phone. `egma self-host up` reads the file and hands the
-pair over, which is why it is the way to start this platform.
+secret, and the address this platform answers as.** The first two are in
+`.egma-platform/platform.env`, nothing points compose at that file, and a
+container reads that pair when it is *created* — so it cannot come from the
+platform's database. The pair has no default anywhere, deliberately, so a
+deployment never runs on a credential published in this repository. `egma
+self-host up` reads the file, hands the pair over, and sets `EGMA_BASE_URL` to
+the address it prints, which is why it is the way to start this platform.
+
+Drive compose yourself and you supply those three, in `.env` like the rest.
+**Compose refuses and names the one it is missing** — it does not start a media
+server with no password and leave you with a simulator that waits for ever on a
+health check nothing will pass, which is what an empty value used to do.
 
 There is a second, smaller difference. `egma self-host up` waits for the
 platform to answer for itself, tells you what to type next, and tries once more
@@ -141,9 +163,18 @@ the container health checks poll.
 Ports, the two stores' credentials and the settings below come from the
 environment; see `.env.example` for the names and their defaults.
 
+**The division there is worth knowing.** What the deployment creates for itself
+— the two stores' own users and databases, every port, every bind — has a
+working default, so a self-hoster who sets none of them gets exactly the
+deployment this page documents. What the deployment *cannot* invent has no
+default at all: its own secrets, and its own address. Those are the ten marked
+REQUIRED in `.env.example`, and a start missing one of them is refused by name.
+Per-container tuning keeps its defaults too, because how many simulations one
+simulator takes at once is a property of your machine rather than of egma.
+
 **`EGMA_AUTH_SECRET` signs session cookies and the API refuses to start without
-one.** Compose supplies a development default so that `docker compose up` works
-out of the box. Change it before anybody else can reach your instance.
+one.** It has no default: one written into this repository is one every reader
+of it can mint a session with. `openssl rand -base64 32` makes one.
 
 **`EGMA_BASE_URL` is the whole address people reach this instance at, and
 nothing more than that** — scheme, host and port. It is what the pages, the
@@ -195,10 +226,13 @@ with a player that does nothing.
 **The store is published to this machine and no further**, and opening it is a
 decision rather than a default. What answers on that port is not only the
 recordings: it is the store's admin surface and its root credential, which can
-list, replace and delete every recording you hold — and this repository ships a
-development default for that credential, so on `0.0.0.0` a `docker compose up`
-on shared wifi hands every recording to the room, to read and to overwrite. A
-recording is evidence, and evidence somebody else can replace is not evidence.
+list, replace and delete every recording you hold — so on `0.0.0.0` a
+`docker compose up` on shared wifi hands every recording to the room, to read
+and to overwrite. A recording is evidence, and evidence somebody else can
+replace is not evidence. This repository used to ship a development default for
+that credential, which made the same sentence true on the machine's own network
+too; it has none now, and a deployment that states no credential of its own is
+refused at start.
 Loopback costs the default deployment nothing, because the default assumes the
 browser is on this machine. When it is not — a server, a colleague — set
 `EGMA_S3_BIND=0.0.0.0` and point `EGMA_BLOB_PUBLIC_URL` at the address those
@@ -221,9 +255,8 @@ an `amazonaws.com` address without one rather than signing everything for
 **`EGMA_SIMULATOR_SERVICE_TOKEN` is what the simulator shows the API to claim
 work, and the API refuses to start without one.** The answers to a claim carry
 your live provider credentials, and port 3100 is published on the host, so the
-check is always on. Compose supplies one development default to both
-containers so they match out of the box. Change it — one line in `.env` covers
-both — before anybody else can reach your instance:
+check is always on and there is no default. Both containers read the same
+variable, so one line in `.env` covers both and the two halves always match:
 `echo "egma_st_$(openssl rand -hex 32)"` makes one.
 
 Email is optional, and this is load-bearing rather than a convenience. See
@@ -602,6 +635,14 @@ database of its own in whichever store it uses and drops it afterwards, so
 `pnpm test` needs credentials that may create databases. `pnpm db:up` starts
 both; point `TEST_DATABASE_URL` and `TEST_CLICKHOUSE_URL` somewhere else if you
 would rather use your own.
+
+**Contributing costs you no `.env`.** The stores' own users, databases and
+ports keep their defaults, so a fresh checkout runs `pnpm db:up` and then
+`pnpm test`. The deployment's REQUIRED secrets are a different matter — running
+the platform needs them, and starting two stores does not — so `pnpm db:up`
+hands Compose a placeholder for each and neither container ever reads one. See
+`packages/db/test/support/start-stores.ts`, which explains why that wrapper
+exists at all.
 
 The object store is real for the same reason and asks you for nothing. The
 handful of tests that need one start their own MinIO container, on a port of

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -75,8 +75,10 @@ export type Config = {
    * service will not start: the claim answers carry customers' live provider
    * credentials, port 3100 is published on the host, and a claim door that
    * quietly served whoever asked would hand those credentials to the LAN.
-   * The compose file has a development default on the `EGMA_AUTH_SECRET`
-   * pattern, so `docker compose up` still works with zero setup.
+   * The compose file has no default for it, on the `EGMA_AUTH_SECRET` pattern:
+   * a token written into a public repository is a token every reader of it
+   * holds, so a deployment that states none is refused at start by name rather
+   * than started with a claim door the world already has the key to.
    */
   readonly simulatorServiceToken: string;
   /**

--- a/apps/api/test/deployment.test.ts
+++ b/apps/api/test/deployment.test.ts
@@ -159,10 +159,15 @@ describe("the API's deployment story", () => {
     // The one port in this file whose default bind is a security decision.
     // What answers on it is the store's admin surface and its *root*
     // credential — which can list, replace and delete every recording a
-    // deployment holds — and the development default for that credential is
-    // written in this repository. Bound to 0.0.0.0, `docker compose up` on a
-    // shared network hands every customer's recording to the room, to read and
-    // to overwrite. This product calls a recording evidence.
+    // deployment holds. Bound to 0.0.0.0, `docker compose up` on a shared
+    // network offers every customer's recording to the room, to read and to
+    // overwrite. This product calls a recording evidence.
+    //
+    // That credential no longer has a default written in this repository, so
+    // the wide bind is no longer a hole anybody can walk through from reading
+    // the source. The loopback default stays, because the two are one pair: a
+    // password is one mistake away from a wide port, and closing the port by
+    // default is the half that costs nothing.
     //
     // Held as a test rather than as the comment beside it, because a comment
     // does not close a port. The publishing itself is required — a browser has

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -48,7 +48,12 @@ import { credentialsFileIn, UnusableUrlError } from "../platform/credentials.ts"
 import { PlatformUnreachableError } from "../platform/device-flow.ts";
 import { normalizePlatformOrigin } from "../platform/identity.ts";
 import { signedInAt } from "../platform/signed-in.ts";
-import { compose, DockerMissingError, type ComposeOptions } from "../self-host/compose.ts";
+import {
+  compose,
+  DockerMissingError,
+  missingRequiredVariable,
+  type ComposeOptions,
+} from "../self-host/compose.ts";
 import {
   recordMediaCredential,
   MEDIA_SECRET_VARIABLE,
@@ -441,6 +446,24 @@ async function runUp(
   // fails once and works when you type the same thing again is a product that
   // taught its first user to distrust it.
   let started = await compose(["up", "-d", "--wait", "--wait-timeout", "300"], composeOptions);
+  // Asked before the retry, because the two failures look alike and want
+  // opposite answers. A missing bootstrap variable is refused while Compose is
+  // still reading the file — nothing was created, and a second attempt would
+  // invent no value the first one lacked — so it is reported by name here
+  // rather than dressed up as a store that would not start, which would send
+  // an operator reading container logs for a variable they never set.
+  const missing = missingRequiredVariable(started);
+  if (missing !== null) {
+    options.out("status: failed");
+    options.out(
+      `reason: ${missing} has no value, and this deployment deliberately has no ` +
+        "default for it. It is one of the secrets or addresses egma cannot invent " +
+        "for you, so nothing was started at all rather than started on a value " +
+        "published in this repository. Set it in .env in this workspace — the line " +
+        "above says what makes one — and run this again.",
+    );
+    return SELF_HOST_EXIT.refused;
+  }
   if (started.code !== 0) {
     options.fail(
       "one of the services did not come up on the first try. That is usual on a " +

--- a/apps/cli/src/self-host/compose.ts
+++ b/apps/cli/src/self-host/compose.ts
@@ -41,6 +41,32 @@ export class DockerMissingError extends Error {
   }
 }
 
+/**
+ * What Compose says when a variable the deployment description requires was
+ * not supplied.
+ *
+ * This deployment's own secrets and its own address have no defaults — a
+ * default for one of them is a value every reader of a public repository holds
+ * — so Compose refuses while it is still reading the file, before a container
+ * is created, and names the variable. That refusal is the whole point of the
+ * required form, and it must not be mistaken for a service that failed to
+ * start: nothing is half-done, no second attempt can help, and what the
+ * operator needs is the name.
+ */
+const REQUIRED_VARIABLE = /required variable ([A-Z0-9_]+) is missing a value/u;
+
+/**
+ * The first variable Compose refused for, or `null` where it refused for
+ * anything else.
+ *
+ * Both streams are read, because which one carries the line is Compose's
+ * business rather than a contract.
+ */
+export function missingRequiredVariable(result: ComposeResult): string | null {
+  if (result.code === 0) return null;
+  return REQUIRED_VARIABLE.exec(`${result.stderr}\n${result.stdout}`)?.[1] ?? null;
+}
+
 /** Run one `docker compose` subcommand in a workspace. */
 export async function compose(
   args: readonly string[],

--- a/apps/cli/test/self-host-up.test.ts
+++ b/apps/cli/test/self-host-up.test.ts
@@ -147,6 +147,43 @@ describe("egma self-host up", () => {
     }
   });
 
+  it("says which variable is missing, and does not try again for one", async () => {
+    // The other half of the retry above, and the reason the two have to be told
+    // apart. A bootstrap variable this deployment cannot invent — the key that
+    // seals every stored credential, the token a simulator claims with — has no
+    // default any more, so Compose refuses before it creates a container and
+    // names the one it is missing. A second attempt would invent nothing, and
+    // reporting it as a store's first boot would send an operator reading
+    // ClickHouse logs for a variable they never set.
+    const platform = await startPlatform();
+    const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);
+    await writeFile(
+      workspace.dockerShim,
+      `#!/bin/sh\necho "ARGS $@" >> "${workspace.callsFile}"\n` +
+        "echo 'error while interpolating services.api.environment.EGMA_ENCRYPTION_KEY: " +
+        "required variable EGMA_ENCRYPTION_KEY is missing a value: no default' >&2\n" +
+        "exit 1\n",
+    );
+    await chmod(workspace.dockerShim, 0o755);
+
+    try {
+      const run = await runSelfHost(workspace, ["up"], { EGMA_BASE_URL: platform.url });
+
+      expect(run.code).not.toBe(0);
+      expect(run.stdout).toContain("status: failed");
+      expect(run.stdout).toContain("EGMA_ENCRYPTION_KEY");
+      expect(run.stdout).toContain(".env");
+      // Compose's own sentence reached the operator too, because it carries
+      // what to do about that particular variable.
+      expect(run.stderr).toContain("required variable EGMA_ENCRYPTION_KEY");
+      expect(run.stderr).not.toContain("did not come up on the first try");
+      const said = await workspace.dockerCalls();
+      expect(said.match(/^ARGS compose up/gmu)).toHaveLength(1);
+    } finally {
+      await platform.close();
+    }
+  });
+
   it("refuses in a directory that is not a platform workspace", async () => {
     const notAWorkspace = await mkdtemp(path.join(tmpdir(), "egma-not-platform-"));
     const workspace = await makePlatformWorkspace(WORKSPACE_PREFIX);

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -319,7 +319,7 @@ workbench story and every contributor's checkout run.
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `EGMA_SIMULATOR_CONTROL_PLANE_URL` | (required) | Where to claim, heartbeat, and report. |
-| `EGMA_SIMULATOR_SERVICE_TOKEN` | (none) | Sent as `Authorization: Bearer` on every outbound call. The real control plane requires it and checks it against its own `EGMA_SIMULATOR_SERVICE_TOKEN` — under compose one development default reaches both sides, and changing it (once, in `.env`) before anybody else can reach the machine is part of deploying; the claim answers carry live provider credentials. The workbench asks for none. |
+| `EGMA_SIMULATOR_SERVICE_TOKEN` | (none) | Sent as `Authorization: Bearer` on every outbound call. The real control plane requires it and checks it against its own `EGMA_SIMULATOR_SERVICE_TOKEN` — under compose one variable reaches both sides and neither has a default, so a deployment states it once in `.env` and Compose refuses by name until it does; the claim answers carry live provider credentials. The workbench asks for none. |
 | `EGMA_SIMULATOR_CAPACITY` | `4` | Most simulations conducted at once. |
 | `EGMA_SIMULATOR_CLAIMANT` | `egma-simulator-<host>-<pid>` | The name stamped on claims. |
 | `EGMA_SIMULATOR_HEARTBEAT_SECONDS` | `5` | Beat interval per running simulation. |

--- a/apps/simulator/tests/test_deployment.py
+++ b/apps/simulator/tests/test_deployment.py
@@ -300,6 +300,14 @@ def test_no_development_media_credential_is_left_in_the_deployment_description()
     default is left in the files a self-hoster copies, and that all three
     containers read the same two variables, so no two of them can end up
     holding different halves of one password.
+
+    **The form this pair is read in changed once the bootstrap work landed.**
+    It used to be asserted as the silent-empty `${VAR:-}` — no default, which
+    was the whole of the fix at the time — and an empty value still started
+    the media server with no password and took the simulator down with it,
+    naming neither variable. It is the required `${VAR:?…}` now, so Compose
+    refuses and says which of the two is missing. The rest of the bootstrap
+    set is held to the same form below.
     """
     compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
     example = (ROOT / ".env.example").read_text(encoding="utf-8")
@@ -316,17 +324,234 @@ def test_no_development_media_credential_is_left_in_the_deployment_description()
         )
 
     for name in MEDIA_CREDENTIAL:
-        read = re.findall(rf"\$\{{{name}(:-[^}}]*)?\}}", compose)
+        read = interpolations(compose, name)
         assert len(read) == 3, (
             f"docker-compose.yml reads {name} {len(read)} time(s); the media "
             "server, the simulator and the SIP gateway all read it, and one "
             "of them left out is one container holding a different password"
         )
-        assert set(read) == {":-"}, (
-            f"{name} has a default in docker-compose.yml: {sorted(set(read))}. "
-            "This pair is generated per workspace and has no default; any "
-            "value written here is a credential the whole world already has"
+        assert set(read) == {":?"}, (
+            f"{name} does not use the required form in docker-compose.yml: "
+            f"{sorted(set(read))}. This pair is generated per workspace and "
+            "has no default anywhere; a value written here is a credential the "
+            "whole world already has, and an empty one is a media server that "
+            "starts on no password and a simulator that never starts at all"
         )
+
+
+REQUIRED_IN_THE_ENVIRONMENT = {
+    "EGMA_ENCRYPTION_KEY": (
+        "seals every stored credential and every platform setting. A default "
+        "is a deployment sealed with a key printed in a public repository, "
+        "which is not sealed"
+    ),
+    "EGMA_AUTH_SECRET": (
+        "signs browser sessions. A default is every reader of this repository "
+        "able to mint one"
+    ),
+    "EGMA_SIMULATOR_SERVICE_TOKEN": (
+        "is what a simulator shows to claim work, and a claim answer carries a "
+        "customer's live credentials to whoever holds it"
+    ),
+    "EGMA_LIVEKIT_API_KEY": "is half the password egma's own parts hold",
+    "EGMA_LIVEKIT_API_SECRET": "is the other half",
+    "EGMA_S3_ACCESS_KEY_ID": (
+        "opens the store every recording lives in, with rights to replace one"
+    ),
+    "EGMA_S3_SECRET_ACCESS_KEY": "is that credential's secret half",
+    "EGMA_S3_READ_ACCESS_KEY_ID": (
+        "is what playback links are signed with, and a leak of it reads every "
+        "recording a deployment holds"
+    ),
+    "EGMA_S3_READ_SECRET_ACCESS_KEY": "is that credential's secret half",
+    "EGMA_BASE_URL": (
+        "is the address this platform answers as, and every agent repository "
+        "binds to what it says"
+    ),
+}
+"""The bootstrap set: what a deployment must state before it may start.
+
+Each of these is a secret the deployment cannot invent, or the address it
+announces itself as. **Not one of them may have a default**, because a
+default here is a value every reader of this repository already holds — the
+finding that took the media pair's default away, one file wider.
+
+They are the required `${VAR:?…}` form, so an absent one stops Compose with
+the variable's name and what to do about it, rather than starting a platform
+that looks healthy and is not.
+
+What is deliberately **not** here is anything the deployment creates for
+itself. The stores' own users and databases, every port and every bind are
+values this file chooses and then uses consistently — a self-hoster who sets
+none of them gets the deployment the README documents, and the two binds
+default to loopback because that is a security decision this file makes
+rather than one it asks for. Per-container tuning is not here either, for
+the reason the spec gives: how many simulations one simulator takes at once
+is a property of the host, not of the deployment.
+
+**A store address is missing from this list on purpose, and is not
+unguarded.** `DATABASE_URL` and `CLICKHOUSE_URL` are what the API and the
+grader actually read, and this file builds each of them out of the store it
+starts beside them — so under Compose the address of a container this file
+creates cannot go missing. Both processes refuse to start without one and
+name it, which is what covers every other way of running them: a bare
+process, an override, somebody's managed Postgres. See the API's own
+configuration tests.
+"""
+
+MAY_BE_ABSENT = {
+    # The platform's own settings. They are seeded into the platform's store
+    # on boot for anything it does not already hold, and a platform holding
+    # none of them starts and reports `setup required` naming each one —
+    # which is the whole difference this effort made. Requiring them here
+    # would put readiness back behind carrier paperwork.
+    "EGMA_PERSONA_MODEL_PROVIDER": "seeded",
+    "EGMA_PERSONA_MODEL": "seeded",
+    "EGMA_PERSONA_MODEL_API_KEY": "seeded",
+    "EGMA_PERSONA_STT_PROVIDER": "seeded",
+    "EGMA_PERSONA_STT_API_KEY": "seeded",
+    "EGMA_PERSONA_TTS_PROVIDER": "seeded",
+    "EGMA_PERSONA_TTS_API_KEY": "seeded",
+    "EGMA_PERSONA_TTS_MODEL": "seeded",
+    "EGMA_PERSONA_TTS_VOICE": "seeded",
+    "EGMA_PERSONA_VAD_PROVIDER": "seeded",
+    "EGMA_MEDIA_BACKEND": "seeded",
+    "EGMA_PHONE_TRUNK_ADDRESS": "seeded",
+    "EGMA_PHONE_SOURCE_NUMBER": "seeded",
+    "EGMA_PHONE_TRUNK_USERNAME": "seeded",
+    "EGMA_PHONE_TRUNK_PASSWORD": "seeded",
+    # The default judge, which is a project's rather than the deployment's.
+    # All three or none, and none is an ordinary deployment: the
+    # deterministic graders judge for free either way.
+    "EGMA_JUDGE_PROVIDER": "a judge belongs to the project that chose it",
+    "EGMA_JUDGE_MODEL": "a judge belongs to the project that chose it",
+    "EGMA_JUDGE_API_KEY": "a judge belongs to the project that chose it",
+    # Mail, which is optional and load-bearing in being optional: with none,
+    # an invitation hands its link back to whoever sent it.
+    "EGMA_SMTP_URL": "optional by design",
+    "EGMA_MAIL_FROM": "optional by design",
+    # Per-container tuning. The spec puts these out of scope by name: how many
+    # simulations one simulator takes at once and how often the grader sweeps
+    # are properties of the host, not of the deployment.
+    "EGMA_SIMULATOR_CLAIMANT": "per-container tuning",
+    "EGMA_SIMULATOR_HEARTBEAT_SECONDS": "per-container tuning",
+    "EGMA_SIMULATOR_CLAIM_WAIT_SECONDS": "per-container tuning",
+    "EGMA_SIMULATOR_REPORT_DEADLINE_SECONDS": "per-container tuning",
+    "EGMA_GRADER_CLAIMANT": "per-container tuning",
+    "EGMA_GRADER_HEARTBEAT_SECONDS": "per-container tuning",
+    "EGMA_GRADER_LEASE_SECONDS": "per-container tuning",
+    "EGMA_GRADER_SWEEP_SECONDS": "per-container tuning",
+    "EGMA_GRADER_TRACE_IDLE_SECONDS": "per-container tuning",
+    # Facts about the network a container sits on rather than about the
+    # deployment, and each one's empty value is a real answer: egma's own
+    # default endpoint, egma's own default model, an address the server works
+    # out for itself.
+    "EGMA_SIMULATOR_MODEL_BASE_URL": "a property of this container's network",
+    "EGMA_SIMULATOR_STT_MODEL": "empty means egma's own default",
+    "EGMA_LIVEKIT_ADVERTISE_IP": "empty is right for every ordinary deployment",
+    "EGMA_LIVEKIT_SIP_EXTERNAL_IP": "empty means ask a STUN server",
+    # Empty is right for the MinIO this file runs, which ignores regions; the
+    # API refuses to start pointed at Amazon's own S3 without one.
+    "EGMA_S3_REGION": "empty is right for the store this file runs",
+}
+"""Every variable the deployment description may leave empty, and why.
+
+**This is the list the guard below is really about.** A variable written
+`${VAR:-}` is absent and empty at once, and nothing says so: the container
+starts, the health check passes, and the failure arrives minutes later as a
+provider or carrier refusal naming nothing about configuration. That was the
+original failure, and every setting in the deployment was written that way.
+
+So an empty default is now a decision somebody records here rather than a
+shape somebody reaches for. Each name above is one the platform, a project or
+the host answers for instead — never one a deployment needs in order to run.
+"""
+
+
+def interpolations(text: str, name: str) -> list[str]:
+    """How each `${NAME…}` in a compose file is written, in order.
+
+    One of `:-` (a default, silent when the default is empty), `:?` (required,
+    and the message after it is what Compose prints), or `}` for the bare
+    form. Enough to tell the three apart, which is the whole question here.
+    """
+    return re.findall(rf"\$\{{{re.escape(name)}(:-|:\?|\}})", text)
+
+
+@pytest.mark.parametrize("name", sorted(REQUIRED_IN_THE_ENVIRONMENT))
+def test_a_bootstrap_variable_refuses_to_start_the_platform_when_absent(name):
+    """The change that closes the original failure, held in the file it lives in.
+
+    A deployment started without one of these does not start at all, and
+    Compose names the variable and what to do about it. Before this, every one
+    of them had a default — a published development value, or nothing — so a
+    platform started any way but through the CLI came up hollow, reported
+    itself ready, and failed minutes later on the first simulation.
+    """
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    forms = interpolations(compose, name)
+    assert forms, (
+        f"docker-compose.yml never reads {name}, so no container can be given "
+        f"it: it {REQUIRED_IN_THE_ENVIRONMENT[name]}"
+    )
+    wrong = sorted({form for form in set(forms) if form != ":?"})
+    assert not wrong, (
+        f"{name} is read as {wrong} in docker-compose.yml rather than in the "
+        f"required ${{{name}:?…}} form. It {REQUIRED_IN_THE_ENVIRONMENT[name]}, "
+        "so a deployment that does not state it must be refused at start with "
+        "the variable's name — not started hollow and failed later by a "
+        "provider that names nothing about configuration"
+    )
+    for message in re.findall(rf"\$\{{{re.escape(name)}:\?([^}}]*)\}}", compose):
+        assert message.strip(), (
+            f"{name} is required with no message, so all a self-hoster is told "
+            "is the variable's name. Say what it is for and how to make one"
+        )
+
+
+def test_no_variable_in_the_deployment_description_has_a_silent_empty_default():
+    """The regression this whole seam exists for: a new bootstrap variable
+    written `${VAR:-}`.
+
+    That form is why the original failure was silent. It makes an absent
+    setting an empty setting, and an empty setting starts every container,
+    passes every health check, and reports the platform ready — so the first
+    anybody hears of it is a carrier refusal minutes later that names nothing
+    about configuration.
+
+    The guard is deliberately in this direction. Asserting that the ten
+    required variables are still required catches somebody undoing this work,
+    which is the unlikely half; nobody would notice a *new* variable arriving
+    with an empty default, which is exactly how this failure was built the
+    first time. So every empty default in the file has to be one of the ones
+    `MAY_BE_ABSENT` explains, and a name that is not there fails until
+    somebody writes down why the platform can run without it.
+    """
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    hollow = set(re.findall(r"\$\{([A-Z0-9_]+):-\}", compose))
+    unexplained = sorted(hollow - set(MAY_BE_ABSENT))
+    assert not unexplained, (
+        f"docker-compose.yml gives {unexplained} a silent empty default. An "
+        "absent one of those is an empty one, and nothing says so — every "
+        "container starts, every health check passes, and the platform reports "
+        "itself ready. Use the required ${VAR:?…} form and add it to "
+        "REQUIRED_IN_THE_ENVIRONMENT, or say in MAY_BE_ABSENT who answers for "
+        "it instead: the platform's own store, a project, or the host."
+    )
+
+
+def test_nothing_is_excused_that_no_longer_needs_excusing():
+    """The allow-list above tells a story about the file, and a story about a
+    variable that has moved on is a story nobody checks."""
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    hollow = set(re.findall(r"\$\{([A-Z0-9_]+):-\}", compose))
+    stale = sorted(set(MAY_BE_ABSENT) - hollow)
+    assert not stale, (
+        f"MAY_BE_ABSENT excuses {stale}, which docker-compose.yml no longer "
+        "leaves empty. Drop them, so the list stays the list of live decisions"
+    )
+    both = sorted(set(MAY_BE_ABSENT) & set(REQUIRED_IN_THE_ENVIRONMENT))
+    assert not both, f"{both} is called required and optional at once"
 
 
 OVERLAY_VARIABLE = re.compile(r"\$\{(EGMA_(?:LIVEKIT|WORKBENCH)_[A-Z0-9_]+)")

--- a/apps/simulator/tests/test_deployment.py
+++ b/apps/simulator/tests/test_deployment.py
@@ -24,6 +24,7 @@ them.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -324,18 +325,23 @@ def test_no_development_media_credential_is_left_in_the_deployment_description()
         )
 
     for name in MEDIA_CREDENTIAL:
-        read = interpolations(compose, name)
+        read = [
+            found
+            for found in interpolations(compose, "docker-compose.yml")
+            if found.name == name
+        ]
         assert len(read) == 3, (
             f"docker-compose.yml reads {name} {len(read)} time(s); the media "
             "server, the simulator and the SIP gateway all read it, and one "
             "of them left out is one container holding a different password"
         )
-        assert set(read) == {":?"}, (
+        forms = sorted({found.operator for found in read})
+        assert forms == [":?"], (
             f"{name} does not use the required form in docker-compose.yml: "
-            f"{sorted(set(read))}. This pair is generated per workspace and "
-            "has no default anywhere; a value written here is a credential the "
-            "whole world already has, and an empty one is a media server that "
-            "starts on no password and a simulator that never starts at all"
+            f"{forms}. This pair is generated per workspace and has no default "
+            "anywhere; a value written here is a credential the whole world "
+            "already has, and an empty one is a media server that starts on no "
+            "password and a simulator that never starts at all"
         )
 
 
@@ -451,8 +457,17 @@ MAY_BE_ABSENT = {
     "EGMA_LIVEKIT_ADVERTISE_IP": "empty is right for every ordinary deployment",
     "EGMA_LIVEKIT_SIP_EXTERNAL_IP": "empty means ask a STUN server",
     # Empty is right for the MinIO this file runs, which ignores regions; the
-    # API refuses to start pointed at Amazon's own S3 without one.
+    # API refuses to start pointed at Amazon's own S3 without one. The two
+    # beside it fall back to it, so their chains end empty as well — which is
+    # the same decision reached twice rather than a second one.
     "EGMA_S3_REGION": "empty is right for the store this file runs",
+    "EGMA_BLOB_REGION": "falls back to EGMA_S3_REGION, which may be empty",
+    "EGMA_SIMULATOR_S3_REGION": "falls back to EGMA_S3_REGION, which may be empty",
+    # The workbench overlay, which `docker compose up` does not start. Empty is
+    # the ordinary case and the useful one: every fixture is queued as written
+    # and the phone fixture dials an obvious placeholder, so setting this is
+    # what turns a demo into a real call rather than what makes one work.
+    "EGMA_WORKBENCH_PHONE_NUMBER": "empty queues every fixture as written",
 }
 """Every variable the deployment description may leave empty, and why.
 
@@ -468,14 +483,124 @@ the host answers for instead — never one a deployment needs in order to run.
 """
 
 
-def interpolations(text: str, name: str) -> list[str]:
-    """How each `${NAME…}` in a compose file is written, in order.
+SHIPPED_COMPOSE_FILES = ("docker-compose.yml", "docker-compose.workbench.yml")
+"""Every compose file this repository ships, which is what the guards read.
 
-    One of `:-` (a default, silent when the default is empty), `:?` (required,
-    and the message after it is what Compose prints), or `}` for the bare
-    form. Enough to tell the three apart, which is the whole question here.
+Named rather than globbed, and that is the difference between guarding the
+deployment and guarding somebody's laptop: `docker-compose.override.yml` is
+gitignored and belongs to whoever wrote it, so a developer's own override must
+not be able to fail this suite. What must not escape is anything a self-hoster
+receives from us — and the workbench overlay is one of those, which is why the
+guards below are not the deployment description alone.
+"""
+
+
+@dataclass(frozen=True)
+class Interpolation:
+    """One `${…}` in a compose file, read the way Compose reads it."""
+
+    name: str
+    where: str
+    #: `:-` `-` `:?` `?` `:+` `+`, or empty for a bare `${VAR}`.
+    operator: str
+    #: Whatever follows the operator — a default, a message, or an alternate.
+    tail: str
+    #: Whether an unset variable leaves this expression empty.
+    hollow: bool
+
+
+BODY = re.compile(r"([A-Z0-9_]+)(:-|-|:\?|\?|:\+|\+)?(.*)", re.DOTALL)
+ONE_EXPRESSION = re.compile(r"\A\$\{.*\}\Z", re.DOTALL)
+
+
+def interpolations(text: str, where: str = "") -> list[Interpolation]:
+    """Every `${…}` in some compose text, nested ones included.
+
+    Written as a scanner rather than as one regular expression because the
+    question is not what the text looks like — it is **what an unset variable
+    leaves behind**, and Compose answers that differently for six operators and
+    recursively for a default that is itself an expression. A pattern that
+    matched `${VAR:-}` and stopped would call `${VAR}`, `${VAR-}`, `${VAR:- }`
+    and `${NEW:-${OTHER:-}}` safe, and every one of those puts an empty string
+    into a container exactly as the original failure did.
+
+    So braces are counted, the body is split into name, operator and tail, and
+    the tail is read again — which is what makes a chain of defaults ending in
+    nothing a hollow variable rather than a clever one.
     """
-    return re.findall(rf"\$\{{{re.escape(name)}(:-|:\?|\}})", text)
+    found: list[Interpolation] = []
+    at = 0
+    while (start := text.find("${", at)) != -1:
+        depth, cursor = 0, start
+        while cursor < len(text):
+            if text.startswith("${", cursor):
+                depth += 1
+                cursor += 2
+                continue
+            if text[cursor] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            cursor += 1
+        if depth != 0:
+            break  # An unbalanced `${`: there is nothing more to read here.
+        at = cursor + 1
+        parsed = BODY.fullmatch(text[start + 2 : cursor])
+        if parsed is None:
+            continue  # Not a variable — compose files carry `$$` and `${1}`.
+        name, operator, tail = parsed.group(1), parsed.group(2) or "", parsed.group(3)
+        nested = interpolations(tail, where)
+        found.append(
+            Interpolation(
+                name=name,
+                where=where,
+                operator=operator,
+                tail=tail,
+                hollow=is_hollow(operator, tail, nested),
+            )
+        )
+        found.extend(nested)
+    return found
+
+
+def is_hollow(operator: str, tail: str, nested: list[Interpolation]) -> bool:
+    """Whether an unset variable leaves this expression empty.
+
+    - no operator — Compose warns and substitutes empty. A warning in a build
+      log is not a refusal, and the container starts either way.
+    - `:-` and `-` — empty when what follows them is empty, whitespace, or one
+      nested expression that is itself hollow. A chain of fallbacks ending in
+      nothing ends in nothing.
+    - `:+` and `+` — the alternate is used only when the variable is *set*, so
+      an unset one is empty by construction.
+    - `:?` and `?` — the required form, which is the only one that refuses.
+    """
+    if operator in ("", ":+", "+"):
+        return True
+    if operator in (":?", "?"):
+        return False
+    if tail.strip() == "":
+        return True
+    return (
+        ONE_EXPRESSION.fullmatch(tail.strip()) is not None
+        and len(nested) > 0
+        and nested[0].hollow
+    )
+
+
+def shipped_interpolations() -> list[Interpolation]:
+    """Every `${…}` in every compose file this repository ships."""
+    found: list[Interpolation] = []
+    for name in SHIPPED_COMPOSE_FILES:
+        found.extend(
+            interpolations((ROOT / name).read_text(encoding="utf-8"), name)
+        )
+    return found
+
+
+def hollow_variables() -> set[str]:
+    """Every variable some shipped compose file leaves empty when it is unset."""
+    return {read.name for read in shipped_interpolations() if read.hollow}
 
 
 @pytest.mark.parametrize("name", sorted(REQUIRED_IN_THE_ENVIRONMENT))
@@ -488,32 +613,44 @@ def test_a_bootstrap_variable_refuses_to_start_the_platform_when_absent(name):
     platform started any way but through the CLI came up hollow, reported
     itself ready, and failed minutes later on the first simulation.
     """
-    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
-    forms = interpolations(compose, name)
-    assert forms, (
-        f"docker-compose.yml never reads {name}, so no container can be given "
-        f"it: it {REQUIRED_IN_THE_ENVIRONMENT[name]}"
+    read = [found for found in shipped_interpolations() if found.name == name]
+    assert read, (
+        f"no compose file reads {name}, so no container can be given it: it "
+        f"{REQUIRED_IN_THE_ENVIRONMENT[name]}"
     )
-    wrong = sorted({form for form in set(forms) if form != ":?"})
+    wrong = sorted(
+        f"{found.where}:${{{name}{found.operator}…"
+        for found in read
+        if found.operator != ":?"
+    )
     assert not wrong, (
-        f"{name} is read as {wrong} in docker-compose.yml rather than in the "
-        f"required ${{{name}:?…}} form. It {REQUIRED_IN_THE_ENVIRONMENT[name]}, "
-        "so a deployment that does not state it must be refused at start with "
-        "the variable's name — not started hollow and failed later by a "
-        "provider that names nothing about configuration"
+        f"{name} is read as {wrong} rather than in the required "
+        f"${{{name}:?…}} form. It {REQUIRED_IN_THE_ENVIRONMENT[name]}, so a "
+        "deployment that does not state it must be refused at start with the "
+        "variable's name — not started hollow and failed later by a provider "
+        "that names nothing about configuration"
     )
-    for message in re.findall(rf"\$\{{{re.escape(name)}:\?([^}}]*)\}}", compose):
-        assert message.strip(), (
-            f"{name} is required with no message, so all a self-hoster is told "
-            "is the variable's name. Say what it is for and how to make one"
+    for found in read:
+        # What Compose prints after the variable's name, and the only sentence
+        # a self-hoster meeting this refusal gets. Two things are checked
+        # because two things are needed to act: where the value belongs, and
+        # how to come by one. A name alone sends somebody to read this file.
+        assert ".env" in found.tail, (
+            f"{name} is required without saying where the value goes. Name the "
+            f"file it belongs in; this one says {found.tail.strip()!r}"
+        )
+        assert "openssl" in found.tail or "egma self-host" in found.tail, (
+            f"{name} is required without saying how to come by a value. Name "
+            "the command that makes one, or the egma command that generates it; "
+            f"this one says {found.tail.strip()!r}"
         )
 
 
-def test_no_variable_in_the_deployment_description_has_a_silent_empty_default():
-    """The regression this whole seam exists for: a new bootstrap variable
-    written `${VAR:-}`.
+def test_no_variable_in_a_shipped_compose_file_is_hollow_when_it_is_absent():
+    """The regression this whole seam exists for: a new bootstrap variable that
+    is empty when nobody set it.
 
-    That form is why the original failure was silent. It makes an absent
+    That shape is why the original failure was silent. It makes an absent
     setting an empty setting, and an empty setting starts every container,
     passes every health check, and reports the platform ready — so the first
     anybody hears of it is a carrier refusal minutes later that names nothing
@@ -522,36 +659,60 @@ def test_no_variable_in_the_deployment_description_has_a_silent_empty_default():
     The guard is deliberately in this direction. Asserting that the ten
     required variables are still required catches somebody undoing this work,
     which is the unlikely half; nobody would notice a *new* variable arriving
-    with an empty default, which is exactly how this failure was built the
-    first time. So every empty default in the file has to be one of the ones
-    `MAY_BE_ABSENT` explains, and a name that is not there fails until
-    somebody writes down why the platform can run without it.
+    empty, which is exactly how this failure was built the first time. So every
+    hollow variable in every file we ship has to be one `MAY_BE_ABSENT`
+    explains, and a name that is not there fails until somebody writes down why
+    the platform can run without it.
+
+    `${VAR:-}` is only the commonest spelling of it. See `is_hollow` for the
+    others, each of which reaches a container as the same empty string.
     """
-    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
-    hollow = set(re.findall(r"\$\{([A-Z0-9_]+):-\}", compose))
-    unexplained = sorted(hollow - set(MAY_BE_ABSENT))
+    unexplained = sorted(hollow_variables() - set(MAY_BE_ABSENT))
     assert not unexplained, (
-        f"docker-compose.yml gives {unexplained} a silent empty default. An "
-        "absent one of those is an empty one, and nothing says so — every "
-        "container starts, every health check passes, and the platform reports "
-        "itself ready. Use the required ${VAR:?…} form and add it to "
-        "REQUIRED_IN_THE_ENVIRONMENT, or say in MAY_BE_ABSENT who answers for "
-        "it instead: the platform's own store, a project, or the host."
+        f"the compose files this repository ships leave {unexplained} empty "
+        "when nobody sets them. An absent one of those is an empty one, and "
+        "nothing says so — every container starts, every health check passes, "
+        "and the platform reports itself ready. Use the required ${VAR:?…} "
+        "form and add it to REQUIRED_IN_THE_ENVIRONMENT, or say in "
+        "MAY_BE_ABSENT who answers for it instead: the platform's own store, a "
+        "project, or the host."
     )
 
 
 def test_nothing_is_excused_that_no_longer_needs_excusing():
-    """The allow-list above tells a story about the file, and a story about a
-    variable that has moved on is a story nobody checks."""
-    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
-    hollow = set(re.findall(r"\$\{([A-Z0-9_]+):-\}", compose))
-    stale = sorted(set(MAY_BE_ABSENT) - hollow)
+    """The allow-list above tells a story about the files we ship, and a story
+    about a variable that has moved on is a story nobody checks."""
+    stale = sorted(set(MAY_BE_ABSENT) - hollow_variables())
     assert not stale, (
-        f"MAY_BE_ABSENT excuses {stale}, which docker-compose.yml no longer "
-        "leaves empty. Drop them, so the list stays the list of live decisions"
+        f"MAY_BE_ABSENT excuses {stale}, which no shipped compose file leaves "
+        "empty any more. Drop them, so the list stays the list of live decisions"
     )
     both = sorted(set(MAY_BE_ABSENT) & set(REQUIRED_IN_THE_ENVIRONMENT))
     assert not both, f"{both} is called required and optional at once"
+
+
+@pytest.mark.parametrize("name", sorted(REQUIRED_IN_THE_ENVIRONMENT))
+def test_env_example_supplies_no_value_for_a_variable_that_must_be_stated(name):
+    """The file the README tells everybody to copy may not answer for them.
+
+    A required variable with a value in `.env.example` is a required variable
+    in name only: the copy supplies it, the deployment starts, and nobody is
+    ever asked. `EGMA_BASE_URL` is the one that showed why this needs a guard
+    rather than care — a copied `http://localhost:3101` is correct on a laptop
+    and wrong on every deployment anybody else reaches, and wrong in the quiet
+    way, because the platform runs perfectly while every agent repository is
+    refused a directory away from the cause.
+    """
+    for line in (ROOT / ".env.example").read_text(encoding="utf-8").splitlines():
+        if not line.startswith(f"{name}="):
+            continue
+        assert line.strip() == f"{name}=", (
+            f".env.example answers {name} for the reader — the line is "
+            f"{line.strip()!r}. It has no default anywhere else on purpose, so "
+            "a value here is the default arriving by the one route nobody "
+            "checks: the file the README says to copy. Leave it empty and say "
+            "in the comment above it what to put there."
+        )
 
 
 OVERLAY_VARIABLE = re.compile(r"\$\{(EGMA_(?:LIVEKIT|WORKBENCH)_[A-Z0-9_]+)")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,13 +70,18 @@ services:
     environment:
       # The store's own root credential, and the one the simulator writes
       # with. Interpolated into both from one pair here so the two halves can
-      # never disagree — the same idiom the LiveKit key below uses. It is a
-      # development default like every other in this file: change it, once, in
-      # .env, before anybody else can reach the machine. MinIO refuses a root
-      # password under eight characters, so a short one fails loudly at `up`
-      # rather than quietly at the first recording.
-      MINIO_ROOT_USER: ${EGMA_S3_ACCESS_KEY_ID:-egma}
-      MINIO_ROOT_PASSWORD: ${EGMA_S3_SECRET_ACCESS_KEY:-egma-development-only-object-storage-secret-change-it}
+      # never disagree — the same idiom the LiveKit key below uses.
+      #
+      # **It has no default, and that is the point.** It used to be a
+      # development pair written in this file, in a public repository, and
+      # what it opens is the admin surface of the store every recording lives
+      # in — rights to list, replace and delete a customer's call audio. A
+      # deployment must state its own, and one that states none is refused at
+      # `up` with the variable's name rather than started on a password every
+      # reader of this repository holds. MinIO refuses a root password under
+      # eight characters, so a short one fails at `up` too.
+      MINIO_ROOT_USER: ${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential, set it in .env}
+      MINIO_ROOT_PASSWORD: ${EGMA_S3_SECRET_ACCESS_KEY:?no default — at least 8 characters, set it in .env}
     volumes:
       - minio-data:/data
     ports:
@@ -104,23 +109,31 @@ services:
       # server's idiom above and for a sharper version of its reason. What
       # answers on this port is not only the recordings: it is the store's
       # admin surface and its *root* credential, which can list, replace and
-      # delete every recording a deployment holds — and the development default
-      # for that credential is written in this repository, where anybody can
-      # read it. On 0.0.0.0 that is `docker compose up` on a coffee-shop
-      # network handing every customer's recording to the room, to read and to
-      # overwrite. This product calls a recording evidence, and evidence
-      # somebody else can replace is not evidence.
+      # delete every recording a deployment holds. On 0.0.0.0 that is
+      # `docker compose up` on a coffee-shop network offering every customer's
+      # recording to the room, to read and to overwrite. This product calls a
+      # recording evidence, and evidence somebody else can replace is not
+      # evidence.
       #
-      # The default costs the default deployment nothing, because
+      # That credential used to have a development default written in this
+      # repository, where anybody could read it, which made the paragraph above
+      # true on the machine's own network too. It has none now — see the store
+      # above — so what stands between a wide bind and a stranger is a password
+      # this deployment chose. The bind stays loopback all the same: a
+      # credential is one mistake away from a wide port, and this is the cheap
+      # half of that pair.
+      #
+      # The loopback bind costs the default deployment nothing, because
       # EGMA_BLOB_PUBLIC_URL defaults to `http://localhost:9000` — a browser on
       # this machine, which is the deployment this file is written for.
       #
       # **Opening it is one variable, and it is a real decision.** A deployment
       # whose browsers are somewhere else — a server, a colleague's laptop —
       # sets `EGMA_S3_BIND=0.0.0.0` and sets EGMA_BLOB_PUBLIC_URL to the
-      # address those browsers use. Change EGMA_S3_SECRET_ACCESS_KEY *first*:
-      # widening the bind without it is the one step in this file that hands a
-      # published, writable store to whoever can route to the machine.
+      # address those browsers use. What that then offers the network is a
+      # writable store behind the credential above, so it is worth having
+      # chosen that one deliberately rather than typed the shortest thing that
+      # got `up` to stop complaining.
       #
       # **EGMA_BLOB_PUBLIC_URL on the api service must name this address**, and
       # naming the wrong one is the single most common way a self-hosted object
@@ -176,15 +189,16 @@ services:
   minio-bucket:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
-      EGMA_S3_ACCESS_KEY_ID: ${EGMA_S3_ACCESS_KEY_ID:-egma}
-      EGMA_S3_SECRET_ACCESS_KEY: ${EGMA_S3_SECRET_ACCESS_KEY:-egma-development-only-object-storage-secret-change-it}
+      EGMA_S3_ACCESS_KEY_ID: ${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential, set it in .env}
+      EGMA_S3_SECRET_ACCESS_KEY: ${EGMA_S3_SECRET_ACCESS_KEY:?no default — at least 8 characters, set it in .env}
       EGMA_S3_BUCKET: ${EGMA_S3_BUCKET:-egma-recordings}
       # The read-only half, interpolated into the api service below from the
-      # same pair so the two can never disagree. A development default like
-      # every other in this file: change it, once, in .env, before anybody else
-      # can reach the machine.
-      EGMA_S3_READ_ACCESS_KEY_ID: ${EGMA_S3_READ_ACCESS_KEY_ID:-egma-read}
-      EGMA_S3_READ_SECRET_ACCESS_KEY: ${EGMA_S3_READ_SECRET_ACCESS_KEY:-egma-development-only-read-only-secret-change-it}
+      # same pair so the two can never disagree. It has no default for the
+      # reason the root pair above has none: a credential written in a public
+      # repository is a credential every reader of it holds, and this one
+      # reads every recording a deployment has.
+      EGMA_S3_READ_ACCESS_KEY_ID: ${EGMA_S3_READ_ACCESS_KEY_ID:?no default — the read-only credential playback links are signed with, set it in .env}
+      EGMA_S3_READ_SECRET_ACCESS_KEY: ${EGMA_S3_READ_SECRET_ACCESS_KEY:?no default — set it in .env beside EGMA_S3_READ_ACCESS_KEY_ID}
     # Everything reaches `mc` through the environment rather than as arguments,
     # and `$$` is an escaped `$`: compose leaves it alone and the shell inside
     # the container reads it.
@@ -229,24 +243,32 @@ services:
       CLICKHOUSE_URL: http://${CLICKHOUSE_USER:-egma}:${CLICKHOUSE_PASSWORD:-egma}@clickhouse:8123/${CLICKHOUSE_DB:-egma}
       HOST: 0.0.0.0
       PORT: "3100"
-      # Signs session cookies. The default is a development one and every
-      # instance that anybody else can reach needs its own; see .env.example.
-      EGMA_AUTH_SECRET: ${EGMA_AUTH_SECRET:-development-only-change-this-before-anybody-else-can-reach-it}
-      # Seals connection credentials before they reach the database. The
-      # default is a development one and every instance that anybody else can
-      # reach needs its own — `openssl rand -hex 32` makes one. Back it up
-      # alongside the database; losing it loses every stored credential.
-      EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
+      # Signs session cookies. No default — one written here is one every
+      # reader of this repository can mint a session with. `openssl rand
+      # -base64 32` makes one; see .env.example.
+      EGMA_AUTH_SECRET: ${EGMA_AUTH_SECRET:?no default — openssl rand -base64 32 makes one, set it in .env}
+      # Seals connection credentials and every platform setting before they
+      # reach the database. No default, and this is the sharpest of the three:
+      # a deployment sealed with a key printed in a public repository is not
+      # sealed, and a copy of its database is a copy of its provider accounts.
+      # `openssl rand -hex 32` makes one. Back it up alongside the database;
+      # losing it loses every stored credential and every stored setting.
+      EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:?no default — openssl rand -hex 32 makes one, set it in .env and back it up beside the database}
       # What the simulator must show to claim work. Claim answers carry
       # customers' live connection credentials and port 3100 is published on
-      # this machine, so the check is always on: the default is a development
-      # one, interpolated identically into the simulator below so the two
-      # halves always match, and every instance that anybody else can reach
-      # needs its own — egma_st_ then `openssl rand -hex 32`.
-      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:-egma_st_development-only-change-this-before-anybody-else-can-reach-it}
+      # this machine, so the check is always on and there is no default: it is
+      # interpolated identically into the simulator below, so one line in .env
+      # sets both halves and they always match. egma_st_ then `openssl rand
+      # -hex 32` makes one.
+      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:?no default — egma_st_ then openssl rand -hex 32, set it in .env for both containers}
       # Where a browser reaches this instance. The pages and the API answer on
-      # one origin, and that origin is the self-hoster's own.
-      EGMA_BASE_URL: ${EGMA_BASE_URL:-http://localhost:3101}
+      # one origin, and that origin is the self-hoster's own — which is why
+      # there is no default for it to quietly be wrong about. Every agent
+      # repository binds to what this says, and an instance others reach at
+      # 192.168.1.10 while this says localhost refuses their first command
+      # rather than answering it about somebody else's machine. `egma
+      # self-host up` sets this to the address it prints.
+      EGMA_BASE_URL: ${EGMA_BASE_URL:?no default — the whole address a browser reaches egma at, scheme host and port, set it in .env}
       # Where **a browser** reaches the recording store, which is not where this
       # container reaches it. Beside EGMA_BASE_URL because it is the same kind
       # of fact and gets set at the same moment: an egma other people reach at
@@ -295,8 +317,8 @@ services:
       # cannot delete and cannot list, so a leak of it reads a recording rather
       # than replacing one. A deployment pointed at somebody else's S3 sets
       # these two directly and gives that credential the same shape.
-      EGMA_BLOB_ACCESS_KEY_ID: ${EGMA_BLOB_ACCESS_KEY_ID:-${EGMA_S3_READ_ACCESS_KEY_ID:-egma-read}}
-      EGMA_BLOB_SECRET_ACCESS_KEY: ${EGMA_BLOB_SECRET_ACCESS_KEY:-${EGMA_S3_READ_SECRET_ACCESS_KEY:-egma-development-only-read-only-secret-change-it}}
+      EGMA_BLOB_ACCESS_KEY_ID: ${EGMA_BLOB_ACCESS_KEY_ID:-${EGMA_S3_READ_ACCESS_KEY_ID:?no default — the read-only credential playback links are signed with, set it in .env}}
+      EGMA_BLOB_SECRET_ACCESS_KEY: ${EGMA_BLOB_SECRET_ACCESS_KEY:-${EGMA_S3_READ_SECRET_ACCESS_KEY:?no default — set it in .env beside EGMA_S3_READ_ACCESS_KEY_ID}}
       EGMA_SINGLE_ORGANIZATION: ${EGMA_SINGLE_ORGANIZATION:-true}
       EGMA_TRUST_PROXY: ${EGMA_TRUST_PROXY:-false}
       # The budget belongs to the organization rather than to a key, so
@@ -425,10 +447,10 @@ services:
       EGMA_SIMULATOR_CONTROL_PLANE_URL: ${EGMA_SIMULATOR_CONTROL_PLANE_URL:-http://api:3100}
       # What it shows the control plane to be allowed to claim, as a bearer
       # — the same header an egma key uses everywhere else. The API checks it
-      # on every claim, so this interpolates the same development default as
-      # the api service above and the two halves always match. Change it —
-      # once, in .env, for both — before anybody else can reach the machine.
-      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:-egma_st_development-only-change-this-before-anybody-else-can-reach-it}
+      # on every claim, so this reads the same variable as the api service
+      # above and the two halves always match. It has no default there and
+      # none here: one line in .env sets both.
+      EGMA_SIMULATOR_SERVICE_TOKEN: ${EGMA_SIMULATOR_SERVICE_TOKEN:?no default — egma_st_ then openssl rand -hex 32, set it in .env for both containers}
       # How many simulations one simulator conducts at once. It claims only
       # what it has room for, so a big run degrades to a queue rather than
       # to overload — raise this, or start a second simulator, and they
@@ -469,8 +491,8 @@ services:
       # carrier starts exactly as it always did, and platform readiness
       # never waits on carrier setup.
       EGMA_SIMULATOR_LIVEKIT_URL: ${EGMA_SIMULATOR_LIVEKIT_URL:-ws://livekit:7880}
-      EGMA_SIMULATOR_LIVEKIT_API_KEY: ${EGMA_SIMULATOR_LIVEKIT_API_KEY:-${EGMA_LIVEKIT_API_KEY:-}}
-      EGMA_SIMULATOR_LIVEKIT_API_SECRET: ${EGMA_SIMULATOR_LIVEKIT_API_SECRET:-${EGMA_LIVEKIT_API_SECRET:-}}
+      EGMA_SIMULATOR_LIVEKIT_API_KEY: ${EGMA_SIMULATOR_LIVEKIT_API_KEY:-${EGMA_LIVEKIT_API_KEY:?no default anywhere — egma self-host up generates this pair and writes it to .egma-platform/platform.env}}
+      EGMA_SIMULATOR_LIVEKIT_API_SECRET: ${EGMA_SIMULATOR_LIVEKIT_API_SECRET:-${EGMA_LIVEKIT_API_SECRET:?no default anywhere — egma self-host up generates this pair and writes it to .egma-platform/platform.env}}
       # Where recordings go. Naming an endpoint is the whole of what sends
       # them to object storage; naming none keeps them in a directory on
       # whatever disk the process is running on, which is what a bare
@@ -494,8 +516,8 @@ services:
       # above is stood up with so the two halves always match. A
       # deployment pointed at somebody else's S3 sets these two directly
       # and leaves the store above unused.
-      EGMA_SIMULATOR_S3_ACCESS_KEY_ID: ${EGMA_SIMULATOR_S3_ACCESS_KEY_ID:-${EGMA_S3_ACCESS_KEY_ID:-egma}}
-      EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY: ${EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY:-${EGMA_S3_SECRET_ACCESS_KEY:-egma-development-only-object-storage-secret-change-it}}
+      EGMA_SIMULATOR_S3_ACCESS_KEY_ID: ${EGMA_SIMULATOR_S3_ACCESS_KEY_ID:-${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential, set it in .env}}
+      EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY: ${EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY:-${EGMA_S3_SECRET_ACCESS_KEY:?no default — at least 8 characters, set it in .env}}
       # The volume below, and the one thing kept on it. The write-ahead
       # log is the only record of a report that never got through, so
       # losing it to a container being replaced would lose a simulation's
@@ -574,14 +596,15 @@ services:
       # judge key is resolved through one door that refuses every caller whose
       # context did not come from a grading claim, and a connection's
       # credentials sit behind a door asking for a permission the engine's
-      # context does not carry. Leave it unset for a deployment whose projects
-      # configure no judge — the deterministic graders judge for free either
-      # way, and a project that did configure one gets `errored` verdicts saying
-      # the key could not be read rather than a silent green tick.
+      # context does not carry. It is the same variable the api service reads
+      # and it has no default on either — one line in .env, and the two
+      # processes open the same envelopes. A deployment whose projects
+      # configure no judge still needs it, because the platform's own settings
+      # are sealed with it too.
       #
       # There is still deliberately no model key here. A judge belongs to the
       # project that configured it, never to a container.
-      EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
+      EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:?no default — openssl rand -hex 32 makes one, set it in .env and back it up beside the database}
       # This copy's own name for itself, in claims and in its log. Unset is
       # fine and usual — it names itself after its host and process, which is
       # what tells two copies apart.
@@ -698,10 +721,15 @@ services:
   # machine was accepting anyone who had read the repository. `egma
   # self-host` now generates a pair for the workspace and hands the same
   # one to this server, the simulator and the gateway below.
+  #
+  # It is the *required* form rather than merely a missing default, which is
+  # the difference between a refusal and a puzzle. Empty, this server started
+  # on no password at all, the simulator waiting on its health check never
+  # started either, and nothing in either log named a variable.
   livekit:
     image: livekit/livekit-server:v1.13.5
     environment:
-      LIVEKIT_KEYS: "${EGMA_LIVEKIT_API_KEY:-}: ${EGMA_LIVEKIT_API_SECRET:-}"
+      LIVEKIT_KEYS: "${EGMA_LIVEKIT_API_KEY:?no default anywhere — egma self-host up generates this pair and writes it to .egma-platform/platform.env}: ${EGMA_LIVEKIT_API_SECRET:?no default anywhere — egma self-host up generates this pair and writes it to .egma-platform/platform.env}"
       LIVEKIT_CONFIG: |
         port: 7880
         rtc:
@@ -757,8 +785,8 @@ services:
       SIP_CONFIG_BODY: |
         # The generated pair, the same one the media server and the
         # simulator hold. No default, for the reason stated above it.
-        api_key: ${EGMA_LIVEKIT_API_KEY:-}
-        api_secret: ${EGMA_LIVEKIT_API_SECRET:-}
+        api_key: ${EGMA_LIVEKIT_API_KEY:?no default anywhere — egma self-host up generates this pair and writes it to .egma-platform/platform.env}
+        api_secret: ${EGMA_LIVEKIT_API_SECRET:?no default anywhere — egma self-host up generates this pair and writes it to .egma-platform/platform.env}
         ws_url: ws://livekit:7880
         redis:
           address: livekit-redis:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,23 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-egma}
       POSTGRES_DB: ${POSTGRES_DB:-egma}
     ports:
-      - "${POSTGRES_PORT:-5433}:5432"
+      # **Published to this machine and no further**, which is the object
+      # store's idiom below and the media server's, for the same reason and a
+      # blunter version of it. What answers here is every row this platform
+      # holds — organizations, keys, and the sealed settings this effort just
+      # moved into the database — and the user and password it answers to are
+      # written a few lines above, in a public repository. On 0.0.0.0 that is
+      # `docker compose up` on a coffee-shop network offering every customer's
+      # data to the room.
+      #
+      # A default is right for these two where it was wrong for the secrets,
+      # because this file creates the container it names them for: the value is
+      # consistent with itself, and a self-hoster who sets nothing gets the
+      # deployment the README documents. What the default must not also do is
+      # carry that consistency onto the network, so the bind closes the door
+      # the published pair would otherwise open. Widen it deliberately — and
+      # set POSTGRES_PASSWORD in the same breath.
+      - "${POSTGRES_BIND:-127.0.0.1}:${POSTGRES_PORT:-5433}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql
     healthcheck:
@@ -29,7 +45,11 @@ services:
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-egma}
       CLICKHOUSE_DB: ${CLICKHOUSE_DB:-egma}
     ports:
-      - "${CLICKHOUSE_PORT:-8124}:8123"
+      # Loopback by default, for the reason Postgres beside it is: the user and
+      # password this store answers to are published in this repository, and
+      # what it holds is every conversation this platform has ever recorded a
+      # trace of. See the paragraph on the Postgres port.
+      - "${CLICKHOUSE_BIND:-127.0.0.1}:${CLICKHOUSE_PORT:-8124}:8123"
     volumes:
       - clickhouse-data:/var/lib/clickhouse
     # No `ulimits` here on purpose. ClickHouse wants far more descriptors than
@@ -80,8 +100,8 @@ services:
       # `up` with the variable's name rather than started on a password every
       # reader of this repository holds. MinIO refuses a root password under
       # eight characters, so a short one fails at `up` too.
-      MINIO_ROOT_USER: ${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential, set it in .env}
-      MINIO_ROOT_PASSWORD: ${EGMA_S3_SECRET_ACCESS_KEY:?no default — at least 8 characters, set it in .env}
+      MINIO_ROOT_USER: ${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential. openssl rand -hex 8 makes one, set it in .env}
+      MINIO_ROOT_PASSWORD: ${EGMA_S3_SECRET_ACCESS_KEY:?no default — openssl rand -base64 24 makes one, at least 8 characters, set it in .env}
     volumes:
       - minio-data:/data
     ports:
@@ -189,16 +209,16 @@ services:
   minio-bucket:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
-      EGMA_S3_ACCESS_KEY_ID: ${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential, set it in .env}
-      EGMA_S3_SECRET_ACCESS_KEY: ${EGMA_S3_SECRET_ACCESS_KEY:?no default — at least 8 characters, set it in .env}
+      EGMA_S3_ACCESS_KEY_ID: ${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential. openssl rand -hex 8 makes one, set it in .env}
+      EGMA_S3_SECRET_ACCESS_KEY: ${EGMA_S3_SECRET_ACCESS_KEY:?no default — openssl rand -base64 24 makes one, at least 8 characters, set it in .env}
       EGMA_S3_BUCKET: ${EGMA_S3_BUCKET:-egma-recordings}
       # The read-only half, interpolated into the api service below from the
       # same pair so the two can never disagree. It has no default for the
       # reason the root pair above has none: a credential written in a public
       # repository is a credential every reader of it holds, and this one
       # reads every recording a deployment has.
-      EGMA_S3_READ_ACCESS_KEY_ID: ${EGMA_S3_READ_ACCESS_KEY_ID:?no default — the read-only credential playback links are signed with, set it in .env}
-      EGMA_S3_READ_SECRET_ACCESS_KEY: ${EGMA_S3_READ_SECRET_ACCESS_KEY:?no default — set it in .env beside EGMA_S3_READ_ACCESS_KEY_ID}
+      EGMA_S3_READ_ACCESS_KEY_ID: ${EGMA_S3_READ_ACCESS_KEY_ID:?no default — the read-only credential playback links are signed with. openssl rand -hex 8 makes one, set it in .env}
+      EGMA_S3_READ_SECRET_ACCESS_KEY: ${EGMA_S3_READ_SECRET_ACCESS_KEY:?no default — openssl rand -base64 24 makes one, set it in .env beside EGMA_S3_READ_ACCESS_KEY_ID}
     # Everything reaches `mc` through the environment rather than as arguments,
     # and `$$` is an escaped `$`: compose leaves it alone and the shell inside
     # the container reads it.
@@ -268,7 +288,7 @@ services:
       # 192.168.1.10 while this says localhost refuses their first command
       # rather than answering it about somebody else's machine. `egma
       # self-host up` sets this to the address it prints.
-      EGMA_BASE_URL: ${EGMA_BASE_URL:?no default — the whole address a browser reaches egma at, scheme host and port, set it in .env}
+      EGMA_BASE_URL: ${EGMA_BASE_URL:?no default — the whole address a browser reaches egma at, scheme host and port. egma self-host up sets it for you, or set it in .env}
       # Where **a browser** reaches the recording store, which is not where this
       # container reaches it. Beside EGMA_BASE_URL because it is the same kind
       # of fact and gets set at the same moment: an egma other people reach at
@@ -317,8 +337,8 @@ services:
       # cannot delete and cannot list, so a leak of it reads a recording rather
       # than replacing one. A deployment pointed at somebody else's S3 sets
       # these two directly and gives that credential the same shape.
-      EGMA_BLOB_ACCESS_KEY_ID: ${EGMA_BLOB_ACCESS_KEY_ID:-${EGMA_S3_READ_ACCESS_KEY_ID:?no default — the read-only credential playback links are signed with, set it in .env}}
-      EGMA_BLOB_SECRET_ACCESS_KEY: ${EGMA_BLOB_SECRET_ACCESS_KEY:-${EGMA_S3_READ_SECRET_ACCESS_KEY:?no default — set it in .env beside EGMA_S3_READ_ACCESS_KEY_ID}}
+      EGMA_BLOB_ACCESS_KEY_ID: ${EGMA_BLOB_ACCESS_KEY_ID:-${EGMA_S3_READ_ACCESS_KEY_ID:?no default — the read-only credential playback links are signed with. openssl rand -hex 8 makes one, set it in .env}}
+      EGMA_BLOB_SECRET_ACCESS_KEY: ${EGMA_BLOB_SECRET_ACCESS_KEY:-${EGMA_S3_READ_SECRET_ACCESS_KEY:?no default — openssl rand -base64 24 makes one, set it in .env beside EGMA_S3_READ_ACCESS_KEY_ID}}
       EGMA_SINGLE_ORGANIZATION: ${EGMA_SINGLE_ORGANIZATION:-true}
       EGMA_TRUST_PROXY: ${EGMA_TRUST_PROXY:-false}
       # The budget belongs to the organization rather than to a key, so
@@ -516,8 +536,8 @@ services:
       # above is stood up with so the two halves always match. A
       # deployment pointed at somebody else's S3 sets these two directly
       # and leaves the store above unused.
-      EGMA_SIMULATOR_S3_ACCESS_KEY_ID: ${EGMA_SIMULATOR_S3_ACCESS_KEY_ID:-${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential, set it in .env}}
-      EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY: ${EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY:-${EGMA_S3_SECRET_ACCESS_KEY:?no default — at least 8 characters, set it in .env}}
+      EGMA_SIMULATOR_S3_ACCESS_KEY_ID: ${EGMA_SIMULATOR_S3_ACCESS_KEY_ID:-${EGMA_S3_ACCESS_KEY_ID:?no default — the recording store's own credential. openssl rand -hex 8 makes one, set it in .env}}
+      EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY: ${EGMA_SIMULATOR_S3_SECRET_ACCESS_KEY:-${EGMA_S3_SECRET_ACCESS_KEY:?no default — openssl rand -base64 24 makes one, at least 8 characters, set it in .env}}
       # The volume below, and the one thing kept on it. The write-ahead
       # log is the only record of a report that never got through, so
       # losing it to a container being replaced would lose a simulation's

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "pnpm build && tsc -p tsconfig.tests.json && pnpm --filter @egma/web typecheck",
     "clean": "tsc -b --clean packages/ids packages/db packages/lint apps/api apps/grader apps/cli",
     "db:up": "node packages/db/test/support/start-stores.ts && node packages/db/test/support/sweep-stale-databases.ts",
-    "db:down": "docker compose down",
+    "db:down": "node packages/db/test/support/stop-stores.ts",
     "db:generate": "pnpm --filter @egma/db generate",
     "test": "pnpm db:up && { vitest run; ts=$?; pnpm test:simulator; sim=$?; pnpm test:sdk; sdk=$?; pnpm test:fixture; fix=$?; exit $(( ts || sim || sdk || fix )); }",
     "test:simulator": "pnpm --filter @egma/simulator test",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "pnpm lint && tsc -b packages/ids packages/db packages/lint apps/api apps/grader apps/cli",
     "typecheck": "pnpm build && tsc -p tsconfig.tests.json && pnpm --filter @egma/web typecheck",
     "clean": "tsc -b --clean packages/ids packages/db packages/lint apps/api apps/grader apps/cli",
-    "db:up": "docker compose up -d --wait postgres clickhouse && node packages/db/test/support/sweep-stale-databases.ts",
+    "db:up": "node packages/db/test/support/start-stores.ts && node packages/db/test/support/sweep-stale-databases.ts",
     "db:down": "docker compose down",
     "db:generate": "pnpm --filter @egma/db generate",
     "test": "pnpm db:up && { vitest run; ts=$?; pnpm test:simulator; sim=$?; pnpm test:sdk; sdk=$?; pnpm test:fixture; fix=$?; exit $(( ts || sim || sdk || fix )); }",

--- a/packages/db/test/support/compose.ts
+++ b/packages/db/test/support/compose.ts
@@ -1,0 +1,95 @@
+/**
+ * Driving this repository's compose file from a developer command.
+ *
+ * One wrapper, for one reason, and it is a property of Compose rather than of
+ * egma: **Compose interpolates the entire file before it looks at which
+ * services you named, and before it does anything at all.** So a variable the
+ * api service requires has to resolve for `docker compose up postgres`, for
+ * `docker compose down`, and even for `docker compose ps` — and a contributor
+ * who has never written a `.env` would meet
+ * `required variable EGMA_ENCRYPTION_KEY is missing a value` on their way to
+ * running the tests, or to stopping the two containers they started.
+ *
+ * That refusal is the point everywhere else. This deployment's own secrets have
+ * no defaults any more — a default is a value every reader of a public
+ * repository holds — so `docker compose up` refuses and names what is missing
+ * rather than starting a platform sealed with a published key. See
+ * `.env.example`, and the deployment test that holds the rule.
+ *
+ * But operating the two stores a test suite needs is not operating the
+ * platform. Neither container reads one of the values below: they read
+ * `POSTGRES_*` and `CLICKHOUSE_*`, which keep their defaults precisely so that
+ * a checkout costs a contributor no configuration at all. So the placeholders
+ * here satisfy the interpolation and reach nothing — no container is created
+ * with one, and none is a value anybody should ever hold.
+ *
+ * **They are placed under the real environment rather than over it**, so a
+ * developer who exported a real one keeps it. A value in a `.env` file does
+ * lose to these, and that is harmless for the same reason: the two stores read
+ * none of them, and their own configuration — user, password, database, port,
+ * bind — is untouched, so this never recreates a container another worktree is
+ * using for a reason of its own.
+ *
+ * If this list ever falls behind the compose file, the symptom is loud and says
+ * which variable: Compose refuses and names it.
+ */
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+/** The repository root, which is where the compose file lives. */
+const ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+
+/**
+ * Every variable the deployment description requires, with a value that is
+ * obviously not a credential.
+ *
+ * Most of them are the same string, because telling them apart would suggest
+ * one of them is read. None is. Two are shaped rather than repeated — the
+ * service token because the API refuses a token without its prefix, and the
+ * address because it is parsed as a URL — so that this list stays usable if
+ * somebody ever points it at a command that does start the platform. Neither
+ * shaping makes them any more used than the rest.
+ */
+const NOT_READ_BY_EITHER_STORE = "unused-by-the-two-stores";
+
+const BOOTSTRAP_PLACEHOLDERS: Record<string, string> = {
+  EGMA_ENCRYPTION_KEY: NOT_READ_BY_EITHER_STORE,
+  EGMA_AUTH_SECRET: NOT_READ_BY_EITHER_STORE,
+  EGMA_SIMULATOR_SERVICE_TOKEN: `egma_st_${NOT_READ_BY_EITHER_STORE}`,
+  EGMA_BASE_URL: "http://localhost:3101",
+  EGMA_LIVEKIT_API_KEY: NOT_READ_BY_EITHER_STORE,
+  EGMA_LIVEKIT_API_SECRET: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_ACCESS_KEY_ID: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_SECRET_ACCESS_KEY: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_READ_ACCESS_KEY_ID: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_READ_SECRET_ACCESS_KEY: NOT_READ_BY_EITHER_STORE,
+};
+
+/**
+ * Run one `docker compose` subcommand at the repository root, and exit with
+ * whatever it exited with.
+ *
+ * This never returns: a developer command is what it wraps, and a wrapper that
+ * swallowed a non-zero exit would make `pnpm test` run against stores that
+ * never came up.
+ */
+export function composeOrExit(args: readonly string[]): never {
+  const ran = spawnSync("docker", ["compose", ...args], {
+    cwd: ROOT,
+    env: { ...BOOTSTRAP_PLACEHOLDERS, ...process.env },
+    stdio: "inherit",
+  });
+
+  if (ran.error !== undefined) {
+    console.error(
+      `could not run docker compose: ${ran.error.message}\n\n` +
+        "The test suite runs against a real Postgres and a real ClickHouse. " +
+        "Install Docker with the compose plugin, or point TEST_DATABASE_URL and " +
+        "TEST_CLICKHOUSE_URL at stores you already run.",
+    );
+    process.exit(1);
+  }
+
+  process.exit(ran.status ?? 1);
+}

--- a/packages/db/test/support/start-stores.ts
+++ b/packages/db/test/support/start-stores.ts
@@ -2,84 +2,13 @@
  * Start the two stores the test suite needs, and nothing else.
  *
  * `docker compose up -d --wait postgres clickhouse` is the whole of the work.
- * This wrapper exists for one reason, and it is a property of Compose rather
- * than of egma: **Compose interpolates the entire file before it looks at which
- * services you named.** So a variable the api service requires has to resolve
- * even when the command starts neither the api service nor anything that reads
- * it, and a contributor who has never written a `.env` would meet
- * `required variable EGMA_ENCRYPTION_KEY is missing a value` on their way to
- * running the tests.
+ * Naming the two services is what holds this to the two stores: neither has a
+ * `depends_on`, so nothing else in the deployment comes up beside them.
  *
- * That refusal is the point everywhere else. This deployment's own secrets have
- * no defaults any more — a default is a value every reader of a public
- * repository holds — so `docker compose up` refuses and names what is missing
- * rather than starting a platform sealed with a published key. See
- * `.env.example`, and the deployment test that holds the rule.
- *
- * But starting Postgres and ClickHouse is not starting the platform. Neither
- * container reads one of the values below: they read `POSTGRES_*` and
- * `CLICKHOUSE_*`, which keep their defaults precisely so that a checkout costs
- * a contributor no configuration at all. So the placeholders here satisfy the
- * interpolation and reach nothing — no container is created with one, and none
- * is a value anybody should ever hold.
- *
- * **They are placed under the real environment rather than over it**, so a
- * developer who exported a real one keeps it. A value in a `.env` file does
- * lose to these, and that is harmless for the same reason: the two stores read
- * none of them, and their own configuration — user, password, database, port —
- * is untouched, so this never recreates a container somebody else's worktree is
- * using.
- *
- * If this list ever falls behind the compose file, the symptom is loud and says
- * which variable: Compose refuses and names it.
+ * Why it is a wrapper at all, and why the values it hands Compose reach no
+ * container, is in `compose.ts` next to the values themselves.
  */
 
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { composeOrExit } from "./compose.ts";
 
-/** The repository root, which is where the compose file lives. */
-const ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
-
-/**
- * Every variable the deployment description requires, with a value that is
- * obviously not a credential.
- *
- * One string for all of them, because telling them apart would suggest one of
- * them is used. None is.
- */
-const NOT_READ_BY_EITHER_STORE = "unused-by-pnpm-db-up";
-
-const BOOTSTRAP_PLACEHOLDERS: Record<string, string> = {
-  EGMA_ENCRYPTION_KEY: NOT_READ_BY_EITHER_STORE,
-  EGMA_AUTH_SECRET: NOT_READ_BY_EITHER_STORE,
-  EGMA_SIMULATOR_SERVICE_TOKEN: `egma_st_${NOT_READ_BY_EITHER_STORE}`,
-  EGMA_BASE_URL: "http://localhost:3101",
-  EGMA_LIVEKIT_API_KEY: NOT_READ_BY_EITHER_STORE,
-  EGMA_LIVEKIT_API_SECRET: NOT_READ_BY_EITHER_STORE,
-  EGMA_S3_ACCESS_KEY_ID: NOT_READ_BY_EITHER_STORE,
-  EGMA_S3_SECRET_ACCESS_KEY: NOT_READ_BY_EITHER_STORE,
-  EGMA_S3_READ_ACCESS_KEY_ID: NOT_READ_BY_EITHER_STORE,
-  EGMA_S3_READ_SECRET_ACCESS_KEY: NOT_READ_BY_EITHER_STORE,
-};
-
-const started = spawnSync(
-  "docker",
-  ["compose", "up", "-d", "--wait", "postgres", "clickhouse"],
-  {
-    cwd: ROOT,
-    env: { ...BOOTSTRAP_PLACEHOLDERS, ...process.env },
-    stdio: "inherit",
-  },
-);
-
-if (started.error !== undefined) {
-  console.error(
-    `could not run docker compose: ${started.error.message}\n\n` +
-      "The test suite runs against a real Postgres and a real ClickHouse. " +
-      "Install Docker with the compose plugin, or point TEST_DATABASE_URL and " +
-      "TEST_CLICKHOUSE_URL at stores you already run.",
-  );
-  process.exit(1);
-}
-
-process.exit(started.status ?? 1);
+composeOrExit(["up", "-d", "--wait", "postgres", "clickhouse"]);

--- a/packages/db/test/support/start-stores.ts
+++ b/packages/db/test/support/start-stores.ts
@@ -1,0 +1,85 @@
+/**
+ * Start the two stores the test suite needs, and nothing else.
+ *
+ * `docker compose up -d --wait postgres clickhouse` is the whole of the work.
+ * This wrapper exists for one reason, and it is a property of Compose rather
+ * than of egma: **Compose interpolates the entire file before it looks at which
+ * services you named.** So a variable the api service requires has to resolve
+ * even when the command starts neither the api service nor anything that reads
+ * it, and a contributor who has never written a `.env` would meet
+ * `required variable EGMA_ENCRYPTION_KEY is missing a value` on their way to
+ * running the tests.
+ *
+ * That refusal is the point everywhere else. This deployment's own secrets have
+ * no defaults any more — a default is a value every reader of a public
+ * repository holds — so `docker compose up` refuses and names what is missing
+ * rather than starting a platform sealed with a published key. See
+ * `.env.example`, and the deployment test that holds the rule.
+ *
+ * But starting Postgres and ClickHouse is not starting the platform. Neither
+ * container reads one of the values below: they read `POSTGRES_*` and
+ * `CLICKHOUSE_*`, which keep their defaults precisely so that a checkout costs
+ * a contributor no configuration at all. So the placeholders here satisfy the
+ * interpolation and reach nothing — no container is created with one, and none
+ * is a value anybody should ever hold.
+ *
+ * **They are placed under the real environment rather than over it**, so a
+ * developer who exported a real one keeps it. A value in a `.env` file does
+ * lose to these, and that is harmless for the same reason: the two stores read
+ * none of them, and their own configuration — user, password, database, port —
+ * is untouched, so this never recreates a container somebody else's worktree is
+ * using.
+ *
+ * If this list ever falls behind the compose file, the symptom is loud and says
+ * which variable: Compose refuses and names it.
+ */
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+/** The repository root, which is where the compose file lives. */
+const ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+
+/**
+ * Every variable the deployment description requires, with a value that is
+ * obviously not a credential.
+ *
+ * One string for all of them, because telling them apart would suggest one of
+ * them is used. None is.
+ */
+const NOT_READ_BY_EITHER_STORE = "unused-by-pnpm-db-up";
+
+const BOOTSTRAP_PLACEHOLDERS: Record<string, string> = {
+  EGMA_ENCRYPTION_KEY: NOT_READ_BY_EITHER_STORE,
+  EGMA_AUTH_SECRET: NOT_READ_BY_EITHER_STORE,
+  EGMA_SIMULATOR_SERVICE_TOKEN: `egma_st_${NOT_READ_BY_EITHER_STORE}`,
+  EGMA_BASE_URL: "http://localhost:3101",
+  EGMA_LIVEKIT_API_KEY: NOT_READ_BY_EITHER_STORE,
+  EGMA_LIVEKIT_API_SECRET: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_ACCESS_KEY_ID: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_SECRET_ACCESS_KEY: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_READ_ACCESS_KEY_ID: NOT_READ_BY_EITHER_STORE,
+  EGMA_S3_READ_SECRET_ACCESS_KEY: NOT_READ_BY_EITHER_STORE,
+};
+
+const started = spawnSync(
+  "docker",
+  ["compose", "up", "-d", "--wait", "postgres", "clickhouse"],
+  {
+    cwd: ROOT,
+    env: { ...BOOTSTRAP_PLACEHOLDERS, ...process.env },
+    stdio: "inherit",
+  },
+);
+
+if (started.error !== undefined) {
+  console.error(
+    `could not run docker compose: ${started.error.message}\n\n` +
+      "The test suite runs against a real Postgres and a real ClickHouse. " +
+      "Install Docker with the compose plugin, or point TEST_DATABASE_URL and " +
+      "TEST_CLICKHOUSE_URL at stores you already run.",
+  );
+  process.exit(1);
+}
+
+process.exit(started.status ?? 1);

--- a/packages/db/test/support/stop-stores.ts
+++ b/packages/db/test/support/stop-stores.ts
@@ -1,0 +1,17 @@
+/**
+ * Stop what `pnpm db:up` started, and whatever else this workspace is running.
+ *
+ * `docker compose down`, unchanged from what this command has always been: it
+ * takes the whole project down rather than the two stores, because a developer
+ * asking for the deployment to stop means the deployment.
+ *
+ * It needs the same wrapper `start-stores.ts` does, and that is worth saying
+ * plainly because it is the half that is easy to forget: Compose reads the
+ * whole file before it does anything, `down` included. A `down` that refused
+ * over a variable no container it is stopping ever read would leave a developer
+ * unable to stop what they had just been able to start. See `compose.ts`.
+ */
+
+import { composeOrExit } from "./compose.ts";
+
+composeOrExit(["down"]);


### PR DESCRIPTION
## The failure this closes

A self-hoster configures their platform once. Every variable in `docker-compose.yml` was written with a default, so an absent setting became an empty one: every container started, every health check passed, the platform reported itself ready, and the failure arrived minutes later as a carrier or provider refusal that named nothing about configuration.

The four changes before this one moved the settings themselves into the platform's own store. What is left in the environment is only what cannot live anywhere else — and this makes a missing one of those stop the platform with a sentence instead of starting it hollow.

## Ten variables now have no default anywhere

`EGMA_ENCRYPTION_KEY`, `EGMA_AUTH_SECRET`, `EGMA_SIMULATOR_SERVICE_TOKEN`, `EGMA_S3_ACCESS_KEY_ID`, `EGMA_S3_SECRET_ACCESS_KEY`, `EGMA_S3_READ_ACCESS_KEY_ID`, `EGMA_S3_READ_SECRET_ACCESS_KEY`, `EGMA_BASE_URL`, `EGMA_LIVEKIT_API_KEY`, `EGMA_LIVEKIT_API_SECRET`.

Each is a secret this deployment cannot invent, or the address it announces itself as. Seven of them used to fall back to a value written in this repository — so a deployment could seal every provider key it holds with a key every reader of the source knows, sign its sessions with a published secret, and answer a claim for anybody who had read it. Nothing said so.

They use Compose's required form now, and the message says what to do:

```
error while interpolating services.api.environment.EGMA_ENCRYPTION_KEY:
required variable EGMA_ENCRYPTION_KEY is missing a value:
no default — openssl rand -hex 32 makes one, set it in .env and back it up beside the database
```

`egma self-host up` reports that by name and does **not** retry — a second attempt invents no value the first one lacked, and reporting it as a store's first boot would send an operator reading container logs for a variable they never set.

## What kept its defaults, and the rule

**The deployment keeps a default for what it creates itself.** The two stores' users, passwords and database names, every port, every bind, and all per-container tuning are values this file chooses and then uses consistently, so a self-hoster who sets none of them gets the deployment the README documents.

**This is a deviation from the spec and the issue, which both name ports and bind addresses as taking the required form.** They keep their defaults here. An unset port yields a working deployment rather than a hollow one, which is not the failure this work is about; and requiring six port numbers before a documented default deployment will start is a cost with no matching risk. Two of them are also load-bearing *as* defaults — the SIP port and the RTP range each appear in two places that must agree, and existing tests read those defaults to prove they do.

A store address is not in the required set either. `DATABASE_URL` and `CLICKHOUSE_URL` are what the API and the grader read, and this file builds each from the store it starts beside them, so under Compose an address for a container this file creates cannot go missing. Both processes already refuse to start without one and name it (`apps/api/test/health.test.ts`), which covers every other way of running them.

## Two ports that were open

`POSTGRES_PORT` and `CLICKHOUSE_PORT` published to every interface, behind `egma`/`egma` printed in this repository. Both now bind to `127.0.0.1` by default, through `POSTGRES_BIND` and `CLICKHOUSE_BIND`, which is the idiom the object store and the media server already use. Widening either is a variable somebody sets on purpose.

*One consequence:* the port line changes, so the next `pnpm db:up` recreates those two containers once. Both keep named volumes, so no data is lost. A client asking for `localhost` still reaches a container bound to `127.0.0.1` — checked against a real `postgres:18-alpine` with the same `pg` client the suite uses.

## The first run is two steps

```bash
cp .env.example .env      # then fill in the seven this command cannot make for you
npx @egma/cli self-host up
```

Three of the ten are never typed: `egma self-host up` generates the media pair and sets `EGMA_BASE_URL` to the address it prints. `.env.example` marks all ten REQUIRED and gives the `openssl` line for each.

`EGMA_BASE_URL` is deliberately empty in `.env.example`. A copied `http://localhost:3101` is right on a laptop and wrong on every deployment anybody else reaches — and wrong in the quiet way, because the platform runs perfectly while every agent repository is refused a directory away from the cause.

## The guard, and its perimeter

`apps/simulator/tests/test_deployment.py` reads the deployment description rather than observing behaviour. That is the weakest kind of test here and it is knowingly so: asserting that Compose refused to start is slow and awkward, and the regression it catches is the exact original failure — somebody adding a new bootstrap variable that is empty when nobody sets it.

It is written in the direction that catches that. Every variable a shipped compose file leaves empty must be one an allow-list explains, each with its reason, so a new one fails until somebody writes down who answers for it instead — the platform's own store, a project, or the host.

The matching is a scanner rather than a pattern, because the question is not what the text looks like but what an unset variable leaves behind: `${VAR}`, `${VAR-}`, `${VAR:- }` and `${NEW:-${OTHER:-}}` all reach a container as the same empty string as `${VAR:-}`. Braces are counted, six operators are told apart, and a default that is itself an expression is read again. Both compose files this repository ships are read, not only the deployment description; a gitignored local override is not, because it belongs to whoever wrote it.

**It was broken on purpose to check it can fail.** A bare `${EGMA_BARE_NEW_THING}` in `docker-compose.yml` and a nested `${A:-${B:- }}` in the workbench overlay were both caught, by name, with the sentence the test carries — including both halves of the nested chain, in the file the narrower guard never read. Putting `EGMA_BASE_URL=http://localhost:3101` back into `.env.example` fails the new `.env.example` guard the same way.

## Developer workflow

`pnpm db:up` and `pnpm db:down` go through one wrapper that hands Compose a placeholder for each of the ten. Compose interpolates the whole file before it looks at which services were named — before `up`, `down` and `ps` alike — so operating two stores would otherwise refuse over a variable neither of them reads. Neither store reads one: they read `POSTGRES_*` and `CLICKHOUSE_*`, which are untouched. The placeholders sit under the real environment rather than over it.

Plain `docker compose` in a checkout still refuses until `.env` carries the ten, which is right for a deployment and merely inconvenient in a checkout nobody runs the platform from. The README says so and says what to use instead.

## Tests

`apps/simulator/tests/test_deployment.py` 41 passed, ruff clean. `apps/api/test/deployment.test.ts`, `apps/grader/test/deployment.test.ts`, `apps/cli/test/self-host-up.test.ts`, `self-host-setup.test.ts`, `self-host-media-credential.test.ts` — 52 passed. `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789348950&installation_model_id=431960&pr_number=81&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F81&signature=27f8e175c79766483a176aaa618e52c27e04edaa9d9bef05e2912e89b9433a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes insecure or empty defaults from ten bootstrap variables so Compose refuses incomplete deployments before starting containers.
- Uses required Compose interpolation for deployment secrets and the platform URL.
- Adds CLI handling that reports missing variables without retrying.
- Restricts Postgres and ClickHouse host bindings to loopback by default.
- Adds deployment guards and database-workflow wrappers for the new interpolation requirements.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker-compose.yml | Replaces bootstrap defaults with required interpolation and changes database port bindings to loopback defaults. |
| apps/cli/src/commands/self-host.ts | Detects missing-variable interpolation failures before the existing first-boot retry path. |
| apps/cli/src/self-host/compose.ts | Adds extraction of a missing required variable from failed Compose output. |
| apps/simulator/tests/test_deployment.py | Adds interpolation parsing and guards for required and deliberately optional deployment variables. |
| packages/db/test/support/compose.ts | Supplies interpolation-only placeholders when contributor commands operate the database services. |
| .env.example | Documents required bootstrap values, loopback database bindings, and the intentionally retained local MinIO credential requirement. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start self-host deployment] --> B[CLI supplies generated media credentials and base URL]
    B --> C{All required bootstrap variables set?}
    C -- No --> D[Compose refuses interpolation]
    D --> E[CLI reports missing variable and does not retry]
    C -- Yes --> F[Compose starts platform services]
    F --> G[Postgres and ClickHouse bind to loopback by default]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Say that an external store still needs t..."](https://github.com/egma-ai/egma/commit/fe0fbafe97f1eebb4773675c17eda5ddbe02e4c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53540990)</sub>

<!-- /greptile_comment -->