### PR TITLE
Tell a dead invitation from a live one, and prove the Settings scope note

### DIFF
--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { readJson, writeJson, type Refusal } from "../../../../../lib/api.ts";
+import { asDay } from "../../../../../lib/instants.ts";
 import { roleOf } from "../../../../../lib/me.ts";
 import {
   ASSIGNABLE_ROLES,
@@ -11,6 +12,7 @@ import {
   MEMBERS_PATH,
   memberActionPath,
   rowsIn,
+  standingOf,
   type Invitation,
   type InvitationList,
   type Member,
@@ -338,6 +340,13 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
  * **The link is the whole promise of this page on a self-hosted install.** A
  * form that quietly dropped it would leave somebody with an invitation that
  * exists and cannot be delivered, which is worse than a refusal.
+ *
+ * **An invitation whose day has passed is drawn as its own thing.** The list
+ * route answers with everything nobody has accepted, expired ones included, so
+ * a single "waiting to be accepted" list says something untrue about half of
+ * what is in it — and somebody reading it waits for a person who can no longer
+ * accept. The standing is said in words on the row, and the only thing to do
+ * about a dead invitation, sending another, is the only control it carries.
  */
 function Invitations({
   invitations,
@@ -357,8 +366,15 @@ function Invitations({
   const [link, setLink] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
 
-  async function invite(): Promise<void> {
-    if (busy || email.trim() === "") return;
+  /**
+   * One invitation asked for, whether the form asked for it or a dead row did.
+   *
+   * Both go through here so that sending again hands back the link on an
+   * install with no mail transport, exactly as the form does. A second path
+   * that dropped it would be the failure this page exists to avoid, arriving
+   * by the back door.
+   */
+  async function send(toEmail: string, atRole: string): Promise<boolean> {
     onRefused(null);
     setLink(null);
     setNote(null);
@@ -370,88 +386,142 @@ function Invitations({
       readonly accept_url?: string;
     }>(INVITATIONS_PATH, {
       method: "POST",
-      body: { email: email.trim(), role },
+      body: { email: toEmail, role: atRole },
     });
 
     onBusy(false);
     if (written.status === "signed-out") {
       window.location.replace("/sign-in");
-      return;
+      return false;
     }
     if (written.status !== "ready") {
       onRefused(written.refusal);
-      return;
+      return false;
     }
 
-    setEmail("");
     if (written.value.delivered) {
       setNote(`An invitation is on its way to ${written.value.email}.`);
     } else {
       setLink(written.value.accept_url ?? null);
     }
     onSent();
+    return true;
   }
 
-  return (
-    <Section
-      title="Invite somebody"
-      lead="If no mail transport is configured, egma gives you a one-time link to send yourself."
-    >
-      {note === null ? null : <Help>{note}</Help>}
-      {link === null ? null : (
-        <p>
-          <strong>Here is the link.</strong> It works once, for the person named
-          above. {link}
-        </p>
-      )}
+  async function invite(): Promise<void> {
+    if (busy || email.trim() === "") return;
+    if (await send(email.trim(), role)) setEmail("");
+  }
 
-      <Form onSubmit={() => void invite()}>
-        <FormRow>
-          <Field label="Email" htmlFor="invite-email">
-            <TextInput
-              id="invite-email"
-              value={email}
-              disabled={busy}
-              onChange={setEmail}
-            />
-          </Field>
-          <Field label="Role" htmlFor="invite-role">
-            <Select
-              id="invite-role"
-              value={role}
-              disabled={busy}
-              options={ASSIGNABLE_ROLES.map((one) => ({
-                value: one,
-                label: one,
-              }))}
-              onChange={setRole}
-            />
-          </Field>
-        </FormRow>
-        <FormActions>
+  const columns: readonly Column<Invitation>[] = [
+    {
+      key: "email",
+      header: "Person",
+      primary: true,
+      cell: (invitation) => invitation.email,
+    },
+    {
+      key: "role",
+      header: "Role",
+      cell: (invitation) => invitation.role,
+    },
+    {
+      key: "standing",
+      header: "Standing",
+      cell: (invitation) =>
+        standingOf(invitation) === "expired" ? (
+          <Badge tone="warn">Expired</Badge>
+        ) : (
+          <Badge>Pending</Badge>
+        ),
+    },
+    {
+      key: "expiry",
+      header: "Expiry",
+      mono: true,
+      cell: (invitation) => asDay(invitation.expires_at),
+    },
+    {
+      key: "actions",
+      header: "Actions",
+      // Nothing on a pending row: waiting is what it is for. An expired one
+      // cannot be waited on, so the one thing left to do about it is here.
+      cell: (invitation) =>
+        standingOf(invitation) === "expired" ? (
           <Button
-            weight="strong"
-            type="submit"
-            disabled={busy || email.trim() === ""}
+            disabled={busy}
+            onClick={() => void send(invitation.email, invitation.role)}
           >
-            {busy ? "Inviting…" : "Send invitation"}
+            Send again
           </Button>
-        </FormActions>
-      </Form>
+        ) : null,
+    },
+  ];
 
-      <h3>Waiting to be accepted</h3>
-      {invitations.length === 0 ? (
-        <p>No invitations are waiting.</p>
-      ) : (
-        <ul>
-          {invitations.map((invitation) => (
-            <li key={invitation.id}>
-              {invitation.email} · {invitation.role} · expires{" "}
-              {new Date(invitation.expires_at).toLocaleDateString()}
-            </li>
-          ))}
-        </ul>
-      )}
-    </Section>
+  return (
+    <>
+      <Section
+        title="Invite somebody"
+        lead="If no mail transport is configured, egma gives you a one-time link to send yourself."
+      >
+        {note === null ? null : <Help>{note}</Help>}
+        {link === null ? null : (
+          <p>
+            <strong>Here is the link.</strong> It works once, for the person named
+            above. {link}
+          </p>
+        )}
+
+        <Form onSubmit={() => void invite()}>
+          <FormRow>
+            <Field label="Email" htmlFor="invite-email">
+              <TextInput
+                id="invite-email"
+                value={email}
+                disabled={busy}
+                onChange={setEmail}
+              />
+            </Field>
+            <Field label="Role" htmlFor="invite-role">
+              <Select
+                id="invite-role"
+                value={role}
+                disabled={busy}
+                options={ASSIGNABLE_ROLES.map((one) => ({
+                  value: one,
+                  label: one,
+                }))}
+                onChange={setRole}
+              />
+            </Field>
+          </FormRow>
+          <FormActions>
+            <Button
+              weight="strong"
+              type="submit"
+              disabled={busy || email.trim() === ""}
+            >
+              {busy ? "Inviting…" : "Send invitation"}
+            </Button>
+          </FormActions>
+        </Form>
+      </Section>
+
+      <Section
+        title="Invitations sent"
+        lead="Nobody has accepted these yet. An expired one cannot be accepted at all — send another."
+      >
+        {invitations.length === 0 ? (
+          <Empty title="No invitations are outstanding." />
+        ) : (
+          <DataTable
+            label="Invitations"
+            columns={columns}
+            rows={invitations}
+            keyOf={(invitation) => invitation.id}
+          />
+        )}
+      </Section>
+    </>
   );
 }

--- a/apps/web/lib/settings.ts
+++ b/apps/web/lib/settings.ts
@@ -61,6 +61,31 @@ export type Invitation = {
 
 export type InvitationList = { readonly invitations: readonly Invitation[] };
 
+/**
+ * Whether an invitation can still be accepted.
+ *
+ * **Two states and not one.** The list route answers with every invitation
+ * nobody has accepted, and the ones whose day has passed are in it: they read
+ * as waiting when nothing is coming. Somebody who cannot tell them apart waits
+ * for a person who was never going to be able to accept.
+ *
+ * `accepted` is the third state a link can be in and is deliberately not here —
+ * an accepted invitation is a member, and the roster is where it shows up.
+ *
+ * The comparison is the one `stateOf` makes on the server, on the same field.
+ * A date egma did not send, or sent unreadably, leaves this `pending`: a
+ * standing this could not work out is not grounds for calling an invitation
+ * dead.
+ */
+export type InvitationStanding = "pending" | "expired";
+
+export function standingOf(
+  invitation: Invitation,
+  now: number = Date.now(),
+): InvitationStanding {
+  return Date.parse(invitation.expires_at) <= now ? "expired" : "pending";
+}
+
 export type ApiKey = {
   readonly id: string;
   readonly name: string | null;

--- a/apps/web/test/settings.test.tsx
+++ b/apps/web/test/settings.test.tsx
@@ -198,6 +198,49 @@ afterEach(() => {
 
 /* ------------------------------------------------------------------------ */
 
+/**
+ * The three Settings pages whose subject is the organization rather than the
+ * project the address names, and the sentence each one says about that.
+ *
+ * Every one of them is here rather than one standing in for the rest: the note
+ * is written per page, in that page's own words about that page's own subject,
+ * so a page that lost it would go on passing a test written against a sibling.
+ */
+const ORGANIZATION_WIDE: readonly {
+  readonly page: string;
+  readonly answers: Record<string, Stubbed | readonly Stubbed[]>;
+  readonly open: () => void;
+  readonly says: RegExp;
+}[] = [
+  {
+    page: "Organization",
+    answers: {
+      "/api/organization": { status: 200, body: ORGANIZATION },
+      "/api/judge-credentials": { status: 200, body: { items: [] } },
+    },
+    open: () => render(<OrganizationSettingsPage />),
+    says: /Everything on this page belongs to the whole organization/,
+  },
+  {
+    page: "People",
+    answers: {
+      "/api/members": {
+        status: 200,
+        body: { members: [], may_manage_members: true },
+      },
+      "/api/invitations": { status: 200, body: { invitations: [] } },
+    },
+    open: () => render(<PeoplePage />),
+    says: /Membership belongs to the whole organization/,
+  },
+  {
+    page: "API keys",
+    answers: { "/api/keys": { status: 200, body: { keys: [] } } },
+    open: () => render(<ApiKeysPage />),
+    says: /Keys belong to the organization/,
+  },
+];
+
 describe("the Settings navigation", () => {
   it("says which settings belong to the project and which to the organization", async () => {
     apiAnswers({
@@ -224,22 +267,35 @@ describe("the Settings navigation", () => {
    * The note is the whole reason an organization-wide page can live under a
    * project's address. The selector is still on screen and still naming a
    * project; without a sentence saying otherwise, that reads as a claim.
+   *
+   * Both halves of that are asserted here, because the arrangement only works
+   * if both are true at once: a selector with no note is a page making a claim
+   * about a project, and a note with no selector is a page nobody can leave.
    */
-  it("says on an organization-wide page that the project shown is not its subject", async () => {
-    apiAnswers({
-      "/api/me": { status: 200, body: meWith("admin") },
-      "/api/members": {
-        status: 200,
-        body: { members: [], may_manage_members: true },
-      },
-      "/api/invitations": { status: 200, body: { invitations: [] } },
-    });
-    render(<PeoplePage />);
+  it.each(ORGANIZATION_WIDE)(
+    "keeps the selector on $page and says the project it names is not the subject",
+    async ({ answers, open, says }) => {
+      apiAnswers({
+        "/api/me": { status: 200, body: meWith("admin") },
+        ...answers,
+      });
+      open();
 
-    expect(
-      await screen.findByText(/belongs to the whole organization/),
-    ).toBeTruthy();
-  });
+      // The note is drawn only once the page's own read has answered, so
+      // finding it is also what says the page is showing itself rather than a
+      // loading or a failure state.
+      expect(await screen.findByText(says)).toBeTruthy();
+
+      // And the selector is still on screen, naming the project the address
+      // does. Waited for rather than read on sight: the shell draws the
+      // control before `/api/me` lands and it says "No organization" until
+      // then, so an immediate read would pass on a session nobody had.
+      const selectors = await screen.findAllByRole("button", {
+        name: /^Organization Acme, project Default\./,
+      });
+      expect(selectors.length).toBeGreaterThan(0);
+    },
+  );
 });
 
 /* ------------------------------------------------------------------------ */
@@ -1119,6 +1175,32 @@ const BOB = {
   deactivated_at: null,
 };
 
+/**
+ * Two invitations differing in exactly one thing: whether their day has passed.
+ *
+ * Measured from now rather than written out as a date, so what is asserted is
+ * the page's reading of the field and not the calendar the suite happens to be
+ * run on. A fixed date would make this test pass until it silently stopped
+ * testing anything.
+ */
+const A_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+const WAITING_INVITATION = {
+  id: "inv_1",
+  email: "cleo@acme.example",
+  role: "member",
+  expires_at: new Date(Date.now() + A_WEEK).toISOString(),
+  created_at: new Date(Date.now() - A_WEEK).toISOString(),
+};
+
+const DEAD_INVITATION = {
+  id: "inv_2",
+  email: "dev@acme.example",
+  role: "viewer",
+  expires_at: new Date(Date.now() - A_WEEK).toISOString(),
+  created_at: new Date(Date.now() - 2 * A_WEEK).toISOString(),
+};
+
 describe("people and invitations", () => {
   function open(
     role = "admin",
@@ -1287,6 +1369,89 @@ describe("people and invitations", () => {
       await screen.findByText(/on its way to bob@acme.example/),
     ).toBeTruthy();
     expect(screen.queryByText(/Here is the link/)).toBeNull();
+  });
+
+  /**
+   * The list route answers with every invitation nobody has accepted, and the
+   * ones whose day has passed are in it. Drawn the same as the rest, they read
+   * as waiting when nothing is coming — so somebody waits for a person who can
+   * no longer accept, and the invitation that would let them in is never sent.
+   */
+  it("tells an invitation nobody can accept any more from one still waiting", async () => {
+    open("admin", true, [ADA], [WAITING_INVITATION, DEAD_INVITATION]);
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Invitations" }));
+
+    // The invitations are their own read, answered after the roster that drew
+    // this tab. Finding the table is what says that second answer landed —
+    // and the *absence* asserted at the end is only worth anything once it
+    // has, because an empty page has no control on it either.
+    const table = await screen.findByRole("table", { name: "Invitations" });
+    const rows = await within(table).findAllByRole("row");
+    const waiting = rows.find((row) =>
+      row.textContent?.includes(WAITING_INVITATION.email),
+    )!;
+    const dead = rows.find((row) =>
+      row.textContent?.includes(DEAD_INVITATION.email),
+    )!;
+
+    expect(waiting.textContent).toContain("Pending");
+    expect(waiting.textContent).not.toContain("Expired");
+    expect(dead.textContent).toContain("Expired");
+
+    // And what each one offers matches what it is. A live invitation is waited
+    // on and carries no control; a dead one cannot be waited on, so the one
+    // move left is on it and only on it.
+    expect(within(dead).getByRole("button", { name: "Send again" })).toBeTruthy();
+    expect(
+      within(waiting).queryByRole("button", { name: "Send again" }),
+    ).toBeNull();
+  });
+
+  /**
+   * Sending again goes the same way a first invitation does, which is what
+   * makes it worth offering: on an install with no mail transport the new link
+   * comes back to the person who asked for it, exactly as the form's does.
+   */
+  it("sends another invitation for a dead one, and hands the new link back", async () => {
+    apiAnswers({
+      "/api/me": { status: 200, body: meWith("admin") },
+      "/api/members": {
+        status: 200,
+        body: { members: [ADA], may_manage_members: true },
+      },
+      // Named in the order the page asks: the list it opens with, the new
+      // invitation, and the list again once one has been sent.
+      "/api/invitations": [
+        { status: 200, body: { invitations: [DEAD_INVITATION] } },
+        {
+          status: 201,
+          body: {
+            ...DEAD_INVITATION,
+            id: "inv_9",
+            delivered: false,
+            accept_url: "http://egma.test/invite?token=xyz",
+          },
+        },
+        { status: 200, body: { invitations: [DEAD_INVITATION] } },
+      ],
+    });
+    render(<PeoplePage />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Invitations" }));
+
+    const table = await screen.findByRole("table", { name: "Invitations" });
+    fireEvent.click(within(table).getByRole("button", { name: "Send again" }));
+
+    expect(await screen.findByText(/Here is the link/)).toBeTruthy();
+    expect(document.body.textContent).toContain(
+      "http://egma.test/invite?token=xyz",
+    );
+    // The same person, at the same role, and nothing retyped to get there.
+    expect(sent.find((one) => one.method === "POST")?.body).toEqual({
+      email: DEAD_INVITATION.email,
+      role: DEAD_INVITATION.role,
+    });
   });
 
   it("shows the refusal in its own words when the last admin is protected", async () => {


### PR DESCRIPTION
Closes the two loose ends a verification pass left on ticket 06, which is merged. Base is the integration branch, not `main`.

## An invitation past its expiry looked exactly like one still waiting

The criterion names `expired` as its own state. The page drew it as `pending`, so somebody watched the list and waited for a person who was never going to be able to accept.

This product does not collapse states that lead somewhere different — a **verdict** keeps `skipped` and `errored` apart from `failed`; a **connection**'s unmeasured capability is kept apart from a measured absence. A dead invitation is not a slow one.

The invitation list is now a `DataTable` matching the Members table — Person, Role, Standing, Expiry, Actions — with `Pending` as a neutral badge and `Expired` as a warning one. **The two states differ in what you can do, not only in what they say**: an expired row carries `Send again`, a pending row carries none. The heading changed from "Waiting to be accepted", which was untrue of half the list, to "Invitations sent".

`standingOf` reads `expires_at` with the same comparison the server's `stateOf` makes, so the page and the server cannot disagree about what expired means. No data-layer change.

### Three judgement calls worth naming

**An unreadable `expires_at` reads as `pending`, not `expired`.** A standing the page could not work out is not grounds for calling an invitation dead.

**`accepted` is deliberately not a standing.** The list route filters those out, and an accepted invitation is a member — which the roster already shows.

**Withdrawing is not offered, because there is no route to withdraw an invitation.** The API has `POST /api/invitations` and nothing that retires one, so `Send again` is the only truthful control. The consequence is named rather than hidden: re-sending leaves the expired row beside its new pending replacement, so one address appears twice with different standings. That is honest about what was sent, and it is noise. Closing it needs a delete route, which is API work rather than page work — filed, not smuggled in here.

## The scope criterion was built and unproven

*"The Project selector remains visible throughout Settings, but organization-wide pages do not pretend that membership, invitations, retention, or API keys belong to one Project."*

All three organization-wide pages called `ScopeNote`, but only People had a test reading it back — and API keys is one of the things the criterion names. The selector half had no test at all: true structurally, proven nowhere.

One table-driven test now covers all three pages, asserting both the page's own scope sentence and that the selector is on screen naming the organization and project.

The selector assertion is **waited for rather than read on sight**: `AppShell` draws the control before `/api/me` lands and it says "No organization" until then, so an immediate read would have passed against a session nobody had. That is the shape that produced three intermittent failures in ticket 06, one of which was passing for the wrong reason.

## Every assertion proved by breaking what it guards

| broken | failure |
|---|---|
| `ScopeNote` off the API keys page | `Unable to find text: /Keys belong to the organization/` — on the `API keys` case only |
| `ScopeNote` off the Organization page | `Unable to find text: /Everything on this page belongs to the whole organization/` |
| `AppShell`'s selector returns null | `Unable to find role="button" name /^Organization Acme, project Default\./` — all three cases |
| `standingOf` always answers `pending` | `expected '…viewerPending2026-08-08' to contain 'Expired'`, then `Unable to find button "Send again"` |
| `Send again` offered on every row | `expected <button …> to be null` |
| invitations back to a bare `<ul>` | `Unable to find role="table" name "Invitations"` — both tests |

## Not done, deliberately

**Bounded reads stay unticked on ticket 06.** `listMembers` still selects every row. That is a data-access change with its own shape — a cursor, a bounded read, a `Show more`, and a guard against a late answer landing in the wrong list — and it is now **ticket 15**, carrying forward the paging defect ticket 02 already paid for. `packages/db/src/access/memberships.ts` is untouched here.

## Verification

`apps/web/test` — **10 consecutive clean runs** by the author, 6 more by me on the merged base, 283 tests each. `pnpm lint` and `pnpm typecheck` clean. `apps/web/ui/controls.tsx` and `system.module.css` are byte-identical to the base; ticket 07 is still building against them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789378214&installation_model_id=431960&pr_number=105&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F105&signature=3e84427a2d2d953ab37aaf0aed4f50c094a3e930495cc0115c2f36ee820db9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR distinguishes pending and expired invitations and adds a resend action for expired entries. It also expands Settings scope tests across organization-wide pages.
- Replaces the invitation list with a structured table showing standing, expiry, and contextual actions.
- Centralizes first-send and resend behavior through the same invitation request path.
- Adds table-driven coverage for organization scope notes and the persistent project selector.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/settings/people/page.tsx | Refactors invitation sending and renders pending versus expired invitations in a DataTable with resend available only for expired rows. |
| apps/web/lib/settings.ts | Adds a client-side invitation-standing helper using the same timestamp comparison semantics as the server. |
| apps/web/test/settings.test.tsx | Adds coverage for invitation standings, resend behavior, organization scope notes, and selector visibility. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Invitation row] --> B{Expiry reached?}
    B -- No --> C[Show Pending]
    C --> D[No row action]
    B -- Yes --> E[Show Expired]
    E --> F[Offer Send again]
    F --> G[POST invitation]
    G --> H{Delivered?}
    H -- Yes --> I[Show delivery note]
    H -- No --> J[Show acceptance link]
    I --> K[Refresh invitation list]
    J --> K
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/ui/..."](https://github.com/egma-ai/egma/commit/09970b475c64fe352d8942701d908e3dc287275e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53594503)</sub>

<!-- /greptile_comment -->