### PR TITLE
Turn the echo off before printing the prompt that promises no echo

### DIFF
--- a/apps/cli/src/self-host/protected-input.ts
+++ b/apps/cli/src/self-host/protected-input.ts
@@ -237,9 +237,17 @@ export function asStop(error: unknown): unknown {
 async function askWithoutEcho(prompt: string, options: AskOptions): Promise<string> {
   const terminal = options.input as NodeJS.ReadStream;
   const wasRaw = terminal.isRaw === true;
-  options.output.write(prompt);
+  // Echo off **before** the prompt, never after. A prompt is an invitation to
+  // type, so printing one while the driver is still echoing opens a window
+  // where what somebody types lands on the screen — and this prompt's own words
+  // are "not shown as you type". The window is small and it is real: CI caught
+  // the first secret of a run in the scrollback, with every later one correctly
+  // hidden, because by then the terminal had already been through raw mode once.
+  // Anybody pasting, or typing ahead of a prompt they knew was coming, is in
+  // that window too.
   if (terminal.setRawMode !== undefined) terminal.setRawMode(true);
   terminal.resume();
+  options.output.write(prompt);
   try {
     const answer = await new Promise<string>((resolve, reject) => {
       let typed = "";

--- a/apps/cli/test/secret-echo-order.test.ts
+++ b/apps/cli/test/secret-echo-order.test.ts
@@ -1,0 +1,111 @@
+import { EventEmitter } from "node:events";
+
+import { expect, it } from "vitest";
+
+import { askSecret, type AskOptions } from "../src/self-host/protected-input.ts";
+
+/**
+ * Echo goes off before the prompt invites anybody to type.
+ *
+ * **The order is the whole guarantee.** A prompt is an invitation, and this one
+ * says "not shown as you type" in its own words. Printing it while the terminal
+ * driver is still echoing leaves a window where what somebody types lands on
+ * the screen and stays in the scrollback — with the prompt above it promising
+ * the opposite.
+ *
+ * It was that way round, and CI found it: the first secret of a self-host run
+ * turned up in the scrollback while every later secret was correctly hidden,
+ * because by the second one the terminal had already been through raw mode. A
+ * person is in that window too — pasting, or typing ahead of a prompt they knew
+ * was coming.
+ *
+ * **This test records the order rather than reading the screen.** The terminal
+ * check next door asserts the same guarantee by scraping what was rendered,
+ * which is true but races the renderer under load and fails for reasons that
+ * have nothing to do with echo. Two calls on one fake, in order, cannot race.
+ */
+
+type Step = "raw-on" | "raw-off" | "resume" | "pause" | `write:${string}`;
+
+function terminalRecording(steps: Step[]): AskOptions {
+  const input = Object.assign(new EventEmitter(), {
+    isTTY: true,
+    isRaw: false,
+    setRawMode(on: boolean) {
+      steps.push(on ? "raw-on" : "raw-off");
+      (input as { isRaw: boolean }).isRaw = on;
+      return input;
+    },
+    resume() {
+      steps.push("resume");
+      // The answer arrives once somebody is listening for it, which is the
+      // earliest a real keystroke could: nothing is typed into a stream that
+      // has not been resumed.
+      queueMicrotask(() => input.emit("data", Buffer.from("sk-typed\r")));
+      return input;
+    },
+    pause() {
+      steps.push("pause");
+      return input;
+    },
+  });
+
+  const output = {
+    write(chunk: string) {
+      steps.push(`write:${chunk}`);
+      return true;
+    },
+  };
+
+  return {
+    env: {},
+    input: input as unknown as AskOptions["input"],
+    output: output as unknown as AskOptions["output"],
+  };
+}
+
+it("turns the echo off before it prints the prompt that promises no echo", async () => {
+  const steps: Step[] = [];
+  const answered = await askSecret(
+    "EGMA_PERSONA_MODEL_API_KEY",
+    "the persona's model key (not shown as you type)",
+    terminalRecording(steps),
+  );
+
+  expect(answered.value).toBe("sk-typed");
+  expect(answered.from).toBe("typed");
+
+  const rawOn = steps.indexOf("raw-on");
+  const prompted = steps.findIndex(
+    (step) => step.startsWith("write:") && step.includes("not shown as you type"),
+  );
+
+  expect(rawOn, "the echo was never turned off").toBeGreaterThanOrEqual(0);
+  expect(prompted, "the prompt was never printed").toBeGreaterThanOrEqual(0);
+  // The one assertion this file exists for.
+  expect(rawOn).toBeLessThan(prompted);
+});
+
+it("puts the echo back, so the next command is not typed into blind", async () => {
+  const steps: Step[] = [];
+  await askSecret("EGMA_PERSONA_MODEL_API_KEY", "a key", terminalRecording(steps));
+
+  expect(steps.at(-1)).toBe("write:\n");
+  expect(steps).toContain("raw-off");
+  expect(steps.indexOf("raw-off")).toBeGreaterThan(steps.indexOf("raw-on"));
+});
+
+it("asks nothing at all when the variable already holds the secret", async () => {
+  const steps: Step[] = [];
+  const options = terminalRecording(steps);
+  const answered = await askSecret("EGMA_PERSONA_MODEL_API_KEY", "a key", {
+    ...options,
+    env: { EGMA_PERSONA_MODEL_API_KEY: "  sk-from-the-environment  " },
+  });
+
+  expect(answered.value).toBe("sk-from-the-environment");
+  expect(answered.from).toBe("EGMA_PERSONA_MODEL_API_KEY");
+  // Nothing was printed and the terminal was never touched, so there is no
+  // window to get wrong on this path.
+  expect(steps).toEqual([]);
+});


### PR DESCRIPTION
A two-line reorder and one test. Base is the integration branch, not `main`.

## What was wrong

```js
options.output.write(prompt);                                     // prompt first
if (terminal.setRawMode !== undefined) terminal.setRawMode(true);  // echo off second
```

Between those two statements the terminal driver is still echoing — and the prompt just printed says **"not shown as you type"**. A secret typed into that window lands on the screen and stays in the scrollback, under a line promising it would not.

## How it was found, and why it is not a flake

CI failed twice on a branch that changes only `apps/web`. The second failure carried the screen, and the screen is what makes this legible:

```
the persona's model key (not shown as you type): skSENTINELmodelkey9a7c3e5f1b2d   ← echoed
the speech-to-text key (not shown as you type):                                   ← empty
the text-to-speech key (not shown as you type):                                   ← empty
Twilio Auth Token (used by this command only, never kept):                        ← empty
```

**Only the first secret of the run echoes. Every later one is correctly hidden.**

That asymmetry is the diagnosis. By the second prompt the terminal has already been through raw mode once, so the first entry into it is the slow one and the only window wide enough to lose. Under CI load it opens far enough for a write to fall in.

A person is in that window too. Not somebody who reads the prompt and then types — anybody pasting, or typing ahead of a prompt they knew was coming.

## Worth noting

The comment above this function already records that its first version echoed secrets through `readline`, and that the terminal check next door read a token straight off the screen. That was fixed by reading bytes directly and printing none of them. **The ordering was left behind** — the same defect, one layer down.

## The test

It records the two calls and asserts their order. It does **not** scrape the rendered screen.

That distinction is the point. The existing check asserts the same guarantee by reading what was rendered, which is true but races the renderer under load — so it has been failing for reasons that have nothing to do with echo, and a security assertion that fails at random is one people learn to re-run. Two calls on one fake, in order, cannot race.

Putting the original two statements back:

```
× turns the echo off before it prints the prompt that promises no echo
  → expected 1 to be less than 0
✓ puts the echo back, so the next command is not typed into blind
✓ asks nothing at all when the variable already holds the secret
```

The other two stay green, so this is the only thing that catches the ordering.

## Verification

The whole CLI suite passes apart from `connect-screen.test.ts`, which fails about half of all runs **on the base with none of this applied** — independently reproduced at 3 failures in 6 runs on `c5eaaaa`. It is `apps/cli/test`'s own pty flake, filed on the effort's ticket 13, and nothing here touches that screen.

`self-host-setup-interactive.test.ts` and the new file: 6 consecutive clean runs together. `pnpm lint` and `pnpm typecheck` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789379504&installation_model_id=431960&pr_number=106&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F106&signature=c8c34773525277d267674bd26ddab7d138263c45cee406b08c0d6e43ddb2fe5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR closes the secret-echo window by enabling raw mode before displaying an interactive secret prompt.
- Reorders terminal setup so echo is disabled before the prompt invites input.
- Adds deterministic tests for ordering, raw-mode restoration, and the environment-variable path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and fixes the secret-prompt echo window without introducing an actionable regression.

The supported interactive path disables terminal echo before rendering the prompt, restores the prior terminal state during cleanup, and the new tests directly enforce the intended ordering.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/self-host/protected-input.ts | Moves prompt output after raw-mode activation, preventing typed or pasted secrets from being echoed during the prompt transition. |
| apps/cli/test/secret-echo-order.test.ts | Adds focused tests that verify echo is disabled before prompting, restored afterward, and untouched when the secret comes from the environment. |

<sub>Reviews (1): Last reviewed commit: ["Turn the echo off before printing the pr..."](https://github.com/egma-ai/egma/commit/9fe3a340fb706668ef3f73996146293e9b265542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53596393)</sub>

<!-- /greptile_comment -->