### PR TITLE
Prove three Archive guards, and hold the newest snapshot to what the migrations build

### DIFF
--- a/apps/api/test/agents-lifecycle.test.ts
+++ b/apps/api/test/agents-lifecycle.test.ts
@@ -353,6 +353,156 @@ describe("archiving an agent", () => {
   });
 });
 
+/**
+ * The sentence a caller reads when the thing it opened has moved since.
+ *
+ * Written out here in full rather than imported from the product, because the
+ * wording is the contract: a coding agent reads it off a terminal and a browser
+ * shows it unchanged. Sharing the product's own composer would make this file
+ * agree with whatever the product says today, which is not the same as proving
+ * it says what was promised.
+ */
+function movedOn(resource: "agent" | "connection", id: string): string {
+  return (
+    `${resource} ${id} changed after you opened it. Read it again, keep or ` +
+    `reapply your edits, and send the update with expected_revision set to ` +
+    `its new revision.`
+  );
+}
+
+/**
+ * Archive and Restore are identity writes, and they are guarded exactly as an
+ * edit is.
+ *
+ * **Every other Archive and Restore in this file sends the revision it read a
+ * line earlier**, so a handler that took `expected_revision` and dropped it
+ * would leave all of them green. What that would let through is the race the
+ * guard exists for: one tab archives an agent while another, holding a page
+ * from before a rename, restores it — and neither person is ever told that
+ * they were looking at different things.
+ *
+ * These are the twins of "refuses an edit written against a revision the agent
+ * has moved past", and they are written so Agents read the way Personas
+ * already do.
+ */
+describe("the revision an Archive or a Restore is written against", () => {
+  it("guards Archive and Restore on the same terms, for an agent", async () => {
+    api = await createApi("agents_browser_archive_stale_revision");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+    const agent = await anAgent(ada, "Front desk");
+
+    // Two tabs on the same agent. The first renames it, which moves the
+    // revision the second is still holding.
+    const renamed = await browser("PATCH", `/api/agents/${agent.id}`, ada, {
+      name: "Front desk, renamed",
+      expected_revision: agent.revision,
+    });
+    expect(renamed.status).toBe(200);
+    const current = held<AgentBody>(renamed, "agent").revision;
+
+    const stale = await browser("POST", `/api/agents/${agent.id}/archive`, ada, {
+      expected_revision: agent.revision,
+    });
+    expect(stale.status).toBe(409);
+    expect(stale.body.error).toBe("identity_conflict");
+    expect(stale.body.message).toBe(movedOn("agent", agent.id));
+
+    // Refused means nothing written: the agent is still in new work.
+    const standing = await browser("GET", `/api/agents/${agent.id}`, ada);
+    expect(held<AgentBody>(standing, "agent").archived).toBe(false);
+
+    const archived = await browser(
+      "POST",
+      `/api/agents/${agent.id}/archive`,
+      ada,
+      { expected_revision: current },
+    );
+    expect(archived.status).toBe(200);
+    const afterArchive = held<AgentBody>(archived, "agent").revision;
+
+    // The revision the Archive replaced is exactly what a page opened before it
+    // is holding, and Restore refuses it for the same reason.
+    const staleRestore = await browser(
+      "POST",
+      `/api/agents/${agent.id}/restore`,
+      ada,
+      { expected_revision: current },
+    );
+    expect(staleRestore.status).toBe(409);
+    expect(staleRestore.body.error).toBe("identity_conflict");
+    expect(staleRestore.body.message).toBe(movedOn("agent", agent.id));
+
+    const filed = await browser("GET", `/api/agents/${agent.id}`, ada);
+    expect(held<AgentBody>(filed, "agent").archived).toBe(true);
+
+    const back = await browser("POST", `/api/agents/${agent.id}/restore`, ada, {
+      expected_revision: afterArchive,
+    });
+    expect(back.status).toBe(200);
+    expect(held<AgentBody>(back, "agent").archived).toBe(false);
+  });
+
+  it("guards Archive and Restore on the same terms, for a connection", async () => {
+    api = await createApi("agents_browser_connection_stale_revision");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+    const agent = await anAgent(ada, "Front desk");
+    const wiring = await aConnection(ada, agent.id, { name: "staging" });
+    const at = `/api/agents/${agent.id}/connections/${wiring.id}`;
+
+    const renamed = await browser("PATCH", at, ada, {
+      name: "staging, renamed",
+      expected_revision: wiring.revision,
+    });
+    expect(renamed.status).toBe(200);
+    const current = held<ConnectionBody>(renamed, "connection").revision;
+
+    const stale = await browser("POST", `${at}/archive`, ada, {
+      expected_revision: wiring.revision,
+    });
+    expect(stale.status).toBe(409);
+    expect(stale.body.error).toBe("identity_conflict");
+    expect(stale.body.message).toBe(movedOn("connection", wiring.id));
+
+    // Nothing written, so the target is still reachable — which matters more
+    // here than on the agent: an Archive that landed would have settled the
+    // work going over it.
+    const standing = await browser("GET", at, ada);
+    expect(held<ConnectionBody>(standing, "connection").archived).toBe(false);
+
+    const archived = await browser("POST", `${at}/archive`, ada, {
+      expected_revision: current,
+    });
+    expect(archived.status).toBe(200);
+    const afterArchive = held<ConnectionBody>(archived, "connection").revision;
+
+    // The Restore carries the credential `retell` requires, so the revision is
+    // the only thing left that can refuse it.
+    const credential = {
+      choice: "replace",
+      credentials: { apiKey: "retell-secret-NEW1NEW2ABCD" },
+    };
+    const staleRestore = await browser("POST", `${at}/restore`, ada, {
+      expected_revision: current,
+      credential,
+    });
+    expect(staleRestore.status).toBe(409);
+    expect(staleRestore.body.error).toBe("identity_conflict");
+    expect(staleRestore.body.message).toBe(movedOn("connection", wiring.id));
+
+    const filed = await browser("GET", at, ada);
+    expect(held<ConnectionBody>(filed, "connection").archived).toBe(true);
+
+    const back = await browser("POST", `${at}/restore`, ada, {
+      expected_revision: afterArchive,
+      credential,
+    });
+    expect(back.status).toBe(200);
+    expect(held<ConnectionBody>(back, "connection").archived).toBe(false);
+  });
+});
+
 describe("a connection's stored credential", () => {
   it("never comes back, and a read says only that one is there", async () => {
     api = await createApi("agents_browser_credential_secrecy");

--- a/packages/db/test/migrations.test.ts
+++ b/packages/db/test/migrations.test.ts
@@ -173,6 +173,138 @@ describe("the newest snapshot", () => {
   });
 });
 
+/**
+ * The newest snapshot, held to the database the migrations actually build.
+ *
+ * **The two tests above cost nothing because they read files, and that is also
+ * their limit: a snapshot is generated, but a migration's SQL body is not
+ * always.** Drizzle writes the naive diff — `ADD COLUMN … NOT NULL` — which
+ * fails outright on a table that already holds rows and moves no data, so a
+ * migration that has to backfill is authored by hand: add nullable, fill every
+ * row, then `SET NOT NULL`. That is correct and it is what `0026` does.
+ *
+ * It leaves a gap nothing else covers. Drizzle never reads the `.sql` when it
+ * diffs, so an authored body and its generated snapshot can disagree and no
+ * tool notices — and the next `generate` would then plan against a schema that
+ * does not exist. The file tests cannot see it, because both files can be
+ * internally consistent while the SQL between them builds something else.
+ *
+ * Nullability is where they come apart, and it is the one thing nothing checked:
+ * the type test above compares types only, and `schema-shape.test.ts` pins
+ * nullability for exactly two columns of `simulation` as a structural claim
+ * about runs. A column left nullable by an authored body while the snapshot
+ * claims otherwise passed every test in this repository until this one.
+ *
+ * So: build from empty, ask Postgres what it ended up with, and hold every
+ * column to what the snapshot claims.
+ */
+describe("the newest snapshot, against what the migrations build", () => {
+  let database: EmptyDatabase;
+
+  beforeAll(async () => {
+    database = await createEmptyDatabase("snapshot_agreement");
+    await runMigrations(database.url);
+  });
+
+  afterAll(async () => {
+    await database.drop();
+  });
+
+  it("claims every column the migrations build, and no other", async () => {
+    const journal = JSON.parse(
+      await readFile(
+        path.join(MIGRATIONS_DIRECTORY, "meta", "_journal.json"),
+        "utf8",
+      ),
+    ) as { entries: readonly { idx: number }[] };
+    const last = journal.entries.at(-1);
+    if (last === undefined) throw new Error("the journal holds no entries");
+
+    const snapshot = JSON.parse(
+      await readFile(
+        path.join(
+          MIGRATIONS_DIRECTORY,
+          "meta",
+          `${String(last.idx).padStart(4, "0")}_snapshot.json`,
+        ),
+        "utf8",
+      ),
+    ) as {
+      readonly tables: Readonly<
+        Record<
+          string,
+          {
+            readonly name: string;
+            readonly columns: Readonly<
+              Record<string, { readonly name: string; readonly notNull: boolean }>
+            >;
+          }
+        >
+      >;
+    };
+
+    const client = new pg.Client({ connectionString: database.url });
+    await client.connect();
+    let built: Map<string, boolean>;
+    try {
+      const { rows } = await client.query<{
+        table_name: string;
+        column_name: string;
+        is_nullable: string;
+      }>(
+        `select table_name, column_name, is_nullable
+           from information_schema.columns
+          where table_schema = 'public'`,
+      );
+      built = new Map(
+        rows.map((row) => [
+          `${row.table_name}.${row.column_name}`,
+          row.is_nullable === "NO",
+        ]),
+      );
+    } finally {
+      await client.end();
+    }
+
+    const disagreements: string[] = [];
+    let compared = 0;
+
+    for (const table of Object.values(snapshot.tables)) {
+      for (const column of Object.values(table.columns)) {
+        const key = `${table.name}.${column.name}`;
+        const inDatabase = built.get(key);
+        if (inDatabase === undefined) {
+          disagreements.push(
+            `${key}: the snapshot claims it, the migrations build no such column`,
+          );
+          continue;
+        }
+        compared += 1;
+        if (inDatabase !== column.notNull) {
+          disagreements.push(
+            `${key}: the snapshot says notNull=${column.notNull}, the migrations build notNull=${inDatabase}`,
+          );
+        }
+        built.delete(key);
+      }
+    }
+
+    for (const key of built.keys()) {
+      // Drizzle's own bookkeeping is not part of the schema it describes.
+      if (key.startsWith("__drizzle")) continue;
+      disagreements.push(
+        `${key}: the migrations build it, the snapshot claims no such column`,
+      );
+    }
+
+    // Named rather than counted, for the same reason as the type test above:
+    // the fix is per column, and a count sends somebody hunting through
+    // thousands of lines of JSON to find which one.
+    expect(disagreements).toEqual([]);
+    expect(compared).toBeGreaterThan(0);
+  });
+});
+
 describe("applying migrations on boot", () => {
   let database: EmptyDatabase;
 

--- a/packages/db/test/simulation-claims.test.ts
+++ b/packages/db/test/simulation-claims.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
   addConnection,
+  archiveAgent,
   claimSimulations,
   completeSimulation,
   createAgent,
@@ -682,5 +683,199 @@ describe("a livekit connection's two credential shapes, through the claim", () =
     const reached = await resolveSimulationConnection(claim.auth, claim.id);
 
     expect(reached?.credentials).toBeNull();
+  });
+});
+
+/**
+ * What Archive does to work that is already moving.
+ *
+ * **Archiving a target is a decision about work in flight, not an edit to a
+ * list**, and the two halves of that decision are settled in different places:
+ * a queued conversation ends here, because nothing dispatched it, and a
+ * conversation somebody is already having is *asked* to stop and honors it at
+ * its next heartbeat. Egma does not reach into a call in progress, and it never
+ * writes down that a conversation ended when it has not.
+ *
+ * Nothing proved the second half. The one cancellation test built a queued
+ * simulation, so the branch that stamps a claimed or running row was never
+ * entered and no test read the run's own record back — `appendRunEvents` could
+ * have been deleted and the suite would have stayed green, leaving a run that
+ * was canceled underneath a follower with no event to say so.
+ *
+ * The claim, the start and the heartbeat here are the product's own, taken
+ * through the same door the simulator uses, because a second way of claiming a
+ * row would prove something no simulator does.
+ */
+describe("archiving a target out from under work", () => {
+  /**
+   * A second way into the agent everything else here runs over, so archiving
+   * it settles this test's work and no other test's.
+   */
+  async function aSpareConnection(name: string): Promise<string> {
+    const added = await addConnection(actingAsAcme(), acmeSeed.agentId, {
+      name,
+      type: "retell",
+      modality: "chat",
+      config: { retellAgentId: `agent_${name}` },
+      credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    });
+    return added?.id ?? "";
+  }
+
+  /** An agent of its own, wired once — the thing an agent Archive cascades from. */
+  async function anAgentToArchive(
+    name: string,
+  ): Promise<{ agentId: string; connectionId: string }> {
+    const created = await createAgent(actingAsAcme(), {
+      name,
+      connection: {
+        type: "retell",
+        modality: "chat",
+        config: { retellAgentId: `agent_${name}` },
+        credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+      },
+    });
+    return { agentId: created.id, connectionId: created.connection?.id ?? "" };
+  }
+
+  /**
+   * A conversation nobody has stopped: still held by its simulator, cancel
+   * asked for, nothing about it ended, and the record saying so.
+   *
+   * Both live states are checked through this, because the promise is one
+   * promise — whatever a claimed conversation gets, a running one gets.
+   */
+  async function expectAskedToStop(
+    runId: string,
+    simulationId: string,
+    claimant: string,
+    status: "claimed" | "running",
+  ): Promise<void> {
+    const held = await getSimulation(actingAsAcme(), simulationId);
+    expect(held?.status).toBe(status);
+    expect(held?.cancelRequestedAt).toBeInstanceOf(Date);
+    // Not ended, and not judged: the conversation is still somebody's, and
+    // what it produced before it stops stays on the record.
+    expect(held?.endedAt).toBeNull();
+
+    // Where the ask is actually delivered. A stamp no heartbeat reports is a
+    // cancel nobody carries out.
+    expect(
+      await recordSimulationHeartbeat({ simulationId, claimant }),
+    ).toEqual({ cancelRequested: true });
+
+    const feed = await listRunEvents(actingAsAcme(), runId, { after: 0 });
+    expect(feed?.events.at(-1)?.kind).toBe("run");
+    expect(feed?.events.at(-1)?.status).toBe("canceled");
+
+    // And nothing says the conversation itself is over, because it is not.
+    expect(
+      feed?.events
+        .filter((event) => event.simulationId === simulationId)
+        .map((event) => event.status),
+    ).not.toContain("canceled");
+  }
+
+  /**
+   * A queued conversation, settled. This is the shape both Archives have to
+   * produce: archiving the agent above a connection may not leave the work
+   * under it in a state archiving the connection itself would never leave it.
+   */
+  async function expectSettled(
+    runId: string,
+    simulationId: string,
+  ): Promise<void> {
+    const settled = await getSimulation(actingAsAcme(), simulationId);
+    expect(settled?.status).toBe("canceled");
+    expect(settled?.cancelRequestedAt).toBeInstanceOf(Date);
+    expect(settled?.endedAt).toBeInstanceOf(Date);
+
+    const header = await getRun(actingAsAcme(), runId);
+    expect(header?.status).toBe("canceled");
+    expect(header?.canceledCount).toBe(1);
+    expect(header?.finishedAt).toBeInstanceOf(Date);
+
+    const feed = await listRunEvents(actingAsAcme(), runId, { after: 0 });
+    expect(
+      feed?.events.map((event) => [event.kind, event.simulationId, event.status]),
+    ).toEqual([
+      ["simulation", simulationId, "canceled"],
+      ["run", null, "canceled"],
+    ]);
+    expect(feed?.done).toBe(true);
+  }
+
+  it("asks a claimed conversation to stop, and says so on the run's record", async () => {
+    const connectionId = await aSpareConnection("claimed-work");
+    const { runId, simulationId } = await oneQueuedSimulation(actingAsAcme(), {
+      ...acmeSeed,
+      connectionId,
+    });
+    const claim = await claimOne(simulationId, "simulator-blue-1");
+
+    const archived = await archiveConnection(
+      actingAsAcme(),
+      acmeSeed.agentId,
+      connectionId,
+    );
+    expect(archived?.canceledRuns).toEqual([runId]);
+
+    await expectAskedToStop(runId, simulationId, claim.claimedBy, "claimed");
+  });
+
+  it("asks a running conversation to stop on the same terms", async () => {
+    const connectionId = await aSpareConnection("running-work");
+    const { runId, simulationId } = await oneQueuedSimulation(actingAsAcme(), {
+      ...acmeSeed,
+      connectionId,
+    });
+    const claim = await claimOne(simulationId, "simulator-green-2");
+    await startSimulation(claim.auth, claim.id, claim.claimedBy);
+
+    const archived = await archiveConnection(
+      actingAsAcme(),
+      acmeSeed.agentId,
+      connectionId,
+    );
+    expect(archived?.canceledRuns).toEqual([runId]);
+
+    await expectAskedToStop(runId, simulationId, claim.claimedBy, "running");
+  });
+
+  it("ends the queued conversation where the connection is archived", async () => {
+    const connectionId = await aSpareConnection("queued-work");
+    const { runId, simulationId } = await oneQueuedSimulation(actingAsAcme(), {
+      ...acmeSeed,
+      connectionId,
+    });
+
+    const archived = await archiveConnection(
+      actingAsAcme(),
+      acmeSeed.agentId,
+      connectionId,
+    );
+    expect(archived?.canceledRuns).toEqual([runId]);
+
+    await expectSettled(runId, simulationId);
+  });
+
+  it("ends it exactly the same way when the agent above it is archived", async () => {
+    const { agentId, connectionId } = await anAgentToArchive("cascading-desk");
+    const { runId, simulationId } = await oneQueuedSimulation(actingAsAcme(), {
+      ...acmeSeed,
+      agentId,
+      connectionId,
+    });
+
+    // The Archive names the agent, and nobody names the connection — the
+    // cascade has to find the work under it. Without that, a queued
+    // conversation would sit in the claim queue for a target no simulator can
+    // resolve a credential for, and would land as a failure the agent never
+    // caused.
+    const archived = await archiveAgent(actingAsAcme(), agentId);
+    expect(archived?.connections).toEqual([connectionId]);
+    expect(archived?.canceledRuns).toEqual([runId]);
+
+    await expectSettled(runId, simulationId);
   });
 });


### PR DESCRIPTION
Tests only. No product code changed. Base is the effort's integration branch, not `main`.

## Why

Closing out wave 1 raised two separate holes, both of the same kind: behaviour that is really there, and nothing that would notice if it stopped being there.

## Three Archive guards ticket 03 shipped but never tested

A pass over ticket 03's acceptance criteria found three behaviours the code implements and no test proves. Each was written, then **verified by breaking the product code it targets and confirming the test fails on the assertion it exists for**. All three guards hold — nothing turned out to be a defect.

**`expected_revision` on Archive and Restore.** The edit path was proven end to end, but every existing Archive and Restore test sent the *current* revision, so a handler that threw the field away would have left the suite green. Two tabs, a rename that moves the revision, then a stale Archive and a stale Restore — for the agent and for the connection.

Dropping `writtenAgainst(...)` from `archiveAgent`/`archiveConnection` → `expected 200 to be 409`. Same from the restore pair → the same at the stale-Restore assertion. Changing the wording in `identityConflict` → the sentence diff, because the sentence is written out here rather than imported.

**Connection Archive against work already claimed or running.** The one cancellation test built a *queued* simulation only, so the branch stamping `cancel_requested_at` on claimed or running work was never entered and nothing read the run events back — `appendRunEvents` could have been deleted with the suite staying green.

Disabling that branch → `expected null to be an instance of Date`. Disabling the `appendRunEvents` call → `expected 'running' to be 'canceled'` and three more, so all four new tests hold it down.

**Agent Archive's cascade.** No test archived an *agent* with work queued under one of its connections. Queued work is now asserted through one shared `expectSettled`, used by both the direct connection Archive and the agent Archive, so "settled exactly as archiving the connection settles it" is literally the same assertion.

Passing `[]` instead of the archived children → `expected [] to deeply equal [ 'run_01M022…' ]`, and **only** the agent test failed. The three connection tests stayed green, which is the isolation you want.

One thing worth knowing: `restoreConnection` checks the shape's credential rule *before* the revision, so a stale Restore bringing no credential answers `credential_required` (422), not `identity_conflict`. The connection test therefore sends a valid replacement credential on the refused call — without it the test would have proved the credential rule and nothing about the revision.

## The newest snapshot, against what the migrations build

Ticket 05 hit the limit of "always let drizzle generate the migration". Its renumbered `0026` has to move data, and drizzle's body was the naive diff — `ADD COLUMN … NOT NULL` against tables that already hold rows, and no data move at all. So the snapshot and journal entry stay machine-made, which is what drizzle diffs against and what drifts silently when hand-written, and the SQL body is authored.

Drizzle never reads the `.sql` when it diffs, so that split is safe in itself. What it was not is *checked*: an authored body and its generated snapshot can disagree with nothing to notice, and the next `generate` would then plan against a schema that does not exist.

Nullability is where the two come apart, and it was the one property nothing held. `migrations.test.ts` compared column *types* only; `schema-shape.test.ts` pins nullability for exactly two columns of `simulation`, as a structural claim about runs. A column left nullable by an authored body while the snapshot claimed otherwise passed every test in this repository.

The new test builds a database from empty, asks Postgres what it ended up with, and holds every column to the snapshot's claim. Dropping `NOT NULL` from `agent.name` in the newest migration fails it with one named disagreement and leaves **every other test in the file green** — which is both the proof it works and the measure of what was missing.

It runs against ticket 05's authored `0026` and agrees: 319 columns, none missing, none extra, no nullability disagreement.

## Verification

`packages/db/test` + `apps/api/test/agents-lifecycle.test.ts` + `apps/api/test/agents.test.ts` → 50 files, 1049 tests. The three touched files together → 114 tests. `pnpm lint` and `pnpm typecheck` clean.

6 new Archive tests, 1 new migration test, 345 + 130 added lines, tests only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789368599&installation_model_id=431960&pr_number=99&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F99&signature=c387aefd3ce07db0d1367b88817059f91082ac098a67b69133d0b65bf2e54a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds regression coverage without changing product code.
- Verifies optimistic revision guards for agent and connection Archive/Restore operations.
- Covers cancellation behavior for queued, claimed, and running simulations, including agent-archive cascading.
- Compares the newest Drizzle snapshot’s columns and nullability against a database built from all migrations.

<h3>Confidence Score: 5/5</h3>

The tests-only PR appears safe to merge, with no actionable defects identified.

The added tests align with the established migration, archive-scoping, and deterministic run-event contracts, and no changed path introduces a blocking or non-blocking failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/test/agents-lifecycle.test.ts | Adds end-to-end stale-revision coverage for agent and connection Archive/Restore operations, including conflict responses and unchanged state. |
| packages/db/test/migrations.test.ts | Adds a migrated-database comparison that detects missing, extra, or nullability-divergent public columns relative to the newest snapshot. |
| packages/db/test/simulation-claims.test.ts | Adds isolated coverage for queued settlement, in-flight cancellation requests, run events, and agent archive cascading. |

<sub>Reviews (1): Last reviewed commit: ["Hold the newest snapshot to the database..."](https://github.com/egma-ai/egma/commit/3d676587dc5be37de67138515add67a91258d18b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53581295)</sub>

<!-- /greptile_comment -->