### PR TITLE
Put the grader pages on the shared controls, and prove a threshold may narrow

### DIFF
--- a/apps/web/app/projects/[projectId]/graders/editor.tsx
+++ b/apps/web/app/projects/[projectId]/graders/editor.tsx
@@ -15,7 +15,7 @@ import {
   type Priority,
   type Scope,
 } from "../../../../lib/graders.ts";
-import { Field, TextInput } from "../../../../ui/controls.tsx";
+import { Field, Select, TextArea, TextInput } from "../../../../ui/controls.tsx";
 
 /**
  * The fields a grader is written through, and the one rule they all obey: **a
@@ -132,67 +132,35 @@ export function phrasesFromLines(
     .map((text) => ({ text }));
 }
 
-function TextArea({
-  id,
-  label,
-  value,
-  hint,
-  disabled,
-  onChange,
-}: {
-  readonly id: string;
-  readonly label: string;
-  readonly value: string;
-  readonly hint?: string;
-  readonly disabled: boolean;
-  readonly onChange: (value: string) => void;
-}) {
-  return (
-    <Field label={label} htmlFor={id}>
-      <textarea
-        id={id}
-        rows={4}
-        value={value}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value)}
-      />
-      {hint === undefined ? null : <small>{hint}</small>}
-    </Field>
-  );
+/**
+ * A closed list whose entries say themselves — an aggregation, a comparator, a
+ * priority. The shared `Select` asks for a label beside every value because
+ * most lists it draws name something the server owns; these name themselves,
+ * and writing each one out twice would only invite the two to drift.
+ */
+function asOptions<Value extends string>(
+  values: readonly Value[],
+): readonly { readonly value: Value; readonly label: string }[] {
+  return values.map((value) => ({ value, label: value }));
 }
 
-function Choice<Value extends string>({
-  id,
-  label,
-  value,
-  options,
-  disabled,
-  onChange,
-}: {
-  readonly id: string;
-  readonly label: string;
-  readonly value: Value;
-  readonly options: readonly Value[];
-  readonly disabled: boolean;
-  readonly onChange: (value: Value) => void;
-}) {
-  return (
-    <Field label={label} htmlFor={id}>
-      <select
-        id={id}
-        value={value}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value as Value)}
-      >
-        {options.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
-    </Field>
-  );
-}
+const AGGREGATIONS = [
+  "mean",
+  "median",
+  "p90",
+  "p95",
+  "max",
+  "min",
+  "sum",
+  "count",
+] as const;
+const COMPARATORS = ["below", "at_most", "above", "at_least"] as const;
+const SPEAKERS = ["agent", "persona", "either"] as const;
+const PRIORITIES: readonly Priority[] = ["P0", "P1", "P2"];
+const SCOPES: readonly Scope[] = ["simulations", "production", "both"];
+
+/** How tall a grader's written content sits, wherever one is typed. */
+const CONTENT_ROWS = 4;
 
 /**
  * A set of checkboxes over a settled list, which **refuses to become empty**.
@@ -280,48 +248,61 @@ export function ConfigFields({
 
   if (type === "llm_rubric") {
     return (
-      <TextArea
-        id="grader-rubric"
+      <Field
         label="Rubric"
+        htmlFor="grader-rubric"
         hint="The criteria a judge model reads, in your own words."
-        value={String(config.rubric ?? "")}
-        disabled={disabled}
-        onChange={(rubric) => set({ rubric })}
-      />
+      >
+        <TextArea
+          id="grader-rubric"
+          rows={CONTENT_ROWS}
+          value={String(config.rubric ?? "")}
+          disabled={disabled}
+          onChange={(rubric) => set({ rubric })}
+        />
+      </Field>
     );
   }
 
   if (type === "metric_threshold") {
     return (
       <>
-        <Field label="Measure" htmlFor="grader-measure">
+        <Field
+          label="Measure"
+          htmlFor="grader-measure"
+          hint="The name of what egma measured. A name nothing emits is refused when you save, because a grader reading it could never fire."
+        >
           <TextInput
             id="grader-measure"
             value={String(config.measure ?? "")}
             onChange={(measure) => set({ measure })}
           />
-          <small>
-            The name of what egma measured. A name nothing emits is refused when
-            you save, because a grader reading it could never fire.
-          </small>
         </Field>
-        <Choice
-          id="grader-aggregation"
-          label="Reduced by"
-          value={String(config.aggregation ?? "p90")}
-          options={["mean", "median", "p90", "p95", "max", "min", "sum", "count"]}
-          disabled={disabled}
-          onChange={(aggregation) => set({ aggregation })}
-        />
-        <Choice
-          id="grader-comparator"
-          label="Passes when it is"
-          value={String(config.comparator ?? "below")}
-          options={["below", "at_most", "above", "at_least"]}
-          disabled={disabled}
-          onChange={(comparator) => set({ comparator })}
-        />
+        <Field label="Reduced by" htmlFor="grader-aggregation">
+          <Select
+            id="grader-aggregation"
+            value={String(config.aggregation ?? "p90")}
+            options={asOptions(AGGREGATIONS)}
+            disabled={disabled}
+            onChange={(aggregation) => set({ aggregation })}
+          />
+        </Field>
+        <Field label="Passes when it is" htmlFor="grader-comparator">
+          <Select
+            id="grader-comparator"
+            value={String(config.comparator ?? "below")}
+            options={asOptions(COMPARATORS)}
+            disabled={disabled}
+            onChange={(comparator) => set({ comparator })}
+          />
+        </Field>
         <Field label="Threshold" htmlFor="grader-threshold">
+          {/*
+           * A number, and one of only two in the product. The shared library
+           * has no numeric control: a text one would take the spinner and the
+           * browser's own range check away, so this stays a bare input until a
+           * shared one exists rather than becoming a worse control today.
+           */}
           <input
             id="grader-threshold"
             type="number"
@@ -337,52 +318,73 @@ export function ConfigFields({
   if (type === "tool_calls") {
     return (
       <>
-        <TextArea
-          id="grader-required-tools"
+        <Field
           label="Tools that must have fired"
+          htmlFor="grader-required-tools"
           hint="One tool name per line."
-          value={linesOf(toolNames(config.required))}
-          disabled={disabled}
-          onChange={(lines) => set({ required: toolsFromLines(lines) })}
-        />
-        <TextArea
-          id="grader-forbidden-tools"
+        >
+          <TextArea
+            id="grader-required-tools"
+            rows={CONTENT_ROWS}
+            value={linesOf(toolNames(config.required))}
+            disabled={disabled}
+            onChange={(lines) => set({ required: toolsFromLines(lines) })}
+          />
+        </Field>
+        <Field
           label="Tools that must never fire"
+          htmlFor="grader-forbidden-tools"
           hint="One tool name per line."
-          value={linesOf(toolNames(config.forbidden))}
-          disabled={disabled}
-          onChange={(lines) => set({ forbidden: toolsFromLines(lines) })}
-        />
+        >
+          <TextArea
+            id="grader-forbidden-tools"
+            rows={CONTENT_ROWS}
+            value={linesOf(toolNames(config.forbidden))}
+            disabled={disabled}
+            onChange={(lines) => set({ forbidden: toolsFromLines(lines) })}
+          />
+        </Field>
       </>
     );
   }
 
   return (
     <>
-      <TextArea
-        id="grader-required-phrases"
+      <Field
         label="Words that must be said"
+        htmlFor="grader-required-phrases"
         hint="One phrase per line."
-        value={linesOf(phraseTexts(config.required))}
-        disabled={disabled}
-        onChange={(lines) => set({ required: phrasesFromLines(lines) })}
-      />
-      <TextArea
-        id="grader-banned-phrases"
+      >
+        <TextArea
+          id="grader-required-phrases"
+          rows={CONTENT_ROWS}
+          value={linesOf(phraseTexts(config.required))}
+          disabled={disabled}
+          onChange={(lines) => set({ required: phrasesFromLines(lines) })}
+        />
+      </Field>
+      <Field
         label="Words that must never be said"
+        htmlFor="grader-banned-phrases"
         hint="One phrase per line."
-        value={linesOf(phraseTexts(config.banned))}
-        disabled={disabled}
-        onChange={(lines) => set({ banned: phrasesFromLines(lines) })}
-      />
-      <Choice
-        id="grader-speaker"
-        label="Whose turns are searched"
-        value={String(config.speaker ?? "agent")}
-        options={["agent", "persona", "either"]}
-        disabled={disabled}
-        onChange={(speaker) => set({ speaker })}
-      />
+      >
+        <TextArea
+          id="grader-banned-phrases"
+          rows={CONTENT_ROWS}
+          value={linesOf(phraseTexts(config.banned))}
+          disabled={disabled}
+          onChange={(lines) => set({ banned: phrasesFromLines(lines) })}
+        />
+      </Field>
+      <Field label="Whose turns are searched" htmlFor="grader-speaker">
+        <Select
+          id="grader-speaker"
+          value={String(config.speaker ?? "agent")}
+          options={asOptions(SPEAKERS)}
+          disabled={disabled}
+          onChange={(speaker) => set({ speaker })}
+        />
+      </Field>
     </>
   );
 }
@@ -494,31 +496,40 @@ export function LiveFields({
           onChange={(next) => onChange({ name: next })}
         />
       </Field>
-      <TextArea
-        id="grader-description"
-        label="Description"
-        value={description}
-        disabled={disabled}
-        onChange={(next) => onChange({ description: next })}
-      />
-      <Choice
-        id="grader-priority"
-        label="Priority"
-        value={priority}
-        options={["P0", "P1", "P2"] as const}
-        disabled={disabled}
-        onChange={(next) => onChange({ priority: next })}
-      />
-      <Choice
-        id="grader-scope"
-        label="Applies to"
-        value={scope}
-        options={["simulations", "production", "both"] as const}
-        disabled={disabled}
-        onChange={(next) => onChange({ scope: next })}
-      />
+      <Field label="Description" htmlFor="grader-description">
+        <TextArea
+          id="grader-description"
+          rows={CONTENT_ROWS}
+          value={description}
+          disabled={disabled}
+          onChange={(next) => onChange({ description: next })}
+        />
+      </Field>
+      <Field label="Priority" htmlFor="grader-priority">
+        <Select
+          id="grader-priority"
+          value={priority}
+          options={asOptions(PRIORITIES)}
+          disabled={disabled}
+          onChange={(next) => onChange({ priority: next })}
+        />
+      </Field>
+      <Field label="Applies to" htmlFor="grader-scope">
+        <Select
+          id="grader-scope"
+          value={scope}
+          options={asOptions(SCOPES)}
+          disabled={disabled}
+          onChange={(next) => onChange({ scope: next })}
+        />
+      </Field>
       {samplingApplies(scope) ? (
-        <Field label="Production sampling (%)" htmlFor="grader-sample-rate">
+        <Field
+          label="Production sampling (%)"
+          htmlFor="grader-sample-rate"
+          hint="How much of the traffic egma did not cause gets judged. Simulations are always all judged."
+        >
+          {/* A number, for the reason written beside the threshold above. */}
           <input
             id="grader-sample-rate"
             type="number"
@@ -530,10 +541,6 @@ export function LiveFields({
               onChange({ sampleRate: Number(event.target.value) })
             }
           />
-          <small>
-            How much of the traffic egma did not cause gets judged. Simulations
-            are always all judged.
-          </small>
         </Field>
       ) : null}
     </>

--- a/apps/web/app/projects/[projectId]/graders/judge/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/judge/page.tsx
@@ -21,7 +21,15 @@ import {
 } from "../../../../../lib/judge.ts";
 import { roleOf } from "../../../../../lib/me.ts";
 import { projectPath } from "../../../../../lib/project-context.ts";
-import { Badge, Button, ButtonLink, Field, TextInput } from "../../../../../ui/controls.tsx";
+import {
+  Badge,
+  Button,
+  ButtonLink,
+  Field,
+  Select,
+  TextInput,
+} from "../../../../../ui/controls.tsx";
+import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
 import { Failure, Loading } from "../../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
 import {
@@ -252,63 +260,66 @@ function JudgeSettings({ projectId }: { readonly projectId: string }) {
             />
           ) : (
             <>
-          <Field label="Provider" htmlFor="judge-provider">
-            <select
-              id="judge-provider"
-              value={provider}
-              disabled={!mayAdminister}
-              onChange={(event) => {
-                setProvider(event.target.value);
-                // A credential of the old provider cannot answer for the new
-                // one, so the choice is cleared rather than left pointing at
-                // something the server would refuse.
-                setSource("");
-              }}
-            >
-              {(registry?.status === "ready" ? registry.value.providers : []).map(
-                (one) => (
-                  <option key={one.provider} value={one.provider}>
-                    {one.provider}
-                  </option>
-                ),
-              )}
-            </select>
-          </Field>
+              <Field label="Provider" htmlFor="judge-provider">
+                <Select
+                  id="judge-provider"
+                  value={provider}
+                  options={(registry?.status === "ready"
+                    ? registry.value.providers
+                    : []
+                  ).map((one) => ({ value: one.provider, label: one.provider }))}
+                  disabled={!mayAdminister}
+                  onChange={(chosen) => {
+                    setProvider(chosen);
+                    // A credential of the old provider cannot answer for the
+                    // new one, so the choice is cleared rather than left
+                    // pointing at something the server would refuse.
+                    setSource("");
+                  }}
+                />
+              </Field>
 
-          <Field label="Key" htmlFor="judge-source">
-            <select
-              id="judge-source"
-              value={source}
-              disabled={!mayAdminister}
-              onChange={(event) => setSource(event.target.value)}
-            >
-              <option value="">Choose a key</option>
-              {choosable.map((credential) => (
-                <option key={credential.id} value={credential.id}>
-                  {credentialLabel(credential)}
-                </option>
-              ))}
-              {/*
-                * Offered when **the deployment has a judge**, and never when
-                * the project happens to be using one. Reading it off the
-                * project's current choice would make moving to a key of your
-                * own a one-way door — the option would vanish the moment you
-                * stopped using it, and the way back would be unreachable from
-                * the one page that exists to take it. The registry answers
-                * this because it is the deployment's fact to state.
-                */}
-              {platformJudge ? (
-                <option value={PLATFORM_SOURCE}>
-                  This deployment&apos;s own judge
-                </option>
-              ) : null}
-            </select>
-            {choosable.length === 0 ? (
-              <small>
-                This organization holds no {provider} key yet. Add one below.
-              </small>
-            ) : null}
-          </Field>
+              <Field
+                label="Key"
+                htmlFor="judge-source"
+                {...(choosable.length === 0
+                  ? {
+                      hint: `This organization holds no ${provider} key yet. Add one below.`,
+                    }
+                  : {})}
+              >
+                <Select
+                  id="judge-source"
+                  value={source}
+                  /*
+                   * The deployment's own judge is offered when **the deployment
+                   * has one**, and never when the project happens to be using
+                   * it. Reading it off the project's current choice would make
+                   * moving to a key of your own a one-way door — the option
+                   * would vanish the moment you stopped using it, and the way
+                   * back would be unreachable from the one page that exists to
+                   * take it. The registry answers this because it is the
+                   * deployment's fact to state.
+                   */
+                  options={[
+                    { value: "", label: "Choose a key" },
+                    ...choosable.map((credential) => ({
+                      value: credential.id,
+                      label: credentialLabel(credential),
+                    })),
+                    ...(platformJudge
+                      ? [
+                          {
+                            value: PLATFORM_SOURCE,
+                            label: "This deployment's own judge",
+                          },
+                        ]
+                      : []),
+                  ]}
+                  disabled={!mayAdminister}
+                  onChange={setSource}
+                />
+              </Field>
             </>
           )}
 
@@ -448,6 +459,48 @@ function Credentials({
     onChanged();
   }
 
+  /** The row whose replacement form is open, if the row is still on the list. */
+  const rotatingCredential = credentials.find(
+    (credential) => credential.id === rotating,
+  );
+
+  const columns: readonly Column<JudgeCredential>[] = [
+    {
+      key: "label",
+      header: "Key",
+      primary: true,
+      cell: (credential) => credential.label,
+    },
+    {
+      key: "provider",
+      header: "Provider",
+      width: "120px",
+      cell: (credential) => credential.provider,
+    },
+    {
+      key: "hint",
+      header: "Ends",
+      mono: true,
+      width: "90px",
+      cell: (credential) => `…${credential.hint}`,
+    },
+    {
+      key: "rotate",
+      header: "",
+      width: "150px",
+      cell: (credential) => (
+        <Button
+          disabled={!mayAdminister || busy}
+          onClick={() =>
+            setRotating(rotating === credential.id ? null : credential.id)
+          }
+        >
+          Replace key
+        </Button>
+      ),
+    },
+  ];
+
   return (
     <section aria-label="Judge credentials">
       <h2>Organization keys</h2>
@@ -468,46 +521,47 @@ function Credentials({
       {credentials.length === 0 ? (
         <p>No judge credentials yet.</p>
       ) : (
-        <ul>
-          {credentials.map((credential) => (
-            <li key={credential.id}>
-              {credential.label} · {credential.provider} · ends …{credential.hint}{" "}
-              <Button
-                disabled={!mayAdminister || busy}
-                onClick={() =>
-                  setRotating(rotating === credential.id ? null : credential.id)
-                }
+        <>
+          <DataTable
+            label="Organization keys"
+            columns={columns}
+            rows={credentials}
+            keyOf={(credential) => credential.id}
+          />
+
+          {/*
+           * The replacement form is drawn once, under the table, for whichever
+           * row asked for it — never inside a cell. A table draws every row
+           * twice, once wide and once narrow, so a form living in a cell would
+           * be two forms over one piece of state: two fields carrying one
+           * value, and whichever the browser focused would be the one somebody
+           * could not see.
+           */}
+          {rotatingCredential === undefined ? null : (
+            <>
+              <Field
+                label="New key"
+                htmlFor={`rotate-${rotatingCredential.id}`}
+                hint="Replaces the stored key whole. You do not need the old one, and egma will not show it to you."
               >
-                Replace key
+                <TextInput
+                  id={`rotate-${rotatingCredential.id}`}
+                  value={replacement}
+                  secret
+                  disabled={!mayAdminister || busy}
+                  onChange={setReplacement}
+                />
+              </Field>
+              <Button
+                weight="strong"
+                disabled={!mayAdminister || busy || replacement.trim() === ""}
+                onClick={() => void rotate(rotatingCredential)}
+              >
+                Save new key
               </Button>
-              {rotating === credential.id ? (
-                <>
-                  <Field label="New key" htmlFor={`rotate-${credential.id}`}>
-                    <input
-                      id={`rotate-${credential.id}`}
-                      type="password"
-                      value={replacement}
-                      autoComplete="off"
-                      disabled={!mayAdminister || busy}
-                      onChange={(event) => setReplacement(event.target.value)}
-                    />
-                    <small>
-                      Replaces the stored key whole. You do not need the old one,
-                      and egma will not show it to you.
-                    </small>
-                  </Field>
-                  <Button
-                    weight="strong"
-                    disabled={!mayAdminister || busy || replacement.trim() === ""}
-                    onClick={() => void rotate(credential)}
-                  >
-                    Save new key
-                  </Button>
-                </>
-              ) : null}
-            </li>
-          ))}
-        </ul>
+            </>
+          )}
+        </>
       )}
 
       <h3>Add a key</h3>
@@ -515,13 +569,12 @@ function Credentials({
         <TextInput id="credential-label" value={label} onChange={setLabel} />
       </Field>
       <Field label="OpenAI key" htmlFor="credential-key">
-        <input
+        <TextInput
           id="credential-key"
-          type="password"
           value={key}
-          autoComplete="off"
+          secret
           disabled={!mayAdminister || busy}
-          onChange={(event) => setKey(event.target.value)}
+          onChange={setKey}
         />
       </Field>
       <Button

--- a/apps/web/app/projects/[projectId]/graders/judge/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/judge/page.tsx
@@ -492,13 +492,24 @@ function Credentials({
         <Button
           disabled={!mayAdminister || busy}
           onClick={() => {
-            // Cleared whenever the open row changes, because one form under the
-            // table means one `replacement` for every row. Without this, a key
-            // typed for this credential stays in the field when somebody opens
-            // another, and Save sends it to whichever credential is open now —
-            // rotating the wrong one, to a key its owner never chose for it.
-            // Retyping is the small cost; the alternative is a silent mix-up.
+            // One form under the table means one `replacement` and one `failed`
+            // for every row, so opening a different row has to empty both.
+            //
+            // `replacement`: a key typed for one credential would stay in the
+            // field, and Save would send it to whichever credential is open
+            // now — rotating the wrong one to a key its owner never chose.
+            //
+            // `failed`: worse, because it survives a closed form. Its `again`
+            // is bound to the credential that failed, but `rotate` reads the
+            // field as it stands when the button is pressed. So a failure on
+            // one credential, then opening another and typing its key, leaves
+            // a Try again that writes this row's key to the other row — and
+            // reports success for a credential nobody was looking at.
+            //
+            // Both are the same mistake: state that means "for the open row",
+            // with nothing making it true. Retyping is the price.
             setReplacement("");
+            setFailed(null);
             setRotating(rotating === credential.id ? null : credential.id);
           }}
         >

--- a/apps/web/app/projects/[projectId]/graders/judge/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/judge/page.tsx
@@ -491,9 +491,16 @@ function Credentials({
       cell: (credential) => (
         <Button
           disabled={!mayAdminister || busy}
-          onClick={() =>
-            setRotating(rotating === credential.id ? null : credential.id)
-          }
+          onClick={() => {
+            // Cleared whenever the open row changes, because one form under the
+            // table means one `replacement` for every row. Without this, a key
+            // typed for this credential stays in the field when somebody opens
+            // another, and Save sends it to whichever credential is open now —
+            // rotating the wrong one, to a key its owner never chose for it.
+            // Retyping is the small cost; the alternative is a silent mix-up.
+            setReplacement("");
+            setRotating(rotating === credential.id ? null : credential.id);
+          }}
         >
           Replace key
         </Button>

--- a/apps/web/test/graders.test.tsx
+++ b/apps/web/test/graders.test.tsx
@@ -1206,6 +1206,100 @@ describe("judge settings", () => {
   });
 
   /**
+   * A failed rotation leaves a Try again behind, and that retry has to go when
+   * a different credential is opened.
+   *
+   * The retry is bound to the credential that failed, but the rotation it calls
+   * reads the field as it stands when the button is pressed. So a failure on
+   * one credential, then opening another and typing its key, leaves a Try again
+   * that writes this row's key to the other row — and then reports success for
+   * a credential nobody was looking at.
+   *
+   * This is the same defect as the one above wearing different clothes: state
+   * that means "for the open row", with nothing making it true. It is written
+   * separately because clearing the field does not clear this, and the first
+   * fix for the field left it standing.
+   */
+  it("drops a failed rotation's retry when a different credential is opened", async () => {
+    const twoKeys = [
+      {
+        id: "jcr_1",
+        label: "Acme production",
+        provider: "openai",
+        hint: "1234",
+        revision: "rev_1",
+        created_at: "2026-08-01T10:00:00.000Z",
+        updated_at: "2026-08-01T10:00:00.000Z",
+      },
+      {
+        id: "jcr_2",
+        label: "Acme staging",
+        provider: "openai",
+        hint: "5678",
+        revision: "rev_2",
+        created_at: "2026-08-02T10:00:00.000Z",
+        updated_at: "2026-08-02T10:00:00.000Z",
+      },
+    ];
+    apiAnswers({
+      "/api/me": { status: 200, body: meWith("admin") },
+      "/api/judge": {
+        status: 200,
+        body: {
+          state: "needs_setup",
+          provider: null,
+          model: null,
+          source: null,
+          credential_id: null,
+          hint: null,
+        },
+      },
+      "/api/judge/registry": {
+        status: 200,
+        body: {
+          providers: [{ provider: "openai", model_is_free_text: true }],
+          platform_sentinel: "platform",
+          platform_judge_available: false,
+        },
+      },
+      "/api/judge-credentials": { status: 200, body: { items: twoKeys } },
+      "/api/judge-credentials/jcr_1": {
+        status: 422,
+        body: {
+          error: "unprocessable",
+          message: "a judge key is at least 8 characters.",
+        },
+      },
+    });
+    render(<JudgeSettingsPage />);
+
+    const keys = await screen.findByRole("table", { name: "Organization keys" });
+    const [openProduction, openStaging] = within(keys).getAllByRole("button", {
+      name: "Replace key",
+    });
+
+    fireEvent.click(openProduction as HTMLElement);
+    fireEvent.change(screen.getByLabelText("New key"), {
+      target: { value: "sk-short" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save new key" }));
+
+    expect(
+      await screen.findByText("Egma did not replace the key for Acme production."),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+
+    // Opening another credential takes the retry with it. Anything else leaves
+    // a button that writes staging's key to production.
+    fireEvent.click(openStaging as HTMLElement);
+
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    expect(
+      screen.queryByText("Egma did not replace the key for Acme production."),
+    ).toBeNull();
+  });
+
+  /**
    * A failure has to report the thing that failed. Sending a credential failure
    * up to the judge section put "Egma did not save the judge" on screen when
    * adding a key had failed, beside a Try again that saved the judge — a

--- a/apps/web/test/graders.test.tsx
+++ b/apps/web/test/graders.test.tsx
@@ -1060,8 +1060,8 @@ describe("judge settings", () => {
       expect(
         within(
           screen.getByRole("region", { name: "Judge credentials" }),
-        ).getByText(/Acme production/),
-      ).toBeTruthy();
+        ).getAllByText(/Acme production/),
+      ).not.toHaveLength(0);
     });
     expect(
       (screen.getByLabelText("OpenAI key") as HTMLInputElement).value,
@@ -1141,7 +1141,8 @@ describe("judge settings", () => {
       },
     ]);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Replace key" }));
+    const keys = await screen.findByRole("table", { name: "Organization keys" });
+    fireEvent.click(within(keys).getByRole("button", { name: "Replace key" }));
 
     const field = screen.getByLabelText("New key") as HTMLInputElement;
     expect(field.value).toBe("");

--- a/apps/web/test/graders.test.tsx
+++ b/apps/web/test/graders.test.tsx
@@ -1151,6 +1151,61 @@ describe("judge settings", () => {
   });
 
   /**
+   * One form under the table means one field for every row, so opening another
+   * credential has to empty it.
+   *
+   * A key typed for one credential and left in the field when somebody opens
+   * another is not a cosmetic carry-over: Save sends whatever the field holds
+   * to whichever credential is open, so the wrong one is rotated to a key its
+   * owner never chose for it, and the key its owner did choose is now on a
+   * credential they were not looking at. Nothing on the page would say so.
+   *
+   * Retyping is the cost, and it is the right one to pay.
+   */
+  it("empties the replacement field when a different credential is opened", async () => {
+    settings("admin", undefined as never, [
+      {
+        id: "jcr_1",
+        label: "Acme production",
+        provider: "openai",
+        hint: "1234",
+        revision: "rev_1",
+        created_at: "2026-08-01T10:00:00.000Z",
+        updated_at: "2026-08-01T10:00:00.000Z",
+      },
+      {
+        id: "jcr_2",
+        label: "Acme staging",
+        provider: "openai",
+        hint: "5678",
+        revision: "rev_2",
+        created_at: "2026-08-02T10:00:00.000Z",
+        updated_at: "2026-08-02T10:00:00.000Z",
+      },
+    ]);
+
+    const keys = await screen.findByRole("table", { name: "Organization keys" });
+    const [openFirst, openSecond] = within(keys).getAllByRole("button", {
+      name: "Replace key",
+    });
+
+    fireEvent.click(openFirst as HTMLElement);
+    const forProduction = screen.getByLabelText("New key") as HTMLInputElement;
+    fireEvent.change(forProduction, { target: { value: "sk-meant-for-production" } });
+    expect(
+      (screen.getByLabelText("New key") as HTMLInputElement).value,
+    ).toBe("sk-meant-for-production");
+
+    fireEvent.click(openSecond as HTMLElement);
+
+    expect((screen.getByLabelText("New key") as HTMLInputElement).value).toBe("");
+    // And with nothing typed for this one, there is nothing to send.
+    expect(
+      screen.getByRole("button", { name: "Save new key" }).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  /**
    * A failure has to report the thing that failed. Sending a credential failure
    * up to the judge section put "Egma did not save the judge" on screen when
    * adding a key had failed, beside a Try again that saved the judge — a

--- a/packages/db/test/graders-reads-and-modalities.test.ts
+++ b/packages/db/test/graders-reads-and-modalities.test.ts
@@ -120,6 +120,40 @@ describe("what a grader reads", () => {
     });
     expect(narrowed.modalities).toEqual(["voice"]);
   });
+
+  /**
+   * **Every type may narrow, and a deterministic one is the case nothing else
+   * here covers.**
+   *
+   * The two sets on a grader are governed by opposite rules, and the test above
+   * only proves the easy half. Reads are the type's for three of the four
+   * types, so a threshold asking to read the transcript is refused. Modalities
+   * belong to the author whatever the type is, because *which conversations
+   * this check is about* is a fact about the check and never about the kind of
+   * judgment it makes — a latency threshold written for a phone call has no
+   * business scoring a chat, and the author is the only one who knows that.
+   *
+   * Every other narrowing test in this repository writes an `llm_rubric`, and
+   * the one narrowed deterministic grader anywhere is a fixture handed straight
+   * to the grading side, never written through this door. So a rubric-only rule
+   * added here tomorrow would break nothing, and the product would quietly stop
+   * letting three of its four types say what they can score.
+   *
+   * It is read back rather than believed, because a write that answers
+   * correctly and stores something else is the failure a write-only test cannot
+   * see.
+   */
+  it("lets a deterministic grader narrow what it scores, and keeps it", async () => {
+    const written = await createGrader(actingAsAcme(), {
+      ...threshold,
+      modalities: ["chat"],
+    });
+    expect(written.modalities).toEqual(["chat"]);
+
+    const read = await getGrader(actingAsAcme(), written.id);
+    expect(read?.type).toBe("metric_threshold");
+    expect(read?.modalities).toEqual(["chat"]);
+  });
 });
 
 describe("editing what a grader reads or scores", () => {


### PR DESCRIPTION
Follow-up on ticket 05, which is merged. Base is the effort's integration branch, not `main`.

A verification pass over ticket 05's acceptance criteria found two of seventeen unmet. This closes both.

## The grader pages hand-rolled controls the shared library already provides

The ticket asks that all pages reuse the shared forms, tables, dialogs, status and page-state components. Two did not: `graders/editor.tsx` declared its **own local** `TextArea` and `Choice`, and `graders/judge/page.tsx` hand-rolled both `<select>` controls, both password `<input>` controls, and the credential list as a `<ul>`.

This is the wave 1 collision shape — three tickets each grew their own `Choice` and `Facts`, and reconciling them cost real time. It matters more than tidiness here because nine tickets remain and will read these pages as precedent.

Both local components are deleted. Every field is now `Field` wrapping the shared `TextArea` or `Select`, with hints moved onto `Field`'s `hint` prop, which is what wires `aria-describedby` from the hint to the control — nine call sites that previously had a loose `<small>` connected to nothing. The passwords use the shared `TextInput` with `secret`. The credential list is `DataTable`.

**`apps/web/ui/controls.tsx` is untouched** — byte-identical to the base. Two tickets are being built against it right now, so no optional-prop exception was used either.

### Two things flagged rather than decided

**Two bare `<input type="number">` remain**, for the grader threshold and the production sample rate. The shared set has no numeric control; routing them through `TextInput` would lose the spinner and the browser's own range check, which is a worse control rather than a shared one. Both carry a comment saying so. Adding a numeric control means touching `controls.tsx`, which is closed while wave 2 is in flight — so this is left as the one real gap in the shared set, to be closed after wave 2 merges.

**`DataTable` moved the replacement-key form.** It draws every row twice, a wide table and a narrow list, so a form inside a cell would have been two forms over one piece of state — two fields carrying one value, and whichever the browser focused would be the one nobody could see. The form now sits once under the table, opened by whichever row asked. Same clicks, same fields, same behaviour.

### Two test assertions edited, both from row duplication

Not behaviour changes. `DataTable` renders each row in both layouts, exactly as every other list in the product — `personas.test.tsx` already asserts `toHaveLength(2)` for the same reason.

- `graders.test.tsx:1059` — `getByText(/Acme production/)` → `getAllByText(...)`, the label is in both layouts
- `graders.test.tsx:1144` — `findByRole("button", …)` scoped to the table via `within(...)`, the button is in both layouts

The other 42 tests in that file pass **unedited**, including everything about the editor, both judge selects, and the "never a stored key" claims.

## A deterministic grader narrowing its modalities was untested

The ticket says all grader types may narrow their supported modalities. The code is right — `validModalities` branches on nothing — but every narrowing test wrote an `llm_rubric`, and the only narrowed deterministic grader in the repository was a fixture handed straight to `judgmentsOf`, never written through the door. Nothing would have failed if a rubric-only rule appeared at the write door tomorrow.

The new test writes a `metric_threshold` with `modalities: ["chat"]` through `createGrader` and reads it back. With a rubric-only guard put into `validModalities` it fails on the write path's own answer:

```
AssertionError: expected [ 'voice', 'chat' ] to deeply equal [ 'chat' ]
```

Running the whole scoped set plus `apps/grader/test/modality.test.ts` with that guard in place: **1 failed, 329 passed.** The new test is the only thing in 330 that notices, which is the measure of what was missing.

## Verification

331 tests across 13 files, `pnpm lint` and `pnpm typecheck` clean, `apps/web/ui/` untouched. Latest base merged in cleanly.

## Noted, not fixed here

The product has **two control vocabularies**: `apps/web/app/ui.tsx` on the signed-out surface and `apps/web/ui/controls.tsx` in the product shell, with `Field` declared in both under one name. The signed-out pages follow their own module consistently, so this is not new drift — but it is the wave 1 collision shape already sitting in the tree rather than arriving at a merge. Filed separately; out of scope for this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789370202&installation_model_id=431960&pr_number=101&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F101&signature=ec22f41baa4af98c4fef313229500fa9055da8a6c4fce8703638eede00c60228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up adopts shared controls across the grader editor and judge settings while adding regression coverage for credential-rotation state and deterministic grader modality narrowing.
- Replaces local and native grader form controls with shared `Field`, `Select`, `TextArea`, and `TextInput` components.
- Moves credential replacement into one row-selected form beneath the shared `DataTable`.
- Clears replacement and retry state whenever a credential row is opened or closed.
- Adds coverage proving deterministic graders can persist narrowed modalities.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/graders/editor.tsx | Replaces local textarea and select abstractions with shared controls while preserving field values, options, disabled states, and change handlers. |
| apps/web/app/projects/[projectId]/graders/judge/page.tsx | Migrates judge settings and credential management to shared controls and clears row-scoped replacement and retry state on every credential-selection transition. |
| apps/web/test/graders.test.tsx | Updates assertions for DataTable’s dual layouts and verifies that replacement values and failed retries cannot cross credential selections. |
| packages/db/test/graders-reads-and-modalities.test.ts | Adds write-and-read regression coverage for narrowing a deterministic metric-threshold grader to chat modality. |

<sub>Reviews (3): Last reviewed commit: ["Drop a failed rotation&#39;s retry when a di..."](https://github.com/egma-ai/egma/commit/574da8b6c23b9ecf04cd66adcd9b8976c2ef55c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53583589)</sub>

<!-- /greptile_comment -->