### PR TITLE
The bare command reaches hosted egma, and says which one

### DIFF
--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -32,6 +32,7 @@ import {
   writeMockTools,
   type MockToolEntry,
 } from "./mock-tools.ts";
+import { normalizePlatformOrigin } from "../platform/identity.ts";
 import { parseTestFile, serializeTestFile, type TestFile } from "./test-file.ts";
 import { mappingAtKey, readYaml, textAt, yamlScalar } from "./yaml.ts";
 
@@ -144,6 +145,27 @@ export function serializeConfig(config: FolderConfig): string {
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * The committed origin, in the one shape every origin is compared in.
+ *
+ * A person edits this file, and a person writes `https://egma.example/`, or
+ * `https://EGMA.example`, or the default port spelled out, where egma would
+ * have written `https://egma.example`. All of them name the same platform, so
+ * all of them have to read back as the same platform — otherwise the binding
+ * disagrees with itself, and a repository is refused for moving nowhere.
+ *
+ * An origin egma cannot make sense of is left exactly as it was written. It is
+ * refused by name one step later, at the edge that takes addresses, and quietly
+ * rewriting it here would hide which line in the file is the wrong one.
+ */
+function committedOrigin(written: string): string {
+  try {
+    return normalizePlatformOrigin(written);
+  } catch {
+    return written;
+  }
+}
+
 export function parseConfig(document: string, where: string): FolderConfig {
   const mapping = readYaml(document, where);
   const platformMapping = mappingAtKey(mapping, "platform");
@@ -166,7 +188,7 @@ export function parseConfig(document: string, where: string): FolderConfig {
               `${where} has an incomplete platform binding. Run the Egma wizard to repair it.`,
             );
           }
-          return { origin, instance };
+          return { origin: committedOrigin(origin), instance };
         })();
   const read = (key: (typeof CONFIG_KEYS)[number]): NamedThing | null => {
     const under = mappingAtKey(mapping, key);
@@ -229,14 +251,26 @@ export async function updateConfig(
  * It is a block of plain lines rather than a paragraph because a coding agent
  * reads this too, and it should be able to act on it without a person reading
  * the message out to it.
+ *
+ * **The platform block comes out last, and that order is the safety.** Deleting
+ * it is what unbinds the repository, and an unbound repository falls back to
+ * egma's own platform — so a list that named it first would have somebody
+ * working top-down arrive, one line in, at a repository holding another
+ * platform's identifiers and nothing left to keep them there. The next command
+ * would carry them to hosted egma. Identifiers and version pins come out first
+ * and the binding comes out last, so every partial application of this list
+ * leaves the repository still bound, and ADR-0008's rule that resource
+ * identifiers cannot silently cross platform boundaries holds at every step
+ * rather than only at the end.
  */
 export const MOVE_TO_ANOTHER_PLATFORM: readonly string[] = [
-  "To move this repository to another platform, delete these and run egma again:",
-  `  - the whole platform: block in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
+  "To move this repository to another platform, delete these in this order and run egma again:",
   `  - the id: line under agent: in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
   `  - the id: line under connection: in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
   `  - the id: line under suite: in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
   `  - the version: line at the top of every file in ${FOLDER_NAME}/${TESTS_FOLDER_NAME}/`,
+  `  - last of all, the whole platform: block in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
+  "Delete the platform block last: it is what keeps every id above it on the platform that issued it, so until it is gone nothing can leave for another one.",
   "Keep every name. Your tests move with you and are created again on the new platform; the runs you have already done stay on the platform that ran them, because a run's numbers only mean anything against the versions that platform minted.",
 ];
 

--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -217,6 +217,30 @@ export async function updateConfig(
 }
 
 /**
+ * Every line a developer deletes to move a repository to another platform, and
+ * what moving costs them.
+ *
+ * No command performs this move, and none is planned: every line of it is in a
+ * file they already commit, so the move is a diff their colleagues review like
+ * any other. What egma owes them is the whole list at once — a refusal naming
+ * one line at a time is a developer deleting it, running again, and meeting the
+ * next refusal.
+ *
+ * It is a block of plain lines rather than a paragraph because a coding agent
+ * reads this too, and it should be able to act on it without a person reading
+ * the message out to it.
+ */
+export const MOVE_TO_ANOTHER_PLATFORM: readonly string[] = [
+  "To move this repository to another platform, delete these and run egma again:",
+  `  - the whole platform: block in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
+  `  - the id: line under agent: in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
+  `  - the id: line under connection: in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
+  `  - the id: line under suite: in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,
+  `  - the version: line at the top of every file in ${FOLDER_NAME}/${TESTS_FOLDER_NAME}/`,
+  "Keep every name. Your tests move with you and are created again on the new platform; the runs you have already done stay on the platform that ran them, because a run's numbers only mean anything against the versions that platform minted.",
+];
+
+/**
  * Commit the verified platform before anything creates platform-owned resource
  * identifiers.
  *
@@ -248,7 +272,11 @@ export async function bindRepositoryPlatform(
   if (held.platform !== null) {
     if (held.platform.instance !== binding.instance) {
       throw new Error(
-        `This repository is already bound to Egma platform ${held.platform.instance} at ${held.platform.origin}. Rebinding is not supported yet.`,
+        [
+          `This repository is already bound to Egma platform ${held.platform.instance} at ${held.platform.origin}, and this run reached Egma platform ${binding.instance} at ${binding.origin}. egma does not move a repository between platforms, and nothing was sent.`,
+          "",
+          ...MOVE_TO_ANOTHER_PLATFORM,
+        ].join("\n"),
       );
     }
     if (held.platform.origin !== binding.origin) {

--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -241,6 +241,20 @@ export const MOVE_TO_ANOTHER_PLATFORM: readonly string[] = [
 ];
 
 /**
+ * A refusal with the whole move under it, one blank line apart.
+ *
+ * Every refusal that stands between a developer and another platform ends the
+ * same way, because they are not different problems to the person who has one:
+ * whichever of them fires, the next thing they need is the same list. One
+ * function so that the list cannot drift into three versions of itself, and so
+ * that the blank line before it is always there — it is what makes the block
+ * below it a block rather than the tail of a paragraph.
+ */
+export function teachingTheMove(refusal: string): string {
+  return [refusal, "", ...MOVE_TO_ANOTHER_PLATFORM].join("\n");
+}
+
+/**
  * Commit the verified platform before anything creates platform-owned resource
  * identifiers.
  *
@@ -272,11 +286,9 @@ export async function bindRepositoryPlatform(
   if (held.platform !== null) {
     if (held.platform.instance !== binding.instance) {
       throw new Error(
-        [
+        teachingTheMove(
           `This repository is already bound to Egma platform ${held.platform.instance} at ${held.platform.origin}, and this run reached Egma platform ${binding.instance} at ${binding.origin}. egma does not move a repository between platforms, and nothing was sent.`,
-          "",
-          ...MOVE_TO_ANOTHER_PLATFORM,
-        ].join("\n"),
+        ),
       );
     }
     if (held.platform.origin !== binding.origin) {

--- a/apps/cli/src/folder/egma-folder.ts
+++ b/apps/cli/src/folder/egma-folder.ts
@@ -263,6 +263,30 @@ export async function updateConfig(
  * identifiers cannot silently cross platform boundaries holds at every step
  * rather than only at the end.
  */
+/**
+ * Which committed names carry an identifier only one platform can resolve.
+ *
+ * These three are written by exactly two places — the `connect` verb and the
+ * wizard's connect step — and **both of them bind the repository first**, at
+ * the moment before anything is registered. So a folder holding one of these
+ * and naming no platform is a shape egma never writes. It comes from a hand
+ * edit, which makes it the half-applied move: the binding gone, the identifiers
+ * still here, and the next command about to carry them to whichever platform
+ * answers the built-in address.
+ *
+ * A version pin in a test file is deliberately not among them, and the reason
+ * is that `push` writes pins and does not bind — so `egma init` followed by
+ * `egma push` in a repository that names nothing leaves pins with no binding as
+ * egma's own ordinary output. Refusing that shape would refuse the mainline it
+ * was just written by.
+ */
+export function platformOwnedIds(config: FolderConfig): readonly string[] {
+  return CONFIG_KEYS.filter((key) => {
+    const named = config[key];
+    return named !== null && named.id !== null && named.id !== "";
+  });
+}
+
 export const MOVE_TO_ANOTHER_PLATFORM: readonly string[] = [
   "To move this repository to another platform, delete these in this order and run egma again:",
   `  - the id: line under agent: in ${FOLDER_NAME}/${CONFIG_FILE_NAME}`,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -462,6 +462,11 @@ function retellReach(env: NodeJS.ProcessEnv): { readonly url: string } | undefin
  * sentence or the number they get.
  */
 function platformRefusal(error: unknown): "refused" | "unreachable" | null {
+  // egma's own built-in address is the one refusal that can be either. Nobody
+  // typed it, so what is at it decides: a redirect or a page that is not a
+  // platform will still be there in a minute, and saying `unreachable` about it
+  // would send whoever is driving into a retry loop that cannot end.
+  if (error instanceof DefaultPlatformUnusableError) return error.refusal;
   if (
     error instanceof PlatformBindingMismatchError ||
     error instanceof BoundPlatformAddressError ||
@@ -473,8 +478,7 @@ function platformRefusal(error: unknown): "refused" | "unreachable" | null {
   if (
     error instanceof PlatformUnreachableError ||
     error instanceof PlatformIdentityError ||
-    error instanceof BoundPlatformUnavailableError ||
-    error instanceof DefaultPlatformUnusableError
+    error instanceof BoundPlatformUnavailableError
   ) {
     return "unreachable";
   }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -481,9 +481,23 @@ function platformRefusal(error: unknown): "refused" | "unreachable" | null {
   return null;
 }
 
-/** Says the refusal both ways — machine-readable, and to a person — and answers 4. */
+/**
+ * Says the refusal both ways — machine-readable, and to a person — and answers 4.
+ *
+ * A refusal that teaches something is more than one line now: the one that
+ * keeps a bound repository where it belongs ends with every line a developer
+ * deletes to move it. Those lines go to the error stream, whole, where every
+ * other block egma teaches with already goes — the refusal of a piped wizard
+ * and the refusal of a key in an argument are both written that way.
+ *
+ * What goes on the output stream is the sentence alone. That stream is one fact
+ * per line, which is what makes it readable by the thing that started the
+ * command, and a `reason:` running to eight lines would break that reading to
+ * repeat what is already on the other stream.
+ */
 function sayPlatformRefusal(status: "refused" | "unreachable", message: string): void {
-  process.stdout.write(`status: ${status}\nreason: ${message}\n`);
+  const sentence = message.split("\n")[0] as string;
+  process.stdout.write(`status: ${status}\nreason: ${sentence}\n`);
   process.stderr.write(`${message}\n`);
   process.exitCode = 4;
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -39,14 +39,16 @@ import {
 import {
   BoundPlatformAddressError,
   BoundPlatformUnavailableError,
+  choosePlatform,
   credentialsFileIn,
-  NoPlatformNamedError,
+  DefaultPlatformUnusableError,
   KEYS_UNUSABLE,
   KeysUnusableError,
   PlatformBindingMismatchError,
   RepositoryPlatformConfigError,
-  resolvePlatformAccess,
   UnusableUrlError,
+  verifyPlatform,
+  type ChosenPlatform,
   type PlatformAccess,
   type VerifiedPlatformAccess,
 } from "./platform/credentials.ts";
@@ -58,7 +60,7 @@ import {
 import { RETELL_API } from "./retell/client.ts";
 import { HeadlessUI } from "./ui/headless-ui.ts";
 import { buildExitNotice, exitLines, type ExitReport } from "./wizard/exit-line.ts";
-import type { PlatformAccess as WizardPlatformAccess } from "./wizard/login-step.ts";
+import type { WalkPlatform } from "./wizard/login-step.ts";
 import { pasteFallbackMessage } from "./wizard/no-coding-agent.ts";
 import type { StopReason } from "./wizard/stop.ts";
 
@@ -445,6 +447,48 @@ function retellReach(env: NodeJS.ProcessEnv): { readonly url: string } | undefin
 }
 
 /**
+ * egma declining to talk to an address, in the one shape every command answers
+ * it in.
+ *
+ * Two kinds, and the difference is whether anything is worth retrying.
+ * `unreachable` is nobody answering; `refused` is egma declining to send this
+ * repository's identifiers to the address on offer. `null` is anything else,
+ * which is not this function's to explain.
+ *
+ * It is one function because two surfaces raise these now. A verb asks the
+ * address who it is before it starts; the wizard asks after the keystroke of
+ * consent, so its refusal arrives out of the walk rather than in front of it.
+ * The developer must not be able to tell which of the two happened from the
+ * sentence or the number they get.
+ */
+function platformRefusal(error: unknown): "refused" | "unreachable" | null {
+  if (
+    error instanceof PlatformBindingMismatchError ||
+    error instanceof BoundPlatformAddressError ||
+    error instanceof PlatformOriginMismatchError ||
+    error instanceof RepositoryPlatformConfigError
+  ) {
+    return "refused";
+  }
+  if (
+    error instanceof PlatformUnreachableError ||
+    error instanceof PlatformIdentityError ||
+    error instanceof BoundPlatformUnavailableError ||
+    error instanceof DefaultPlatformUnusableError
+  ) {
+    return "unreachable";
+  }
+  return null;
+}
+
+/** Says the refusal both ways — machine-readable, and to a person — and answers 4. */
+function sayPlatformRefusal(status: "refused" | "unreachable", message: string): void {
+  process.stdout.write(`status: ${status}\nreason: ${message}\n`);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 4;
+}
+
+/**
  * What a headless walk would have been told, for the one question it cannot
  * ask: the key, which arrives from the environment because a run with nobody
  * watching has nobody to type it.
@@ -492,7 +536,7 @@ async function runHeadless(
   invocation: Invocation,
   launch: DrivenAgentLaunch,
   cwd: string,
-  platform: WizardPlatformAccess,
+  platform: WalkPlatform,
 ): Promise<number> {
   const controller = new AbortController();
   const stop = (reason: StopReason): void => controller.abort(reason);
@@ -527,7 +571,7 @@ async function runHeadless(
 async function runWizard(
   launch: DrivenAgentLaunch,
   cwd: string,
-  platform: WizardPlatformAccess,
+  platform: WalkPlatform,
 ): Promise<number> {
   const { startTui, walk } = await wizardMachinery();
   const controller = new AbortController();
@@ -551,6 +595,14 @@ async function runWizard(
     tui.close(report);
     return walkExitCode(report);
   } catch (error) {
+    // A platform refusal is not the walk failing. It is egma declining to talk
+    // to an address, and it is answered in plain lines with a number of its own
+    // — the same ones every verb answers with. So the screen comes down leaving
+    // nothing behind, and the sentence is written once, by the caller.
+    if (platformRefusal(error) !== null) {
+      tui.close(null);
+      throw error;
+    }
     const reason = error instanceof Error ? error.message : String(error);
     tui.close({ kind: "failed", reason });
     return 1;
@@ -747,7 +799,7 @@ export async function main(argv: readonly string[]): Promise<void> {
   // keystroke of consent, the coding agent it will drive — is settled here,
   // before a single network read, and what comes out is either the rest of the
   // walk or nothing at all.
-  let theWizard: ((access: VerifiedPlatformAccess) => Promise<number>) | null = null;
+  let theWizard: ((platform: WalkPlatform) => Promise<number>) | null = null;
   if (invocation.verb === null) {
     // Consent is checked before a network read. A piped bare command cannot
     // start either the wizard or platform selection.
@@ -768,48 +820,33 @@ export async function main(argv: readonly string[]): Promise<void> {
       }
       throw error;
     }
-    theWizard = async (access) =>
+    theWizard = async (platform) =>
       invocation.headless
-        ? runHeadless(invocation, launch, cwd, access)
-        : runWizard(launch, cwd, access);
+        ? runHeadless(invocation, launch, cwd, platform)
+        : runWizard(launch, cwd, platform);
   }
 
-  // Which egma, resolved once for every path below, and refused here when the
-  // address a developer named is not one. A bad address is turned away before
-  // anything is started on it rather than after.
-  let access: VerifiedPlatformAccess;
+  // Which egma, chosen once for every path below out of what is already on this
+  // machine, and refused here when the address a developer named is not one. A
+  // bad address is turned away before anything is started on it rather than
+  // after, and nothing has been asked of any address yet.
+  let chosen: ChosenPlatform;
+  let access: VerifiedPlatformAccess | null = null;
   try {
-    access = await resolvePlatformAccess({
-      env: process.env,
-      flag: invocation.url,
-      cwd,
-    });
+    chosen = await choosePlatform({ env: process.env, flag: invocation.url, cwd });
+    // A verb has no screen to say which egma this is on and no keystroke to
+    // take, so it asks the address who it is here, exactly as it always has.
+    // The wizard asks after its first screen — see below.
+    if (invocation.verb !== null) access = await verifyPlatform(chosen);
   } catch (error) {
     if (error instanceof UnusableUrlError) {
       process.stderr.write(`${error.message}\n`);
       process.exitCode = 1;
       return;
     }
-    // Two shapes, and the difference is whether anything is worth retrying.
-    // `unreachable` is nobody answering; `refused` is egma declining to send
-    // this repository's identifiers to the address on offer.
-    const refused =
-      error instanceof PlatformBindingMismatchError ||
-      error instanceof BoundPlatformAddressError ||
-      error instanceof PlatformOriginMismatchError ||
-      error instanceof RepositoryPlatformConfigError;
-    if (
-      refused ||
-      error instanceof PlatformUnreachableError ||
-      error instanceof PlatformIdentityError ||
-      error instanceof BoundPlatformUnavailableError ||
-      error instanceof NoPlatformNamedError
-    ) {
-      const status = refused ? "refused" : "unreachable";
-      const message = (error as Error).message;
-      process.stdout.write(`status: ${status}\nreason: ${message}\n`);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 4;
+    const status = platformRefusal(error);
+    if (status !== null) {
+      sayPlatformRefusal(status, (error as Error).message);
       return;
     }
     throw error;
@@ -818,27 +855,45 @@ export async function main(argv: readonly string[]): Promise<void> {
   try {
     // A verb needs no terminal and takes no keystroke: it drives no coding
     // agent, so there is nothing for a keystroke to agree to.
-    if (invocation.verb === "login") {
-      process.exitCode = await runLogin(invocation, access);
-      return;
-    }
-    if (invocation.verb === "connect") {
-      process.exitCode = await runConnect(invocation, access);
-      return;
-    }
-    if (
-      invocation.verb === "pull" ||
-      invocation.verb === "push" ||
-      invocation.verb === "run"
-    ) {
-      process.exitCode = await runFolderVerb(invocation.verb, invocation, access);
-      return;
+    if (access !== null) {
+      if (invocation.verb === "login") {
+        process.exitCode = await runLogin(invocation, access);
+        return;
+      }
+      if (invocation.verb === "connect") {
+        process.exitCode = await runConnect(invocation, access);
+        return;
+      }
+      if (
+        invocation.verb === "pull" ||
+        invocation.verb === "push" ||
+        invocation.verb === "run"
+      ) {
+        process.exitCode = await runFolderVerb(invocation.verb, invocation, access);
+        return;
+      }
     }
 
     // Every verb has returned by now, so what is left is the bare command, and
-    // the walk it needs was built above.
-    if (theWizard !== null) process.exitCode = await theWizard(access);
+    // the walk it needs was built above. It is handed the address and the way
+    // to ask who is there, and it asks only once the developer has read the
+    // address and pressed the key that agrees to the rest.
+    if (theWizard !== null) {
+      const selected = chosen;
+      process.exitCode = await theWizard({
+        url: selected.url,
+        verify: () => verifyPlatform(selected),
+      });
+    }
   } catch (error) {
+    // The wizard's platform read happens inside the walk, so its refusal
+    // arrives here rather than above. Same sentence, same number, whichever
+    // side of the keystroke it came from.
+    const status = platformRefusal(error);
+    if (status !== null) {
+      sayPlatformRefusal(status, (error as Error).message);
+      return;
+    }
     if (!(error instanceof KeysUnusableError)) throw error;
     // Whatever is wrong with this machine's keys file, egma decided not to
     // write over it — and a decision is a sentence, not a stack trace. Every

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -46,6 +46,7 @@ import {
   KeysUnusableError,
   PlatformBindingMismatchError,
   RepositoryPlatformConfigError,
+  UnboundPlatformIdentifiersError,
   UnusableUrlError,
   verifyPlatform,
   type ChosenPlatform,
@@ -471,7 +472,8 @@ function platformRefusal(error: unknown): "refused" | "unreachable" | null {
     error instanceof PlatformBindingMismatchError ||
     error instanceof BoundPlatformAddressError ||
     error instanceof PlatformOriginMismatchError ||
-    error instanceof RepositoryPlatformConfigError
+    error instanceof RepositoryPlatformConfigError ||
+    error instanceof UnboundPlatformIdentifiersError
   ) {
     return "refused";
   }

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -25,18 +25,32 @@ import {
 import { PlatformUnreachableError, type Fetch } from "./device-flow.ts";
 
 /**
- * There is no fallback address, and that is the honest state of the world.
+ * The egma an agent repository uses when nothing else names one.
  *
- * egma has no hosted platform yet. A built-in default pointing at one that does
- * not exist would send an unbound repository to probe somebody else's website
- * and then report *their* server as a broken egma — which is the opposite of
- * useful. So a command that names no platform is refused here, before any
- * address is asked anything, and the refusal says the one move that is the
- * developer's: name theirs.
- *
- * When there is a hosted platform, this is where its address goes and
- * `NoPlatformNamedError` becomes the fallback again.
+ * It is the last step of resolution and the only one nobody typed: a flag, the
+ * environment and the repository's own binding all come first, and a bound
+ * repository never falls back to it. A developer with nothing configured
+ * reaches egma's own platform — and the wizard says which egma that is on its
+ * first screen, before it asks that address anything at all.
  */
+export const DEFAULT_PLATFORM_URL = "https://app.egma.ai";
+
+/**
+ * A test seam, not product surface: this stands in for the built-in address
+ * while a check runs, so the suite never signs in to the real hosted egma.
+ *
+ * It is not documented and it is not stable — the same treatment `main.ts`
+ * gives the `-- <command>` seam that starts a scripted coding agent in place of
+ * a real one. It is not a second way for a developer to select a platform:
+ * `EGMA_URL` is that, and it sits above the built-in address in the order.
+ */
+export const TEST_DEFAULT_URL_VARIABLE = "EGMA_TEST_DEFAULT_URL";
+
+/** Which built-in address this run uses: egma's own, or a check's stand-in. */
+export function defaultPlatformUrlIn(env: NodeJS.ProcessEnv): string {
+  const named = env[TEST_DEFAULT_URL_VARIABLE]?.trim();
+  return named === undefined || named === "" ? DEFAULT_PLATFORM_URL : named;
+}
 
 /** Owner only, on the file and on the folder that holds it. */
 const FILE_MODE = 0o600;
@@ -326,6 +340,14 @@ export type PlatformChoice = {
   readonly env?: string | undefined;
   /** The platform committed in this agent repository. */
   readonly binding?: string | null;
+  /**
+   * The built-in address, for a repository that names none.
+   *
+   * Passed in rather than reached for, so that the one place which decides
+   * *which* built-in address this run has — egma's own, or a check's stand-in —
+   * is the caller that also holds the environment.
+   */
+  readonly fallback: string;
 };
 
 /** What a developer is told when the address they named is not one. */
@@ -339,7 +361,7 @@ export class UnusableUrlError extends Error {
 }
 
 /** Where a selected address came from. It decides who a refusal names. */
-export type PlatformSource = "--url" | "EGMA_URL" | "binding";
+export type PlatformSource = "--url" | "EGMA_URL" | "binding" | "default";
 
 export type SelectedPlatform = {
   readonly url: string;
@@ -350,14 +372,15 @@ const SOURCE_NAMES: Record<PlatformSource, string> = {
   "--url": "--url",
   EGMA_URL: "EGMA_URL",
   binding: "the repository platform binding",
+  default: "egma's built-in address",
 };
 
 /**
  * Which egma this command talks to, and which of the four places said so.
  *
  * Deliberate beats ambient beats committed: a flag on the command, then the
- * environment, then the repository binding, then Egma Cloud for an unbound
- * repository. A machine-level login never chooses a repository target.
+ * environment, then the repository binding, then egma's own platform for an
+ * unbound repository. A machine-level login never chooses a repository target.
  *
  * The source travels with the address because a refusal that names the wrong
  * platform sends a developer to fix something they did not ask for: told to
@@ -372,6 +395,7 @@ export function selectPlatform(choice: PlatformChoice): SelectedPlatform {
     ["--url", choice.flag],
     ["EGMA_URL", choice.env],
     ["binding", choice.binding],
+    ["default", choice.fallback],
   ];
   for (const [source, candidate] of named) {
     const tidy = typeof candidate === "string" ? candidate.trim() : "";
@@ -384,7 +408,11 @@ export function selectPlatform(choice: PlatformChoice): SelectedPlatform {
       throw new UnusableUrlError(SOURCE_NAMES[source]);
     }
   }
-  throw new NoPlatformNamedError();
+  // The built-in address is always there, so nothing reaches this in a shipped
+  // copy. It is a sentence rather than an exhausted `switch` because the one
+  // way to get here is a stand-in address set to nothing, and a test seam that
+  // was set wrong should say so rather than resolve to something.
+  throw new UnusableUrlError(SOURCE_NAMES.default);
 }
 
 /** The address alone, for callers that do not have to say where it came from. */
@@ -443,20 +471,22 @@ export class BoundPlatformUnavailableError extends Error {
 }
 
 /**
- * Nothing named a platform, and the built-in default is not one.
+ * Nothing named a platform, so egma used its own, and its own is no use today.
  *
- * The developer never typed this address, does not run what is at it, and
- * cannot fix it — so the sentence points at the one move that is theirs: name
- * their own platform. Every other refusal in this file describes a deployment
- * somebody can go and look at, and saying that about this address would send a
- * developer off to inspect a website that is not theirs.
+ * One refusal for every way that address can fail, because the developer never
+ * typed it, does not run what is at it, and cannot fix any of them. Handing on
+ * the underlying sentence would send them to check an address they did not
+ * choose, or to reconfigure a deployment that is not theirs. So this says the
+ * two moves that are theirs — wait, or name a platform of their own — and keeps
+ * the real fault as the cause for anybody who goes looking.
  */
-export class NoPlatformNamedError extends Error {
-  constructor() {
+export class DefaultPlatformUnusableError extends Error {
+  constructor(url: string, cause: unknown) {
     super(
-      "This repository names no Egma platform, and egma has no hosted one to fall back to. Point egma at yours: run it again with --url <address>, or set EGMA_URL for this shell. Nothing was sent.",
+      `This repository names no Egma platform, so egma used its own at ${url}, and it did not answer. Try again in a moment, or point egma at another platform with --url <address> or EGMA_URL. Nothing was sent.`,
+      { cause },
     );
-    this.name = "NoPlatformNamedError";
+    this.name = "DefaultPlatformUnusableError";
   }
 }
 
@@ -480,9 +510,87 @@ async function bindingIn(repository: string): Promise<PlatformBinding | null> {
   }
 }
 
+/** Which egma a command will use, before anybody there has been asked anything. */
+export type ChosenPlatform = SelectedPlatform & {
+  /** The platform committed in this repository, when there is one. */
+  readonly binding: PlatformBinding | null;
+  readonly credentialsFile: string;
+};
+
+/**
+ * Which egma, chosen without asking anybody anything.
+ *
+ * Separate from the read that follows it because the wizard names the address
+ * on its first screen and takes the keystroke of consent there: a bare command
+ * asks nothing of any address until the developer has read which address it is.
+ * A verb has no screen and no keystroke to take, so it does both in one step.
+ *
+ * Everything refused here is refused on what is already on this machine — a bad
+ * address, an unreadable config, a bound repository pointed somewhere else — so
+ * none of it costs a request.
+ */
+export async function choosePlatform(choice: {
+  readonly env: NodeJS.ProcessEnv;
+  /** `--url`, when one was given. */
+  readonly flag: string | null;
+  /** The agent repository whose binding is part of resolution. */
+  readonly cwd: string;
+}): Promise<ChosenPlatform> {
+  const credentialsFile = credentialsFileIn(choice.env);
+  const binding = await bindingIn(choice.cwd);
+  const selected = selectPlatform({
+    flag: choice.flag,
+    env: choice.env.EGMA_URL,
+    binding: binding?.origin ?? null,
+    fallback: defaultPlatformUrlIn(choice.env),
+  });
+
+  // Refused before anybody is asked anything: a bound repository is reached at
+  // the address it recorded, and at no other.
+  if (binding !== null && selected.url !== binding.origin) {
+    throw new BoundPlatformAddressError(binding, selected.source, selected.url);
+  }
+
+  return { ...selected, binding, credentialsFile };
+}
+
+/** Who is answering there — the first thing a command asks of any address. */
+export async function verifyPlatform(
+  chosen: ChosenPlatform,
+  fetchImpl?: Fetch,
+): Promise<VerifiedPlatformAccess> {
+  const { binding } = chosen;
+  let identity: PlatformIdentity;
+  try {
+    identity = await readPlatformIdentity(chosen.url, fetchImpl);
+  } catch (cause) {
+    // Safe to name the binding here, and only here: any address that is not the
+    // bound one was already refused above, so a bound repository that got this
+    // far was reaching its own platform.
+    if (binding !== null && cause instanceof PlatformUnreachableError) {
+      throw new BoundPlatformUnavailableError(binding, cause);
+    }
+    // Nobody chose this address, so nobody can be sent to go and look at it.
+    if (chosen.source === "default") {
+      throw new DefaultPlatformUnusableError(chosen.url, cause);
+    }
+    throw cause;
+  }
+
+  if (binding !== null && binding.instance !== identity.instanceId) {
+    throw new PlatformBindingMismatchError(binding, identity);
+  }
+
+  return {
+    url: identity.origin,
+    instanceId: identity.instanceId,
+    credentialsFile: chosen.credentialsFile,
+  };
+}
+
 /**
  * Resolved once, in one place, so the wizard and every verb read the same
- * answer from the same three places in the same order. Two copies of this would
+ * answer from the same four places in the same order. Two copies of this would
  * be two answers to "which egma is this", and the one that is wrong would be
  * the one that wrote the key.
  */
@@ -494,41 +602,5 @@ export async function resolvePlatformAccess(choice: {
   readonly cwd: string;
   readonly fetchImpl?: Fetch;
 }): Promise<VerifiedPlatformAccess> {
-  const credentialsFile = credentialsFileIn(choice.env);
-  const binding = await bindingIn(choice.cwd);
-  const selected = selectPlatform({
-    flag: choice.flag,
-    env: choice.env.EGMA_URL,
-    binding: binding?.origin ?? null,
-  });
-
-  // Refused before anybody is asked anything: a bound repository is reached at
-  // the address it recorded, and at no other.
-  if (binding !== null && selected.url !== binding.origin) {
-    throw new BoundPlatformAddressError(binding, selected.source, selected.url);
-  }
-
-  let identity: PlatformIdentity;
-  try {
-    identity = await readPlatformIdentity(selected.url, choice.fetchImpl);
-  } catch (cause) {
-    // Safe to name the binding here, and only here: any address that is not the
-    // bound one was already refused above, so a bound repository that got this
-    // far was reaching its own platform.
-    if (binding !== null && cause instanceof PlatformUnreachableError) {
-      throw new BoundPlatformUnavailableError(binding, cause);
-    }
-    // Nobody chose this address, so nobody can be sent to go and look at it.
-    throw cause;
-  }
-
-  if (binding !== null && binding.instance !== identity.instanceId) {
-    throw new PlatformBindingMismatchError(binding, identity);
-  }
-
-  return {
-    url: identity.origin,
-    instanceId: identity.instanceId,
-    credentialsFile,
-  };
+  return verifyPlatform(await choosePlatform(choice), choice.fetchImpl);
 }

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -16,7 +16,12 @@ import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
-import { folderPathsIn, readConfig, type PlatformBinding } from "../folder/egma-folder.ts";
+import {
+  folderPathsIn,
+  readConfig,
+  teachingTheMove,
+  type PlatformBinding,
+} from "../folder/egma-folder.ts";
 import {
   normalizePlatformOrigin,
   readPlatformIdentity,
@@ -431,11 +436,22 @@ export type VerifiedPlatformAccess = PlatformAccess & {
   readonly instanceId: string;
 };
 
-/** A selected instance is not the platform committed in this repository. */
+/**
+ * A selected instance is not the platform committed in this repository.
+ *
+ * This and the address refusal below are the two a developer meets when they
+ * really are moving a repository — they point egma at the platform they want
+ * and are told no — so both end with the whole move rather than its first step.
+ * Naming one deletion and stopping is what leaves somebody deleting a line,
+ * running again, and meeting a stranger failure about identifiers the new
+ * platform never issued.
+ */
 export class PlatformBindingMismatchError extends Error {
   constructor(binding: PlatformBinding, selected: PlatformIdentity) {
     super(
-      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, but the selected address identifies platform ${selected.instanceId} at ${selected.origin}. Remove --url or EGMA_URL to use the bound platform. Rebinding is not supported yet. No repository identifiers were sent.`,
+      teachingTheMove(
+        `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, but the selected address identifies platform ${selected.instanceId} at ${selected.origin}. Remove --url or EGMA_URL to use the bound platform. egma does not move a repository between platforms, and no repository identifiers were sent.`,
+      ),
     );
     this.name = "PlatformBindingMismatchError";
   }
@@ -446,24 +462,29 @@ export class PlatformBindingMismatchError extends Error {
  * recorded, whoever is answering there.
  *
  * Separate from the instance mismatch above because it is refused before
- * anybody answers: rebinding is out of this effort either way, and the same
+ * anybody answers: the move is out of this effort either way, and the same
  * instance served at a new address is still a change to a committed file that
- * a developer has to make on purpose rather than have made for them.
+ * a developer has to make on purpose rather than have made for them. That case
+ * keeps its own sentence, because editing one address is not the move and
+ * treating it as one would have somebody throw away identifiers that are still
+ * good.
  */
 export class BoundPlatformAddressError extends Error {
   constructor(binding: PlatformBinding, source: PlatformSource, selected: string) {
     super(
-      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and ${SOURCE_NAMES[source]} names ${selected} instead. Drop it to use the bound platform. If the platform really has moved, edit the platform origin in egma/config.yaml on purpose — rebinding is not supported yet. No repository identifiers were sent.`,
+      teachingTheMove(
+        `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and ${SOURCE_NAMES[source]} names ${selected} instead. Drop it to use the bound platform. If that platform has only changed address, edit the platform origin in egma/config.yaml on purpose. egma does not move a repository between platforms, and no repository identifiers were sent.`,
+      ),
     );
     this.name = "BoundPlatformAddressError";
   }
 }
 
-/** The bound platform did not answer, and Cloud was deliberately not tried. */
+/** The bound platform did not answer, and egma's own was deliberately not tried. */
 export class BoundPlatformUnavailableError extends Error {
   constructor(binding: PlatformBinding, cause: unknown) {
     super(
-      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and it did not answer. Start the bound platform and run this again. Egma Cloud was not used, and no repository identifiers were sent.`,
+      `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and it did not answer. Start the bound platform and run this again. egma did not fall back to its own platform, and no repository identifiers were sent.`,
       { cause },
     );
     this.name = "BoundPlatformUnavailableError";
@@ -494,7 +515,7 @@ export class DefaultPlatformUnusableError extends Error {
 export class RepositoryPlatformConfigError extends Error {
   constructor(cause: unknown) {
     super(
-      "Egma could not read this repository's egma/config.yaml, so it did not select a platform. Fix that file and run this again. Egma Cloud was not used.",
+      "Egma could not read this repository's egma/config.yaml, so it did not select a platform. Fix that file and run this again. egma did not fall back to its own platform.",
       { cause },
     );
     this.name = "RepositoryPlatformConfigError";

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -18,8 +18,10 @@ import process from "node:process";
 
 import {
   folderPathsIn,
+  platformOwnedIds,
   readConfig,
   teachingTheMove,
+  type FolderConfig,
   type PlatformBinding,
 } from "../folder/egma-folder.ts";
 import {
@@ -537,6 +539,31 @@ export class DefaultPlatformUnusableError extends Error {
   }
 }
 
+/**
+ * The folder holds identifiers from a platform it no longer names.
+ *
+ * The half-applied move, refused rather than acted on. Deleting the platform
+ * block is one edit; deleting the identifiers it was keeping in place is four
+ * more. Between those two moments the repository names nothing and still holds
+ * everything — and the step below "names nothing" is now egma's own platform,
+ * so without this the next command carries another platform's identifiers to
+ * hosted egma. ADR-0008's rule is that they cannot silently cross that line.
+ *
+ * It ends with the same block every other refusal about moving ends with,
+ * because the developer is in the middle of exactly that list: what they need
+ * next is the rest of it, not a new set of words for the same five lines.
+ */
+export class UnboundPlatformIdentifiersError extends Error {
+  constructor(held: readonly string[]) {
+    super(
+      teachingTheMove(
+        `This repository names no Egma platform, and it still holds identifiers that only the platform which issued them can resolve — under ${held.join(", ")} in egma/config.yaml. egma will not send those to its own platform. Put the platform: block back to use the platform they came from, or finish the move below by deleting them. Nothing was sent.`,
+      ),
+    );
+    this.name = "UnboundPlatformIdentifiersError";
+  }
+}
+
 /** The committed config could not safely take part in platform resolution. */
 export class RepositoryPlatformConfigError extends Error {
   constructor(cause: unknown) {
@@ -548,9 +575,17 @@ export class RepositoryPlatformConfigError extends Error {
   }
 }
 
-async function bindingIn(repository: string): Promise<PlatformBinding | null> {
+/**
+ * The committed folder config, or `null` when this repository has none.
+ *
+ * The whole config rather than only its binding, because resolution needs two
+ * things out of this file and reading it twice would be two answers to one
+ * question: which platform it names, and — when it names none — whether it is
+ * still holding identifiers that belong to one.
+ */
+async function committedIn(repository: string): Promise<FolderConfig | null> {
   try {
-    return (await readConfig(folderPathsIn(repository).config)).platform;
+    return await readConfig(folderPathsIn(repository).config);
   } catch (cause) {
     if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw new RepositoryPlatformConfigError(cause);
@@ -584,7 +619,8 @@ export async function choosePlatform(choice: {
   readonly cwd: string;
 }): Promise<ChosenPlatform> {
   const credentialsFile = credentialsFileIn(choice.env);
-  const binding = await bindingIn(choice.cwd);
+  const committed = await committedIn(choice.cwd);
+  const binding = committed?.platform ?? null;
   const selected = selectPlatform({
     flag: choice.flag,
     env: choice.env.EGMA_URL,
@@ -603,6 +639,21 @@ export async function choosePlatform(choice: {
   // this refusal can be about a move somebody is really making.
   if (binding !== null && selected.source !== "binding" && selected.url !== binding.origin) {
     throw new BoundPlatformAddressError(binding, selected.source, selected.url);
+  }
+
+  // And refused before anybody is asked anything for the other direction: a
+  // folder that names no platform and is still holding one platform's
+  // identifiers. Only against the built-in address, because that is the step
+  // nobody typed — an address a developer named on the command line or in their
+  // shell is a deliberate act, and it is how a self-hoster worked before there
+  // was any built-in address to fall back to.
+  //
+  // A folder with no identifiers at all is untouched by this, which is what
+  // keeps `egma init`'s own output — a bare `platform:` line and three names —
+  // working exactly as it did.
+  if (binding === null && selected.source === "default" && committed !== null) {
+    const held = platformOwnedIds(committed);
+    if (held.length > 0) throw new UnboundPlatformIdentifiersError(held);
   }
 
   return { ...selected, binding, credentialsFile };

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -545,11 +545,20 @@ export class DefaultPlatformUnusableError extends Error {
  * The half-applied move, refused rather than acted on. Deleting the platform
  * block is one edit; deleting the identifiers it was keeping in place is four
  * more. Between those two moments the repository names nothing and still holds
- * everything — and the step below "names nothing" is now egma's own platform,
- * so without this the next command carries another platform's identifiers to
- * hosted egma. ADR-0008's rule is that they cannot silently cross that line.
+ * everything, and ADR-0008's rule is that those identifiers cannot silently
+ * cross a platform boundary.
  *
- * It ends with the same block every other refusal about moving ends with,
+ * **The deleted line is the one that said which platform they belong to**, so
+ * once it is gone there is no address egma can safely send them to — not the
+ * built-in one it would have chosen, and not one somebody types either. That is
+ * why this cannot end by offering to use another platform, and why the two ways
+ * out are the only two there are: put the line back, or take the identifiers
+ * out. Both are named, because somebody who deleted that block by mistake is
+ * not making the move at all and must not be told to throw away four working
+ * identifiers to recover from a typo. The block is committed, which is exactly
+ * what makes putting it back an ordinary thing to do.
+ *
+ * It ends with the same list every other refusal about moving ends with,
  * because the developer is in the middle of exactly that list: what they need
  * next is the rest of it, not a new set of words for the same five lines.
  */
@@ -557,7 +566,7 @@ export class UnboundPlatformIdentifiersError extends Error {
   constructor(held: readonly string[]) {
     super(
       teachingTheMove(
-        `This repository names no Egma platform, and it still holds identifiers that only the platform which issued them can resolve — under ${held.join(", ")} in egma/config.yaml. egma will not send those to its own platform. Put the platform: block back to use the platform they came from, or finish the move below by deleting them. Nothing was sent.`,
+        `This repository names no Egma platform, and it still holds identifiers that only the platform which issued them can resolve — under ${held.join(", ")} in egma/config.yaml. egma will not send them anywhere, because the line that said which platform they came from is the one that is gone. Two ways on: put the platform: block back in egma/config.yaml, which is committed and so is in this repository's history, or delete the identifiers below and connect again on whichever platform you name next. Nothing was sent.`,
       ),
     );
     this.name = "UnboundPlatformIdentifiersError";
@@ -643,15 +652,20 @@ export async function choosePlatform(choice: {
 
   // And refused before anybody is asked anything for the other direction: a
   // folder that names no platform and is still holding one platform's
-  // identifiers. Only against the built-in address, because that is the step
-  // nobody typed — an address a developer named on the command line or in their
-  // shell is a deliberate act, and it is how a self-hoster worked before there
-  // was any built-in address to fall back to.
+  // identifiers.
   //
-  // A folder with no identifiers at all is untouched by this, which is what
-  // keeps `egma init`'s own output — a bare `platform:` line and three names —
+  // Whichever of the three places named the address, because the question this
+  // asks is about the folder and not about the address. Once the platform block
+  // is gone, egma cannot tell the platform that issued these identifiers from
+  // any other — that is the one fact the deleted line held — so there is no
+  // address it can safely send them to, including one somebody typed. Refusing
+  // only the address egma chose would also be the wrong half: somebody moving a
+  // repository types `--url` mid-move, which is exactly when this is true.
+  //
+  // A folder with no identifiers at all is untouched, which is what keeps
+  // `egma init`'s own output — a bare `platform:` line and three names —
   // working exactly as it did.
-  if (binding === null && selected.source === "default" && committed !== null) {
+  if (binding === null && committed !== null) {
     const held = platformOwnedIds(committed);
     if (held.length > 0) throw new UnboundPlatformIdentifiersError(held);
   }

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -25,6 +25,7 @@ import {
 import {
   normalizePlatformOrigin,
   readPlatformIdentity,
+  whatAnswered,
   type PlatformIdentity,
 } from "./identity.ts";
 import { PlatformUnreachableError, type Fetch } from "./device-flow.ts";
@@ -468,14 +469,21 @@ export class PlatformBindingMismatchError extends Error {
  * keeps its own sentence, because editing one address is not the move and
  * treating it as one would have somebody throw away identifiers that are still
  * good.
+ *
+ * The sentence offers two edits that contradict each other — change the
+ * platform origin, or delete the whole platform block — so it says which one
+ * belongs to which situation. Under ADR-0007 a refusal that holds both without
+ * a condition is one a coding agent cannot act on.
+ *
+ * The block under it is attached only when a developer really is being told no
+ * about another platform. `binding` as the source would be the binding refusing
+ * itself, which is not a move and must never end with four deletions.
  */
 export class BoundPlatformAddressError extends Error {
   constructor(binding: PlatformBinding, source: PlatformSource, selected: string) {
-    super(
-      teachingTheMove(
-        `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and ${SOURCE_NAMES[source]} names ${selected} instead. Drop it to use the bound platform. If that platform has only changed address, edit the platform origin in egma/config.yaml on purpose. egma does not move a repository between platforms, and no repository identifiers were sent.`,
-      ),
-    );
+    const named = SOURCE_NAMES[source];
+    const refusal = `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and ${named} names ${selected} instead. Drop ${named} to use the bound platform. If ${selected} is that same platform at a new address, edit the platform origin in egma/config.yaml to ${selected} and change nothing else — the move below is for a different platform, not a new address for this one. egma does not move a repository between platforms, and no repository identifiers were sent.`;
+    super(source === "binding" ? refusal : teachingTheMove(refusal));
     this.name = "BoundPlatformAddressError";
   }
 }
@@ -495,19 +503,37 @@ export class BoundPlatformUnavailableError extends Error {
  * Nothing named a platform, so egma used its own, and its own is no use today.
  *
  * One refusal for every way that address can fail, because the developer never
- * typed it, does not run what is at it, and cannot fix any of them. Handing on
- * the underlying sentence would send them to check an address they did not
- * choose, or to reconfigure a deployment that is not theirs. So this says the
- * two moves that are theirs — wait, or name a platform of their own — and keeps
- * the real fault as the cause for anybody who goes looking.
+ * typed it, does not run what is at it, and cannot fix any of them. What is
+ * suppressed is the advice — "check the address", "look at the proxy in front
+ * of it", "set EGMA_BASE_URL on the platform" — every word of which is
+ * addressed to somebody who is not reading. **What happened is not suppressed.**
+ * A redirect told as "it did not answer" is wrong about the fact and wrong
+ * about the remedy, and it is the one shape the spec relies on egma reporting.
+ *
+ * So the shape travels with the refusal. Something that answered wrongly and
+ * will answer wrongly again is `refused`: it is stated plainly, and nobody is
+ * invited into a retry loop over it. Nobody answering, a connection that stalls
+ * and a platform having a bad minute are `unreachable`, and those do say to try
+ * again. The real fault stays on as the cause for whoever goes looking.
  */
 export class DefaultPlatformUnusableError extends Error {
+  /** Which of egma's two refusal shapes this is, decided by what answered. */
+  readonly refusal: "refused" | "unreachable";
+
   constructor(url: string, cause: unknown) {
+    const answered = whatAnswered(cause);
     super(
-      `This repository names no Egma platform, so egma used its own at ${url}, and it did not answer. Try again in a moment, or point egma at another platform with --url <address> or EGMA_URL. Nothing was sent.`,
+      [
+        `This repository names no Egma platform, so egma used its own at ${url}, and ${answered.said}`,
+        answered.worthRetrying
+          ? "Try again in a moment, or point egma at another platform with --url <address> or EGMA_URL."
+          : "That is egma's to fix and not yours, and waiting will not change it. To carry on now, point egma at another platform with --url <address> or EGMA_URL.",
+        "Nothing was sent.",
+      ].join(" "),
       { cause },
     );
     this.name = "DefaultPlatformUnusableError";
+    this.refusal = answered.worthRetrying ? "unreachable" : "refused";
   }
 }
 
@@ -568,7 +594,14 @@ export async function choosePlatform(choice: {
 
   // Refused before anybody is asked anything: a bound repository is reached at
   // the address it recorded, and at no other.
-  if (binding !== null && selected.url !== binding.origin) {
+  //
+  // The binding cannot disagree with itself. An address that came *from* the
+  // binding is the bound address by definition — the committed origin is read
+  // in the one shape origins are compared in, so a trailing slash or an
+  // upper-case host in the file is the same platform and not a different one.
+  // Only the two places above it can raise this, which is also the only way
+  // this refusal can be about a move somebody is really making.
+  if (binding !== null && selected.source !== "binding" && selected.url !== binding.origin) {
     throw new BoundPlatformAddressError(binding, selected.source, selected.url);
   }
 

--- a/apps/cli/src/platform/identity.ts
+++ b/apps/cli/src/platform/identity.ts
@@ -67,11 +67,34 @@ export const IDENTITY_TIMEOUT_MS = 10_000;
 const NOT_A_PLATFORM =
   "Check the address. If it is right, this is probably not an Egma platform, or it is older than this copy of egma.";
 
-/** A platform answered, but not with the public contract the CLI requires. */
+/**
+ * A platform answered, but not with the public contract the CLI requires.
+ *
+ * The clause saying what happened is kept apart from the advice that follows
+ * it, because one caller needs the first half without the second: the built-in
+ * address is one nobody typed and nobody outside egma can fix, so a developer
+ * who reaches it must be told what happened there and never sent to go and look
+ * at it.
+ */
 export class PlatformIdentityError extends Error {
-  constructor(origin: string, because: string, advice: string = NOT_A_PLATFORM) {
-    super(`egma asked ${origin} which platform it is, and ${because} ${advice}`);
+  /** What happened, in one clause, with no advice attached to it. */
+  readonly said: string;
+  /** Whether asking this same address again in a moment could answer differently. */
+  readonly worthRetrying: boolean;
+
+  constructor(
+    origin: string,
+    because: string,
+    options: { readonly advice?: string; readonly worthRetrying?: boolean } = {},
+  ) {
+    super(
+      `egma asked ${origin} which platform it is, and ${because} ${options.advice ?? NOT_A_PLATFORM}`,
+    );
     this.name = "PlatformIdentityError";
+    this.said = because;
+    // An answer that is not the contract is the address being what it is, not a
+    // bad moment, so waiting changes nothing unless the caller says otherwise.
+    this.worthRetrying = options.worthRetrying ?? false;
   }
 }
 
@@ -91,7 +114,10 @@ export class PlatformRedirectedError extends PlatformIdentityError {
       to === ""
         ? "it answered with a redirect somewhere else instead."
         : `it redirected to ${to} instead.`,
-      "egma does not follow that. Something in front of this address is answering for it — a sign-in page or a proxy — so this is where to look, not at your copy of egma.",
+      {
+        advice:
+          "egma does not follow that. Something in front of this address is answering for it — a sign-in page or a proxy — so this is where to look, not at your copy of egma.",
+      },
     );
     this.name = "PlatformRedirectedError";
   }
@@ -137,6 +163,9 @@ function isLoopback(origin: string): boolean {
  * listening. So the second half of the advice is only given when it is true.
  */
 export class PlatformOriginMismatchError extends Error {
+  /** The address the platform named for itself, which egma did not follow. */
+  readonly stated: string;
+
   constructor(asked: string, stated: string) {
     const statedIsOnlyItsOwnMachine = isLoopback(stated) && !isLoopback(asked);
     super(
@@ -152,7 +181,47 @@ export class PlatformOriginMismatchError extends Error {
       ].join(" "),
     );
     this.name = "PlatformOriginMismatchError";
+    this.stated = stated;
   }
+}
+
+/**
+ * What happened at an address, in one clause, and whether waiting could change
+ * it.
+ *
+ * Written for the one caller that must not relay these refusals whole: egma's
+ * own built-in address. The developer never typed it, does not run what is at
+ * it, and cannot reconfigure it — so the advice half of every sentence below is
+ * addressed to nobody who is reading. What happened is still theirs to know:
+ * "it did not answer" told about a platform that answered with a redirect is
+ * wrong about the fact and wrong about the remedy, and "try again in a moment"
+ * on a permanent shape is a retry loop.
+ *
+ * `worthRetrying` is deliberately generous at the edges. A 5xx is a bad moment
+ * on a deployment that is otherwise the right one; anything egma cannot place
+ * is treated the same way, because inviting one wasted retry costs less than
+ * telling somebody a passing fault is permanent.
+ */
+export type WhatAnswered = {
+  /** Reads after "…egma used its own at <address>, and ". */
+  readonly said: string;
+  readonly worthRetrying: boolean;
+};
+
+export function whatAnswered(cause: unknown): WhatAnswered {
+  if (cause instanceof PlatformTimedOutError) {
+    return { said: "it took the connection and then said nothing.", worthRetrying: true };
+  }
+  if (cause instanceof PlatformUnreachableError) {
+    return { said: "nothing answered there.", worthRetrying: true };
+  }
+  if (cause instanceof PlatformOriginMismatchError) {
+    return { said: `it answered that it lives at ${cause.stated} instead.`, worthRetrying: false };
+  }
+  if (cause instanceof PlatformIdentityError) {
+    return { said: cause.said, worthRetrying: cause.worthRetrying };
+  }
+  return { said: "egma could not use what came back.", worthRetrying: true };
 }
 
 function text(value: unknown): string {
@@ -202,6 +271,10 @@ export async function readPlatformIdentity(
     throw new PlatformIdentityError(
       selectedOrigin,
       `it answered ${String(response.status)} rather than its identity.`,
+      // A platform having a bad minute answers in the 500s, and the same
+      // address a minute later is the ordinary way that ends. A 4xx is the
+      // address being what it is, and no amount of waiting makes it egma.
+      { worthRetrying: response.status >= 500 },
     );
   }
 

--- a/apps/cli/src/ui/headless-ui.ts
+++ b/apps/cli/src/ui/headless-ui.ts
@@ -35,6 +35,8 @@ import type { AskId, DrivenAgent, GateId, WizardUI } from "./wizard-ui.ts";
 export type HeadlessRecord = {
   drivenAgent: DrivenAgent | null;
   drivenAgentLog: string | null;
+  /** Which egma this walk will use, as it was named before the gate. */
+  platform: string | null;
   /** What egma worked out for itself before it asked anybody anything. */
   detection: Detection | null;
   logins: LoginPrompt[];
@@ -72,6 +74,7 @@ export class HeadlessUI implements WizardUI {
   readonly record: HeadlessRecord = {
     drivenAgent: null,
     drivenAgentLog: null,
+    platform: null,
     detection: null,
     logins: [],
     keyAsks: [],
@@ -111,6 +114,20 @@ export class HeadlessUI implements WizardUI {
 
   setDrivenAgentLog(file: string): void {
     this.record.drivenAgentLog = file;
+  }
+
+  /**
+   * Which egma, as one plain line, in the same place in the walk the wizard's
+   * first screen says it.
+   *
+   * The same `url:` line every verb prints, from a run that has nobody to draw
+   * a screen for: whoever reads this output afterwards can see which egma this
+   * repository's identifiers were about to go to, before any of them went.
+   */
+  setPlatform(url: string | null): void {
+    if (url === null) return;
+    this.record.platform = url;
+    this.write(`url: ${url}`);
   }
 
   /**

--- a/apps/cli/src/ui/tui/ink-ui.ts
+++ b/apps/cli/src/ui/tui/ink-ui.ts
@@ -39,6 +39,10 @@ export class InkUI implements WizardUI {
     this.store.setDrivenAgentLog(file);
   }
 
+  setPlatform(url: string | null): void {
+    this.store.setPlatform(url);
+  }
+
   setDetection(detection: Detection | null): void {
     this.store.setDetection(detection);
   }

--- a/apps/cli/src/ui/tui/screens/IntroScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/IntroScreen.tsx
@@ -5,6 +5,12 @@
  * developer's own coding agent will be driven and that every action it takes
  * will be shown. Consent is earned afterwards by showing everything, not by
  * asking again.
+ *
+ * It also names the egma this walk will use, and how to choose another. A bare
+ * command in a repository that names no platform reaches egma's own, so which
+ * egma this is stopped being something the developer chose and started being
+ * something they have to be told — and told here, on the screen that takes the
+ * keystroke, before that address has been asked anything at all.
  */
 
 import { Box, Text, useInput } from "ink";
@@ -12,6 +18,16 @@ import { Box, Text, useInput } from "ink";
 import { FACTS } from "../../../wizard/facts.ts";
 import { dispatchKey, hintBar, type KeyBinding } from "../keybindings.ts";
 import type { WizardState } from "../state.ts";
+
+/**
+ * How to use a different egma, in the two ways that really select one.
+ *
+ * `EGMA_TEST_DEFAULT_URL` is not among them and never will be: it is a test
+ * seam that stands in for the built-in address, not a way for a developer to
+ * choose a platform.
+ */
+export const ANOTHER_PLATFORM =
+  "For a different egma, quit and run it again with --url <address>, or set EGMA_URL.";
 
 export type IntroScreenProps = {
   readonly state: WizardState;
@@ -48,6 +64,13 @@ export function IntroScreen({ state, onBegin, onQuit }: IntroScreenProps) {
       <Text>egma tells it to change nothing. Your code stays on this machine.</Text>
       <Box height={1} />
       <Text>Every action your coding agent takes appears below as it happens.</Text>
+      {state.platform === null ? null : (
+        <>
+          <Box height={1} />
+          <Text>{`This uses ${state.platform}. Nothing has been sent to it yet.`}</Text>
+          <Text dimColor>{ANOTHER_PLATFORM}</Text>
+        </>
+      )}
       <Box height={1} />
       <Text dimColor>{hintBar(bindings)}</Text>
     </Box>

--- a/apps/cli/src/ui/tui/start-tui.ts
+++ b/apps/cli/src/ui/tui/start-tui.ts
@@ -24,8 +24,15 @@ import { enterAlternateScreen, leaveAlternateScreen } from "./terminal.ts";
 export type TuiHandle = {
   readonly ui: WizardUI;
   readonly store: WizardStore;
-  /** Leaves the alternate screen and prints the one line that survives. */
-  close(report: ExitReport): void;
+  /**
+   * Leaves the alternate screen and prints the one line that survives.
+   *
+   * `null` leaves nothing behind: the wizard is handing the last word to
+   * whoever called it, which is what happens when egma declines to talk to a
+   * platform at all. That sentence is not the wizard's to say, and saying it
+   * here as well would print it twice.
+   */
+  close(report: ExitReport | null): void;
 };
 
 export type StartTuiOptions = {
@@ -52,11 +59,12 @@ export function startTui(options: StartTuiOptions): TuiHandle {
   );
 
   let closed = false;
-  const close = (report: ExitReport): void => {
+  const close = (report: ExitReport | null): void => {
     if (closed) return;
     closed = true;
     instance.unmount();
     leaveAlternateScreen(stdout);
+    if (report === null) return;
     const notice = buildExitNotice(report);
     if (notice !== null) stdout.write(`${notice}\n\n`);
     stdout.write(`${exitLines(report).join("\n")}\n`);

--- a/apps/cli/src/ui/tui/state.ts
+++ b/apps/cli/src/ui/tui/state.ts
@@ -21,6 +21,14 @@ export type WizardState = {
   readonly drivenAgent: DrivenAgent | null;
   /** Where the coding agent's own output is kept, for a screen that tails it. */
   readonly drivenAgentLog: string | null;
+  /**
+   * Which egma this walk will use, or `null` when it will use none.
+   *
+   * Set before the intro is dismissed, so the screen that takes the keystroke
+   * of consent is the screen that says where this repository's identifiers are
+   * about to go.
+   */
+  readonly platform: string | null;
   /** What egma worked out about this machine for itself, or `null` before it has. */
   readonly detection: Detection | null;
   /** What has to be approved in a browser, while it still has to be. */
@@ -72,6 +80,7 @@ export function emptyState(): WizardState {
   return {
     drivenAgent: null,
     drivenAgentLog: null,
+    platform: null,
     detection: null,
     login: null,
     loginTyping: "",

--- a/apps/cli/src/ui/tui/store.ts
+++ b/apps/cli/src/ui/tui/store.ts
@@ -176,6 +176,10 @@ export class WizardStore {
     this.change({ drivenAgentLog });
   }
 
+  setPlatform(platform: string | null): void {
+    this.change({ platform });
+  }
+
   setDetection(detection: Detection | null): void {
     this.change({ detection });
   }

--- a/apps/cli/src/ui/wizard-ui.ts
+++ b/apps/cli/src/ui/wizard-ui.ts
@@ -74,6 +74,17 @@ export interface WizardUI {
   setDrivenAgentLog(file: string): void;
 
   /**
+   * Which egma this walk will use, or `null` when it will use none.
+   *
+   * Written before the gate that takes the keystroke of consent, and before
+   * that address has been asked anything, so whatever draws the first screen
+   * can say where this repository's identifiers are about to go. A bare command
+   * now reaches egma's own platform when nothing names another, which is
+   * exactly why it has to be said rather than assumed.
+   */
+  setPlatform(url: string | null): void;
+
+  /**
    * What egma worked out about this machine for itself, or `null` before it
    * has.
    *

--- a/apps/cli/src/wizard/exit-line.ts
+++ b/apps/cli/src/wizard/exit-line.ts
@@ -128,6 +128,29 @@ function oneLine(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
+/**
+ * A reason, split into the sentence that goes on the line and the block that
+ * goes under it.
+ *
+ * Almost every reason is one paragraph and stays one line, whatever whitespace
+ * it arrived with — a wrapped sentence or a stack trace squashed onto one line
+ * is still readable, and it keeps the promise that the last thing in scrollback
+ * selects whole with one triple-click.
+ *
+ * A reason that arrived as a paragraph **and** a block is the exception, and
+ * the block is the reason it exists: the refusal that keeps a repository on its
+ * own platform ends with every line a developer deletes to move it, and a
+ * coding agent is supposed to act on those lines without a person reading them
+ * out. Squashed into the sentence they are unreadable and unusable, so they
+ * survive as lines. A blank line is what marks one, which is exactly how the
+ * refusal is built.
+ */
+function saidAndBlock(reason: string): readonly [string, readonly string[]] {
+  const at = reason.indexOf("\n\n");
+  if (at === -1) return [oneLine(reason), []];
+  return [oneLine(reason.slice(0, at)), reason.slice(at + 2).split("\n")];
+}
+
 /** Where the files are, said the same way in both endings that mention them. */
 const TESTS_FOLDER = "egma/tests/";
 
@@ -207,20 +230,32 @@ export function buildExitLine(report: ExitReport): string {
         : `${stopped} Your ${kept} tests are in ${TESTS_FOLDER}.`;
     }
     case "failed":
-      return `egma could not finish: ${oneLine(report.reason)}`;
+      return `egma could not finish: ${saidAndBlock(report.reason)[0]}`;
   }
 }
 
 /**
  * Everything that survives the wizard, in the order it is printed.
  *
- * Every ending but one is a single line and comes back as one. The ending the
+ * Every ending but two is a single line and comes back as one. The ending the
  * walk is for is a short block, and its shape is the promise: a headline, the
  * results address alone on its line, and then the two sentences a developer
  * takes with them. The blank lines between them are the only decoration, and
  * they are there so that no line has anything beside it.
+ *
+ * The other is a failure that arrived carrying a block — which today is one
+ * refusal, the one that keeps a repository on the platform it is bound to and
+ * ends with every line a developer deletes to move it. It goes under the line,
+ * whole and one line each, because that block is what a coding agent acts on
+ * and a squashed copy of it is neither readable nor usable.
  */
 export function exitLines(report: ExitReport): readonly string[] {
+  if (report.kind === "failed") {
+    const [, block] = saidAndBlock(report.reason);
+    return block.length === 0
+      ? [buildExitLine(report)]
+      : [buildExitLine(report), "", ...block];
+  }
   if (report.kind !== "run-started") return [buildExitLine(report)];
   return [
     buildExitLine(report),

--- a/apps/cli/src/wizard/login-step.ts
+++ b/apps/cli/src/wizard/login-step.ts
@@ -25,6 +25,32 @@ export type PlatformAccess = ResolvedPlatform & {
 };
 
 /**
+ * Which egma the walk uses, in the two parts the wizard needs it in.
+ *
+ * The address is here from the start, because the wizard's first screen names
+ * it. Who is answering there is asked for by `verify`, which the walk calls
+ * once — after the keystroke of consent and never before. That ordering is the
+ * whole point of the split: a developer reads which egma their repository is
+ * about to talk to before egma has said one word to it.
+ */
+export type WalkPlatform = {
+  readonly url: string;
+  verify(): Promise<PlatformAccess>;
+};
+
+/**
+ * A platform whoever is calling has already asked.
+ *
+ * Every check that stands its own platform up knows the answer before the walk
+ * starts, and so does anything else that resolved a platform for its own
+ * reasons. They hand it over through here rather than each writing a `verify`
+ * that asks nobody anything.
+ */
+export function alreadyAsked(access: PlatformAccess): WalkPlatform {
+  return { url: access.url, verify: () => Promise.resolve(access) };
+}
+
+/**
  * Logs in, or answers with the line the wizard should close on.
  *
  * `null` means the developer is signed in and the walk carries on. Everything

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -27,7 +27,7 @@ import { findTheAgent } from "./discovery.ts";
 import { openDrivenAgentLog, type DrivenAgentLog } from "./driven-agent-log.ts";
 import type { ExitReport } from "./exit-line.ts";
 import { generateStep } from "./generate-step.ts";
-import { logInStep, type PlatformAccess } from "./login-step.ts";
+import { logInStep, type PlatformAccess, type WalkPlatform } from "./login-step.ts";
 import { runStep } from "./run-step.ts";
 import { stopReport, untilAborted } from "./stop.ts";
 
@@ -43,7 +43,7 @@ export type WalkOptions = {
    * in to nothing — which is how the checks that are only about driving a
    * coding agent stay about that.
    */
-  readonly platform?: PlatformAccess;
+  readonly platform?: WalkPlatform;
   /** Where Retell is. Retell's own address when omitted. */
   readonly retell?: ConnectOptions["retell"];
   /** How many tests a first suite holds. egma's own default when omitted. */
@@ -101,6 +101,12 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
   const log = options.log ?? openDrivenAgentLog();
   ui.setDrivenAgentLog(log.file);
 
+  // Which egma, said before the keystroke that agrees to all of it and before
+  // egma has asked that address anything. A bare command now reaches egma's own
+  // platform by default, so where a repository's identifiers are going is the
+  // developer's to read first, not to find out afterwards.
+  ui.setPlatform(options.platform?.url ?? null);
+
   await untilAborted(ui.waitForGate("begin"), signal);
   if (signal.aborted) {
     const report = stopReport(signal, launch.name);
@@ -110,8 +116,17 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
 
   // Before anything is driven: who this is. Nothing else in the walk can name
   // an agent, a connection or a test until egma knows whose they are.
+  //
+  // Asking the address who it is happens here, on the far side of the gate, so
+  // that a developer who reads the first screen and closes the wizard has sent
+  // nothing anywhere. A refusal from it leaves the walk entirely: it is not the
+  // walk failing, it is egma declining to talk to an address, and it is
+  // answered in the same plain sentence and the same number every verb answers
+  // with.
+  let platform: PlatformAccess | undefined;
   if (options.platform !== undefined) {
-    const refusal = await logInStep(options.platform, ui, signal);
+    platform = await options.platform.verify();
+    const refusal = await logInStep(platform, ui, signal);
     if (refusal !== null) {
       ui.setExit(refusal);
       return refusal;
@@ -125,7 +140,7 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
   // an egma to register on and an agent to register: a run that only drives a
   // coding agent has neither, and asking it for a provider key would be asking
   // for a secret nothing was going to use.
-  if (found.report.kind !== "found-agent" || options.platform === undefined) {
+  if (found.report.kind !== "found-agent" || platform === undefined) {
     ui.setExit(found.report);
     return found.report;
   }
@@ -137,7 +152,7 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
   // binding, in a repository the developer had decided not to connect.
   const connected = await connectStep({
     ui,
-    platform: options.platform,
+    platform,
     cwd,
     // What the coding agent said about where the words live, carried forward
     // so the two prompts can be compared once the provider's is in hand.
@@ -148,7 +163,7 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
 
   // Nothing after this can name what a test is about, so a connect that did not
   // connect is where the walk stops.
-  const signedIn = await signedInAt(options.platform);
+  const signedIn = await signedInAt(platform);
   if (connected.connected === null || signedIn === null) {
     ui.setExit(connected.report);
     return connected.report;

--- a/apps/cli/test/assembly.test.ts
+++ b/apps/cli/test/assembly.test.ts
@@ -34,6 +34,7 @@ import { parseTestFile } from "../src/folder/test-file.ts";
 import { readCredentials } from "../src/platform/credentials.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
 import { buildExitNotice, exitLines } from "../src/wizard/exit-line.ts";
+import { alreadyAsked } from "../src/wizard/login-step.ts";
 import { walk } from "../src/wizard/walk.ts";
 import type { FakeStep } from "./support/fake-agent.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
@@ -213,15 +214,15 @@ describe("the whole walk, offline", () => {
         launch: { ...workspace.launch(script), id: "claude-acp" },
         cwd: workspace.dir,
         signal: new AbortController().signal,
-        platform: {
+        platform: alreadyAsked({
           url: platform.url,
           instanceId: platform.instanceId,
           credentialsFile: workspace.credentialsFile,
-          openBrowser: async (url) => {
+          openBrowser: async (url: string) => {
             const code = new URL(url).searchParams.get("user_code") ?? "";
             return platform.device.approve(code);
           },
-        },
+        }),
         retell: { url: retell.url },
         howManyTests: SUITE_SIZE,
         home,

--- a/apps/cli/test/cli.test.ts
+++ b/apps/cli/test/cli.test.ts
@@ -98,8 +98,11 @@ describe("the egma command", () => {
     expect(help.stdout).toContain("--no-follow");
     expect(help.stdout).toContain("What egma run answers with:");
 
-    // The test seam is not product surface, so it is not offered.
+    // The test seams are not product surface, so neither is offered: not the
+    // one that starts a scripted coding agent, and not the one that stands an
+    // address in for egma's own.
     expect(help.stdout).not.toContain("-- <command>");
+    expect(help.stdout).not.toContain("EGMA_TEST_DEFAULT_URL");
 
     const version = await egma(["--version"], workspace);
     expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);

--- a/apps/cli/test/egma-folder.test.ts
+++ b/apps/cli/test/egma-folder.test.ts
@@ -390,13 +390,43 @@ describe("the egma folder", () => {
       }),
     ).rejects.toThrow("will not move a committed platform address");
 
-    // And another platform entirely is the refusal it always was.
-    await expect(
-      bindRepositoryPlatform(workspace.dir, {
-        origin: "https://old.example",
-        instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEQ",
-      }),
-    ).rejects.toThrow("Rebinding is not supported yet");
+    // And another platform entirely is the refusal it always was — which now
+    // teaches the whole move, because nothing performs it.
+    const moving = await bindRepositoryPlatform(workspace.dir, {
+      origin: "https://old.example",
+      instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEQ",
+    }).then(
+      () => null,
+      (refusal: Error) => refusal,
+    );
+
+    expect(moving).not.toBeNull();
+    const said = moving?.message ?? "";
+    expect(said).toContain("egma does not move a repository between platforms");
+    expect(said).toContain("nothing was sent");
+
+    // All four things a developer deletes, named at once. A refusal naming one
+    // at a time is a second failure after the first.
+    expect(said).toContain("the whole platform: block in egma/config.yaml");
+    expect(said).toContain("the id: line under agent: in egma/config.yaml");
+    expect(said).toContain("the id: line under connection: in egma/config.yaml");
+    expect(said).toContain("the id: line under suite: in egma/config.yaml");
+    expect(said).toContain("the version: line at the top of every file in egma/tests/");
+
+    // What moving costs, said plainly rather than found out afterwards.
+    expect(said).toContain("Your tests move with you");
+    expect(said).toContain("stay on the platform that ran them");
+
+    // One plain block of lines, so a coding agent can act on it without a
+    // person reading the message out to it.
+    const deletions = said
+      .split("\n")
+      .filter((line) => line.startsWith("  - "));
+    expect(deletions).toHaveLength(5);
+
+    // And no command that does it: the refusal teaches the move and nothing
+    // offers to perform it.
+    expect(said).not.toMatch(/egma rebind|--rebind|egma move/u);
 
     expect(await readFile(paths.config, "utf8")).toBe(asCommitted);
   });

--- a/apps/cli/test/egma-folder.test.ts
+++ b/apps/cli/test/egma-folder.test.ts
@@ -424,6 +424,21 @@ describe("the egma folder", () => {
       .filter((line) => line.startsWith("  - "));
     expect(deletions).toHaveLength(5);
 
+    // **And in that order.** Deleting the platform block is what unbinds the
+    // repository, and an unbound repository falls back to egma's own platform
+    // — so a list that named it first would have somebody working top-down
+    // arrive, one line in, at a repository still holding another platform's
+    // identifiers and nothing left to keep them there. Identifiers and pins
+    // come out first, the binding last, and the list says so out loud.
+    expect(deletions.map((line) => line.slice(4))).toEqual([
+      "the id: line under agent: in egma/config.yaml",
+      "the id: line under connection: in egma/config.yaml",
+      "the id: line under suite: in egma/config.yaml",
+      "the version: line at the top of every file in egma/tests/",
+      "last of all, the whole platform: block in egma/config.yaml",
+    ]);
+    expect(said).toContain("Delete the platform block last");
+
     // And no command that does it: the refusal teaches the move and nothing
     // offers to perform it.
     expect(said).not.toMatch(/egma rebind|--rebind|egma move/u);
@@ -579,6 +594,41 @@ describe("the egma folder", () => {
     expect(config.agent).toEqual({ name: "receptionist", id: null });
     expect(config.connection).toBeNull();
     expect(config.suite).toEqual({ name: "first-suite", id: null });
+  });
+
+  /**
+   * A person edits this file, and a person does not spell an origin the way
+   * egma spells one.
+   *
+   * Every one of these names the same platform. Read as written, they name a
+   * platform that disagrees with itself — and the refusal a developer then
+   * meets says the binding does not match the binding, tells them to drop
+   * something that is not there, and ends with four deletions for a move they
+   * are not making. So the shape is settled here, once, where the file is read.
+   */
+  it("reads a committed origin somebody wrote their own way as the address it is", () => {
+    for (const written of [
+      "https://egma.acme.example/",
+      "https://EGMA.acme.example",
+      "https://egma.acme.example:443",
+      "  https://egma.acme.example  ",
+    ]) {
+      const config = parseConfig(
+        `platform:\n  origin: ${JSON.stringify(written)}\n  instance: pf_01K3XQ7M4E8YB2FVN0H9TZQWEP\n`,
+        "config.yaml",
+      );
+      expect(config.platform?.origin, written).toBe("https://egma.acme.example");
+    }
+
+    // And a line egma cannot make sense of is left exactly as it was written:
+    // it is refused by name at the edge that takes addresses, and rewriting it
+    // here would hide which line in the file is the wrong one.
+    expect(
+      parseConfig(
+        "platform:\n  origin: not-an-address\n  instance: pf_01K3XQ7M4E8YB2FVN0H9TZQWEP\n",
+        "config.yaml",
+      ).platform?.origin,
+    ).toBe("not-an-address");
   });
 
   it("reads what it writes, and steps over comments while it does", () => {

--- a/apps/cli/test/exit-line.test.ts
+++ b/apps/cli/test/exit-line.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MOVE_TO_ANOTHER_PLATFORM,
+  teachingTheMove,
+} from "../src/folder/egma-folder.ts";
+import {
   buildExitLine,
   buildExitNotice,
   exitLines,
@@ -316,5 +320,39 @@ describe("the exit line", () => {
       if (report.kind === "run-started") continue;
       expect(exitLines(report)).toEqual([buildExitLine(report)]);
     }
+  });
+
+  /**
+   * A reason that arrived carrying a block keeps the block.
+   *
+   * One refusal in egma is more than a sentence: the one that keeps a
+   * repository on the platform it is bound to ends with every line a developer
+   * deletes to move it, and a coding agent is meant to act on those lines
+   * without a person reading them out. Squashed into the exit line they are
+   * neither readable nor usable — which is exactly what happened, because a
+   * reason is otherwise flattened to one line on purpose.
+   *
+   * The flattening stays for everything else. A wrapped sentence and a stack
+   * trace are still one line, so the last thing in scrollback still selects
+   * whole with one triple-click.
+   */
+  it("keeps a block under the line, and flattens everything else onto it", () => {
+    const refusal = teachingTheMove(
+      "This repository is already bound to Egma platform pf_01K3XQ7M4E8YB2FVN0H9TZQWEP at https://theirs.example, and this run reached Egma platform pf_01K3XQ7M4E8YB2FVN0H9TZQWEQ at https://ours.example. egma does not move a repository between platforms, and nothing was sent.",
+    );
+    const lines = exitLines({ kind: "failed", reason: refusal });
+
+    expect(lines[0]).toBe(
+      "egma could not finish: This repository is already bound to Egma platform pf_01K3XQ7M4E8YB2FVN0H9TZQWEP at https://theirs.example, and this run reached Egma platform pf_01K3XQ7M4E8YB2FVN0H9TZQWEQ at https://ours.example. egma does not move a repository between platforms, and nothing was sent.",
+    );
+    expect(lines[1]).toBe("");
+    expect(lines.slice(2)).toEqual([...MOVE_TO_ANOTHER_PLATFORM]);
+    // One line each, which is what "one plain block of lines" means.
+    expect(lines.filter((line) => line.startsWith("  - "))).toHaveLength(5);
+
+    // And a reason that is one paragraph is still one line, however it wrapped.
+    expect(
+      exitLines({ kind: "failed", reason: "no answer\n  from the\n  platform" }),
+    ).toEqual(["egma could not finish: no answer from the platform"]);
   });
 });

--- a/apps/cli/test/failure-branches.test.ts
+++ b/apps/cli/test/failure-branches.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { INVALID_KEY_LINE } from "../src/retell/connect.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
 import { buildExitLine, buildExitNotice } from "../src/wizard/exit-line.ts";
+import { alreadyAsked } from "../src/wizard/login-step.ts";
 import { walk } from "../src/wizard/walk.ts";
 import type { FakeStep } from "./support/fake-agent.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
@@ -118,11 +119,11 @@ async function walkWith(options: {
       launch: workspace.launch(options.script),
       cwd: workspace.dir,
       signal: new AbortController().signal,
-      platform: {
+      platform: alreadyAsked({
         url: platform.url,
         instanceId: platform.instanceId,
         credentialsFile: workspace.credentialsFile,
-      },
+      }),
       retell: { url: retell.url },
       howManyTests: 1,
       home: path.join(workspace.dir, "pretend-home"),

--- a/apps/cli/test/generate.test.ts
+++ b/apps/cli/test/generate.test.ts
@@ -28,6 +28,7 @@ import {
   convertTask as buildConvertTask,
   generateTask as buildGenerateTask,
 } from "../src/wizard/test-generation.ts";
+import { alreadyAsked } from "../src/wizard/login-step.ts";
 import { walk } from "../src/wizard/walk.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
 import type { FakeStep } from "./support/fake-agent.ts";
@@ -174,11 +175,11 @@ async function runWalk(options: {
       launch: workspace.launch(options.script),
       cwd: workspace.dir,
       signal: new AbortController().signal,
-      platform: {
+      platform: alreadyAsked({
         url: platform.url,
         instanceId: platform.instanceId,
         credentialsFile: workspace.credentialsFile,
-      },
+      }),
       retell: { url: retell.url },
       home: path.join(workspace.dir, "pretend-home"),
       runPollMs: 20,

--- a/apps/cli/test/hosted-default-process.test.ts
+++ b/apps/cli/test/hosted-default-process.test.ts
@@ -258,9 +258,20 @@ describe("a repository that names no platform", () => {
       expect(connected.stdout).toContain("status: connected");
       expect(connected.stdout).toContain(`url: ${own.url}`);
 
-      // `connect` binds, so the platform block goes back out to leave `run`
-      // where every other command here was: naming nothing.
-      await updateConfig(paths.config, { platform: null });
+      // `run` is the one verb that cannot be asked this question with nothing
+      // in the folder: it needs the agent and connection ids, and those are
+      // only ever written by `connect`, which binds before it writes them. So
+      // an unbound repository that `run` could run in is not a state egma can
+      // produce — taking the platform block back out here would leave the
+      // half-moved folder, which is refused on purpose by the check below.
+      //
+      // What is proven instead is the same claim from the other side: `connect`
+      // reached the built-in address with nothing naming one, and bound this
+      // repository to what answered there, so `run` goes to that same egma.
+      expect((await readConfig(paths.config)).platform).toEqual({
+        origin: own.url,
+        instance: own.instanceId,
+      });
       const ran = await egma(workspace, ["run", "--no-follow"], seam);
       expect(ran.code, ran.stderr).toBe(0);
       expect(ran.stdout).toContain("status: started");
@@ -483,6 +494,73 @@ describe("a repository that names no platform", () => {
           expect(reached, line).toEqual([]);
         }
       }
+    } finally {
+      await workspace.remove();
+    }
+  });
+
+  /**
+   * The half-applied move, refused rather than acted on.
+   *
+   * Deleting the platform block is one edit; deleting the identifiers it was
+   * keeping in place is four more. In between, the repository names no platform
+   * and still holds every identifier the old one issued — and the step below
+   * "names nothing" is now egma's own platform. Without this refusal the next
+   * command carries somebody else's identifiers to hosted egma, which is the
+   * one thing ADR-0008 exists to stop.
+   *
+   * It is refused on what is already on this machine, so the address egma would
+   * have used is not asked so much as who it is.
+   */
+  it("refuses a folder holding identifiers from a platform it no longer names", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      await workspace.signIn(own.url, PLATFORM_KEY);
+      const paths = folderPathsIn(workspace.dir);
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: elsewhere.url, instance: elsewhere.instanceId },
+          agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+          connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+          suite: { name: "first-suite", id: "sui_01K3XQ7M4E8YB2FVN0H9TZQWET" },
+        },
+      });
+      // The one edit that unbinds it, and nothing else — a developer starting
+      // the move at the wrong end of the list.
+      await updateConfig(paths.config, { platform: null });
+
+      const before = own.records.length;
+      const elsewhereBefore = elsewhere.records.length;
+      const refused = await egma(workspace, ["pull"], { EGMA_TEST_DEFAULT_URL: own.url });
+
+      expect(refused.code).toBe(4);
+      expect(refused.stdout).toContain("status: refused");
+      expect(refused.stderr).toContain("This repository names no Egma platform");
+      expect(refused.stderr).toContain("agent, connection, suite");
+      expect(refused.stderr).toContain("Nothing was sent");
+      // The rest of the list, so the developer can finish what they started
+      // rather than meet a second refusal for the next line.
+      expect(refused.stderr).toContain(
+        "To move this repository to another platform, delete these in this order and run egma again:",
+      );
+
+      // Nothing reached the address egma would have fallen back to, and nothing
+      // reached the platform the identifiers came from either.
+      expect(own.records.slice(before)).toEqual([]);
+      expect(elsewhere.records.slice(elsewhereBefore)).toEqual([]);
+
+      // And the folder egma writes for a repository that has connected nothing
+      // is untouched by this: a bare platform: line with no identifiers under
+      // it is what `egma init` leaves behind, and it still resolves.
+      await updateConfig(paths.config, {
+        agent: { name: "receptionist", id: null },
+        connection: { name: "retell-1", id: null },
+        suite: { name: "first-suite", id: null },
+      });
+      const pulled = await egma(workspace, ["pull"], { EGMA_TEST_DEFAULT_URL: own.url });
+      expect(pulled.code, pulled.stderr).toBe(0);
+      expect(pulled.stdout).toContain(`url: ${own.url}`);
     } finally {
       await workspace.remove();
     }

--- a/apps/cli/test/hosted-default-process.test.ts
+++ b/apps/cli/test/hosted-default-process.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 
@@ -22,10 +22,12 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   createEgmaFolder,
   folderPathsIn,
+  MOVE_TO_ANOTHER_PLATFORM,
   readConfig,
   updateConfig,
   writeTestFile,
 } from "../src/folder/egma-folder.ts";
+import { parseTestFile } from "../src/folder/test-file.ts";
 import { DEFAULT_TEST_COUNT } from "../src/wizard/test-generation.ts";
 import { startFakeRetell, type FakeRetell } from "./support/fake-retell.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
@@ -351,6 +353,136 @@ describe("a repository that names no platform", () => {
       expect(byBinding.stdout).toContain(`url: ${elsewhere.url}`);
 
       expect(own.records.slice(before)).toEqual([]);
+    } finally {
+      await workspace.remove();
+    }
+  });
+
+  /**
+   * egma's own instructions, followed the way they are written.
+   *
+   * The refusal that keeps a bound repository where it belongs ends with a list
+   * of lines to delete, and a developer — or the coding agent reading it out of
+   * their terminal — works down that list from the top. Every state on the way
+   * down is a real repository somebody runs a command in.
+   *
+   * Deleting the platform block is the line that unbinds the repository, and an
+   * unbound repository falls back to egma's own platform. So if that line came
+   * first, applying egma's own list top-down would leave, after one edit, a
+   * repository with no binding and every other platform's identifiers still
+   * committed — and the next command would carry them to hosted egma. That is
+   * why it is last, and this is the check that keeps it there: the list is
+   * driven in its own order, and nothing may reach the built-in address until
+   * the last line has been applied and there is nothing left to leak.
+   */
+  it("applies its own list top-down without anything reaching the built-in address", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      await workspace.signIn(own.url, PLATFORM_KEY);
+      await workspace.signIn(elsewhere.url, PLATFORM_KEY);
+
+      const paths = folderPathsIn(workspace.dir);
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: elsewhere.url, instance: elsewhere.instanceId },
+          agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+          connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+          suite: { name: "first-suite", id: "sui_01K3XQ7M4E8YB2FVN0H9TZQWET" },
+        },
+      });
+      const pinned = path.join(paths.tests, "moves-appointment.md");
+      await writeTestFile(pinned, {
+        name: "moves-appointment",
+        personas: [],
+        version: "tv_01K3XQ7M4E8YB2FVN0H9TZQWEU",
+        scenario: "The persona needs a different appointment time.",
+        expectedBehaviors: ["The agent confirms the new time."],
+        mockTools: [],
+      });
+
+      /** One line of egma's list, and the edit it asks for. */
+      const deletions: readonly {
+        readonly mentions: string;
+        readonly apply: () => Promise<void>;
+      }[] = [
+        {
+          mentions: "under agent:",
+          apply: async () => {
+            const held = await readConfig(paths.config);
+            await updateConfig(paths.config, {
+              agent: { name: held.agent?.name ?? "receptionist", id: null },
+            });
+          },
+        },
+        {
+          mentions: "under connection:",
+          apply: async () => {
+            const held = await readConfig(paths.config);
+            await updateConfig(paths.config, {
+              connection: { name: held.connection?.name ?? "retell-1", id: null },
+            });
+          },
+        },
+        {
+          mentions: "under suite:",
+          apply: async () => {
+            const held = await readConfig(paths.config);
+            await updateConfig(paths.config, {
+              suite: { name: held.suite?.name ?? "first-suite", id: null },
+            });
+          },
+        },
+        {
+          mentions: "the version: line",
+          apply: async () => {
+            const held = parseTestFile(
+              await readFile(pinned, "utf8"),
+              "moves-appointment.md",
+              "moves-appointment",
+            );
+            await writeTestFile(pinned, { ...held, version: null });
+          },
+        },
+        {
+          mentions: "the whole platform: block",
+          apply: async () => {
+            await updateConfig(paths.config, { platform: null });
+          },
+        },
+      ];
+
+      // Driven in the list's own order, so that reordering the list is what
+      // this check reads — not a copy of the order written out again here.
+      const listed = MOVE_TO_ANOTHER_PLATFORM.filter((line) => line.startsWith("  - "));
+      expect(listed).toHaveLength(deletions.length);
+
+      const seam = { EGMA_TEST_DEFAULT_URL: own.url };
+      for (const [index, line] of listed.entries()) {
+        const deletion = deletions.find((step) => line.includes(step.mentions));
+        expect(deletion, line).toBeDefined();
+        await deletion?.apply();
+
+        const before = own.records.length;
+        const pulled = await egma(workspace, ["pull"], seam);
+        const reached = own.records.slice(before);
+        const last = index === listed.length - 1;
+
+        expect(pulled.code, `${line}: ${pulled.stderr}`).toBe(0);
+        if (last) {
+          // The list is applied. Nothing in the folder belongs to the old
+          // platform any more, so the repository is free to reach egma's own —
+          // which is the whole point of doing the deletions.
+          expect(pulled.stdout).toContain(`url: ${own.url}`);
+          expect(reached.map((request) => request.path)).toContain("/api/platform");
+        } else {
+          // Part way down the list, and still bound. Every command still goes
+          // to the platform that issued these identifiers, and egma's own
+          // address is not asked so much as who it is.
+          expect(pulled.stdout, line).toContain(`url: ${elsewhere.url}`);
+          expect(reached, line).toEqual([]);
+        }
+      }
     } finally {
       await workspace.remove();
     }

--- a/apps/cli/test/hosted-default-process.test.ts
+++ b/apps/cli/test/hosted-default-process.test.ts
@@ -332,6 +332,24 @@ describe("a repository that names no platform", () => {
       expect(byFlag.code, byFlag.stderr).toBe(0);
       expect(byFlag.stdout).toContain(`url: ${elsewhere.url}`);
 
+      // And the committed file, with neither of those in play. This is the step
+      // directly above the built-in address, so it is the one whose win the new
+      // last step could have taken away.
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: elsewhere.url, instance: elsewhere.instanceId },
+          agent: null,
+          connection: null,
+          suite: null,
+        },
+      });
+      const byBinding = await egma(workspace, ["login"], {
+        EGMA_TEST_DEFAULT_URL: own.url,
+      });
+      expect(byBinding.code, byBinding.stderr).toBe(0);
+      expect(byBinding.stdout).toContain(`url: ${elsewhere.url}`);
+
       expect(own.records.slice(before)).toEqual([]);
     } finally {
       await workspace.remove();

--- a/apps/cli/test/hosted-default-process.test.ts
+++ b/apps/cli/test/hosted-default-process.test.ts
@@ -509,14 +509,19 @@ describe("a repository that names no platform", () => {
    * command carries somebody else's identifiers to hosted egma, which is the
    * one thing ADR-0008 exists to stop.
    *
-   * It is refused on what is already on this machine, so the address egma would
-   * have used is not asked so much as who it is.
+   * It is refused on what is already on this machine, so no address is asked so
+   * much as who it is — and it is refused **whichever of the three places named
+   * that address.** The deleted line is the one that said which platform these
+   * identifiers belong to, so once it is gone there is nowhere egma can safely
+   * send them, including somewhere a developer typed. `--url` is not an escape
+   * from this; it is the flag somebody reaches for in the middle of the move.
    */
   it("refuses a folder holding identifiers from a platform it no longer names", async () => {
-    const workspace = await makeWorkspace();
-    try {
+    /** The half-applied move: the binding gone, everything it held still here. */
+    async function halfMoved(): Promise<Workspace> {
+      const workspace = await makeWorkspace();
       await workspace.signIn(own.url, PLATFORM_KEY);
-      const paths = folderPathsIn(workspace.dir);
+      await workspace.signIn(elsewhere.url, PLATFORM_KEY);
       await createEgmaFolder({
         repository: workspace.dir,
         config: {
@@ -526,43 +531,80 @@ describe("a repository that names no platform", () => {
           suite: { name: "first-suite", id: "sui_01K3XQ7M4E8YB2FVN0H9TZQWET" },
         },
       });
-      // The one edit that unbinds it, and nothing else — a developer starting
-      // the move at the wrong end of the list.
-      await updateConfig(paths.config, { platform: null });
+      // The one edit that unbinds it, and nothing else — somebody starting the
+      // move at the wrong end of the list.
+      await updateConfig(folderPathsIn(workspace.dir).config, { platform: null });
+      return workspace;
+    }
 
-      const before = own.records.length;
-      const elsewhereBefore = elsewhere.records.length;
-      const refused = await egma(workspace, ["pull"], { EGMA_TEST_DEFAULT_URL: own.url });
+    // Every way a platform gets selected, and the same answer from all three.
+    for (const [how, args, extra] of [
+      ["the built-in address", ["pull"], {}],
+      ["--url", ["pull", "--url", own.url], {}],
+      ["EGMA_URL", ["pull"], { EGMA_URL: own.url }],
+    ] as const) {
+      const workspace = await halfMoved();
+      try {
+        const before = own.records.length;
+        const elsewhereBefore = elsewhere.records.length;
+        const refused = await egma(workspace, [...args], {
+          EGMA_TEST_DEFAULT_URL: own.url,
+          ...extra,
+        });
 
-      expect(refused.code).toBe(4);
-      expect(refused.stdout).toContain("status: refused");
-      expect(refused.stderr).toContain("This repository names no Egma platform");
-      expect(refused.stderr).toContain("agent, connection, suite");
-      expect(refused.stderr).toContain("Nothing was sent");
-      // The rest of the list, so the developer can finish what they started
-      // rather than meet a second refusal for the next line.
-      expect(refused.stderr).toContain(
-        "To move this repository to another platform, delete these in this order and run egma again:",
-      );
+        expect(refused.code, how).toBe(4);
+        expect(refused.stdout, how).toContain("status: refused");
+        expect(refused.stderr, how).toContain("This repository names no Egma platform");
+        expect(refused.stderr, how).toContain("agent, connection, suite");
+        expect(refused.stderr, how).toContain("Nothing was sent");
 
-      // Nothing reached the address egma would have fallen back to, and nothing
-      // reached the platform the identifiers came from either.
-      expect(own.records.slice(before)).toEqual([]);
-      expect(elsewhere.records.slice(elsewhereBefore)).toEqual([]);
+        // Both ways out, because somebody who deleted that block by mistake is
+        // not making the move at all and must not be told to throw away four
+        // working identifiers to recover from a typo.
+        expect(refused.stderr, how).toContain("put the platform: block back");
+        expect(refused.stderr, how).toContain(
+          "To move this repository to another platform, delete these in this order and run egma again:",
+        );
 
-      // And the folder egma writes for a repository that has connected nothing
-      // is untouched by this: a bare platform: line with no identifiers under
-      // it is what `egma init` leaves behind, and it still resolves.
+        // Nothing reached the address egma would have used, and nothing reached
+        // the platform the identifiers came from either.
+        expect(own.records.slice(before), how).toEqual([]);
+        expect(elsewhere.records.slice(elsewhereBefore), how).toEqual([]);
+      } finally {
+        await workspace.remove();
+      }
+    }
+
+    // The first way out: the block put back. It is a committed line, so this is
+    // recovering a file from history rather than knowing something egma hid.
+    const restored = await halfMoved();
+    try {
+      await updateConfig(folderPathsIn(restored.dir).config, {
+        platform: { origin: elsewhere.url, instance: elsewhere.instanceId },
+      });
+      const pulled = await egma(restored, ["pull"], { EGMA_TEST_DEFAULT_URL: own.url });
+      expect(pulled.code, pulled.stderr).toBe(0);
+      expect(pulled.stdout).toContain(`url: ${elsewhere.url}`);
+    } finally {
+      await restored.remove();
+    }
+
+    // The second: the identifiers taken out. That is also the shape `egma init`
+    // leaves behind — a bare platform: line and three names with no ids under
+    // them — which this must never refuse.
+    const emptied = await halfMoved();
+    try {
+      const paths = folderPathsIn(emptied.dir);
       await updateConfig(paths.config, {
         agent: { name: "receptionist", id: null },
         connection: { name: "retell-1", id: null },
         suite: { name: "first-suite", id: null },
       });
-      const pulled = await egma(workspace, ["pull"], { EGMA_TEST_DEFAULT_URL: own.url });
+      const pulled = await egma(emptied, ["pull"], { EGMA_TEST_DEFAULT_URL: own.url });
       expect(pulled.code, pulled.stderr).toBe(0);
       expect(pulled.stdout).toContain(`url: ${own.url}`);
     } finally {
-      await workspace.remove();
+      await emptied.remove();
     }
   });
 

--- a/apps/cli/test/hosted-default-process.test.ts
+++ b/apps/cli/test/hosted-default-process.test.ts
@@ -1,0 +1,374 @@
+/**
+ * The bare command, as a developer with nothing configured really types it.
+ *
+ * No `--url`, no `EGMA_URL`, no platform in the committed folder: the last step
+ * of resolution is egma's own platform, and this is the check that proves it
+ * the way it is run — the built CLI as its own process, against a platform
+ * standing where the built-in address is. Proving it only inside the resolver
+ * would leave the one thing a developer meets — typing `npx @egma/cli` and
+ * getting the wizard — unproven.
+ *
+ * The stand-in arrives through `EGMA_TEST_DEFAULT_URL`, which is why that seam
+ * exists. Nothing here dials the real hosted platform.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  createEgmaFolder,
+  folderPathsIn,
+  readConfig,
+  updateConfig,
+  writeTestFile,
+} from "../src/folder/egma-folder.ts";
+import { DEFAULT_TEST_COUNT } from "../src/wizard/test-generation.ts";
+import { startFakeRetell, type FakeRetell } from "./support/fake-retell.ts";
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { gradeEveryRun } from "./support/grading.ts";
+import {
+  CLI_ENTRY,
+  FAKE_AGENT,
+  makeWorkspace,
+  NO_DEFAULT_PLATFORM,
+  type Workspace,
+} from "./support/workspace.ts";
+
+const PLATFORM_KEY = "egma_sk_for-the-built-in-address";
+const PROVIDER_KEY = "synthetic-retell-key-for-the-built-in-address";
+
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
+type Ended = { readonly stdout: string; readonly stderr: string; readonly code: number };
+
+describe("a repository that names no platform", () => {
+  /** The platform standing where egma's own address is. */
+  let own: Platform;
+  /** A second platform, which must never see a request. */
+  let elsewhere: Platform;
+  let retell: FakeRetell;
+
+  beforeAll(async () => {
+    [own, elsewhere, retell] = await Promise.all([
+      startPlatform(),
+      startPlatform(),
+      startFakeRetell({
+        keys: [PROVIDER_KEY],
+        agents: [
+          {
+            agent_id: "synthetic-retell-agent",
+            agent_name: "Default receptionist",
+            response_engine: { type: "retell-llm", llm_id: "synthetic-llm" },
+          },
+        ],
+        llms: [
+          {
+            llm_id: "synthetic-llm",
+            general_prompt: "Help each persona move an appointment.",
+          },
+        ],
+      }),
+    ]);
+    own.signedInWith(PLATFORM_KEY);
+    elsewhere.signedInWith(PLATFORM_KEY);
+  });
+
+  afterAll(async () => {
+    await Promise.all([own.close(), elsewhere.close(), retell.close()]);
+  });
+
+  /**
+   * The command, run the way a developer runs it: never with `--url`, and
+   * never with `EGMA_URL` in the environment. Both are asserted rather than
+   * assumed, because either one would make every claim below vacuous.
+   */
+  async function egma(
+    workspace: Workspace,
+    args: readonly string[],
+    extra: NodeJS.ProcessEnv = {},
+  ): Promise<Ended> {
+    const env = workspace.env({ EGMA_RETELL_URL: retell.url, ...extra });
+    // Unless the check is deliberately proving that one of them wins, neither
+    // way of naming a platform is in play — and that is asserted rather than
+    // assumed, because either one would make every claim below vacuous.
+    if (!args.includes("--url") && extra.EGMA_URL === undefined) {
+      expect(env.EGMA_URL).toBeUndefined();
+    }
+
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+      cwd: workspace.dir,
+      env,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    // `connect` checks standard input before its environment. End the pipe so
+    // the real process sees the same promptless EOF a coding agent sends.
+    child.stdin.end();
+    const code = await new Promise<number>((resolve) => {
+      child.on("close", (value) => resolve(value ?? 1));
+    });
+    return { stdout, stderr, code };
+  }
+
+  /**
+   * The whole walk, from a folder with nothing in it, on the platform nobody
+   * named. It is the claim the published package's front page makes.
+   */
+  it("takes the bare command through the whole walk on egma's own platform", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      await workspace.signIn(own.url, PLATFORM_KEY);
+      // Written second on purpose: a key this machine holds for another
+      // platform still selects nothing.
+      await workspace.signIn(elsewhere.url, PLATFORM_KEY);
+
+      const paths = folderPathsIn(workspace.dir);
+      // Tests the developer already had, and deliberately no config file at
+      // all: nothing here names a platform.
+      await mkdir(paths.tests, { recursive: true });
+      await expect(readConfig(paths.config)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const script = await workspace.script({
+        steps: [
+          { kind: "say", text: "egma:found framework retell-sdk\n" },
+          { kind: "stop", reason: "end_turn" },
+        ],
+      });
+      for (let number = 1; number <= DEFAULT_TEST_COUNT; number += 1) {
+        const name = `moves-appointment-${number}`;
+        await writeTestFile(path.join(paths.tests, `${name}.md`), {
+          name,
+          personas: [],
+          version: null,
+          scenario: `The persona needs a different appointment time in case ${number}.`,
+          expectedBehaviors: ["The agent confirms the new time."],
+          mockTools: [],
+        });
+      }
+
+      const before = own.records.length;
+      const grading = gradeEveryRun(own);
+      let walked: Ended;
+      try {
+        walked = await egma(
+          workspace,
+          ["--headless", "--", process.execPath, FAKE_AGENT, script],
+          {
+            EGMA_TEST_DEFAULT_URL: own.url,
+            EGMA_RETELL_API_KEY: PROVIDER_KEY,
+            EGMA_REACH: "text",
+          },
+        );
+      } finally {
+        grading.stop();
+      }
+
+      expect(walked.code, walked.stderr).toBe(0);
+      expect(walked.stdout).toMatch(/^first-verdict: /mu);
+
+      // Which egma, said as one plain line in the same place in the walk the
+      // wizard's first screen says it: before the login, and before anything
+      // this repository owns has moved.
+      const named = walked.stdout.indexOf(`url: ${own.url}`);
+      expect(named).toBeGreaterThanOrEqual(0);
+      expect(walked.stdout.indexOf("signed in to")).toBeGreaterThan(named);
+
+      const asked = own.records.slice(before);
+      expect(asked[0]).toMatchObject({ method: "GET", path: "/api/platform" });
+      for (const expected of ["/api/agents", "/api/tests", "/api/runs"]) {
+        expect(asked.some((request) => request.path === expected), expected).toBe(true);
+      }
+
+      // And the repository is now bound to the platform it reached, so the next
+      // command in it needs nothing said either.
+      const config = await readConfig(paths.config);
+      expect(config.platform).toEqual({ origin: own.url, instance: own.instanceId });
+
+      expect(elsewhere.records).toEqual([]);
+    } finally {
+      await workspace.remove();
+    }
+  });
+
+  /**
+   * One repository, one platform, for every command in it — which is the whole
+   * claim, and the reason resolution lives in one place rather than per verb.
+   */
+  it("sends every verb there too, while nothing else names one", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      await workspace.signIn(own.url, PLATFORM_KEY);
+      const seam = { EGMA_TEST_DEFAULT_URL: own.url };
+      const paths = folderPathsIn(workspace.dir);
+
+      // `init` writes a folder and talks to nothing, so it names no platform
+      // and reaches none.
+      const started = await egma(
+        workspace,
+        ["init", "--agent", "Receptionist", "--connection", "retell-1"],
+        seam,
+      );
+      expect(started.code, started.stderr).toBe(0);
+      expect((await readConfig(paths.config)).platform).toBeNull();
+
+      await writeTestFile(path.join(paths.tests, "moves-appointment.md"), {
+        name: "moves-appointment",
+        personas: [],
+        version: null,
+        scenario: "The persona needs a different appointment time.",
+        expectedBehaviors: ["The agent confirms the new time."],
+        mockTools: [],
+      });
+
+      for (const [verb, args] of [
+        ["login", ["login"]],
+        ["push", ["push"]],
+        ["pull", ["pull"]],
+      ] as const) {
+        const before = own.records.length;
+        const result = await egma(workspace, args, seam);
+        expect(result.code, `${verb}: ${result.stderr}`).toBe(0);
+        expect(result.stdout, verb).toContain(`url: ${own.url}`);
+        expect(own.records.slice(before)[0], verb).toMatchObject({
+          method: "GET",
+          path: "/api/platform",
+        });
+      }
+
+      const connected = await egma(workspace, ["connect"], {
+        ...seam,
+        EGMA_RETELL_API_KEY: PROVIDER_KEY,
+        EGMA_REACH: "text",
+      });
+      expect(connected.code, connected.stderr).toBe(0);
+      expect(connected.stdout).toContain("status: connected");
+      expect(connected.stdout).toContain(`url: ${own.url}`);
+
+      // `connect` binds, so the platform block goes back out to leave `run`
+      // where every other command here was: naming nothing.
+      await updateConfig(paths.config, { platform: null });
+      const ran = await egma(workspace, ["run", "--no-follow"], seam);
+      expect(ran.code, ran.stderr).toBe(0);
+      expect(ran.stdout).toContain("status: started");
+      expect(ran.stdout).toContain(`url: ${own.url}`);
+
+      expect(elsewhere.records).toEqual([]);
+    } finally {
+      await workspace.remove();
+    }
+  });
+
+  /**
+   * The developer never typed this address and cannot fix what is at it, so the
+   * refusal names it, says nothing was sent, and answers with the number every
+   * other unreachable platform answers with.
+   */
+  it("refuses by name when egma's own platform does not answer", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      // The stand-in every workspace uses by default is a closed port.
+      const refused = await egma(workspace, ["login"]);
+
+      expect(refused.code).toBe(4);
+      expect(refused.stdout).toContain("status: unreachable");
+      expect(refused.stderr).toContain(NO_DEFAULT_PLATFORM);
+      expect(refused.stderr).toContain("Nothing was sent");
+      expect(refused.stderr).toContain("--url <address>");
+      expect(refused.stderr).toContain("EGMA_URL");
+
+      // The wizard answers the same way, and says which address it was going to
+      // use before it finds out that nothing is there.
+      const script = await workspace.script({
+        steps: [{ kind: "stop", reason: "end_turn" }],
+      });
+      const wizard = await egma(workspace, [
+        "--headless",
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ]);
+
+      expect(wizard.code).toBe(4);
+      expect(wizard.stdout).toContain(`url: ${NO_DEFAULT_PLATFORM}`);
+      expect(wizard.stdout).toContain("status: unreachable");
+      expect(wizard.stderr).toContain("Nothing was sent");
+    } finally {
+      await workspace.remove();
+    }
+  });
+
+  /** The three deliberate places still win, in their order, over egma's own. */
+  it("keeps every step above it winning", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      await workspace.signIn(elsewhere.url, PLATFORM_KEY);
+      const before = own.records.length;
+
+      // A whole shell pointed elsewhere: the built-in address is not consulted.
+      const byEnvironment = await egma(workspace, ["login"], {
+        EGMA_TEST_DEFAULT_URL: own.url,
+        EGMA_URL: elsewhere.url,
+      });
+      expect(byEnvironment.code, byEnvironment.stderr).toBe(0);
+      expect(byEnvironment.stdout).toContain(`url: ${elsewhere.url}`);
+
+      // And one command pointed elsewhere beats even that.
+      const byFlag = await egma(workspace, ["login", "--url", elsewhere.url], {
+        EGMA_TEST_DEFAULT_URL: own.url,
+      });
+      expect(byFlag.code, byFlag.stderr).toBe(0);
+      expect(byFlag.stdout).toContain(`url: ${elsewhere.url}`);
+
+      expect(own.records.slice(before)).toEqual([]);
+    } finally {
+      await workspace.remove();
+    }
+  });
+
+  /**
+   * The rule the whole binding exists for, now that there is something to fall
+   * back to: a repository that named its platform is never quietly moved to
+   * egma's own, whatever is wrong with the one it named.
+   */
+  it("never falls back to egma's own from a repository that is bound", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      await workspace.signIn(own.url, PLATFORM_KEY);
+      const closed = "http://127.0.0.1:2";
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: closed, instance: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEP" },
+          agent: null,
+          connection: null,
+          suite: null,
+        },
+      });
+
+      const before = own.records.length;
+      const refused = await egma(workspace, ["push"], { EGMA_TEST_DEFAULT_URL: own.url });
+
+      expect(refused.code).toBe(4);
+      expect(refused.stdout).toContain("status: unreachable");
+      expect(refused.stderr).toContain(closed);
+      expect(refused.stderr).toContain("no repository identifiers were sent");
+      // The platform standing where egma's own address is saw nothing at all.
+      expect(own.records.slice(before)).toEqual([]);
+    } finally {
+      await workspace.remove();
+    }
+  });
+});

--- a/apps/cli/test/hosted-default-real.test.ts
+++ b/apps/cli/test/hosted-default-real.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The bare command's last resort, against a real platform.
+ *
+ * `hosted-default-process.test.ts` drives the built CLI against the fixture
+ * platform, and that is where the branches of this behaviour are covered.
+ * Fixture tests cover branches; this proves the one thing they cannot — that a
+ * repository naming no platform, in a shell naming none either, reaches an
+ * actual Egma platform with its own database and leaves real rows in it.
+ *
+ * That rule belongs to the platform-binding effort and applies here for the
+ * same reason: the step being added is the one nobody typed, so the only honest
+ * proof is the whole real thing, run the way a developer runs it.
+ *
+ * The address it reaches is a local instance, put in the built-in address's
+ * place through `EGMA_TEST_DEFAULT_URL`. Nothing here dials hosted egma.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+import { expect, it, vi } from "vitest";
+
+import { startInstance, type Instance } from "../../api/test/support/instance.ts";
+import { signUp } from "../../api/test/support/traces.ts";
+import { folderPathsIn, readConfig, writeTestFile } from "../src/folder/egma-folder.ts";
+import { CLI_ENTRY, makeWorkspace } from "./support/workspace.ts";
+
+type Ended = { readonly code: number; readonly stdout: string; readonly stderr: string };
+
+/** The built CLI, as its own process, ended rather than thrown. */
+async function egma(
+  args: readonly string[],
+  where: { readonly cwd: string; readonly env: NodeJS.ProcessEnv },
+): Promise<Ended> {
+  const child = spawn(process.execPath, [CLI_ENTRY, ...args], where);
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  child.stdin.end();
+  const code = await new Promise<number>((resolve) => {
+    child.on("close", (value) => resolve(value ?? 1));
+  });
+  return { stdout, stderr, code };
+}
+
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
+it("reaches a real local platform with nothing configured anywhere", async () => {
+  const workspace = await makeWorkspace();
+  let platform: Instance | undefined;
+
+  try {
+    platform = await startInstance("cli_hosted_default", { web: false });
+    const customer = await signUp(platform.api, "unbound@acme.example", "Acme Unbound");
+    // A key this machine holds. It is not what selects a platform — the
+    // built-in address is — and it is only what lets the command do its work
+    // once it has got there.
+    await workspace.signIn(platform.origin, customer.secret);
+
+    // Nothing names a platform: no `--url` in any command below, no `EGMA_URL`
+    // in the shell, and no egma folder in the repository yet. The environment
+    // is asserted rather than assumed, because it would make this vacuous.
+    const env = workspace.env({ EGMA_TEST_DEFAULT_URL: platform.origin });
+    expect(env.EGMA_URL).toBeUndefined();
+    const paths = folderPathsIn(workspace.dir);
+
+    const started = await egma(
+      ["init", "--agent", "Receptionist", "--connection", "retell-1", "--cwd", workspace.dir],
+      { cwd: workspace.dir, env },
+    );
+    expect(started.code, started.stderr).toBe(0);
+    // What `egma init` writes: names, and no platform of any kind.
+    expect((await readConfig(paths.config)).platform).toBeNull();
+
+    await writeTestFile(path.join(paths.tests, "moves-appointment.md"), {
+      name: "moves-appointment",
+      personas: [],
+      version: null,
+      scenario: "The persona needs a different appointment time.",
+      expectedBehaviors: ["The agent confirms the new time."],
+      mockTools: [],
+    });
+
+    const pushed = await egma(["push", "--cwd", workspace.dir], {
+      cwd: workspace.dir,
+      env,
+    });
+
+    expect(pushed.code, pushed.stderr).toBe(0);
+    expect(pushed.stdout).toContain("status: pushed");
+    // The address it went to, said back to the developer, and it is the one
+    // nobody typed.
+    expect(pushed.stdout).toContain(`url: ${platform.origin}`);
+
+    // And it really arrived: the row is in that platform's own database. A
+    // fixture and a test can agree with each other about a request and prove
+    // neither, which is why this half is here.
+    const stored = await platform.database.sql<{ name: string }>("select name from test");
+    expect(stored.rows.map((row) => row.name)).toEqual(["moves-appointment"]);
+
+    // The public identity was read before any of that. The address the CLI
+    // prints is the origin that platform names for itself, which only that read
+    // can supply — a platform naming any other origin is refused rather than
+    // printed. `push` writes no binding; committing one is `connect`'s job.
+    const identity = (await fetch(`${platform.origin}/api/platform`).then((answer) =>
+      answer.json(),
+    )) as { instance_id: string; origin: string };
+    expect(pushed.stdout).toContain(`url: ${identity.origin}`);
+    expect((await readConfig(paths.config)).platform).toBeNull();
+  } finally {
+    await platform?.close();
+    await workspace.remove();
+  }
+});

--- a/apps/cli/test/hosted-default.test.ts
+++ b/apps/cli/test/hosted-default.test.ts
@@ -20,6 +20,7 @@ import {
   selectPlatform,
   TEST_DEFAULT_URL_VARIABLE,
 } from "../src/platform/credentials.ts";
+import { makeWorkspace, NO_DEFAULT_PLATFORM } from "./support/workspace.ts";
 
 const CLI = fileURLToPath(new URL("..", import.meta.url));
 
@@ -61,6 +62,31 @@ describe("the built-in address", () => {
       if (held.includes(hosted)) naming.push(path.relative(CLI, file));
     }
     expect(naming).toEqual(["test/hosted-default.test.ts"]);
+  });
+
+  /**
+   * The fence above scans text, and text is a proxy. **This is the guard.**
+   *
+   * What actually keeps the suite away from hosted egma is that every workspace
+   * hands the command a closed port in the built-in address's place. A check
+   * that resolved a platform without going through a workspace would dial
+   * production, and the scan above would still pass — it names no host, because
+   * it names no address at all. So the mechanism is asserted, not assumed.
+   */
+  it("is stood aside by every workspace, which is what really keeps the suite off it", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      expect(workspace.env()[TEST_DEFAULT_URL_VARIABLE]).toBe(NO_DEFAULT_PLATFORM);
+      expect(defaultPlatformUrlIn(workspace.env())).toBe(NO_DEFAULT_PLATFORM);
+      expect(defaultPlatformUrlIn(workspace.env())).not.toBe(DEFAULT_PLATFORM_URL);
+      // And a check that names its own platform still never reaches the real
+      // one: what it names replaces the stand-in, not the fence.
+      expect(
+        defaultPlatformUrlIn(workspace.env({ [TEST_DEFAULT_URL_VARIABLE]: "http://own.example" })),
+      ).toBe("http://own.example");
+    } finally {
+      await workspace.remove();
+    }
   });
 
   it("is replaced by the test seam whenever the seam names one", () => {

--- a/apps/cli/test/hosted-default.test.ts
+++ b/apps/cli/test/hosted-default.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The address a repository with nothing configured reaches, and the fence that
+ * keeps the suite away from it.
+ *
+ * Everything else about the unbound path is proven against a platform standing
+ * in for that address. This file is the one place the real one is named, so
+ * that "the shipped default is hosted egma" is asserted once, and so that a
+ * check which quietly started signing in to production would fail here first.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_PLATFORM_URL,
+  defaultPlatformUrlIn,
+  selectPlatform,
+  TEST_DEFAULT_URL_VARIABLE,
+} from "../src/platform/credentials.ts";
+
+const CLI = fileURLToPath(new URL("..", import.meta.url));
+
+/** Every file under a folder, skipping what is built rather than written. */
+async function filesUnder(folder: string): Promise<string[]> {
+  const found: string[] = [];
+  for (const entry of await readdir(folder, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const here = path.join(folder, entry.name);
+    if (entry.isDirectory()) found.push(...(await filesUnder(here)));
+    else found.push(here);
+  }
+  return found;
+}
+
+describe("the built-in address", () => {
+  it("ships hosted egma", () => {
+    expect(DEFAULT_PLATFORM_URL).toBe("https://app.egma.ai");
+  });
+
+  /**
+   * The fence, and the reason for it: a check that dialled the real hosted
+   * platform would sign in to production, create real organizations there, and
+   * fail whenever the network did. Every behavioral check stands a platform of
+   * its own in that address's place, so the name itself belongs in exactly one
+   * source file and one check.
+   */
+  it("is named nowhere a check could dial it", async () => {
+    const hosted = new URL(DEFAULT_PLATFORM_URL).host;
+    const written = [
+      ...(await filesUnder(path.join(CLI, "test"))),
+      ...(await filesUnder(path.join(CLI, "smoke"))),
+    ];
+    expect(written.length).toBeGreaterThan(20);
+
+    const naming: string[] = [];
+    for (const file of written) {
+      const held = await readFile(file, "utf8").catch(() => "");
+      if (held.includes(hosted)) naming.push(path.relative(CLI, file));
+    }
+    expect(naming).toEqual(["test/hosted-default.test.ts"]);
+  });
+
+  it("is replaced by the test seam whenever the seam names one", () => {
+    expect(defaultPlatformUrlIn({})).toBe(DEFAULT_PLATFORM_URL);
+    expect(defaultPlatformUrlIn({ [TEST_DEFAULT_URL_VARIABLE]: "  " })).toBe(
+      DEFAULT_PLATFORM_URL,
+    );
+    expect(
+      defaultPlatformUrlIn({ [TEST_DEFAULT_URL_VARIABLE]: " http://stood-in.example " }),
+    ).toBe("http://stood-in.example");
+  });
+
+  /**
+   * The seam is not a second way for a developer to select a platform, and it
+   * does not behave like one: `EGMA_URL` sits above the built-in address in the
+   * order, so a shell that sets both is a shell that uses `EGMA_URL`.
+   */
+  it("is still the last step, whatever the seam holds", () => {
+    expect(
+      selectPlatform({
+        flag: null,
+        env: "http://named-for-this-shell.example",
+        binding: null,
+        fallback: defaultPlatformUrlIn({
+          [TEST_DEFAULT_URL_VARIABLE]: "http://stood-in.example",
+        }),
+      }),
+    ).toEqual({ url: "http://named-for-this-shell.example", source: "EGMA_URL" });
+  });
+
+  /**
+   * Not documented and not stable — the same treatment `-- <command>` already
+   * carries. A seam a developer found written down would become a seam they
+   * used, and then a promise egma has to keep. `--help` is checked where every
+   * other `--help` claim is, against the built command.
+   */
+  it("has a seam that is written down nowhere a developer reads", async () => {
+    for (const readme of [
+      path.join(CLI, "README.md"),
+      path.join(CLI, "..", "..", "README.md"),
+    ]) {
+      expect(await readFile(readme, "utf8"), readme).not.toContain(
+        TEST_DEFAULT_URL_VARIABLE,
+      );
+    }
+  });
+});

--- a/apps/cli/test/intro-screen.test.ts
+++ b/apps/cli/test/intro-screen.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The wizard's first screen, on a real terminal, in a repository that names no
+ * platform.
+ *
+ * A bare command now reaches egma's own platform when nothing else names one,
+ * so which egma this is stopped being something the developer chose. It is
+ * therefore something they have to be told — and told on the screen that takes
+ * the keystroke of consent, before that address has been asked anything at all.
+ * Both halves of that are terminal facts, so both are checked here: what the
+ * screen says, and that the platform has heard nothing while it says it.
+ */
+
+import process from "node:process";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
+import { runInTerminal, showingIn, type TerminalRun } from "./support/pty.ts";
+import {
+  CLI_ENTRY,
+  FAKE_AGENT,
+  MANIFEST,
+  makeWorkspace,
+  type Workspace,
+} from "./support/workspace.ts";
+
+// A real subprocess, a real terminal and a test run using every core: the
+// budget is generous so that only a broken wizard can reach it.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+let platform: Platform;
+let workspace: Workspace;
+
+beforeEach(async () => {
+  platform = await startPlatform();
+  workspace = await makeWorkspace({ "package.json": MANIFEST });
+});
+
+afterEach(async () => {
+  await platform.close();
+  await workspace.remove();
+});
+
+/** Everything on screen as one run of words, for text the box has wrapped. */
+function asOneLine(screen: string): string {
+  return screen
+    .split("\n")
+    .map((line) => line.replaceAll("│", "").trim())
+    .join(" ")
+    .replaceAll(/\s+/gu, " ");
+}
+
+/** The bare command: no verb, no `--url`, and no `EGMA_URL` in the shell. */
+function bareWizard(): TerminalRun {
+  const args = [CLI_ENTRY, "--cwd", workspace.dir];
+  expect(args).not.toContain("--url");
+  const env = workspace.env({
+    // The stand-in for egma's own address. Nothing here dials the real one.
+    EGMA_TEST_DEFAULT_URL: platform.url,
+  });
+  expect(env.EGMA_URL).toBeUndefined();
+
+  return runInTerminal({
+    command: process.execPath,
+    args: [...args, "--", process.execPath, FAKE_AGENT, "no-script"],
+    cwd: workspace.dir,
+    env,
+    cols: 100,
+  });
+}
+
+describe("the wizard's first screen", () => {
+  it("names the egma it will use, and says how to choose another", async () => {
+    const terminal = bareWizard();
+    try {
+      const screen = await showingIn(
+        terminal,
+        asOneLine,
+        platform.url,
+        "--url <address>",
+        "[enter] begin",
+      );
+
+      // The address, and the two ways to name a different one. This is the
+      // screen the keystroke of consent is taken on: nothing else stands
+      // between reading it and agreeing to the walk.
+      const said = asOneLine(screen);
+      expect(said).toContain("--url <address>");
+      expect(said).toContain("EGMA_URL");
+      // And the seam that stands the address in is not offered as a third way.
+      expect(said).not.toContain("EGMA_TEST_DEFAULT_URL");
+
+      // Nothing has been asked of that address. The whole reason the screen is
+      // here rather than after resolution: a developer who reads this and quits
+      // has sent nothing anywhere.
+      expect(platform.records).toEqual([]);
+
+      // And the keystroke is what lets egma speak to it.
+      terminal.write("\r");
+      expect(
+        await terminal.waitFor(() =>
+          platform.records.some((record) => record.path === "/api/platform"),
+        ),
+      ).toBe(true);
+    } finally {
+      await terminal.kill();
+    }
+  });
+});

--- a/apps/cli/test/key-custody.test.ts
+++ b/apps/cli/test/key-custody.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { MASKED, RetellKey } from "../src/retell/key.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import { alreadyAsked } from "../src/wizard/login-step.ts";
 import { walk } from "../src/wizard/walk.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
@@ -146,11 +147,11 @@ describe("a whole run, swept afterwards", () => {
         launch: workspace.launch(script),
         cwd: workspace.dir,
         signal: new AbortController().signal,
-        platform: {
+        platform: alreadyAsked({
           url: platform.url,
           instanceId: platform.instanceId,
           credentialsFile: workspace.credentialsFile,
-        },
+        }),
         retell: { url: retell.url },
         home: path.join(workspace.dir, "pretend-home"),
         runPollMs: 20,

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -420,46 +420,74 @@ describe("reading a code out of whatever was pasted", () => {
 });
 
 describe("which egma a command talks to", () => {
-  it("takes the flag first, then the environment, then the repository binding", () => {
+  // The address egma falls back to, stood in for so that reading this test
+  // never says which address ships. That is asserted in one place, on its own.
+  const BUILT_IN = "http://built-in.example";
+
+  it("takes the flag, then the environment, then the binding, then egma's own", () => {
     expect(
       resolvePlatformUrl({
         flag: "http://flag.example/",
         env: "http://env.example",
         binding: "http://bound.example",
+        fallback: BUILT_IN,
       }),
     ).toBe("http://flag.example");
 
     expect(
-      resolvePlatformUrl({ flag: null, env: "http://env.example", binding: "http://bound.example" }),
+      resolvePlatformUrl({
+        flag: null,
+        env: "http://env.example",
+        binding: "http://bound.example",
+        fallback: BUILT_IN,
+      }),
     ).toBe("http://env.example");
 
     // The repository, not the latest login on the machine, is what makes the
     // selection stable after onboarding.
-    expect(resolvePlatformUrl({ flag: null, binding: "http://bound.example/" })).toBe(
-      "http://bound.example",
+    expect(
+      resolvePlatformUrl({ flag: null, binding: "http://bound.example/", fallback: BUILT_IN }),
+    ).toBe("http://bound.example");
+
+    // Nothing names a platform, so egma uses its own. This is the step ADR-0008
+    // always had and the tree could not have while there was no hosted egma to
+    // point at.
+    expect(resolvePlatformUrl({ flag: null, env: "", binding: null, fallback: BUILT_IN })).toBe(
+      BUILT_IN,
     );
 
-    // Nothing names a platform, and egma has no hosted one to fall back to, so
-    // this refuses rather than inventing an address to go and probe.
-    expect(() => resolvePlatformUrl({ flag: null, env: "", binding: null })).toThrow(
-      "names no Egma platform",
+    // And it really is last: each of the three deliberate places still wins
+    // over it on its own.
+    expect(resolvePlatformUrl({ flag: "http://flag.example", fallback: BUILT_IN })).toBe(
+      "http://flag.example",
     );
+    expect(
+      resolvePlatformUrl({ flag: null, env: "http://env.example", fallback: BUILT_IN }),
+    ).toBe("http://env.example");
   });
 
   it("refuses an address that is not one, and names where it came from", () => {
     // The next thing that happens to this address is that a browser is started
     // on it, so it is checked at the edge that takes it and not after.
     for (const given of ["javascript:alert(1)", "file:///etc/passwd", "not an address at all"]) {
-      expect(() => resolvePlatformUrl({ flag: given })).toThrow(UnusableUrlError);
-      expect(() => resolvePlatformUrl({ flag: null, env: given })).toThrow(UnusableUrlError);
+      expect(() =>
+        resolvePlatformUrl({ flag: given, fallback: BUILT_IN }),
+      ).toThrow(UnusableUrlError);
+      expect(() =>
+        resolvePlatformUrl({ flag: null, env: given, fallback: BUILT_IN }),
+      ).toThrow(UnusableUrlError);
     }
 
-    expect(() => resolvePlatformUrl({ flag: "ftp://egma.example" })).toThrow(/--url/u);
-    expect(() => resolvePlatformUrl({ flag: null, env: "ftp://egma.example" })).toThrow(/EGMA_URL/u);
-
-    // A committed binding is never stepped over in favour of Cloud.
     expect(() =>
-      resolvePlatformUrl({ flag: null, binding: "javascript:alert(1)" }),
+      resolvePlatformUrl({ flag: "ftp://egma.example", fallback: BUILT_IN }),
+    ).toThrow(/--url/u);
+    expect(() =>
+      resolvePlatformUrl({ flag: null, env: "ftp://egma.example", fallback: BUILT_IN }),
+    ).toThrow(/EGMA_URL/u);
+
+    // A committed binding is never stepped over in favour of egma's own.
+    expect(() =>
+      resolvePlatformUrl({ flag: null, binding: "javascript:alert(1)", fallback: BUILT_IN }),
     ).toThrow(/repository platform binding/u);
   });
 });

--- a/apps/cli/test/platform-binding-process.test.ts
+++ b/apps/cli/test/platform-binding-process.test.ts
@@ -1,6 +1,7 @@
 /**
  * Every later headless command, as a real CLI process, follows the committed
- * repository binding with no flag or environment URL to help it.
+ * repository binding with no flag or environment URL to help it — and the
+ * refusal that keeps it there arrives whole in a real terminal.
  */
 
 import { spawn } from "node:child_process";
@@ -32,6 +33,31 @@ type CommandResult = {
 };
 
 vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
+/** The built CLI as its own process, ended rather than thrown. */
+async function runEgma(
+  where: { readonly cwd: string; readonly env: NodeJS.ProcessEnv },
+  args: readonly string[],
+): Promise<CommandResult> {
+  const child = spawn(process.execPath, [CLI_ENTRY, ...args], where);
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  // `connect` checks standard input before its environment. End the pipe so
+  // the real process sees the same promptless EOF a coding agent sends.
+  child.stdin.end();
+  const code = await new Promise<number>((resolve) => {
+    child.on("close", (value) => resolve(value ?? 1));
+  });
+  return { stdout, stderr, code };
+}
 
 describe("commands after a repository is bound", () => {
   let bound: Platform;
@@ -91,27 +117,7 @@ describe("commands after a repository is bound", () => {
     const env = workspace.env({ EGMA_RETELL_URL: retell.url, ...extra });
     expect(args).not.toContain("--url");
     expect(env.EGMA_URL).toBeUndefined();
-    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
-      cwd: workspace.dir,
-      env,
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-    // `connect` checks standard input before its environment. End the pipe so
-    // the real process sees the same promptless EOF a coding agent sends.
-    child.stdin.end();
-    const code = await new Promise<number>((resolve) => {
-      child.on("close", (value) => resolve(value ?? 1));
-    });
-    return { stdout, stderr, code };
+    return runEgma({ cwd: workspace.dir, env }, args);
   }
 
   async function reachesBound(
@@ -212,5 +218,89 @@ describe("commands after a repository is bound", () => {
     }
     expect(bound.running.runs).toHaveLength(beforeRuns + 1);
     expect(other.records).toEqual([]);
+  });
+});
+
+/**
+ * The refusal a developer meets when they really are moving, in the terminal
+ * they meet it in.
+ *
+ * Now that an unbound repository falls back to egma's own platform, the first
+ * thing somebody moving off their own deployment types is the address they want
+ * — and this is what answers. It has to arrive whole: one sentence saying egma
+ * will not do it, then every line to delete, then what moving costs. A refusal
+ * that named the first step and stopped is what left a developer deleting the
+ * platform block, running again, and meeting a stranger failure about
+ * identifiers the new platform never issued.
+ *
+ * Checked here as one real process, because a coding agent reads this out of a
+ * terminal and acts on it. Whether the lines say the right thing is
+ * `egma-folder.test.ts`; whether they survive the trip is this.
+ */
+describe("moving a bound repository to another platform", () => {
+  let here: Platform;
+  let there: Platform;
+  let workspace: Workspace;
+
+  beforeAll(async () => {
+    [here, there, workspace] = await Promise.all([
+      startPlatform(),
+      startPlatform(),
+      makeWorkspace(),
+    ]);
+    here.signedInWith(BOUND_KEY);
+    there.signedInWith(OTHER_KEY);
+    await workspace.signIn(here.url, BOUND_KEY);
+    await workspace.signIn(there.url, OTHER_KEY);
+    await createEgmaFolder({
+      repository: workspace.dir,
+      config: {
+        platform: { origin: here.url, instance: here.instanceId },
+        agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+        connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+        suite: { name: "first-suite", id: "sui_01K3XQ7M4E8YB2FVN0H9TZQWET" },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all([here.close(), there.close(), workspace.remove()]);
+  });
+
+  it("refuses, and teaches the whole move in plain lines", async () => {
+    const refused = await runEgma(
+      { cwd: workspace.dir, env: workspace.env() },
+      ["push", "--url", there.url],
+    );
+
+    expect(refused.code).toBe(4);
+    expect(refused.stdout).toContain("status: refused");
+    expect(refused.stderr).toContain("egma does not move a repository between platforms");
+    expect(refused.stderr).toContain("no repository identifiers were sent");
+
+    // Every line to delete, in the terminal, as a block that starts on its own
+    // line rather than trailing off the end of a sentence.
+    const said = refused.stderr.split("\n").map((line) => line.trimEnd());
+    const opens = said.indexOf(
+      "To move this repository to another platform, delete these and run egma again:",
+    );
+    expect(opens).toBeGreaterThan(0);
+    expect(said[opens - 1]).toBe("");
+    expect(said.slice(opens + 1, opens + 6)).toEqual([
+      "  - the whole platform: block in egma/config.yaml",
+      "  - the id: line under agent: in egma/config.yaml",
+      "  - the id: line under connection: in egma/config.yaml",
+      "  - the id: line under suite: in egma/config.yaml",
+      "  - the version: line at the top of every file in egma/tests/",
+    ]);
+    expect(said[opens + 6]).toContain("Your tests move with you");
+    expect(said[opens + 6]).toContain("stay on the platform that ran them");
+
+    // No command performs the move, so none is offered.
+    expect(refused.stderr).not.toMatch(/egma rebind|--rebind|egma move/u);
+
+    // And nothing was sent: neither platform was asked so much as who it is.
+    expect(here.records).toEqual([]);
+    expect(there.records).toEqual([]);
   });
 });

--- a/apps/cli/test/platform-binding-process.test.ts
+++ b/apps/cli/test/platform-binding-process.test.ts
@@ -282,19 +282,25 @@ describe("moving a bound repository to another platform", () => {
     // line rather than trailing off the end of a sentence.
     const said = refused.stderr.split("\n").map((line) => line.trimEnd());
     const opens = said.indexOf(
-      "To move this repository to another platform, delete these and run egma again:",
+      "To move this repository to another platform, delete these in this order and run egma again:",
     );
     expect(opens).toBeGreaterThan(0);
     expect(said[opens - 1]).toBe("");
+    // In that order, and the platform block last. Deleting it is what unbinds
+    // the repository, and an unbound repository falls back to egma's own
+    // platform — so a developer following this list top-down must never be one
+    // line in and holding another platform's identifiers with nothing left to
+    // keep them there.
     expect(said.slice(opens + 1, opens + 6)).toEqual([
-      "  - the whole platform: block in egma/config.yaml",
       "  - the id: line under agent: in egma/config.yaml",
       "  - the id: line under connection: in egma/config.yaml",
       "  - the id: line under suite: in egma/config.yaml",
       "  - the version: line at the top of every file in egma/tests/",
+      "  - last of all, the whole platform: block in egma/config.yaml",
     ]);
-    expect(said[opens + 6]).toContain("Your tests move with you");
-    expect(said[opens + 6]).toContain("stay on the platform that ran them");
+    expect(said[opens + 6]).toContain("Delete the platform block last");
+    expect(said[opens + 7]).toContain("Your tests move with you");
+    expect(said[opens + 7]).toContain("stay on the platform that ran them");
 
     // No command performs the move, so none is offered.
     expect(refused.stderr).not.toMatch(/egma rebind|--rebind|egma move/u);

--- a/apps/cli/test/platform-binding-real.test.ts
+++ b/apps/cli/test/platform-binding-real.test.ts
@@ -194,10 +194,14 @@ it("refuses a repository bound to another real local platform before sending its
 
     expect(result.code).toBe(4);
     expect(result.stdout).toContain("status: refused");
-    expect(result.stdout).toContain("No repository identifiers were sent");
+    expect(result.stdout).toContain("no repository identifiers were sent");
     expect(result.stderr).toContain(firstIdentity.instance_id);
     expect(result.stderr).toContain(secondIdentity.instance_id);
-    expect(result.stderr).toContain("No repository identifiers were sent");
+    expect(result.stderr).toContain("no repository identifiers were sent");
+    // The move this refusal teaches goes to the error stream whole. The output
+    // stream stays one fact per line, which is what `--help` promises of it.
+    expect(result.stderr).toContain("To move this repository to another platform");
+    expect(result.stdout.split("\n")).toHaveLength(3);
 
     const identifierBearing = observedBySecond.filter((request) => {
       const shown = JSON.stringify(request);
@@ -232,7 +236,10 @@ it("refuses a repository bound to another real local platform before sending its
     expect(elsewhere.stdout).toContain("status: refused");
     expect(elsewhere.stderr).toContain(firstIdentity.origin);
     expect(elsewhere.stderr).toContain(secondIdentity.origin);
-    expect(elsewhere.stderr).toContain("No repository identifiers were sent");
+    expect(elsewhere.stderr).toContain("no repository identifiers were sent");
+    // Naming another platform on the command line is a developer saying they
+    // want to move, so this refusal teaches the whole move too.
+    expect(elsewhere.stderr).toContain("To move this repository to another platform");
     expect(observedBySecond).toEqual([]);
   } finally {
     await first?.close();
@@ -245,10 +252,12 @@ it("refuses a repository bound to another real local platform before sending its
  * The other half of the safety rule, and the one a self-hoster meets by
  * accident: the platform this repository is bound to is simply not running.
  *
- * The tempting behaviour is to carry on with Egma Cloud, and it is the one
- * failure this ticket exists to make impossible — a repository full of
- * local-platform identifiers would start posting them at a platform that has
- * never seen them. So the command stops, names the platform it wanted, and says
+ * The tempting behaviour is to carry on with egma's own hosted platform — and
+ * now that there is one to carry on with, this is the failure that rule exists
+ * to make impossible — a repository full of local-platform identifiers would
+ * start posting them at a platform that has never seen them. There is a real
+ * fall-back step below the binding now, and a bound repository still never
+ * takes it. So the command stops, names the platform it wanted, and says
  * what to do. A second real platform is left running throughout, standing in
  * for every platform this machine could have wandered to, and it must see
  * nothing at all.
@@ -361,7 +370,7 @@ it("refuses when the bound real platform is down, and reaches no other platform"
     expect(result.stdout).toContain("status: unreachable");
     expect(result.stderr).toContain(boundIdentity.instance_id);
     expect(result.stderr).toContain(boundOrigin);
-    expect(result.stderr).toContain("Egma Cloud was not used");
+    expect(result.stderr).toContain("egma did not fall back to its own platform");
     expect(result.stderr).toContain("no repository identifiers were sent");
 
     // The platform that is up saw nothing: not a request carrying an

--- a/apps/cli/test/platform-credentials-real.test.ts
+++ b/apps/cli/test/platform-credentials-real.test.ts
@@ -1,7 +1,7 @@
 /**
  * Two real platforms, two real logins, one machine.
  *
- * A developer who self-hosts and also uses Egma Cloud signs in to both from the
+ * A developer who self-hosts and also uses hosted egma signs in to both from the
  * same laptop. The promise is that the second login does not sign them out of
  * the first, and that the key each platform minted is only ever offered back to
  * that platform. Both halves are proved here against real API processes with

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -1,6 +1,12 @@
+import { rm } from "node:fs/promises";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { createEgmaFolder } from "../src/folder/egma-folder.ts";
+import {
+  bindRepositoryPlatform,
+  createEgmaFolder,
+  folderPathsIn,
+} from "../src/folder/egma-folder.ts";
 import {
   BoundPlatformAddressError,
   BoundPlatformUnavailableError,
@@ -41,9 +47,15 @@ async function refusalFrom(work: Promise<unknown>): Promise<Error> {
  */
 function expectTheWholeMove(said: string): void {
   expect(said).toContain(
-    "To move this repository to another platform, delete these and run egma again:",
+    "To move this repository to another platform, delete these in this order and run egma again:",
   );
-  expect(said.split("\n").filter((line) => line.startsWith("  - "))).toHaveLength(5);
+  const deletions = said.split("\n").filter((line) => line.startsWith("  - "));
+  expect(deletions).toHaveLength(5);
+  // And the platform block last, wherever this refusal is raised from. It is
+  // the line that unbinds the repository, and an unbound repository falls back
+  // to egma's own platform — so a list that named it first would send every
+  // other identifier in the folder to hosted egma on the very next command.
+  expect(deletions.at(-1)).toContain("the whole platform: block");
   expect(said).toContain("Your tests move with you");
   expect(said).toContain("stay on the platform that ran them");
   // The refusal teaches the move. Nothing offers to perform it.
@@ -99,6 +111,53 @@ describe("verifying an Egma platform", () => {
     });
   });
 
+  /**
+   * A binding cannot disagree with itself.
+   *
+   * The origin is a line in a file a person edits, and a person writes a
+   * trailing slash, or the host in capitals, or the default port spelled out.
+   * Every one of those is the same platform. Read as written, the repository is
+   * refused for moving nowhere — told that the binding names something other
+   * than the binding, told to drop something that is not there, and handed four
+   * deletions for a move it is not making. So the committed origin is read in
+   * the one shape origins are compared in, and this is a repository reached
+   * rather than refused.
+   */
+  it("reaches a bound platform whose committed origin is written another way", async () => {
+    await workspace.signIn(platform.url);
+    for (const written of [`${platform.url}/`, `  ${platform.url}  `]) {
+      await rm(folderPathsIn(workspace.dir).root, { recursive: true, force: true });
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: written, instance: platform.instanceId },
+          agent: { name: "receptionist", id: "agt_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+          connection: { name: "retell-1", id: "con_01K3XQ7M4E8YB2FVN0H9TZQWES" },
+          suite: { name: "first-suite", id: "sui_01K3XQ7M4E8YB2FVN0H9TZQWET" },
+        },
+      });
+
+      const access = await resolvePlatformAccess({
+        env: workspace.env(),
+        flag: null,
+        cwd: workspace.dir,
+      });
+      expect(access, written).toMatchObject({
+        url: platform.url,
+        instanceId: platform.instanceId,
+      });
+
+      // And the binding is still what it always was: the same platform reached
+      // at the address it recorded, so nothing is rewritten for anybody.
+      expect(
+        (await bindRepositoryPlatform(workspace.dir, {
+          origin: platform.url,
+          instance: platform.instanceId,
+        })).platform,
+      ).toEqual({ origin: platform.url, instance: platform.instanceId });
+    }
+  });
+
   it("refuses a different explicit address before asking anybody anything", async () => {
     const other = await startPlatform();
     try {
@@ -124,10 +183,18 @@ describe("verifying an Egma platform", () => {
       // Naming another platform on the command line is how a developer says
       // they want to move, so this is the refusal that has to teach the move.
       expectTheWholeMove(refusal.message);
-      // And the one case that is not a move keeps its own sentence: the same
-      // platform at a new address needs an address edited, not four
-      // identifiers thrown away.
-      expect(refusal.message).toContain("only changed address");
+
+      // The two edits it offers contradict each other — change the platform
+      // origin, or delete the whole platform block — so the sentence says which
+      // situation each belongs to. Under ADR-0007 a refusal holding both
+      // without a condition is one a coding agent cannot act on.
+      expect(refusal.message).toContain("Drop --url to use the bound platform.");
+      expect(refusal.message).toContain(
+        `edit the platform origin in egma/config.yaml to ${other.url} and change nothing else`,
+      );
+      expect(refusal.message).toContain(
+        "the move below is for a different platform, not a new address for this one",
+      );
 
       // Neither platform was asked so much as who it is. The address a bound
       // repository uses is decided by the file, so an address that is not the
@@ -280,39 +347,97 @@ describe("verifying an Egma platform", () => {
 
   /**
    * Nobody typed egma's built-in address, nobody but egma runs what is at it,
-   * and nobody outside egma can fix it — so the refusal says the two moves that
-   * do belong to the developer, waiting and naming a platform of their own, and
-   * never hands on advice about checking an address they did not choose or
-   * reconfiguring a deployment that is not theirs.
+   * and nobody outside egma can fix it. So the **advice** is suppressed — go
+   * and look at that address, reconfigure that deployment — because every word
+   * of it is addressed to somebody who is not reading.
+   *
+   * **What happened is not suppressed.** A redirect, a 500 and a page that is
+   * not a platform are three different things, and a refusal that called all
+   * three "it did not answer" was wrong about the fact for two of them. The
+   * shape travels too: something that will answer the same way in a minute is
+   * `refused` and does not invite a retry, and only a bad moment says to wait.
    */
-  it("answers for its own built-in address rather than passing on its faults", async () => {
-    for (const answer of [
-      () => new Response(null, { status: 307, headers: { location: "/login" } }),
-      () => new Response("nope", { status: 502 }),
-      () => Response.json({ nothing: "useful" }),
-    ]) {
-      const refusal = await refusalFrom(
+  it("says what happened at its own built-in address, without passing on its advice", async () => {
+    const answers = [
+      {
+        what: "a redirect",
+        answer: () => new Response(null, { status: 307, headers: { location: "/login" } }),
+        says: "it redirected to /login instead.",
+        refusal: "refused" as const,
+      },
+      {
+        what: "a bad minute",
+        answer: () => new Response("nope", { status: 502 }),
+        says: "it answered 502 rather than its identity.",
+        refusal: "unreachable" as const,
+      },
+      {
+        what: "an address that is not egma",
+        answer: () => new Response("<html>somebody else</html>", { status: 404 }),
+        says: "it answered 404 rather than its identity.",
+        refusal: "refused" as const,
+      },
+      {
+        what: "a page that answers but says nothing egma knows",
+        answer: () => Response.json({ nothing: "useful" }),
+        says: "what came back carries no platform identity egma can use.",
+        refusal: "refused" as const,
+      },
+      {
+        what: "a platform naming an address nobody asked for",
+        answer: () =>
+          Response.json({
+            instance_id: "pf_01K3XQ7M4E8YB2FVN0H9TZQWEA",
+            origin: "https://somewhere.else.example",
+          }),
+        says: "it answered that it lives at https://somewhere.else.example instead.",
+        refusal: "refused" as const,
+      },
+    ];
+
+    for (const shape of answers) {
+      const refusal = (await refusalFrom(
         resolvePlatformAccess({
           env: workspace.env({ EGMA_TEST_DEFAULT_URL: "https://built-in.example" }),
           flag: null,
           cwd: workspace.dir,
-          fetchImpl: async () => answer(),
+          fetchImpl: async () => shape.answer(),
         }),
-      );
+      )) as DefaultPlatformUnusableError;
 
-      expect(refusal).toBeInstanceOf(DefaultPlatformUnusableError);
+      expect(refusal, shape.what).toBeInstanceOf(DefaultPlatformUnusableError);
       // The address egma tried, so "hosted egma is down" can be told apart from
       // "I typed something wrong" — and there was nothing to type.
-      expect(refusal.message).toContain("https://built-in.example");
-      expect(refusal.message).toContain("--url <address>");
-      expect(refusal.message).toContain("EGMA_URL");
-      expect(refusal.message).toContain("Nothing was sent");
-      // Not the underlying complaint: none of it is the developer's to act on.
-      expect(refusal.message).not.toMatch(/sign-in page|proxy|this is where to look/u);
-      expect(refusal.message).not.toContain("Check the address");
-      expect(refusal.message).not.toContain("EGMA_BASE_URL");
+      expect(refusal.message, shape.what).toContain("https://built-in.example");
+      // What happened there, said rather than flattened into "it did not
+      // answer". The spec's own further notes rely on a developer being told
+      // about a redirect.
+      expect(refusal.message, shape.what).toContain(shape.says);
+      // The one move that is theirs is always offered.
+      expect(refusal.message, shape.what).toContain("--url <address>");
+      expect(refusal.message, shape.what).toContain("EGMA_URL");
+      expect(refusal.message, shape.what).toContain("Nothing was sent");
+
+      // Not the underlying advice: none of it is the developer's to act on.
+      expect(refusal.message, shape.what).not.toMatch(
+        /sign-in page|proxy|this is where to look/u,
+      );
+      expect(refusal.message, shape.what).not.toContain("Check the address");
+      expect(refusal.message, shape.what).not.toContain("EGMA_BASE_URL");
+
+      // And the shape, which is what decides whether anything is worth
+      // retrying. "Try again in a moment" over a permanent answer is a loop
+      // with no way out of it.
+      expect(refusal.refusal, shape.what).toBe(shape.refusal);
+      if (shape.refusal === "refused") {
+        expect(refusal.message, shape.what).not.toContain("Try again in a moment");
+        expect(refusal.message, shape.what).toContain("waiting will not change it");
+      } else {
+        expect(refusal.message, shape.what).toContain("Try again in a moment");
+      }
+
       // And the real fault is still there for whoever goes looking.
-      expect(refusal.cause).toBeInstanceOf(Error);
+      expect(refusal.cause, shape.what).toBeInstanceOf(Error);
     }
   });
 
@@ -333,7 +458,12 @@ describe("verifying an Egma platform", () => {
 
     expect(refusal).toBeInstanceOf(DefaultPlatformUnusableError);
     expect(refusal.message).toContain(NO_DEFAULT_PLATFORM);
+    expect(refusal.message).toContain("nothing answered there");
     expect(refusal.message).toContain("Nothing was sent");
+    // The one shape where waiting really can change the answer, and the only
+    // one that says so.
+    expect((refusal as DefaultPlatformUnusableError).refusal).toBe("unreachable");
+    expect(refusal.message).toContain("Try again in a moment");
   });
 
   it("keeps the address it was given, whatever the platform calls itself", async () => {

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -30,6 +30,26 @@ async function refusalFrom(work: Promise<unknown>): Promise<Error> {
   throw new Error("that was supposed to be refused, and it was not");
 }
 
+/**
+ * The whole move, under a refusal a developer meets while trying to make it.
+ *
+ * These two refusals are what somebody pointing egma at the platform they want
+ * is answered with, so each has to end where `bindRepositoryPlatform` ends: the
+ * five lines to delete, and what moving costs. Each line is checked in
+ * `egma-folder.test.ts`, which owns the wording; what is checked here is that
+ * this refusal carries it at all rather than naming a first step and stopping.
+ */
+function expectTheWholeMove(said: string): void {
+  expect(said).toContain(
+    "To move this repository to another platform, delete these and run egma again:",
+  );
+  expect(said.split("\n").filter((line) => line.startsWith("  - "))).toHaveLength(5);
+  expect(said).toContain("Your tests move with you");
+  expect(said).toContain("stay on the platform that ran them");
+  // The refusal teaches the move. Nothing offers to perform it.
+  expect(said).not.toMatch(/egma rebind|--rebind|egma move/u);
+}
+
 describe("verifying an Egma platform", () => {
   let platform: Platform;
   let workspace: Workspace;
@@ -92,13 +112,22 @@ describe("verifying an Egma platform", () => {
         },
       });
 
-      await expect(
+      const refusal = await refusalFrom(
         resolvePlatformAccess({
           env: workspace.env(),
           flag: other.url,
           cwd: workspace.dir,
         }),
-      ).rejects.toBeInstanceOf(BoundPlatformAddressError);
+      );
+      expect(refusal).toBeInstanceOf(BoundPlatformAddressError);
+
+      // Naming another platform on the command line is how a developer says
+      // they want to move, so this is the refusal that has to teach the move.
+      expectTheWholeMove(refusal.message);
+      // And the one case that is not a move keeps its own sentence: the same
+      // platform at a new address needs an address edited, not four
+      // identifiers thrown away.
+      expect(refusal.message).toContain("only changed address");
 
       // Neither platform was asked so much as who it is. The address a bound
       // repository uses is decided by the file, so an address that is not the
@@ -131,9 +160,15 @@ describe("verifying an Egma platform", () => {
       },
     });
 
-    await expect(
+    const refusal = await refusalFrom(
       resolvePlatformAccess({ env: workspace.env(), flag: null, cwd: workspace.dir }),
-    ).rejects.toBeInstanceOf(PlatformBindingMismatchError);
+    );
+    expect(refusal).toBeInstanceOf(PlatformBindingMismatchError);
+
+    // A rebuilt stack is the same repository meeting a platform that issued
+    // none of its identifiers, which is the move whether the developer meant
+    // it or not — so this refusal teaches it too.
+    expectTheWholeMove(refusal.message);
 
     // One question asked, and it was the public one that carries nothing.
     expect(platform.records.map((record) => `${record.method} ${record.path}`)).toEqual([
@@ -402,8 +437,11 @@ describe("verifying an Egma platform", () => {
     expect(platform.records).toEqual([]);
   });
 
-  it("refuses an unavailable bound platform and does not try Egma Cloud", async () => {
-    const boundOrigin = "http://127.0.0.1:1";
+  it("refuses an unavailable bound platform and does not try egma's own", async () => {
+    // A closed port, and deliberately not the one standing in for the built-in
+    // address: the request list below is the proof that the fall-back step was
+    // never taken, and two identical addresses would make it prove nothing.
+    const boundOrigin = "http://127.0.0.1:2";
     await createEgmaFolder({
       repository: workspace.dir,
       config: {
@@ -429,7 +467,12 @@ describe("verifying an Egma platform", () => {
     });
 
     await expect(resolution).rejects.toBeInstanceOf(BoundPlatformUnavailableError);
-    await expect(resolution).rejects.toThrow("Egma Cloud was not used");
+    await expect(resolution).rejects.toThrow(
+      "egma did not fall back to its own platform",
+    );
+    // One address asked, and it is the bound one. The built-in address exists
+    // now, so this list is what proves a bound repository never reaches it.
     expect(requested).toEqual([`${boundOrigin}/api/platform`]);
+    expect(requested).not.toContain(`${NO_DEFAULT_PLATFORM}/api/platform`);
   });
 });

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -4,7 +4,7 @@ import { createEgmaFolder } from "../src/folder/egma-folder.ts";
 import {
   BoundPlatformAddressError,
   BoundPlatformUnavailableError,
-  NoPlatformNamedError,
+  DefaultPlatformUnusableError,
   PlatformBindingMismatchError,
   resolvePlatformAccess,
 } from "../src/platform/credentials.ts";
@@ -14,7 +14,11 @@ import {
   readPlatformIdentity,
 } from "../src/platform/identity.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
-import { makeWorkspace, type Workspace } from "./support/workspace.ts";
+import {
+  makeWorkspace,
+  NO_DEFAULT_PLATFORM,
+  type Workspace,
+} from "./support/workspace.ts";
 
 /** The refusal a promise ended with, or a failure saying it did not refuse. */
 async function refusalFrom(work: Promise<unknown>): Promise<Error> {
@@ -240,30 +244,61 @@ describe("verifying an Egma platform", () => {
   });
 
   /**
-   * Nobody typed egma's built-in default address, nobody runs what is at it,
-   * and nobody can fix it — so the refusal points at the one move that belongs
-   * to the developer, and never sends them off to inspect a website that is
-   * not theirs.
+   * Nobody typed egma's built-in address, nobody but egma runs what is at it,
+   * and nobody outside egma can fix it — so the refusal says the two moves that
+   * do belong to the developer, waiting and naming a platform of their own, and
+   * never hands on advice about checking an address they did not choose or
+   * reconfiguring a deployment that is not theirs.
    */
-  it("does not send a developer to inspect its own built-in default address", async () => {
+  it("answers for its own built-in address rather than passing on its faults", async () => {
+    for (const answer of [
+      () => new Response(null, { status: 307, headers: { location: "/login" } }),
+      () => new Response("nope", { status: 502 }),
+      () => Response.json({ nothing: "useful" }),
+    ]) {
+      const refusal = await refusalFrom(
+        resolvePlatformAccess({
+          env: workspace.env({ EGMA_TEST_DEFAULT_URL: "https://built-in.example" }),
+          flag: null,
+          cwd: workspace.dir,
+          fetchImpl: async () => answer(),
+        }),
+      );
+
+      expect(refusal).toBeInstanceOf(DefaultPlatformUnusableError);
+      // The address egma tried, so "hosted egma is down" can be told apart from
+      // "I typed something wrong" — and there was nothing to type.
+      expect(refusal.message).toContain("https://built-in.example");
+      expect(refusal.message).toContain("--url <address>");
+      expect(refusal.message).toContain("EGMA_URL");
+      expect(refusal.message).toContain("Nothing was sent");
+      // Not the underlying complaint: none of it is the developer's to act on.
+      expect(refusal.message).not.toMatch(/sign-in page|proxy|this is where to look/u);
+      expect(refusal.message).not.toContain("Check the address");
+      expect(refusal.message).not.toContain("EGMA_BASE_URL");
+      // And the real fault is still there for whoever goes looking.
+      expect(refusal.cause).toBeInstanceOf(Error);
+    }
+  });
+
+  /**
+   * The same refusal for the way it will really happen: nobody answering at
+   * all. It is the one an unbound repository meets on a train.
+   */
+  it("names the built-in address it tried when nothing answers there", async () => {
     const refusal = await refusalFrom(
       resolvePlatformAccess({
+        // A closed port, which is what every workspace stands in for the real
+        // built-in address by default.
         env: workspace.env(),
         flag: null,
         cwd: workspace.dir,
-        fetchImpl: async () =>
-          new Response(null, { status: 307, headers: { location: "/login" } }),
       }),
     );
 
-    expect(refusal).toBeInstanceOf(NoPlatformNamedError);
-    expect(refusal.message).toContain("--url <address>");
-    expect(refusal.message).toContain("EGMA_URL");
+    expect(refusal).toBeInstanceOf(DefaultPlatformUnusableError);
+    expect(refusal.message).toContain(NO_DEFAULT_PLATFORM);
     expect(refusal.message).toContain("Nothing was sent");
-    // No address is named, because there is none to name — and nothing was
-    // asked of any host, so no deployment is described as broken.
-    expect(refusal.message).not.toMatch(/https?:\/\//u);
-    expect(refusal.message).not.toMatch(/sign-in page|proxy|this is where to look/u);
   });
 
   it("keeps the address it was given, whatever the platform calls itself", async () => {
@@ -313,27 +348,27 @@ describe("verifying an Egma platform", () => {
     await expect(stalled).rejects.toThrow("did not answer within");
   });
 
-  it("asks nothing at all when no platform is named", async () => {
+  it("asks egma's own platform, and only that, when nothing names another", async () => {
     const requested: string[] = [];
-    await expect(
-      resolvePlatformAccess({
-        env: workspace.env(),
-        flag: null,
-        cwd: workspace.dir,
-        fetchImpl: async (input) => {
-          requested.push(String(input));
-          return new Response(null, { status: 200 });
-        },
-      }),
-    ).rejects.toBeInstanceOf(NoPlatformNamedError);
+    const access = await resolvePlatformAccess({
+      env: workspace.env({ EGMA_TEST_DEFAULT_URL: platform.url }),
+      flag: null,
+      cwd: workspace.dir,
+      fetchImpl: async (input, init) => {
+        requested.push(String(input));
+        return fetch(input, init);
+      },
+    });
 
-    // The whole point of refusing here rather than falling back: with no
-    // hosted platform to reach for, an address invented at this moment would
-    // belong to somebody else, and probing it would report their server as a
-    // broken egma.
-    expect(requested).toEqual([]);
+    // The last step of the order, and the only one nobody typed: a repository
+    // with nothing configured reaches egma's own platform.
+    expect(access.url).toBe(platform.url);
+    expect(access.instanceId).toBe(platform.instanceId);
+
+    // One address asked, and it is that one. Nothing goes looking anywhere else
+    // for a repository that named nothing.
+    expect(requested).toEqual([`${platform.url}/api/platform`]);
   });
-
 
   /**
    * A refusal names the platform the developer asked about.

--- a/apps/cli/test/run-command.test.ts
+++ b/apps/cli/test/run-command.test.ts
@@ -97,14 +97,25 @@ async function register(type = "retell"): Promise<Registered> {
   return { agentId: body.agent.id, connectionId: body.connection.id };
 }
 
-/** The folder, pointing at what was registered, as connect would have left it. */
+/**
+ * The folder, pointing at what was registered, as connect would have left it.
+ *
+ * With the binding, because that is what connect really writes: it binds the
+ * repository at the moment before it registers anything, so an id under `agent`
+ * or `connection` never exists in this file without the platform block above it
+ * naming who issued it. A folder holding one and not the other is the
+ * half-applied move, and egma refuses to resolve a platform from it.
+ */
 async function makeFolder(registered: Registered | null): Promise<void> {
   const made = await createEgmaFolder({ repository: workspace.dir });
   // Written rather than passed to the maker, because the maker deliberately
   // never rewrites a config that is already there — and a check that changes
   // what the folder points at is exactly the thing that rule protects against.
   await writeConfig(made.paths.config, {
-    platform: null,
+    platform:
+      registered === null
+        ? null
+        : { origin: platform.url, instance: platform.instanceId },
     agent: registered === null ? null : { name: "order-line", id: registered.agentId },
     connection: registered === null ? null : { name: "retell-1", id: registered.connectionId },
     suite: { name: "first-suite", id: null },

--- a/apps/cli/test/support/workspace.ts
+++ b/apps/cli/test/support/workspace.ts
@@ -119,6 +119,17 @@ export const NO_BROWSER = "/usr/bin/true";
  */
 export const NO_RETELL = "http://127.0.0.1:1";
 
+/**
+ * An egma that is not hosted egma.
+ *
+ * The built-in address a repository falls back to is the real hosted platform,
+ * and a check that reached it would sign in to production, create real
+ * organizations there, and fail whenever the network did. So every run started
+ * from here stands a closed port in its place unless the check itself names a
+ * platform to stand there — which is what the tests of the unbound path do.
+ */
+export const NO_DEFAULT_PLATFORM = "http://127.0.0.1:1";
+
 export async function makeWorkspace(
   files: Readonly<Record<string, string>> = {},
   options: WorkspaceOptions = {},
@@ -144,6 +155,7 @@ export async function makeWorkspace(
         EGMA_HOME: egmaFolder,
         BROWSER: NO_BROWSER,
         EGMA_RETELL_URL: NO_RETELL,
+        EGMA_TEST_DEFAULT_URL: NO_DEFAULT_PLATFORM,
         ...extra,
       };
       // Whatever the person running the suite has set, a check talks to the

--- a/apps/cli/test/teaching.test.ts
+++ b/apps/cli/test/teaching.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LEARN_CARDS, CARD_WIDTH, cardAt } from "../src/wizard/teaching.ts";
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
 import { exitLines } from "../src/wizard/exit-line.ts";
+import { alreadyAsked } from "../src/wizard/login-step.ts";
 import { walk } from "../src/wizard/walk.ts";
 import type { FakeStep } from "./support/fake-agent.ts";
 import { startFakeRetell, type FakeRetell, type FakeRetellScript } from "./support/fake-retell.ts";
@@ -255,11 +256,11 @@ describe("the pane, while the files land", () => {
           launch: second.launch(await scriptFor(second)),
           cwd: second.dir,
           signal: new AbortController().signal,
-          platform: {
+          platform: alreadyAsked({
             url: elsewhere.url,
             instanceId: elsewhere.instanceId,
             credentialsFile: second.credentialsFile,
-          },
+          }),
           retell: { url: retell.url },
           home: path.join(second.dir, "pretend-home"),
           runPollMs: 20,

--- a/apps/cli/test/walk.test.ts
+++ b/apps/cli/test/walk.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { HeadlessUI } from "../src/ui/headless-ui.ts";
+import type { GateId } from "../src/ui/wizard-ui.ts";
 import { buildExitLine } from "../src/wizard/exit-line.ts";
 import { walk } from "../src/wizard/walk.ts";
 import {
@@ -314,5 +315,63 @@ describe("one task, driven on a scripted agent", () => {
 
     // The agent started a process of its own; ending the agent ended that too.
     expect(await waitUntil(() => !isAlive(childPid as number))).toBe(true);
+  });
+
+  /**
+   * Which egma is said first, and asked second.
+   *
+   * A bare command reaches egma's own platform when nothing else names one, so
+   * where a repository's identifiers are about to go is the developer's to read
+   * before egma has said one word to that address. The gate is where the
+   * keystroke of consent is taken, so the gate is what the first request waits
+   * behind — and a developer who reads the address and closes the wizard has
+   * sent nothing anywhere.
+   */
+  it("names the platform before the gate, and asks it nothing until the gate opens", async () => {
+    const script = await workspace.script({
+      steps: [{ kind: "stop", reason: "end_turn" }],
+    });
+
+    let openTheGate = (): void => undefined;
+    const held = new Promise<void>((open) => {
+      openTheGate = open;
+    });
+    const lines: string[] = [];
+    const ui = new (class extends HeadlessUI {
+      override waitForGate(gate: GateId): Promise<void> {
+        void super.waitForGate(gate);
+        return gate === "begin" ? held : Promise.resolve();
+      }
+    })({ write: (line) => lines.push(line) });
+
+    let asked = 0;
+    const running = walk({
+      ui,
+      launch: workspace.launch(script),
+      cwd: workspace.dir,
+      signal: new AbortController().signal,
+      platform: {
+        url: "http://named-before-it-is-asked.example",
+        verify: () => {
+          asked += 1;
+          return Promise.reject(new Error("this platform did not answer"));
+        },
+      },
+    });
+
+    expect(await waitUntil(() => ui.record.platform !== null)).toBe(true);
+    expect(ui.record.platform).toBe("http://named-before-it-is-asked.example");
+    // The same fact as one plain line, in the same place in the walk.
+    expect(lines).toContain("url: http://named-before-it-is-asked.example");
+    expect(asked).toBe(0);
+
+    openTheGate();
+
+    // And a refusal from that read leaves the walk rather than becoming an exit
+    // line: it is egma declining to talk to an address, which is answered in
+    // the same sentence and the same number every verb answers it with.
+    await expect(running).rejects.toThrow("this platform did not answer");
+    expect(asked).toBe(1);
+    expect(ui.record.exit).toBeNull();
   });
 });


### PR DESCRIPTION
Ticket 03 of the hosted-egma effort.

A developer types `npx @egma/cli` in a repository that names no platform, and the wizard opens on hosted egma — after telling them which egma it is about to use and how to choose another.

## The shape

Platform resolution gains its last step. The order is unchanged above it — explicit `--url`, then `EGMA_URL`, then the repository's platform binding — and the step after those stops being a refusal and becomes `https://app.egma.ai`. Machine-level last-login state still selects nothing.

**A bound repository still never falls back.** Review traced eight ways a binding can be wrong — platform down, platform reinstalled, address overridden, unparseable, empty, unreadable, non-canonical — and the property holds in every one. Two tests prove it by asserting the stand-in for the built-in address received **zero** requests.

An unbound repository that cannot reach the built-in address refuses by name, says nothing was sent, and answers with the same exit code as egma's other unreachable refusals. `EGMA_TEST_DEFAULT_URL` replaces the address while a test runs; it is absent from `--help` and the README and carries the same "neither documented nor stable" treatment `main.ts` already gives the scripted-coding-agent seam.

## The defect this ticket created, and how it was caught

The spec said to put the move-teaching block on `bindRepositoryPlatform`. It was, correctly. Review then asked whether anyone reaches that branch — and nobody does: the resolver refuses a bound repository long before anything reaches the folder writer. Meanwhile the refusal a moving developer *does* meet said only "edit the platform origin in `egma/config.yaml`" — step one of five. That is exactly the second, stranger failure the spec's problem statement exists to remove.

Worse, the list itself was ordered wrongly. **It named the platform block first.** Deleting that first line unbinds the repository — and an unbound repository now falls back to hosted egma, which is this ticket's whole point. So a developer following egma's own instructions top-down reached a state with no binding and every other platform's identifiers still committed. Review reproduced it with the built CLI and captured a private platform's test-version identifier arriving at egma's servers, followed by advice that would have overwritten their files.

Before this ticket the same edit was refused locally with nothing sent. The fallback is what turned a safe intermediate state into a disclosure.

**The list is now inverted — identifiers and version pins first, the platform block last.** Every intermediate state leaves the repository either still bound, or empty. ADR-0008's rule that resource identifiers cannot silently cross platform boundaries holds at every step, not only at the ends.

Also fixed: a committed origin with a trailing slash or an uppercase host refused itself, and then attached "delete these five things" to a developer who had never left their platform.

## Not done, deliberately

**The package is not published.** That is a release action, and it is the one criterion left unticked, with the reason recorded on the ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BR47cXBaM7NkbTp764ecLX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789357420&installation_model_id=431960&pr_number=89&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F89&signature=6ac741c0052fd37a14a1f952562e77b8d7e9a0af2178f7e66b0b86ececfa2c1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds hosted Egma as the final platform-resolution fallback, delays bare-wizard verification until after consent, and improves platform-move refusals.
- Normalizes committed platform origins before comparison.
- Refuses unbound repositories retaining agent, connection, or suite IDs across default and explicit platform selection.
- Adds hosted-default messaging, UI state, and coverage for platform resolution and migration behavior.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because unbound repositories retaining only platform-scoped test-version pins can still send them to hosted or explicitly selected platforms.

The new guard blocks retained agent, connection, and suite IDs, but deliberately excludes test-version pins even though subsequent folder commands resolve those pins against the selected platform; the previously reported cross-platform disclosure therefore remains reachable for both default and explicit selection.

**Files Needing Attention:** apps/cli/src/folder/egma-folder.ts and apps/cli/src/platform/credentials.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/platform/credentials.ts | Adds hosted fallback selection, separates platform choice from verification, and introduces a source-independent guard for retained configuration IDs. |
| apps/cli/src/folder/egma-folder.ts | Normalizes committed origins and centralizes platform-move guidance and detection of retained configuration identifiers. |
| apps/cli/src/main.ts | Integrates deferred wizard verification and unified platform-refusal reporting. |
| apps/cli/src/platform/identity.ts | Adds structured identity-failure details used to classify hosted-platform failures as retryable or permanent. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[CLI invocation] --> B{Platform source}
  B -->|--url| C[Choose explicit URL]
  B -->|EGMA_URL| D[Choose environment URL]
  B -->|Repository binding| E[Choose bound origin]
  B -->|None| F[Choose hosted Egma]
  C --> G{Bound repository mismatch?}
  D --> G
  E --> H[Verify platform identity]
  F --> I{Unbound config IDs retained?}
  G -->|Yes| J[Refuse without sending identifiers]
  G -->|No| H
  I -->|Yes| J
  I -->|No| H
  H --> K[Run verb or wizard]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Refuse the unbound half-move whichever p..."](https://github.com/egma-ai/egma/commit/828b7f6c43f4925efe6f23998b3d8326515aee0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53560166)</sub>

<!-- /greptile_comment -->