### PR TITLE
Deploy from what the cloud repository published, not from the box

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -128,17 +128,25 @@ jobs:
         # this deployment can make.
         run: |
           set -euo pipefail
-          # The steps run from a script on the box rather than from a document
-          # built here. It keeps this file free of a shell script nested inside
-          # JSON nested inside YAML — three levels of quoting, and every one of
-          # them a way to ship a deployment that fails on a stray character.
-          # It also means the same steps can be run by hand, on the box, when
-          # something has gone wrong and nobody wants to drive it through CI.
+          # The steps run from a script rather than from a document built here.
+          # It keeps this file free of a shell script nested inside JSON nested
+          # inside YAML — three levels of quoting, and every one of them a way
+          # to ship a deployment that fails on a stray character. It also means
+          # the same steps can be run by hand, on the box, when something has
+          # gone wrong and nobody wants to drive it through CI.
+          #
+          # The script is synced from object storage first, never resident: the
+          # box authors nothing and keeps nothing worth keeping. Whatever the
+          # deployment's own repository published last is what runs — so a
+          # config change is a merge there, not an edit anywhere else. The
+          # bucket is derived from the registry's account the same way the
+          # registry itself is derived, so no extra variable exists to set.
+          ACCOUNT="${REGISTRY%%.*}"
           command_id=$(aws ssm send-command \
             --instance-ids "$INSTANCE" \
             --document-name AWS-RunShellScript \
             --comment "deploy $GITHUB_SHA" \
-            --parameters commands="/opt/egma/deploy.sh $GITHUB_SHA" \
+            --parameters commands="aws s3 sync s3://egma-deploy-${ACCOUNT}/deployment /opt/egma/deployment --delete && bash /opt/egma/deployment/deploy.sh $GITHUB_SHA" \
             --query Command.CommandId --output text)
           echo "SSM command: $command_id"
           aws ssm wait command-executed \


### PR DESCRIPTION
One step changes in `deploy-platform.yml`: before running the deploy script, the box syncs `/opt/egma/deployment` fresh from object storage — published there by the private cloud repository on every merge — instead of trusting whatever the machine holds.

## Why

Production broke this morning in a way no test could catch: the box ran deployment files written by hand on the machine. A rename that landed in this repository on 14 August (`EGMA_SIMULATOR_*` → `EGMA_PERSONA_*`) passed every test here, and the box kept answering the old names until the next deploy took the persona's settings down silently.

The fix is structural: the box authors nothing. What runs is always what a repository holds — this one for the compose files and images, the private cloud repository for the overlay and settings. That side also runs a nightly check that goes red the day the two repositories disagree about which settings exist, so the next rename fails a check instead of production.

## The change stays generic

The bucket name is derived from the registry's account exactly the way the registry itself already is, so nothing hosted-egma-specific enters this file and no new repository variable exists to set. A self-hoster pointing this workflow at their own account gets their own bucket.

One file, +14/−7.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BR47cXBaM7NkbTp764ecLX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789368670&installation_model_id=431960&pr_number=100&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F100&signature=a6baa57b3826f48b016b57a094351d7f3881bd45a3ba60f54132d30ad13afa4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes deployment execution so the target instance first mirrors the account-specific deployment package from object storage and then runs the synchronized script, rather than executing a script already resident on the machine.
- Derives the deployment bucket suffix from the configured ECR account.
- Synchronizes `/opt/egma/deployment` with deletion of stale local files.
- Runs the synchronized `deploy.sh` only after a successful sync.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge based on the reviewed workflow change and available repository contracts.

The command preserves the deployment SHA argument, gates script execution on a successful synchronization, and reports the resulting SSM command status; no concrete reachable failure caused by the change remains established.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-platform.yml | Replaces execution of a machine-resident deployment script with an S3 synchronization followed by execution of the synchronized script; no actionable defect is established by the available repository context. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant SSM as AWS Systems Manager
    participant EC2 as Deployment instance
    participant S3 as Deployment bucket
    GH->>SSM: Send AWS-RunShellScript command
    SSM->>EC2: Execute deployment command
    EC2->>S3: Sync deployment directory (--delete)
    S3-->>EC2: Published deployment files
    EC2->>EC2: Run deployment/deploy.sh with GITHUB_SHA
    EC2-->>SSM: Command status
    SSM-->>GH: Deployment result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Deploy from what the cloud repository pu..."](https://github.com/egma-ai/egma/commit/d93fa571cab6cbc141daaede692f5861073acebc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53581413)</sub>

<!-- /greptile_comment -->