### PR TITLE
Give both Postgres pools an error listener

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -40,6 +40,14 @@ export function connect(options: ConnectOptions): void {
     connectionString: options.databaseUrl,
     max: options.maxConnections ?? 10,
   });
+  // An idle pooled connection can die between checkouts — Postgres restarted,
+  // a failover, or a test database force-dropped under it. pg reports that by
+  // emitting `error` on the pool, and an unlistened `error` event brings the
+  // whole process down for a connection nothing was even using. The pool
+  // already discards the broken client and mints a fresh one on the next
+  // checkout; a query in flight on that client still gets its own rejection.
+  // So the listener's whole job is to exist.
+  pool.on("error", () => undefined);
   databaseUrl = options.databaseUrl;
   database = drizzle(pool, { schema, casing: "snake_case" });
 }

--- a/packages/db/test/pool-admin-shutdown.test.ts
+++ b/packages/db/test/pool-admin-shutdown.test.ts
@@ -1,0 +1,58 @@
+import { setTimeout as after } from "node:timers/promises";
+
+import { expect, it } from "vitest";
+
+import { ping } from "../src/client.ts";
+import {
+  createConnectedDatabase,
+  createMigratedDatabase,
+  forceDrop,
+} from "./support/database.ts";
+
+/**
+ * A killed idle connection must never take the process with it.
+ *
+ * Teardown drops each test database `with (force)`, which terminates any
+ * backend still attached. The terminated backend's FATAL — `57P01`,
+ * `admin_shutdown` — arrives asynchronously on whichever pool held the idle
+ * connection, as an `error` event. An unlistened `error` event is an uncaught
+ * exception: the run fails with every test green, which is how this file's
+ * absence looked in CI. In production the same event is a restarted or failed-
+ * over Postgres, and the cost is the whole API process.
+ *
+ * Both pools — the application's in `src/client.ts` and the test support's in
+ * `support/database.ts` — park an idle connection here, have the database
+ * dropped out from under them on purpose, and the assertion is arriving at the
+ * end of the file at all. Before the listeners existed, this file failed the
+ * run exactly the way CI did.
+ */
+
+it("the support pool survives its database being force-dropped under it", async () => {
+  const database = await createMigratedDatabase("admin_shutdown_support");
+  // One answered query parks an idle connection in the pool.
+  const answered = await database.sql("select 1 as one");
+  expect(answered.rows[0]).toEqual({ one: 1 });
+
+  await forceDrop(database.name);
+  // The FATAL from the killed backend arrives asynchronously; give it time to
+  // land while the pool sits idle. There is nothing to assert afterwards — an
+  // uncaught exception here fails the run, and its absence is the proof.
+  await after(400);
+
+  await database.close();
+});
+
+it("the application pool survives the same, and stays usable", async () => {
+  const database = await createConnectedDatabase("admin_shutdown_app");
+  await ping();
+
+  await forceDrop(database.name);
+  await after(400);
+
+  // The pool discarded the killed client. It must still be usable — the next
+  // checkout mints a fresh connection; against a dropped database that is an
+  // ordinary rejection on the query itself, never a process-level event.
+  await expect(ping()).rejects.toThrow();
+
+  await database.close();
+});

--- a/packages/db/test/support/database.ts
+++ b/packages/db/test/support/database.ts
@@ -38,6 +38,18 @@ async function onMaintenanceConnection<T>(
   }
 }
 
+/**
+ * Drop a test database out from under whatever is still attached to it —
+ * deliberately, without closing anything first. This is what teardown does by
+ * accident when an order goes wrong; the test that proves the pools survive it
+ * needs to do it on purpose.
+ */
+export async function forceDrop(databaseName: string): Promise<void> {
+  await onMaintenanceConnection((client) =>
+    client.query(`drop database if exists "${databaseName}" with (force)`),
+  );
+}
+
 export type EmptyDatabase = {
   readonly name: string;
   readonly url: string;
@@ -77,6 +89,11 @@ export async function createMigratedDatabase(
   await runMigrations(database.url);
 
   const pool = new pg.Pool({ connectionString: database.url, max: 4 });
+  // Same reason as the pool in `src/client.ts`: teardown drops databases
+  // `with (force)`, which kills any backend still attached, and the killed
+  // connection's FATAL arrives as `error` on the pool. Unlistened, that is an
+  // uncaught exception that fails a run whose every test passed.
+  pool.on("error", () => undefined);
 
   return {
     ...database,


### PR DESCRIPTION
A small infrastructure fix that was randomly failing green CI runs, found while driving the wave-1 pull requests.

## The symptom

A fast-lane run on #92 came back red with **every test passing**: 160 files green, 2500+ tests green, exit 1. Vitest's tail told the story:

```
Vitest caught 1 unhandled error during the test run.
Uncaught Exception: error: terminating connection due to administrator command
```

## The cause

Test teardown drops each test database `with (force)`, which terminates any backend still attached. The terminated backend's FATAL — `57P01`, `admin_shutdown` — arrives asynchronously as an `error` event on whichever pool held an idle connection to that database.

Neither pool listened: not the application's in `packages/db/src/client.ts`, not the test support's in `packages/db/test/support/database.ts`. An unlistened `error` event is an uncaught exception. In CI that is a coin-flip red on any pull request. **In production it is worse: a restarted or failed-over Postgres would take the whole API process down for a connection nothing was even using.** pg's own guidance is that a pool must always have an error listener for exactly this reason.

Both reviewers in this effort had already logged the `57P01` teardown noise as "run still green" locally — the exit code was the half nobody looked at.

## The fix

An error listener on each pool whose whole job is to exist. The pool already discards the broken client and mints a fresh one at the next checkout, and a query in flight on the killed client still gets its own rejection — so there is nothing to do, only something to not crash over.

## Proven both ways

`packages/db/test/pool-admin-shutdown.test.ts` parks an idle connection in each pool, force-drops the database out from under it on purpose, and the assertion is reaching the end of the file at all. The application pool is additionally proven still usable afterwards — the next query is an ordinary rejection, never a process-level event.

With the two listeners deleted, the file reproduces CI exactly: **2 tests passed, 2 errors, exit 1.** With them, clean.

The test support gains `forceDrop(name)` — the accident, available on purpose — so the test states its scenario in one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789362356&installation_model_id=431960&pr_number=95&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F95&signature=d42f779dadec2487df497b406e449087e4d92462342f0e4425a204b7d4eff3d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents idle PostgreSQL connection errors from becoming uncaught process-level exceptions and adds regression coverage for forced database shutdowns.
- Adds error listeners to the application and test-support pools.
- Adds a force-drop test helper and exercises both pools after administrative shutdown.
- The application-pool test does not fully release the singleton state it initializes.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking test-cleanup issue that should be corrected to release the application database singleton.

The pool listeners address the reported uncaught error path, while the only retained concern is incomplete lifecycle cleanup confined to the new regression test.

**Files Needing Attention:** packages/db/test/pool-admin-shutdown.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/client.ts | Adds the required application-pool error listener so idle-client failures no longer terminate the process. |
| packages/db/test/support/database.ts | Adds the corresponding support-pool listener and a test-only force-drop helper. |
| packages/db/test/pool-admin-shutdown.test.ts | Covers forced shutdown behavior for both pools, but leaves the application singleton initialized after the second test. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Test
  participant Pool
  participant PostgreSQL
  Test->>Pool: Run query and park idle client
  Test->>PostgreSQL: DROP DATABASE ... WITH (FORCE)
  PostgreSQL-->>Pool: Emit idle-client error (57P01)
  Pool->>Pool: Error listener handles event
  Test->>Pool: Next query
  Pool-->>Test: Ordinary query rejection
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fready-to-go-ueiinn-pool-error%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fready-to-go-ueiinn-pool-error%22.%0A%0AGreploop%20egma-ai%2Fegma%20PR%20%2395%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=egma-ai%2Fegma&pr=95&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fready-to-go-ueiinn-pool-error%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fready-to-go-ueiinn-pool-error%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fdb%2Ftest%2Fpool-admin-shutdown.test.ts%3A57%0A**Application%20singleton%20remains%20connected**%0A%0A%60database.close%28%29%60%20ends%20only%20the%20support%20pool%2C%20leaving%20the%20application%20pool%2C%20database%20URL%2C%20and%20encryption-key%20state%20initialized%20until%20Vitest%20disposes%20the%20file%20context.%20This%20makes%20the%20test%20lifecycle%20incomplete%20and%20causes%20any%20later%20test%20added%20to%20this%20file%20that%20calls%20%60connect%28%29%60%20to%20fail%20with%20%60already%20connected%20to%20Postgres%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fdb%2Ftest%2Fpool-admin-shutdown.test.ts%3A57%0A**Application%20singleton%20remains%20connected**%0A%0A%60database.close%28%29%60%20ends%20only%20the%20support%20pool%2C%20leaving%20the%20application%20pool%2C%20database%20URL%2C%20and%20encryption-key%20state%20initialized%20until%20Vitest%20disposes%20the%20file%20context.%20This%20makes%20the%20test%20lifecycle%20incomplete%20and%20causes%20any%20later%20test%20added%20to%20this%20file%20that%20calls%20%60connect%28%29%60%20to%20fail%20with%20%60already%20connected%20to%20Postgres%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Give both Postgres pools an error listen..."](https://github.com/egma-ai/egma/commit/521e878df72fb3b4a2dba227ff853e41ae603b62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53571748)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->