### PR TITLE
Wait for the request the test is about, not for any request to the address

### DIFF
--- a/apps/web/test/tests-pages.test.tsx
+++ b/apps/web/test/tests-pages.test.tsx
@@ -189,6 +189,22 @@ function sentTo(path: string): { method: string; body: unknown }[] {
     .map((one) => ({ method: one.method, body: one.body }));
 }
 
+/**
+ * The requests of one method to one path.
+ *
+ * **A page reads the path it writes to**, so waiting on "anything reached this
+ * address" is satisfied by the page's own load and says nothing about the save.
+ * Under load the assertion then runs against the GET, and `body` is undefined —
+ * which arrives as a TypeError about a property of undefined rather than as
+ * anything about the save that had not happened yet.
+ */
+function sentWith(
+  path: string,
+  method: string,
+): { method: string; body: unknown }[] {
+  return sentTo(path).filter((one) => one.method === method);
+}
+
 /* ------------------------------------------------------------------------ */
 
 describe("the list of tests", () => {
@@ -458,9 +474,9 @@ describe("one test's page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
     await waitFor(() => {
-      expect(sentTo("/api/tests/tst_1").length).toBeGreaterThan(0);
+      expect(sentWith("/api/tests/tst_1", "PATCH").length).toBeGreaterThan(0);
     });
-    const body = sentTo("/api/tests/tst_1").at(-1)?.body as Record<string, unknown>;
+    const body = sentWith("/api/tests/tst_1", "PATCH").at(-1)?.body as Record<string, unknown>;
     expect(body.name).toBe("Renamed");
     expect(body.expected_revision).toBe("rev_1");
     // Sending the version too would make a rename fail because somebody else
@@ -478,9 +494,9 @@ describe("one test's page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save version" }));
 
     await waitFor(() => {
-      expect(sentTo("/api/tests/tst_1").length).toBeGreaterThan(0);
+      expect(sentWith("/api/tests/tst_1", "PATCH").length).toBeGreaterThan(0);
     });
-    const body = sentTo("/api/tests/tst_1").at(-1)?.body as Record<string, unknown>;
+    const body = sentWith("/api/tests/tst_1", "PATCH").at(-1)?.body as Record<string, unknown>;
     expect(body.expected_version_id).toBe("tstv_1");
     expect(body.expected_revision).toBeUndefined();
     // The whole of what stops a partial form erasing hidden versioned content:
@@ -503,9 +519,9 @@ describe("one test's page", () => {
     );
 
     await waitFor(() => {
-      expect(sentTo("/api/tests/tst_1/agents").length).toBeGreaterThan(0);
+      expect(sentWith("/api/tests/tst_1/agents", "POST").length).toBeGreaterThan(0);
     });
-    const call = sentTo("/api/tests/tst_1/agents").at(-1);
+    const call = sentWith("/api/tests/tst_1/agents", "POST").at(-1);
     expect(call?.method).toBe("POST");
     const body = call?.body as Record<string, unknown>;
     expect(body.agents).toEqual(["agt_1", "agt_2"]);


### PR DESCRIPTION
Tests only. Base is the integration branch, not `main`.

## What was wrong

`sentTo` filters by path alone, and a detail page **reads the path it writes to**. So:

```js
await waitFor(() => {
  expect(sentTo("/api/tests/tst_1").length).toBeGreaterThan(0);
});
const body = sentTo("/api/tests/tst_1").at(-1)?.body;
expect(body.name).toBe("Renamed");
```

The wait was satisfied by the page's own load. It said nothing about the save. Under load the assertion then ran against the `GET`, whose body is `undefined`, and surfaced as:

```
TypeError: Cannot read properties of undefined (reading 'name')
```

— which names neither the save nor the wait, and points at a line that is not the problem.

It failed in CI on a branch that **touches no browser code at all**, which is how it came to light.

## Proven, not assumed

A temporary probe asserting the first request to that path is something other than a `GET`:

```
AssertionError: expected 'GET' to be '__PROVE_IT_IS_A_GET__'
```

So the first request really is the page's own read, and the old wait was satisfiable before any save had happened. A race cannot be sabotaged the way a logic bug can — this demonstrates the mechanism instead.

## All three sites, not just the one that failed

| site | method | how it failed |
|---|---|---|
| rename → `/api/tests/tst_1` | `PATCH` | TypeError on `body.name` |
| save version → `/api/tests/tst_1` | `PATCH` | same shape, same file |
| save agents → `/api/tests/tst_1/agents` | `POST` | its own method assertion — loud, but the same cause |

`sentWith(path, method)` takes the method, so the wait and the read are about the same request.

## Why this keeps happening

This is the fourth time today in this effort, and every one has been the same shape: **asserting on something before the thing that produces it has landed.** Two in ticket 06 typed into a page before it finished reading. One asserted an option was absent before the read that would have supplied it answered — it passed for the wrong reason. One in the CLI read a terminal's counts line before it was drawn.

The pattern is now written up in the effort's `running-tickets-in-parallel.md`. This one is worth adding to the list because it is the variant where the *wait itself* is the vacuous part, rather than a missing wait.

## Verification

`apps/web/test/tests-pages.test.tsx` — 6 consecutive clean runs, 20 tests each. `pnpm lint` and `pnpm typecheck` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789388516&installation_model_id=431960&pr_number=109&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F109&signature=906a7517257b7a00879bdf9f5350df8f3a8ff521610954c8453288fceebd6c1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes three browser tests wait for the specific write request rather than an earlier read to the same path.
- Adds a helper that filters captured requests by both path and HTTP method.
- Uses that helper for rename, version-save, and agent-save assertions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because each updated assertion now selects the intended write request.

The affected actions issue uppercase PATCH or POST methods unchanged through the request helper, matching the new filters and preventing initial GET requests from satisfying the waits.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/test/tests-pages.test.tsx | Method-specific request selection removes vacuous waits caused by initial GET requests without introducing a current test failure. |

<sub>Reviews (1): Last reviewed commit: ["Wait for the request the test is about, ..."](https://github.com/egma-ai/egma/commit/d8f7909679e18844c1e7b4f6d42b8eb89d633667) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53607175)</sub>

<!-- /greptile_comment -->