### PR TITLE
One way to name a platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ With an instance up and an account on it, the walk is one command:
 
 ```bash
 cd ~/your-voice-agent
-EGMA_URL=http://localhost:3101 npx @egma/cli
+npx @egma/cli --url http://localhost:3101
 ```
 
 To run it from this checkout instead — for development, or ahead of a release:
@@ -293,7 +293,7 @@ you signed up on:
 
 ```bash
 cd ~/your-voice-agent
-EGMA_URL=http://localhost:3101 node ~/egma/apps/cli/dist/bin.js
+node ~/egma/apps/cli/dist/bin.js --url http://localhost:3101
 ```
 
 `~/egma` is this checkout. The published package is `@egma/cli`; the command it installs is `egma`.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -96,12 +96,14 @@ wider it needs to be instead of drawing an address that breaks across two lines.
 ### Your own instance
 
 ```
-EGMA_URL=http://localhost:3101 egma
+egma --url http://localhost:3101
 ```
 
-or `--url`. It is kept beside the key after the first login, so later commands
-find it without being told again. `3101` is where `docker compose up` puts an
-instance; see [Trying it on an instance of your own](#trying-it-on-an-instance-of-your-own),
+`--url` is the one way to name an egma, and it names it for that one command.
+To say it once and be done, bind the repository — `egma init --url
+http://localhost:3101` writes that instance's verified identity into
+`egma/config.yaml`, and every later command in the repository finds it there.
+`3101` is where `docker compose up` puts an instance; see [Trying it on an instance of your own](#trying-it-on-an-instance-of-your-own),
 which is also where the `egma` in that line comes from today.
 
 ## Connecting your voice agent
@@ -572,7 +574,8 @@ egma connect [options]   Register your voice agent and a way to reach it.
                          The key comes in on standard input or from the
                          environment, never as an argument.
 egma init [options]      Make the egma folder this repository's tests live
-                         in. Safe to run again.
+                         in. Talks to nobody, unless --url names an egma to
+                         bind this repository to. Safe to run again.
 egma pull [options]      Write egma's current test versions into it.
 egma push [options]      Upload the tests in it. Refuses, naming names, when
                          egma has moved on since your last pull.
@@ -582,9 +585,12 @@ egma run [options]       Run this folder's tests, pinning the version of each.
   --coding-agent <id>  Which coding agent to drive, named as the agent
                        registry names it. Default: claude-acp
   --cwd <path>         The folder to work in. Default: this folder.
-  --url <address>      The egma to talk to, for a self-hosted one. Kept
-                       after the first login, so it is set once. EGMA_URL
-                       does the same for a whole shell.
+  --url <address>      Which egma this one command talks to. It is the only
+                       way to name one, so a command that should reach that
+                       egma carries it. With init and with the wizard: egma
+                       asks that address who it is and records its verified
+                       identity in egma/config.yaml, and every later command
+                       in this repository then needs no address at all.
   --force              With login: sign in again even when this machine
                        already holds a key.
   --no-follow          With run: start the run and return at once, without
@@ -613,7 +619,6 @@ egma run [options]       Run this folder's tests, pinning the version of each.
   -v, --version        Print the version.
 
 Environment:
-  EGMA_URL             The egma to talk to, for a whole shell. Same as --url.
   EGMA_HOME            The folder egma keeps this machine's key in.
                        Default: ~/.egma
   EGMA_RETELL_API_KEY  Your Retell key, for egma connect. RETELL_API_KEY is
@@ -703,11 +708,11 @@ instance you just signed up on:
 
 ```
 cd ~/your-voice-agent
-EGMA_URL=http://localhost:3101 node ~/egma/apps/cli/dist/bin.js
+node ~/egma/apps/cli/dist/bin.js --url http://localhost:3101
 ```
 
 (`~/egma` is wherever you cloned this. From npm, that whole line is
-`EGMA_URL=http://localhost:3101 npx @egma/cli`.)
+`npx @egma/cli --url http://localhost:3101`.)
 
 The wizard signs this machine in against that instance, registers your agent
 and a way to reach it, writes a first suite of tests with your coding agent,

--- a/apps/cli/smoke/real-platform-login.ts
+++ b/apps/cli/smoke/real-platform-login.ts
@@ -64,9 +64,7 @@ async function throwawayHome(label: string): Promise<Home> {
 }
 
 function envFor(home: Home): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env, EGMA_HOME: home.folder, BROWSER: NO_BROWSER };
-  delete env.EGMA_URL;
-  return env;
+  return { ...process.env, EGMA_HOME: home.folder, BROWSER: NO_BROWSER };
 }
 
 /** What is on disk after a login, and what the file is readable by. */

--- a/apps/cli/smoke/real-retell-connect.ts
+++ b/apps/cli/smoke/real-retell-connect.ts
@@ -191,6 +191,9 @@ async function main(): Promise<void> {
   try {
     platform = await startPlatform();
     gate = await openGate();
+    // Said on every invocation below, because that is the only way to name an
+    // egma: one explicit address per command, and no shell that names one.
+    const platformUrl = platform.url;
 
     // A key this fixture accepts, written where a login would have put it. No
     // real egma is touched and the credentials of whoever runs this are not
@@ -204,7 +207,6 @@ async function main(): Promise<void> {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       EGMA_HOME: home,
-      EGMA_URL: platform.url,
       EGMA_RETELL_URL: gate.url,
       [KEY_VARIABLE]: key.trim(),
     };
@@ -226,7 +228,7 @@ async function main(): Promise<void> {
     // The reach is said, because egma will not choose between text and phone
     // on anybody's behalf. Text here: this check has no platform to dial from
     // and no business registering somebody's telephone number.
-    const first = await egma(["connect", "--reach", "text"], env, workdir);
+    const first = await egma(["connect", "--url", platformUrl, "--reach", "text"], env, workdir);
     const listed = agentIdsIn(first.stdout);
 
     let connected = first;
@@ -241,7 +243,7 @@ async function main(): Promise<void> {
       for (const id of listed.slice(0, MOST_AGENTS_TRIED)) {
         chosen += 1;
         connected = await egma(
-          ["connect", "--reach", "text", "--retell-agent", id],
+          ["connect", "--url", platformUrl, "--reach", "text", "--retell-agent", id],
           env,
           workdir,
         );
@@ -379,7 +381,15 @@ async function main(): Promise<void> {
     // starts and throws away, which is nowhere and nobody's, and it is the only
     // way the confirming read gets exercised at all.
     const numbered = await egma(
-      ["connect", "--reach", "phone", "--retell-agent", result.retell_agent_id ?? ""],
+      [
+        "connect",
+        "--url",
+        platformUrl,
+        "--reach",
+        "phone",
+        "--retell-agent",
+        result.retell_agent_id ?? "",
+      ],
       env,
       workdir,
     );

--- a/apps/cli/smoke/real-whole-walk.ts
+++ b/apps/cli/smoke/real-whole-walk.ts
@@ -693,7 +693,6 @@ async function main(): Promise<void> {
       BROWSER: NO_BROWSER,
       EGMA_RETELL_URL: vendor.url,
     };
-    delete env.EGMA_URL;
     delete env[KEY_VARIABLE];
     delete env.EGMA_RETELL_API_KEY;
     delete env.EGMA_RETELL_AGENT_ID;

--- a/apps/cli/smoke/real-whole-walk.ts
+++ b/apps/cli/smoke/real-whole-walk.ts
@@ -337,10 +337,10 @@ async function register(
   // never guesses between the two, so this walk says which one it means. The
   // phone path is proven where a real number and a real carrier are, and this
   // walk has neither.
-  let ran = await egma(["connect", "--cwd", repository, "--reach", "text"], {
-    env,
-    stdin: `${vendor.key}\n`,
-  });
+  let ran = await egma(
+    ["connect", "--url", instance.origin, "--cwd", repository, "--reach", "text"],
+    { env, stdin: `${vendor.key}\n` },
+  );
 
   // A real account may hold several agents, and egma refuses to guess which
   // one. Any of them proves the same thing about the walk, so the first is
@@ -350,7 +350,17 @@ async function register(
     secrets.push(listed);
     say(`  (the account holds several agents; the first was taken)`);
     ran = await egma(
-      ["connect", "--cwd", repository, "--reach", "text", "--retell-agent", listed],
+      [
+        "connect",
+        "--url",
+        instance.origin,
+        "--cwd",
+        repository,
+        "--reach",
+        "text",
+        "--retell-agent",
+        listed,
+      ],
       { env, stdin: `${vendor.key}\n` },
     );
   }
@@ -425,7 +435,9 @@ async function pushTheTests(
     await writeFile(path.join(paths.tests, `${test.name}.md`), testFile(test.name, test.body), "utf8");
   }
 
-  const pushed = await egma(["push", "--cwd", repository], { env });
+  const pushed = await egma(["push", "--url", instance.origin, "--cwd", repository], {
+    env,
+  });
   exited(pushed, "egma push");
   check(first(pushed.said, "status") === "pushed", "egma push said it pushed");
   check(
@@ -488,7 +500,7 @@ async function runAndFollow(
   say("");
   say("── the run, created and followed ─────────────────────────");
 
-  const running = start(["run", "--cwd", repository], { env });
+  const running = start(["run", "--url", instance.origin, "--cwd", repository], { env });
   try {
     await waitUntil(
       () => /^run: run_\S+$/mu.test(running.out()) && /^results: \S+$/mu.test(running.out()),

--- a/apps/cli/smoke/real-wizard-e2e.ts
+++ b/apps/cli/smoke/real-wizard-e2e.ts
@@ -413,7 +413,6 @@ async function walkOnce(options: {
   // wizard — or the coding agent it starts, which inherits this — can read.
   delete env[KEY_VARIABLE];
   for (const other of OTHER_KEY_VARIABLES) delete env[other];
-  delete env.EGMA_URL;
   delete env.EGMA_RETELL_AGENT_ID;
   delete env[TARGET_VARIABLE];
 

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,22 +1,32 @@
 /**
  * `egma init`: make the folder this repository's tests live in.
  *
- * It asks nothing and it needs no key, because nothing here talks to egma. What
- * it makes is a folder a team commits: a config file naming what the folder
- * points at, a file for the mock tools this project answers with, and a
+ * What it makes is a folder a team commits: a config file naming what the
+ * folder points at, a file for the mock tools this project answers with, and a
  * directory for the tests. Nothing secret can land in any of them, so there is
  * no gitignore line to write.
  *
+ * On its own it asks nothing, needs no key, and talks to nobody — a developer
+ * with the network cable out gets the whole folder. Naming an address with
+ * `--url` adds one thing to that: the platform's verified identity, already
+ * read by the time this runs, committed beside the names. It is the only
+ * binding a repository can gain before anybody has signed in, because the
+ * identity contract is the one read egma makes with no credential at all.
+ *
  * Running it twice is safe. A folder that is already here is recognised and
  * left as it is — the second developer to clone the repository runs the same
- * command as the first and changes nothing by it.
+ * command as the first and changes nothing by it. The one exception is the
+ * binding, which a folder committed before this repository was on any platform
+ * can still gain.
  */
 
 import {
+  bindRepositoryPlatform,
   createEgmaFolder,
   MEMORY_FOLDER_NAME,
   type FolderConfig,
   type NamedThing,
+  type PlatformBinding,
 } from "../folder/egma-folder.ts";
 import { FOLDER_EXIT, type FolderCommandOptions } from "./folder-verbs.ts";
 
@@ -27,6 +37,15 @@ export type InitCommandOptions = FolderCommandOptions & {
     readonly connection: string | null;
     readonly suite: string | null;
   };
+  /**
+   * The platform to commit, verified, or `null` when the command named none.
+   *
+   * Whole or absent, never half: this address has already been asked who it is
+   * and has answered, so there is no origin-without-instance state for anything
+   * downstream to reason about. An address that could not answer never reaches
+   * here at all.
+   */
+  readonly binding: PlatformBinding | null;
 };
 
 function named(name: string | null): NamedThing | null {
@@ -35,27 +54,65 @@ function named(name: string | null): NamedThing | null {
 
 export async function runInitCommand(options: InitCommandOptions): Promise<number> {
   const config: FolderConfig = {
-    platform: null,
+    platform: options.binding,
     agent: named(options.names.agent),
     connection: named(options.names.connection),
     suite: named(options.names.suite),
   };
 
+  // Which egma this command talked to, first and in the shape every other verb
+  // says it in — and only when it talked to one. `init` on its own reaches no
+  // address at all, so it has none to print. What the folder *names* is a
+  // different fact, and it is printed below beside everything else the folder
+  // names, whether this run wrote it or found it.
+  if (options.binding !== null) options.out(`url: ${options.binding.origin}`);
+
   const folder = await createEgmaFolder({ repository: options.cwd, config });
+
+  // A folder that is already here keeps every byte it has, with one exception,
+  // and the exception is why `--url` is worth typing on a second run. A folder
+  // somebody committed before this repository was on any platform is how a
+  // teammate ordinarily arrives, and recognising that folder and dropping the
+  // flag would be the silent no-op this command used to be, moved one case
+  // along.
+  //
+  // Through the same door `connect` binds through, so one function commits a
+  // verified platform and there is one place to read to know what that means.
+  // Nothing it can refuse is reachable from here: an address that disagrees
+  // with a binding already in this folder was turned away before any of this
+  // ran, and a binding that agrees is handed straight back unwritten.
+  const held = folder.config;
+  const committed =
+    options.binding !== null && held.platform === null
+      ? await bindRepositoryPlatform(options.cwd, options.binding)
+      : held;
+  const newlyBound = held.platform === null && committed.platform !== null;
 
   options.out(`folder: ${folder.paths.root}`);
   options.out(`config: ${folder.paths.config}`);
   options.out(`mock-tools: ${folder.paths.mockTools}`);
   options.out(`tests: ${folder.paths.tests}`);
+  // Read from the file for the same reason the names under it are: what this
+  // reports is what a teammate cloning the repository will get, not what this
+  // one run happened to be handed.
+  if (committed.platform !== null) {
+    options.out(`platform: ${committed.platform.instance}`);
+  }
   for (const key of ["agent", "connection", "suite"] as const) {
-    const thing = folder.config[key];
+    const thing = committed[key];
     if (thing !== null) options.out(`${key}: ${thing.name}${thing.id === null ? "" : ` ${thing.id}`}`);
   }
   options.out("committable: yes");
   options.out(`status: ${folder.created ? "created" : "already-there"}`);
 
   if (!folder.created) {
-    options.out(`note: the folder was already here, and nothing in it was changed`);
+    // `already-there` on its own reads as a run that changed nothing, so the
+    // one run that changes something says which thing it changed.
+    options.out(
+      newlyBound
+        ? "note: the folder was already here, and gained the platform it names"
+        : "note: the folder was already here, and nothing in it was changed",
+    );
   }
   // Named so that nothing else claims it, and deliberately not made.
   options.out(`reserved: ${MEMORY_FOLDER_NAME}`);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -362,8 +362,8 @@ export function helpText(): string {
     "What egma init, pull and push print, one fact per line:",
     "  url, folder, and then one line per test: what happened to it, the file,",
     "  and the version the file now pins. push names every conflicting test on",
-    "  its own conflict: line. init adds a platform: line when --url gave it an",
-    "  egma to bind this repository to.",
+    "  its own conflict: line. init adds a platform: line whenever this repository",
+    "  is bound, whether this run bound it or found it already bound.",
     "",
     "What egma init, pull and push answer with:",
     "  0 done   1 no egma folder here   2 not signed in",
@@ -933,6 +933,7 @@ export async function main(argv: readonly string[]): Promise<void> {
       const selected = chosen;
       process.exitCode = await theWizard({
         url: selected.url,
+        bound: selected.binding !== null,
         verify: () => verifyPlatform(selected),
       });
     }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -36,6 +36,7 @@ import {
   isSelfHostInvocation,
   runSelfHostCommand,
 } from "./commands/self-host.ts";
+import type { PlatformBinding } from "./folder/egma-folder.ts";
 import {
   BoundPlatformAddressError,
   BoundPlatformUnavailableError,
@@ -242,7 +243,9 @@ export function helpText(): string {
     "                           The key comes in on standard input or from the",
     "                           environment, never as an argument.",
     "  egma init [options]      Make the egma folder this repository's tests",
-    "                           live in. Safe to run again.",
+    "                           live in. Talks to nobody, unless --url names an",
+    "                           egma to bind this repository to. Safe to run",
+    "                           again.",
     "  egma pull [options]      Write egma's current test versions, and the mock",
     "                           tools it answers with, into it.",
     "  egma push [options]      Upload what is in it. Refuses, naming names,",
@@ -275,9 +278,12 @@ export function helpText(): string {
     "  --coding-agent <id>  Which coding agent to drive, named as the agent",
     `                       registry names it. Default: ${DEFAULT_DRIVEN_AGENT_ID}`,
     "  --cwd <path>         The folder to work in. Default: this folder.",
-    "  --url <address>      The egma to talk to. The wizard records its verified",
-    "                       identity in egma/config.yaml. EGMA_URL selects one",
-    "                       for a whole shell.",
+    "  --url <address>      Which egma this one command talks to. It is the only",
+    "                       way to name one, so a command that should reach that",
+    "                       egma carries it. With init and with the wizard: egma",
+    "                       asks that address who it is and records its verified",
+    "                       identity in egma/config.yaml, and every later command",
+    "                       in this repository then needs no address at all.",
     "  --force              With login: sign in again even when this machine",
     "                       already holds a key.",
     "  --no-follow          With run: start the run and return at once, without",
@@ -308,7 +314,6 @@ export function helpText(): string {
     "  -v, --version        Print the version.",
     "",
     "Environment:",
-    "  EGMA_URL             The egma to talk to, for a whole shell. Same as --url.",
     "  EGMA_HOME            The folder egma keeps this machine's keys in, one",
     "                       for each platform origin.",
     "                       Default: ~/.egma",
@@ -357,7 +362,8 @@ export function helpText(): string {
     "What egma init, pull and push print, one fact per line:",
     "  url, folder, and then one line per test: what happened to it, the file,",
     "  and the version the file now pins. push names every conflicting test on",
-    "  its own conflict: line.",
+    "  its own conflict: line. init adds a platform: line when --url gave it an",
+    "  egma to bind this repository to.",
     "",
     "What egma init, pull and push answer with:",
     "  0 done   1 no egma folder here   2 not signed in",
@@ -648,6 +654,8 @@ async function runFolderVerb(
   verb: "init" | "pull" | "push" | "run",
   invocation: Invocation,
   access: PlatformAccess,
+  /** For `init`: the verified platform to commit, when `--url` named one. */
+  binding: PlatformBinding | null = null,
 ): Promise<number> {
   const controller = new AbortController();
   const onSignal = (): void => controller.abort("interrupt");
@@ -670,6 +678,7 @@ async function runFolderVerb(
           connection: invocation.connectionName,
           suite: invocation.suiteName,
         },
+        binding,
       });
     }
     if (verb === "run") {
@@ -806,13 +815,20 @@ export async function main(argv: readonly string[]): Promise<void> {
 
   const cwd = path.resolve(invocation.cwd ?? process.cwd());
 
-  // `init` is only a local folder write. It never verifies a platform, signs
-  // in, or sends an identifier anywhere.
-  if (invocation.verb === "init") {
+  // `init` with no address named is only a local folder write. It never
+  // verifies a platform, signs in, or sends an identifier anywhere, so it is
+  // settled here rather than below and works with the network cable out.
+  //
+  // `init --url` is the one exception, and it falls through to the ordinary
+  // resolution below: it asks that address who it is and commits the answer.
+  // Sending it through the same path as every other verb is what makes a bound
+  // repository refuse a second, different address here exactly as it does
+  // everywhere else.
+  if (invocation.verb === "init" && invocation.url === null) {
     process.exitCode = await runFolderVerb(invocation.verb, invocation, {
-      // `init` writes a folder and talks to nothing, so there is no platform to
-      // name. Empty rather than a placeholder address: a real-looking one here
-      // would be a lie the next reader has to disprove.
+      // Nothing was asked of any address, so there is no platform to name.
+      // Empty rather than a placeholder address: a real-looking one here would
+      // be a lie the next reader has to disprove.
       url: "",
       credentialsFile: credentialsFileIn(process.env),
     });
@@ -887,6 +903,16 @@ export async function main(argv: readonly string[]): Promise<void> {
       }
       if (invocation.verb === "connect") {
         process.exitCode = await runConnect(invocation, access);
+        return;
+      }
+      // Only `init --url` reaches here: the flagless form was answered above.
+      // The address has already said who it is, so what is committed is a whole
+      // binding or the command has already refused and written nothing.
+      if (invocation.verb === "init") {
+        process.exitCode = await runFolderVerb(invocation.verb, invocation, access, {
+          origin: access.url,
+          instance: access.instanceId,
+        });
         return;
       }
       if (

--- a/apps/cli/src/platform/address.ts
+++ b/apps/cli/src/platform/address.ts
@@ -2,10 +2,10 @@
  * Which addresses egma will act on, and which it will only ever print.
  *
  * Two addresses arrive from outside and neither can be believed. The one a
- * developer types (`--url`, `EGMA_URL`) decides what egma talks to. The one the
- * instance sends back (`verification_uri_complete`) is handed to a browser, and
- * handing a string to a browser opener is handing it to a program: on Windows
- * the opener is `cmd /c start`, and a command interpreter reads `&` and `|` as
+ * developer types (`--url`) decides what egma talks to. The one the instance
+ * sends back (`verification_uri_complete`) is handed to a browser, and handing
+ * a string to a browser opener is handing it to a program: on Windows the
+ * opener is `cmd /c start`, and a command interpreter reads `&` and `|` as
  * syntax rather than as characters in an address.
  *
  * So an address is checked before it reaches anything that starts a program.

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -35,11 +35,11 @@ import { PlatformUnreachableError, type Fetch } from "./device-flow.ts";
 /**
  * The egma an agent repository uses when nothing else names one.
  *
- * It is the last step of resolution and the only one nobody typed: a flag, the
- * environment and the repository's own binding all come first, and a bound
- * repository never falls back to it. A developer with nothing configured
- * reaches egma's own platform — and the wizard says which egma that is on its
- * first screen, before it asks that address anything at all.
+ * It is the last step of resolution and the only one nobody typed: `--url` and
+ * the repository's own binding both come first, and a bound repository never
+ * falls back to it. A developer with nothing configured reaches egma's own
+ * platform — and the wizard says which egma that is on its first screen, before
+ * it asks that address anything at all.
  */
 export const DEFAULT_PLATFORM_URL = "https://app.egma.ai";
 
@@ -49,8 +49,9 @@ export const DEFAULT_PLATFORM_URL = "https://app.egma.ai";
  *
  * It is not documented and it is not stable — the same treatment `main.ts`
  * gives the `-- <command>` seam that starts a scripted coding agent in place of
- * a real one. It is not a second way for a developer to select a platform:
- * `EGMA_URL` is that, and it sits above the built-in address in the order.
+ * a real one. It is not a way for a developer to select a platform either:
+ * `--url` is the one way to do that, and it sits above the built-in address in
+ * the order rather than replacing it.
  */
 export const TEST_DEFAULT_URL_VARIABLE = "EGMA_TEST_DEFAULT_URL";
 
@@ -344,8 +345,6 @@ export async function writeCredentials(
 export type PlatformChoice = {
   /** `--url`, which beats everything because it is the most deliberate. */
   readonly flag?: string | null;
-  /** `EGMA_URL`, which is how a self-hoster sets it for a whole shell. */
-  readonly env?: string | undefined;
   /** The platform committed in this agent repository. */
   readonly binding?: string | null;
   /**
@@ -369,7 +368,7 @@ export class UnusableUrlError extends Error {
 }
 
 /** Where a selected address came from. It decides who a refusal names. */
-export type PlatformSource = "--url" | "EGMA_URL" | "binding" | "default";
+export type PlatformSource = "--url" | "binding" | "default";
 
 export type SelectedPlatform = {
   readonly url: string;
@@ -378,17 +377,26 @@ export type SelectedPlatform = {
 
 const SOURCE_NAMES: Record<PlatformSource, string> = {
   "--url": "--url",
-  EGMA_URL: "EGMA_URL",
   binding: "the repository platform binding",
   default: "egma's built-in address",
 };
 
 /**
- * Which egma this command talks to, and which of the four places said so.
+ * Which egma this command talks to, and which of the three places said so.
  *
- * Deliberate beats ambient beats committed: a flag on the command, then the
- * environment, then the repository binding, then egma's own platform for an
- * unbound repository. A machine-level login never chooses a repository target.
+ * Said on the command beats committed in the repository beats egma's own: one
+ * explicit way to name a platform per invocation, one committed way per
+ * repository, one default, and nothing else. A machine-level login never
+ * chooses a repository target.
+ *
+ * There was a fourth place: an environment variable that was a second name for
+ * `--url` over a whole shell. Two ways to say one thing is two answers to
+ * "which egma is this" to keep straight — in a refusal, in a `--help` line, and
+ * in the head of whoever is debugging — so the shell-wide one went and the flag
+ * stayed. What it was for is served better by the rung below it: a script or a
+ * container that cannot type a flag on each command binds the repository once
+ * with `egma init --url`, and a binding is a committed file that travels with
+ * the checkout rather than a shell nobody else has.
  *
  * The source travels with the address because a refusal that names the wrong
  * platform sends a developer to fix something they did not ask for: told to
@@ -401,7 +409,6 @@ const SOURCE_NAMES: Record<PlatformSource, string> = {
 export function selectPlatform(choice: PlatformChoice): SelectedPlatform {
   const named: readonly [PlatformSource, string | null | undefined][] = [
     ["--url", choice.flag],
-    ["EGMA_URL", choice.env],
     ["binding", choice.binding],
     ["default", choice.fallback],
   ];
@@ -453,7 +460,7 @@ export class PlatformBindingMismatchError extends Error {
   constructor(binding: PlatformBinding, selected: PlatformIdentity) {
     super(
       teachingTheMove(
-        `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, but the selected address identifies platform ${selected.instanceId} at ${selected.origin}. Remove --url or EGMA_URL to use the bound platform. egma does not move a repository between platforms, and no repository identifiers were sent.`,
+        `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, but the selected address identifies platform ${selected.instanceId} at ${selected.origin}. Remove --url to use the bound platform. egma does not move a repository between platforms, and no repository identifiers were sent.`,
       ),
     );
     this.name = "PlatformBindingMismatchError";
@@ -528,8 +535,8 @@ export class DefaultPlatformUnusableError extends Error {
       [
         `This repository names no Egma platform, so egma used its own at ${url}, and ${answered.said}`,
         answered.worthRetrying
-          ? "Try again in a moment, or point egma at another platform with --url <address> or EGMA_URL."
-          : "That is egma's to fix and not yours, and waiting will not change it. To carry on now, point egma at another platform with --url <address> or EGMA_URL.",
+          ? "Try again in a moment, or point egma at another platform with --url <address>."
+          : "That is egma's to fix and not yours, and waiting will not change it. To carry on now, point egma at another platform with --url <address>.",
         "Nothing was sent.",
       ].join(" "),
       { cause },
@@ -632,7 +639,6 @@ export async function choosePlatform(choice: {
   const binding = committed?.platform ?? null;
   const selected = selectPlatform({
     flag: choice.flag,
-    env: choice.env.EGMA_URL,
     binding: binding?.origin ?? null,
     fallback: defaultPlatformUrlIn(choice.env),
   });
@@ -644,8 +650,8 @@ export async function choosePlatform(choice: {
   // binding is the bound address by definition — the committed origin is read
   // in the one shape origins are compared in, so a trailing slash or an
   // upper-case host in the file is the same platform and not a different one.
-  // Only the two places above it can raise this, which is also the only way
-  // this refusal can be about a move somebody is really making.
+  // Only `--url` above it can raise this, which is also the only way this
+  // refusal can be about a move somebody is really making.
   if (binding !== null && selected.source !== "binding" && selected.url !== binding.origin) {
     throw new BoundPlatformAddressError(binding, selected.source, selected.url);
   }
@@ -654,7 +660,7 @@ export async function choosePlatform(choice: {
   // folder that names no platform and is still holding one platform's
   // identifiers.
   //
-  // Whichever of the three places named the address, because the question this
+  // Whichever of the two places named the address, because the question this
   // asks is about the folder and not about the address. Once the platform block
   // is gone, egma cannot tell the platform that issued these identifiers from
   // any other — that is the one fact the deleted line held — so there is no
@@ -709,7 +715,7 @@ export async function verifyPlatform(
 
 /**
  * Resolved once, in one place, so the wizard and every verb read the same
- * answer from the same four places in the same order. Two copies of this would
+ * answer from the same three places in the same order. Two copies of this would
  * be two answers to "which egma is this", and the one that is wrong would be
  * the one that wrote the key.
  */

--- a/apps/cli/src/platform/credentials.ts
+++ b/apps/cli/src/platform/credentials.ts
@@ -447,20 +447,33 @@ export type VerifiedPlatformAccess = PlatformAccess & {
 };
 
 /**
- * A selected instance is not the platform committed in this repository.
+ * The platform answering at the recorded address is not the one recorded.
  *
- * This and the address refusal below are the two a developer meets when they
- * really are moving a repository — they point egma at the platform they want
- * and are told no — so both end with the whole move rather than its first step.
- * Naming one deletion and stopping is what leaves somebody deleting a line,
- * running again, and meeting a stranger failure about identifiers the new
- * platform never issued.
+ * This and the address refusal below are the two a developer meets when a
+ * repository and a platform have come apart, so both end with the whole move
+ * rather than its first step. Naming one deletion and stopping is what leaves
+ * somebody deleting a line, running again, and meeting a stranger failure about
+ * identifiers the new platform never issued.
+ *
+ * **Nothing anybody typed can be the cause, and the sentence must not pretend
+ * otherwise.** An address that is not the bound one is refused above, before
+ * anybody is asked anything, so the only ways to reach this are the binding
+ * choosing its own address and a flag naming that same address — and dropping a
+ * flag that names the bound platform changes nothing. So this says what really
+ * happened: the address held still and the platform at it changed. That is a
+ * colleague's rebuilt stack, or a redeployment with a fresh database, and the
+ * developer meeting it has no reason yet to know that.
+ *
+ * The two ways on are the same two the address refusal offers, one rung down.
+ * The address is not in question here, so the deliberate edit on offer is the
+ * instance rather than the origin — and it is offered only for the case where
+ * it is honest, which is this platform reinstalled rather than another one.
  */
 export class PlatformBindingMismatchError extends Error {
   constructor(binding: PlatformBinding, selected: PlatformIdentity) {
     super(
       teachingTheMove(
-        `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, but the selected address identifies platform ${selected.instanceId} at ${selected.origin}. Remove --url to use the bound platform. egma does not move a repository between platforms, and no repository identifiers were sent.`,
+        `This repository is bound to Egma platform ${binding.instance} at ${binding.origin}, and the platform answering there now says it is ${selected.instanceId}. That address is the one this repository records, so what changed is the platform at it rather than an address anybody named. If it is this same platform reinstalled — a rebuilt stack has a new database and so a new identity — edit the platform instance in egma/config.yaml to ${selected.instanceId} and change nothing else; the move below is for a different platform, not a reinstall of this one. egma does not move a repository between platforms, and no repository identifiers were sent.`,
       ),
     );
     this.name = "PlatformBindingMismatchError";

--- a/apps/cli/src/ui/headless-ui.ts
+++ b/apps/cli/src/ui/headless-ui.ts
@@ -30,7 +30,7 @@ import type { Detection } from "../wizard/detection.ts";
 import type { ExitReport } from "../wizard/exit-line.ts";
 import type { TestGate } from "../wizard/gate.ts";
 import type { GenerationProgress } from "../wizard/test-generation.ts";
-import type { AskId, DrivenAgent, GateId, WizardUI } from "./wizard-ui.ts";
+import type { AskId, DrivenAgent, GateId, PlatformNotice, WizardUI } from "./wizard-ui.ts";
 
 export type HeadlessRecord = {
   drivenAgent: DrivenAgent | null;
@@ -124,10 +124,10 @@ export class HeadlessUI implements WizardUI {
    * a screen for: whoever reads this output afterwards can see which egma this
    * repository's identifiers were about to go to, before any of them went.
    */
-  setPlatform(url: string | null): void {
-    if (url === null) return;
-    this.record.platform = url;
-    this.write(`url: ${url}`);
+  setPlatform(chosen: PlatformNotice | null): void {
+    if (chosen === null) return;
+    this.record.platform = chosen.url;
+    this.write(`url: ${chosen.url}`);
   }
 
   /**

--- a/apps/cli/src/ui/tui/ink-ui.ts
+++ b/apps/cli/src/ui/tui/ink-ui.ts
@@ -14,7 +14,7 @@ import type { Detection } from "../../wizard/detection.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { TestGate } from "../../wizard/gate.ts";
 import type { GenerationProgress } from "../../wizard/test-generation.ts";
-import type { AskId, DrivenAgent, GateId, WizardUI } from "../wizard-ui.ts";
+import type { AskId, DrivenAgent, GateId, PlatformNotice, WizardUI } from "../wizard-ui.ts";
 import type { WizardStore } from "./store.ts";
 
 export class InkUI implements WizardUI {
@@ -39,8 +39,8 @@ export class InkUI implements WizardUI {
     this.store.setDrivenAgentLog(file);
   }
 
-  setPlatform(url: string | null): void {
-    this.store.setPlatform(url);
+  setPlatform(chosen: PlatformNotice | null): void {
+    this.store.setPlatform(chosen);
   }
 
   setDetection(detection: Detection | null): void {

--- a/apps/cli/src/ui/tui/screens/IntroScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/IntroScreen.tsx
@@ -29,6 +29,19 @@ import type { WizardState } from "../state.ts";
 export const ANOTHER_PLATFORM =
   "For a different egma, quit and run it again with --url <address>.";
 
+/**
+ * The same offer for a repository that has already committed a platform, where
+ * the line above would be advice egma itself refuses.
+ *
+ * A bound repository pointed at another address is turned away, with every line
+ * of the move under it — so telling somebody here to quit and re-run with a
+ * flag sends them to a command that will not run. This is the screen that takes
+ * the keystroke of consent, which makes it the worst place in the product to be
+ * wrong about what happens next.
+ */
+export const BOUND_PLATFORM =
+  "This repository names that egma in egma/config.yaml. A different one is an edit to that file, not a flag on this command.";
+
 export type IntroScreenProps = {
   readonly state: WizardState;
   readonly onBegin: () => void;
@@ -67,8 +80,10 @@ export function IntroScreen({ state, onBegin, onQuit }: IntroScreenProps) {
       {state.platform === null ? null : (
         <>
           <Box height={1} />
-          <Text>{`This uses ${state.platform}. Nothing has been sent to it yet.`}</Text>
-          <Text dimColor>{ANOTHER_PLATFORM}</Text>
+          <Text>{`This uses ${state.platform.url}. Nothing has been sent to it yet.`}</Text>
+          <Text dimColor>
+            {state.platform.bound ? BOUND_PLATFORM : ANOTHER_PLATFORM}
+          </Text>
         </>
       )}
       <Box height={1} />

--- a/apps/cli/src/ui/tui/screens/IntroScreen.tsx
+++ b/apps/cli/src/ui/tui/screens/IntroScreen.tsx
@@ -20,14 +20,14 @@ import { dispatchKey, hintBar, type KeyBinding } from "../keybindings.ts";
 import type { WizardState } from "../state.ts";
 
 /**
- * How to use a different egma, in the two ways that really select one.
+ * How to use a different egma, in the one way that selects one.
  *
- * `EGMA_TEST_DEFAULT_URL` is not among them and never will be: it is a test
+ * `EGMA_TEST_DEFAULT_URL` is not a second way and never will be: it is a test
  * seam that stands in for the built-in address, not a way for a developer to
  * choose a platform.
  */
 export const ANOTHER_PLATFORM =
-  "For a different egma, quit and run it again with --url <address>, or set EGMA_URL.";
+  "For a different egma, quit and run it again with --url <address>.";
 
 export type IntroScreenProps = {
   readonly state: WizardState;

--- a/apps/cli/src/ui/tui/state.ts
+++ b/apps/cli/src/ui/tui/state.ts
@@ -15,7 +15,7 @@ import type { Detection } from "../../wizard/detection.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { TestGate } from "../../wizard/gate.ts";
 import type { GenerationProgress } from "../../wizard/test-generation.ts";
-import type { AskId, DrivenAgent } from "../wizard-ui.ts";
+import type { AskId, DrivenAgent, PlatformNotice } from "../wizard-ui.ts";
 
 export type WizardState = {
   readonly drivenAgent: DrivenAgent | null;
@@ -26,9 +26,10 @@ export type WizardState = {
    *
    * Set before the intro is dismissed, so the screen that takes the keystroke
    * of consent is the screen that says where this repository's identifiers are
-   * about to go.
+   * about to go — and, with it, the one thing that decides how a developer
+   * reading that screen would use a different egma.
    */
-  readonly platform: string | null;
+  readonly platform: PlatformNotice | null;
   /** What egma worked out about this machine for itself, or `null` before it has. */
   readonly detection: Detection | null;
   /** What has to be approved in a browser, while it still has to be. */

--- a/apps/cli/src/ui/tui/store.ts
+++ b/apps/cli/src/ui/tui/store.ts
@@ -26,7 +26,7 @@ import type { Detection } from "../../wizard/detection.ts";
 import type { ExitReport } from "../../wizard/exit-line.ts";
 import type { TestGate } from "../../wizard/gate.ts";
 import type { GenerationProgress } from "../../wizard/test-generation.ts";
-import type { AskId, DrivenAgent, GateId } from "../wizard-ui.ts";
+import type { AskId, DrivenAgent, GateId, PlatformNotice } from "../wizard-ui.ts";
 
 /** The screens of the walk, in order. */
 export const WALK_SCREENS: Sequence = [
@@ -176,7 +176,7 @@ export class WizardStore {
     this.change({ drivenAgentLog });
   }
 
-  setPlatform(platform: string | null): void {
+  setPlatform(platform: PlatformNotice | null): void {
     this.change({ platform });
   }
 

--- a/apps/cli/src/ui/wizard-ui.ts
+++ b/apps/cli/src/ui/wizard-ui.ts
@@ -66,6 +66,22 @@ export type AskId =
 /** The coding agent egma is driving. */
 export type DrivenAgent = { readonly id: string; readonly name: string };
 
+/**
+ * Which egma a walk will use, and how a developer would change it.
+ *
+ * The address alone is not enough for the screen that shows it. An unbound
+ * repository changes egma by naming another one on the command; a bound one
+ * cannot — a different `--url` is refused, with the whole move under it — and
+ * changes egma by editing the file it already commits. Offering the wrong one
+ * of those sends somebody to a command egma turns away, so the fact that
+ * decides which is carried here rather than guessed at the screen.
+ */
+export type PlatformNotice = {
+  readonly url: string;
+  /** True when `egma/config.yaml` names it. */
+  readonly bound: boolean;
+};
+
 export interface WizardUI {
   /** Name the coding agent egma will drive, as soon as it is known. */
   setDrivenAgent(drivenAgent: DrivenAgent | null): void;
@@ -82,7 +98,7 @@ export interface WizardUI {
    * now reaches egma's own platform when nothing names another, which is
    * exactly why it has to be said rather than assumed.
    */
-  setPlatform(url: string | null): void;
+  setPlatform(chosen: PlatformNotice | null): void;
 
   /**
    * What egma worked out about this machine for itself, or `null` before it

--- a/apps/cli/src/wizard/login-step.ts
+++ b/apps/cli/src/wizard/login-step.ts
@@ -35,6 +35,15 @@ export type PlatformAccess = ResolvedPlatform & {
  */
 export type WalkPlatform = {
   readonly url: string;
+  /**
+   * True when this address came out of `egma/config.yaml` rather than a flag.
+   *
+   * It decides one sentence on the first screen and nothing else: a bound
+   * repository is refused a different `--url`, so the wizard must not offer one
+   * there. It is passed in rather than read here, because which egma this is
+   * has one answer and one place that works it out.
+   */
+  readonly bound: boolean;
   verify(): Promise<PlatformAccess>;
 };
 
@@ -47,7 +56,11 @@ export type WalkPlatform = {
  * that asks nobody anything.
  */
 export function alreadyAsked(access: PlatformAccess): WalkPlatform {
-  return { url: access.url, verify: () => Promise.resolve(access) };
+  // Not bound: whoever hands a platform over this way resolved it for their own
+  // reasons rather than reading it out of a committed file. The one path where
+  // a binding really chose the address builds its own, in `main.ts`, from the
+  // resolution that read that file.
+  return { url: access.url, bound: false, verify: () => Promise.resolve(access) };
 }
 
 /**

--- a/apps/cli/src/wizard/walk.ts
+++ b/apps/cli/src/wizard/walk.ts
@@ -105,7 +105,11 @@ async function walkThrough(options: WalkOptions): Promise<ExitReport> {
   // egma has asked that address anything. A bare command now reaches egma's own
   // platform by default, so where a repository's identifiers are going is the
   // developer's to read first, not to find out afterwards.
-  ui.setPlatform(options.platform?.url ?? null);
+  ui.setPlatform(
+    options.platform === undefined
+      ? null
+      : { url: options.platform.url, bound: options.platform.bound },
+  );
 
   await untilAborted(ui.waitForGate("begin"), signal);
   if (signal.aborted) {

--- a/apps/cli/test/cli.test.ts
+++ b/apps/cli/test/cli.test.ts
@@ -121,6 +121,12 @@ describe("the egma command", () => {
     // And what it does with init, which used to accept it and drop it.
     expect(help.stdout).toContain("egma/config.yaml");
 
+    // The platform: line init prints is a fact about the repository, not about
+    // the flag: plain init in a repository that is already bound prints it too,
+    // so the help must not promise it only where --url was given.
+    expect(help.stdout).toContain("adds a platform: line whenever this repository");
+    expect(help.stdout).not.toContain("--url gave it");
+
     const version = await egma(["--version"], workspace);
     expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });

--- a/apps/cli/test/cli.test.ts
+++ b/apps/cli/test/cli.test.ts
@@ -25,15 +25,23 @@ import {
 const run = promisify(execFile);
 let platform: Platform;
 
+/**
+ * The built command, with the platform named on the command itself.
+ *
+ * `--url` on every invocation rather than a shell that names one once: a flag
+ * on the command is the only way to name a platform, so a check that reached
+ * this one any other way would be checking something egma does not offer.
+ */
 async function egma(
   args: readonly string[],
   workspace: Workspace,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   try {
-    const { stdout, stderr } = await run(process.execPath, [CLI_ENTRY, ...args], {
-      cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
-    });
+    const { stdout, stderr } = await run(
+      process.execPath,
+      [CLI_ENTRY, "--url", platform.url, ...args],
+      { cwd: workspace.dir, env: workspace.env() },
+    );
     return { stdout, stderr, code: 0 };
   } catch (error) {
     const failure = error as { stdout?: string; stderr?: string; code?: number };
@@ -63,7 +71,7 @@ describe("the egma command", () => {
       const child = spawn(
         process.execPath,
         ["--import", PRETEND_OLD_NODE, CLI_ENTRY, "--help"],
-        { cwd: workspace.dir, env: workspace.env({ EGMA_URL: platform.url }) },
+        { cwd: workspace.dir, env: workspace.env() },
       );
       let stderr = "";
       child.stderr.setEncoding("utf8");
@@ -103,6 +111,15 @@ describe("the egma command", () => {
     // address in for egma's own.
     expect(help.stdout).not.toContain("-- <command>");
     expect(help.stdout).not.toContain("EGMA_TEST_DEFAULT_URL");
+
+    // One explicit way to name a platform, and it is offered as one. The
+    // whole-shell variable that used to sit beside it is a setting egma no
+    // longer has, and offering a setting that does nothing is worse than
+    // offering none.
+    expect(help.stdout).toContain("--url <address>");
+    expect(help.stdout).not.toContain("EGMA_URL");
+    // And what it does with init, which used to accept it and drop it.
+    expect(help.stdout).toContain("egma/config.yaml");
 
     const version = await egma(["--version"], workspace);
     expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
@@ -235,8 +252,19 @@ describe("the egma command", () => {
 
     const child = spawn(
       process.execPath,
-      [CLI_ENTRY, "--headless", "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
-      { cwd: workspace.dir, env: workspace.env({ EGMA_URL: platform.url }) },
+      [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--headless",
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
+      { cwd: workspace.dir, env: workspace.env() },
     );
     let stdout = "";
     child.stdout.setEncoding("utf8");

--- a/apps/cli/test/connect-command.test.ts
+++ b/apps/cli/test/connect-command.test.ts
@@ -80,16 +80,16 @@ type Result = { stdout: string; stderr: string; code: number };
 /**
  * The built command, with everything it is allowed to read set on purpose.
  *
- * Both key variables are cleared unless a check sets one, so a machine that
- * happens to have a real Retell key in its environment cannot make a check
- * about a missing key pass.
+ * The platform is named on every invocation, because a flag on the command is
+ * the one way to name one. Both key variables are cleared unless a check sets
+ * one, so a machine that happens to have a real Retell key in its environment
+ * cannot make a check about a missing key pass.
  */
 function egma(
   args: readonly string[],
   options: { readonly env?: NodeJS.ProcessEnv; readonly stdin?: string } = {},
 ): Promise<Result> {
   const env = workspace.env({
-    EGMA_URL: platform.url,
     ...(retell === undefined ? {} : { EGMA_RETELL_URL: retell.url }),
     // Every check written before there was a choice is about the connection
     // egma made then, and that is the text one. The checks that are about the
@@ -98,7 +98,10 @@ function egma(
     ...options.env,
   });
 
-  const child = spawn(process.execPath, [CLI_ENTRY, ...args], { cwd: workspace.dir, env });
+  const child = spawn(process.execPath, [CLI_ENTRY, "--url", platform.url, ...args], {
+    cwd: workspace.dir,
+    env,
+  });
 
   let stdout = "";
   let stderr = "";
@@ -315,9 +318,9 @@ describe("egma connect", () => {
     retell = await startFakeRetell(ONE_AGENT);
     const fresh = await makeWorkspace();
     try {
-      const child = spawn(process.execPath, [CLI_ENTRY, "connect"], {
+      const child = spawn(process.execPath, [CLI_ENTRY, "connect", "--url", platform.url], {
         cwd: fresh.dir,
-        env: fresh.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+        env: fresh.env({ EGMA_RETELL_URL: retell.url }),
       });
       child.stdin.end(KEY);
       let stdout = "";

--- a/apps/cli/test/connect-screen.test.ts
+++ b/apps/cli/test/connect-screen.test.ts
@@ -121,6 +121,8 @@ async function wizard(): Promise<TerminalRun> {
     command: process.execPath,
     args: [
       CLI_ENTRY,
+      "--url",
+      platform.url,
       "--cwd",
       workspace.dir,
       "--",
@@ -130,7 +132,6 @@ async function wizard(): Promise<TerminalRun> {
     ],
     cwd: workspace.dir,
     env: workspace.env({
-      EGMA_URL: platform.url,
       EGMA_RETELL_URL: retell?.url ?? NO_RETELL,
     }),
     cols: 100,

--- a/apps/cli/test/failure-branches.test.ts
+++ b/apps/cli/test/failure-branches.test.ts
@@ -144,10 +144,19 @@ describe("no coding agent on this machine", () => {
     const result = await new Promise<{ stdout: string; code: number }>((resolve) => {
       const child = spawn(
         process.execPath,
-        [CLI_ENTRY, "--headless", "--cwd", workspace.dir, "--", missing],
+        [
+          CLI_ENTRY,
+          "--url",
+          platform.url,
+          "--headless",
+          "--cwd",
+          workspace.dir,
+          "--",
+          missing,
+        ],
         {
           cwd: workspace.dir,
-          env: workspace.env({ EGMA_URL: platform.url }),
+          env: workspace.env(),
           stdio: ["ignore", "pipe", "pipe"],
         },
       );

--- a/apps/cli/test/gate-screen.test.ts
+++ b/apps/cli/test/gate-screen.test.ts
@@ -143,10 +143,19 @@ async function toTheGate(
 
   const run = runInTerminal({
     command: process.execPath,
-    args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+    args: [
+      CLI_ENTRY,
+      "--url",
+      platform.url,
+      "--cwd",
+      workspace.dir,
+      "--",
+      process.execPath,
+      FAKE_AGENT,
+      script,
+    ],
     cwd: workspace.dir,
     env: workspace.env({
-      EGMA_URL: platform.url,
       EGMA_RETELL_URL: retell?.url ?? "",
       EGMA_RETELL_API_KEY: KEY,
       // Whatever the person running the suite edits with is not what this
@@ -273,10 +282,19 @@ describe("the files arriving", () => {
 
     const run = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
       env: workspace.env({
-        EGMA_URL: platform.url,
         EGMA_RETELL_URL: retell?.url ?? "",
         EGMA_RETELL_API_KEY: KEY,
         VISUAL: "",

--- a/apps/cli/test/generate.test.ts
+++ b/apps/cli/test/generate.test.ts
@@ -596,6 +596,8 @@ async function withNobodyWatching(
         process.execPath,
         [
           CLI_ENTRY,
+          "--url",
+          platform.url,
           "--headless",
           "--cwd",
           workspace.dir,
@@ -608,7 +610,6 @@ async function withNobodyWatching(
         {
           cwd: workspace.dir,
           env: workspace.env({
-            EGMA_URL: platform.url,
             EGMA_RETELL_URL: retell.url,
             EGMA_RETELL_API_KEY: KEY,
             EGMA_REACH: "text",

--- a/apps/cli/test/hosted-default-process.test.ts
+++ b/apps/cli/test/hosted-default-process.test.ts
@@ -1,8 +1,8 @@
 /**
  * The bare command, as a developer with nothing configured really types it.
  *
- * No `--url`, no `EGMA_URL`, no platform in the committed folder: the last step
- * of resolution is egma's own platform, and this is the check that proves it
+ * No `--url` and no platform in the committed folder: the last step of
+ * resolution is egma's own platform, and this is the check that proves it
  * the way it is run — the built CLI as its own process, against a platform
  * standing where the built-in address is. Proving it only inside the resolver
  * would leave the one thing a developer meets — typing `npx @egma/cli` and
@@ -84,9 +84,12 @@ describe("a repository that names no platform", () => {
   });
 
   /**
-   * The command, run the way a developer runs it: never with `--url`, and
-   * never with `EGMA_URL` in the environment. Both are asserted rather than
-   * assumed, because either one would make every claim below vacuous.
+   * The command, run the way a developer runs it: with nothing naming a
+   * platform, so that the last step of resolution is what answers.
+   *
+   * There is one way to name one — `--url` — so a check that is deliberately
+   * proving the flag wins says it in its own arguments, and every other check
+   * here is one where nothing did.
    */
   async function egma(
     workspace: Workspace,
@@ -94,13 +97,6 @@ describe("a repository that names no platform", () => {
     extra: NodeJS.ProcessEnv = {},
   ): Promise<Ended> {
     const env = workspace.env({ EGMA_RETELL_URL: retell.url, ...extra });
-    // Unless the check is deliberately proving that one of them wins, neither
-    // way of naming a platform is in play — and that is asserted rather than
-    // assumed, because either one would make every claim below vacuous.
-    if (!args.includes("--url") && extra.EGMA_URL === undefined) {
-      expect(env.EGMA_URL).toBeUndefined();
-    }
-
     const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
       cwd: workspace.dir,
       env,
@@ -299,7 +295,6 @@ describe("a repository that names no platform", () => {
       expect(refused.stderr).toContain(NO_DEFAULT_PLATFORM);
       expect(refused.stderr).toContain("Nothing was sent");
       expect(refused.stderr).toContain("--url <address>");
-      expect(refused.stderr).toContain("EGMA_URL");
 
       // The wizard answers the same way, and says which address it was going to
       // use before it finds out that nothing is there.
@@ -323,22 +318,14 @@ describe("a repository that names no platform", () => {
     }
   });
 
-  /** The three deliberate places still win, in their order, over egma's own. */
+  /** Both deliberate places still win, in their order, over egma's own. */
   it("keeps every step above it winning", async () => {
     const workspace = await makeWorkspace();
     try {
       await workspace.signIn(elsewhere.url, PLATFORM_KEY);
       const before = own.records.length;
 
-      // A whole shell pointed elsewhere: the built-in address is not consulted.
-      const byEnvironment = await egma(workspace, ["login"], {
-        EGMA_TEST_DEFAULT_URL: own.url,
-        EGMA_URL: elsewhere.url,
-      });
-      expect(byEnvironment.code, byEnvironment.stderr).toBe(0);
-      expect(byEnvironment.stdout).toContain(`url: ${elsewhere.url}`);
-
-      // And one command pointed elsewhere beats even that.
+      // One command pointed elsewhere: the built-in address is not consulted.
       const byFlag = await egma(workspace, ["login", "--url", elsewhere.url], {
         EGMA_TEST_DEFAULT_URL: own.url,
       });
@@ -364,6 +351,53 @@ describe("a repository that names no platform", () => {
       expect(byBinding.stdout).toContain(`url: ${elsewhere.url}`);
 
       expect(own.records.slice(before)).toEqual([]);
+    } finally {
+      await workspace.remove();
+    }
+  });
+
+  /**
+   * The rung that went, proven gone from the outside.
+   *
+   * `EGMA_URL` used to sit between the flag and the binding, so a shell that
+   * held it decided every command run in that shell. There is one explicit way
+   * to name a platform per invocation now, which makes the variable an ordinary
+   * word in the environment: it selects nothing, and — this is the half that
+   * could have been missed — it refuses nothing either. A bound repository used
+   * to be told it was being moved by a shell somebody set up months ago, which
+   * is a refusal about a decision nobody made today.
+   */
+  it("is not moved by EGMA_URL, on a repository bound or unbound", async () => {
+    const workspace = await makeWorkspace();
+    try {
+      await workspace.signIn(own.url, PLATFORM_KEY);
+      await workspace.signIn(elsewhere.url, PLATFORM_KEY);
+      const shell = { EGMA_TEST_DEFAULT_URL: own.url, EGMA_URL: elsewhere.url };
+      const elsewhereBefore = elsewhere.records.length;
+
+      // Unbound: the built-in address, exactly as with nothing in the shell.
+      const unbound = await egma(workspace, ["login"], shell);
+      expect(unbound.code, unbound.stderr).toBe(0);
+      expect(unbound.stdout).toContain(`url: ${own.url}`);
+
+      // Bound: the committed platform, and no refusal about a move nobody is
+      // making.
+      await createEgmaFolder({
+        repository: workspace.dir,
+        config: {
+          platform: { origin: own.url, instance: own.instanceId },
+          agent: null,
+          connection: null,
+          suite: null,
+        },
+      });
+      const bound = await egma(workspace, ["login"], shell);
+      expect(bound.code, bound.stderr).toBe(0);
+      expect(bound.stdout).toContain(`url: ${own.url}`);
+      expect(bound.stdout).not.toContain("status: refused");
+
+      // And the platform that shell named was never asked so much as who it is.
+      expect(elsewhere.records.slice(elsewhereBefore)).toEqual([]);
     } finally {
       await workspace.remove();
     }
@@ -537,11 +571,10 @@ describe("a repository that names no platform", () => {
       return workspace;
     }
 
-    // Every way a platform gets selected, and the same answer from all three.
+    // Every way a platform gets selected, and the same answer from both.
     for (const [how, args, extra] of [
       ["the built-in address", ["pull"], {}],
       ["--url", ["pull", "--url", own.url], {}],
-      ["EGMA_URL", ["pull"], { EGMA_URL: own.url }],
     ] as const) {
       const workspace = await halfMoved();
       try {

--- a/apps/cli/test/hosted-default-real.test.ts
+++ b/apps/cli/test/hosted-default-real.test.ts
@@ -65,11 +65,9 @@ it("reaches a real local platform with nothing configured anywhere", async () =>
     // once it has got there.
     await workspace.signIn(platform.origin, customer.secret);
 
-    // Nothing names a platform: no `--url` in any command below, no `EGMA_URL`
-    // in the shell, and no egma folder in the repository yet. The environment
-    // is asserted rather than assumed, because it would make this vacuous.
+    // Nothing names a platform: no `--url` in any command below, which is the
+    // one way to name one, and no egma folder in the repository yet.
     const env = workspace.env({ EGMA_TEST_DEFAULT_URL: platform.origin });
-    expect(env.EGMA_URL).toBeUndefined();
     const paths = folderPathsIn(workspace.dir);
 
     const started = await egma(

--- a/apps/cli/test/hosted-default.test.ts
+++ b/apps/cli/test/hosted-default.test.ts
@@ -100,21 +100,26 @@ describe("the built-in address", () => {
   });
 
   /**
-   * The seam is not a second way for a developer to select a platform, and it
-   * does not behave like one: `EGMA_URL` sits above the built-in address in the
-   * order, so a shell that sets both is a shell that uses `EGMA_URL`.
+   * The seam is not a way for a developer to select a platform, and it does not
+   * behave like one: it stands in for the last step of the order rather than
+   * joining it, so both steps above it still win over whatever it holds.
    */
   it("is still the last step, whatever the seam holds", () => {
+    const seam = defaultPlatformUrlIn({
+      [TEST_DEFAULT_URL_VARIABLE]: "http://stood-in.example",
+    });
+
     expect(
       selectPlatform({
-        flag: null,
-        env: "http://named-for-this-shell.example",
+        flag: "http://named-on-this-command.example",
         binding: null,
-        fallback: defaultPlatformUrlIn({
-          [TEST_DEFAULT_URL_VARIABLE]: "http://stood-in.example",
-        }),
+        fallback: seam,
       }),
-    ).toEqual({ url: "http://named-for-this-shell.example", source: "EGMA_URL" });
+    ).toEqual({ url: "http://named-on-this-command.example", source: "--url" });
+
+    expect(
+      selectPlatform({ flag: null, binding: "http://committed.example", fallback: seam }),
+    ).toEqual({ url: "http://committed.example", source: "binding" });
   });
 
   /**

--- a/apps/cli/test/interrupt.test.ts
+++ b/apps/cli/test/interrupt.test.ts
@@ -85,9 +85,19 @@ afterEach(async () => {
 function startWizard(script: string) {
   return runInTerminal({
     command: process.execPath,
-    args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+    args: [
+      CLI_ENTRY,
+      "--url",
+      platform.url,
+      "--cwd",
+      workspace.dir,
+      "--",
+      process.execPath,
+      FAKE_AGENT,
+      script,
+    ],
     cwd: workspace.dir,
-    env: workspace.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+    env: workspace.env({ EGMA_RETELL_URL: retell.url }),
     cols: 100,
   });
 }
@@ -311,9 +321,19 @@ describe("Ctrl-C at the run screen, with the suite already going", () => {
     // line as two would be checking the terminal's width and not egma's.
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+      env: workspace.env({ EGMA_RETELL_URL: retell.url }),
       cols: 200,
     });
 

--- a/apps/cli/test/intro-screen.test.ts
+++ b/apps/cli/test/intro-screen.test.ts
@@ -50,7 +50,7 @@ function asOneLine(screen: string): string {
     .replaceAll(/\s+/gu, " ");
 }
 
-/** The bare command: no verb, no `--url`, and no `EGMA_URL` in the shell. */
+/** The bare command: no verb, and no `--url`, which is the one way to say one. */
 function bareWizard(): TerminalRun {
   const args = [CLI_ENTRY, "--cwd", workspace.dir];
   expect(args).not.toContain("--url");
@@ -58,7 +58,6 @@ function bareWizard(): TerminalRun {
     // The stand-in for egma's own address. Nothing here dials the real one.
     EGMA_TEST_DEFAULT_URL: platform.url,
   });
-  expect(env.EGMA_URL).toBeUndefined();
 
   return runInTerminal({
     command: process.execPath,
@@ -81,13 +80,12 @@ describe("the wizard's first screen", () => {
         "[enter] begin",
       );
 
-      // The address, and the two ways to name a different one. This is the
+      // The address, and the one way to name a different one. This is the
       // screen the keystroke of consent is taken on: nothing else stands
       // between reading it and agreeing to the walk.
       const said = asOneLine(screen);
       expect(said).toContain("--url <address>");
-      expect(said).toContain("EGMA_URL");
-      // And the seam that stands the address in is not offered as a third way.
+      // And the seam that stands the address in is not offered as a second way.
       expect(said).not.toContain("EGMA_TEST_DEFAULT_URL");
 
       // Nothing has been asked of that address. The whole reason the screen is

--- a/apps/cli/test/intro-screen.test.ts
+++ b/apps/cli/test/intro-screen.test.ts
@@ -14,6 +14,7 @@ import process from "node:process";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createEgmaFolder } from "../src/folder/egma-folder.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
 import { runInTerminal, showingIn, type TerminalRun } from "./support/pty.ts";
 import {
@@ -68,6 +69,36 @@ function bareWizard(): TerminalRun {
   });
 }
 
+/**
+ * The same bare command, in a repository that has committed its platform.
+ *
+ * The stand-in for egma's own address is left as the closed port every
+ * workspace hands over, so the address this screen names can only have come out
+ * of the committed file.
+ */
+async function wizardInBoundRepository(): Promise<TerminalRun> {
+  await createEgmaFolder({
+    repository: workspace.dir,
+    config: {
+      platform: { origin: platform.url, instance: platform.instanceId },
+      agent: null,
+      connection: null,
+      suite: null,
+    },
+  });
+
+  const args = [CLI_ENTRY, "--cwd", workspace.dir];
+  expect(args).not.toContain("--url");
+
+  return runInTerminal({
+    command: process.execPath,
+    args: [...args, "--", process.execPath, FAKE_AGENT, "no-script"],
+    cwd: workspace.dir,
+    env: workspace.env(),
+    cols: 100,
+  });
+}
+
 describe("the wizard's first screen", () => {
   it("names the egma it will use, and says how to choose another", async () => {
     const terminal = bareWizard();
@@ -100,6 +131,38 @@ describe("the wizard's first screen", () => {
           platform.records.some((record) => record.path === "/api/platform"),
         ),
       ).toBe(true);
+    } finally {
+      await terminal.kill();
+    }
+  });
+
+  /**
+   * A bound repository is offered the change it can actually make.
+   *
+   * `--url <address>` naming another platform is refused, with the whole move
+   * block under it, once a repository has committed one. Offering it here would
+   * be egma sending a developer to a command egma turns away — and offering it
+   * from the screen that takes the keystroke of consent is the worst place in
+   * the product to be wrong about what happens next.
+   */
+  it("offers a bound repository the edit it can make, not a flag egma refuses", async () => {
+    const terminal = await wizardInBoundRepository();
+    try {
+      const screen = await showingIn(terminal, asOneLine, platform.url, "[enter] begin");
+      const said = asOneLine(screen);
+
+      // The address came out of the committed file: the built-in address is
+      // stood aside by a closed port for this run, so nothing else could
+      // have named it.
+      expect(said).toContain(platform.url);
+
+      // The change a bound repository can make is an edit to the file it
+      // already commits, and that is what is offered.
+      expect(said).toContain("egma/config.yaml");
+      expect(said).not.toContain("--url <address>");
+
+      // Still before anything is asked of that address, exactly as above.
+      expect(platform.records).toEqual([]);
     } finally {
       await terminal.kill();
     }

--- a/apps/cli/test/key-custody.test.ts
+++ b/apps/cli/test/key-custody.test.ts
@@ -224,10 +224,9 @@ describe("a whole run, swept afterwards", () => {
   });
 
   it("never appears in the process table while the command is running", async () => {
-    const child = spawn(process.execPath, [CLI_ENTRY, "connect"], {
+    const child = spawn(process.execPath, [CLI_ENTRY, "connect", "--url", platform.url], {
       cwd: workspace.dir,
       env: workspace.env({
-        EGMA_URL: platform.url,
         EGMA_RETELL_URL: retell.url,
         EGMA_RETELL_API_KEY: KEY,
         EGMA_REACH: "text",

--- a/apps/cli/test/login-command.test.ts
+++ b/apps/cli/test/login-command.test.ts
@@ -127,7 +127,7 @@ describe("egma login", () => {
 
   it("does not use the most recent login as the next command's target", async () => {
     // A self-hoster selects the platform for this command.
-    const first = await egma(["login"], { EGMA_URL: platform.url });
+    const first = await egma(["login", "--url", platform.url]);
     expect(first.code).toBe(0);
     expect(facts(first.stdout).status).toBe("stored");
 
@@ -303,10 +303,13 @@ describe("egma login", () => {
     expect(help.stdout).toContain("4 egma did not answer, or refused");
   });
 
-  it("names the two things a self-hoster sets, in the help", async () => {
+  it("names what a self-hoster sets, in the help", async () => {
     const help = await egma(["--help"]);
 
-    expect(help.stdout).toContain("EGMA_URL");
+    // Which egma is said on the command and nowhere else, so the flag is the
+    // whole of that half. What is left in the environment is where the key it
+    // brings back is kept.
+    expect(help.stdout).toContain("--url <address>");
     expect(help.stdout).toContain("EGMA_HOME");
     expect(help.stdout).toContain("--force");
   });

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -504,10 +504,14 @@ describe("which egma a command talks to", () => {
    * variable is inert means naming it.
    */
   it("offers one way to name a platform, and names the old one nowhere", async () => {
+    // Everything `package.json` puts in the published package, plus the
+    // repository's own front page. `dist` is left out because it is `src`
+    // compiled, and a scan of both would go red twice for one mention.
     const written = [
       ...(await filesIn(path.join(CLI_PACKAGE, "src"))),
       ...(await filesIn(path.join(CLI_PACKAGE, "skills"))),
       ...(await filesIn(path.join(CLI_PACKAGE, "smoke"))),
+      path.join(CLI_PACKAGE, "NOTICE"),
       path.join(CLI_PACKAGE, "README.md"),
       path.join(CLI_PACKAGE, "..", "..", "README.md"),
     ];

--- a/apps/cli/test/login.test.ts
+++ b/apps/cli/test/login.test.ts
@@ -19,6 +19,7 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -424,24 +425,25 @@ describe("which egma a command talks to", () => {
   // never says which address ships. That is asserted in one place, on its own.
   const BUILT_IN = "http://built-in.example";
 
-  it("takes the flag, then the environment, then the binding, then egma's own", () => {
+  /** The published package, whose every written word is egma's to a reader. */
+  const CLI_PACKAGE = fileURLToPath(new URL("..", import.meta.url));
+
+  /** Every file under a folder, as full paths. */
+  async function filesIn(folder: string): Promise<readonly string[]> {
+    const entries = await readdir(folder, { recursive: true, withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => path.join(entry.parentPath, entry.name));
+  }
+
+  it("takes the flag, then the binding, then egma's own", () => {
     expect(
       resolvePlatformUrl({
         flag: "http://flag.example/",
-        env: "http://env.example",
         binding: "http://bound.example",
         fallback: BUILT_IN,
       }),
     ).toBe("http://flag.example");
-
-    expect(
-      resolvePlatformUrl({
-        flag: null,
-        env: "http://env.example",
-        binding: "http://bound.example",
-        fallback: BUILT_IN,
-      }),
-    ).toBe("http://env.example");
 
     // The repository, not the latest login on the machine, is what makes the
     // selection stable after onboarding.
@@ -452,18 +454,18 @@ describe("which egma a command talks to", () => {
     // Nothing names a platform, so egma uses its own. This is the step ADR-0008
     // always had and the tree could not have while there was no hosted egma to
     // point at.
-    expect(resolvePlatformUrl({ flag: null, env: "", binding: null, fallback: BUILT_IN })).toBe(
+    expect(resolvePlatformUrl({ flag: null, binding: null, fallback: BUILT_IN })).toBe(
       BUILT_IN,
     );
 
-    // And it really is last: each of the three deliberate places still wins
-    // over it on its own.
+    // And it really is last: each of the two deliberate places still wins over
+    // it on its own.
     expect(resolvePlatformUrl({ flag: "http://flag.example", fallback: BUILT_IN })).toBe(
       "http://flag.example",
     );
-    expect(
-      resolvePlatformUrl({ flag: null, env: "http://env.example", fallback: BUILT_IN }),
-    ).toBe("http://env.example");
+    expect(resolvePlatformUrl({ binding: "http://bound.example", fallback: BUILT_IN })).toBe(
+      "http://bound.example",
+    );
   });
 
   it("refuses an address that is not one, and names where it came from", () => {
@@ -473,22 +475,51 @@ describe("which egma a command talks to", () => {
       expect(() =>
         resolvePlatformUrl({ flag: given, fallback: BUILT_IN }),
       ).toThrow(UnusableUrlError);
-      expect(() =>
-        resolvePlatformUrl({ flag: null, env: given, fallback: BUILT_IN }),
-      ).toThrow(UnusableUrlError);
     }
 
     expect(() =>
       resolvePlatformUrl({ flag: "ftp://egma.example", fallback: BUILT_IN }),
     ).toThrow(/--url/u);
-    expect(() =>
-      resolvePlatformUrl({ flag: null, env: "ftp://egma.example", fallback: BUILT_IN }),
-    ).toThrow(/EGMA_URL/u);
 
     // A committed binding is never stepped over in favour of egma's own.
     expect(() =>
       resolvePlatformUrl({ flag: null, binding: "javascript:alert(1)", fallback: BUILT_IN }),
     ).toThrow(/repository platform binding/u);
+  });
+
+  /**
+   * One explicit way, and the second one really gone.
+   *
+   * `EGMA_URL` was a whole-shell name for `--url`, and taking the rung out of
+   * resolution is only half of taking it out: a `--help` line, a README
+   * paragraph or a refusal that still tells somebody to set it is a setting
+   * egma no longer has, offered by egma. The one that would have survived a
+   * careful edit is the refusal — "Remove --url or EGMA_URL" is the sentence a
+   * developer meets at the exact moment they are least able to tell that half
+   * of it is fiction.
+   *
+   * So the whole of what egma ships is scanned rather than the places anybody
+   * remembered — the help text and every refusal are inside `src/`, so both are
+   * covered by reading it. The checks themselves are not scanned: proving the
+   * variable is inert means naming it.
+   */
+  it("offers one way to name a platform, and names the old one nowhere", async () => {
+    const written = [
+      ...(await filesIn(path.join(CLI_PACKAGE, "src"))),
+      ...(await filesIn(path.join(CLI_PACKAGE, "skills"))),
+      ...(await filesIn(path.join(CLI_PACKAGE, "smoke"))),
+      path.join(CLI_PACKAGE, "README.md"),
+      path.join(CLI_PACKAGE, "..", "..", "README.md"),
+    ];
+    expect(written.length).toBeGreaterThan(20);
+
+    const naming: string[] = [];
+    for (const file of written) {
+      if ((await readFile(file, "utf8")).includes("EGMA_URL")) {
+        naming.push(path.relative(CLI_PACKAGE, file));
+      }
+    }
+    expect(naming).toEqual([]);
   });
 });
 

--- a/apps/cli/test/platform-binding-process.test.ts
+++ b/apps/cli/test/platform-binding-process.test.ts
@@ -1,7 +1,7 @@
 /**
  * Every later headless command, as a real CLI process, follows the committed
- * repository binding with no flag or environment URL to help it — and the
- * refusal that keeps it there arrives whole in a real terminal.
+ * repository binding with no flag to help it — and the refusal that keeps it
+ * there arrives whole in a real terminal.
  */
 
 import { spawn } from "node:child_process";
@@ -115,8 +115,10 @@ describe("commands after a repository is bound", () => {
     extra: NodeJS.ProcessEnv = {},
   ): Promise<CommandResult> {
     const env = workspace.env({ EGMA_RETELL_URL: retell.url, ...extra });
+    // Nothing names a platform, which is what leaves the committed binding to
+    // choose one — asserted rather than assumed, because a flag here would make
+    // every claim below vacuous.
     expect(args).not.toContain("--url");
-    expect(env.EGMA_URL).toBeUndefined();
     return runEgma({ cwd: workspace.dir, env }, args);
   }
 
@@ -196,7 +198,7 @@ describe("commands after a repository is bound", () => {
     const grading = gradeEveryRun(bound);
     let wizard: CommandResult;
     try {
-      // No verb and no platform selector: this is the wizard, with headless
+      // No verb and no platform named: this is the wizard, with headless
       // consent only so a real terminal is not needed in CI.
       wizard = await command(
         ["--headless", "--", process.execPath, FAKE_AGENT, script],

--- a/apps/cli/test/platform-binding-real.test.ts
+++ b/apps/cli/test/platform-binding-real.test.ts
@@ -186,7 +186,6 @@ it("refuses a repository bound to another real local platform before sending its
     // No flag: the committed binding chooses the address, and what answers
     // there is not the platform that issued anything in this folder.
     const env = workspace.env();
-    expect(env.EGMA_URL).toBeUndefined();
     const result = await egma(["run", "--cwd", workspace.dir, "--no-follow"], {
       cwd: workspace.dir,
       env,
@@ -358,9 +357,8 @@ it("refuses when the bound real platform is down, and reaches no other platform"
     await workspace.signIn(stillRunning.origin, otherCustomer.secret);
     observed.length = 0;
 
-    // No flag and no environment URL: this is the repository binding alone.
+    // No flag: this is the repository binding alone.
     const env = workspace.env();
-    expect(env.EGMA_URL).toBeUndefined();
     const result = await egma(["run", "--cwd", workspace.dir, "--no-follow"], {
       cwd: workspace.dir,
       env,

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -243,20 +243,22 @@ describe("verifying an Egma platform", () => {
     ]);
   });
 
-  it("takes the explicit URL before EGMA_URL, then verifies the selected instance", async () => {
-    const ambient = await startPlatform();
+  it("takes the explicit URL before egma's own, then verifies the selected instance", async () => {
+    const built = await startPlatform();
     try {
       const access = await resolvePlatformAccess({
-        env: workspace.env({ EGMA_URL: ambient.url }),
+        // The step below the flag, stood in for. Nothing else names a platform:
+        // this repository has no folder, so the flag is against the last step.
+        env: workspace.env({ EGMA_TEST_DEFAULT_URL: built.url }),
         flag: platform.url,
         cwd: workspace.dir,
       });
 
       expect(access.url).toBe(platform.url);
       expect(platform.records.map((record) => record.path)).toEqual(["/api/platform"]);
-      expect(ambient.records).toEqual([]);
+      expect(built.records).toEqual([]);
     } finally {
-      await ambient.close();
+      await built.close();
     }
   });
 
@@ -413,9 +415,10 @@ describe("verifying an Egma platform", () => {
       // answer". The spec's own further notes rely on a developer being told
       // about a redirect.
       expect(refusal.message, shape.what).toContain(shape.says);
-      // The one move that is theirs is always offered.
+      // The one move that is theirs is always offered — and it is one move,
+      // because naming a platform on the command is the only way to name one.
       expect(refusal.message, shape.what).toContain("--url <address>");
-      expect(refusal.message, shape.what).toContain("EGMA_URL");
+      expect(refusal.message, shape.what).not.toContain("EGMA_URL");
       expect(refusal.message, shape.what).toContain("Nothing was sent");
 
       // Not the underlying advice: none of it is the developer's to act on.

--- a/apps/cli/test/platform-identity.test.ts
+++ b/apps/cli/test/platform-identity.test.ts
@@ -232,6 +232,20 @@ describe("verifying an Egma platform", () => {
     );
     expect(refusal).toBeInstanceOf(PlatformBindingMismatchError);
 
+    // Both identities, because which one is which is the whole of what
+    // happened: the one the repository recorded, and the one answering now.
+    expect(refusal.message).toContain("pf_01K3XQ7M4E8YB2FVN0H9TZQWEA");
+    expect(refusal.message).toContain(platform.instanceId);
+
+    // And no flag anywhere in it. Nothing a developer typed can be the cause
+    // here — an address that is not the bound one was refused before anybody
+    // was asked, and the same address is the same address — so the only way to
+    // arrive is the platform at the recorded address having changed. Telling
+    // somebody to remove a flag is unfollowable at the one moment this fires,
+    // and it fires when they have least idea why.
+    expect(refusal.message).not.toContain("--url");
+    expect(refusal.message).toContain("edit the platform instance in egma/config.yaml");
+
     // A rebuilt stack is the same repository meeting a platform that issued
     // none of its identifiers, which is the move whether the developer meant
     // it or not — so this refusal teaches it too.

--- a/apps/cli/test/platform-onboarding-process.test.ts
+++ b/apps/cli/test/platform-onboarding-process.test.ts
@@ -84,7 +84,6 @@ it("verifies an explicitly selected platform and commits its identity on first o
       EGMA_RETELL_API_KEY: PROVIDER_KEY,
       EGMA_REACH: "text",
     });
-    expect(env.EGMA_URL).toBeUndefined();
 
     const grading = gradeEveryRun(platform);
     let stdout = "";

--- a/apps/cli/test/pull-push.test.ts
+++ b/apps/cli/test/pull-push.test.ts
@@ -23,6 +23,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createEgmaFolder,
   parseMockToolsFile,
+  readConfig,
 } from "../src/folder/egma-folder.ts";
 import { startPlatform, type Platform } from "./support/fixture-platform/index.ts";
 import { CLI_ENTRY, makeWorkspace, type Workspace } from "./support/workspace.ts";
@@ -49,17 +50,32 @@ afterEach(async () => {
 
 type Result = { stdout: string; stderr: string; code: number };
 
-async function egma(args: readonly string[], env: NodeJS.ProcessEnv = {}): Promise<Result> {
+/** The built command, exactly as the words are given, ended rather than thrown. */
+async function runEgma(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = {},
+): Promise<Result> {
   try {
     const { stdout, stderr } = await run(process.execPath, [CLI_ENTRY, ...args], {
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url, ...env }),
+      env: workspace.env(env),
     });
     return { stdout, stderr, code: 0 };
   } catch (error) {
     const failure = error as { stdout?: string; stderr?: string; code?: number };
     return { stdout: failure.stdout ?? "", stderr: failure.stderr ?? "", code: failure.code ?? 1 };
   }
+}
+
+/**
+ * The same command, pointed at the fixture platform on every invocation.
+ *
+ * `--url` on each one rather than a shell that names it once: one explicit way
+ * to name a platform per invocation is the whole order, so a check that reached
+ * this platform any other way would be checking something egma does not offer.
+ */
+async function egma(args: readonly string[], env: NodeJS.ProcessEnv = {}): Promise<Result> {
+  return runEgma(["--url", platform.url, ...args], env);
 }
 
 /** Every printed line as the pair it is, in order, repeats and all. */
@@ -172,8 +188,10 @@ function freshFile(input: {
 }
 
 describe("egma init", () => {
+  const configFile = (): string => path.join(workspace.dir, "egma", "config.yaml");
+
   it("makes a folder whose every file is committable as it stands", async () => {
-    const result = await egma([
+    const result = await runEgma([
       "init",
       "--agent",
       "receptionist",
@@ -218,26 +236,182 @@ describe("egma init", () => {
   });
 
   it("recognises a folder that is already here, and touches nothing in it", async () => {
-    await egma(["init", "--agent", "receptionist"]);
-    const before = await readFile(path.join(workspace.dir, "egma", "config.yaml"), "utf8");
+    await runEgma(["init", "--agent", "receptionist"]);
+    const before = await readFile(configFile(), "utf8");
 
-    const again = await egma(["init", "--agent", "something-else"]);
+    const again = await runEgma(["init", "--agent", "something-else"]);
 
     expect(again.code).toBe(0);
     expect(factOf(again.stdout, "status")).toBe("already-there");
-    expect(await readFile(path.join(workspace.dir, "egma", "config.yaml"), "utf8")).toBe(before);
+    expect(await readFile(configFile(), "utf8")).toBe(before);
   });
 
-  it("needs no key, because nothing in it talks to egma", async () => {
+  it("needs no key and no network, because on its own it talks to nobody", async () => {
     const nowhere = await makeWorkspace();
     try {
       const result = await run(process.execPath, [CLI_ENTRY, "init"], {
         cwd: nowhere.dir,
+        // Every stand-in this workspace holds is a closed port, so a command
+        // that reached for any address at all would fail here rather than pass.
         env: nowhere.env(),
       });
       expect(result.stdout).toContain("status: created");
+      // And it names no platform, which is what makes the folder above safe to
+      // make before anybody has decided which egma this repository is on.
+      expect(
+        (await readConfig(path.join(nowhere.dir, "egma", "config.yaml"))).platform,
+      ).toBeNull();
+      expect(platform.records).toEqual([]);
     } finally {
       await nowhere.remove();
+    }
+  });
+
+  /**
+   * The one binding a repository can gain before anybody has signed in.
+   *
+   * The identity contract is unauthenticated by design, so `init` can ask an
+   * address who it is and commit the answer with no key in existence — which is
+   * what lets a developer who knows their platform's address say it once, here,
+   * instead of on every command afterwards.
+   */
+  it("writes the whole binding when the command names an address", async () => {
+    const result = await runEgma(["init", "--url", platform.url, "--agent", "receptionist"]);
+
+    expect(result.code, result.stderr).toBe(0);
+    expect(factOf(result.stdout, "url")).toBe(platform.url);
+    expect(factOf(result.stdout, "platform")).toBe(platform.instanceId);
+    expect(factOf(result.stdout, "status")).toBe("created");
+    expect((await readConfig(configFile())).platform).toEqual({
+      origin: platform.url,
+      instance: platform.instanceId,
+    });
+
+    // One question, and it is the public one that carries nothing. No key
+    // exists yet and none was needed.
+    expect(platform.records.map((record) => `${record.method} ${record.path}`)).toEqual([
+      "GET /api/platform",
+    ]);
+  });
+
+  it("leaves the committed binding byte for byte the same when it is run again", async () => {
+    await runEgma(["init", "--url", platform.url, "--agent", "receptionist"]);
+    const before = await readFile(configFile(), "utf8");
+
+    const again = await runEgma(["init", "--url", platform.url, "--agent", "receptionist"]);
+
+    expect(again.code, again.stderr).toBe(0);
+    expect(factOf(again.stdout, "status")).toBe("already-there");
+    expect(await readFile(configFile(), "utf8")).toBe(before);
+    expect((await readConfig(configFile())).platform).toEqual({
+      origin: platform.url,
+      instance: platform.instanceId,
+    });
+  });
+
+  /**
+   * The one thing a second run does change, and the reason it has to.
+   *
+   * A folder somebody else committed before this repository was on any platform
+   * is how a teammate ordinarily arrives: the folder is there, nothing in it
+   * names an egma, and `init --url` is what they are told to run. Recognising
+   * the folder and dropping the flag would be the silent no-op this command
+   * used to be, moved one case along.
+   */
+  it("binds a folder that was already here and named no platform", async () => {
+    await runEgma(["init", "--agent", "receptionist"]);
+    expect((await readConfig(configFile())).platform).toBeNull();
+
+    const bound = await runEgma(["init", "--url", platform.url]);
+
+    expect(bound.code, bound.stderr).toBe(0);
+    expect(factOf(bound.stdout, "status")).toBe("already-there");
+    expect(factOf(bound.stdout, "platform")).toBe(platform.instanceId);
+
+    const held = await readConfig(configFile());
+    expect(held.platform).toEqual({
+      origin: platform.url,
+      instance: platform.instanceId,
+    });
+    // And nothing else in the file moved: the name the first run wrote is the
+    // name that is still there.
+    expect(held.agent).toEqual({ name: "receptionist", id: null });
+    // Said out loud, because "already-there" on its own would read as a run
+    // that changed nothing.
+    expect(bound.stdout).toContain("note: the folder was already here, and gained the platform");
+  });
+
+  /**
+   * `init` is safe to run again, and that is not a licence to rebind.
+   *
+   * The flag naming another platform is how somebody says they want to move,
+   * and no command performs that move — so this is the same refusal every other
+   * verb answers it with, met here because `init --url` resolves through the
+   * same path they do rather than through one of its own.
+   */
+  it("refuses to move a folder that is already bound somewhere else", async () => {
+    const elsewhere = await startPlatform();
+    try {
+      await runEgma(["init", "--url", platform.url]);
+      const before = await readFile(configFile(), "utf8");
+
+      const refused = await runEgma(["init", "--url", elsewhere.url]);
+
+      expect(refused.code).toBe(4);
+      expect(refused.stdout).toContain("status: refused");
+      expect(refused.stderr).toContain("egma does not move a repository between platforms");
+      expect(await readFile(configFile(), "utf8")).toBe(before);
+      // Neither platform was asked so much as who it is: the file decided.
+      expect(elsewhere.records).toEqual([]);
+    } finally {
+      await elsewhere.close();
+    }
+  });
+
+  /**
+   * **Never a partial binding.** `bound` has to keep meaning `verified`, so an
+   * address that cannot say who it is leaves nothing behind at all — not an
+   * origin waiting for an instance, and not an empty folder either. Anything
+   * less would be a state somebody has to reason about for the rest of the
+   * product's life.
+   */
+  it("refuses an address that does not answer, and leaves no folder behind", async () => {
+    const dead = "http://127.0.0.1:1";
+
+    const refused = await runEgma(["init", "--url", dead]);
+
+    expect(refused.code).toBe(4);
+    expect(refused.stdout).toContain("status: unreachable");
+    expect(refused.stderr).toContain(dead);
+    await expect(stat(path.join(workspace.dir, "egma"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  /**
+   * The address-check refusal, met at the one moment it costs nothing.
+   *
+   * A platform that answers to an address other than the one it was asked at is
+   * a service door — the API's own origin, or a deployment whose `EGMA_BASE_URL`
+   * is not the address people reach it at. Binding to it would commit an origin
+   * every teammate who clones this repository would fail to reach.
+   */
+  it("refuses a platform that names an address other than the one asked", async () => {
+    const canonicalOrigin = "https://canonical.egma.example";
+    const alias = await startPlatform({ canonicalOrigin });
+    try {
+      const refused = await runEgma(["init", "--url", alias.url]);
+
+      expect(refused.code).toBe(4);
+      expect(refused.stdout).toContain("status: refused");
+      expect(refused.stderr).toContain(canonicalOrigin);
+      expect(refused.stderr).toContain("EGMA_BASE_URL");
+      expect(refused.stderr).toContain("Nothing was sent");
+      await expect(stat(path.join(workspace.dir, "egma"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await alias.close();
     }
   });
 });
@@ -1039,9 +1213,9 @@ describe("both verbs, run with nobody watching", () => {
     platform.tests.add({ name: "one", scenario: "s", expectedBehaviors: ["b"] });
     await makeFolder();
 
-    const child = spawn(process.execPath, [CLI_ENTRY, "pull"], {
+    const child = spawn(process.execPath, [CLI_ENTRY, "pull", "--url", platform.url], {
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -1133,7 +1307,10 @@ describe("both verbs, run with nobody watching", () => {
    */
   it("never print the key, and never write it into the folder", async () => {
     platform.tests.add({ name: "one", scenario: "s", expectedBehaviors: ["b"] });
-    await egma(["init", "--agent", "receptionist"]);
+    // The folder, and deliberately no binding with it: what is under check
+    // below includes an egma that does not answer, and a bound repository
+    // would be refused for naming another address before it ever got there.
+    await runEgma(["init", "--agent", "receptionist"]);
     await egma(["pull"]);
 
     // A conflict, a refusal at the door, and an egma that does not answer.
@@ -1175,7 +1352,8 @@ describe("both verbs, run with nobody watching", () => {
     const BANNED = ["organization", "organisation", "project", "tenant"];
 
     platform.tests.add({ name: "one", scenario: "s", expectedBehaviors: ["b"] });
-    await egma(["init", "--agent", "receptionist"]);
+    // The folder alone: `init` needs no platform, so it is given none.
+    await runEgma(["init", "--agent", "receptionist"]);
     await egma(["pull"]);
     platform.tests.editInDashboard("one", { scenario: "s, changed" });
 

--- a/apps/cli/test/pull-push.test.ts
+++ b/apps/cli/test/pull-push.test.ts
@@ -310,6 +310,27 @@ describe("egma init", () => {
   });
 
   /**
+   * What the `platform:` line is a fact about, which is the repository.
+   *
+   * A developer — or a coding agent — running `init` in a folder somebody else
+   * committed is asking what this repository points at, and whether it is bound
+   * is part of the answer whether or not this run had anything to do with it.
+   * The `url:` line is the other half and stays absent: this run reached no
+   * address, and a command that talked to nobody must not print one.
+   */
+  it("reports the binding a bound folder already had, and reaches nothing", async () => {
+    await runEgma(["init", "--url", platform.url]);
+    const before = platform.records.length;
+
+    const again = await runEgma(["init"]);
+
+    expect(again.code, again.stderr).toBe(0);
+    expect(factOf(again.stdout, "platform")).toBe(platform.instanceId);
+    expect(factOf(again.stdout, "url")).toBeUndefined();
+    expect(platform.records.slice(before)).toEqual([]);
+  });
+
+  /**
    * The one thing a second run does change, and the reason it has to.
    *
    * A folder somebody else committed before this repository was on any platform

--- a/apps/cli/test/run-command.test.ts
+++ b/apps/cli/test/run-command.test.ts
@@ -661,9 +661,9 @@ describe("egma run, as the built command", () => {
     await makeFolder(registered);
     await seed(["quoted-a-price", "open-on-sunday"]);
 
-    const { stdout } = await run(process.execPath, [CLI_ENTRY, "run", "--no-follow"], {
+    const { stdout } = await run(process.execPath, [CLI_ENTRY, "run", "--url", platform.url, "--no-follow"], {
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
     });
 
     const lines = stdout.trimEnd().split("\n");
@@ -685,9 +685,9 @@ describe("egma run, as the built command", () => {
     await makeFolder(registered);
     await seed(["quoted-a-price", "open-on-sunday"]);
 
-    const command = run(process.execPath, [CLI_ENTRY, "run"], {
+    const command = run(process.execPath, [CLI_ENTRY, "run", "--url", platform.url], {
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
     });
 
     await scriptOnceStarted([

--- a/apps/cli/test/run-screen.test.ts
+++ b/apps/cli/test/run-screen.test.ts
@@ -144,6 +144,8 @@ async function toTheRun(cols = 100): Promise<TerminalRun> {
     command: process.execPath,
     args: [
       CLI_ENTRY,
+      "--url",
+      platform.url,
       "--cwd",
       workspace.dir,
       "--coding-agent",
@@ -155,7 +157,6 @@ async function toTheRun(cols = 100): Promise<TerminalRun> {
     ],
     cwd: workspace.dir,
     env: workspace.env({
-      EGMA_URL: platform.url,
       EGMA_RETELL_URL: retell?.url ?? "",
       EGMA_RETELL_API_KEY: KEY,
       // The home a global skill would land in. Never the real one.

--- a/apps/cli/test/support/workspace.ts
+++ b/apps/cli/test/support/workspace.ts
@@ -158,12 +158,9 @@ export async function makeWorkspace(
         EGMA_TEST_DEFAULT_URL: NO_DEFAULT_PLATFORM,
         ...extra,
       };
-      // Whatever the person running the suite has set, a check talks to the
-      // egma it is checking against and to nothing else. Removed rather than
-      // set to nothing: a pseudo-terminal turns an unset value into the word.
-      if (extra.EGMA_URL === undefined) delete env.EGMA_URL;
-      // And a key the person running the suite happens to have in their shell
-      // is not a key any check may use.
+      // A key the person running the suite happens to have in their shell is
+      // not a key any check may use. Removed rather than set to nothing: a
+      // pseudo-terminal turns an unset value into the word.
       if (extra.EGMA_RETELL_API_KEY === undefined) delete env.EGMA_RETELL_API_KEY;
       if (extra.RETELL_API_KEY === undefined) delete env.RETELL_API_KEY;
       if (extra.EGMA_RETELL_AGENT_ID === undefined) delete env.EGMA_RETELL_AGENT_ID;

--- a/apps/cli/test/teaching.test.ts
+++ b/apps/cli/test/teaching.test.ts
@@ -197,9 +197,19 @@ describe("the pane, while the files land", () => {
 
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+      env: workspace.env({ EGMA_RETELL_URL: retell.url }),
       // Wide, because the ending under check here is lines rather than
       // sentences. A terminal wraps whatever will not fit, and a check that
       // read a wrapped line as two would be checking the terminal's width and
@@ -297,9 +307,19 @@ describe("the pane, while the files land", () => {
 
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url, EGMA_RETELL_URL: retell.url }),
+      env: workspace.env({ EGMA_RETELL_URL: retell.url }),
       cols: 64,
     });
 

--- a/apps/cli/test/tui.test.ts
+++ b/apps/cli/test/tui.test.ts
@@ -54,9 +54,19 @@ describe("the wizard on a real terminal", () => {
 
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
     });
 
     try {
@@ -109,9 +119,19 @@ describe("the wizard on a real terminal", () => {
 
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
     });
 
     try {
@@ -147,9 +167,19 @@ describe("the wizard on a real terminal", () => {
 
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
     });
 
     try {
@@ -171,9 +201,19 @@ describe("the wizard on a real terminal", () => {
 
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
     });
 
     try {
@@ -200,9 +240,19 @@ describe("the wizard on a real terminal", () => {
 
     const terminal = runInTerminal({
       command: process.execPath,
-      args: [CLI_ENTRY, "--cwd", workspace.dir, "--", process.execPath, FAKE_AGENT, script],
+      args: [
+        CLI_ENTRY,
+        "--url",
+        platform.url,
+        "--cwd",
+        workspace.dir,
+        "--",
+        process.execPath,
+        FAKE_AGENT,
+        script,
+      ],
       cwd: workspace.dir,
-      env: workspace.env({ EGMA_URL: platform.url }),
+      env: workspace.env(),
     });
 
     try {

--- a/apps/cli/test/walk.test.ts
+++ b/apps/cli/test/walk.test.ts
@@ -352,6 +352,7 @@ describe("one task, driven on a scripted agent", () => {
       signal: new AbortController().signal,
       platform: {
         url: "http://named-before-it-is-asked.example",
+        bound: false,
         verify: () => {
           asked += 1;
           return Promise.reject(new Error("this platform did not answer"));


### PR DESCRIPTION
Platform resolution loses a rung and `egma init` gains the one it was already accepting.

```
--url  →  platform binding  →  built-in address
```

One explicit way to name a platform per invocation. One committed way per repository. One default.

## `egma init --url <address>` binds the repository

It accepted `--url` before and silently dropped it — `--url` is global, so `init` took it, then wrote `platform: null` unconditionally and returned before any platform was chosen. A developer who did exactly the right thing got nothing and was told nothing.

Now it asks the address for its public identity contract and writes `{origin, instance}` into `egma/config.yaml`. The contract is unauthenticated by design, so no login is needed to bind.

**It writes a whole binding or none at all.** Verification runs before anything touches the disk, so an address that does not answer leaves no `egma/` folder behind at all — not even an empty one. There is no `{origin}`-without-`{instance}` state to reason about later, because `bound` has to keep meaning `verified`.

Plain `init` is unchanged: offline, `platform: null`, works with the network cable out.

It also binds a folder that was already here and named no platform — beyond the ticket's literal text, and stated here rather than left to be discovered. It goes through `bindRepositoryPlatform`, the same door `connect` binds through, so the guard on retained identifiers still applies: a repository holding another platform's **agent**, **connection** or **suite** ids refuses, and refuses *before contacting anything*.

## `EGMA_URL` is gone

The CLI's own help called it "Same as `--url`", and above the binding it could only ever name the platform a repository was already on. It leaves the resolution order, the help text, both READMEs, the wizard's consent screen, and the refusal messages.

`EGMA_TEST_DEFAULT_URL` is untouched — different variable, different job, still undocumented.

**Two costs, stated rather than discovered.** A shell-wide name is genuinely lost: CI jobs and containers now pass `--url` per invocation. And this is breaking for `@egma/cli` if that publishes first.

## What review changed

An independent review found four sentences that were false, and one gap. All fixed:

- **`PlatformBindingMismatchError` named a flag that can never be its cause.** It said "Remove `--url`", but it only fires when the selected address *is* the bound origin — so there is either no flag to remove or removing it changes nothing. A self-hoster whose instance is rebuilt met an instruction they could not follow. It now says what happened: the address held still and the platform at it changed.
- **The wizard's consent screen offered a move a bound repository refuses.** It told everyone to quit and re-run with `--url`, which is then refused. Whether the address came from `egma/config.yaml` now travels with it, so the screen offers the edit that is actually available.
- **The `--help` claim about the `platform:` line was false** — written in this branch, about output added in this branch. It said the line appears with `--url`; it appears whenever the repository is bound.
- The `EGMA_URL` scan now covers `NOTICE`, which the package ships.

## Proof

Full suite, once, after the fixes: **158 files passed, 2483 tests passed, 4 skipped**, plus simulator 612, SDK 66, fixture 8. Zero failures.

Every new test was watched failing against the unfixed source before it passed — including one verified by stashing two files, rebuilding, and watching the refusal not fire. One new test passed on its first run and is called out as closing a coverage gap rather than fixing behaviour.

Recorded and deliberately not fixed here, as `cli-docs-drift` in the tracker: `apps/cli/README.md`'s hand-typed `## Options` snapshot has drifted on its own, and `real-whole-walk.ts` has a stale `init` assertion. The `--url` additions to that smoke walk are **unverified** — it needs Docker and a real browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BR47cXBaM7NkbTp764ecLX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789376028&installation_model_id=431960&pr_number=104&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F104&signature=188f05ed05bfdf662a5fe04b5abb8ff01a59f5d53ddb1229854bfac702b01227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes `EGMA_URL` from platform resolution and makes `egma init --url` verify and persist a complete repository platform binding before writing.

- Platform selection now resolves through an explicit `--url`, then the committed repository binding, then the built-in address.
- `init --url` verifies platform identity and binds both new and existing unbound repositories while preserving identifier guards.
- Wizard messaging now distinguishes repository-bound addresses from per-invocation or default addresses.
- Documentation, smoke checks, and focused platform-resolution tests are updated for the new contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security defects identified.

Platform verification precedes repository writes, binding guards remain centralized, plain initialization remains offline, and the revised selection order is consistently propagated through implementation, user guidance, and focused tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/commands/init.ts | Adds verified platform bindings to new or existing unbound repositories while preserving existing configuration and identifier guards. |
| apps/cli/src/main.ts | Routes `init --url` through ordinary platform selection and verification while retaining offline behavior for plain `init`. |
| apps/cli/src/platform/credentials.ts | Removes `EGMA_URL` from resolution and consistently applies the explicit flag, repository binding, and built-in fallback order. |
| apps/cli/src/ui/tui/screens/IntroScreen.tsx | Adjusts platform guidance according to whether the selected address came from the repository binding. |
| apps/cli/test/pull-push.test.ts | Adds extensive coverage for verified init binding, existing-folder behavior, refusals, and no-write failure paths. |
| apps/cli/test/hosted-default-process.test.ts | Verifies the revised resolution order and confirms that `EGMA_URL` no longer affects platform selection. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI invocation] --> B{Explicit --url?}
    B -->|Yes| C[Select explicit address]
    B -->|No| D{Repository binding?}
    D -->|Yes| E[Select bound origin]
    D -->|No| F[Select built-in address]
    C --> G{egma init?}
    E --> H[Verify selected platform]
    F --> H
    G -->|Yes| I[Verify public identity]
    G -->|No| H
    I --> J[Persist origin and instance binding]
    J --> K[Later commands use repository binding]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Say the true thing at each of the four p..."](https://github.com/egma-ai/egma/commit/cd195c901918c12a86aac46717f63eda5a3736f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53591919)</sub>

<!-- /greptile_comment -->