### PR TITLE
Decide what a run will do before it does any of it

### DIFF
--- a/apps/api/src/http/refusals.ts
+++ b/apps/api/src/http/refusals.ts
@@ -107,6 +107,30 @@ export const CODES = {
    * settings simply cannot both be true — so it is its own answer.
    */
   judge_credential_provider_mismatch: 422,
+  /**
+   * A run refused because its project has no LLM judge. Its own code beside
+   * the run refusals because nothing about the selection is wrong: the fix is
+   * one page away, and a run builder shows it as a state rather than as a
+   * mistake somebody made.
+   */
+  judge_not_configured: 409,
+  /**
+   * A judge credential that something still needs. Its own code so a settings
+   * page can list the blocking projects, runs and jobs rather than showing one
+   * general sentence about a key.
+   */
+  judge_credential_in_use: 409,
+  /**
+   * A start action that named no idempotency key. 422 rather than 409: nothing
+   * conflicts, something required is missing, and the fix is to send one.
+   */
+  idempotency_key_required: 422,
+  /**
+   * A key reused over a different request. Answering the original run would
+   * tell somebody their new selection had started when it had not, so the
+   * third answer is the only honest one.
+   */
+  idempotency_conflict: 409,
   unsignable_reference: 422,
   no_adapter: 422,
   phone_setup_required: 422,
@@ -275,6 +299,24 @@ export const REFUSALS = {
   projectSlugTaken: (slug: string): string =>
     `Project slug ${slug} is already in use in this organization. Choose a ` +
     "different slug and save the project again.",
+
+  judgeNotConfigured: (projectId: string): string =>
+    `This run needs an LLM judge, but project ${projectId} has no judge ` +
+    "configured. Open project Settings, configure the judge, and start the " +
+    "run again.",
+
+  judgeCredentialInUse: (credentialId: string, uses: string): string =>
+    `Judge credential ${credentialId} is used by ${uses}. Point those ` +
+    "projects at another credential and let pending grading finish, then " +
+    "archive this credential.",
+
+  idempotencyKeyRequired:
+    "Starting a run requires an idempotency key. Send one stable key for " +
+    "this start action and try again.",
+
+  idempotencyConflict: (key: string): string =>
+    `Idempotency key ${key} already started a different run. Reuse the ` +
+    "original request, or send a new key for this run.",
 
   judgeCredentialProviderMismatch: (
     credentialId: string,

--- a/apps/api/src/routes/judge.ts
+++ b/apps/api/src/routes/judge.ts
@@ -1,9 +1,11 @@
 import {
+  archiveJudgeCredential,
   createJudgeCredential,
   editJudgeCredential,
   getJudgeCredential,
   getProjectJudge,
   IdentityConflictError,
+  JudgeCredentialInUseError,
   JudgeProviderMismatchError,
   listJudgeCredentials,
   NotPermittedError,
@@ -74,6 +76,16 @@ export type JudgeRoutesOptions = {
 
 export const JUDGE_CREDENTIALS_PATH = "/api/judge-credentials";
 export const JUDGE_CREDENTIAL_PATH = "/api/judge-credentials/:credentialId";
+/**
+ * Taking a credential out of use.
+ *
+ * Its own path rather than a field on the PATCH above, because it is a
+ * different kind of decision: a relabel or a rotation always succeeds, and this
+ * is refused while anything still needs the key behind it. A verb that
+ * sometimes refuses should not share a door with one that never does.
+ */
+export const JUDGE_CREDENTIAL_ARCHIVE_PATH =
+  "/api/judge-credentials/:credentialId/archive";
 export const PROJECT_JUDGE_PATH = "/api/judge";
 
 type Body = Record<string, unknown>;
@@ -253,6 +265,51 @@ export async function judgeRoutes(
   });
 
   /**
+   * Take a credential out of use, once nothing needs it.
+   *
+   * **Refused rather than cascading**, and the refusal names every blocking
+   * use. A project pointing at it would lose its judge outright; a run whose
+   * frozen plan names it while a conversation is still moving would be judged
+   * against a key that had gone; a grading job that is `pending` or `claimed`
+   * is about to resolve exactly this secret. Archiving under any of them turns
+   * a whole run's judgments into errors nobody can act on.
+   *
+   * The row stays, so every frozen plan that ever named it keeps naming
+   * something readable. Archive means only *stop choosing this from now on*.
+   */
+  app.post(JUDGE_CREDENTIAL_ARCHIVE_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { credentialId } = request.params as { credentialId: string };
+    const body = (request.body ?? {}) as Body;
+
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "manage judge credentials");
+    }
+
+    const unknown = unknownKeyIn(
+      body,
+      ["expected_revision"],
+      "a judge credential archive",
+    );
+    if (unknown !== undefined) return invalid(reply, unknown);
+
+    const archived = await archiveJudgeCredential(auth, credentialId, {
+      ...(given(text(body.expected_revision)) === undefined
+        ? {}
+        : { expectedRevision: text(body.expected_revision) }),
+    });
+
+    if (archived === undefined) {
+      return sendRefusal(
+        reply,
+        "not_found",
+        REFUSALS.notFound("judge credential", credentialId),
+      );
+    }
+    return reply.send(described(archived));
+  });
+
+  /**
    * A single credential, by its id — a label and a hint, and never a key.
    *
    * It exists so that a page can name the credential a project spends from
@@ -358,6 +415,20 @@ export async function judgeRoutes(
   });
 
   app.setErrorHandler(async (error, request, reply) => {
+    // Every blocking use, spelled into the one sentence the product contract
+    // names — "used by {uses}" — so a page can show it word for word and a
+    // person can go and deal with each one.
+    if (error instanceof JudgeCredentialInUseError) {
+      return sendRefusal(
+        reply,
+        "judge_credential_in_use",
+        REFUSALS.judgeCredentialInUse(
+          error.credentialId,
+          error.uses.map((use) => `${use.kind} ${use.id}`).join(", "),
+        ),
+      );
+    }
+
     if (error instanceof JudgeProviderMismatchError) {
       return sendRefusal(
         reply,

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -3,6 +3,9 @@ import {
   cancelRun,
   connectionTypeOf,
   getRun,
+  IdempotencyConflictError,
+  JudgeNotConfiguredError,
+  planRun,
   listRunEvents,
   listSimulations,
   NotPermittedError,
@@ -19,6 +22,8 @@ import {
   type Run,
   type RecordedVerdict,
   type RunEvent,
+  type JudgeChoice,
+  type RunPlan,
   type RunVerdicts,
   type SimulationVerdicts,
 } from "@egma/db";
@@ -33,6 +38,7 @@ import { given, text } from "../http/reading.ts";
 import {
   conflict,
   invalid,
+  REFUSALS,
   noAdapter,
   notFound,
   notPermitted,
@@ -109,6 +115,16 @@ export type RunRoutesOptions = {
 const NEEDS_THE_PLATFORMS_CARRIER: readonly string[] = ["phone"];
 
 export const RUNS_PATH = "/api/runs";
+/**
+ * What a run would freeze, read before anybody starts one.
+ *
+ * A read rather than a dry-run write, and it is deliberately not under
+ * `/api/runs`: nothing is created and nothing is reserved. It answers the same
+ * resolution `POST /api/runs` performs, so a review step and the run it starts
+ * can never disagree about which tests would be skipped, which versions would
+ * be pinned, or which graders would judge.
+ */
+export const RUN_PLAN_PATH = "/api/run-plan";
 export const RUN_PATH = "/api/runs/:runId";
 export const RUN_EVENTS_PATH = "/api/runs/:runId/events";
 export const RUN_CANCEL_PATH = "/api/runs/:runId/cancel";
@@ -227,6 +243,14 @@ function describedSimulation(
       judged_at: its.judgedAt,
     })),
     reason: one.endingReason,
+    // Why egma never conducted this conversation, and which capabilities
+    // decided it. Null on every conversation that actually happened — the two
+    // vocabularies are separate because `reason` is how a conversation ended
+    // and this is why one never began.
+    skip_reason: one.skipReason,
+    skipped_capabilities: one.skippedCapabilities === null
+      ? null
+      : [...one.skippedCapabilities],
     mock_tool_coverage: describedMockToolCoverage(one.mockToolCoverage),
     // What this conversation was: the row's own modality rather than the run's,
     // because the row is what the database enforces the audio rule against.
@@ -292,6 +316,114 @@ function describedMockTools(
 }
 
 /**
+ * What a run would freeze, as the review step reads it.
+ *
+ * Every version, its personas at the exact versions the run would pin, its
+ * required capabilities and what this connection makes of them, and the plan
+ * items that would judge it — grader by grader, at the version each would be
+ * frozen at.
+ *
+ * **The judge is a state rather than a refusal here**, because a page has to
+ * draw it. `needs_setup` is what a project with no judge reads as, and starting
+ * from that state is what the run door refuses.
+ *
+ * **No secret travels.** A configured judge choice carries the provider, the
+ * model and the *reference* — a `jcr_` credential of this organization, or the
+ * `platform` sentinel — and there is no field here a key could ride in.
+ */
+function describedPlan(plan: RunPlan): Record<string, unknown> {
+  return {
+    agent_id: plan.agentId,
+    connection_id: plan.connectionId,
+    connection: {
+      type: plan.connection.type,
+      modality: plan.connection.modality,
+      environment: plan.connection.environment,
+      // Unknown and known-and-bare are different facts and read differently:
+      // one is a Refresh away from an answer, the other is settled.
+      capabilities:
+        plan.connection.capabilities.state === "unknown"
+          ? { state: "unknown" }
+          : {
+              state: "known",
+              measured: [...plan.connection.capabilities.measured],
+              supported: [...plan.connection.capabilities.supported],
+              checked_at: plan.connection.capabilities.checkedAt.toISOString(),
+              source: plan.connection.capabilities.source,
+            },
+    },
+    judge:
+      plan.judge.state === "needs_setup"
+        ? { state: "needs_setup" }
+        : {
+            state: "configured",
+            provider: plan.judge.provider,
+            model: plan.judge.model,
+            source: plan.judge.source,
+          },
+    runnable_simulation_count: plan.runnableSimulationCount,
+    skipped_simulation_count: plan.skippedSimulationCount,
+    tests: plan.groups.map((group) => ({
+      test_id: group.testId,
+      test_version_id: group.testVersionId,
+      test_name: group.testName,
+      personas: group.personas.map((one) => ({
+        persona_id: one.personaId,
+        persona_version_id: one.personaVersionId,
+        name: one.name,
+      })),
+      required_capabilities: [...group.requiredCapabilities],
+      // Runnable, or the structured reason and the keys that decided it. The
+      // two skip reasons are never folded together: one means write a
+      // different test, the other means measure this connection.
+      skip: group.capability.runnable
+        ? null
+        : {
+            reason: group.capability.reason,
+            capabilities: [...group.capability.capabilities],
+          },
+      graders: group.items.map((item) =>
+        item.kind === "built_in"
+          ? {
+              kind: "built_in",
+              grader_key: item.graderKey,
+              engine_version: item.engineVersion,
+              reads: [...item.reads],
+              modalities: [...item.modalities],
+              judge: describedJudgeChoice(item.judge),
+            }
+          : {
+              kind: "authored",
+              grader_id: item.graderId,
+              grader_version_id: item.graderVersionId,
+              name: item.graderName,
+              origin: item.origin,
+              priority: item.priority,
+              scope: item.scope,
+              reads: [...item.reads],
+              modalities: [...item.modalities],
+              judge: describedJudgeChoice(item.judge),
+            },
+      ),
+    })),
+  };
+}
+
+/** A judge choice on the wire: tagged, and never carrying a secret. */
+function describedJudgeChoice(
+  choice: JudgeChoice,
+): Record<string, unknown> {
+  return choice.tag === "configured"
+    ? {
+        tag: "configured",
+        provider: choice.provider,
+        model: choice.model,
+        source: choice.source,
+      }
+    : { tag: choice.tag };
+}
+
+/**
  * The run and its conversations — one shape for starting, reading and stopping.
  *
  * `judged` is absent wherever the caller could not or need not pay for a
@@ -329,6 +461,10 @@ function describedRun(
     completed_count: one.completedCount,
     failed_count: one.failedCount,
     canceled_count: one.canceledCount,
+    // Its own number beside the three above, never folded into any of them.
+    // A conversation egma declined to conduct is not a failure of the agent,
+    // not something anybody canceled, and certainly not a pass.
+    skipped_count: one.skippedCount,
     // No token, no key, no query at all. A person opens it and the browser
     // they signed in with is already signed in — so the address is safe to
     // paste into a message, a ticket or a terminal somebody else can read.
@@ -441,6 +577,45 @@ export async function runRoutes(
    * folder and a selection, and the fields that matter each refuse for
    * themselves in words that say what to send instead.
    */
+  /**
+   * What a run would freeze, for whichever selection is on screen.
+   *
+   * **The same resolution the start does, and that is the whole point.** A
+   * review step that worked out the pins, the skips and the judge for itself
+   * would be a second opinion, and the moment the two disagreed a person would
+   * have approved one run and started another. So this calls `planRun`, and so
+   * does `startRun`.
+   *
+   * It answers rather than refuses wherever the answer is a state the page has
+   * to draw — a project with no judge, a test that would be skipped — and
+   * refuses only what could never be written at all.
+   */
+  app.get(RUN_PLAN_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const query = (request.query ?? {}) as Record<string, unknown>;
+
+    const acting = await actingIn(auth, given(text(query.project)));
+    if ("refusal" in acting) return refuseActing(reply, acting);
+
+    const selected = given(text(query.test_versions));
+    const pinned = pinnedVersions(
+      selected === undefined ? [] : selected.split(","),
+    );
+    if ("refusal" in pinned) return unprocessable(reply, pinned.refusal);
+
+    const onAgent = given(text(query.agent));
+    // Every refusal `planRun` raises is one `startRun` raises for the same
+    // reason, so this group's own error handler answers both identically —
+    // which is what stops a review step and a start disagreeing about a
+    // selection that could never be written.
+    const plan = await planRun(acting.auth, {
+      connectionId: text(query.connection),
+      ...(onAgent === undefined ? {} : { agentId: onAgent }),
+      testVersionIds: pinned.entries,
+    });
+    return reply.send(describedPlan(plan));
+  });
+
   app.post(RUNS_PATH, async (request, reply) => {
     const { auth } = requesterOf(request);
     const body = (request.body ?? {}) as Body;
@@ -487,10 +662,27 @@ export async function runRoutes(
     const onAgent = given(text(body.agent));
     const label = given(text(body.label));
 
+    /**
+     * **Required here, and optional one layer down.** A run dials real
+     * telephony and spends a real judge, so an answer lost on the way back must
+     * never become a second conversation with somebody's agent — and the only
+     * thing that can prevent it is a word the *client* chose, because only the
+     * client knows that its second request is its first one again.
+     *
+     * The seam beneath takes it optionally because egma's own fixtures start a
+     * run once inside a process they control. Every path a person or a client
+     * comes in on is this one.
+     */
+    const idempotencyKey = given(text(body.idempotency_key));
+    if (idempotencyKey === undefined) {
+      return unprocessable(reply, REFUSALS.idempotencyKeyRequired);
+    }
+
     const started = await startRun(acting.auth, {
       ...(onAgent === undefined ? {} : { agentId: onAgent }),
       connectionId: text(body.connection),
       testVersionIds: pinned.entries,
+      idempotencyKey,
       ...(label === undefined ? {} : { label }),
     });
 
@@ -606,7 +798,7 @@ export async function runRoutes(
    * and paraphrasing here would put a second, quieter copy of it in a file
    * nobody would think to check.
    */
-  app.setErrorHandler(async (error, _request, reply) => {
+  app.setErrorHandler(async (error: unknown, _request, reply) => {
     if (error instanceof RunWriteRefusedError) {
       // A map from the reason to the answer, and nothing else. The sentence is
       // written whole where the refusal was decided and travels untouched:
@@ -625,6 +817,28 @@ export async function runRoutes(
         default:
           return unprocessable(reply, error.message);
       }
+    }
+
+    // A project with no judge, refused before any conversation is dialed. Its
+    // own code and its own sentence, because the fix is one page away and
+    // nothing about the selection is wrong.
+    if (error instanceof JudgeNotConfiguredError) {
+      return sendRefusal(
+        reply,
+        "judge_not_configured",
+        REFUSALS.judgeNotConfigured(error.projectId),
+      );
+    }
+
+    // A key reused over a different request. Answering the original run would
+    // tell somebody their new selection had started when it had not, so this
+    // is refused out loud and names both moves that fix it.
+    if (error instanceof IdempotencyConflictError) {
+      return sendRefusal(
+        reply,
+        "idempotency_conflict",
+        REFUSALS.idempotencyConflict(error.idempotencyKey),
+      );
     }
 
     // Reachable only in a race — the project was checked before the write, and

--- a/apps/api/test/agents-lifecycle.test.ts
+++ b/apps/api/test/agents-lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { newId } from "@egma/ids";
 import {
   getSimulation,
   registerCapabilityDiscovery,
@@ -1423,6 +1424,7 @@ async function aQueuedRunFor(who: Customer): Promise<{
   const started = await browser("POST", "/api/runs", who, {
     connection: wiring.id,
     test_versions: [versionId],
+    idempotency_key: newId("run"),
   });
   expect(started.status, JSON.stringify(started.body)).toBe(201);
   const simulations = started.body.simulations as readonly { id: string }[];

--- a/apps/api/test/claims-hold.test.ts
+++ b/apps/api/test/claims-hold.test.ts
@@ -1,3 +1,4 @@
+import { newId } from "@egma/ids";
 import { createPersona, type AuthContext } from "@egma/db";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -77,7 +78,11 @@ async function aQueuedRun(): Promise<void> {
     "POST",
     "/api/runs",
     { authorization: `Bearer ${key}` },
-    { connection: connectionId, test_versions: [versionId] },
+    {
+      connection: connectionId,
+      test_versions: [versionId],
+      idempotency_key: newId("run"),
+    },
   );
   expect(started.status, JSON.stringify(started.body)).toBe(201);
 }

--- a/apps/api/test/claims-routes.test.ts
+++ b/apps/api/test/claims-routes.test.ts
@@ -1,3 +1,4 @@
+import { newId } from "@egma/ids";
 import {
   createPersona,
   getSimulation,
@@ -159,6 +160,7 @@ async function aQueuedRun(
   const started = await ask(api.app, "POST", "/api/runs", key, {
     connection: connectionId,
     test_versions: [versionId],
+    idempotency_key: newId("run"),
   });
   expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
   const simulations = started.body.simulations as { id: string }[];

--- a/apps/api/test/default-judge-on-signup.test.ts
+++ b/apps/api/test/default-judge-on-signup.test.ts
@@ -177,7 +177,7 @@ describe("a platform with a default judge and no projects yet", () => {
   it("leaves a project unjudged when the platform has no judge of its own", async () => {
     // A deployment that configured none is unchanged: its projects have no
     // judge, model-based grading says so, and nothing is invented.
-    api = await createApi("default_judge_absent");
+    api = await createApi("default_judge_absent", { defaultJudge: null });
 
     const { organizationId, projectId } = await signUpFor("ada");
 

--- a/apps/api/test/heartbeats-routes.test.ts
+++ b/apps/api/test/heartbeats-routes.test.ts
@@ -121,6 +121,7 @@ async function aQueuedRun(
   const started = await ask(api.app, "POST", "/api/runs", key, {
     connection: connectionId,
     test_versions: [versionId],
+    idempotency_key: newId("run"),
   });
   expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
   const simulations = started.body.simulations as { id: string }[];

--- a/apps/api/test/judge-routes.test.ts
+++ b/apps/api/test/judge-routes.test.ts
@@ -474,7 +474,7 @@ describe("an organization's judge credentials", () => {
 
 describe("a project's judge", () => {
   it("is needs_setup when the deployment configured none, which is a state and not a failure", async () => {
-    api = await createApi("judge_needs_setup");
+    api = await createApi("judge_needs_setup", { defaultJudge: null });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
 
     const judge = await asBrowser(
@@ -633,7 +633,7 @@ describe("a project's judge", () => {
   });
 
   it("refuses the platform sentinel on a deployment that configured no judge", async () => {
-    api = await createApi("judge_no_platform_judge");
+    api = await createApi("judge_no_platform_judge", { defaultJudge: null });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
 
     const refused = await asBrowser(ada, "PUT", "/api/judge", {

--- a/apps/api/test/mock-tools-world.test.ts
+++ b/apps/api/test/mock-tools-world.test.ts
@@ -305,6 +305,7 @@ describe("the world a run freezes", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [pinned.versionId],
+      idempotency_key: newId("run"),
     });
     expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
     const runId = String(started.body.id);
@@ -347,6 +348,7 @@ describe("the world a run freezes", () => {
     const after = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [pinned.versionId],
+      idempotency_key: newId("run"),
     });
     expect(
       (after.body.mock_tools as { defaults: { delay_ms: number }[] }).defaults[0]
@@ -379,6 +381,7 @@ describe("the world a run freezes", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [plain.versionId, forcing.versionId],
+      idempotency_key: newId("run"),
     });
     expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
 
@@ -434,6 +437,7 @@ describe("the world a run freezes", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [pinned.versionId],
+      idempotency_key: newId("run"),
     });
     expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
 
@@ -472,6 +476,7 @@ describe("the world a run freezes", () => {
       const started = await request("POST", "/api/runs", key, {
         connection: connectionId,
         test_versions: [pinned.versionId],
+        idempotency_key: newId("run"),
       });
       expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
       const held = await getRun(auth, String(started.body.id));
@@ -500,6 +505,7 @@ describe("the world a run freezes", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [pinned.versionId],
+      idempotency_key: newId("run"),
     });
     expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
     expect(started.body.mock_tools).toEqual({ defaults: [], overrides: {} });

--- a/apps/api/test/projects-routes.test.ts
+++ b/apps/api/test/projects-routes.test.ts
@@ -197,7 +197,9 @@ describe("creating a project", () => {
   });
 
   it("starts a project in needs_setup where the deployment configured no judge", async () => {
-    api = await createApi("projects_create_needs_setup");
+    api = await createApi("projects_create_needs_setup", {
+      defaultJudge: null,
+    });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
 
     const made = await request("POST", "/api/projects", { cookie: ada.cookie }, {

--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -103,6 +103,8 @@ describe("the provider's footprint on the schema", () => {
     "grader",
     "grader_version",
     "grading_job",
+    "grading_plan",
+    "idempotent_operation",
     "invitation",
     "judge_configuration",
     "judge_credential",

--- a/apps/api/test/reports-routes.test.ts
+++ b/apps/api/test/reports-routes.test.ts
@@ -1,3 +1,4 @@
+import { newId } from "@egma/ids";
 import { createPersona, getSimulation } from "@egma/db";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -175,6 +176,7 @@ async function aClaimedSimulation(
   const started = await ask(api.app, "POST", "/api/runs", key, {
     connection: connectionId,
     test_versions: [versionId],
+    idempotency_key: newId("run"),
   });
   expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
   const simulations = started.body.simulations as { id: string }[];

--- a/apps/api/test/run-planning-routes.test.ts
+++ b/apps/api/test/run-planning-routes.test.ts
@@ -1,0 +1,567 @@
+import { createPersona, refreshConnectionCapabilities } from "@egma/db";
+import { newId } from "@egma/ids";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  colleagueOf,
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Answer,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * Planning a run, starting it safely, and taking a judge credential out of use
+ * — over real HTTP against a real Postgres.
+ *
+ * What is asserted here is what a client observes: the shape of the plan, every
+ * refusal sentence word for word, and the three promises the surface rests on.
+ *
+ * **The review and the start agree, because they are one resolution.** What
+ * `GET /api/run-plan` says would be pinned and skipped is what `POST /api/runs`
+ * writes, and this file checks the two against each other rather than checking
+ * each against a hand-written expectation.
+ *
+ * **A start is idempotent under a key the client chose.** The same key and the
+ * same body answers the run that already exists; the same key and a different
+ * body is refused out loud, because telling somebody their new selection had
+ * started when it had not is the one failure the key exists to prevent.
+ *
+ * **A credential nothing needs is archivable, and one something needs is not.**
+ * The refusal names every blocking use, because the fix for each is somewhere
+ * different.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+function request(
+  method: "GET" | "POST",
+  url: string,
+  key: string,
+  payload?: Record<string, unknown>,
+): Promise<Answer> {
+  return ask(api.app, method, url, key, payload);
+}
+
+const RETELL = {
+  type: "retell",
+  modality: "chat",
+  config: { retellAgentId: "agent_in_retell_1" },
+  credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+} as const;
+
+/** Somebody with an agent to check and two tests to check it with. */
+async function aCustomerReadyToPlan(
+  label: string,
+  options: { readonly defaultJudge?: null } = {},
+): Promise<{
+  readonly ada: Customer;
+  readonly key: string;
+  readonly agentId: string;
+  readonly connectionId: string;
+  readonly plain: string;
+  readonly needsAudio: string;
+}> {
+  api = await createApi(
+    label,
+    options.defaultJudge === null ? { defaultJudge: null } : {},
+  );
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await request("POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: RETELL,
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+  const agentId = String((registered.body.agent as { id: string }).id);
+  const connectionId = String(
+    (registered.body.connection as { id: string }).id,
+  );
+
+  await createPersona(contextFor(ada, "member"), {
+    name: "Impatient Rita",
+    traits: NEUTRAL_TRAITS,
+  });
+
+  const push = async (
+    name: string,
+    requiredCapabilities: readonly string[],
+  ): Promise<string> => {
+    const created = await request("POST", "/api/tests", key, {
+      name,
+      scenario:
+        "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+      expected_behaviors: ["confirms the new time back before finishing"],
+      personas: ["Impatient Rita"],
+      required_capabilities: [...requiredCapabilities],
+    });
+    expect(created.statusCode, JSON.stringify(created.body)).toBe(201);
+    return String(created.body.version_id);
+  };
+
+  return {
+    ada,
+    key,
+    agentId,
+    connectionId,
+    plain: await push("Reschedules", []),
+    needsAudio: await push("Hears the hold music", ["raw_audio"]),
+  };
+}
+
+function planQuery(
+  agentId: string,
+  connectionId: string,
+  versions: readonly string[],
+): string {
+  const asked = new URLSearchParams();
+  asked.set("agent", agentId);
+  asked.set("connection", connectionId);
+  asked.set("test_versions", versions.join(","));
+  return `/api/run-plan?${asked.toString()}`;
+}
+
+describe("reading what a run would freeze", () => {
+  it("names the versions, the personas and every grader, and carries no key", async () => {
+    const { key, agentId, connectionId, plain } =
+      await aCustomerReadyToPlan("run_plan_shape");
+
+    const plan = await request(
+      "GET",
+      planQuery(agentId, connectionId, [plain]),
+      key,
+    );
+
+    expect(plan.statusCode, JSON.stringify(plan.body)).toBe(200);
+    expect(plan.body).toMatchObject({
+      agent_id: agentId,
+      connection_id: connectionId,
+      runnable_simulation_count: 1,
+      skipped_simulation_count: 0,
+    });
+
+    const [test] = plan.body.tests as Record<string, unknown>[];
+    expect(test?.test_version_id).toBe(plain);
+    expect(
+      (test?.personas as { name: string }[])[0]?.name,
+    ).toBe("Impatient Rita");
+    expect(test?.skip).toBeNull();
+
+    // The built-in is in every group, because applying it is part of what
+    // running a test means.
+    const graders = test?.graders as Record<string, unknown>[];
+    const builtIn = graders.find((one) => one.kind === "built_in");
+    expect(builtIn?.grader_key).toBe("expected_behaviors_v1");
+    expect(builtIn?.judge).toMatchObject({ tag: "configured" });
+
+    // A judge choice names a reference and never a secret, and the whole answer
+    // is checked as bytes rather than field by field.
+    expect(JSON.stringify(plan.body)).not.toContain("sk-");
+  });
+
+  it("says which conversations would be skipped, and why, without refusing", async () => {
+    const { ada, key, agentId, connectionId, plain, needsAudio } =
+      await aCustomerReadyToPlan("run_plan_skip");
+
+    // Measured: a chat connection carries no audio, and the adapter says so.
+    await refreshConnectionCapabilities(
+      contextFor(ada, "member"),
+      agentId,
+      connectionId,
+    );
+
+    const plan = await request(
+      "GET",
+      planQuery(agentId, connectionId, [plain, needsAudio]),
+      key,
+    );
+
+    expect(plan.statusCode, JSON.stringify(plan.body)).toBe(200);
+    expect(plan.body).toMatchObject({
+      runnable_simulation_count: 1,
+      skipped_simulation_count: 1,
+    });
+    const tests = plan.body.tests as Record<string, unknown>[];
+    expect(tests[0]?.skip).toBeNull();
+    expect(tests[1]?.skip).toEqual({
+      reason: "required_capability_unsupported",
+      capabilities: ["raw_audio"],
+    });
+  });
+
+  it("tells an unmeasured connection from a measured one", async () => {
+    const { key, agentId, connectionId, needsAudio } =
+      await aCustomerReadyToPlan("run_plan_unmeasured");
+
+    // No refresh: nobody has looked, which is a different answer from looking
+    // and finding nothing, and has a different fix.
+    const plan = await request(
+      "GET",
+      planQuery(agentId, connectionId, [needsAudio]),
+      key,
+    );
+
+    expect(plan.statusCode).toBe(200);
+    expect(plan.body.connection).toMatchObject({
+      capabilities: { state: "unknown" },
+    });
+    expect((plan.body.tests as Record<string, unknown>[])[0]?.skip).toEqual({
+      reason: "required_capability_unknown",
+      capabilities: ["raw_audio"],
+    });
+  });
+
+  it("says a project has no judge rather than refusing, so a page can draw it", async () => {
+    const { key, agentId, connectionId, plain } = await aCustomerReadyToPlan(
+      "run_plan_needs_setup",
+      { defaultJudge: null },
+    );
+
+    const plan = await request(
+      "GET",
+      planQuery(agentId, connectionId, [plain]),
+      key,
+    );
+
+    expect(plan.statusCode).toBe(200);
+    expect(plan.body.judge).toEqual({ state: "needs_setup" });
+  });
+
+  it("refuses a test that does not apply to the agent, in the contract's own sentence", async () => {
+    const { key, agentId, connectionId, plain } = await aCustomerReadyToPlan(
+      "run_plan_not_applicable",
+    );
+
+    const second = await request("POST", "/api/agents", key, {
+      name: "Night desk",
+      connection: {
+        ...RETELL,
+        config: { retellAgentId: "agent_in_retell_2" },
+      },
+    });
+    const otherAgent = (second.body.agent as { id: string }).id;
+    const otherConnection = (second.body.connection as { id: string }).id;
+
+    // Take the test off the second agent, so the pair is genuinely unlinked.
+    const version = await request("GET", `/api/test-versions/${plain}`, key);
+    await request(
+      "POST",
+      `/api/tests/${String(version.body.test_id)}/agents`,
+      key,
+      { agents: [agentId] },
+    );
+
+    const refused = await request(
+      "GET",
+      planQuery(otherAgent, otherConnection, [plain]),
+      key,
+    );
+
+    expect(refused.statusCode).toBe(409);
+    expect(refused.body.error).toBe("test_not_applicable");
+    expect(String(refused.body.message)).toContain(
+      `does not apply to agent ${otherAgent}`,
+    );
+    expect(connectionId).not.toBe(otherConnection);
+  });
+});
+
+describe("starting a run safely", () => {
+  it("refuses a start that named no idempotency key, in the contract's exact words", async () => {
+    const { key, agentId, connectionId, plain } = await aCustomerReadyToPlan(
+      "run_start_no_key",
+    );
+
+    const refused = await request("POST", "/api/runs", key, {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [plain],
+    });
+
+    expect(refused.statusCode).toBe(422);
+    expect(refused.body).toEqual({
+      error: "unprocessable",
+      message:
+        "Starting a run requires an idempotency key. Send one stable key " +
+        "for this start action and try again.",
+    });
+
+    const { rows } = await api.database.sql("select id from run");
+    expect(rows).toEqual([]);
+  });
+
+  it("answers the original run when the same key and body arrive again", async () => {
+    const { key, agentId, connectionId, plain } = await aCustomerReadyToPlan(
+      "run_start_same_key",
+    );
+    const body = {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [plain],
+      idempotency_key: "the-terminal-said-this-once",
+    };
+
+    const first = await request("POST", "/api/runs", key, body);
+    expect(first.statusCode, JSON.stringify(first.body)).toBe(201);
+    const again = await request("POST", "/api/runs", key, body);
+
+    expect(again.statusCode).toBe(201);
+    expect(again.body.id).toBe(first.body.id);
+
+    const { rows } = await api.database.sql("select id from run");
+    expect(rows).toHaveLength(1);
+  });
+
+  it("refuses the same key over a different selection, in the contract's exact words", async () => {
+    const { key, agentId, connectionId, plain, needsAudio } =
+      await aCustomerReadyToPlan("run_start_key_conflict");
+    const idempotencyKey = "the-terminal-said-this-once";
+
+    const first = await request("POST", "/api/runs", key, {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [plain],
+      idempotency_key: idempotencyKey,
+    });
+    expect(first.statusCode, JSON.stringify(first.body)).toBe(201);
+
+    const refused = await request("POST", "/api/runs", key, {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [plain, needsAudio],
+      idempotency_key: idempotencyKey,
+    });
+
+    expect(refused.statusCode).toBe(409);
+    expect(refused.body).toEqual({
+      error: "idempotency_conflict",
+      message:
+        `Idempotency key ${idempotencyKey} already started a different run. ` +
+        "Reuse the original request, or send a new key for this run.",
+    });
+
+    const { rows } = await api.database.sql("select id from run");
+    expect(rows).toHaveLength(1);
+  });
+
+  it("refuses a project with no judge before anything is dialed, in the contract's exact words", async () => {
+    const { ada, key, agentId, connectionId, plain } =
+      await aCustomerReadyToPlan("run_start_no_judge", { defaultJudge: null });
+
+    const refused = await request("POST", "/api/runs", key, {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [plain],
+      idempotency_key: newId("run"),
+    });
+
+    expect(refused.statusCode).toBe(409);
+    expect(refused.body).toEqual({
+      error: "judge_not_configured",
+      message:
+        `This run needs an LLM judge, but project ${ada.projectId} has no ` +
+        "judge configured. Open project Settings, configure the judge, and " +
+        "start the run again.",
+    });
+
+    const { rows } = await api.database.sql("select id from run");
+    expect(rows).toEqual([]);
+  });
+
+  it("writes exactly the skips the review promised, and completes an all-skipped run", async () => {
+    const { ada, key, agentId, connectionId, needsAudio } =
+      await aCustomerReadyToPlan("run_start_all_skipped");
+    await refreshConnectionCapabilities(
+      contextFor(ada, "member"),
+      agentId,
+      connectionId,
+    );
+
+    const plan = await request(
+      "GET",
+      planQuery(agentId, connectionId, [needsAudio]),
+      key,
+    );
+    expect(plan.body).toMatchObject({
+      runnable_simulation_count: 0,
+      skipped_simulation_count: 1,
+    });
+
+    const started = await request("POST", "/api/runs", key, {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [needsAudio],
+      idempotency_key: newId("run"),
+    });
+
+    expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+    expect(started.body).toMatchObject({
+      status: "completed",
+      completed_count: 0,
+      failed_count: 0,
+      canceled_count: 0,
+      skipped_count: 1,
+    });
+    const [only] = started.body.simulations as Record<string, unknown>[];
+    expect(only?.status).toBe("skipped");
+    expect(only?.skip_reason).toBe("required_capability_unsupported");
+    expect(only?.skipped_capabilities).toEqual(["raw_audio"]);
+    // No verdict is invented for a conversation that never happened.
+    expect(only?.verdict).toBeNull();
+  });
+
+  it("lets a viewer read the plan and refuses their start", async () => {
+    const { ada, key, agentId, connectionId, plain } =
+      await aCustomerReadyToPlan("run_start_viewer");
+
+    const viewer = await colleagueOf(
+      api.app,
+      ada,
+      "quinn@acme.example",
+      "viewer",
+    );
+    const viewerKey = await projectKeyFor(api.app, viewer);
+
+    const plan = await request(
+      "GET",
+      planQuery(agentId, connectionId, [plain]),
+      viewerKey,
+    );
+    expect(plan.statusCode, JSON.stringify(plan.body)).toBe(200);
+
+    const refused = await request("POST", "/api/runs", viewerKey, {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [plain],
+      idempotency_key: newId("run"),
+    });
+    expect(refused.statusCode).toBe(403);
+    expect(refused.body.error).toBe("not_permitted");
+
+    // And nothing was written by the refused request, whatever the page showed.
+    const started = await request("POST", "/api/runs", key, {
+      agent: agentId,
+      connection: connectionId,
+      test_versions: [plain],
+      idempotency_key: newId("run"),
+    });
+    expect(started.statusCode).toBe(201);
+    const { rows } = await api.database.sql("select id from run");
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("taking a judge credential out of use", () => {
+  /** A credential, and the project pointed at it. */
+  async function aCredential(
+    ada: Customer,
+    label: string,
+    secret: string,
+  ): Promise<string> {
+    const created = await api.app.inject({
+      method: "POST",
+      url: "/api/judge-credentials",
+      headers: { cookie: ada.cookie },
+      payload: { label, provider: "openai", key: secret },
+    });
+    expect(created.statusCode, created.body).toBe(201);
+    return String((created.json() as { id: string }).id);
+  }
+
+  it("refuses while a project points at it, and names the project", async () => {
+    const { ada } = await aCustomerReadyToPlan("credential_in_use_project");
+    const credentialId = await aCredential(
+      ada,
+      "The team's key",
+      "sk-a-real-looking-openai-key-0001",
+    );
+
+    const pointed = await api.app.inject({
+      method: "PUT",
+      url: "/api/judge",
+      headers: { cookie: ada.cookie },
+      payload: {
+        project: ada.projectId,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        source: credentialId,
+      },
+    });
+    expect(pointed.statusCode, pointed.body).toBe(200);
+
+    const refused = await api.app.inject({
+      method: "POST",
+      url: `/api/judge-credentials/${credentialId}/archive`,
+      headers: { cookie: ada.cookie },
+      payload: {},
+    });
+
+    expect(refused.statusCode).toBe(409);
+    const body = refused.json() as { error: string; message: string };
+    expect(body.error).toBe("judge_credential_in_use");
+    expect(body.message).toBe(
+      `Judge credential ${credentialId} is used by project ${ada.projectId}. ` +
+        "Point those projects at another credential and let pending grading " +
+        "finish, then archive this credential.",
+    );
+  });
+
+  it("succeeds once nothing needs it, and stops offering it", async () => {
+    const { ada } = await aCustomerReadyToPlan("credential_archive");
+    const credentialId = await aCredential(
+      ada,
+      "Nothing needs it",
+      "sk-a-real-looking-openai-key-0002",
+    );
+
+    const archived = await api.app.inject({
+      method: "POST",
+      url: `/api/judge-credentials/${credentialId}/archive`,
+      headers: { cookie: ada.cookie },
+      payload: {},
+    });
+    expect(archived.statusCode, archived.body).toBe(200);
+
+    const listed = await api.app.inject({
+      method: "GET",
+      url: "/api/judge-credentials",
+      headers: { cookie: ada.cookie },
+    });
+    const items = (listed.json() as { items: { id: string }[] }).items;
+    expect(items.map((one) => one.id)).not.toContain(credentialId);
+  });
+
+  it("refuses anybody but an admin", async () => {
+    const { ada } = await aCustomerReadyToPlan("credential_archive_role");
+    const credentialId = await aCredential(
+      ada,
+      "Not a member's to remove",
+      "sk-a-real-looking-openai-key-0003",
+    );
+    const member = await colleagueOf(
+      api.app,
+      ada,
+      "quinn@acme.example",
+      "member",
+    );
+
+    const refused = await api.app.inject({
+      method: "POST",
+      url: `/api/judge-credentials/${credentialId}/archive`,
+      headers: { cookie: member.cookie },
+      payload: {},
+    });
+
+    expect(refused.statusCode).toBe(403);
+    expect((refused.json() as { error: string }).error).toBe("not_permitted");
+  });
+});

--- a/apps/api/test/runs-routes.test.ts
+++ b/apps/api/test/runs-routes.test.ts
@@ -215,6 +215,7 @@ describe("starting a run", () => {
       agent: agentId,
       connection: connectionId,
       test_versions: [oneCaller, twoCallers],
+      idempotency_key: newId("run"),
       label: "the whole folder",
     });
 
@@ -270,6 +271,7 @@ describe("starting a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(started.body.results_url).toBe(
@@ -286,6 +288,7 @@ describe("starting a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
@@ -300,6 +303,7 @@ describe("starting a run", () => {
     const unknown = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller, missing, twoCallers],
+      idempotency_key: newId("run"),
     });
     expect(unknown.statusCode).toBe(422);
     expect(unknown.body).toEqual({
@@ -312,6 +316,7 @@ describe("starting a run", () => {
     const doubled = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller, oneCaller],
+      idempotency_key: newId("run"),
     });
     expect(doubled.statusCode).toBe(422);
     expect(doubled.body).toEqual({
@@ -327,6 +332,7 @@ describe("starting a run", () => {
     const unusable = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller, 7],
+      idempotency_key: newId("run"),
     });
     expect(unusable.statusCode).toBe(422);
     expect(unusable.body).toEqual({
@@ -340,6 +346,7 @@ describe("starting a run", () => {
     const none = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [],
+      idempotency_key: newId("run"),
     });
     expect(none.statusCode).toBe(422);
     expect(none.body).toEqual({
@@ -371,6 +378,7 @@ describe("starting a run", () => {
     const nowhere = await request("POST", "/api/runs", key, {
       connection: missing,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     expect(nowhere.statusCode).toBe(404);
     expect(nowhere.body).toEqual({
@@ -384,6 +392,7 @@ describe("starting a run", () => {
       agent: other.agentId,
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     expect(mismatched.statusCode).toBe(404);
     expect(mismatched.body).toEqual({
@@ -400,6 +409,7 @@ describe("starting a run", () => {
       agent: connectionId,
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     expect(misread.statusCode).toBe(404);
     expect(misread.body).toEqual({
@@ -414,6 +424,7 @@ describe("starting a run", () => {
     const unreadable = await request("POST", "/api/runs", key, {
       connection: other.agentId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     expect(unreadable.statusCode).toBe(404);
     expect(unreadable.body).toEqual({
@@ -430,9 +441,17 @@ describe("starting a run", () => {
     // Absent and blank are the same mistake, and "no connection of yours has
     // that id" would be a sentence about an id the request never sent.
     for (const body of [
-      { test_versions: [oneCaller] },
-      { connection: "", test_versions: [oneCaller] },
-      { connection: "   ", test_versions: [oneCaller] },
+      { test_versions: [oneCaller], idempotency_key: newId("run") },
+      {
+        connection: "",
+        test_versions: [oneCaller],
+        idempotency_key: newId("run"),
+      },
+      {
+        connection: "   ",
+        test_versions: [oneCaller],
+        idempotency_key: newId("run"),
+      },
     ]) {
       const refused = await request("POST", "/api/runs", key, body);
       expect(refused.statusCode, JSON.stringify(body)).toBe(422);
@@ -482,6 +501,7 @@ describe("starting a run", () => {
     const refused = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: versions,
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode).toBe(422);
@@ -522,6 +542,7 @@ describe("starting a run", () => {
     const refused = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [pinned.versionId],
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode).toBe(422);
@@ -546,6 +567,7 @@ describe("starting a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: dialled.connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     // This used to be the `no_adapter` refusal. The adapter is in the shipped
@@ -582,6 +604,7 @@ describe("starting a run", () => {
     const refused = await request("POST", "/api/runs", key, {
       connection: dialled.connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode, JSON.stringify(refused.body)).toBe(422);
@@ -624,6 +647,7 @@ describe("starting a run", () => {
     const refused = await request("POST", "/api/runs", key, {
       connection: dialled.connectionId,
       test_versions: [versionId],
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode, JSON.stringify(refused.body)).toBe(422);
@@ -644,6 +668,7 @@ describe("starting a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
@@ -668,6 +693,7 @@ describe("starting a run", () => {
     const refused = await request("POST", "/api/runs", key, {
       connection: theirs.connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode).toBe(404);
@@ -686,6 +712,7 @@ describe("starting a run", () => {
     const refused = await request("POST", "/api/runs", quentin.secret, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode).toBe(403);
@@ -703,6 +730,7 @@ describe("starting a run", () => {
     const refused = await request("POST", "/api/runs", "egma_not_a_key", {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode).toBe(401);
@@ -728,6 +756,7 @@ describe("the project a run lands in", () => {
     const refused = await request("POST", "/api/runs", ada.secret, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     expect(refused.statusCode).toBe(400);
@@ -749,6 +778,7 @@ describe("the project a run lands in", () => {
     const refused = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
       project: grace.projectId,
     });
 
@@ -775,6 +805,7 @@ describe("the project a run lands in", () => {
     const refused = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
       project: outbound.id,
     });
 
@@ -800,6 +831,7 @@ describe("reading one run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
 
@@ -818,6 +850,7 @@ describe("reading one run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
 
     const theirs = await request(
@@ -848,6 +881,7 @@ describe("following a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller, twoCallers],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
 
@@ -936,6 +970,7 @@ describe("following a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
 
@@ -991,6 +1026,7 @@ describe("following a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
 
@@ -1024,6 +1060,7 @@ describe("following a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
 
@@ -1078,6 +1115,7 @@ describe("stopping a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller, twoCallers],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
 
@@ -1122,6 +1160,7 @@ describe("stopping a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
     const [only] = await claimOwn(runId);
@@ -1161,6 +1200,7 @@ describe("stopping a run", () => {
     const stopped = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     const stoppedId = String(stopped.body.id);
     await request("POST", `/api/runs/${stoppedId}/cancel`, key);
@@ -1173,6 +1213,7 @@ describe("stopping a run", () => {
     const ran = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [twoCallers],
+      idempotency_key: newId("run"),
     });
     const ranId = String(ran.body.id);
     for (const one of await claimOwn(ranId)) {
@@ -1202,6 +1243,7 @@ describe("stopping a run", () => {
     const started = await request("POST", "/api/runs", key, {
       connection: connectionId,
       test_versions: [oneCaller],
+      idempotency_key: newId("run"),
     });
     const runId = String(started.body.id);
 

--- a/apps/api/test/simulation-sweep.test.ts
+++ b/apps/api/test/simulation-sweep.test.ts
@@ -1,3 +1,4 @@
+import { newId } from "@egma/ids";
 import { claimSimulations, createPersona, getSimulation } from "@egma/db";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -94,6 +95,7 @@ async function anOrphan(
   const started = await ask(api.app, "POST", "/api/runs", key, {
     connection: connectionId,
     test_versions: [String(pushed.body.version_id)],
+    idempotency_key: newId("run"),
   });
   expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
   const simulations = started.body.simulations as { id: string }[];

--- a/apps/api/test/simulator-walk.test.ts
+++ b/apps/api/test/simulator-walk.test.ts
@@ -1,3 +1,4 @@
+import { newId } from "@egma/ids";
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -538,7 +539,11 @@ describe("the shipped simulator against the real API", () => {
       const startRunOver = async (connection: string) => {
         const started = await call("POST", "/api/runs", {
           key,
-          body: { connection, test_versions: [versionId] },
+          body: {
+            connection,
+            test_versions: [versionId],
+            idempotency_key: newId("run"),
+          },
         });
         expect(started.status, JSON.stringify(started.body)).toBe(201);
         const simulations = started.body.simulations as { id: string }[];

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -49,14 +49,39 @@ export type TestApi = {
   close(): Promise<void>;
 };
 
+/**
+ * The judge a test deployment has, unless the test says it has none.
+ *
+ * The key is nonsense and never reaches a provider: nothing in these tests asks
+ * a model anything, and the one door to a plaintext judge key opens only for
+ * egma's own grading engine.
+ */
+const THE_TEST_DEPLOYMENTS_JUDGE = {
+  provider: "openai",
+  model: "gpt-4o-mini",
+  key: "sk-test-deployment-judge",
+} as const;
+
 export type TestApiOptions = {
   readonly singleOrganization?: boolean;
   /**
    * The judge this deployment gives a project that has configured none, as
-   * `egma self-host setup` supplies one. Absent by default, because most
-   * tests are not about grading configuration at all.
+   * `egma self-host setup` supplies one.
+   *
+   * **A deployment has one unless a test says otherwise**, and that default
+   * moved when runs began requiring a judge. Every run carries the judge-backed
+   * expected-behaviors built-in, so a project in `needs_setup` is refused
+   * before anything is dialed — which would make every test that starts a run
+   * fail on a configuration nobody in it is writing about. A real self-hosted
+   * deployment is set up with one key that covers the persona's brain, its
+   * voice and the default judge, so the configured deployment is the ordinary
+   * one and this default says so.
+   *
+   * Pass `null` for a deployment that configured none. That is the state a
+   * project lands in `needs_setup` from, and it is what the run door's refusal
+   * is proved against.
    */
-  readonly defaultJudge?: Config["defaultJudge"];
+  readonly defaultJudge?: Config["defaultJudge"] | null;
   /**
    * Settings this instance starts holding, seeded exactly as a deployment's own
    * environment seeds them — through `seedPlatformSettings`, sealed, into the
@@ -163,9 +188,9 @@ export async function createApi(
     singleOrganization: options.singleOrganization ?? false,
     trustProxy: options.trustProxy ?? false,
     ...(options.blob === undefined ? {} : { blob: options.blob }),
-    ...(options.defaultJudge === undefined
+    ...(options.defaultJudge === null
       ? {}
-      : { defaultJudge: options.defaultJudge }),
+      : { defaultJudge: options.defaultJudge ?? THE_TEST_DEPLOYMENTS_JUDGE }),
   });
 
   // Through the deployment's own seeding door rather than written straight

--- a/apps/api/test/support/instance.ts
+++ b/apps/api/test/support/instance.ts
@@ -189,6 +189,13 @@ export async function startInstance(
         EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
         EGMA_BASE_URL: origin,
         EGMA_SINGLE_ORGANIZATION: "false",
+        // A deployment set up the way `egma self-host setup` sets one up. Runs
+        // need a judge — every run carries the judge-backed expected-behaviors
+        // built-in — so an instance without one could start no run at all. The
+        // key is nonsense and never reaches a provider; nothing here judges.
+        EGMA_JUDGE_PROVIDER: "openai",
+        EGMA_JUDGE_MODEL: "gpt-4o-mini",
+        EGMA_JUDGE_API_KEY: "sk-test-instance-judge",
       }),
       ...(options.blob === undefined ? {} : { blob: options.blob }),
     },

--- a/apps/api/test/support/recordings.ts
+++ b/apps/api/test/support/recordings.ts
@@ -1,3 +1,4 @@
+import { newId } from "@egma/ids";
 import {
   claimSimulations,
   completeSimulation,
@@ -300,6 +301,7 @@ export async function aConductedRun(
   const started = await ask(app, "POST", "/api/runs", who.key, {
     connection: connectionId,
     test_versions: [String(pushed.body.version_id)],
+    idempotency_key: newId("run"),
     label: options.label ?? "the whole folder",
   });
   expect(started.statusCode, JSON.stringify(started.body)).toBe(201);

--- a/apps/cli/src/platform/runs.ts
+++ b/apps/cli/src/platform/runs.ts
@@ -22,7 +22,7 @@
  * make.
  */
 
-import { newId } from "@egma/ids";
+import { randomUUID } from "node:crypto";
 
 import type { Fetch } from "./device-flow.ts";
 import { PlatformRefusedError } from "./refused.ts";
@@ -247,7 +247,17 @@ export async function startRun(
       agent: input.agentId,
       connection: input.connectionId,
       test_versions: [...input.testVersionIds],
-      idempotency_key: input.idempotencyKey ?? newId("run"),
+      // Node's own, deliberately, and not `newId` from `@egma/ids`. That
+      // package is private and never published, so an import of it survives
+      // into `dist/` — which this package ships unbundled — and `npx @egma/cli`
+      // would fail to resolve it at the moment somebody started a run. The
+      // build caught it here only because nothing built the package first; the
+      // published crash would have had no such warning.
+      //
+      // Nothing wants an egma-shaped id anyway. A key has one job: to be
+      // different from every other invocation's, so a retry of *this* start is
+      // told apart from a new one.
+      idempotency_key: input.idempotencyKey ?? `run_${randomUUID()}`,
       ...(input.label === undefined ? {} : { label: input.label }),
     },
     ...(fetchImpl === undefined ? {} : { fetchImpl }),

--- a/apps/cli/src/platform/runs.ts
+++ b/apps/cli/src/platform/runs.ts
@@ -22,6 +22,8 @@
  * make.
  */
 
+import { newId } from "@egma/ids";
+
 import type { Fetch } from "./device-flow.ts";
 import { PlatformRefusedError } from "./refused.ts";
 import type { SignedIn } from "./signed-in.ts";
@@ -132,6 +134,17 @@ export type NewRun = {
   readonly testVersionIds: readonly string[];
   /** Something to recognise this run by in a list. */
   readonly label?: string;
+  /**
+   * The word this attempt is remembered by, so a retried request starts one
+   * run.
+   *
+   * Left out, one is minted for this call. A terminal that dials a real agent
+   * and loses the answer on the way back must never produce a second
+   * conversation, and the platform can only prevent that if the client names
+   * the attempt — nothing on the server can tell a repeat from a new request.
+   * A caller that retries the same start itself passes the same word twice.
+   */
+  readonly idempotencyKey?: string;
 };
 
 /** A whole number off the wire, or zero for anything that is not one. */
@@ -234,6 +247,7 @@ export async function startRun(
       agent: input.agentId,
       connection: input.connectionId,
       test_versions: [...input.testVersionIds],
+      idempotency_key: input.idempotencyKey ?? newId("run"),
       ...(input.label === undefined ? {} : { label: input.label }),
     },
     ...(fetchImpl === undefined ? {} : { fetchImpl }),

--- a/apps/grader/test/judge-configuration.test.ts
+++ b/apps/grader/test/judge-configuration.test.ts
@@ -29,9 +29,16 @@ import { projectJudge, NoJudge } from "../src/judge/index.ts";
  * Which judge answers, where its key comes from, and where the key never goes.
  *
  * **The order of this file matters and is deliberate.** The first case is a
- * project that has configured no judge at all, and it has to run before
- * anything sets one — a project's judge is one row, and there is no way to
- * un-set it once it is there. Everything after seeds the judge first.
+ * project with no judge behind its grading, and it has to run before anything
+ * re-seeds one — a project's judge is one row, and nothing in the product
+ * un-sets it. Everything after seeds the judge first.
+ *
+ * The run itself is started under a judge, because it has to be: a run carries
+ * the judge-backed built-in and a project in `needs_setup` is refused before
+ * anything is conducted. The row is then cleared, which is what the state
+ * actually looks like when it reaches grading — a plan captured during an
+ * upgrade with no judge behind it, or an operator who removed the row — and it
+ * is the state the engine must never let go green.
  *
  * A grading `AuthContext` is built by the queue and never by a caller, so where
  * a case needs one it is written out here exactly as `claimGradingJobs` builds
@@ -78,6 +85,13 @@ describe("a project that configured no judge", () => {
       testId,
       spans: aConversation(),
     });
+
+    // Cleared after the conversation exists and before anything judges it.
+    // Raw SQL because no product verb removes a judge — which is exactly why
+    // this state is reached by an upgrade or an operator rather than by a form.
+    await world.database.sql("delete from judge_configuration where project_id = $1", [
+      world.projectId,
+    ]);
 
     const rows = await eventually("the behaviors to be errored", async () => {
       const read = await readVerdicts(world.auth, simulationId);

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -156,6 +156,20 @@ export async function makeWorld(label: string): Promise<World> {
     },
   });
 
+  /**
+   * A judge, because a run cannot start without one.
+   *
+   * Every run carries the judge-backed expected-behaviors built-in, so a
+   * project in `needs_setup` is refused before anything is conducted — which
+   * makes "a provisioned project" and "a project with a judge" the same thing.
+   * A test about the *absence* of a judge clears the row after its run exists,
+   * which is also the only way that state can arise now.
+   */
+  await setJudgeConfiguration(
+    { ...auth, role: "admin" },
+    { provider: "openai", model: "gpt-4.1-mini", key: THE_JUDGE_KEY },
+  );
+
   const bare = await createTest(auth, {
     name: "A conversation with nothing named about it",
     scenario: "Their cleaning has to move to any afternoon next week.",

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
@@ -230,6 +230,23 @@ function AgentDetailView({
         action={
           role === null ? undefined : (
             <Actions>
+              {/*
+               * Straight into the builder with this agent already chosen.
+               *
+               * **It preselects and bypasses nothing.** The connection still
+               * has to be this agent's, every test still has to apply to it,
+               * and the project still has to have a judge — all of it checked
+               * on the server, exactly as it is for somebody who chose the
+               * agent from the list. Hidden while the agent is archived,
+               * because an archived agent cannot enter new work at all.
+               */}
+              {agent.archived ? null : (
+                <ButtonLink
+                  href={`${projectPath(projectId, "runs", "new")}?agent=${encodeURIComponent(agent.id)}`}
+                >
+                  Plan a run
+                </ButtonLink>
+              )}
               <Button
                 disabled={!mayAuthor || agent.archived}
                 onClick={() => setEditing(true)}

--- a/apps/web/app/projects/[projectId]/runs/new/builder.module.css
+++ b/apps/web/app/projects/[projectId]/runs/new/builder.module.css
@@ -1,0 +1,147 @@
+/*
+ * The parts a run builder needs and no other page has: a step whose heading
+ * says where it sits in an order, a panel drawn once under a table for
+ * whichever row is open, and a strip of counted facts about what a run would
+ * do.
+ *
+ * They live beside the builder rather than in the shared system module, because
+ * they are this page's and nothing else uses them. Every value is a token:
+ * density and colour are tuned once, in `tokens.css`, and nothing here decides
+ * either for itself.
+ */
+
+.steps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+/*
+ * One step, numbered.
+ *
+ * The number is drawn rather than implied, because order is the whole of what a
+ * builder promises: an agent decides which connections exist, a connection
+ * decides which capabilities are measured, and both decide which tests can
+ * honestly run. Somebody who changes the first step has to be able to see that
+ * everything under it is downstream of that choice.
+ */
+.step {
+  display: grid;
+  grid-template-columns: var(--control-md) 1fr;
+  align-items: start;
+  gap: var(--space-3);
+}
+
+.stepNumber {
+  min-height: var(--control-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-sm);
+}
+
+.stepNumberDone {
+  background: var(--surface);
+  color: var(--foreground);
+}
+
+.stepBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+/*
+ * The panel drawn once, under the table, for whichever row is open.
+ *
+ * Once and never inside a cell: the table draws every row twice, once wide and
+ * once narrow, so a panel living in a cell would be two panels over one piece
+ * of state — and whichever the browser focused would be the one nobody could
+ * see.
+ */
+.openRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+}
+
+.openRowTitle {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.graders {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.grader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.graderName {
+  color: var(--foreground);
+}
+
+.graderNote {
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
+/* What a run would do, counted. */
+.tally {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.tallyItem {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.tallyNumber {
+  font-size: var(--text-lg);
+  font-variant-numeric: tabular-nums;
+  color: var(--foreground);
+}
+
+.tallyLabel {
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
+
+.selection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+@media (max-width: 40rem) {
+  .step {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/app/projects/[projectId]/runs/new/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/new/page.tsx
@@ -1,0 +1,879 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { readJson, sendJson, type Refusal } from "../../../../../lib/api.ts";
+import {
+  agentsQuery,
+  agentDetailQuery,
+  type AgentDetail,
+  type AgentPage,
+  type ListedConnection,
+} from "../../../../../lib/agents.ts";
+import { roleOf } from "../../../../../lib/me.ts";
+import { projectPath } from "../../../../../lib/project-context.ts";
+import { canAuthor } from "../../../../../lib/roles.ts";
+import {
+  plannedSimulationCount,
+  preselectedAgent,
+  runPlanQuery,
+  RUNS_PATH,
+  skipExplanation,
+  whyNotStartable,
+  type PlanGrader,
+  type PlannedTest,
+  type RunPlan,
+  type StartedRun,
+} from "../../../../../lib/runs.ts";
+import {
+  activeAgents,
+  testsPath,
+  testVersionsPath,
+  type ListedTest,
+  type TestPage,
+  type TestVersionPage,
+} from "../../../../../lib/tests.ts";
+import {
+  Badge,
+  Button,
+  ButtonLink,
+  Facts,
+  Field,
+  Problem,
+  Refused,
+  Section,
+  Select,
+  TextInput,
+} from "../../../../../ui/controls.tsx";
+import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
+import { Empty, Failure, Loading } from "../../../../../ui/page-state.tsx";
+import { useProjectRead } from "../../../../../ui/resource.ts";
+import {
+  AppShell,
+  PageBody,
+  PageHeader,
+  ProductPage,
+  useShellSession,
+} from "../../../../../ui/shell.tsx";
+import styles from "./builder.module.css";
+
+/**
+ * Planning a run, and starting it.
+ *
+ * **The order of the steps is the safety.** An agent decides which connections
+ * exist; a connection decides which capabilities have been measured; and both
+ * decide which of the project's tests can honestly be executed at all. Offering
+ * the four choices at once would let somebody assemble a selection that is
+ * refused on Start, at which point they would have to work out which of the
+ * four was wrong.
+ *
+ * **Nothing on this page decides anything.** Which versions would be pinned,
+ * which conversations would be skipped and why, which graders would judge and
+ * at which versions, and whether the project has a judge at all — all of it is
+ * `GET /api/run-plan`, which is the same resolution `POST /api/runs` performs.
+ * A page that worked any of it out for itself would be a second opinion, and
+ * the moment the two disagreed somebody would approve one run and start
+ * another.
+ *
+ * **Start carries an idempotency key.** A run dials a real agent and spends a
+ * real judge, so an answer lost on the way back must never become a second
+ * conversation. The key is minted once for the selection on screen and reused
+ * by every retry of that selection; changing the selection mints a new one,
+ * because it is a different run.
+ */
+export default function NewRunPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  return (
+    <AppShell>
+      <RunBuilder projectId={projectId} />
+    </AppShell>
+  );
+}
+
+/** One numbered step, and whether the choice under it has been made. */
+function Step({
+  number,
+  title,
+  lead,
+  done,
+  children,
+}: {
+  readonly number: number;
+  readonly title: string;
+  readonly lead?: string;
+  readonly done: boolean;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.step}>
+      <div
+        className={`${styles.stepNumber} ${done ? styles.stepNumberDone : ""}`}
+        aria-hidden="true"
+      >
+        {number}
+      </div>
+      <div className={styles.stepBody}>
+        <Section title={title} lead={lead}>
+          {children}
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+/** How a connection reads in the chooser: what it is, and where it points. */
+function connectionLabel(connection: ListedConnection): string {
+  const where =
+    connection.environment === null ? "" : ` · ${connection.environment}`;
+  return `${connection.name} · ${connection.type} · ${connection.modality}${where}`;
+}
+
+/** One grader a run would freeze, said in a line. */
+function graderLine(grader: PlanGrader): {
+  readonly name: string;
+  readonly note: string;
+} {
+  if (grader.kind === "built_in") {
+    return {
+      name: "Expected behaviors",
+      note: `built in · engine ${grader.engine_version} · one verdict per behavior, each at its own priority`,
+    };
+  }
+  const origin =
+    grader.origin === "scenario_specific"
+      ? "on this test"
+      : "project default";
+  const judge =
+    grader.judge.tag === "configured"
+      ? `${grader.judge.provider}/${grader.judge.model}`
+      : grader.judge.tag === "not_required"
+        ? "no judge needed"
+        : "no judge recorded";
+  return {
+    name: grader.name,
+    note: `${origin} · ${grader.priority} · ${judge}`,
+  };
+}
+
+function RunBuilder({ projectId }: { readonly projectId: string }) {
+  const router = useRouter();
+  const { me } = useShellSession();
+  // Null until the session read answers. A page that guessed would tell a
+  // member their role cannot start a run, on every load.
+  const role = me === null ? null : roleOf(me);
+  const mayStart = role !== null && canAuthor(role);
+
+  /**
+   * The agent this builder opened on, when it was opened from one.
+   *
+   * Read once, from the address, and then owned by the field like any other
+   * choice. It preselects and bypasses nothing: the connection still has to be
+   * that agent's, every test still has to apply to it, and the project still
+   * has to have a judge — all of it checked on the server, exactly as it is for
+   * somebody who chose the agent from the list.
+   */
+  const [agentId, setAgentId] = useState<string>("");
+  useEffect(() => {
+    const named = preselectedAgent(window.location.search);
+    if (named !== null) setAgentId(named);
+  }, []);
+
+  const [connectionId, setConnectionId] = useState("");
+  const [chosen, setChosen] = useState<readonly string[]>([]);
+  const [label, setLabel] = useState("");
+
+  /**
+   * Which test row has its detail panel open, what its history read answered,
+   * and whatever went wrong reading it.
+   *
+   * **All three belong to the open row, and all three are cleared when a
+   * different row opens.** The panel is drawn once, under the table, because a
+   * table draws every row twice — once wide and once narrow — so a panel inside
+   * a cell would be two panels over one piece of state. That makes every value
+   * here shared by every row, and each one is a different way of showing
+   * somebody the wrong thing:
+   *
+   * - `history` would put one test's versions under another test's heading, and
+   *   the heading is the only thing on screen saying which test it is.
+   * - `openFailure` is worse, because it survives a closed panel and carries a
+   *   *Try again* bound to the row that failed. Left behind, pressing it reads
+   *   the old test again and draws its answer under the new one — a wrong
+   *   reading, attributed to a test nobody asked about, reported as a success.
+   *
+   * Clearing the first does not clear the second, which is exactly why they are
+   * two lines rather than one.
+   */
+  const [openTest, setOpenTest] = useState<string | null>(null);
+  const [history, setHistory] = useState<TestVersionPage | null>(null);
+  const [openFailure, setOpenFailure] = useState<{
+    readonly message: string;
+    readonly again: () => void;
+  } | null>(null);
+
+  /**
+   * The open test's version history, read when a row opens.
+   *
+   * It answers the one question a review cannot answer for itself: whether the
+   * version this run would pin is the one somebody last looked at. The read is
+   * per row because history is per test, and it is what makes the panel's state
+   * genuinely the open row's rather than the page's.
+   */
+  async function readHistory(testId: string): Promise<void> {
+    const answered = await readJson<TestVersionPage>(
+      testVersionsPath(testId),
+      { project: projectId },
+    );
+    if (answered.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (answered.status !== "ready") {
+      setOpenFailure({
+        message: answered.refusal.message,
+        again: () => void readHistory(testId),
+      });
+      return;
+    }
+    // **Cleared on the way in and not on the way out**, deliberately: a read
+    // that has not answered yet has cleared nothing, so a row opened while a
+    // previous row's failure is on screen must be cleared by whoever changed
+    // the row rather than by whoever eventually answers.
+    setOpenFailure(null);
+    setHistory(answered.value);
+  }
+
+  const [starting, setStarting] = useState(false);
+  const [refused, setRefused] = useState<Refusal | null>(null);
+
+  const { answer: agents } = useProjectRead<AgentPage>(
+    agentsQuery({}),
+    projectId,
+  );
+  const { answer: detail } = useProjectRead<AgentDetail>(
+    agentId === "" ? "" : agentDetailQuery(agentId, "active"),
+    agentId === "" ? null : projectId,
+  );
+  const { answer: tests } = useProjectRead<TestPage>(
+    agentId === "" ? "" : testsPath({ archived: false, agent: agentId }),
+    agentId === "" ? null : projectId,
+  );
+
+  const agentRows = agents?.status === "ready" ? agents.value.items : [];
+  const connections =
+    detail?.status === "ready"
+      ? detail.value.connections.filter((one) => !one.archived)
+      : [];
+  /**
+   * The tests a run could use: active, and applying to the chosen agent with an
+   * agent that is itself active.
+   *
+   * The applicability filter is the server's — the list was asked for this
+   * agent — and this only removes the ones whose every linked agent has since
+   * been archived, which are active tests with nowhere to run.
+   */
+  const testRows: readonly ListedTest[] =
+    tests?.status === "ready"
+      ? tests.value.items.filter((one) => activeAgents(one).length > 0)
+      : [];
+
+  /**
+   * A choice that is no longer on offer is no choice at all.
+   *
+   * Changing the agent changes which connections and which tests exist, so
+   * anything selected under the old agent is dropped rather than carried
+   * forward — a connection of another agent would be refused on Start, and a
+   * test that does not apply would be refused with it.
+   */
+  useEffect(() => {
+    setConnectionId("");
+    setChosen([]);
+    setOpenTest(null);
+    setOpenFailure(null);
+    setRefused(null);
+  }, [agentId]);
+
+  const selection = useMemo(
+    () =>
+      testRows
+        .filter((one) => chosen.includes(one.id))
+        .map((one) => one.version_id),
+    [testRows, chosen],
+  );
+
+  const readyToPlan = agentId !== "" && connectionId !== "" && selection.length > 0;
+  const { answer: plan, reload: replan } = useProjectRead<RunPlan>(
+    readyToPlan
+      ? runPlanQuery({ agentId, connectionId, testVersionIds: selection })
+      : "",
+    readyToPlan ? projectId : null,
+  );
+
+  /**
+   * The word this attempt is remembered by.
+   *
+   * **One key per selection, and a new one when the selection changes.** Sending
+   * the same request twice under one key answers the original run; sending a
+   * different selection under it is refused out loud. So the key has to move
+   * exactly when the request does, which is what tying it to the selection
+   * does — and what makes a second click, or a browser retrying a request whose
+   * answer was lost, land on the run that already exists.
+   */
+  const idempotencyKey = useMemo(() => {
+    if (!readyToPlan) return "";
+    return `run:${agentId}:${connectionId}:${[...selection].join(",")}`;
+  }, [readyToPlan, agentId, connectionId, selection]);
+
+  async function start(): Promise<void> {
+    if (!mayStart || starting || !readyToPlan) return;
+    setRefused(null);
+    setStarting(true);
+    const written = await sendJson<StartedRun>(RUNS_PATH, {
+      method: "POST",
+      project: projectId,
+      body: {
+        agent: agentId,
+        connection: connectionId,
+        test_versions: [...selection],
+        idempotency_key: idempotencyKey,
+        ...(label.trim() === "" ? {} : { label: label.trim() }),
+      },
+    });
+    setStarting(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    router.push(projectPath(projectId, "runs"));
+  }
+
+  if (agents === null) return <Loading what="the agents in this project" />;
+  if (agents.status === "signed-out") {
+    window.location.replace("/sign-in");
+    return null;
+  }
+  if (agents.status !== "ready") {
+    return (
+      <Failure
+        title="Egma could not list this project's agents."
+        message={agents.refusal.message}
+      />
+    );
+  }
+
+  const active = agentRows.filter((one) => !one.archived);
+  const planned = plan?.status === "ready" ? plan.value : null;
+  const blocked = planned === null ? null : whyNotStartable(planned);
+
+  return (
+    <ProductPage>
+      <PageHeader
+        eyebrow="Runs"
+        title="Plan a run"
+        lead="A run executes a selection of tests against one agent over one connection. Every simulation it produces is pinned to the exact test, persona and grader versions egma froze when it started."
+        action={
+          <ButtonLink href={projectPath(projectId, "runs")}>Cancel</ButtonLink>
+        }
+      />
+      <PageBody>
+        {mayStart ? null : (
+          <Problem>
+            Your role can read this page and cannot start a run. Ask an
+            organization admin to change your role, then try again.
+          </Problem>
+        )}
+
+        <div className={styles.steps}>
+          <Step
+            number={1}
+            title="Agent"
+            lead="The agent under test. It decides which connections and which tests are available below."
+            done={agentId !== ""}
+          >
+            {active.length === 0 ? (
+              <Empty
+                title="This project has no active agent."
+                lead="Register an agent and give it a connection, then come back and plan a run."
+              />
+            ) : (
+              <Field label="Agent" htmlFor="run-agent">
+                <Select
+                  id="run-agent"
+                  value={agentId}
+                  onChange={setAgentId}
+                  options={[
+                    { value: "", label: "Choose an agent" },
+                    ...active.map((one) => ({ value: one.id, label: one.name })),
+                  ]}
+                />
+              </Field>
+            )}
+          </Step>
+
+          <Step
+            number={2}
+            title="Connection"
+            lead="How egma reaches the agent. The modality, the environment and the transport are all this choice, and what it was measured to support decides which tests can run."
+            done={connectionId !== ""}
+          >
+            {agentId === "" ? (
+              <p>Choose an agent first.</p>
+            ) : detail === null ? (
+              <Loading what="this agent's connections" />
+            ) : detail.status === "signed-out" ? (
+              <Failure
+                title="This session has ended."
+                message="Sign in again, then plan the run."
+              />
+            ) : detail.status !== "ready" ? (
+              <Failure
+                title="Egma could not read this agent."
+                message={detail.refusal.message}
+              />
+            ) : connections.length === 0 ? (
+              <Empty
+                title="This agent has no active connection."
+                lead="Add a connection on the agent's page, then come back and plan a run."
+              />
+            ) : (
+              <Field label="Connection" htmlFor="run-connection">
+                <Select
+                  id="run-connection"
+                  value={connectionId}
+                  onChange={setConnectionId}
+                  options={[
+                    { value: "", label: "Choose a connection" },
+                    ...connections.map((one) => ({
+                      value: one.id,
+                      label: connectionLabel(one),
+                    })),
+                  ]}
+                />
+              </Field>
+            )}
+          </Step>
+
+          <Step
+            number={3}
+            title="Tests"
+            lead="Only the project's active tests that apply to this agent. A test that does not apply cannot start against it, so it is not offered."
+            done={selection.length > 0}
+          >
+            {agentId === "" ? (
+              <p>Choose an agent first.</p>
+            ) : tests === null ? (
+              <Loading what="the tests that apply to this agent" />
+            ) : tests.status === "signed-out" ? (
+              <Failure
+                title="This session has ended."
+                message="Sign in again, then plan the run."
+              />
+            ) : tests.status !== "ready" ? (
+              <Failure
+                title="Egma could not list the tests for this agent."
+                message={tests.refusal.message}
+              />
+            ) : testRows.length === 0 ? (
+              <Empty
+                title="No active test applies to this agent."
+                lead="Link a test to this agent on the Tests page, then come back and plan a run."
+              />
+            ) : (
+              <TestChoices
+                tests={testRows}
+                chosen={chosen}
+                onChoose={setChosen}
+                openTest={openTest}
+                onOpen={(testId) => {
+                  // One panel under the table means one `history` and one
+                  // `openFailure` for every row, so opening a different row has
+                  // to empty both.
+                  //
+                  // `history`: another test's versions would sit under this
+                  // test's heading, and the heading is the only thing on screen
+                  // saying which test the panel is about.
+                  //
+                  // `openFailure`: worse, because it survives a closed panel.
+                  // Its `again` is bound to the row that failed, so pressing it
+                  // here reads that row again and draws its history under this
+                  // one — a wrong reading, attributed to a test nobody asked
+                  // about, and reported as a success.
+                  setHistory(null);
+                  setOpenFailure(null);
+                  const opening = openTest === testId ? null : testId;
+                  setOpenTest(opening);
+                  if (opening !== null) void readHistory(opening);
+                }}
+                history={history}
+                plan={planned}
+                planLoading={readyToPlan && plan === null}
+                failure={openFailure}
+              />
+            )}
+          </Step>
+
+          <Step
+            number={4}
+            title="Review"
+            lead="Exactly what egma would freeze, and what it would not conduct. Nothing here is decided by this page: it is the same resolution the start performs."
+            done={planned !== null && blocked === null}
+          >
+            {!readyToPlan ? (
+              <p>Choose an agent, a connection and at least one test.</p>
+            ) : plan === null ? (
+              <Loading what="what this run would freeze" />
+            ) : plan.status === "signed-out" ? (
+              <Failure
+                title="This session has ended."
+                message="Sign in again, then plan the run."
+              />
+            ) : plan.status !== "ready" ? (
+              <Failure
+                title="Egma could not plan this run."
+                message={plan.refusal.message}
+                onRetry={replan}
+              />
+            ) : (
+              <Review
+                plan={plan.value}
+                label={label}
+                onLabel={setLabel}
+                mayStart={mayStart}
+                starting={starting}
+                blocked={blocked}
+                refused={refused}
+                onStart={() => void start()}
+              />
+            )}
+          </Step>
+        </div>
+      </PageBody>
+    </ProductPage>
+  );
+}
+
+/**
+ * The tests on offer, with the one open row's detail drawn once beneath them.
+ *
+ * The detail is what the plan says about that test — the version that would be
+ * pinned, who would call at which persona version, and every grader that would
+ * judge it. It is read off the plan rather than fetched per row, so the panel
+ * and the review can never disagree.
+ */
+function TestChoices({
+  tests,
+  chosen,
+  onChoose,
+  openTest,
+  onOpen,
+  history,
+  plan,
+  planLoading,
+  failure,
+}: {
+  readonly tests: readonly ListedTest[];
+  readonly chosen: readonly string[];
+  readonly onChoose: (chosen: readonly string[]) => void;
+  readonly openTest: string | null;
+  readonly onOpen: (testId: string) => void;
+  /** The open row's versions, and nobody else's. */
+  readonly history: TestVersionPage | null;
+  readonly plan: RunPlan | null;
+  readonly planLoading: boolean;
+  readonly failure: {
+    readonly message: string;
+    readonly again: () => void;
+  } | null;
+}) {
+  const columns: readonly Column<ListedTest>[] = [
+    {
+      key: "chosen",
+      header: "",
+      width: "44px",
+      cell: (test) => (
+        <input
+          type="checkbox"
+          aria-label={`Include ${test.name}`}
+          checked={chosen.includes(test.id)}
+          onChange={() =>
+            onChoose(
+              chosen.includes(test.id)
+                ? chosen.filter((one) => one !== test.id)
+                : [...chosen, test.id],
+            )
+          }
+        />
+      ),
+    },
+    {
+      key: "name",
+      header: "Test",
+      primary: true,
+      cell: (test) => test.name,
+    },
+    {
+      key: "personas",
+      header: "Personas",
+      width: "150px",
+      cell: (test) => test.personas.map((one) => one.name).join(", "),
+    },
+    {
+      key: "version",
+      header: "Version",
+      mono: true,
+      width: "90px",
+      cell: (test) => `v${test.version}`,
+    },
+    {
+      key: "requires",
+      header: "Requires",
+      width: "160px",
+      cell: (test) =>
+        test.required_capabilities.length === 0
+          ? "—"
+          : test.required_capabilities.join(", "),
+    },
+    {
+      key: "detail",
+      header: "",
+      width: "110px",
+      cell: (test) => (
+        <Button onClick={() => onOpen(test.id)}>
+          {openTest === test.id ? "Hide" : "Details"}
+        </Button>
+      ),
+    },
+  ];
+
+  const opened = tests.find((one) => one.id === openTest);
+  const planned =
+    opened === undefined
+      ? undefined
+      : plan?.tests.find((one) => one.test_id === opened.id);
+
+  return (
+    <div className={styles.selection}>
+      <DataTable
+        label="Tests that apply to this agent"
+        columns={columns}
+        rows={tests}
+        keyOf={(test) => test.id}
+      />
+
+      {/*
+       * Drawn once, under the table, for whichever row is open — never inside a
+       * cell. A table draws every row twice, once wide and once narrow, so a
+       * panel living in a cell would be two panels over one piece of state.
+       */}
+      {opened === undefined ? null : (
+        <div className={styles.openRow}>
+          <h3 className={styles.openRowTitle}>{opened.name}</h3>
+          {failure === null ? null : (
+            <Failure
+              title="Egma could not read this test's history."
+              message={failure.message}
+              onRetry={failure.again}
+            />
+          )}
+          <p className={styles.graderNote}>
+            {history === null
+              ? failure === null
+                ? "Reading this test's version history…"
+                : "No version history read."
+              : `${String(history.items.length)} ${
+                  history.items.length === 1 ? "version" : "versions"
+                }; this run would pin v${String(
+                  history.items.find((one) => one.current)?.version ??
+                    opened.version,
+                )}.`}
+          </p>
+          {planned === undefined ? (
+            <p>
+              {planLoading
+                ? "Reading what this test would freeze…"
+                : "Choose this test to see the versions and graders a run would freeze for it."}
+            </p>
+          ) : (
+            <PlannedTestDetail planned={planned} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** What one selected test would freeze, exactly as the plan answered it. */
+function PlannedTestDetail({ planned }: { readonly planned: PlannedTest }) {
+  return (
+    <>
+      <Facts
+        facts={[
+          { label: "Test version", value: planned.test_version_id },
+          {
+            label: "Personas",
+            value: planned.personas
+              .map((one) => `${one.name} (${one.persona_version_id})`)
+              .join(", "),
+          },
+          {
+            label: "Requires",
+            value:
+              planned.required_capabilities.length === 0
+                ? "nothing of the connection"
+                : planned.required_capabilities.join(", "),
+          },
+        ]}
+      />
+      {planned.skip === null ? null : (
+        <Problem>{skipExplanation(planned.skip)}</Problem>
+      )}
+      <ul className={styles.graders}>
+        {planned.graders.map((grader) => {
+          const line = graderLine(grader);
+          return (
+            <li
+              className={styles.grader}
+              key={
+                grader.kind === "built_in"
+                  ? grader.grader_key
+                  : grader.grader_id
+              }
+            >
+              <span className={styles.graderName}>{line.name}</span>
+              <span className={styles.graderNote}>{line.note}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}
+
+/** The review step: what would be frozen, what would be skipped, and Start. */
+function Review({
+  plan,
+  label,
+  onLabel,
+  mayStart,
+  starting,
+  blocked,
+  refused,
+  onStart,
+}: {
+  readonly plan: RunPlan;
+  readonly label: string;
+  readonly onLabel: (label: string) => void;
+  readonly mayStart: boolean;
+  readonly starting: boolean;
+  readonly blocked: string | null;
+  readonly refused: Refusal | null;
+  readonly onStart: () => void;
+}) {
+  return (
+    <>
+      <div className={styles.tally}>
+        <div className={styles.tallyItem}>
+          <span className={styles.tallyNumber}>
+            {plannedSimulationCount(plan)}
+          </span>
+          <span className={styles.tallyLabel}>simulations planned</span>
+        </div>
+        <div className={styles.tallyItem}>
+          <span className={styles.tallyNumber}>
+            {plan.runnable_simulation_count}
+          </span>
+          <span className={styles.tallyLabel}>would be conducted</span>
+        </div>
+        <div className={styles.tallyItem}>
+          <span className={styles.tallyNumber}>
+            {plan.skipped_simulation_count}
+          </span>
+          <span className={styles.tallyLabel}>
+            would be skipped, not failed
+          </span>
+        </div>
+      </div>
+
+      <Facts
+        facts={[
+          {
+            label: "Connection",
+            value: `${plan.connection.type} · ${plan.connection.modality}${
+              plan.connection.environment === null
+                ? ""
+                : ` · ${plan.connection.environment}`
+            }`,
+          },
+          {
+            label: "Capabilities",
+            value:
+              plan.connection.capabilities.state === "unknown" ? (
+                <Badge tone="warn">
+                  Unknown — nobody has measured this connection
+                </Badge>
+              ) : (
+                `measured ${plan.connection.capabilities.measured.join(", ") || "nothing"}; supports ${
+                  plan.connection.capabilities.supported.join(", ") || "nothing"
+                }`
+              ),
+          },
+          {
+            label: "Judge",
+            value:
+              plan.judge.state === "needs_setup" ? (
+                <Badge tone="bad">Not configured</Badge>
+              ) : (
+                `${plan.judge.provider}/${plan.judge.model} · ${
+                  plan.judge.source === "platform"
+                    ? "this deployment's own key"
+                    : `credential ${plan.judge.source}`
+                }`
+              ),
+          },
+        ]}
+      />
+
+      {/*
+       * Every selected test, said in full, in the review itself.
+       *
+       * It belongs here rather than only in the open row's panel because the
+       * panel shows one test at a time and somebody about to press Start is
+       * approving all of them. The exact version that would be pinned, the
+       * exact persona version each conversation would carry, every grader that
+       * would judge it at the version it would be frozen at — and, where egma
+       * would conduct nothing, the reason, said as a skip and never as a
+       * failure of the agent.
+       */}
+      {plan.tests.map((one) => (
+        <Section key={one.test_version_id} title={one.test_name}>
+          <PlannedTestDetail planned={one} />
+        </Section>
+      ))}
+
+      <Field
+        label="Label"
+        htmlFor="run-label"
+        hint="Optional. Something to recognise this run by in the list."
+      >
+        <TextInput id="run-label" value={label} onChange={onLabel} />
+      </Field>
+
+      {blocked === null ? null : <Problem>{blocked}</Problem>}
+      {refused === null ? null : (
+        <Refused message={refused.message} />
+      )}
+
+      <Button
+        weight="strong"
+        disabled={!mayStart || starting || blocked !== null}
+        onClick={onStart}
+      >
+        {starting ? "Starting…" : "Start run"}
+      </Button>
+    </>
+  );
+}

--- a/apps/web/app/projects/[projectId]/runs/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/page.tsx
@@ -1,12 +1,79 @@
-import { AwaitingArea } from "../awaiting.tsx";
+"use client";
 
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../lib/project-context.ts";
+import { roleOf } from "../../../../lib/me.ts";
+import { canAuthor } from "../../../../lib/roles.ts";
+import { ButtonLink } from "../../../../ui/controls.tsx";
+import { Empty } from "../../../../ui/page-state.tsx";
+import {
+  AppShell,
+  PageBody,
+  PageHeader,
+  ProductPage,
+  useShellSession,
+} from "../../../../ui/shell.tsx";
+
+/**
+ * Runs, as far as this build goes: the way into the builder.
+ *
+ * **The history is deliberately not here yet**, and this page says so rather
+ * than showing an empty list — an empty list would read as *this project has
+ * never run anything*, which is a different and possibly false sentence. The
+ * list, its filters, live progress, Cancel and Retry are the next ticket's.
+ *
+ * What is here is the entry point, because a builder nobody can reach is a
+ * builder nobody uses. A viewer sees the page and not the button: hiding it is
+ * courtesy rather than authorization, and the server refuses a viewer's start
+ * whether or not this page offered one.
+ */
 export default function RunsPage() {
+  const { projectId } = useParams<{ projectId: string }>();
   return (
-    <AwaitingArea
-      area="Run history"
-      title="Runs"
-      what="Every execution of a selection of tests against one agent over one connection."
-      meanwhile="Start a run with egma run, and open the address it prints to read its results. The list and the run builder arrive with Runs."
-    />
+    <AppShell>
+      <Runs projectId={projectId} />
+    </AppShell>
+  );
+}
+
+function Runs({ projectId }: { readonly projectId: string }) {
+  const { me } = useShellSession();
+  // Null until the session read answers. A page that guessed would offer a
+  // viewer a control the server refuses, on every load.
+  const role = me === null ? null : roleOf(me);
+  const mayStart = role !== null && canAuthor(role);
+
+  return (
+    <ProductPage>
+      <PageHeader
+        eyebrow="Project"
+        title="Runs"
+        lead="Every execution of a selection of tests against one agent over one connection."
+        action={
+          mayStart ? (
+            <ButtonLink
+              weight="strong"
+              href={projectPath(projectId, "runs", "new")}
+            >
+              Plan a run
+            </ButtonLink>
+          ) : undefined
+        }
+      />
+      <PageBody>
+        <Empty
+          title="Run history is not in the browser yet"
+          lead="Plan and start a run here, then open the address egma prints to read its results. The list, live progress, Cancel and Retry arrive with Run history."
+          action={
+            mayStart ? (
+              <ButtonLink href={projectPath(projectId, "runs", "new")}>
+                Plan a run
+              </ButtonLink>
+            ) : undefined
+          }
+        />
+      </PageBody>
+    </ProductPage>
   );
 }

--- a/apps/web/app/projects/[projectId]/settings/organization/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/page.tsx
@@ -7,6 +7,7 @@ import { sendJson, writeJson, type Refusal } from "../../../../../lib/api.ts";
 import {
   credentialsIn,
   JUDGE_CREDENTIALS_PATH,
+  judgeCredentialArchivePath,
   judgeCredentialPath,
   type JudgeCredential,
   type JudgeCredentialPage,
@@ -257,10 +258,14 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
  * identity survives, so every project pointing at this credential keeps
  * pointing at it and pending grading picks the new key up when it claims.
  *
- * There is no Archive here on purpose. Removing a credential has to be refused
- * while a project points at it and while frozen grading work still needs it,
- * and frozen grading plans arrive with run planning. A control with none of
- * that behind it would strand work mid-flight.
+ * **Archive is here now, and it is refused rather than cascading.** Removing a
+ * credential has to be refused while a project points at it, while a run whose
+ * frozen grading plan names it still has a conversation moving, and while a
+ * grading job is waiting to be judged or already claimed — and frozen grading
+ * plans arrived with run planning, which is what made the second and third
+ * questions askable at all. The refusal names every blocking use and this page
+ * shows that sentence unchanged, because it is the sentence that says what to
+ * go and do.
  */
 function Credentials({
   credentials,
@@ -326,6 +331,42 @@ function Credentials({
     onChanged();
   }
 
+  async function archive(credential: JudgeCredential): Promise<void> {
+    if (!mayAdminister || busy) return;
+    setFailed(null);
+    setBusy(true);
+    const written = await sendJson<JudgeCredential>(
+      judgeCredentialArchivePath(credential.id),
+      {
+        method: "POST",
+        body: { expected_revision: credential.revision },
+      },
+    );
+    setBusy(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setFailed({
+        what: `Egma did not archive ${credential.label}.`,
+        refusal: written.refusal,
+        // Bound to the credential that failed, and cleared the moment a
+        // different row opens — the same rule the replacement field is held
+        // to, and for the same reason.
+        again: () => void archive(credential),
+      });
+      return;
+    }
+    // The row leaves the list, so the form that was open on it must close with
+    // it rather than sit over a credential that is no longer there.
+    if (rotating === credential.id) {
+      setRotating(null);
+      setReplacement("");
+    }
+    onChanged();
+  }
+
   async function rotate(credential: JudgeCredential): Promise<void> {
     if (!mayAdminister || busy || replacement.trim() === "") return;
     setFailed(null);
@@ -382,6 +423,24 @@ function Credentials({
       mono: true,
       width: "90px",
       cell: (credential) => `…${credential.hint}`,
+    },
+    {
+      key: "archive",
+      header: "",
+      width: "110px",
+      cell: (credential) => (
+        <Button
+          disabled={!mayAdminister || busy}
+          onClick={() => {
+            // Archiving is not opening a row, so it does not change which row
+            // is open — but it does replace whatever failure was on screen
+            // with its own, bound to this credential.
+            void archive(credential);
+          }}
+        >
+          Archive
+        </Button>
+      ),
     },
     {
       key: "rotate",

--- a/apps/web/lib/judge.ts
+++ b/apps/web/lib/judge.ts
@@ -90,6 +90,20 @@ export function judgeCredentialPath(credentialId: string): string {
 }
 
 /**
+ * Taking a credential out of use.
+ *
+ * Its own address rather than a field on the edit, because it is a different
+ * kind of decision: a relabel or a rotation always succeeds, and this is
+ * refused while a project points at the credential, while a run whose frozen
+ * grading plan names it still has a conversation moving, or while a grading job
+ * is waiting to be judged or already claimed. The refusal names every blocking
+ * use and the page shows it word for word.
+ */
+export function judgeCredentialArchivePath(credentialId: string): string {
+  return `${judgeCredentialPath(credentialId)}/archive`;
+}
+
+/**
  * The credentials an answer actually carried, and none at all when it carried
  * something this page cannot read.
  *

--- a/apps/web/lib/runs.ts
+++ b/apps/web/lib/runs.ts
@@ -1,0 +1,226 @@
+/**
+ * Planning a run and starting it, as the API answers and accepts them.
+ *
+ * A **run** is one execution of a selection of tests against one agent over one
+ * connection. It holds one **simulation** per test per persona — one
+ * conversation, start to finish — and each of those is judged by **graders**
+ * into a **verdict**.
+ *
+ * The shapes are the API's own, field names included. Renaming its fields on
+ * the way in would put a second vocabulary between the contract and the page,
+ * and the two would drift the first time the API grew a field.
+ *
+ * **The whole point of this module is that the browser decides nothing.** Which
+ * versions would be pinned, which conversations would be skipped and why, which
+ * graders would judge and at which versions, and whether the project even has a
+ * judge — every one of those is answered by `GET /api/run-plan`, which is the
+ * same resolution `POST /api/runs` performs. A page that worked any of it out
+ * for itself would be a second opinion, and the moment the two disagreed
+ * somebody would approve one run and start another.
+ */
+
+export type CapabilityStanding = "supported" | "unsupported" | "not_measured";
+
+/**
+ * What is known about the connection a run would use — or the fact that nobody
+ * has measured it.
+ *
+ * `unknown` and a `known` state with nothing in its list are different
+ * sentences and lead somewhere different: one is a Refresh away from an answer,
+ * the other is a settled fact about the target.
+ */
+export type PlanCapabilities =
+  | { readonly state: "unknown" }
+  | {
+      readonly state: "known";
+      readonly measured: readonly string[];
+      readonly supported: readonly string[];
+      readonly checked_at: string;
+      readonly source: string;
+    };
+
+/**
+ * Which model would judge, whose account would pay, and the honest answer when
+ * neither question has one.
+ *
+ * `configured` carries the provider, the model and the **reference** to a key —
+ * an organization credential or the deployment's `platform` sentinel. There is
+ * no field here a secret could travel in, and there never will be.
+ */
+export type JudgeChoice =
+  | { readonly tag: "not_required" }
+  | {
+      readonly tag: "configured";
+      readonly provider: string;
+      readonly model: string;
+      readonly source: string;
+    }
+  | { readonly tag: "unavailable_at_capture" };
+
+/** One grader a run would freeze, in whichever of its two shapes it has. */
+export type PlanGrader =
+  | {
+      readonly kind: "built_in";
+      /** The reserved key. `expected_behaviors_v1` is the first and only one. */
+      readonly grader_key: string;
+      readonly engine_version: string;
+      readonly reads: readonly string[];
+      readonly modalities: readonly string[];
+      readonly judge: JudgeChoice;
+    }
+  | {
+      readonly kind: "authored";
+      readonly grader_id: string;
+      readonly grader_version_id: string;
+      readonly name: string;
+      /** How it got here. A direct link is the per-test scoping decision. */
+      readonly origin: "project_default" | "scenario_specific";
+      readonly priority: string;
+      readonly scope: string;
+      readonly reads: readonly string[];
+      readonly modalities: readonly string[];
+      readonly judge: JudgeChoice;
+    };
+
+/**
+ * Why egma would not conduct a test's conversations at all.
+ *
+ * **Two reasons, never one.** `required_capability_unsupported` is a settled
+ * fact about the target and the fix is to write a different test;
+ * `required_capability_unknown` means nobody has measured this connection and a
+ * Refresh may change the answer. A page that folded them would send somebody
+ * the wrong way, and neither is ever a failure of the agent.
+ */
+export type PlanSkip = {
+  readonly reason:
+    | "required_capability_unsupported"
+    | "required_capability_unknown";
+  readonly capabilities: readonly string[];
+};
+
+export type PlannedTest = {
+  readonly test_id: string;
+  readonly test_version_id: string;
+  readonly test_name: string;
+  readonly personas: readonly {
+    readonly persona_id: string;
+    readonly persona_version_id: string;
+    readonly name: string;
+  }[];
+  readonly required_capabilities: readonly string[];
+  /** Null where the conversations would happen. */
+  readonly skip: PlanSkip | null;
+  readonly graders: readonly PlanGrader[];
+};
+
+export type RunPlan = {
+  readonly agent_id: string;
+  readonly connection_id: string;
+  readonly connection: {
+    readonly type: string;
+    readonly modality: string;
+    readonly environment: string | null;
+    readonly capabilities: PlanCapabilities;
+  };
+  readonly judge:
+    | { readonly state: "needs_setup" }
+    | {
+        readonly state: "configured";
+        readonly provider: string;
+        readonly model: string;
+        readonly source: string;
+      };
+  readonly runnable_simulation_count: number;
+  readonly skipped_simulation_count: number;
+  readonly tests: readonly PlannedTest[];
+};
+
+/** A started run, as far as a builder needs to read one. */
+export type StartedRun = {
+  readonly id: string;
+  readonly status: string;
+  readonly expected_simulation_count: number;
+  readonly skipped_count: number | null;
+};
+
+export const RUNS_PATH = "/api/runs";
+export const RUN_PLAN_PATH = "/api/run-plan";
+
+/**
+ * The address of one plan read.
+ *
+ * The whole selection is in the address rather than in a body, because it is a
+ * read: reload, Back and a copied link all restore the same review, and nothing
+ * is created by asking.
+ */
+export function runPlanQuery(selection: {
+  readonly agentId: string;
+  readonly connectionId: string;
+  readonly testVersionIds: readonly string[];
+}): string {
+  const asked = new URLSearchParams();
+  asked.set("agent", selection.agentId);
+  asked.set("connection", selection.connectionId);
+  asked.set("test_versions", selection.testVersionIds.join(","));
+  return `${RUN_PLAN_PATH}?${asked.toString()}`;
+}
+
+/** Where the run builder lives inside one project. */
+export const RUN_BUILDER_SECTION = "runs";
+export const RUN_BUILDER_STEP = "new";
+
+/**
+ * The agent a builder should open with, taken from the address.
+ *
+ * **It preselects and never bypasses.** Arriving from an agent's page fills the
+ * first step in; every later check — the connection is that agent's, the test
+ * applies to it, the project has a judge — still runs, on the server, exactly
+ * as it does for somebody who chose the agent from the list.
+ */
+export function preselectedAgent(search: string): string | null {
+  const named = new URLSearchParams(search).get("agent");
+  return named === null || named.trim() === "" ? null : named.trim();
+}
+
+/**
+ * How a page words one skip.
+ *
+ * Two sentences, because the two reasons have two different next moves, and
+ * neither of them says anything about the agent. This is the browser's own
+ * wording rather than a relayed refusal: nothing is being refused, and a run
+ * that skips a test still starts.
+ */
+export function skipExplanation(skip: PlanSkip): string {
+  const named = skip.capabilities.join(", ");
+  return skip.reason === "required_capability_unsupported"
+    ? `This connection was measured and does not support ${named}. Egma will not conduct these simulations, and will say nothing about the agent. Choose a connection that supports it, or a test that does not require it.`
+    : `Nobody has measured whether this connection supports ${named}. Egma will not conduct these simulations, and will say nothing about the agent. Refresh the connection's capabilities, then plan the run again.`;
+}
+
+/** How many conversations a plan would produce, conducted and skipped alike. */
+export function plannedSimulationCount(plan: RunPlan): number {
+  return plan.runnable_simulation_count + plan.skipped_simulation_count;
+}
+
+/**
+ * Whether this plan could be started at all, and what to say when it could not.
+ *
+ * **Two blockers, and only two, and both are states rather than mistakes.** A
+ * project with no judge cannot start any run, because every run carries the
+ * judge-backed expected-behaviors built-in. And a plan in which every
+ * conversation would be skipped is a run with nothing to conduct — it would
+ * complete immediately having judged nothing, and offering Start for it would
+ * be offering somebody a green tick nobody earned.
+ *
+ * The server refuses the first for itself, so this is the page saying so early
+ * rather than the page being the check.
+ */
+export function whyNotStartable(plan: RunPlan): string | null {
+  if (plan.judge.state === "needs_setup") {
+    return "This project has no LLM judge configured, and every run judges its test's expected behaviors with one. An organization admin can set it in project Settings.";
+  }
+  if (plan.runnable_simulation_count === 0) {
+    return "Every simulation in this selection would be skipped, so this run would conduct nothing. Choose a connection that supports what these tests require, or choose tests that require less.";
+  }
+  return null;
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -138,6 +138,10 @@ const config: NextConfig = {
           destination: `${api}/api/test-versions/:path*`,
         },
         { source: "/api/runs", destination: `${api}/api/runs` },
+        // What a run would freeze, read by the builder's review step before
+        // anybody starts one. Its own rule because it is not under
+        // `/api/runs` — nothing is created and nothing is reserved by asking.
+        { source: "/api/run-plan", destination: `${api}/api/run-plan` },
         { source: "/api/runs/:path*", destination: `${api}/api/runs/:path*` },
         // One conversation's own paths — today, resolving its recording into a
         // link the browser then fetches from the object store directly. Without

--- a/apps/web/test/runs.test.tsx
+++ b/apps/web/test/runs.test.tsx
@@ -1,0 +1,743 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import NewRunPage from "../app/projects/[projectId]/runs/new/page.tsx";
+import RunsPage from "../app/projects/[projectId]/runs/page.tsx";
+import type { Me } from "../lib/me.ts";
+
+/**
+ * Planning a run in the browser.
+ *
+ * **Nothing here asserts that a component exists or that a source file contains
+ * a string.** Every test drives a rendered page the way somebody with a keyboard
+ * would and reads what the DOM then says.
+ *
+ * The claims worth having in the fast lane are the ones the page decides for
+ * itself: that the steps narrow in order, that arriving from an agent's page
+ * fills the first one in, that the review shows what the server said would be
+ * frozen and skipped rather than anything the browser worked out, that Start
+ * carries one idempotency key for one selection, and that nothing bound to the
+ * open test row can reach a different one.
+ */
+
+const routed = vi.hoisted(() => ({
+  push: vi.fn(),
+  pathname: "/projects/prj_1/runs/new",
+  projectId: "prj_1",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => routed.pathname,
+  useRouter: () => ({ push: routed.push, replace: vi.fn(), back: vi.fn() }),
+  useParams: () => ({ projectId: routed.projectId }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: unknown }) => (
+    <a href={href} {...rest}>
+      {children as never}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+const PROJECTS = [{ id: "prj_1", name: "Default", slug: "default" }];
+const ACME = { id: "org_1", name: "Acme", slug: "acme", role: "admin" };
+
+function meWith(role: string): Me {
+  return {
+    user: { id: "usr_1", email: "ada@acme.example" },
+    organizations: [{ ...ACME, role }],
+    projects: PROJECTS,
+  };
+}
+
+function agentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "agt_1",
+    project_id: "prj_1",
+    name: "Front desk",
+    description: null,
+    revision: "rev_a",
+    archived: false,
+    archived_at: null,
+    created_at: "2026-08-01T10:00:00.000Z",
+    updated_at: "2026-08-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function connectionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "con_1",
+    agent_id: "agt_1",
+    project_id: "prj_1",
+    name: "retell-1",
+    type: "retell",
+    variant_id: "retell-hosted",
+    modality: "chat",
+    topology: "hosted",
+    environment: "staging",
+    config: {},
+    credential_present: true,
+    credentials_hint: "WXYZ",
+    capabilities: {
+      state: "known",
+      measured: ["raw_audio", "dtmf"],
+      supported: [],
+      checked_at: "2026-08-01T10:00:00.000Z",
+      source: "transport",
+      standing: {
+        raw_audio: "unsupported",
+        dtmf: "unsupported",
+        barge_in: "not_measured",
+      },
+    },
+    revision: "rev_c",
+    archived: false,
+    archived_at: null,
+    created_at: "2026-08-01T10:00:00.000Z",
+    updated_at: "2026-08-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function testRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "tst_1",
+    project_id: "prj_1",
+    name: "Reschedules a booked appointment",
+    description: null,
+    version: 3,
+    version_id: "tstv_1",
+    scenario: "Their cleaning has to move to next week.",
+    expected_behaviors: [
+      { behavior: "confirms the new time back", priority: "P0" },
+    ],
+    personas: [{ id: "prs_1", name: "Impatient Rita", archived_at: null }],
+    graders: [],
+    required_capabilities: [],
+    override_count: 0,
+    agents: [{ id: "agt_1", name: "Front desk", archived_at: null }],
+    revision: "rev_1",
+    applicability_revision: "rev_app_1",
+    archived_at: null,
+    archive_reason: null,
+    created_at: "2026-08-01T10:00:00.000Z",
+    updated_at: "2026-08-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function plannedTest(overrides: Record<string, unknown> = {}) {
+  return {
+    test_id: "tst_1",
+    test_version_id: "tstv_1",
+    test_name: "Reschedules a booked appointment",
+    personas: [
+      {
+        persona_id: "prs_1",
+        persona_version_id: "prsv_7",
+        name: "Impatient Rita",
+      },
+    ],
+    required_capabilities: [],
+    skip: null,
+    graders: [
+      {
+        kind: "built_in",
+        grader_key: "expected_behaviors_v1",
+        engine_version: "1",
+        reads: ["transcript", "outcome", "tool_calls", "measures"],
+        modalities: ["voice", "chat"],
+        judge: {
+          tag: "configured",
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          source: "jcr_1",
+        },
+      },
+      {
+        kind: "authored",
+        grader_id: "grd_1",
+        grader_version_id: "grv_2",
+        name: "Never promises a price",
+        origin: "project_default",
+        priority: "P1",
+        scope: "simulations",
+        reads: ["transcript"],
+        modalities: ["voice", "chat"],
+        judge: { tag: "not_required" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function planBody(overrides: Record<string, unknown> = {}) {
+  return {
+    agent_id: "agt_1",
+    connection_id: "con_1",
+    connection: {
+      type: "retell",
+      modality: "chat",
+      environment: "staging",
+      capabilities: {
+        state: "known",
+        measured: ["raw_audio", "dtmf"],
+        supported: [],
+        checked_at: "2026-08-01T10:00:00.000Z",
+        source: "transport",
+      },
+    },
+    judge: {
+      state: "configured",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      source: "jcr_1",
+    },
+    runnable_simulation_count: 1,
+    skipped_simulation_count: 0,
+    tests: [plannedTest()],
+    ...overrides,
+  };
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type Stubbed = { status: number; body: unknown } | "never";
+
+/** Every request the browser makes, in the order it made them. */
+let sent: { url: string; method: string; body: unknown }[] = [];
+
+function apiAnswers(answers: Record<string, Stubbed | readonly Stubbed[]>): void {
+  const asked: Record<string, number> = {};
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string, init?: RequestInit) => {
+      const url = new URL(input, "http://egma.test");
+      sent.push({
+        url: input,
+        method: init?.method ?? "GET",
+        body:
+          typeof init?.body === "string"
+            ? (JSON.parse(init.body) as unknown)
+            : undefined,
+      });
+
+      const held = answers[url.pathname];
+      if (held === undefined) {
+        throw new Error(`nothing stubbed for ${url.pathname}`);
+      }
+
+      const turn = asked[url.pathname] ?? 0;
+      asked[url.pathname] = turn + 1;
+      const answer = Array.isArray(held)
+        ? ((held[Math.min(turn, held.length - 1)] ?? "never") as Stubbed)
+        : (held as Stubbed);
+
+      if (answer === "never") return new Promise<Response>(() => undefined);
+      return json(answer.status, answer.body);
+    }),
+  );
+}
+
+let wentTo: string[] = [];
+
+beforeEach(() => {
+  sent = [];
+  wentTo = [];
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...window.location,
+      search: "",
+      replace: (url: string) => wentTo.push(url),
+    },
+  });
+  routed.push.mockReset();
+  routed.pathname = "/projects/prj_1/runs/new";
+  routed.projectId = "prj_1";
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+/** What the page sent to one address, most recent last. */
+function sentTo(path: string): { method: string; body: unknown }[] {
+  return sent
+    .filter((one) => new URL(one.url, "http://egma.test").pathname === path)
+    .map((one) => ({ method: one.method, body: one.body }));
+}
+
+/** Every plan address the page asked for, in order. */
+function planQueries(): string[] {
+  return sent
+    .filter(
+      (one) => new URL(one.url, "http://egma.test").pathname === "/api/run-plan",
+    )
+    .map((one) => one.url);
+}
+
+/**
+ * The builder, with everything it reads stubbed.
+ *
+ * The versions read is separate from the plan because it is the open row's own,
+ * which is the whole subject of the last group of tests in this file.
+ */
+function builder(
+  options: {
+    readonly role?: string;
+    readonly tests?: unknown[];
+    readonly plan?: Stubbed | readonly Stubbed[];
+    readonly versions?: Stubbed | readonly Stubbed[];
+    /** The second row's own read, so a test can leave it unanswered. */
+    readonly secondVersions?: Stubbed | readonly Stubbed[];
+    readonly started?: Stubbed | readonly Stubbed[];
+  } = {},
+): void {
+  apiAnswers({
+    "/api/me": { status: 200, body: meWith(options.role ?? "admin") },
+    "/api/agents": { status: 200, body: { items: [agentRow()], next_cursor: null } },
+    "/api/agents/agt_1": {
+      status: 200,
+      body: { agent: agentRow(), connections: [connectionRow()] },
+    },
+    "/api/tests": {
+      status: 200,
+      body: {
+        items: options.tests ?? [testRow()],
+        next_cursor: null,
+      },
+    },
+    "/api/tests/tst_1/versions": options.versions ?? {
+      status: 200,
+      body: {
+        items: [
+          { id: "tstv_1", test_id: "tst_1", version: 3, current: true },
+          { id: "tstv_0", test_id: "tst_1", version: 2, current: false },
+        ],
+        next_cursor: null,
+      },
+    },
+    "/api/tests/tst_2/versions": options.secondVersions ?? {
+      status: 200,
+      body: {
+        items: [{ id: "tstv_2", test_id: "tst_2", version: 1, current: true }],
+        next_cursor: null,
+      },
+    },
+    "/api/run-plan": options.plan ?? { status: 200, body: planBody() },
+    "/api/runs": options.started ?? {
+      status: 201,
+      body: {
+        id: "run_1",
+        status: "pending",
+        expected_simulation_count: 1,
+        skipped_count: null,
+      },
+    },
+  });
+}
+
+/** Choose the agent, the connection and the first test, in that order. */
+async function chooseEverything(): Promise<void> {
+  fireEvent.change(await screen.findByLabelText("Agent"), {
+    target: { value: "agt_1" },
+  });
+  fireEvent.change(await screen.findByLabelText("Connection"), {
+    target: { value: "con_1" },
+  });
+  // A table draws every row twice — once wide and once narrow — so the same
+  // control is on screen twice and either of them is the one somebody clicked.
+  fireEvent.click(
+    (await screen.findAllByLabelText("Include Reschedules a booked appointment"))[0]!,
+  );
+}
+
+/* ------------------------------------------------------------------------ */
+
+describe("the way into the builder", () => {
+  it("offers a member the builder from the runs page", async () => {
+    apiAnswers({ "/api/me": { status: 200, body: meWith("member") } });
+    render(<RunsPage />);
+
+    const into = await screen.findAllByRole("link", { name: "Plan a run" });
+    expect(into.length).toBeGreaterThan(0);
+    expect(into[0]?.getAttribute("href")).toBe("/projects/prj_1/runs/new");
+  });
+
+  it("offers a viewer none, because the server would refuse the start", async () => {
+    apiAnswers({ "/api/me": { status: 200, body: meWith("viewer") } });
+    render(<RunsPage />);
+
+    await screen.findByRole("heading", { name: "Runs" });
+    expect(screen.queryAllByRole("link", { name: "Plan a run" })).toEqual([]);
+  });
+});
+
+describe("the steps", () => {
+  it("asks for a connection only once an agent is chosen", async () => {
+    builder();
+    render(<NewRunPage />);
+
+    await screen.findByLabelText("Agent");
+    expect(screen.queryByLabelText("Connection")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Agent"), {
+      target: { value: "agt_1" },
+    });
+    await screen.findByLabelText("Connection");
+  });
+
+  it("offers only the tests that apply to the chosen agent", async () => {
+    builder();
+    render(<NewRunPage />);
+
+    fireEvent.change(await screen.findByLabelText("Agent"), {
+      target: { value: "agt_1" },
+    });
+
+    await waitFor(() => {
+      const asked = sent.filter((one) =>
+        one.url.startsWith("/api/tests?"),
+      );
+      expect(asked.length).toBeGreaterThan(0);
+      // The applicability filter is the server's, in the address of the
+      // request — a filter applied to what came back would answer differently
+      // depending on what had already been fetched.
+      expect(asked[0]?.url).toContain("agent=agt_1");
+    });
+  });
+
+  it("preselects the agent it was opened from, and still asks the server everything else", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, search: "?agent=agt_1", replace: () => undefined },
+    });
+    builder();
+    render(<NewRunPage />);
+
+    // The first step is filled in…
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Agent") as HTMLSelectElement).value,
+      ).toBe("agt_1");
+    });
+    // …and the connection step opened as a consequence, which is the proof it
+    // preselected rather than bypassed: the same reads happen either way.
+    await screen.findByLabelText("Connection");
+  });
+
+  it("drops a connection and a selection when the agent changes under them", async () => {
+    builder({ tests: [testRow()] });
+    render(<NewRunPage />);
+
+    await chooseEverything();
+    await waitFor(() => {
+      expect(planQueries().length).toBeGreaterThan(0);
+    });
+
+    fireEvent.change(screen.getByLabelText("Agent"), {
+      target: { value: "" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Connection")).toBeNull();
+    });
+  });
+});
+
+describe("the review", () => {
+  it("shows the versions, the personas and the graders the server said it would freeze", async () => {
+    builder();
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    // The version and the persona version are the server's answer, shown as it
+    // came: this page pins nothing and works nothing out.
+    await screen.findByText("tstv_1");
+    await screen.findByText("Impatient Rita (prsv_7)");
+    await screen.findByText("Expected behaviors");
+    await screen.findByText("Never promises a price");
+  });
+
+  it("shows the judge the run would spend, and never a key", async () => {
+    builder();
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    await screen.findByText(/openai\/gpt-4\.1-mini · credential jcr_1/u);
+  });
+
+  it("says a project with no judge cannot start a run, and disables Start", async () => {
+    builder({
+      plan: { status: 200, body: planBody({ judge: { state: "needs_setup" } }) },
+    });
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    await screen.findByText(/no LLM judge configured/u);
+    await waitFor(() => {
+      expect(
+        (screen.getByRole("button", { name: "Start run" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
+    });
+  });
+
+  it("names a skipped test as skipped, and never as a failure of the agent", async () => {
+    builder({
+      plan: {
+        status: 200,
+        body: planBody({
+          runnable_simulation_count: 0,
+          skipped_simulation_count: 1,
+          tests: [
+            plannedTest({
+              required_capabilities: ["raw_audio"],
+              skip: {
+                reason: "required_capability_unsupported",
+                capabilities: ["raw_audio"],
+              },
+            }),
+          ],
+        }),
+      },
+    });
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    const said = await screen.findAllByText(/does not support raw_audio/u);
+    expect(said.length).toBeGreaterThan(0);
+    for (const one of said) {
+      expect(one.textContent).toContain("say nothing about the agent");
+      expect(one.textContent).not.toContain("failed");
+    }
+  });
+
+  it("refuses to offer Start for a run that would conduct nothing", async () => {
+    builder({
+      plan: {
+        status: 200,
+        body: planBody({
+          runnable_simulation_count: 0,
+          skipped_simulation_count: 1,
+          tests: [
+            plannedTest({
+              skip: {
+                reason: "required_capability_unknown",
+                capabilities: ["barge_in"],
+              },
+            }),
+          ],
+        }),
+      },
+    });
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    await screen.findByText(/would conduct nothing/u);
+    await waitFor(() => {
+      expect(
+        (screen.getByRole("button", { name: "Start run" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
+    });
+  });
+});
+
+describe("starting", () => {
+  it("sends the selection with one idempotency key, and reuses it on a retry", async () => {
+    builder({
+      started: [
+        { status: 502, body: { error: "unavailable", message: "Egma could not answer." } },
+        {
+          status: 201,
+          body: {
+            id: "run_1",
+            status: "pending",
+            expected_simulation_count: 1,
+            skipped_count: null,
+          },
+        },
+      ],
+    });
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    const start = await screen.findByRole("button", { name: "Start run" });
+    await waitFor(() => {
+      expect((start as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    fireEvent.click(start);
+    await screen.findByText("Egma could not answer.");
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      expect(sentTo("/api/runs")).toHaveLength(2);
+    });
+    const [first, second] = sentTo("/api/runs");
+    const key = (first?.body as { idempotency_key: string }).idempotency_key;
+    expect(key).not.toBe("");
+    // The same selection under the same word: a lost answer becomes the run
+    // that already exists rather than a second conversation with the agent.
+    expect((second?.body as { idempotency_key: string }).idempotency_key).toBe(
+      key,
+    );
+    expect((first?.body as { test_versions: string[] }).test_versions).toEqual([
+      "tstv_1",
+    ]);
+  });
+
+  it("mints a different key for a different selection, because it is a different run", async () => {
+    builder({ tests: [testRow(), testRow({ id: "tst_2", name: "Cancels", version_id: "tstv_2" })] });
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    const start = await screen.findByRole("button", { name: "Start run" });
+    await waitFor(() => {
+      expect((start as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(start);
+    await waitFor(() => {
+      expect(sentTo("/api/runs")).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getAllByLabelText("Include Cancels")[0]!);
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("button", { name: "Start run" }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      expect(sentTo("/api/runs")).toHaveLength(2);
+    });
+    const [first, second] = sentTo("/api/runs");
+    expect((second?.body as { idempotency_key: string }).idempotency_key).not.toBe(
+      (first?.body as { idempotency_key: string }).idempotency_key,
+    );
+  });
+
+  it("keeps a viewer's Start inert", async () => {
+    builder({ role: "viewer" });
+    render(<NewRunPage />);
+    await chooseEverything();
+
+    const start = await screen.findByRole("button", { name: "Start run" });
+    expect((start as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(start);
+    expect(sentTo("/api/runs")).toEqual([]);
+  });
+});
+
+/**
+ * The panel under the table is drawn once, for whichever row is open, so
+ * everything it holds is shared by every row. Each of these is a different way
+ * of showing somebody the wrong test's answer, and the two fixes are genuinely
+ * two: clearing the read does not clear the pending failure, and the failure
+ * outlives the panel.
+ */
+describe("what belongs to the open test row", () => {
+  /**
+   * Two rows, and the second row's own read left unanswered.
+   *
+   * **The unanswered read is the whole experiment.** A second read that lands
+   * immediately overwrites whatever the first row left behind, so the defect is
+   * invisible and a test that watched for it would pass either way. Holding the
+   * second read open is what opens the window the stale value would be shown
+   * in, which is the window a real slow network opens on its own.
+   */
+  function twoTests(versions?: Stubbed | readonly Stubbed[]): void {
+    builder({
+      tests: [
+        testRow(),
+        testRow({ id: "tst_2", name: "Cancels", version_id: "tstv_2" }),
+      ],
+      secondVersions: "never",
+      ...(versions === undefined ? {} : { versions }),
+    });
+  }
+
+  it("empties one test's version history when a different row opens", async () => {
+    twoTests();
+    render(<NewRunPage />);
+    fireEvent.change(await screen.findByLabelText("Agent"), {
+      target: { value: "agt_1" },
+    });
+
+    const [firstDetails, secondDetails] = await screen.findAllByRole("button", {
+      name: "Details",
+    });
+    if (firstDetails === undefined || secondDetails === undefined) {
+      throw new Error("both rows should offer their details");
+    }
+
+    fireEvent.click(firstDetails);
+    // **Wait for the read that produces the sentence** before asserting it is
+    // gone — asserting an absence before the read has answered would pass for
+    // the wrong reason and keep passing after the behaviour was deleted.
+    await screen.findByText(/2 versions; this run would pin v3\./u);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Details" })[1]!);
+    await waitFor(() => {
+      expect(screen.queryByText(/2 versions/u)).toBeNull();
+    });
+    // The second row is open and its own read has not answered, so the panel
+    // says it is reading rather than showing the first row's answer under the
+    // second row's name.
+    await screen.findByText(/Reading this test's version history…/u);
+  });
+
+  it("drops a failed read's Try again when a different row opens", async () => {
+    twoTests([
+      { status: 500, body: { error: "unavailable", message: "Egma could not answer." } },
+    ]);
+    render(<NewRunPage />);
+    fireEvent.change(await screen.findByLabelText("Agent"), {
+      target: { value: "agt_1" },
+    });
+
+    const rows = await screen.findAllByRole("button", { name: "Details" });
+    fireEvent.click(rows[0]!);
+    // Wait for the failure to actually be on screen before switching, so the
+    // assertion below is about the clearing rather than about the timing.
+    await screen.findByRole("button", { name: "Try again" });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Details" })[1]!);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    });
+    // The heading is the only thing on screen saying which test the panel is
+    // about, so a retry left behind would draw one test's answer under
+    // another's name and report it as a success.
+    expect(
+      screen.getAllByRole("heading", { name: "Cancels" }).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/db/migrations/0029_run_planning_and_grading_plans.sql
+++ b/packages/db/migrations/0029_run_planning_and_grading_plans.sql
@@ -1,0 +1,375 @@
+-- Runs plan before they start, and old runs say honestly what they never planned.
+--
+-- Four changes, and they are one change to what starting a run *means*: egma
+-- decides in advance which conversations it can honestly have, writes down what
+-- will judge each one, remembers which request asked for it, and refuses to
+-- invent any of that for history that predates the decision.
+--
+-- **The generated body for this diff would have been wrong on any installed
+-- deployment**, in two ways. `run_counts_written_together` gains
+-- `skipped_count`, and every run that has already finished holds three counts
+-- and a null fourth — so the constraint would refuse the table it was added to.
+-- And nothing in a generated diff writes a grading plan, so every run on an
+-- upgraded instance would come out of it with no plan at all, which is the one
+-- state a run must never be in when a grader comes looking. The snapshot and
+-- the journal entry are drizzle's, untouched, so the next `generate` diffs
+-- against a schema this file really produces; the body is written, in the order
+-- that makes it safe.
+--
+-- **Judge credentials were migrated first, and by 0026 rather than by this
+-- file.** A plan stores the *reference* to a credential and never a secret, so
+-- there has to be a credential row to point at before any plan is captured.
+-- 0026 created one per project from each project's own judge configuration and
+-- pointed the project at it, which is exactly the order the product requires
+-- and is guaranteed here by nothing more than the migration number.
+--
+-- **An old run gets a captured plan only when it still has work outstanding.**
+-- `migration_snapshot` takes priority whenever any simulation is nonterminal or
+-- any grading job is `pending` or `claimed`, even where the run header itself
+-- reads terminal — because that work is about to be judged and has to be judged
+-- against something written down. Every other old run is `not_recorded`, and no
+-- plan is invented for it: reconstructing one from today's graders would put a
+-- sentence on a run from March claiming it was judged by things that may not
+-- have existed when it ran.
+--
+-- **A migrated simulation with no test version falls into the one testless
+-- group**, which holds only the project's active default authored graders. It
+-- carries no scenario grader and no expected-behaviors built-in, because there
+-- is no stored test content to support either, and inventing one would be a
+-- claim about a conversation nobody can check.
+
+CREATE TABLE "grading_plan" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"run_id" text COLLATE "C" NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"project_id" text COLLATE "C" NOT NULL,
+	"state" text NOT NULL,
+	"captured_at" timestamp with time zone,
+	"groups" jsonb NOT NULL,
+	"judge_credential_ids" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "grading_plan_run_id_unique" UNIQUE("run_id"),
+	CONSTRAINT "grading_plan_id_prefix" CHECK ("grading_plan"."id" ~ '^gpl_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "grading_plan_state_allowed" CHECK ("grading_plan"."state" in ('run_start', 'migration_snapshot', 'not_recorded')),
+	CONSTRAINT "grading_plan_recorded_plans_carry_their_moment" CHECK (("grading_plan"."state" = 'not_recorded')
+        = ("grading_plan"."captured_at" is null)),
+	CONSTRAINT "grading_plan_groups_are_a_list" CHECK (jsonb_typeof("grading_plan"."groups") = 'array'),
+	CONSTRAINT "grading_plan_credentials_are_a_list" CHECK (jsonb_typeof("grading_plan"."judge_credential_ids") = 'array'),
+	CONSTRAINT "grading_plan_unrecorded_holds_nothing" CHECK ("grading_plan"."state" <> 'not_recorded'
+        or ("grading_plan"."groups" = '[]'::jsonb
+          and "grading_plan"."judge_credential_ids" = '[]'::jsonb))
+);
+--> statement-breakpoint
+CREATE TABLE "idempotent_operation" (
+	"organization_id" text COLLATE "C" NOT NULL,
+	"project_id" text COLLATE "C" NOT NULL,
+	"actor_id" text COLLATE "C" NOT NULL,
+	"operation" text NOT NULL,
+	"idempotency_key" text NOT NULL,
+	"request_digest" text NOT NULL,
+	"result_id" text COLLATE "C" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "idempotent_operation_pk" PRIMARY KEY("organization_id","project_id","actor_id","operation","idempotency_key"),
+	CONSTRAINT "idempotent_operation_organization_id_prefix" CHECK ("idempotent_operation"."organization_id" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "idempotent_operation_allowed" CHECK ("idempotent_operation"."operation" in ('start_run')),
+	CONSTRAINT "idempotent_operation_key_is_not_empty" CHECK (length("idempotent_operation"."idempotency_key") > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "run" DROP CONSTRAINT "run_counts_written_together";--> statement-breakpoint
+ALTER TABLE "run" DROP CONSTRAINT "run_counts_are_counts";--> statement-breakpoint
+ALTER TABLE "run_event" DROP CONSTRAINT "run_event_simulation_shape";--> statement-breakpoint
+ALTER TABLE "run_event" DROP CONSTRAINT "run_event_verdict_agrees";--> statement-breakpoint
+ALTER TABLE "simulation" DROP CONSTRAINT "simulation_status_allowed";--> statement-breakpoint
+ALTER TABLE "run" ADD COLUMN "skipped_count" integer;--> statement-breakpoint
+ALTER TABLE "simulation" ADD COLUMN "skip_reason" text;--> statement-breakpoint
+ALTER TABLE "simulation" ADD COLUMN "skipped_capabilities" jsonb;--> statement-breakpoint
+
+-- **Before the constraint that names it.** Every run that has already finished
+-- holds its three counts, and the widened `run_counts_written_together` would
+-- refuse the table outright if this ran after it. Zero is the honest number:
+-- nothing was skipped before egma could skip anything.
+--
+-- **And around the guard, which is doing exactly its job.** A finished run's
+-- header is written once — `guard_run_lifecycle` has refused every update to
+-- one since 0007, and that refusal is what stops a straggling report reopening
+-- a run that already reported its numbers. This backfill is the one write that
+-- legitimately has to reach those rows, because it adds a column rather than
+-- changing an answer, so the guard is lifted for this statement and put back
+-- immediately. It is lifted rather than taught an exception on purpose: an
+-- exception would live in the trigger forever and would be a hole in the rule
+-- for every write afterwards, while this is one statement in one migration.
+ALTER TABLE "run" DISABLE TRIGGER "run_lifecycle_guard";--> statement-breakpoint
+UPDATE "run" SET "skipped_count" = 0 WHERE "finished_at" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "run" ENABLE TRIGGER "run_lifecycle_guard";--> statement-breakpoint
+
+ALTER TABLE "grading_plan" ADD CONSTRAINT "grading_plan_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "grading_plan" ADD CONSTRAINT "grading_plan_project_organization_fk" FOREIGN KEY ("project_id","organization_id") REFERENCES "public"."project"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "grading_plan" ADD CONSTRAINT "grading_plan_run_project_fk" FOREIGN KEY ("run_id","project_id") REFERENCES "public"."run"("id","project_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "idempotent_operation" ADD CONSTRAINT "idempotent_operation_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "idempotent_operation" ADD CONSTRAINT "idempotent_operation_project_organization_fk" FOREIGN KEY ("project_id","organization_id") REFERENCES "public"."project"("id","organization_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "idempotent_operation" ADD CONSTRAINT "idempotent_operation_actor_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "grading_plan_judge_credential_ids_idx" ON "grading_plan" USING gin ("judge_credential_ids");--> statement-breakpoint
+CREATE INDEX "grading_plan_organization_id_project_id_idx" ON "grading_plan" USING btree ("organization_id","project_id");--> statement-breakpoint
+ALTER TABLE "run" ADD CONSTRAINT "run_counts_written_together" CHECK ((("run"."completed_count" is null) = ("run"."failed_count" is null))
+        and (("run"."failed_count" is null) = ("run"."canceled_count" is null))
+        and (("run"."canceled_count" is null) = ("run"."skipped_count" is null))
+        and (("run"."canceled_count" is null) = ("run"."finished_at" is null)));--> statement-breakpoint
+ALTER TABLE "run" ADD CONSTRAINT "run_counts_are_counts" CHECK (("run"."completed_count" is null)
+        or ("run"."completed_count" >= 0 and "run"."failed_count" >= 0
+          and "run"."canceled_count" >= 0 and "run"."skipped_count" >= 0));--> statement-breakpoint
+ALTER TABLE "run_event" ADD CONSTRAINT "run_event_simulation_shape" CHECK ("run_event"."kind" <> 'simulation'
+        or ("run_event"."simulation_id" is not null
+          and "run_event"."status" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped')));--> statement-breakpoint
+ALTER TABLE "run_event" ADD CONSTRAINT "run_event_verdict_agrees" CHECK ("run_event"."verdict" is null
+        or ("run_event"."status" = 'completed' and "run_event"."verdict" in ('passed', 'failed', 'skipped'))
+        or ("run_event"."status" = 'failed' and "run_event"."verdict" = 'errored')
+        or ("run_event"."status" = 'canceled' and "run_event"."verdict" = 'skipped')
+        or ("run_event"."status" = 'skipped' and "run_event"."verdict" = 'skipped'));--> statement-breakpoint
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_skipped_shape" CHECK ("simulation"."status" <> 'skipped'
+        or ("simulation"."ended_at" is not null and "simulation"."claimed_at" is null
+          and "simulation"."started_at" is null and "simulation"."cancel_requested_at" is null
+          and "simulation"."skip_reason" is not null
+          and "simulation"."skipped_capabilities" is not null));--> statement-breakpoint
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_skip_reason_belongs_to_a_skip" CHECK ("simulation"."status" = 'skipped'
+        or ("simulation"."skip_reason" is null and "simulation"."skipped_capabilities" is null));--> statement-breakpoint
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_skip_reason_allowed" CHECK ("simulation"."skip_reason" is null or "simulation"."skip_reason" in ('required_capability_unsupported', 'required_capability_unknown'));--> statement-breakpoint
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_status_allowed" CHECK ("simulation"."status" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped'));--> statement-breakpoint
+
+-- `skipped` is terminal from birth, and the guard has to say so. Without this
+-- line the lifecycle trigger would read a skipped row as a live one and permit
+-- `skipped → claimed`, which is the one transition that would put a
+-- conversation egma declined to have in front of a simulator. `OR REPLACE`
+-- rather than a new name, because the trigger already points at this function
+-- and the point is to change what it does, not where it lives.
+CREATE OR REPLACE FUNCTION guard_simulation_lifecycle() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.status IN ('completed', 'failed', 'canceled', 'skipped') THEN
+    RAISE EXCEPTION 'simulation % is %, and a terminal simulation is written once',
+      OLD.id, OLD.status;
+  END IF;
+
+  IF NEW.status = OLD.status THEN
+    RETURN NEW;
+  END IF;
+
+  IF (OLD.status = 'queued'  AND NEW.status IN ('claimed', 'canceled'))
+  OR (OLD.status = 'claimed' AND NEW.status IN ('running', 'failed', 'canceled'))
+  OR (OLD.status = 'running' AND NEW.status IN ('completed', 'failed', 'canceled'))
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'simulation % may not move from % to %',
+    OLD.id, OLD.status, NEW.status;
+END
+$$;--> statement-breakpoint
+
+-- An identifier in egma's own format, minted in SQL for rows nobody was there
+-- to mint one for — 0026's helper, verbatim, for the same reason it was written
+-- there. `OR REPLACE`, because earlier migrations define the same helper and all
+-- of them run in one session.
+CREATE OR REPLACE FUNCTION pg_temp.migration_id(prefix text, seed text) RETURNS text AS $$
+	SELECT prefix || '_' || upper(substr(md5(seed), 1, 26));
+$$ LANGUAGE sql IMMUTABLE;--> statement-breakpoint
+
+-- One judge choice, in the tagged shape the plan stores and the grader service
+-- reads. Written once here because it is decided four times below — for the
+-- built-in and for each authored grader, in the version groups and in the
+-- testless one — and four copies of a rule are four things to keep in step.
+--
+-- `source` null is a project that had configured no judge at the moment of
+-- capture, and it records `unavailable_at_capture` rather than inventing a
+-- credential reference that would resolve to somebody else's key.
+CREATE OR REPLACE FUNCTION pg_temp.judge_choice(
+	judged boolean,
+	provider text,
+	model text,
+	source text,
+	override_provider text,
+	override_model text
+) RETURNS jsonb AS $$
+	SELECT CASE
+		WHEN NOT judged THEN jsonb_build_object('tag', 'not_required')
+		WHEN source IS NULL THEN jsonb_build_object('tag', 'unavailable_at_capture')
+		ELSE jsonb_build_object(
+			'tag', 'configured',
+			'provider', COALESCE(override_provider, provider),
+			'model', COALESCE(override_model, model),
+			'source', source)
+	END;
+$$ LANGUAGE sql IMMUTABLE;--> statement-breakpoint
+
+-- The captured plans: one per old run that still has work outstanding.
+INSERT INTO "grading_plan" (
+	"id", "run_id", "organization_id", "project_id",
+	"state", "captured_at", "groups", "judge_credential_ids", "created_at"
+)
+WITH outstanding AS (
+	SELECT r."id", r."organization_id", r."project_id"
+	FROM "run" AS r
+	WHERE EXISTS (
+			SELECT 1 FROM "simulation" AS s
+			WHERE s."run_id" = r."id"
+				AND s."status" IN ('queued', 'claimed', 'running')
+		)
+		OR EXISTS (
+			SELECT 1 FROM "grading_job" AS g
+			JOIN "simulation" AS s ON s."id" = g."simulation_id"
+			WHERE s."run_id" = r."id" AND g."status" IN ('pending', 'claimed')
+		)
+),
+-- The project's judge as it stands right now, which is what "captured during
+-- the upgrade" means. A project with no row is absent here and reads as no
+-- judge, which is the honest state rather than a guess.
+project_judge AS (
+	SELECT jc."project_id",
+		jc."provider",
+		jc."model",
+		CASE WHEN jc."source" = 'platform' THEN 'platform' ELSE jc."credential_id" END AS "source"
+	FROM "judge_configuration" AS jc
+),
+-- Every active authored grader of a project, with its current version's
+-- judged content. Archived graders are left out: Archive means stop entering
+-- new plans, and this is a new plan.
+project_graders AS (
+	SELECT g."id", g."project_id", g."name", g."type", g."priority", g."scope",
+		g."current_version_id", gv."reads", gv."modalities", gv."judge_model"
+	FROM "grader" AS g
+	JOIN "grader_version" AS gv ON gv."id" = g."current_version_id"
+	WHERE g."deleted_at" IS NULL
+),
+-- Which pinned test versions each outstanding run actually executed.
+run_versions AS (
+	SELECT DISTINCT o."id" AS "run_id", o."project_id", s."test_id", s."test_version_id", t."name" AS "test_name"
+	FROM outstanding AS o
+	JOIN "simulation" AS s ON s."run_id" = o."id"
+	JOIN "test" AS t ON t."id" = s."test_id"
+	WHERE s."test_version_id" IS NOT NULL
+),
+-- One authored item per grader per version: a project default whose live scope
+-- reaches simulations, or a grader the version names directly — and a direct
+-- link wins the origin, because it is the scoping decision somebody made.
+version_items AS (
+	SELECT rv."run_id", rv."test_version_id",
+		jsonb_build_object(
+			'kind', 'authored',
+			'graderId', pg."id",
+			'graderVersionId', pg."current_version_id",
+			'graderName', pg."name",
+			'origin', CASE WHEN tg."grader_id" IS NOT NULL THEN 'scenario_specific' ELSE 'project_default' END,
+			'priority', pg."priority",
+			'scope', pg."scope",
+			'reads', to_jsonb(pg."reads"),
+			'modalities', to_jsonb(pg."modalities"),
+			'judge', pg_temp.judge_choice(
+				pg."type" = 'llm_rubric', j."provider", j."model", j."source",
+				pg."judge_model" ->> 'provider', pg."judge_model" ->> 'model')
+		) AS "item",
+		pg."id" AS "grader_id"
+	FROM run_versions AS rv
+	JOIN project_graders AS pg ON pg."project_id" = rv."project_id"
+	LEFT JOIN "test_grader" AS tg
+		ON tg."test_version_id" = rv."test_version_id" AND tg."grader_id" = pg."id"
+	LEFT JOIN project_judge AS j ON j."project_id" = rv."project_id"
+	WHERE tg."grader_id" IS NOT NULL OR pg."scope" IN ('simulations', 'both')
+),
+version_groups AS (
+	SELECT rv."run_id",
+		jsonb_build_object(
+			'tag', 'version',
+			'testId', rv."test_id",
+			'testVersionId', rv."test_version_id",
+			'testName', rv."test_name",
+			'items', jsonb_build_array(
+				jsonb_build_object(
+					'kind', 'built_in',
+					'graderKey', 'expected_behaviors_v1',
+					'engineVersion', '1',
+					'reads', '["transcript", "outcome", "tool_calls", "measures"]'::jsonb,
+					'modalities', '["voice", "chat"]'::jsonb,
+					'judge', pg_temp.judge_choice(true, j."provider", j."model", j."source", NULL, NULL)
+				)
+			) || COALESCE(
+				(SELECT jsonb_agg(vi."item" ORDER BY vi."grader_id")
+					FROM version_items AS vi
+					WHERE vi."run_id" = rv."run_id" AND vi."test_version_id" = rv."test_version_id"),
+				'[]'::jsonb)
+		) AS "group"
+	FROM run_versions AS rv
+	LEFT JOIN project_judge AS j ON j."project_id" = rv."project_id"
+),
+-- The one testless group, for simulations written before a simulation could
+-- pin a test at all. Project defaults only.
+testless_runs AS (
+	SELECT DISTINCT o."id" AS "run_id", o."project_id"
+	FROM outstanding AS o
+	JOIN "simulation" AS s ON s."run_id" = o."id"
+	WHERE s."test_version_id" IS NULL
+),
+testless_groups AS (
+	SELECT tr."run_id",
+		jsonb_build_object(
+			'tag', 'legacy_testless',
+			'items', COALESCE(
+				(SELECT jsonb_agg(
+						jsonb_build_object(
+							'kind', 'authored',
+							'graderId', pg."id",
+							'graderVersionId', pg."current_version_id",
+							'graderName', pg."name",
+							'origin', 'project_default',
+							'priority', pg."priority",
+							'scope', pg."scope",
+							'reads', to_jsonb(pg."reads"),
+							'modalities', to_jsonb(pg."modalities"),
+							'judge', pg_temp.judge_choice(
+								pg."type" = 'llm_rubric', j."provider", j."model", j."source",
+								pg."judge_model" ->> 'provider', pg."judge_model" ->> 'model')
+						) ORDER BY pg."id")
+					FROM project_graders AS pg
+					WHERE pg."project_id" = tr."project_id"
+						AND pg."scope" IN ('simulations', 'both')),
+				'[]'::jsonb)
+		) AS "group"
+	FROM testless_runs AS tr
+	LEFT JOIN project_judge AS j ON j."project_id" = tr."project_id"
+),
+grouped AS (
+	SELECT o."id", o."organization_id", o."project_id",
+		COALESCE(
+			(SELECT jsonb_agg(vg."group") FROM version_groups AS vg WHERE vg."run_id" = o."id"),
+			'[]'::jsonb)
+		|| COALESCE(
+			(SELECT jsonb_agg(tg."group") FROM testless_groups AS tg WHERE tg."run_id" = o."id"),
+			'[]'::jsonb) AS "groups"
+	FROM outstanding AS o
+)
+SELECT pg_temp.migration_id('gpl', 'grading-plan:' || grouped."id"),
+	grouped."id", grouped."organization_id", grouped."project_id",
+	'migration_snapshot', now(), grouped."groups",
+	-- Derived from the plan itself, in the same statement, so the index of what
+	-- a plan needs can never come apart from the plan. The platform sentinel
+	-- names no customer credential and is deliberately left out.
+	COALESCE((
+		SELECT jsonb_agg(DISTINCT "item" -> 'judge' ->> 'source')
+		FROM jsonb_array_elements(grouped."groups") AS "grp",
+			jsonb_array_elements("grp" -> 'items') AS "item"
+		WHERE "item" -> 'judge' ->> 'tag' = 'configured'
+			AND "item" -> 'judge' ->> 'source' <> 'platform'
+	), '[]'::jsonb),
+	now()
+FROM grouped;--> statement-breakpoint
+
+-- And every other old run says out loud that nothing was written down.
+INSERT INTO "grading_plan" (
+	"id", "run_id", "organization_id", "project_id",
+	"state", "captured_at", "groups", "judge_credential_ids", "created_at"
+)
+SELECT pg_temp.migration_id('gpl', 'grading-plan:' || r."id"),
+	r."id", r."organization_id", r."project_id",
+	'not_recorded', NULL, '[]'::jsonb, '[]'::jsonb, now()
+FROM "run" AS r
+WHERE NOT EXISTS (
+	SELECT 1 FROM "grading_plan" AS gp WHERE gp."run_id" = r."id"
+);

--- a/packages/db/migrations/meta/0029_snapshot.json
+++ b/packages/db/migrations/meta/0029_snapshot.json
@@ -1,0 +1,5470 @@
+{
+  "id": "654da4c6-dc12-4a84-9f7d-899495b50051",
+  "prevId": "d18065b9-fca4-468b-b113-72251b0cc965",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.platform_instance": {
+      "name": "platform_instance",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_instance_id_unique": {
+          "name": "platform_instance_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_instance_id_format": {
+          "name": "platform_instance_id_format",
+          "value": "\"platform_instance\".\"id\" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_setting": {
+      "name": "platform_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_setting_name_unique": {
+          "name": "platform_setting_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "platform_setting_id_prefix": {
+          "name": "platform_setting_id_prefix",
+          "value": "\"platform_setting\".\"id\" ~ '^pfs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_revision_prefix": {
+          "name": "project_revision_prefix",
+          "value": "\"project\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_state": {
+          "name": "capability_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "capabilities_measured": {
+          "name": "capabilities_measured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_supported": {
+          "name": "capabilities_supported",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_checked_at": {
+          "name": "capabilities_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_source": {
+          "name": "capability_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_capability_state_allowed": {
+          "name": "connection_capability_state_allowed",
+          "value": "\"connection\".\"capability_state\" in ('unknown', 'known')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        },
+        "connection_capability_evidence_agrees": {
+          "name": "connection_capability_evidence_agrees",
+          "value": "(\"connection\".\"capability_state\" = 'known') = (\"connection\".\"capabilities_measured\" is not null and \"connection\".\"capabilities_supported\" is not null and \"connection\".\"capabilities_checked_at\" is not null and \"connection\".\"capability_source\" is not null)"
+        },
+        "connection_capabilities_supported_were_measured": {
+          "name": "connection_capabilities_supported_were_measured",
+          "value": "\"connection\".\"capabilities_supported\" is null or \"connection\".\"capabilities_supported\" <@ \"connection\".\"capabilities_measured\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_revision_prefix": {
+          "name": "grader_revision_prefix",
+          "value": "\"grader\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_rubric', 'metric_threshold', 'tool_calls', 'phrase_match')"
+        },
+        "grader_priority_allowed": {
+          "name": "grader_priority_allowed",
+          "value": "\"grader\".\"priority\" in ('P0', 'P1', 'P2')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reads": {
+          "name": "reads",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modalities": {
+          "name": "modalities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_version_reads_are_a_nonempty_known_set": {
+          "name": "grader_version_reads_are_a_nonempty_known_set",
+          "value": "array_length(\"grader_version\".\"reads\", 1) >= 1 and \"grader_version\".\"reads\" <@ array['transcript', 'outcome', 'tool_calls', 'measures']::text[]"
+        },
+        "grader_version_modalities_are_a_nonempty_known_set": {
+          "name": "grader_version_modalities_are_a_nonempty_known_set",
+          "value": "array_length(\"grader_version\".\"modalities\", 1) >= 1 and \"grader_version\".\"modalities\" <@ array['voice', 'chat']::text[]"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_credential_id_judge_credential_id_fk": {
+          "name": "judge_configuration_credential_id_judge_credential_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "judge_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        },
+        "judge_configuration_source_allowed": {
+          "name": "judge_configuration_source_allowed",
+          "value": "\"judge_configuration\".\"source\" in ('credential', 'platform')"
+        },
+        "judge_configuration_has_one_key_source": {
+          "name": "judge_configuration_has_one_key_source",
+          "value": "(\"judge_configuration\".\"source\" = 'credential' and \"judge_configuration\".\"credential_id\" is not null and \"judge_configuration\".\"credentials\" is null and \"judge_configuration\".\"credentials_hint\" is null) or (\"judge_configuration\".\"source\" = 'platform' and \"judge_configuration\".\"credential_id\" is null and \"judge_configuration\".\"credentials\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_credential": {
+      "name": "judge_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "judge_credential_organization_id_idx": {
+          "name": "judge_credential_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"judge_credential\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judge_credential_organization_id_organization_id_fk": {
+          "name": "judge_credential_organization_id_organization_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_credential_created_by_user_id_fk": {
+          "name": "judge_credential_created_by_user_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_credential_id_prefix": {
+          "name": "judge_credential_id_prefix",
+          "value": "\"judge_credential\".\"id\" ~ '^jcr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_revision_prefix": {
+          "name": "judge_credential_revision_prefix",
+          "value": "\"judge_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_provider_allowed": {
+          "name": "judge_credential_provider_allowed",
+          "value": "\"judge_credential\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool": {
+      "name": "mock_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_milliseconds": {
+          "name": "delay_milliseconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_tool_project_id_tool_name_unique": {
+          "name": "mock_tool_project_id_tool_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_tool_organization_id_project_id_idx": {
+          "name": "mock_tool_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_organization_id_organization_id_fk": {
+          "name": "mock_tool_organization_id_organization_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_created_by_user_id_fk": {
+          "name": "mock_tool_created_by_user_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_tool_project_organization_fk": {
+          "name": "mock_tool_project_organization_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mock_tool_id_project_id_unique": {
+          "name": "mock_tool_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_id_prefix": {
+          "name": "mock_tool_id_prefix",
+          "value": "\"mock_tool\".\"id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "mock_tool_delay_within_budget": {
+          "name": "mock_tool_delay_within_budget",
+          "value": "\"mock_tool\".\"delay_milliseconds\" between 0 and 30000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool_agent": {
+      "name": "mock_tool_agent",
+      "schema": "",
+      "columns": {
+        "mock_tool_id": {
+          "name": "mock_tool_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mock_tool_agent_agent_id_idx": {
+          "name": "mock_tool_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_agent_mock_tool_id_mock_tool_id_fk": {
+          "name": "mock_tool_agent_mock_tool_id_mock_tool_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_id_agent_id_fk": {
+          "name": "mock_tool_agent_agent_id_agent_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_mock_tool_project_fk": {
+          "name": "mock_tool_agent_mock_tool_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_project_fk": {
+          "name": "mock_tool_agent_agent_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mock_tool_agent_pk": {
+          "name": "mock_tool_agent_pk",
+          "columns": [
+            "mock_tool_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "mock_tool_agent_mock_tool_id_position_unique": {
+          "name": "mock_tool_agent_mock_tool_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mock_tool_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_agent_mock_tool_id_prefix": {
+          "name": "mock_tool_agent_mock_tool_id_prefix",
+          "value": "\"mock_tool_agent\".\"mock_tool_id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicability_revision": {
+          "name": "applicability_revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_revision_prefix": {
+          "name": "test_revision_prefix",
+          "value": "\"test\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_applicability_revision_prefix": {
+          "name": "test_applicability_revision_prefix",
+          "value": "\"test\".\"applicability_revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_archive_reason_allowed": {
+          "name": "test_archive_reason_allowed",
+          "value": "\"test\".\"archive_reason\" in ('needs_agent')"
+        },
+        "test_archive_reason_needs_an_archive": {
+          "name": "test_archive_reason_needs_an_archive",
+          "value": "\"test\".\"archive_reason\" is null or \"test\".\"archived_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_agent": {
+      "name": "test_agent",
+      "schema": "",
+      "columns": {
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_agent_agent_id_idx": {
+          "name": "test_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_agent_test_id_test_id_fk": {
+          "name": "test_agent_test_id_test_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_id_agent_id_fk": {
+          "name": "test_agent_agent_id_agent_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_created_by_user_id_fk": {
+          "name": "test_agent_created_by_user_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_agent_test_project_fk": {
+          "name": "test_agent_test_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_project_fk": {
+          "name": "test_agent_agent_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_agent_pk": {
+          "name": "test_agent_pk",
+          "columns": [
+            "test_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_agent_test_id_prefix": {
+          "name": "test_agent_test_id_prefix",
+          "value": "\"test_agent\".\"test_id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_grader": {
+      "name": "test_grader",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_grader_grader_id_idx": {
+          "name": "test_grader_grader_id_idx",
+          "columns": [
+            {
+              "expression": "grader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_grader_test_version_id_test_version_id_fk": {
+          "name": "test_grader_test_version_id_test_version_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_grader_grader_id_grader_id_fk": {
+          "name": "test_grader_grader_id_grader_id_fk",
+          "tableFrom": "test_grader",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_grader_pk": {
+          "name": "test_grader_pk",
+          "columns": [
+            "test_version_id",
+            "grader_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_grader_version_id_position_unique": {
+          "name": "test_grader_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_grader_test_version_id_prefix": {
+          "name": "test_grader_test_version_id_prefix",
+          "value": "\"test_grader\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tool_snapshot": {
+          "name": "mock_tool_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"skipped_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0\n          and \"run\".\"canceled_count\" >= 0 and \"run\".\"skipped_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')\n        or (\"run_event\".\"status\" = 'skipped' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_coverage": {
+          "name": "mock_tool_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_capabilities": {
+          "name": "skipped_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_skipped_shape": {
+          "name": "simulation_skipped_shape",
+          "value": "\"simulation\".\"status\" <> 'skipped'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"claimed_at\" is null\n          and \"simulation\".\"started_at\" is null and \"simulation\".\"cancel_requested_at\" is null\n          and \"simulation\".\"skip_reason\" is not null\n          and \"simulation\".\"skipped_capabilities\" is not null)"
+        },
+        "simulation_skip_reason_belongs_to_a_skip": {
+          "name": "simulation_skip_reason_belongs_to_a_skip",
+          "value": "\"simulation\".\"status\" = 'skipped'\n        or (\"simulation\".\"skip_reason\" is null and \"simulation\".\"skipped_capabilities\" is null)"
+        },
+        "simulation_skip_reason_allowed": {
+          "name": "simulation_skip_reason_allowed",
+          "value": "\"simulation\".\"skip_reason\" is null or \"simulation\".\"skip_reason\" in ('required_capability_unsupported', 'required_capability_unknown')"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_mock_tool_coverage_only_when_ended": {
+          "name": "simulation_mock_tool_coverage_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null or \"simulation\".\"mock_tool_coverage\" is null"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_plan": {
+      "name": "grading_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groups": {
+          "name": "groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_credential_ids": {
+          "name": "judge_credential_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_plan_judge_credential_ids_idx": {
+          "name": "grading_plan_judge_credential_ids_idx",
+          "columns": [
+            {
+              "expression": "judge_credential_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "grading_plan_organization_id_project_id_idx": {
+          "name": "grading_plan_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_plan_organization_id_organization_id_fk": {
+          "name": "grading_plan_organization_id_organization_id_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_project_organization_fk": {
+          "name": "grading_plan_project_organization_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_run_project_fk": {
+          "name": "grading_plan_run_project_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_plan_run_id_unique": {
+          "name": "grading_plan_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_plan_id_prefix": {
+          "name": "grading_plan_id_prefix",
+          "value": "\"grading_plan\".\"id\" ~ '^gpl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_plan_state_allowed": {
+          "name": "grading_plan_state_allowed",
+          "value": "\"grading_plan\".\"state\" in ('run_start', 'migration_snapshot', 'not_recorded')"
+        },
+        "grading_plan_recorded_plans_carry_their_moment": {
+          "name": "grading_plan_recorded_plans_carry_their_moment",
+          "value": "(\"grading_plan\".\"state\" = 'not_recorded')\n        = (\"grading_plan\".\"captured_at\" is null)"
+        },
+        "grading_plan_groups_are_a_list": {
+          "name": "grading_plan_groups_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"groups\") = 'array'"
+        },
+        "grading_plan_credentials_are_a_list": {
+          "name": "grading_plan_credentials_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"judge_credential_ids\") = 'array'"
+        },
+        "grading_plan_unrecorded_holds_nothing": {
+          "name": "grading_plan_unrecorded_holds_nothing",
+          "value": "\"grading_plan\".\"state\" <> 'not_recorded'\n        or (\"grading_plan\".\"groups\" = '[]'::jsonb\n          and \"grading_plan\".\"judge_credential_ids\" = '[]'::jsonb)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotent_operation": {
+      "name": "idempotent_operation",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "idempotent_operation_organization_id_organization_id_fk": {
+          "name": "idempotent_operation_organization_id_organization_id_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_project_organization_fk": {
+          "name": "idempotent_operation_project_organization_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_actor_fk": {
+          "name": "idempotent_operation_actor_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotent_operation_pk": {
+          "name": "idempotent_operation_pk",
+          "columns": [
+            "organization_id",
+            "project_id",
+            "actor_id",
+            "operation",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "idempotent_operation_organization_id_prefix": {
+          "name": "idempotent_operation_organization_id_prefix",
+          "value": "\"idempotent_operation\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "idempotent_operation_allowed": {
+          "name": "idempotent_operation_allowed",
+          "value": "\"idempotent_operation\".\"operation\" in ('start_run')"
+        },
+        "idempotent_operation_key_is_not_empty": {
+          "name": "idempotent_operation_key_is_not_empty",
+          "value": "length(\"idempotent_operation\".\"idempotency_key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1786785378610,
       "tag": "0028_tests_apply_to_agents",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1786792133831,
+      "tag": "0029_run_planning_and_grading_plans",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/errors.ts
+++ b/packages/db/src/access/errors.ts
@@ -844,3 +844,98 @@ export class NoCapabilityAdapterError extends Error {
     this.connectionType = connectionType;
   }
 }
+
+/**
+ * A run could not start because the project has no LLM judge.
+ *
+ * **Its own refusal rather than one of the run factory's, because it is a fact
+ * about the project rather than about the selection.** Every run carries the
+ * expected-behaviors built-in — applying it is part of what running a test
+ * means — and that built-in asks a model. A project in `needs_setup` therefore
+ * cannot produce an honest run at all: it would dial real conversations, spend
+ * real telephony, and then write `errored` against every behavior because there
+ * was nobody to ask. Refusing before the money is spent is the whole point, and
+ * the sentence sends an admin to the one page that fixes it.
+ *
+ * It carries the project because the sentence names it: somebody looking at a
+ * run builder may hold several, and "this project" is not enough to act on.
+ */
+export class JudgeNotConfiguredError extends Error {
+  readonly projectId: string;
+
+  constructor(projectId: string) {
+    super(
+      `this run needs an LLM judge, and project ${projectId} has none configured`,
+    );
+    this.name = "JudgeNotConfiguredError";
+    this.projectId = projectId;
+  }
+}
+
+/** One thing that still needs a judge credential, in the words a refusal uses. */
+export type JudgeCredentialUse = {
+  /**
+   * What kind of thing it is: a project pointing at the credential, a run whose
+   * frozen plan names it while a conversation is still moving, or a grading job
+   * that is waiting to be judged or already claimed.
+   */
+  readonly kind: "project" | "run" | "grading_job";
+  readonly id: string;
+};
+
+/**
+ * A judge credential could not be archived, because something still needs the
+ * key behind it.
+ *
+ * **Three blocking uses, and they are three because their fixes are three.** A
+ * project pointing at it is repointed in Settings; a run whose frozen plan
+ * names it while conversations are still moving has to finish or be canceled;
+ * a grading job that is `pending` or `claimed` has to finish. Archiving under
+ * any of them would strand work mid-flight: the grader service resolves the
+ * current secret for a plan's credential source when it claims, so a credential
+ * that went away between freezing and claiming would turn a whole run's
+ * judgments into errors nobody could act on.
+ *
+ * The uses travel as values rather than baked into prose, because the layer
+ * above spells the product's sentence and a page wants to link to each one.
+ */
+export class JudgeCredentialInUseError extends Error {
+  readonly credentialId: string;
+  /** Every blocking use, projects first, then runs, then grading jobs. */
+  readonly uses: readonly JudgeCredentialUse[];
+
+  constructor(credentialId: string, uses: readonly JudgeCredentialUse[]) {
+    super(
+      `judge credential ${credentialId} is still needed by ${uses.length} ${
+        uses.length === 1 ? "thing" : "things"
+      } (${uses.map((use) => `${use.kind} ${use.id}`).join(", ")}); point those projects at another credential and let pending grading finish, then archive it`,
+    );
+    this.name = "JudgeCredentialInUseError";
+    this.credentialId = credentialId;
+    this.uses = uses;
+  }
+}
+
+/**
+ * A start action reused an idempotency key over a different request.
+ *
+ * **The whole value of remembering a key is that it can refuse this.** Answering
+ * the original run would tell somebody their new selection had started when it
+ * had not; starting a second run would make the key mean nothing. So the third
+ * answer is the only honest one, and it says which of the two moves to make:
+ * send the original request again, or send a new key for the new one.
+ */
+export class IdempotencyConflictError extends Error {
+  readonly idempotencyKey: string;
+  /** What the key already produced, so a caller can go and read it. */
+  readonly resultId: string;
+
+  constructor(idempotencyKey: string, resultId: string) {
+    super(
+      `idempotency key ${idempotencyKey} already started run ${resultId}, and this request is not the one it started`,
+    );
+    this.name = "IdempotencyConflictError";
+    this.idempotencyKey = idempotencyKey;
+    this.resultId = resultId;
+  }
+}

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -115,7 +115,10 @@ export {
   ConnectionRestoreRefusedError,
   DefaultPersonaReplacementError,
   GraderNamedByTestsError,
+  IdempotencyConflictError,
   IdentityConflictError,
+  JudgeCredentialInUseError,
+  JudgeNotConfiguredError,
   JudgeProviderMismatchError,
   LastAdminError,
   MockToolTakenError,
@@ -137,6 +140,7 @@ export {
   type AgentWriteRefusal,
   type ArchivedDependency,
   type ConnectionRestoreRefusal,
+  type JudgeCredentialUse,
   type RunWriteRefusal,
   type TestAgentRefusal,
   type TestNamingGrader,
@@ -502,9 +506,11 @@ export {
  * one lives behind the grading engine's own context.
  */
 export {
+  archiveJudgeCredential,
   createJudgeCredential,
   editJudgeCredential,
   getJudgeCredential,
+  judgeCredentialUses,
   listJudgeCredentials,
   type JudgeCredential,
   type JudgeCredentialChanges,
@@ -558,9 +564,36 @@ export type {
   RunStatus,
   RunTrigger,
   SimulationEndingReason,
+  SimulationSkipReason,
   SimulationStatus,
   Verdict,
 } from "../schema/runs.ts";
+
+/**
+ * What a run would freeze, and what one already froze.
+ *
+ * `planRun` is the review step's read and `startRun`'s own resolver, which is
+ * the whole point of it being one function: what the review showed is what
+ * starts. `getGradingPlan` answers with what a run actually froze, including
+ * the honest `not_recorded` state for history that predates plans.
+ */
+export {
+  getGradingPlan,
+  planRun,
+  EXPECTED_BEHAVIORS_ENGINE_VERSION,
+  type AuthoredPlanItem,
+  type BuiltInPlanItem,
+  type CapabilityDecision,
+  type GradingPlan,
+  type JudgeChoice,
+  type PlanGroup,
+  type PlanItem,
+  type PlanJudge,
+  type PlannedSimulationGroup,
+  type RunPlan,
+  type RunPlanRequest,
+} from "./run-plans.ts";
+export type { GradingPlanState } from "../schema/plans.ts";
 
 export {
   claimGradingJobs,

--- a/packages/db/src/access/judge-credentials.ts
+++ b/packages/db/src/access/judge-credentials.ts
@@ -1,16 +1,27 @@
 import { newId } from "@egma/ids";
-import { and, asc, eq, isNull } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 
-import { db } from "../client.ts";
+import { db, type Queryable } from "../client.ts";
 import {
+  judgeConfiguration,
   judgeCredential,
   JUDGE_PROVIDERS,
   type JudgeProvider,
 } from "../schema/graders.ts";
+import { gradingJob } from "../schema/grading.ts";
+import { gradingPlan } from "../schema/plans.ts";
+import { run, simulation } from "../schema/runs.ts";
+import { project } from "../schema/tenancy.ts";
 import { sealCredentials } from "../sealing.ts";
 import type { AuthContext } from "./context.ts";
-import { IdentityConflictError, UnprocessableInputError } from "./errors.ts";
+import {
+  IdentityConflictError,
+  JudgeCredentialInUseError,
+  UnprocessableInputError,
+  type JudgeCredentialUse,
+} from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
+import { plansNeedingCredential } from "./run-plans.ts";
 import { within } from "./within.ts";
 
 /**
@@ -346,4 +357,168 @@ export async function editJudgeCredential(
     }
     return answer(row);
   });
+}
+
+
+/**
+ * Every reason this credential cannot go away yet, read in one place so a
+ * refusal and a page can never disagree about what is blocking.
+ *
+ * **Three questions, and each is asked of a different thing.** A project
+ * pointing at the credential would lose its judge outright. A run whose frozen
+ * plan names it while a conversation is still moving will be graded the moment
+ * that conversation lands, against a plan whose key has gone. And a grading job
+ * that is `pending` or `claimed` is the work already in flight — the service
+ * resolves the current secret when it claims, so archiving under it turns a
+ * whole run's judgments into errors nobody can act on.
+ *
+ * They are asked inside the caller's own transaction, under the lock the
+ * credential is already held by, so nothing can start needing it between the
+ * question and the write.
+ */
+async function usesOf(
+  on: Queryable,
+  auth: AuthContext,
+  credentialId: string,
+): Promise<readonly JudgeCredentialUse[]> {
+  const uses: JudgeCredentialUse[] = [];
+
+  for (const row of await on
+    .select({ projectId: judgeConfiguration.projectId })
+    .from(judgeConfiguration)
+    .innerJoin(project, eq(judgeConfiguration.projectId, project.id))
+    .where(
+      and(
+        eq(judgeConfiguration.organizationId, auth.organizationId),
+        eq(judgeConfiguration.credentialId, credentialId),
+        isNull(project.deletedAt),
+      ),
+    )
+    .orderBy(asc(judgeConfiguration.projectId))) {
+    uses.push({ kind: "project", id: row.projectId });
+  }
+
+  // A plan is needed while anything under its run is still moving. Terminal
+  // rows have been judged or will never be, and a `skipped` one was never
+  // enqueued at all — so a run made entirely of them blocks nothing.
+  for (const row of await on
+    .selectDistinct({ runId: gradingPlan.runId })
+    .from(gradingPlan)
+    .innerJoin(simulation, eq(simulation.runId, gradingPlan.runId))
+    .where(
+      and(
+        eq(gradingPlan.organizationId, auth.organizationId),
+        plansNeedingCredential(credentialId),
+        inArray(simulation.status, ["queued", "claimed", "running"]),
+      ),
+    )
+    .orderBy(asc(gradingPlan.runId))) {
+    uses.push({ kind: "run", id: row.runId });
+  }
+
+  for (const row of await on
+    .selectDistinct({ jobId: gradingJob.id })
+    .from(gradingJob)
+    .innerJoin(simulation, eq(gradingJob.simulationId, simulation.id))
+    .innerJoin(gradingPlan, eq(gradingPlan.runId, simulation.runId))
+    .where(
+      and(
+        eq(gradingJob.organizationId, auth.organizationId),
+        inArray(gradingJob.status, ["pending", "claimed"]),
+        plansNeedingCredential(credentialId),
+      ),
+    )
+    .orderBy(asc(gradingJob.id))) {
+    uses.push({ kind: "grading_job", id: row.jobId });
+  }
+
+  return uses;
+}
+
+/**
+ * Take a credential out of use, once nothing needs it.
+ *
+ * **Archive rather than delete, and refused rather than cascading.** The row
+ * stays, so every frozen plan that ever named it keeps naming something
+ * readable and a run from March remains interpretable. What Archive means is
+ * only *stop choosing this from now on*: a project settings page will no longer
+ * offer it, and `listJudgeCredentials` no longer answers with it.
+ *
+ * The three blocking uses are `usesOf` above, and the refusal carries them
+ * whole. A door with none of that behind it would strand work mid-flight, which
+ * is exactly why this verb did not exist until frozen grading plans did — there
+ * was no way to ask the second and third questions.
+ *
+ * Archiving an archived credential is nothing to do and answers with it. A
+ * credential this caller cannot see answers `undefined`, the same as one that
+ * never existed.
+ */
+export async function archiveJudgeCredential(
+  auth: AuthContext,
+  id: string,
+  expected: { readonly expectedRevision?: string | undefined } = {},
+): Promise<JudgeCredential | undefined> {
+  authorize(auth, "manage_organization", here(auth));
+
+  return db().transaction(async (tx) => {
+    const [locked] = await tx
+      .select({ id: judgeCredential.id, revision: judgeCredential.revision })
+      .from(judgeCredential)
+      .where(theCredential(auth, id))
+      .limit(1)
+      .for("update");
+
+    if (locked === undefined) return undefined;
+
+    if (
+      expected.expectedRevision !== undefined &&
+      expected.expectedRevision !== locked.revision
+    ) {
+      throw new IdentityConflictError("Judge credential", locked.id, {
+        expected: expected.expectedRevision,
+        current: locked.revision,
+      });
+    }
+
+    const uses = await usesOf(tx, auth, locked.id);
+    if (uses.length > 0) throw new JudgeCredentialInUseError(locked.id, uses);
+
+    const [row] = await tx
+      .update(judgeCredential)
+      .set({
+        archivedAt: new Date(),
+        revision: newId("rev"),
+        updatedAt: new Date(),
+      })
+      .where(eq(judgeCredential.id, locked.id))
+      .returning(COLUMNS);
+
+    if (row === undefined) {
+      throw new Error("the judge credential was not written");
+    }
+    return answer(row);
+  });
+}
+
+/**
+ * What is blocking a credential's Archive, asked without attempting one.
+ *
+ * The same read the refusal is built from, offered on its own so a settings
+ * page can say *why* the button will not work before somebody presses it —
+ * and so the page and the refusal can never give two different answers.
+ */
+export async function judgeCredentialUses(
+  auth: AuthContext,
+  id: string,
+): Promise<readonly JudgeCredentialUse[] | undefined> {
+  authorize(auth, "read", here(auth));
+
+  const [found] = await db()
+    .select({ id: judgeCredential.id })
+    .from(judgeCredential)
+    .where(theCredential(auth, id))
+    .limit(1);
+
+  if (found === undefined) return undefined;
+  return usesOf(db(), auth, found.id);
 }

--- a/packages/db/src/access/run-plans.ts
+++ b/packages/db/src/access/run-plans.ts
@@ -1,0 +1,1157 @@
+import { newId } from "@egma/ids";
+import { and, asc, eq, inArray, isNull, sql, type SQL } from "drizzle-orm";
+
+import { db, type Queryable } from "../client.ts";
+import { connection, type Modality } from "../schema/agents.ts";
+import {
+  grader,
+  graderVersion,
+  judgeConfiguration,
+  type GraderRead,
+  type GraderScope,
+  type Priority,
+} from "../schema/graders.ts";
+import { persona } from "../schema/personas.ts";
+import { gradingPlan, type GradingPlanState } from "../schema/plans.ts";
+import type { SimulationSkipReason } from "../schema/runs.ts";
+import {
+  test,
+  testGrader,
+  testPersona,
+  testVersion,
+} from "../schema/tests.ts";
+import {
+  capabilityStanding,
+  CAPABILITIES_UNKNOWN,
+  type ConnectionCapabilities,
+} from "./capabilities.ts";
+import type { AuthContext } from "./context.ts";
+import {
+  JudgeNotConfiguredError,
+  RunWriteRefusedError,
+  type RunWriteRefusal,
+} from "./errors.ts";
+import {
+  EXPECTED_BEHAVIORS_GRADER,
+  GRADER_TYPE_REGISTRY,
+} from "./graders.ts";
+import { PLATFORM_JUDGE } from "./judges.ts";
+import { archivedTests, testsApplyingToAgent } from "./tests.ts";
+import { within } from "./within.ts";
+
+/**
+ * What a run decides before it exists: which conversations it can honestly
+ * conduct, and what will judge each one.
+ *
+ * This module is the **one resolver** behind two surfaces that must never
+ * disagree. A run builder's review step asks it what a run *would* freeze;
+ * `startRun` asks it what to freeze, in the transaction that writes the run.
+ * Two implementations of that question would be two opinions about which tests
+ * are skipped and which graders judge — and the whole value of a review step is
+ * that what it showed is what happened.
+ *
+ * Three decisions live here, and each is somewhere it can be seen:
+ *
+ * **Whether a conversation can honestly happen at all.** A test declares what it
+ * needs of a connection; a connection records what an adapter measured. Where
+ * the two disagree the simulation is written terminal `skipped` with a reason
+ * naming the capabilities, and it is never sent to a simulator and never
+ * enqueued for grading. It is not a failure and must never be reported as one:
+ * a test that could not run says nothing about the agent.
+ *
+ * **What will judge it.** The grading plan groups items under a tagged test
+ * reference — one group per pinned test version — and each group holds the
+ * expected-behaviors built-in plus the authored graders that apply. Frozen at
+ * start, so editing or archiving a grader tomorrow cannot rewrite what this run
+ * meant.
+ *
+ * **Who pays for the judging.** Every judge choice is tagged, and a configured
+ * one stores the provider, the model, and the *reference* to a credential —
+ * never a secret. The grader service resolves the current secret for that
+ * reference when it claims, which is what makes rotation reach pending work and
+ * what makes a credential's Archive have to refuse while a plan still names it.
+ */
+
+/* ------------------------------------------------------------------- *
+ * Refusing a run.
+ * ------------------------------------------------------------------- */
+
+/**
+ * The run factory's refusal, raised from here as well as from `runs.ts`.
+ *
+ * It lives beside the rules rather than beside the writer, because the rules
+ * moved here to be shared with the review and a refusal that stayed behind
+ * would have to be re-raised by hand at every call site.
+ */
+export function refuseRun(reason: RunWriteRefusal, message: string): never {
+  throw new RunWriteRefusedError(reason, message);
+}
+
+/**
+ * Everything about the named versions that is answerable without the database:
+ * there is at least one, and each is named once.
+ *
+ * Naming one twice is refused rather than folded, because the two readings —
+ * "you meant it once" and "run it twice" — are both plausible and only the
+ * caller knows which; a repeat count is a decision nobody has made yet. The
+ * whole creation goes, so nothing half-written is left behind to explain.
+ */
+export function validPinnedVersions(ids: readonly string[]): void {
+  if (ids.length === 0) {
+    refuseRun(
+      "not_admitted",
+      "a run needs at least one test version, because a run with no " +
+        "simulations checks nothing. Pin the version_id of each test this " +
+        "run should execute.",
+    );
+  }
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (seen.has(id)) {
+      refuseRun(
+        "not_admitted",
+        `test version ${id} is pinned twice on one run. Pin each version ` +
+          `once; a run already conducts one simulation per test per persona.`,
+      );
+    }
+    seen.add(id);
+  }
+}
+
+/* ------------------------------------------------------------------- *
+ * Turning ids into what they name.
+ * ------------------------------------------------------------------- */
+
+/** What one pinned version turns into: its test, and who calls about it. */
+export type PinnedVersion = {
+  readonly versionId: string;
+  readonly testId: string;
+  readonly testName: string;
+  readonly personaIds: readonly string[];
+  /** What this version needs of a connection to be meaningful. */
+  readonly requiredCapabilities: readonly string[];
+  /** The graders this version names directly, in the order authored. */
+  readonly graderIds: readonly string[];
+};
+
+/**
+ * Every named version resolved to the test it belongs to, the personas it
+ * names, what it requires of a connection, and the graders it names — before
+ * anything at all is written.
+ *
+ * A version this egma never issued, or one belonging to another customer or
+ * another project, is refused in the same words as one that never existed:
+ * confirming that somebody else's row is there is itself a leak. And **one bad
+ * id refuses the whole creation**, because a run that quietly executed eleven
+ * of the twelve versions somebody named would be a green result about a suite
+ * that did not run.
+ *
+ * Whether the *test* may start is a separate question, asked by
+ * `admitTestsForAgent` below once the agent is known. This read only turns ids
+ * into what they name.
+ */
+export async function resolvePinnedVersions(
+  on: Queryable,
+  auth: AuthContext,
+  projectId: string,
+  ids: readonly string[],
+): Promise<readonly PinnedVersion[]> {
+  const rows = await on
+    .select({
+      id: testVersion.id,
+      testId: testVersion.testId,
+      testName: test.name,
+      content: testVersion.content,
+    })
+    .from(testVersion)
+    .innerJoin(test, eq(testVersion.testId, test.id))
+    .where(
+      within(
+        auth,
+        test,
+        and(inArray(testVersion.id, [...ids]), eq(test.projectId, projectId)),
+      ),
+    );
+
+  const found = new Map(rows.map((row) => [row.id, row] as const));
+
+  const named = new Map<string, string[]>();
+  for (const entry of await on
+    .select({
+      testVersionId: testPersona.testVersionId,
+      personaId: testPersona.personaId,
+      position: testPersona.position,
+    })
+    .from(testPersona)
+    .where(inArray(testPersona.testVersionId, [...found.keys()]))
+    .orderBy(asc(testPersona.position))) {
+    const held = named.get(entry.testVersionId);
+    if (held === undefined) named.set(entry.testVersionId, [entry.personaId]);
+    else held.push(entry.personaId);
+  }
+
+  const scenarioGraders = new Map<string, string[]>();
+  for (const entry of await on
+    .select({
+      testVersionId: testGrader.testVersionId,
+      graderId: testGrader.graderId,
+      position: testGrader.position,
+    })
+    .from(testGrader)
+    .where(inArray(testGrader.testVersionId, [...found.keys()]))
+    .orderBy(asc(testGrader.position))) {
+    const held = scenarioGraders.get(entry.testVersionId);
+    if (held === undefined) scenarioGraders.set(entry.testVersionId, [entry.graderId]);
+    else held.push(entry.graderId);
+  }
+
+  return ids.map((id) => {
+    const row = found.get(id);
+    if (row === undefined) {
+      refuseRun(
+        "not_admitted",
+        `there is no test version ${id} on this egma. Push the test first, ` +
+          `or read the test and pin the version_id it names now.`,
+      );
+    }
+    const personaIds = named.get(id) ?? [];
+    if (personaIds.length === 0) {
+      // Unreachable through the test factory, which gives a version with no
+      // named persona the project's default one. A version that got here
+      // holding nobody would conduct nothing, so it is an instance fault.
+      throw new Error(
+        `test version ${id} names nobody who calls, so it can produce no simulation`,
+      );
+    }
+    return {
+      versionId: id,
+      testId: row.testId,
+      testName: row.testName,
+      personaIds,
+      requiredCapabilities: requiredCapabilitiesOf(row.content),
+      graderIds: scenarioGraders.get(id) ?? [],
+    };
+  });
+}
+
+/** The stored capability array, read back as the list of keys it is. */
+function capabilityKeysFromRow(held: unknown): readonly string[] {
+  if (!Array.isArray(held)) return [];
+  return held.filter((one): one is string => typeof one === "string");
+}
+
+/**
+ * What a stored version requires of a connection.
+ *
+ * Read straight off the content rather than through `getTestVersion`, because
+ * this runs inside the run's own transaction over a whole selection at once,
+ * and because the only field it wants is this one. Absent means the version
+ * predates the field, and absent meant *requires nothing* then too — which is
+ * why an old version reads as runnable everywhere rather than as unmeasured.
+ */
+function requiredCapabilitiesOf(content: unknown): readonly string[] {
+  if (typeof content !== "object" || content === null) return [];
+  return capabilityKeysFromRow(
+    (content as Record<string, unknown>).requiredCapabilities,
+  );
+}
+
+/**
+ * Whether each pinned version's test may be executed against the agent this run
+ * has reached. Two rules, and both are about the test as it stands today rather
+ * than about the frozen version.
+ *
+ * **Applicability is a live admission rule.** A test applies to the agents
+ * somebody linked it to, and a run over an agent it does not apply to is a
+ * result nobody asked for: the comparison the whole relation exists to make
+ * honest is between agents a test was written for. A run already pins the agent
+ * it chose, so a link removed after this run started cannot rewrite what it
+ * executed — this asks only whether it may *start*.
+ *
+ * **An archived test cannot enter a new run.** Archive is exactly the statement
+ * "stop starting new work with this", and it would say nothing at all if a
+ * pinned version could walk around it. Its versions stay readable and every run
+ * that already pinned one stays interpretable, which is the difference between
+ * archiving and deleting.
+ *
+ * One refused version refuses the whole creation, on the terms every other rule
+ * here is held to: a run that quietly executed eleven of the twelve versions
+ * somebody named would be a green result about a suite that did not run.
+ */
+export async function admitTestsForAgent(
+  on: Queryable,
+  agentId: string,
+  versions: readonly PinnedVersion[],
+): Promise<void> {
+  const testIds = [...new Set(versions.map((one) => one.testId))];
+
+  const archived = await archivedTests(on, testIds);
+  for (const version of versions) {
+    if (!archived.has(version.testId)) continue;
+    refuseRun(
+      "not_admitted",
+      `Test ${version.testId} is archived, so version ${version.versionId} ` +
+        `cannot start. Restore the test in the Tests page, or choose another ` +
+        `test for this run.`,
+    );
+  }
+
+  const applying = await testsApplyingToAgent(on, agentId, testIds);
+  for (const version of versions) {
+    if (applying.has(version.testId)) continue;
+    refuseRun(
+      "test_not_applicable",
+      `Test ${version.testId} does not apply to agent ${agentId}, so version ` +
+        `${version.versionId} cannot start. Choose a test linked to this ` +
+        `agent, or link the test in the Tests page before starting the run.`,
+    );
+  }
+}
+
+/**
+ * Each requested persona resolved to the version this run will pin: alive,
+ * this project's, in the order they were named. A persona of another customer
+ * or another project is refused in the same words as one that never existed,
+ * because confirming that somebody else's row exists is itself a leak.
+ *
+ * The read takes a shared lock on every row it finds, held to commit — the
+ * same terms a test's write names personas on — so a concurrent delete either
+ * lands first and is seen here, or waits and sees the pin this run wrote.
+ */
+export async function resolvePersonaVersions(
+  on: Queryable,
+  auth: AuthContext,
+  projectId: string,
+  ids: readonly string[],
+): Promise<readonly { personaId: string; personaVersionId: string }[]> {
+  const found = new Map(
+    (
+      await on
+        .select({
+          id: persona.id,
+          archivedAt: persona.archivedAt,
+          currentVersionId: persona.currentVersionId,
+        })
+        .from(persona)
+        .where(
+          within(
+            auth,
+            persona,
+            and(
+              inArray(persona.id, [...ids]),
+              eq(persona.projectId, projectId),
+            ),
+          ),
+        )
+        .for("share")
+    ).map((row) => [row.id, row] as const),
+  );
+
+  return ids.map((id) => {
+    const row = found.get(id);
+    if (row === undefined) {
+      refuseRun(
+        "not_admitted",
+        `there is no persona ${id} in this project. A test that names ` +
+          `somebody who is not here can produce no simulation; edit the test ` +
+          `to name somebody who is.`,
+      );
+    }
+    if (row.archivedAt !== null) {
+      refuseRun(
+        "not_admitted",
+        `persona ${id} is archived, and a run cannot conduct a simulation ` +
+          `with an archived persona. Edit the tests that name them, then pin ` +
+          `the versions those edits mint.`,
+      );
+    }
+    return { personaId: id, personaVersionId: row.currentVersionId };
+  });
+}
+
+/* ------------------------------------------------------------------- *
+ * Whether a conversation can honestly happen.
+ * ------------------------------------------------------------------- */
+
+/**
+ * What a pinned version's required capabilities come to, against the connection
+ * this run will use.
+ *
+ * `runnable` is the ordinary answer. The other two are the product's two
+ * structured skip reasons, and they are kept apart because they lead somewhere
+ * different: `unsupported` is a settled fact about the target and the fix is to
+ * write a different test, while `unknown` means nobody has measured and a
+ * Refresh may change the answer. Collapsing them would put a false reason on
+ * every simulation an adapter's blind spot touched.
+ *
+ * **Unsupported wins when both are present.** A requirement egma knows is
+ * missing is the stronger fact, and telling somebody to go and measure a
+ * connection that is already known not to do the thing would send them the
+ * wrong way.
+ */
+export type CapabilityDecision =
+  | { readonly runnable: true }
+  | {
+      readonly runnable: false;
+      readonly reason: SimulationSkipReason;
+      /** The catalog keys that decided it, in the order the test named them. */
+      readonly capabilities: readonly string[];
+    };
+
+export function capabilityDecision(
+  required: readonly string[],
+  held: ConnectionCapabilities,
+): CapabilityDecision {
+  const unsupported: string[] = [];
+  const unmeasured: string[] = [];
+
+  for (const key of required) {
+    const standing = capabilityStanding(held, key);
+    if (standing === "unsupported") unsupported.push(key);
+    else if (standing === "not_measured") unmeasured.push(key);
+  }
+
+  if (unsupported.length > 0) {
+    return {
+      runnable: false,
+      reason: "required_capability_unsupported",
+      capabilities: unsupported,
+    };
+  }
+  if (unmeasured.length > 0) {
+    return {
+      runnable: false,
+      reason: "required_capability_unknown",
+      capabilities: unmeasured,
+    };
+  }
+  return { runnable: true };
+}
+
+/** The sentence a skipped conversation carries, in the product's own words. */
+export function skipExplanation(
+  decision: Extract<CapabilityDecision, { runnable: false }>,
+): string {
+  const named = decision.capabilities.join(", ");
+  return decision.reason === "required_capability_unsupported"
+    ? `This connection was measured and does not support ${named}, so egma ` +
+        `did not conduct this simulation. Nothing is being said about the ` +
+        `agent; choose a connection that supports it, or a test that does not ` +
+        `require it.`
+    : `Nobody has measured whether this connection supports ${named}, so egma ` +
+        `did not conduct this simulation. Nothing is being said about the ` +
+        `agent; refresh the connection's capabilities and start the run again.`;
+}
+
+/** The capability record of one connection, read off its row. */
+export function capabilitiesFromRow(row: {
+  readonly capabilityState: string;
+  readonly capabilitiesMeasured: unknown;
+  readonly capabilitiesSupported: unknown;
+  readonly capabilitiesCheckedAt: Date | null;
+  readonly capabilitySource: string | null;
+}): ConnectionCapabilities {
+  if (
+    row.capabilityState !== "known" ||
+    row.capabilitiesCheckedAt === null ||
+    row.capabilitySource === null
+  ) {
+    return CAPABILITIES_UNKNOWN;
+  }
+  return {
+    state: "known",
+    measured: capabilityKeysFromRow(row.capabilitiesMeasured),
+    supported: capabilityKeysFromRow(row.capabilitiesSupported),
+    checkedAt: row.capabilitiesCheckedAt,
+    source: row.capabilitySource,
+  };
+}
+
+/* ------------------------------------------------------------------- *
+ * The plan.
+ * ------------------------------------------------------------------- */
+
+/**
+ * Which model judges, whose account pays, and the honest answer when neither
+ * question has one.
+ *
+ * `not_required` is a deterministic grader: a threshold, a tool-call check, a
+ * phrase check. Nothing is asked of a model, so naming one would be a bill
+ * nobody incurs.
+ *
+ * `configured` names the provider, the model and the **reference** to the key —
+ * an organization's `jcr_` credential, or the deployment's `platform` sentinel.
+ * Never a secret, at any point: the grader service resolves the current one
+ * when it claims, which is what makes a rotation reach work already frozen.
+ *
+ * `unavailable_at_capture` exists only for work upgraded across the migration
+ * that added plans, whose project had no judge at the moment the plan was
+ * captured. It records the honest no-judge state rather than inventing a
+ * credential reference that would resolve to somebody else's key. **New work
+ * never starts in it** — a project with no judge is refused before a run is
+ * written, because every run carries the judge-backed built-in.
+ */
+export type JudgeChoice =
+  | { readonly tag: "not_required" }
+  | {
+      readonly tag: "configured";
+      readonly provider: string;
+      readonly model: string;
+      /** A `jcr_` credential of this organization, or `platform`. */
+      readonly source: string;
+    }
+  | { readonly tag: "unavailable_at_capture" };
+
+/**
+ * One authored grader, as the plan freezes it.
+ *
+ * Keyed by `(test reference, grader_id)` — so the same grader selected on two
+ * test versions is deliberately two items, because a run's judgments are per
+ * conversation and a shared item would make one test's grading depend on
+ * another's. `origin` says how it got here, and it is worth keeping: a grader
+ * added directly to a test is a scoping decision that overrides the grader's
+ * own live scope for that test, and a page has to be able to say so.
+ */
+export type AuthoredPlanItem = {
+  readonly kind: "authored";
+  readonly graderId: string;
+  readonly graderVersionId: string;
+  readonly graderName: string;
+  readonly origin: "project_default" | "scenario_specific";
+  readonly priority: Priority;
+  readonly scope: GraderScope;
+  readonly reads: readonly GraderRead[];
+  readonly modalities: readonly Modality[];
+  readonly judge: JudgeChoice;
+};
+
+/**
+ * The expected-behaviors built-in, as the plan freezes it.
+ *
+ * **It has no grader identity, no grader version, no scope and no item-level
+ * priority**, and every one of those absences is deliberate. It is not a row —
+ * applying it is part of what running a test means — so there is nothing to
+ * point at. And it produces one verdict per expected behavior, each taking its
+ * priority from the behavior it judged in the pinned test version, so an
+ * item-wide priority would flatten exactly the distinction the behaviors carry.
+ *
+ * What it does store is the engine version, because a behavior change in the
+ * built-in requires a new one: that is the only way an old run's judgments stay
+ * interpretable after the engine learns something new.
+ */
+export type BuiltInPlanItem = {
+  readonly kind: "built_in";
+  /** The reserved key. The first and, today, the only one. */
+  readonly graderKey: string;
+  readonly engineVersion: string;
+  readonly reads: readonly GraderRead[];
+  readonly modalities: readonly Modality[];
+  readonly judge: JudgeChoice;
+};
+
+export type PlanItem = AuthoredPlanItem | BuiltInPlanItem;
+
+/**
+ * One group of plan items, under the test reference they judge.
+ *
+ * `version` is every group a new run writes: a pinned test version, and the
+ * items that judge the conversations executing it.
+ *
+ * `legacy_testless` is the one group an upgraded instance can hold, for
+ * simulations written before a simulation could pin a test at all. It carries
+ * only the active project-default authored graders, because there is no stored
+ * test content to support a scenario grader or the expected-behaviors built-in
+ * — and inventing either would be a claim about a conversation nobody can check.
+ */
+export type PlanGroup =
+  | {
+      readonly tag: "version";
+      readonly testId: string;
+      readonly testVersionId: string;
+      readonly testName: string;
+      readonly items: readonly PlanItem[];
+    }
+  | { readonly tag: "legacy_testless"; readonly items: readonly PlanItem[] };
+
+export type GradingPlan = {
+  readonly runId: string;
+  readonly state: GradingPlanState;
+  /** Null exactly on `not_recorded`, where there is no plan. */
+  readonly capturedAt: Date | null;
+  readonly groups: readonly PlanGroup[];
+};
+
+/** The engine version the built-in judges at. A behavior change mints a new one. */
+export const EXPECTED_BEHAVIORS_ENGINE_VERSION = "1";
+
+/** One project-default or scenario grader, as the plan needs it. */
+type ApplicableGrader = {
+  readonly id: string;
+  readonly name: string;
+  readonly currentVersionId: string;
+  readonly priority: Priority;
+  readonly scope: GraderScope;
+  readonly reads: readonly GraderRead[];
+  readonly modalities: readonly Modality[];
+  readonly judged: boolean;
+  readonly judgeModel: { readonly provider: string; readonly model: string } | null;
+};
+
+/**
+ * Every active authored grader of the project, with its current version's
+ * judged content — read once for the whole plan rather than per test version.
+ *
+ * Archived graders are left out entirely: Archive means "stop entering new
+ * grading plans", and a run frozen before it stays on its own plan. The type
+ * registry decides `judged` rather than the row, because whether a kind of
+ * judgment asks a model is a fact about the kind.
+ */
+async function applicableGraders(
+  on: Queryable,
+  auth: AuthContext,
+  projectId: string,
+): Promise<ReadonlyMap<string, ApplicableGrader>> {
+  const rows = await on
+    .select({
+      id: grader.id,
+      name: grader.name,
+      type: grader.type,
+      priority: grader.priority,
+      scope: grader.scope,
+      currentVersionId: grader.currentVersionId,
+      reads: graderVersion.reads,
+      modalities: graderVersion.modalities,
+      judgeModel: graderVersion.judgeModel,
+    })
+    .from(grader)
+    .innerJoin(graderVersion, eq(grader.currentVersionId, graderVersion.id))
+    .where(
+      within(
+        auth,
+        grader,
+        and(eq(grader.projectId, projectId), isNull(grader.deletedAt)),
+      ),
+    )
+    .orderBy(asc(grader.id));
+
+  return new Map(
+    rows.map((row) => {
+      const override = row.judgeModel as {
+        provider?: unknown;
+        model?: unknown;
+      } | null;
+      return [
+        row.id,
+        {
+          id: row.id,
+          name: row.name,
+          currentVersionId: row.currentVersionId,
+          priority: row.priority as Priority,
+          scope: row.scope as GraderScope,
+          reads: row.reads as readonly GraderRead[],
+          modalities: row.modalities as readonly Modality[],
+          judged: judgedTypes.has(row.type),
+          judgeModel:
+            override === null ||
+            typeof override.provider !== "string" ||
+            typeof override.model !== "string"
+              ? null
+              : { provider: override.provider, model: override.model },
+        },
+      ] as const;
+    }),
+  );
+}
+
+/**
+ * Which grader types ask a model, taken from the type registry rather than
+ * written again here — the registry is where "what a kind of judgment reads and
+ * whether it needs a judge" is decided, and a second list beside it would be a
+ * second opinion about whose account pays.
+ */
+const judgedTypes: ReadonlySet<string> = new Set(
+  Object.entries(GRADER_TYPE_REGISTRY)
+    .filter(([, definition]) => definition.judged)
+    .map(([type]) => type),
+);
+
+/** The project's judge as a plan freezes it, or the refusal that stops a run. */
+export type PlanJudge =
+  | { readonly state: "configured"; readonly provider: string; readonly model: string; readonly source: string }
+  | { readonly state: "needs_setup" };
+
+/**
+ * The judge the plan will name, read off the project's own setting.
+ *
+ * A `platform` source keeps the sentinel word rather than a credential id,
+ * because the deployment's own judge is not the customer's to point at, rotate
+ * or archive — and a plan that named an id for it would be naming a row nobody
+ * can reach.
+ *
+ * **It takes the queryable it is to read on, and that is load-bearing.** Run
+ * creation asks this from inside its own transaction, and a read that reached
+ * for a second pool connection while the first was held would take two
+ * connections per run — so a handful of runs starting at once would empty the
+ * pool and wait on each other forever. It is the same rule every other read on
+ * this path already follows; the shape here just makes it impossible to
+ * forget.
+ *
+ * Nothing sealed is selected. The columns are the provider, the model and where
+ * the key comes from — never the envelope, which has exactly one door and it is
+ * not this one.
+ */
+export async function planJudgeOn(
+  on: Queryable,
+  auth: AuthContext,
+  projectId: string,
+): Promise<PlanJudge> {
+  const [row] = await on
+    .select({
+      provider: judgeConfiguration.provider,
+      model: judgeConfiguration.model,
+      source: judgeConfiguration.source,
+      credentialId: judgeConfiguration.credentialId,
+    })
+    .from(judgeConfiguration)
+    .where(
+      within(
+        auth,
+        judgeConfiguration,
+        eq(judgeConfiguration.projectId, projectId),
+      ),
+    )
+    .limit(1);
+
+  if (row === undefined) return { state: "needs_setup" };
+  return {
+    state: "configured",
+    provider: row.provider,
+    model: row.model,
+    // A project spending the deployment's own judge holds no credential row to
+    // point at, so the plan stores the sentinel word instead.
+    source: row.credentialId ?? PLATFORM_JUDGE,
+  };
+}
+
+/** One authored grader's judge choice, under a configured project judge. */
+function judgeFor(one: ApplicableGrader, judge: PlanJudge): JudgeChoice {
+  if (!one.judged) return { tag: "not_required" };
+  if (judge.state === "needs_setup") return { tag: "unavailable_at_capture" };
+  return {
+    tag: "configured",
+    // A grader may insist on its own provider and model; the account behind it
+    // is still the project's, because a grader has no credential of its own and
+    // inventing one here would be egma choosing whose key to spend.
+    provider: one.judgeModel?.provider ?? judge.provider,
+    model: one.judgeModel?.model ?? judge.model,
+    source: judge.source,
+  };
+}
+
+/** The built-in's judge choice. It always asks a model, so it always needs one. */
+function builtInJudge(judge: PlanJudge): JudgeChoice {
+  return judge.state === "needs_setup"
+    ? { tag: "unavailable_at_capture" }
+    : {
+        tag: "configured",
+        provider: judge.provider,
+        model: judge.model,
+        source: judge.source,
+      };
+}
+
+/**
+ * The plan one selection of pinned versions comes to.
+ *
+ * For each version: the built-in, then the active project-default graders whose
+ * live scope is `simulations` or `both`, then every active grader the version
+ * names directly — **whatever its live scope**, because a direct link is the
+ * per-test scoping decision and overrides the grader's own.
+ *
+ * **Deduplication is within one version and never across.** A grader that is
+ * both a project default and directly named by one test yields one item for
+ * that test, and it is the `scenario_specific` one, because the direct link is
+ * the decision somebody actually made. The same grader on two selected versions
+ * stays two items: they judge two different conversations.
+ */
+export function planGroupsFor(
+  versions: readonly PinnedVersion[],
+  graders: ReadonlyMap<string, ApplicableGrader>,
+  judge: PlanJudge,
+): readonly PlanGroup[] {
+  const defaults = [...graders.values()].filter(
+    (one) => one.scope === "simulations" || one.scope === "both",
+  );
+
+  return versions.map((version) => {
+    const items: PlanItem[] = [
+      {
+        kind: "built_in",
+        graderKey: EXPECTED_BEHAVIORS_GRADER.key,
+        engineVersion: EXPECTED_BEHAVIORS_ENGINE_VERSION,
+        reads: [...EXPECTED_BEHAVIORS_GRADER.reads],
+        modalities: [...EXPECTED_BEHAVIORS_GRADER.modalities],
+        judge: builtInJudge(judge),
+      },
+    ];
+
+    /** Where each authored grader landed, so a direct link can replace it. */
+    const placed = new Map<string, number>();
+
+    const add = (
+      one: ApplicableGrader,
+      origin: AuthoredPlanItem["origin"],
+    ): void => {
+      const item: AuthoredPlanItem = {
+        kind: "authored",
+        graderId: one.id,
+        graderVersionId: one.currentVersionId,
+        graderName: one.name,
+        origin,
+        priority: one.priority,
+        scope: one.scope,
+        reads: one.reads,
+        modalities: one.modalities,
+        judge: judgeFor(one, judge),
+      };
+      const already = placed.get(one.id);
+      if (already === undefined) {
+        placed.set(one.id, items.length);
+        items.push(item);
+        return;
+      }
+      // The direct link is the scoping decision, so it replaces the default in
+      // place rather than adding a second item for one grader.
+      items[already] = item;
+    };
+
+    for (const one of defaults) add(one, "project_default");
+    for (const graderId of version.graderIds) {
+      const one = graders.get(graderId);
+      // An archived grader named by an older version simply does not enter a
+      // new plan. Archive is what that means, and the run still starts.
+      if (one !== undefined) add(one, "scenario_specific");
+    }
+
+    return {
+      tag: "version",
+      testId: version.testId,
+      testVersionId: version.versionId,
+      testName: version.testName,
+      items,
+    };
+  });
+}
+
+/** Every `jcr_` credential a plan names, deduplicated, in the order first met. */
+export function judgeCredentialsIn(
+  groups: readonly PlanGroup[],
+): readonly string[] {
+  const named: string[] = [];
+  for (const group of groups) {
+    for (const item of group.items) {
+      if (item.judge.tag !== "configured") continue;
+      if (item.judge.source === PLATFORM_JUDGE) continue;
+      if (!named.includes(item.judge.source)) named.push(item.judge.source);
+    }
+  }
+  return named;
+}
+
+/**
+ * The plan row, written in the same transaction as the run it belongs to.
+ *
+ * The credential list is derived here rather than by a caller, so a plan and
+ * the index of what it needs can never come apart — which is the whole basis of
+ * a credential Archive's refusal.
+ */
+export async function writeGradingPlan(
+  on: Queryable,
+  input: {
+    readonly runId: string;
+    readonly organizationId: string;
+    readonly projectId: string;
+    readonly state: GradingPlanState;
+    readonly capturedAt: Date | null;
+    readonly groups: readonly PlanGroup[];
+  },
+): Promise<void> {
+  await on.insert(gradingPlan).values({
+    id: newId("gpl"),
+    runId: input.runId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    state: input.state,
+    capturedAt: input.capturedAt,
+    groups: input.groups,
+    judgeCredentialIds: judgeCredentialsIn(input.groups),
+  });
+}
+
+/**
+ * One run's frozen plan, or nothing where the run is not this caller's.
+ *
+ * A run created before plans existed and left with nothing outstanding has a
+ * `not_recorded` row and empty groups — the honest answer, and deliberately not
+ * an absent row, so a reader can tell "this run never recorded one" from "this
+ * run is not yours".
+ */
+export async function getGradingPlan(
+  auth: AuthContext,
+  runId: string,
+): Promise<GradingPlan | undefined> {
+  const [row] = await db()
+    .select({
+      runId: gradingPlan.runId,
+      state: gradingPlan.state,
+      capturedAt: gradingPlan.capturedAt,
+      groups: gradingPlan.groups,
+    })
+    .from(gradingPlan)
+    .where(within(auth, gradingPlan, eq(gradingPlan.runId, runId)))
+    .limit(1);
+
+  if (row === undefined) return undefined;
+  return {
+    runId: row.runId,
+    state: row.state as GradingPlanState,
+    capturedAt: row.capturedAt,
+    groups: (row.groups ?? []) as readonly PlanGroup[],
+  };
+}
+
+/* ------------------------------------------------------------------- *
+ * The review: what a run would freeze, before anybody starts it.
+ * ------------------------------------------------------------------- */
+
+/** What a run builder asks about. */
+export type RunPlanRequest = {
+  readonly connectionId: string;
+  /** Checked against the connection's own agent when given. */
+  readonly agentId?: string | undefined;
+  /** The test versions the author selected, in the order they chose them. */
+  readonly testVersionIds: readonly string[];
+};
+
+/** One selected test version, as a review step shows it. */
+export type PlannedSimulationGroup = {
+  readonly testId: string;
+  readonly testVersionId: string;
+  readonly testName: string;
+  /** Who will call, with the exact version this run would pin for each. */
+  readonly personas: readonly {
+    readonly personaId: string;
+    readonly personaVersionId: string;
+    readonly name: string;
+  }[];
+  readonly requiredCapabilities: readonly string[];
+  /** Runnable, or the reason and the capabilities that decided it. */
+  readonly capability: CapabilityDecision;
+  /** What would judge it, at the exact versions this run would freeze. */
+  readonly items: readonly PlanItem[];
+};
+
+/**
+ * Everything a review step shows, and the same resolution `startRun` will do.
+ *
+ * **It answers rather than refuses, wherever the answer is a state a page has to
+ * draw.** A project with no judge is a `needs_setup` field here and a refusal at
+ * start; a test that would be skipped is a group carrying its reason here and a
+ * terminal skipped row at start. What it still refuses outright is a selection
+ * that could never be written at all — an unknown version, a doubled one, a test
+ * that does not apply to this agent — because those are mistakes to fix rather
+ * than states to render.
+ */
+export type RunPlan = {
+  readonly agentId: string;
+  readonly connectionId: string;
+  readonly connection: {
+    readonly type: string;
+    readonly modality: Modality;
+    readonly environment: string | null;
+    readonly capabilities: ConnectionCapabilities;
+  };
+  readonly judge: PlanJudge;
+  readonly groups: readonly PlannedSimulationGroup[];
+  /** How many conversations would actually be conducted. */
+  readonly runnableSimulationCount: number;
+  /** How many would be written off before they began. */
+  readonly skippedSimulationCount: number;
+};
+
+export async function planRun(
+  auth: AuthContext,
+  request: RunPlanRequest,
+): Promise<RunPlan> {
+  const { projectId } = auth;
+  if (projectId === undefined) {
+    throw new Error(
+      "a run happens inside a project, and this credential is for the whole organization and acting in none",
+    );
+  }
+
+  validPinnedVersions(request.testVersionIds);
+
+  const on = db();
+  const [reached] = await on
+    .select({
+      id: connection.id,
+      agentId: connection.agentId,
+      type: connection.type,
+      modality: connection.modality,
+      environment: connection.environment,
+      capabilityState: connection.capabilityState,
+      capabilitiesMeasured: connection.capabilitiesMeasured,
+      capabilitiesSupported: connection.capabilitiesSupported,
+      capabilitiesCheckedAt: connection.capabilitiesCheckedAt,
+      capabilitySource: connection.capabilitySource,
+    })
+    .from(connection)
+    .where(
+      within(
+        auth,
+        connection,
+        and(
+          eq(connection.id, request.connectionId),
+          eq(connection.projectId, projectId),
+          isNull(connection.archivedAt),
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (reached === undefined) {
+    refuseRun(
+      "no_such_connection",
+      `there is no connection ${request.connectionId} in this project. ` +
+        `Check the id, or read your agents to see how each one is reached.`,
+    );
+  }
+  if (request.agentId !== undefined && request.agentId !== reached.agentId) {
+    refuseRun(
+      "connection_not_on_agent",
+      `connection ${request.connectionId} is not on agent ${request.agentId}. ` +
+        `Name the agent that connection is on, or leave the agent out and ` +
+        `egma takes the connection's own.`,
+    );
+  }
+
+  const versions = await resolvePinnedVersions(
+    on,
+    auth,
+    projectId,
+    request.testVersionIds,
+  );
+  await admitTestsForAgent(on, reached.agentId, versions);
+
+  const distinctPersonaIds = [
+    ...new Set(versions.flatMap((one) => one.personaIds)),
+  ];
+  const pinned = new Map(
+    (await resolvePersonaVersions(on, auth, projectId, distinctPersonaIds)).map(
+      (one) => [one.personaId, one.personaVersionId] as const,
+    ),
+  );
+  const names = new Map(
+    (
+      await on
+        .select({ id: persona.id, name: persona.name })
+        .from(persona)
+        .where(inArray(persona.id, distinctPersonaIds))
+    ).map((row) => [row.id, row.name] as const),
+  );
+
+  const judge = await planJudgeOn(on, auth, projectId);
+  const graders = await applicableGraders(on, auth, projectId);
+  const plan = planGroupsFor(versions, graders, judge);
+  const capabilities = capabilitiesFromRow(reached);
+
+  let runnable = 0;
+  let skipped = 0;
+  const groups = versions.map((version, index) => {
+    const decision = capabilityDecision(
+      version.requiredCapabilities,
+      capabilities,
+    );
+    if (decision.runnable) runnable += version.personaIds.length;
+    else skipped += version.personaIds.length;
+
+    return {
+      testId: version.testId,
+      testVersionId: version.versionId,
+      testName: version.testName,
+      personas: version.personaIds.map((personaId) => ({
+        personaId,
+        personaVersionId: pinned.get(personaId) ?? "",
+        name: names.get(personaId) ?? "",
+      })),
+      requiredCapabilities: version.requiredCapabilities,
+      capability: decision,
+      items: plan[index]?.items ?? [],
+    };
+  });
+
+  return {
+    agentId: reached.agentId,
+    connectionId: reached.id,
+    connection: {
+      type: reached.type,
+      modality: reached.modality as Modality,
+      environment: reached.environment,
+      capabilities,
+    },
+    judge,
+    groups,
+    runnableSimulationCount: runnable,
+    skippedSimulationCount: skipped,
+  };
+}
+
+/**
+ * The refusal a run start owes a project with no judge, raised where both the
+ * review and the writer can reach it.
+ */
+export function demandJudge(judge: PlanJudge, projectId: string): void {
+  if (judge.state === "needs_setup") {
+    throw new JudgeNotConfiguredError(projectId);
+  }
+}
+
+/**
+ * Everything a run's creation needs from this module, resolved in the caller's
+ * own transaction.
+ */
+export async function resolveRunPlan(
+  on: Queryable,
+  auth: AuthContext,
+  projectId: string,
+  versions: readonly PinnedVersion[],
+): Promise<{
+  readonly judge: PlanJudge;
+  readonly groups: readonly PlanGroup[];
+}> {
+  const judge = await planJudgeOn(on, auth, projectId);
+  demandJudge(judge, projectId);
+  const graders = await applicableGraders(on, auth, projectId);
+  return { judge, groups: planGroupsFor(versions, graders, judge) };
+}
+
+/* ------------------------------------------------------------------- *
+ * What a credential's Archive has to ask.
+ * ------------------------------------------------------------------- */
+
+/**
+ * Whether any run's frozen plan still needs this credential, and which.
+ *
+ * Two questions, one query each, because they are two different reasons and a
+ * refusal names them separately: a run with a conversation still moving will
+ * be graded against this plan when it lands, and a grading job that is
+ * `pending` or `claimed` is about to resolve this credential's secret.
+ *
+ * It is deliberately not scoped by project: a credential belongs to the
+ * organization and one is archived once, so the question is about everything
+ * the organization has ever frozen.
+ */
+export function plansNeedingCredential(credentialId: string): SQL {
+  return sql`${gradingPlan.judgeCredentialIds} @> ${JSON.stringify([credentialId])}::jsonb`;
+}

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { isId, newId } from "@egma/ids";
 import {
   and,
@@ -25,6 +27,7 @@ import {
 import { persona } from "../schema/personas.ts";
 import { openCredentials } from "../sealing.ts";
 import { test, testVersion, testPersona } from "../schema/tests.ts";
+import { idempotentOperation } from "../schema/plans.ts";
 import {
   COMPLETED_ENDING_REASONS,
   FAILED_ENDING_REASONS,
@@ -35,6 +38,7 @@ import {
   type RunStatus,
   type RunTrigger,
   type SimulationEndingReason,
+  type SimulationSkipReason,
   type SimulationStatus,
   type Verdict,
 } from "../schema/runs.ts";
@@ -48,16 +52,28 @@ import { stringRecordFromRow } from "./agents.ts";
 import { validClaimant } from "./claimants.ts";
 import { descriptorOf, noSimulatorAdapterMessage } from "./connection-registry.ts";
 import type { AuthContext } from "./context.ts";
-import { RunWriteRefusedError, type RunWriteRefusal } from "./errors.ts";
+import {
+  IdempotencyConflictError,
+  RunWriteRefusedError,
+} from "./errors.ts";
 import { enqueueGradingJob } from "./grading.ts";
+import {
+  admitTestsForAgent,
+  capabilitiesFromRow,
+  capabilityDecision,
+  refuseRun,
+  resolvePersonaVersions,
+  resolvePinnedVersions,
+  resolveRunPlan,
+  validPinnedVersions,
+  writeGradingPlan,
+} from "./run-plans.ts";
 import { pageOf, pageWindow, type PageRequest } from "./pages.ts";
 import { authorize, here } from "./permissions.ts";
 import { mockToolsApplyingTo } from "./mock-tools.ts";
 import {
-  archivedTests,
   getTestVersion,
   mockOverridesOfVersions,
-  testsApplyingToAgent,
   type TestVersion,
 } from "./tests.ts";
 import { within } from "./within.ts";
@@ -135,6 +151,24 @@ export type NewRun = {
   readonly label?: string | undefined;
   /** The run this one retries, when it retries one. */
   readonly retryOfRunId?: string | undefined;
+  /**
+   * The caller's own word for this attempt, so that sending it twice starts one
+   * run.
+   *
+   * **Optional here and required at the product door.** This seam is also
+   * reached by egma's own fixtures and by the grader's own world, which start a
+   * run once inside a process they control and have no retry to protect against.
+   * Every path a person or a client comes in on — the browser, the CLI, the
+   * public API — carries one, and `POST /api/runs` refuses without it, because
+   * a run is the expensive write and a lost answer must never become a second
+   * conversation with a real agent.
+   *
+   * The scope is the organization, the project, the actor and this operation.
+   * The same key with the same body answers the original run; the same key with
+   * a different body is refused out loud rather than quietly answered with
+   * somebody else's run.
+   */
+  readonly idempotencyKey?: string | undefined;
 };
 
 /** The connection's non-secret shape as the run executed over it. */
@@ -171,6 +205,12 @@ export type Run = {
   readonly completedCount: number | null;
   readonly failedCount: number | null;
   readonly canceledCount: number | null;
+  /**
+   * How many conversations egma declined to conduct, because a test required
+   * something this connection could not be shown to do. Its own number, never
+   * folded into the failures: nothing about the agent is being said.
+   */
+  readonly skippedCount: number | null;
   readonly retryOfRunId: string | null;
   readonly startedAt: Date | null;
   readonly finishedAt: Date | null;
@@ -223,6 +263,18 @@ export type Simulation = {
    * claimed — which is what every row written before the stamp existed says.
    */
   readonly mockToolCoverage: MockToolCoverage | null;
+  /**
+   * Why this conversation was never conducted, on the one status written
+   * terminal at birth. Null everywhere else, including on a failure — a failed
+   * simulation tried and could not, and this one was never tried.
+   */
+  readonly skipReason: SimulationSkipReason | null;
+  /**
+   * The catalog keys that decided the skip, exactly as they were decided. Null
+   * wherever the reason is; kept on the row rather than re-derived, because the
+   * connection's measurements move and this answer must not.
+   */
+  readonly skippedCapabilities: readonly string[] | null;
   readonly createdAt: Date;
 };
 
@@ -342,6 +394,7 @@ const RUN_COLUMNS = {
   completedCount: run.completedCount,
   failedCount: run.failedCount,
   canceledCount: run.canceledCount,
+  skippedCount: run.skippedCount,
   retryOfRunId: run.retryOfRunId,
   startedAt: run.startedAt,
   finishedAt: run.finishedAt,
@@ -373,6 +426,8 @@ const SIMULATION_COLUMNS = {
   turnCount: simulation.turnCount,
   providerReference: simulation.providerReference,
   mockToolCoverage: simulation.mockToolCoverage,
+  skipReason: simulation.skipReason,
+  skippedCapabilities: simulation.skippedCapabilities,
   createdAt: simulation.createdAt,
 } as const;
 
@@ -394,6 +449,7 @@ type RunRow = {
   readonly completedCount: number | null;
   readonly failedCount: number | null;
   readonly canceledCount: number | null;
+  readonly skippedCount: number | null;
   readonly retryOfRunId: string | null;
   readonly startedAt: Date | null;
   readonly finishedAt: Date | null;
@@ -662,12 +718,19 @@ function runFromRow(row: RunRow): Run {
  * inside the vocabulary, so reading one back is a narrowing, not a guess. */
 type SimulationRow = Omit<
   Simulation,
-  "status" | "endingReason" | "modality" | "mockToolCoverage"
+  | "status"
+  | "endingReason"
+  | "modality"
+  | "mockToolCoverage"
+  | "skipReason"
+  | "skippedCapabilities"
 > & {
   readonly status: string;
   readonly endingReason: string | null;
   readonly modality: string;
   readonly mockToolCoverage: unknown;
+  readonly skipReason: string | null;
+  readonly skippedCapabilities: unknown;
 };
 
 function simulationFromRow(row: SimulationRow): Simulation {
@@ -677,6 +740,16 @@ function simulationFromRow(row: SimulationRow): Simulation {
     endingReason: row.endingReason as SimulationEndingReason | null,
     modality: row.modality as Modality,
     mockToolCoverage: mockToolCoverageFromRow(row.mockToolCoverage, row.id),
+    skipReason: row.skipReason as SimulationSkipReason | null,
+    // Null and an empty list mean different things and both are writable: null
+    // is every conversation that was actually conducted, and a list is the one
+    // that was not. Anything else on the row is a hand edit, and it reads as
+    // no keys rather than as a shape a caller could act on.
+    skippedCapabilities: Array.isArray(row.skippedCapabilities)
+      ? row.skippedCapabilities.filter(
+          (one): one is string => typeof one === "string",
+        )
+      : null,
   };
 }
 
@@ -831,6 +904,11 @@ function theRun(auth: AuthContext, id: string): SQL {
  * whether there are any — a simulation that never ran gets `errored` verdicts,
  * because a broken test is never a broken agent. A `canceled` simulation is
  * neither: nobody was told to stop conducting it and then judged for stopping.
+ * Nor is a `skipped` one, and for the strongest reason of the four — there is
+ * no conversation. Egma declined to conduct it, so there is nothing for a
+ * grader to read and a job filed for it would be judged against an empty
+ * record and come back errored, turning egma's own capability gap into a red
+ * mark against somebody's agent.
  */
 function isGradable(status: SimulationStatus): boolean {
   return status === "completed" || status === "failed";
@@ -872,17 +950,15 @@ async function makeGradable(
 }
 
 /**
- * Every refusal this file makes, in the one shape a layer above branches on.
+ * Every refusal this file makes goes through `refuseRun`, which lives in
+ * `run-plans.ts` beside the admission rules it raises for.
  *
  * The reason is the whole `RunWriteRefusal` rather than a hand-copied subset:
  * a copy would go stale the first time the vocabulary grew, and it would go
- * stale silently. The sentence is whole here too — a layer above relays it
- * word for word, so a half-sentence finished somewhere else would be a
- * contract that exists nowhere as one string.
+ * stale silently. The sentence is whole too — a layer above relays it word for
+ * word, so a half-sentence finished somewhere else would be a contract that
+ * exists nowhere as one string.
  */
-function refuseRun(reason: RunWriteRefusal, message: string): never {
-  throw new RunWriteRefusedError(reason, message);
-}
 
 /** What a caller does instead, when a run named the wrong agent. */
 const NAME_THE_RIGHT_AGENT =
@@ -902,234 +978,6 @@ function nothingLeftToCancel(runId: string): string {
     `cancel. Its counts are final; start a fresh run to conduct those tests ` +
     `again.`
   );
-}
-
-/**
- * Everything about the named versions that is answerable without the database:
- * there is at least one, and each is named once.
- *
- * Naming one twice is refused rather than folded, because the two readings —
- * "you meant it once" and "run it twice" — are both plausible and only the
- * caller knows which; a repeat count is a decision nobody has made yet. The
- * whole creation goes, so nothing half-written is left behind to explain.
- */
-function validPinnedVersions(ids: readonly string[]): void {
-  if (ids.length === 0) {
-    refuseRun(
-      "not_admitted",
-      "a run needs at least one test version, because a run with no " +
-        "simulations checks nothing. Pin the version_id of each test this " +
-        "run should execute.",
-    );
-  }
-  const seen = new Set<string>();
-  for (const id of ids) {
-    if (seen.has(id)) {
-      refuseRun(
-        "not_admitted",
-        `test version ${id} is pinned twice on one run. Pin each version ` +
-          `once; a run already conducts one simulation per test per persona.`,
-      );
-    }
-    seen.add(id);
-  }
-}
-
-/** What one pinned version turns into: its test, and who calls about it. */
-type PinnedVersion = {
-  readonly versionId: string;
-  readonly testId: string;
-  readonly testName: string;
-  readonly personaIds: readonly string[];
-};
-
-/**
- * Every named version resolved to the test it belongs to and the personas it
- * names, in the order they were authored — before anything at all is written.
- *
- * A version this egma never issued, or one belonging to another customer or
- * another project, is refused in the same words as one that never existed:
- * confirming that somebody else's row is there is itself a leak. And **one bad
- * id refuses the whole creation**, because a run that quietly executed eleven
- * of the twelve versions somebody named would be a green result about a suite
- * that did not run.
- *
- * Whether the *test* may start is a separate question, asked by
- * `admitTestsForAgent` below once the agent is known. This read only turns ids
- * into what they name.
- */
-async function resolvePinnedVersions(
-  on: Queryable,
-  auth: AuthContext,
-  projectId: string,
-  ids: readonly string[],
-): Promise<readonly PinnedVersion[]> {
-  const rows = await on
-    .select({
-      id: testVersion.id,
-      testId: testVersion.testId,
-      testName: test.name,
-    })
-    .from(testVersion)
-    .innerJoin(test, eq(testVersion.testId, test.id))
-    .where(
-      within(
-        auth,
-        test,
-        and(inArray(testVersion.id, [...ids]), eq(test.projectId, projectId)),
-      ),
-    );
-
-  const found = new Map(rows.map((row) => [row.id, row] as const));
-
-  const named = new Map<string, string[]>();
-  for (const entry of await on
-    .select({
-      testVersionId: testPersona.testVersionId,
-      personaId: testPersona.personaId,
-      position: testPersona.position,
-    })
-    .from(testPersona)
-    .where(inArray(testPersona.testVersionId, [...found.keys()]))
-    .orderBy(asc(testPersona.position))) {
-    const held = named.get(entry.testVersionId);
-    if (held === undefined) named.set(entry.testVersionId, [entry.personaId]);
-    else held.push(entry.personaId);
-  }
-
-  return ids.map((id) => {
-    const row = found.get(id);
-    if (row === undefined) {
-      refuseRun(
-        "not_admitted",
-        `there is no test version ${id} on this egma. Push the test first, ` +
-          `or read the test and pin the version_id it names now.`,
-      );
-    }
-    const personaIds = named.get(id) ?? [];
-    if (personaIds.length === 0) {
-      // Unreachable through the test factory, which gives a version with no
-      // named persona the project's default one. A version that got here
-      // holding nobody would conduct nothing, so it is an instance fault.
-      throw new Error(
-        `test version ${id} names nobody who calls, so it can produce no simulation`,
-      );
-    }
-    return { versionId: id, ...row, personaIds };
-  });
-}
-
-/**
- * Whether each pinned version's test may be executed against the agent this run
- * has reached. Two rules, and both are about the test as it stands today rather
- * than about the frozen version.
- *
- * **Applicability is a live admission rule.** A test applies to the agents
- * somebody linked it to, and a run over an agent it does not apply to is a
- * result nobody asked for: the comparison the whole relation exists to make
- * honest is between agents a test was written for. A run already pins the agent
- * it chose, so a link removed after this run started cannot rewrite what it
- * executed — this asks only whether it may *start*.
- *
- * **An archived test cannot enter a new run.** Archive is exactly the statement
- * "stop starting new work with this", and it would say nothing at all if a
- * pinned version could walk around it. Its versions stay readable and every run
- * that already pinned one stays interpretable, which is the difference between
- * archiving and deleting.
- *
- * One refused version refuses the whole creation, on the terms every other rule
- * here is held to: a run that quietly executed eleven of the twelve versions
- * somebody named would be a green result about a suite that did not run.
- */
-async function admitTestsForAgent(
-  on: Queryable,
-  agentId: string,
-  versions: readonly PinnedVersion[],
-): Promise<void> {
-  const testIds = [...new Set(versions.map((one) => one.testId))];
-
-  const archived = await archivedTests(on, testIds);
-  for (const version of versions) {
-    if (!archived.has(version.testId)) continue;
-    refuseRun(
-      "not_admitted",
-      `Test ${version.testId} is archived, so version ${version.versionId} ` +
-        `cannot start. Restore the test in the Tests page, or choose another ` +
-        `test for this run.`,
-    );
-  }
-
-  const applying = await testsApplyingToAgent(on, agentId, testIds);
-  for (const version of versions) {
-    if (applying.has(version.testId)) continue;
-    refuseRun(
-      "test_not_applicable",
-      `Test ${version.testId} does not apply to agent ${agentId}, so version ` +
-        `${version.versionId} cannot start. Choose a test linked to this ` +
-        `agent, or link the test in the Tests page before starting the run.`,
-    );
-  }
-}
-
-/**
- * Each requested persona resolved to the version this run will pin: alive,
- * this project's, in the order they were named. A persona of another customer
- * or another project is refused in the same words as one that never existed,
- * because confirming that somebody else's row exists is itself a leak.
- *
- * The read takes a shared lock on every row it finds, held to commit — the
- * same terms a test's write names personas on — so a concurrent delete either
- * lands first and is seen here, or waits and sees the pin this run wrote.
- */
-async function resolvePersonaVersions(
-  on: Queryable,
-  auth: AuthContext,
-  projectId: string,
-  ids: readonly string[],
-): Promise<readonly { personaId: string; personaVersionId: string }[]> {
-  const found = new Map(
-    (
-      await on
-        .select({
-          id: persona.id,
-          archivedAt: persona.archivedAt,
-          currentVersionId: persona.currentVersionId,
-        })
-        .from(persona)
-        .where(
-          within(
-            auth,
-            persona,
-            and(
-              inArray(persona.id, [...ids]),
-              eq(persona.projectId, projectId),
-            ),
-          ),
-        )
-        .for("share")
-    ).map((row) => [row.id, row] as const),
-  );
-
-  return ids.map((id) => {
-    const row = found.get(id);
-    if (row === undefined) {
-      refuseRun(
-        "not_admitted",
-        `there is no persona ${id} in this project. A test that names ` +
-          `somebody who is not here can produce no simulation; edit the test ` +
-          `to name somebody who is.`,
-      );
-    }
-    if (row.archivedAt !== null) {
-      refuseRun(
-        "not_admitted",
-        `persona ${id} is archived, and a run cannot conduct a simulation ` +
-          `with an archived persona. Edit the tests that name them, then pin ` +
-          `the versions those edits mint.`,
-      );
-    }
-    return { personaId: id, personaVersionId: row.currentVersionId };
-  });
 }
 
 /**
@@ -1260,205 +1108,352 @@ export async function startRun(
     throw new Error(`"${retryOfRunId}" is not a run id`);
   }
 
+  const idempotencyKey = input.idempotencyKey?.trim() || undefined;
+  const requestDigest =
+    idempotencyKey === undefined ? undefined : digestOfStart(input);
+
+  // Asked before the transaction, because the common repeat is a client that
+  // never learned its first attempt succeeded: the answer is a read, and there
+  // is nothing to write. The insert inside the transaction is what catches the
+  // two attempts that arrive at the same instant.
+  if (idempotencyKey !== undefined && requestDigest !== undefined) {
+    const already = await originalRunFor(
+      db(),
+      auth,
+      projectId,
+      idempotencyKey,
+      requestDigest,
+    );
+    if (already !== undefined) return already;
+  }
+
   const runId = newId("run");
   const now = new Date();
 
-  const written = await db().transaction(async (tx) => {
-    const [reached] = await tx
-      .select({
-        agentId: connection.agentId,
-        type: connection.type,
-        modality: connection.modality,
-        topology: connection.topology,
-        environment: connection.environment,
-        config: connection.config,
-      })
-      .from(connection)
-      .innerJoin(agent, eq(connection.agentId, agent.id))
-      .where(
-        within(
-          auth,
-          connection,
-          and(
-            eq(connection.id, input.connectionId),
-            eq(connection.projectId, projectId),
-            isNull(connection.archivedAt),
-            isNull(agent.archivedAt),
+  let written;
+  try {
+    written = await db().transaction(async (tx) => {
+      const [reached] = await tx
+        .select({
+          agentId: connection.agentId,
+          type: connection.type,
+          modality: connection.modality,
+          topology: connection.topology,
+          environment: connection.environment,
+          config: connection.config,
+          capabilityState: connection.capabilityState,
+          capabilitiesMeasured: connection.capabilitiesMeasured,
+          capabilitiesSupported: connection.capabilitiesSupported,
+          capabilitiesCheckedAt: connection.capabilitiesCheckedAt,
+          capabilitySource: connection.capabilitySource,
+        })
+        .from(connection)
+        .innerJoin(agent, eq(connection.agentId, agent.id))
+        .where(
+          within(
+            auth,
+            connection,
+            and(
+              eq(connection.id, input.connectionId),
+              eq(connection.projectId, projectId),
+              isNull(connection.archivedAt),
+              isNull(agent.archivedAt),
+            ),
           ),
-        ),
-      )
-      .limit(1);
-
-    if (reached === undefined) {
-      refuseRun(
-        "no_such_connection",
-        `there is no connection ${input.connectionId} in this project. ` +
-          `Check the id, or read your agents to see how each one is reached.`,
-      );
-    }
-    // Named, and it has to be the one the connection is actually on. The
-    // caller asked for that check; answering it quietly the other way would be
-    // egma deciding which of the two ids they meant.
-    if (onAgentId !== undefined && reached.agentId !== onAgentId) {
-      refuseRun(
-        "connection_not_on_agent",
-        `connection ${input.connectionId} is not on agent ${onAgentId}. ` +
-          NAME_THE_RIGHT_AGENT,
-      );
-    }
-    if (!descriptorOf(reached.type).simulatorAdapter) {
-      refuseRun("no_adapter", noSimulatorAdapterMessage(reached.type));
-    }
-
-    if (retryOfRunId !== null) {
-      const [retried] = await tx
-        .select({ id: run.id })
-        .from(run)
-        .where(theRun(auth, retryOfRunId))
+        )
         .limit(1);
-      if (retried === undefined) {
+
+      if (reached === undefined) {
+        refuseRun(
+          "no_such_connection",
+          `there is no connection ${input.connectionId} in this project. ` +
+            `Check the id, or read your agents to see how each one is reached.`,
+        );
+      }
+      // Named, and it has to be the one the connection is actually on. The
+      // caller asked for that check; answering it quietly the other way would be
+      // egma deciding which of the two ids they meant.
+      if (onAgentId !== undefined && reached.agentId !== onAgentId) {
+        refuseRun(
+          "connection_not_on_agent",
+          `connection ${input.connectionId} is not on agent ${onAgentId}. ` +
+            NAME_THE_RIGHT_AGENT,
+        );
+      }
+      if (!descriptorOf(reached.type).simulatorAdapter) {
+        refuseRun("no_adapter", noSimulatorAdapterMessage(reached.type));
+      }
+
+      if (retryOfRunId !== null) {
+        const [retried] = await tx
+          .select({ id: run.id })
+          .from(run)
+          .where(theRun(auth, retryOfRunId))
+          .limit(1);
+        if (retried === undefined) {
+          refuseRun(
+            "not_admitted",
+            `there is no run ${retryOfRunId} in this project, so this run ` +
+              `retries nothing. Leave the retry out, or name a run this ` +
+              `credential can read.`,
+          );
+        }
+      }
+
+      const versions = await resolvePinnedVersions(
+        tx,
+        auth,
+        projectId,
+        input.testVersionIds,
+      );
+      // Inside the transaction, and after the connection has settled which agent
+      // this run reaches: applicability is a fact about that agent, and a check
+      // taken before it would have been about an agent the caller only guessed.
+      await admitTestsForAgent(tx, reached.agentId, versions);
+
+      /**
+       * What will judge this run, and whose account pays — resolved before a row
+       * is written, because a project with no judge is refused here.
+       *
+       * **Every run carries the expected-behaviors built-in**, and the built-in
+       * asks a model. A project in `needs_setup` would therefore dial real
+       * conversations and then write `errored` against every behavior, which is
+       * egma's own configuration reported as an agent's failure. Refusing before
+       * the money is spent is the whole point.
+       */
+      const { groups } = await resolveRunPlan(tx, auth, projectId, versions);
+
+      /**
+       * Which of these conversations egma can honestly have, decided once against
+       * the connection's own measurements and carried onto each row.
+       *
+       * A version whose requirement this connection was measured not to meet — or
+       * that nobody has measured — produces a terminal `skipped` simulation with
+       * its reason and the capabilities that decided it. It is never claimed,
+       * never conducted, and never enqueued for grading, and the rest of the run
+       * continues around it.
+       */
+      const capabilities = capabilitiesFromRow(reached);
+      const decisions = new Map(
+        versions.map(
+          (version) =>
+            [
+              version.versionId,
+              capabilityDecision(version.requiredCapabilities, capabilities),
+            ] as const,
+        ),
+      );
+
+      // The conversations this selection adds up to, in the order they will sit:
+      // each version in turn, and inside it each persona in the order the test
+      // named them.
+      const wanted = versions.flatMap((version) =>
+        version.personaIds.map((personaId) => ({ version, personaId })),
+      );
+      if (wanted.length > MOST_SIMULATIONS_PER_RUN) {
         refuseRun(
           "not_admitted",
-          `there is no run ${retryOfRunId} in this project, so this run ` +
-            `retries nothing. Leave the retry out, or name a run this ` +
-            `credential can read.`,
+          `a run conducts at most ${MOST_SIMULATIONS_PER_RUN} simulations, and ` +
+            `these ${versions.length} versions ask for ${wanted.length}. Split ` +
+            `the selection across runs.`,
         );
       }
-    }
 
-    const versions = await resolvePinnedVersions(
-      tx,
-      auth,
-      projectId,
-      input.testVersionIds,
-    );
-    // Inside the transaction, and after the connection has settled which agent
-    // this run reaches: applicability is a fact about that agent, and a check
-    // taken before it would have been about an agent the caller only guessed.
-    await admitTestsForAgent(tx, reached.agentId, versions);
-
-    // The conversations this selection adds up to, in the order they will sit:
-    // each version in turn, and inside it each persona in the order the test
-    // named them.
-    const wanted = versions.flatMap((version) =>
-      version.personaIds.map((personaId) => ({ version, personaId })),
-    );
-    if (wanted.length > MOST_SIMULATIONS_PER_RUN) {
-      refuseRun(
-        "not_admitted",
-        `a run conducts at most ${MOST_SIMULATIONS_PER_RUN} simulations, and ` +
-          `these ${versions.length} versions ask for ${wanted.length}. Split ` +
-          `the selection across runs.`,
+      // Each distinct persona resolved once, in the order they were first met.
+      const distinctPersonaIds = [
+        ...new Set(wanted.map((one) => one.personaId)),
+      ];
+      const pinnedPersonas = new Map(
+        (
+          await resolvePersonaVersions(tx, auth, projectId, distinctPersonaIds)
+        ).map((one) => [one.personaId, one.personaVersionId] as const),
       );
-    }
+      /**
+       * The version pinned for one of the personas just resolved.
+       *
+       * `resolvePersonaVersions` answers one entry per id or refuses, so a miss
+       * here is this file having lost track of its own input rather than
+       * anything a caller did — and it says so instead of writing a row with a
+       * pin nobody chose.
+       */
+      const versionOf = (personaId: string): string => {
+        const pinned = pinnedPersonas.get(personaId);
+        if (pinned === undefined) {
+          throw new Error(
+            `persona ${personaId} was resolved for this run and then lost before the simulation was written`,
+          );
+        }
+        return pinned;
+      };
 
-    // Each distinct persona resolved once, in the order they were first met.
-    const distinctPersonaIds = [
-      ...new Set(wanted.map((one) => one.personaId)),
-    ];
-    const pinnedPersonas = new Map(
-      (
-        await resolvePersonaVersions(tx, auth, projectId, distinctPersonaIds)
-      ).map((one) => [one.personaId, one.personaVersionId] as const),
-    );
-    /**
-     * The version pinned for one of the personas just resolved.
-     *
-     * `resolvePersonaVersions` answers one entry per id or refuses, so a miss
-     * here is this file having lost track of its own input rather than
-     * anything a caller did — and it says so instead of writing a row with a
-     * pin nobody chose.
-     */
-    const versionOf = (personaId: string): string => {
-      const pinned = pinnedPersonas.get(personaId);
-      if (pinned === undefined) {
-        throw new Error(
-          `persona ${personaId} was resolved for this run and then lost before the simulation was written`,
-        );
-      }
-      return pinned;
-    };
-
-    // Frozen inside the same transaction that writes the header, so an edit
-    // landing between the read and the write cannot reach the row: it either
-    // committed before this read and is in the snapshot, or waits behind it and
-    // changes only the runs started afterwards.
-    const mockToolSnapshot = await freezeMockTools(
-      tx,
-      auth,
-      projectId,
-      reached.agentId,
-      versions.map((one) => one.versionId),
-    );
-
-    const [header] = await tx
-      .insert(run)
-      .values({
-        id: runId,
-        organizationId: auth.organizationId,
+      // Frozen inside the same transaction that writes the header, so an edit
+      // landing between the read and the write cannot reach the row: it either
+      // committed before this read and is in the snapshot, or waits behind it and
+      // changes only the runs started afterwards.
+      const mockToolSnapshot = await freezeMockTools(
+        tx,
+        auth,
         projectId,
-        agentId: reached.agentId,
-        connectionId: input.connectionId,
-        label,
-        status: "pending",
-        triggeredVia: "manual",
-        triggeredBy: auth.userId,
-        pinnedTestVersions: { testVersionIds: input.testVersionIds },
-        requestedPersonas: { personaIds: distinctPersonaIds },
-        connectionSnapshot: {
-          type: reached.type,
-          modality: reached.modality,
-          topology: reached.topology,
-          environment: reached.environment,
-          config: reached.config,
-        },
-        mockToolSnapshot,
-        expectedSimulationCount: wanted.length,
-        retryOfRunId,
-        createdAt: now,
-      })
-      .returning(RUN_COLUMNS);
+        reached.agentId,
+        versions.map((one) => one.versionId),
+      );
 
-    if (header === undefined) throw new Error("the run was not written");
+      const skippedCount = wanted.filter(
+        ({ version }) => decisions.get(version.versionId)?.runnable === false,
+      ).length;
 
-    const simulations = await tx
-      .insert(simulation)
-      .values(
-        wanted.map(({ version, personaId }, index) => ({
-          id: newId("sim"),
-          runId,
+      /**
+       * A run with nothing left to conduct is finished here, in this transaction.
+       *
+       * **And it completes with no passing headline.** The three conducted counts
+       * are zero and the skipped count is everything, so nothing was judged and
+       * nothing can read as green — which is the whole reason `skipped` is a
+       * count of its own. Leaving such a run `pending` would be worse in both
+       * directions: nothing would ever claim it, and a progress page would show a
+       * run that never moves.
+       *
+       * `started_at` is stamped with `finished_at` because the run genuinely did
+       * begin and end — here, in one transaction, having conducted nothing.
+       */
+      const everythingSkipped = skippedCount === wanted.length;
+
+      const [header] = await tx
+        .insert(run)
+        .values({
+          id: runId,
           organizationId: auth.organizationId,
           projectId,
           agentId: reached.agentId,
           connectionId: input.connectionId,
-          personaId,
-          personaVersionId: versionOf(personaId),
-          testId: version.testId,
-          testVersionId: version.versionId,
-          position: index + 1,
-          modality: reached.modality,
-          status: "queued",
+          label,
+          status: everythingSkipped ? "completed" : "pending",
+          triggeredVia: "manual",
+          triggeredBy: auth.userId,
+          pinnedTestVersions: { testVersionIds: input.testVersionIds },
+          requestedPersonas: { personaIds: distinctPersonaIds },
+          connectionSnapshot: {
+            type: reached.type,
+            modality: reached.modality,
+            topology: reached.topology,
+            environment: reached.environment,
+            config: reached.config,
+          },
+          mockToolSnapshot,
+          expectedSimulationCount: wanted.length,
+          retryOfRunId,
           createdAt: now,
-        })),
-      )
-      .returning(SIMULATION_COLUMNS);
+          ...(everythingSkipped
+            ? {
+                completedCount: 0,
+                failedCount: 0,
+                canceledCount: 0,
+                skippedCount,
+                startedAt: now,
+                finishedAt: now,
+              }
+            : {}),
+        })
+        .returning(RUN_COLUMNS);
 
-    // The names come from what was just read rather than from a second query:
-    // this transaction already knows what every one of these is called.
-    const testNames = new Map(
-      versions.map((one) => [one.versionId, one.testName] as const),
-    );
-    const personaNames = new Map(
-      (
-        await tx
-          .select({ id: persona.id, name: persona.name })
-          .from(persona)
-          .where(inArray(persona.id, distinctPersonaIds))
-      ).map((row) => [row.id, row.name] as const),
-    );
+      if (header === undefined) throw new Error("the run was not written");
 
-    return { header, simulations, testNames, personaNames };
-  });
+      const simulations = await tx
+        .insert(simulation)
+        .values(
+          wanted.map(({ version, personaId }, index) => {
+            const decision = decisions.get(version.versionId);
+            const skipped = decision !== undefined && !decision.runnable;
+            return {
+              id: newId("sim"),
+              runId,
+              organizationId: auth.organizationId,
+              projectId,
+              agentId: reached.agentId,
+              connectionId: input.connectionId,
+              personaId,
+              personaVersionId: versionOf(personaId),
+              testId: version.testId,
+              testVersionId: version.versionId,
+              position: index + 1,
+              modality: reached.modality,
+              status: skipped ? ("skipped" as const) : ("queued" as const),
+              createdAt: now,
+              ...(skipped && decision !== undefined && !decision.runnable
+                ? {
+                    endedAt: now,
+                    skipReason: decision.reason,
+                    skippedCapabilities: [...decision.capabilities],
+                  }
+                : {}),
+            };
+          }),
+        )
+        .returning(SIMULATION_COLUMNS);
+
+      // The plan is written in the same transaction as the run and its
+      // conversations, so a run can never exist with nothing to judge it by.
+      await writeGradingPlan(tx, {
+        runId,
+        organizationId: auth.organizationId,
+        projectId,
+        state: "run_start",
+        capturedAt: now,
+        groups,
+      });
+
+      // And the key, last, so that losing the race to another attempt rolls this
+      // whole creation back rather than leaving a second run behind it.
+      if (idempotencyKey !== undefined && requestDigest !== undefined) {
+        await tx.insert(idempotentOperation).values({
+          organizationId: auth.organizationId,
+          projectId,
+          actorId: auth.userId,
+          operation: "start_run",
+          idempotencyKey,
+          requestDigest,
+          resultId: runId,
+        });
+      }
+
+      // The names come from what was just read rather than from a second query:
+      // this transaction already knows what every one of these is called.
+      const testNames = new Map(
+        versions.map((one) => [one.versionId, one.testName] as const),
+      );
+      const personaNames = new Map(
+        (
+          await tx
+            .select({ id: persona.id, name: persona.name })
+            .from(persona)
+            .where(inArray(persona.id, distinctPersonaIds))
+        ).map((row) => [row.id, row.name] as const),
+      );
+
+      return { header, simulations, testNames, personaNames };
+    });
+  } catch (cause) {
+    // Two attempts arrived at once and this one lost the primary key. The
+    // winner's run is the answer both were promised, so the loser reads it
+    // back rather than reporting a collision nobody caused. Its own whole
+    // creation rolled back with the failed insert, so there is no second run
+    // anywhere.
+    if (
+      idempotencyKey === undefined ||
+      requestDigest === undefined ||
+      !lostToIdempotencyKey(cause)
+    ) {
+      throw cause;
+    }
+    const already = await originalRunFor(
+      db(),
+      auth,
+      projectId,
+      idempotencyKey,
+      requestDigest,
+    );
+    if (already === undefined) throw cause;
+    return already;
+  }
 
   return {
     ...runFromRow(written.header),
@@ -1476,6 +1471,94 @@ export async function startRun(
       }))
       .sort((a, b) => a.position - b.position),
   };
+}
+
+/**
+ * The request this key is being remembered for, as one short string.
+ *
+ * **The selection, the connection and the agent — and deliberately not the
+ * label.** What must never differ between two attempts under one key is what
+ * egma would actually do: which agent, over which connection, executing which
+ * versions in which order. Two clients that agreed on all of that and disagreed
+ * about a display name have not asked for two runs.
+ *
+ * The order of the versions is kept rather than sorted, because it is the order
+ * the conversations will sit in and a caller who reordered them asked for
+ * something different.
+ */
+function digestOfStart(input: NewRun): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        agent: input.agentId ?? null,
+        connection: input.connectionId,
+        testVersions: [...input.testVersionIds],
+        retryOf: input.retryOfRunId ?? null,
+      }),
+    )
+    .digest("hex");
+}
+
+/**
+ * Whether a write failed because another attempt under the same key had already
+ * landed.
+ *
+ * Read off the constraint's own name rather than off the message, so the check
+ * survives a driver upgrade rewording its prose — the same shape the agent
+ * factory's name collision uses.
+ */
+function lostToIdempotencyKey(cause: unknown): boolean {
+  const held = cause as { constraint?: unknown; cause?: unknown };
+  if (held?.constraint === "idempotent_operation_pk") return true;
+  const beneath = held?.cause as { constraint?: unknown } | undefined;
+  return beneath?.constraint === "idempotent_operation_pk";
+}
+
+/**
+ * The run a key already started, when this request is the one it started.
+ *
+ * A key with a different body behind it is refused out loud rather than
+ * answered: telling somebody their new selection had started when it had not is
+ * the one failure an idempotency key exists to prevent, and it would be
+ * invisible — they would go and read a run full of the tests they replaced.
+ */
+async function originalRunFor(
+  on: Queryable,
+  auth: AuthContext,
+  projectId: string,
+  idempotencyKey: string,
+  requestDigest: string,
+): Promise<StartedRun | undefined> {
+  const [remembered] = await on
+    .select({
+      resultId: idempotentOperation.resultId,
+      requestDigest: idempotentOperation.requestDigest,
+    })
+    .from(idempotentOperation)
+    .where(
+      and(
+        eq(idempotentOperation.organizationId, auth.organizationId),
+        eq(idempotentOperation.projectId, projectId),
+        eq(idempotentOperation.actorId, auth.userId),
+        eq(idempotentOperation.operation, "start_run"),
+        eq(idempotentOperation.idempotencyKey, idempotencyKey),
+      ),
+    )
+    .limit(1);
+
+  if (remembered === undefined) return undefined;
+  if (remembered.requestDigest !== requestDigest) {
+    throw new IdempotencyConflictError(idempotencyKey, remembered.resultId);
+  }
+
+  const header = await getRun(auth, remembered.resultId);
+  if (header === undefined) {
+    // The run was deleted after the key remembered it. There is nothing to
+    // answer with and nothing honest to invent, so the key stops shielding.
+    throw new IdempotencyConflictError(idempotencyKey, remembered.resultId);
+  }
+  const conducted = await listSimulations(auth, remembered.resultId);
+  return { ...header, simulations: conducted ?? [] };
 }
 
 /** One run as it stands — the header; its conversations are `listSimulations`. */
@@ -1679,6 +1762,10 @@ async function finalizeRunIfDone(
       completedCount: byStatus.get("completed") ?? 0,
       failedCount: byStatus.get("failed") ?? 0,
       canceledCount: byStatus.get("canceled") ?? 0,
+      // Terminal from birth, so it is already in this tally — and it lands in
+      // its own column rather than any of the three above, because nothing was
+      // conducted, nothing failed and nobody stopped anything.
+      skippedCount: byStatus.get("skipped") ?? 0,
       finishedAt: now,
     })
     .where(eq(run.id, runId));

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -9,4 +9,5 @@ export * from "./graders.ts";
 export * from "./mock-tools.ts";
 export * from "./tests.ts";
 export * from "./runs.ts";
+export * from "./plans.ts";
 export * from "./grading.ts";

--- a/packages/db/src/schema/plans.ts
+++ b/packages/db/src/schema/plans.ts
@@ -1,0 +1,248 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  unique,
+} from "drizzle-orm/pg-core";
+
+import { run } from "./runs.ts";
+import { organization, project } from "./tenancy.ts";
+import { user } from "./identity.ts";
+import { createdAt, idText, moment, oneOf, prefixCheck } from "./columns.ts";
+
+/**
+ * The two things run creation has to write down beside the run itself: what
+ * will judge it, and which request created it.
+ *
+ * They live together because they are the same kind of fact — a decision made
+ * once, at the door, that nothing afterwards may quietly change — and because
+ * neither belongs to the run's execution lifecycle, which `runs.ts` is about.
+ */
+
+/**
+ * When a run's grading plan was decided, and whether one was decided at all.
+ *
+ * Three states, and the third is the honest one for history nobody can
+ * reconstruct.
+ *
+ * - `run_start` — the plan was frozen in the transaction that created the run.
+ *   Every run created from now on has this.
+ * - `migration_snapshot` — the run predates frozen plans, and something about
+ *   it was still outstanding when egma was upgraded: a nonterminal simulation,
+ *   or a grading job still `pending` or `claimed`. The upgrade captured the
+ *   plan as it stood *then*, because that work is about to be graded and has to
+ *   be graded against something written down. `captured_at` says when, and a
+ *   reader must be told it was captured during an upgrade rather than at start.
+ * - `not_recorded` — the run predates frozen plans and had nothing outstanding.
+ *   **No plan is invented for it.** Reconstructing one from today's graders
+ *   would put a sentence on an old run claiming it was judged by things that
+ *   may not have existed when it ran, and a page must never present that as a
+ *   pin.
+ */
+export const GRADING_PLAN_STATES = [
+  "run_start",
+  "migration_snapshot",
+  "not_recorded",
+] as const;
+export type GradingPlanState = (typeof GRADING_PLAN_STATES)[number];
+
+export const gradingPlan = pgTable(
+  "grading_plan",
+  {
+    id: idText("id").primaryKey(),
+    /** One plan per run, and the unique below is what makes that true. */
+    runId: idText("run_id").notNull(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    projectId: idText("project_id").notNull(),
+    state: text("state").notNull(),
+    /**
+     * When the plan below was decided. Null exactly on `not_recorded`, where
+     * there is no plan and therefore no moment — the two are one fact and the
+     * check holds them together.
+     */
+    capturedAt: moment("captured_at"),
+    /**
+     * The plan: groups under a tagged test reference, each holding its items.
+     *
+     * **A tagged union, never one nullable shape.** A group is either a pinned
+     * test version or the one testless group an upgraded instance's older
+     * simulations fall into, and an item is either an authored grader or a
+     * built-in — and the two item shapes genuinely differ. An authored item has
+     * a grader identity, a pinned grader version, an origin, a scope and one
+     * priority for the whole item; the built-in has a reserved key and an
+     * engine version, and its verdicts take their priority one at a time from
+     * the behaviors of the pinned test version. Folding the two into one row of
+     * mostly-null columns would make every reader guess which half applied.
+     *
+     * `access/run-plans.ts` owns the shape and is the only thing that writes
+     * one. Empty on `not_recorded`, where the state is the whole answer.
+     */
+    groups: jsonb("groups").notNull(),
+    /**
+     * Every `jcr_` judge credential the plan above names, as a flat array.
+     *
+     * **Derived, and written in the same statement as the plan it summarises.**
+     * It exists so that "is this credential still needed by outstanding work"
+     * is a plain indexed containment query rather than a walk through nested
+     * JSON — the question a credential's Archive has to answer before it can
+     * refuse, on the deployment's whole history. The `platform` sentinel is
+     * deliberately not in it: it names no customer credential and nothing can
+     * archive it.
+     */
+    judgeCredentialIds: jsonb("judge_credential_ids").notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    prefixCheck("grading_plan_id_prefix", table.id, "gpl"),
+    oneOf("grading_plan_state_allowed", table.state, [...GRADING_PLAN_STATES]),
+    // One plan per run: the plan is a property of the run, and a second one
+    // would leave two answers to "what judges this" with nothing to choose
+    // between them.
+    unique("grading_plan_run_id_unique").on(table.runId),
+    // A plan and the moment it was decided arrive together, and `not_recorded`
+    // has neither. Held here so that no reader has to decide what an empty
+    // plan with a timestamp would mean.
+    check(
+      "grading_plan_recorded_plans_carry_their_moment",
+      sql`(${table.state} = 'not_recorded')
+        = (${table.capturedAt} is null)`,
+    ),
+    check(
+      "grading_plan_groups_are_a_list",
+      sql`jsonb_typeof(${table.groups}) = 'array'`,
+    ),
+    check(
+      "grading_plan_credentials_are_a_list",
+      sql`jsonb_typeof(${table.judgeCredentialIds}) = 'array'`,
+    ),
+    // An unrecorded plan holds nothing at all, so nothing can be read off it
+    // as though it were a pin.
+    check(
+      "grading_plan_unrecorded_holds_nothing",
+      sql`${table.state} <> 'not_recorded'
+        or (${table.groups} = '[]'::jsonb
+          and ${table.judgeCredentialIds} = '[]'::jsonb)`,
+    ),
+    // The tenancy triangle, edge by edge, as everywhere else: the project is
+    // this organization's, and the run is that project's.
+    foreignKey({
+      name: "grading_plan_project_organization_fk",
+      columns: [table.projectId, table.organizationId],
+      foreignColumns: [project.id, project.organizationId],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "grading_plan_run_project_fk",
+      columns: [table.runId, table.projectId],
+      foreignColumns: [run.id, run.projectId],
+    }).onDelete("cascade"),
+    // What a credential's Archive asks, over every plan on the deployment.
+    index("grading_plan_judge_credential_ids_idx").using(
+      "gin",
+      table.judgeCredentialIds,
+    ),
+    index("grading_plan_organization_id_project_id_idx").on(
+      table.organizationId,
+      table.projectId,
+    ),
+  ],
+);
+
+/**
+ * The operations a client may safely send twice.
+ *
+ * **A run is the expensive kind of write**: it dials real telephony, spends a
+ * real judge, and is the object a team's release gate reads. A browser that
+ * retried a request whose answer was lost — a dropped connection, a proxy
+ * timeout, somebody's second click — would produce a second run over the same
+ * agent, and the two would disagree about nothing in particular while costing
+ * twice.
+ *
+ * So the client names the attempt and egma remembers the name. The scope is
+ * the organization, the project, the actor and the operation, because a key is
+ * a word somebody's client chose and two people's clients may well choose the
+ * same word: narrowing it to the actor is what stops one person's `retry-1`
+ * from answering another's.
+ *
+ * The body is remembered as a digest rather than kept, because the point of
+ * comparing is only to tell *the same request again* from *a different request
+ * under a reused name* — and the second has to be refused out loud rather than
+ * quietly answered with somebody else's run.
+ */
+export const IDEMPOTENT_OPERATIONS = ["start_run"] as const;
+export type IdempotentOperation = (typeof IDEMPOTENT_OPERATIONS)[number];
+
+export const idempotentOperation = pgTable(
+  "idempotent_operation",
+  {
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    projectId: idText("project_id").notNull(),
+    /**
+     * Who sent it. Never nullable, unlike a run's `triggered_by`: a run of a
+     * person since erased is still the team's record, but a key without an
+     * actor could be reused across people and is not a key this table can hold.
+     */
+    actorId: idText("actor_id").notNull(),
+    operation: text("operation").notNull(),
+    /** The client's own word for this attempt. Opaque, and never egma's. */
+    idempotencyKey: text("idempotency_key").notNull(),
+    /**
+     * A hex digest of the request this key first carried, so a reused key with
+     * different contents is refused rather than answered with the first run.
+     */
+    requestDigest: text("request_digest").notNull(),
+    /** What the first attempt produced — a `run_` id for `start_run`. */
+    resultId: idText("result_id").notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    // The scope *is* the identity: organization, project, actor, operation and
+    // the key, exactly as the contract states it. A second row for the same
+    // five is what the insert races against, and losing that race is how a
+    // duplicate learns it is one.
+    primaryKey({
+      name: "idempotent_operation_pk",
+      columns: [
+        table.organizationId,
+        table.projectId,
+        table.actorId,
+        table.operation,
+        table.idempotencyKey,
+      ],
+    }),
+    // The table's identity is the whole five-column key, so there is no id of
+    // its own to pin. Its leading column is pinned instead — the shape the two
+    // junction tables use, where the row's identity is a tuple and the half
+    // this table owns is the one that carries the format.
+    prefixCheck(
+      "idempotent_operation_organization_id_prefix",
+      table.organizationId,
+      "org",
+    ),
+    oneOf("idempotent_operation_allowed", table.operation, [
+      ...IDEMPOTENT_OPERATIONS,
+    ]),
+    check(
+      "idempotent_operation_key_is_not_empty",
+      sql`length(${table.idempotencyKey}) > 0`,
+    ),
+    foreignKey({
+      name: "idempotent_operation_project_organization_fk",
+      columns: [table.projectId, table.organizationId],
+      foreignColumns: [project.id, project.organizationId],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "idempotent_operation_actor_fk",
+      columns: [table.actorId],
+      foreignColumns: [user.id],
+    }).onDelete("cascade"),
+  ],
+);

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -68,6 +68,15 @@ export type RunTrigger = (typeof RUN_TRIGGERS)[number];
  *
  * `queued → canceled` is the cancel-before-claim path, and a canceled row can
  * never be claimed. A terminal row is frozen entirely.
+ *
+ * `skipped` is outside that lifecycle entirely and is the one status a row can
+ * be **born** in. It is written by run creation, terminal from its first
+ * moment, for a conversation egma decided in advance it could not honestly
+ * conduct — a test requiring something the connection was measured not to have,
+ * or something nobody has measured. It never enters the claim queue, no
+ * simulator ever sees it, and it produces no grading job, because there is no
+ * conversation to judge. It is emphatically not `failed`: nothing about the
+ * agent under test is being said.
  */
 export const SIMULATION_STATUSES = [
   "queued",
@@ -76,8 +85,26 @@ export const SIMULATION_STATUSES = [
   "completed",
   "failed",
   "canceled",
+  "skipped",
 ] as const;
 export type SimulationStatus = (typeof SIMULATION_STATUSES)[number];
+
+/**
+ * Why run creation wrote a conversation off before it began. Two, and they must
+ * never collapse into one, because they are a settled fact and an unasked
+ * question and their fixes are in different places: one means this test cannot
+ * be meaningfully run over this connection at all, the other means nobody has
+ * measured the connection yet and a Refresh may change the answer.
+ *
+ * They are the catalog's own two standings said in the run's vocabulary — see
+ * `capabilityStanding` in `access/capabilities.ts`, which is the one place the
+ * three answers are told apart.
+ */
+export const SIMULATION_SKIP_REASONS = [
+  "required_capability_unsupported",
+  "required_capability_unknown",
+] as const;
+export type SimulationSkipReason = (typeof SIMULATION_SKIP_REASONS)[number];
 
 /**
  * How a completed conversation ended — a fact about the conversation, not a
@@ -219,6 +246,18 @@ export const run = pgTable(
     completedCount: integer("completed_count"),
     failedCount: integer("failed_count"),
     canceledCount: integer("canceled_count"),
+    /**
+     * How many conversations this run never attempted, because a test required
+     * something the connection could not be shown to do.
+     *
+     * Its own count beside the other three rather than folded into any of them.
+     * Folding it into `failed` would report an agent broken by egma's own
+     * capability gap; folding it into `canceled` would say somebody stopped
+     * this work, and nobody did. A run whose every conversation is skipped
+     * completes with this number and three zeroes, which is exactly the shape
+     * a headline has to read as "nothing was judged" rather than as a pass.
+     */
+    skippedCount: integer("skipped_count"),
     /** A new run, retrying an old one — never the old run reopened. */
     retryOfRunId: idText("retry_of_run_id").references(
       (): AnyPgColumn => run.id,
@@ -242,12 +281,14 @@ export const run = pgTable(
       "run_counts_written_together",
       sql`((${table.completedCount} is null) = (${table.failedCount} is null))
         and ((${table.failedCount} is null) = (${table.canceledCount} is null))
+        and ((${table.canceledCount} is null) = (${table.skippedCount} is null))
         and ((${table.canceledCount} is null) = (${table.finishedAt} is null))`,
     ),
     check(
       "run_counts_are_counts",
       sql`(${table.completedCount} is null)
-        or (${table.completedCount} >= 0 and ${table.failedCount} >= 0 and ${table.canceledCount} >= 0)`,
+        or (${table.completedCount} >= 0 and ${table.failedCount} >= 0
+          and ${table.canceledCount} >= 0 and ${table.skippedCount} >= 0)`,
     ),
     // Finished means terminal, and completed means finished; only a canceled
     // run may hold its terminal status while stragglers land.
@@ -428,6 +469,24 @@ export const simulation = pgTable(
      * came back.
      */
     mockToolCoverage: jsonb("mock_tool_coverage"),
+    /**
+     * Why this conversation was never attempted, on the one status that is
+     * written terminal at birth. Null on every other row, including a `failed`
+     * one — a failure has an ending reason, and the two vocabularies are kept
+     * apart because they answer different questions: *the test never ran* and
+     * *the test never started*.
+     */
+    skipReason: text("skip_reason"),
+    /**
+     * Which required capabilities produced the skip, as catalog keys.
+     *
+     * On the row rather than left to be worked out from the pinned version and
+     * the connection, because both of those move: a Refresh tomorrow changes
+     * what the connection is known to do, and the reason this conversation was
+     * written off has to stay readable exactly as it was decided. It is the
+     * same reason the connection snapshot sits on the run.
+     */
+    skippedCapabilities: jsonb("skipped_capabilities"),
     createdAt: createdAt(),
   },
   (table) => [
@@ -509,6 +568,30 @@ export const simulation = pgTable(
       "simulation_canceled_shape",
       sql`${table.status} <> 'canceled'
         or (${table.endedAt} is not null and ${table.cancelRequestedAt} is not null)`,
+    ),
+    // A skipped row is terminal from birth and carries its whole explanation:
+    // it ended when it was written, it was never claimed and never started,
+    // and it names both why and which capabilities decided it. Nothing else
+    // may carry either field — a reason on a conversation that actually
+    // happened would be a sentence about a decision nobody made.
+    check(
+      "simulation_skipped_shape",
+      sql`${table.status} <> 'skipped'
+        or (${table.endedAt} is not null and ${table.claimedAt} is null
+          and ${table.startedAt} is null and ${table.cancelRequestedAt} is null
+          and ${table.skipReason} is not null
+          and ${table.skippedCapabilities} is not null)`,
+    ),
+    check(
+      "simulation_skip_reason_belongs_to_a_skip",
+      sql`${table.status} = 'skipped'
+        or (${table.skipReason} is null and ${table.skippedCapabilities} is null)`,
+    ),
+    check(
+      "simulation_skip_reason_allowed",
+      sql`${table.skipReason} is null or ${table.skipReason} in ${quoted(
+        SIMULATION_SKIP_REASONS,
+      )}`,
     ),
     // The audio facts are terminal facts; nothing running holds one yet.
     // The check keeps its name across the migration that reduced it to
@@ -724,15 +807,17 @@ export const runEvent = pgTable(
     ),
     // The pairing, held by the database: a conversation that ran is passed,
     // failed or skipped; one that never ran errored; one somebody stopped was
-    // never judged and is skipped. `skipped` and `errored` can therefore never
-    // be written as `failed`, which is the one normalisation a test product
-    // cannot get wrong.
+    // never judged and is skipped; and one egma declined to start in the first
+    // place is skipped too. `skipped` and `errored` can therefore never be
+    // written as `failed`, which is the one normalisation a test product cannot
+    // get wrong.
     check(
       "run_event_verdict_agrees",
       sql`${table.verdict} is null
         or (${table.status} = 'completed' and ${table.verdict} in ('passed', 'failed', 'skipped'))
         or (${table.status} = 'failed' and ${table.verdict} = 'errored')
-        or (${table.status} = 'canceled' and ${table.verdict} = 'skipped')`,
+        or (${table.status} = 'canceled' and ${table.verdict} = 'skipped')
+        or (${table.status} = 'skipped' and ${table.verdict} = 'skipped')`,
     ),
     // And the ending reason keeps to its own class, exactly as it does on the
     // simulation row it came from.

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -305,6 +305,18 @@ const CONTEXT_REQUIRING = [
   "setProjectJudge",
   "startRun",
   "startSimulation",
+  // What a run would freeze, answered before anybody starts it — and the same
+  // resolver `startRun` uses, so a review step and the run it produces can
+  // never disagree about which tests are skipped or which graders judge.
+  "planRun",
+  // What a run actually froze, including the honest `not_recorded` state for
+  // history that predates frozen plans.
+  "getGradingPlan",
+  // Taking a judge credential out of use, and asking what is stopping that.
+  // Both refuse and answer from one read, so a settings page and the refusal
+  // can never give two different reasons.
+  "archiveJudgeCredential",
+  "judgeCredentialUses",
   "updateAgent",
   "updateConnection",
   // A project's live name, slug and description, written against the revision
@@ -341,6 +353,14 @@ const PERMISSION = [
  * disagree with itself.
  */
 const THE_PLATFORMS_SETTINGS = ["PLATFORM_SETTINGS"];
+
+/**
+ * The version string the expected-behaviors built-in judges at, exported
+ * because a frozen plan stores it and a reader of one has to be able to say
+ * which engine wrote those verdicts. A behavior change in the built-in mints a
+ * new one; nothing else moves it.
+ */
+const THE_BUILT_IN_ENGINE = ["EXPECTED_BEHAVIORS_ENGINE_VERSION"];
 
 /** Vocabulary: the table definitions, how a caller proved who they are, and the refusals. */
 const VALUES = [
@@ -381,7 +401,20 @@ const VALUES = [
   // An identity write that named the revision it was written against, after
   // somebody else moved the row. `TestMovedOnError` below is the same refusal
   // one level down, about content rather than identity.
+  // A start action that reused an idempotency key over a different request.
+  // Its own class because the answer is neither the original run nor a second
+  // one: telling somebody their new selection had started when it had not is
+  // the one failure the key exists to prevent.
+  "IdempotencyConflictError",
   "IdentityConflictError",
+  // A judge credential something still needs — a project pointing at it, a run
+  // whose frozen plan names it while a conversation is still moving, or a
+  // grading job about to resolve its secret. It carries every blocking use,
+  // because the fix for each is somewhere different.
+  "JudgeCredentialInUseError",
+  // A run refused before anything was dialed, because the project has no LLM
+  // judge and every run carries the judge-backed built-in.
+  "JudgeNotConfiguredError",
   "PersonaNamedByTestsError",
   "ProjectOutsideOrganizationError",
   // A slug an admin typed that a living project of the same organization
@@ -549,6 +582,7 @@ describe("the data-access module's surface", () => {
         ...THE_FOLD,
         ...THE_MOCKED_WORLD,
         ...THE_PLATFORMS_SETTINGS,
+        ...THE_BUILT_IN_ENGINE,
       ].sort(),
     );
   });

--- a/packages/db/test/grading-jobs.test.ts
+++ b/packages/db/test/grading-jobs.test.ts
@@ -30,7 +30,7 @@ import {
   POSTGRES_ERROR,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * The grading queue: how a finished conversation becomes work, and how the
@@ -137,6 +137,8 @@ beforeAll(async () => {
   ]);
   await seedUser(database, ada, "ada@acme.example");
   await seedUser(database, gene, "gene@globex.example");
+  await seedJudge({ ...actingAsAcme(), role: "admin" });
+  await seedJudge({ ...actingAsGlobex(), role: "admin" });
 
   const created = await createAgent(auth, {
     name: "Front desk",

--- a/packages/db/test/migrations.test.ts
+++ b/packages/db/test/migrations.test.ts
@@ -2510,3 +2510,322 @@ describe("tests gaining applicable agents over installed data (0028)", () => {
     ).rejects.toThrow(/test_archive_reason_needs_an_archive/u);
   });
 });
+
+/**
+ * Runs written before egma froze a grading plan, and what the upgrade may say
+ * about them.
+ *
+ * **The rule is that nothing is invented.** A run with work still outstanding
+ * has a plan captured during the upgrade, because that work is about to be
+ * judged and has to be judged against something written down. Every other old
+ * run says `not_recorded` and holds nothing at all — reconstructing a plan from
+ * today's graders would put a sentence on a run from March claiming it was
+ * judged by things that may not have existed when it ran, and a page would
+ * present that as a pin.
+ *
+ * The second claim is the shape of a captured plan on history that predates
+ * stored tests: a simulation with no test version falls into the one testless
+ * group, which carries the project's default authored graders and neither a
+ * scenario grader nor the expected-behaviors built-in.
+ */
+describe("grading plans over installed runs (0029)", () => {
+  let database: EmptyDatabase;
+  let before: string;
+  let client: pg.Client;
+
+  const organizationId = newId("org");
+  const projectId = newId("prj");
+  const agentId = newId("agt");
+  const connectionId = newId("con");
+  const personaId = newId("prs");
+  const personaVersionId = newId("prsv");
+  const testId = newId("tst");
+  const testVersionId = newId("tstv");
+  const graderId = newId("grd");
+  const graderVersionId = newId("grv");
+
+  /** Still conducting when the upgrade landed. */
+  const movingRun = newId("run");
+  const movingSimulation = newId("sim");
+  /** Finished long ago, with nothing left to judge. */
+  const settledRun = newId("run");
+  const settledSimulation = newId("sim");
+  /** Conducted before a simulation could pin a test at all. */
+  const testlessRun = newId("run");
+  const testlessSimulation = newId("sim");
+
+  beforeAll(async () => {
+    database = await createEmptyDatabase("grading_plans");
+
+    before = await mkdtemp(path.join(os.tmpdir(), "egma-before-0029-"));
+    for (const migration of await readMigrations()) {
+      if (migration.name < "0029") {
+        await writeFile(path.join(before, migration.name), migration.sql);
+      }
+    }
+    await runMigrations(database.url, before);
+
+    client = new pg.Client({ connectionString: database.url });
+    await client.connect();
+    await client.query(
+      "insert into organization (id, name, slug) values ($1, 'Acme', 'acme')",
+      [organizationId],
+    );
+    await client.query(
+      `insert into project (id, organization_id, name, slug, revision)
+       values ($1, $2, 'Default', 'default', $3)`,
+      [projectId, organizationId, newId("rev")],
+    );
+    await client.query(
+      `insert into agent (id, organization_id, project_id, name, revision)
+       values ($1, $2, $3, 'Front desk', $4)`,
+      [agentId, organizationId, projectId, newId("rev")],
+    );
+    await client.query(
+      `insert into connection
+         (id, organization_id, project_id, agent_id, name, type, modality, topology, variant_id, config, revision)
+       values ($1, $2, $3, $4, 'retell-1', 'retell', 'chat', 'hosted-broker', 'retell', '{"retellAgentId":"agent_abc"}'::jsonb, $5)`,
+      [connectionId, organizationId, projectId, agentId, newId("rev")],
+    );
+
+    // The project's judge, migrated into its own credential by 0026 — which is
+    // what a plan may point at, and the reason this migration comes after it.
+    const credentialId = newId("jcr");
+    await client.query(
+      `insert into judge_credential
+         (id, organization_id, label, provider, credentials, credentials_hint, revision)
+       values ($1, $2, 'Acme default', 'openai', 'sealed', 'WXYZ', $3)`,
+      [credentialId, organizationId, newId("rev")],
+    );
+    await client.query(
+      `insert into judge_configuration
+         (project_id, organization_id, provider, model, source, credential_id)
+       values ($1, $2, 'openai', 'gpt-4.1-mini', 'credential', $3)`,
+      [projectId, organizationId, credentialId],
+    );
+
+    await client.query("begin");
+    await client.query(
+      `insert into persona (id, organization_id, project_id, name, current_version_id, revision)
+       values ($1, $2, $3, 'Impatient Rita', $4, $5)`,
+      [personaId, organizationId, projectId, personaVersionId, newId("rev")],
+    );
+    await client.query(
+      `insert into persona_version (id, persona_id, version, traits)
+       values ($1, $2, 1, '{"personality":"Plain","language":"en-US"}'::jsonb)`,
+      [personaVersionId, personaId],
+    );
+    await client.query("commit");
+
+    await client.query("begin");
+    await client.query(
+      `insert into test (id, organization_id, project_id, name, current_version_id, revision, applicability_revision)
+       values ($1, $2, $3, 'Reschedules', $4, $5, $6)`,
+      [testId, organizationId, projectId, testVersionId, newId("rev"), newId("rev")],
+    );
+    await client.query(
+      `insert into test_version (id, test_id, version, content)
+       values ($1, $2, 1, '{"scenario":"Moves a booking","expectedBehaviors":["confirms the new time"]}'::jsonb)`,
+      [testVersionId, testId],
+    );
+    await client.query("commit");
+
+    // A project-default grader, which every captured group has to carry.
+    await client.query("begin");
+    await client.query(
+      `insert into grader
+         (id, organization_id, project_id, name, type, priority, scope, current_version_id, revision)
+       values ($1, $2, $3, 'Never promises a price', 'phrase_match', 'P1', 'simulations', $4, $5)`,
+      [graderId, organizationId, projectId, graderVersionId, newId("rev")],
+    );
+    await client.query(
+      `insert into grader_version (id, grader_id, version, config, reads, modalities)
+       values ($1, $2, 1, '{"required":[],"banned":[],"speaker":"agent"}'::jsonb,
+               array['transcript']::text[], array['voice','chat']::text[])`,
+      [graderVersionId, graderId],
+    );
+    await client.query("commit");
+
+    const run = async (
+      id: string,
+      status: string,
+      finished: boolean,
+    ): Promise<void> => {
+      await client.query(
+        `insert into run
+           (id, organization_id, project_id, agent_id, connection_id, status, triggered_via,
+            pinned_test_versions, requested_personas, connection_snapshot, mock_tool_snapshot,
+            expected_simulation_count, completed_count, failed_count, canceled_count,
+            started_at, finished_at)
+         values ($1, $2, $3, $4, $5, $6, 'manual',
+                 '{"testVersionIds":[]}'::jsonb, '{"personaIds":[]}'::jsonb,
+                 '{"type":"retell","modality":"chat","topology":"hosted-broker","environment":null,"config":{}}'::jsonb,
+                 '{"defaults":[],"overrides":{}}'::jsonb,
+                 1, ${finished ? "1" : "null"}, ${finished ? "0" : "null"},
+                 ${finished ? "0" : "null"}, now(), ${finished ? "now()" : "null"})`,
+        [id, organizationId, projectId, agentId, connectionId, status],
+      );
+    };
+
+    const simulation = async (
+      id: string,
+      runId: string,
+      status: string,
+      pinned: boolean,
+    ): Promise<void> => {
+      await client.query(
+        `insert into simulation
+           (id, run_id, organization_id, project_id, agent_id, connection_id,
+            persona_id, persona_version_id, test_id, test_version_id,
+            position, modality, status, started_at, ended_at, ending_reason)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, $9::text, $10::text,
+                 1, 'chat', $11,
+                 ${status === "queued" ? "null" : "now()"},
+                 ${status === "completed" ? "now()" : "null"},
+                 ${status === "completed" ? "'persona_concluded'" : "null"})`,
+        [
+          id,
+          runId,
+          organizationId,
+          projectId,
+          agentId,
+          connectionId,
+          personaId,
+          personaVersionId,
+          // A conversation written before a simulation could pin a test at all
+          // carries neither half of the pin, which is the row the testless
+          // group exists for.
+          pinned ? testId : null,
+          pinned ? testVersionId : null,
+          status,
+        ],
+      );
+    };
+
+    await run(movingRun, "running", false);
+    await simulation(movingSimulation, movingRun, "queued", true);
+
+    await run(settledRun, "completed", true);
+    await simulation(settledSimulation, settledRun, "completed", true);
+
+    await run(testlessRun, "running", false);
+    await simulation(testlessSimulation, testlessRun, "queued", false);
+  });
+
+  afterAll(async () => {
+    await client.end();
+    await rm(before, { recursive: true, force: true });
+    await database.drop();
+  });
+
+  it("is what is still pending on a database that already holds runs", async () => {
+    const upgrade = (await readMigrations()).find((migration) =>
+      migration.name.startsWith("0029_"),
+    );
+    if (upgrade === undefined) throw new Error("0029 is missing");
+    await writeFile(path.join(before, upgrade.name), upgrade.sql);
+
+    const { applied } = await runMigrations(database.url, before);
+    expect(applied).toEqual([upgrade.name]);
+  });
+
+  it("captures a plan only for the run that still has work outstanding", async () => {
+    const { rows } = await client.query<{ run_id: string; state: string }>(
+      "select run_id, state from grading_plan order by run_id",
+    );
+    const byRun = new Map(rows.map((row) => [row.run_id, row.state]));
+
+    expect(byRun.get(movingRun)).toBe("migration_snapshot");
+    expect(byRun.get(testlessRun)).toBe("migration_snapshot");
+    // Nothing outstanding, so nothing is claimed about what judged it.
+    expect(byRun.get(settledRun)).toBe("not_recorded");
+  });
+
+  it("leaves an unrecorded plan holding nothing at all", async () => {
+    const { rows } = await client.query<{
+      groups: unknown;
+      credentials: unknown;
+      captured_at: string | null;
+    }>(
+      `select groups, judge_credential_ids as credentials, captured_at
+       from grading_plan where run_id = $1`,
+      [settledRun],
+    );
+    expect(rows[0]?.groups).toEqual([]);
+    expect(rows[0]?.credentials).toEqual([]);
+    // No plan, and therefore no moment: the two are one fact.
+    expect(rows[0]?.captured_at).toBeNull();
+  });
+
+  it("gives a pinned simulation a version group carrying the built-in and the project's graders", async () => {
+    const { rows } = await client.query<{ groups: PlanShape[] }>(
+      "select groups from grading_plan where run_id = $1",
+      [movingRun],
+    );
+    const [group] = rows[0]?.groups ?? [];
+
+    expect(group?.tag).toBe("version");
+    expect(group?.testVersionId).toBe(testVersionId);
+    expect(group?.items.map((item) => item.kind).sort()).toEqual([
+      "authored",
+      "built_in",
+    ]);
+
+    const builtIn = group?.items.find((item) => item.kind === "built_in");
+    expect(builtIn?.graderKey).toBe("expected_behaviors_v1");
+    // Judged, so it names the migrated credential — and never the secret.
+    expect(builtIn?.judge).toMatchObject({ tag: "configured", provider: "openai" });
+
+    const authored = group?.items.find((item) => item.kind === "authored");
+    expect(authored?.graderId).toBe(graderId);
+    expect(authored?.graderVersionId).toBe(graderVersionId);
+    // A phrase match asks no model, so naming one would be a bill nobody incurs.
+    expect(authored?.judge).toEqual({ tag: "not_required" });
+  });
+
+  it("gives a simulation with no test version the testless group, and nothing it cannot support", async () => {
+    const { rows } = await client.query<{ groups: PlanShape[] }>(
+      "select groups from grading_plan where run_id = $1",
+      [testlessRun],
+    );
+    const [group] = rows[0]?.groups ?? [];
+
+    expect(group?.tag).toBe("legacy_testless");
+    // Only the project's default authored graders. No scenario grader and no
+    // expected-behaviors built-in, because there is no stored test content to
+    // support either — and inventing one would be a claim about a conversation
+    // nobody can check.
+    expect(group?.items.map((item) => item.kind)).toEqual(["authored"]);
+    expect(group?.items[0]?.graderId).toBe(graderId);
+  });
+
+  it("indexes the credentials a captured plan needs, so an archive can refuse", async () => {
+    const { rows } = await client.query<{ credentials: string[] }>(
+      "select judge_credential_ids as credentials from grading_plan where run_id = $1",
+      [movingRun],
+    );
+    expect(rows[0]?.credentials).toHaveLength(1);
+    expect(rows[0]?.credentials[0]).toMatch(/^jcr_/u);
+  });
+
+  it("gives every finished run a skipped count of zero, because nothing was skipped before it could be", async () => {
+    const { rows } = await client.query<{ skipped_count: number | null }>(
+      "select skipped_count from run where id = $1",
+      [settledRun],
+    );
+    expect(rows[0]?.skipped_count).toBe(0);
+  });
+});
+
+/** A captured plan's stored shape, as this file reads it back. */
+type PlanShape = {
+  readonly tag: string;
+  readonly testVersionId?: string;
+  readonly items: readonly {
+    readonly kind: string;
+    readonly graderKey?: string;
+    readonly graderId?: string;
+    readonly graderVersionId?: string;
+    readonly judge: Record<string, unknown>;
+  }[];
+};

--- a/packages/db/test/regrade.test.ts
+++ b/packages/db/test/regrade.test.ts
@@ -27,7 +27,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * Asking for a conversation to be judged again.
@@ -175,6 +175,7 @@ beforeAll(async () => {
   ]);
   await seedUser(database, ada, "ada@acme.example");
   await seedUser(database, gene, "gene@globex.example");
+  await seedJudge(actingAsAcme("admin"));
 
   const created = await createAgent(auth, {
     name: "Front desk",

--- a/packages/db/test/run-events.test.ts
+++ b/packages/db/test/run-events.test.ts
@@ -25,7 +25,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * The run events record, at the seam the rest of egma reaches it through.
@@ -151,6 +151,8 @@ beforeAll(async () => {
   ]);
   await seedUser(database, ada, "ada@acme.example");
   await seedUser(database, grace, "grace@globex.example");
+  await seedJudge({ ...actingAsAcme(), role: "admin" });
+  await seedJudge({ ...actingAsGlobex(), role: "admin" });
 
   const created = await createAgent(actingAsAcme(), {
     name: "Front desk",

--- a/packages/db/test/run-planning.test.ts
+++ b/packages/db/test/run-planning.test.ts
@@ -1,0 +1,836 @@
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  archiveJudgeCredential,
+  createAgent,
+  createGrader,
+  createJudgeCredential,
+  createPersona,
+  createTest,
+  deleteGrader,
+  getGradingPlan,
+  IdempotencyConflictError,
+  JudgeCredentialInUseError,
+  JudgeNotConfiguredError,
+  listSimulations,
+  NotPermittedError,
+  planRun,
+  refreshConnectionCapabilities,
+  setProjectJudge,
+  startRun,
+  type AuthContext,
+  type AuthoredPlanItem,
+  type BuiltInPlanItem,
+  type PlanItem,
+  type Role,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * What a run decides before it exists.
+ *
+ * Three claims, and each of them is a state this product keeps apart from a
+ * state it looks like:
+ *
+ * **A conversation egma cannot honestly have is skipped, never failed.** A test
+ * that requires something the connection was measured not to do, or something
+ * nobody has measured, produces a terminal `skipped` simulation with a
+ * structured reason — no claim, no grading job, and the rest of the run
+ * conducted around it. A run made entirely of those completes with nothing that
+ * can be read as a pass.
+ *
+ * **What will judge a run is written down at the moment it starts.** One group
+ * per pinned test version, the expected-behaviors built-in in every one of
+ * them, the project's default graders, and the graders each version names
+ * directly — with a judge choice on each that carries a credential *reference*
+ * and never a key.
+ *
+ * **Starting is idempotent under a key the client chose.** The same key and the
+ * same selection answers the run that already exists; the same key and a
+ * different selection is refused out loud rather than quietly answered with
+ * somebody else's run.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+
+function actingAsAcme(role: Role = "member"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+const neutralTraits = {
+  personality: "Speaks plainly, stays patient, asks one question at a time.",
+  language: "en-US",
+  voice: { provider: "elevenlabs", voiceId: "EXAVITQu4vr4xnSDxMaL", speed: 1 },
+} as const;
+
+let agentId: string;
+/** A chat connection, measured: it carries no audio and cannot press a digit. */
+let measured: string;
+/** A second connection nobody has ever measured. */
+let unmeasured: string;
+let rita: string;
+
+/** A test with nothing to require of a connection: it runs anywhere. */
+let plain: string;
+/** A test that needs audio, which a measured chat connection does not have. */
+let needsAudio: string;
+/** A test that needs barge-in, which no adapter here speaks to at all. */
+let needsBargeIn: string;
+
+async function seedTestVersion(
+  name: string,
+  requiredCapabilities: readonly string[] = [],
+): Promise<string> {
+  const created = await createTest(actingAsAcme(), {
+    name,
+    scenario:
+      "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+    expectedBehaviors: [
+      "verifies who it is speaking to before discussing the booking",
+      { behavior: "offers at least one afternoon slot next week", priority: "P1" },
+    ],
+    personaIds: [rita],
+    requiredCapabilities: [...requiredCapabilities],
+  });
+  return created.versionId;
+}
+
+/** The plan items of one group, found by the version it judges. */
+function itemsFor(
+  groups: readonly { readonly items: readonly PlanItem[] }[],
+  at: number,
+): readonly PlanItem[] {
+  return groups[at]?.items ?? [];
+}
+
+function authored(items: readonly PlanItem[]): readonly AuthoredPlanItem[] {
+  return items.filter((one): one is AuthoredPlanItem => one.kind === "authored");
+}
+
+function builtIn(items: readonly PlanItem[]): BuiltInPlanItem | undefined {
+  return items.find((one): one is BuiltInPlanItem => one.kind === "built_in");
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("run_planning");
+
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedJudge(actingAsAcme("admin"));
+
+  const created = await createAgent(actingAsAcme(), {
+    name: "Front desk",
+    connection: {
+      type: "retell",
+      modality: "chat",
+      environment: "staging",
+      config: { retellAgentId: "agent_in_retell_1" },
+      credentials: { apiKey: "a-retell-key-for-this-test" },
+    },
+  });
+  agentId = created.id;
+  measured = created.connection?.id ?? "";
+
+  // The shipped adapter's two facts, on a chat connection: it examines
+  // `raw_audio` and `dtmf`, finds neither, and deliberately says nothing about
+  // `barge_in` — which is what makes "unsupported" and "nobody looked" two
+  // different answers in this file rather than one.
+  await refreshConnectionCapabilities(actingAsAcme(), agentId, measured);
+
+  const second = await createAgent(actingAsAcme(), {
+    name: "Night desk",
+    connection: {
+      type: "retell",
+      modality: "chat",
+      environment: "staging",
+      config: { retellAgentId: "agent_in_retell_2" },
+      credentials: { apiKey: "another-retell-key" },
+    },
+  });
+  unmeasured = second.connection?.id ?? "";
+
+  rita = (
+    await createPersona(actingAsAcme(), {
+      name: "Rita",
+      traits: neutralTraits,
+    })
+  ).id;
+
+  plain = await seedTestVersion("Moving a booking");
+  needsAudio = await seedTestVersion("Hearing the hold music", ["raw_audio"]);
+  needsBargeIn = await seedTestVersion("Interrupting mid-sentence", ["barge_in"]);
+
+  // The second agent has to be able to run them too, or applicability refuses
+  // before capabilities are ever consulted.
+  for (const versionId of [plain, needsAudio, needsBargeIn]) {
+    const { rows } = await database.sql<{ test_id: string }>(
+      "select test_id from test_version where id = $1",
+      [versionId],
+    );
+    const testId = rows[0]?.test_id ?? "";
+    // `on conflict do nothing`, because a test created with no explicit
+    // targets is already linked to every active agent of its project.
+    await database.sql(
+      "insert into test_agent (test_id, agent_id, project_id) values ($1, $2, $3) on conflict do nothing",
+      [testId, second.id, acme.project],
+    );
+  }
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("a test this connection cannot honestly run", () => {
+  it("is written terminal skipped with the reason and the capabilities that decided it", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [needsAudio],
+      idempotencyKey: newId("run"),
+    });
+
+    const [only] = started.simulations;
+    expect(only?.status).toBe("skipped");
+    expect(only?.skipReason).toBe("required_capability_unsupported");
+    expect(only?.skippedCapabilities).toEqual(["raw_audio"]);
+    // Terminal from birth: it ended when it was written, and nothing ever
+    // claimed it or started it.
+    expect(only?.endedAt).not.toBeNull();
+    expect(only?.claimedAt).toBeNull();
+    expect(only?.startedAt).toBeNull();
+  });
+
+  it("tells a measured absence from an unmeasured one, because the fixes differ", async () => {
+    const measuredRun = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [needsBargeIn],
+      idempotencyKey: newId("run"),
+    });
+    // The adapter examined `raw_audio` and `dtmf` and said nothing about
+    // `barge_in`, so this is an unasked question rather than a settled fact.
+    expect(measuredRun.simulations[0]?.skipReason).toBe(
+      "required_capability_unknown",
+    );
+
+    const unmeasuredRun = await startRun(actingAsAcme(), {
+      connectionId: unmeasured,
+      testVersionIds: [needsAudio],
+      idempotencyKey: newId("run"),
+    });
+    // Same requirement, a connection nobody has measured: also unknown, and
+    // never "unsupported" — nothing has looked.
+    expect(unmeasuredRun.simulations[0]?.skipReason).toBe(
+      "required_capability_unknown",
+    );
+  });
+
+  it("never becomes grading work, because there is no conversation to judge", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [needsAudio],
+      idempotencyKey: newId("run"),
+    });
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from grading_job where simulation_id = $1",
+      [started.simulations[0]?.id ?? ""],
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+
+  it("leaves the rest of the run to be conducted", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain, needsAudio],
+      idempotencyKey: newId("run"),
+    });
+
+    expect(started.simulations.map((one) => one.status)).toEqual([
+      "queued",
+      "skipped",
+    ]);
+    // Still pending, because something is still to be conducted — and the
+    // counts stay unwritten until the queued one lands.
+    expect(started.status).toBe("pending");
+    expect(started.skippedCount).toBeNull();
+  });
+
+  it("completes an all-skipped run at once, with no passing headline", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [needsAudio, needsBargeIn],
+      idempotencyKey: newId("run"),
+    });
+
+    expect(started.status).toBe("completed");
+    expect(started.finishedAt).not.toBeNull();
+    // Nothing conducted, nothing failed, nobody canceled anything — and the
+    // skipped count is the whole of it. Three zeroes and a number is what makes
+    // this unreadable as a pass.
+    expect(started.completedCount).toBe(0);
+    expect(started.failedCount).toBe(0);
+    expect(started.canceledCount).toBe(0);
+    expect(started.skippedCount).toBe(2);
+  });
+
+  it("is never claimable, whatever a simulator asks for", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [needsAudio],
+      idempotencyKey: newId("run"),
+    });
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from simulation where run_id = $1 and status = 'queued'",
+      [started.id],
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+});
+
+describe("the review, before anybody starts anything", () => {
+  it("answers the same skip the start would write, rather than refusing", async () => {
+    const plan = await planRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain, needsAudio],
+    });
+
+    expect(plan.runnableSimulationCount).toBe(1);
+    expect(plan.skippedSimulationCount).toBe(1);
+    expect(plan.groups[0]?.capability).toEqual({ runnable: true });
+    expect(plan.groups[1]?.capability).toEqual({
+      runnable: false,
+      reason: "required_capability_unsupported",
+      capabilities: ["raw_audio"],
+    });
+  });
+
+  it("names the persona versions the run would pin", async () => {
+    const plan = await planRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+    });
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: newId("run"),
+    });
+
+    expect(plan.groups[0]?.personas[0]?.personaVersionId).toBe(
+      started.simulations[0]?.personaVersionId,
+    );
+  });
+
+  it("refuses a test that does not apply to this agent, exactly as the start does", async () => {
+    const strangerAgent = await createAgent(actingAsAcme(), {
+      name: "Somewhere else",
+      connection: {
+        type: "retell",
+        modality: "chat",
+        config: { retellAgentId: "agent_in_retell_3" },
+        credentials: { apiKey: "a-third-retell-key" },
+      },
+    });
+
+    await expect(
+      planRun(actingAsAcme(), {
+        agentId: strangerAgent.id,
+        connectionId: strangerAgent.connection?.id ?? "",
+        testVersionIds: [plain],
+      }),
+    ).rejects.toThrow(/does not apply to agent/u);
+  });
+});
+
+describe("the grading plan a run freezes", () => {
+  it("holds one group per pinned version, each carrying the built-in", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain, needsAudio],
+      idempotencyKey: newId("run"),
+    });
+
+    const plan = await getGradingPlan(actingAsAcme(), started.id);
+    expect(plan?.state).toBe("run_start");
+    expect(plan?.capturedAt).not.toBeNull();
+    expect(plan?.groups).toHaveLength(2);
+    expect(plan?.groups.map((group) => group.tag)).toEqual([
+      "version",
+      "version",
+    ]);
+
+    for (const group of plan?.groups ?? []) {
+      const item = builtIn(group.items);
+      expect(item?.graderKey).toBe("expected_behaviors_v1");
+      // No grader identity, no version, no scope, no item-wide priority: each
+      // verdict takes its priority from the behavior it judged.
+      expect(item).not.toHaveProperty("graderId");
+      expect(item).not.toHaveProperty("priority");
+      expect(item?.reads).toEqual([
+        "transcript",
+        "outcome",
+        "tool_calls",
+        "measures",
+      ]);
+    }
+  });
+
+  it("is frozen even for a conversation it will never conduct", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [needsAudio],
+      idempotencyKey: newId("run"),
+    });
+    // A run with nothing to conduct still records what would have judged it,
+    // because the plan is what makes the run interpretable afterwards.
+    const plan = await getGradingPlan(actingAsAcme(), started.id);
+    expect(plan?.state).toBe("run_start");
+    expect(plan?.groups).toHaveLength(1);
+  });
+
+  it("carries the project's default graders, at the versions they stand at", async () => {
+    const grader = await createGrader(actingAsAcme(), {
+      name: "Never quotes a price",
+      type: "phrase_match",
+      priority: "P1",
+      config: {
+        required: [],
+        banned: [{ text: "guaranteed", match: "contains" }],
+        speaker: "agent",
+      },
+    });
+
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: newId("run"),
+    });
+    const plan = await getGradingPlan(actingAsAcme(), started.id);
+    const item = authored(itemsFor(plan?.groups ?? [], 0)).find(
+      (one) => one.graderId === grader.id,
+    );
+
+    expect(item?.origin).toBe("project_default");
+    expect(item?.graderVersionId).toBe(grader.versionId);
+    expect(item?.priority).toBe("P1");
+    // A deterministic grader asks no model, so naming one would be a bill
+    // nobody incurs.
+    expect(item?.judge).toEqual({ tag: "not_required" });
+  });
+
+  it("keeps one item where a grader is both a default and named by the test, and it is the direct one", async () => {
+    const grader = await createGrader(actingAsAcme(), {
+      name: "Says the disclosure",
+      type: "phrase_match",
+      config: {
+        required: [{ text: "recorded", match: "contains" }],
+        banned: [],
+        speaker: "agent",
+      },
+    });
+
+    const created = await createTest(actingAsAcme(), {
+      name: "A test that names it directly",
+      scenario: "Their cleaning has to move to any afternoon next week.",
+      expectedBehaviors: ["confirms the new time back before finishing"],
+      personaIds: [rita],
+      graderIds: [grader.id],
+    });
+    await database.sql(
+      "insert into test_agent (test_id, agent_id, project_id) values ($1, $2, $3) on conflict do nothing",
+      [created.id, agentId, acme.project],
+    );
+
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [created.versionId],
+      idempotencyKey: newId("run"),
+    });
+    const plan = await getGradingPlan(actingAsAcme(), started.id);
+    const named = authored(itemsFor(plan?.groups ?? [], 0)).filter(
+      (one) => one.graderId === grader.id,
+    );
+
+    expect(named).toHaveLength(1);
+    // The direct link is the scoping decision, so it is the origin that
+    // survives — a page has to be able to say why this grader is here.
+    expect(named[0]?.origin).toBe("scenario_specific");
+  });
+
+  it("keeps two items for one grader across two selected versions", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain, needsBargeIn],
+      idempotencyKey: newId("run"),
+    });
+    const plan = await getGradingPlan(actingAsAcme(), started.id);
+
+    const first = authored(itemsFor(plan?.groups ?? [], 0));
+    const second = authored(itemsFor(plan?.groups ?? [], 1));
+    expect(first.length).toBeGreaterThan(0);
+    expect(second.map((one) => one.graderId).sort()).toEqual(
+      first.map((one) => one.graderId).sort(),
+    );
+  });
+
+  it("leaves an archived grader out of a new plan, and starts the run anyway", async () => {
+    const grader = await createGrader(actingAsAcme(), {
+      name: "Taken out of use",
+      type: "phrase_match",
+      config: {
+        required: [{ text: "goodbye", match: "contains" }],
+        banned: [],
+        speaker: "agent",
+      },
+    });
+    await deleteGrader(actingAsAcme(), grader.id);
+
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: newId("run"),
+    });
+    const plan = await getGradingPlan(actingAsAcme(), started.id);
+
+    expect(
+      authored(itemsFor(plan?.groups ?? [], 0)).map((one) => one.graderId),
+    ).not.toContain(grader.id);
+    expect(started.status).toBe("pending");
+  });
+
+  it("names the credential a judged grader spends from, and never a key", async () => {
+    const credential = await createJudgeCredential(actingAsAcme("admin"), {
+      label: "The team's key",
+      provider: "openai",
+      key: "sk-a-real-looking-openai-key-0001",
+    });
+    await setProjectJudge(actingAsAcme("admin"), {
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      source: credential.id,
+    });
+
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: newId("run"),
+    });
+    const plan = await getGradingPlan(actingAsAcme(), started.id);
+    const item = builtIn(itemsFor(plan?.groups ?? [], 0));
+
+    expect(item?.judge).toEqual({
+      tag: "configured",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      source: credential.id,
+    });
+
+    // The whole plan, as bytes, with the key it was written under nowhere in it.
+    const { rows } = await database.sql<{ groups: string }>(
+      "select groups::text as groups from grading_plan where run_id = $1",
+      [started.id],
+    );
+    expect(rows[0]?.groups).not.toContain("sk-a-real-looking-openai-key-0001");
+  });
+});
+
+describe("a project with no judge", () => {
+  it("cannot start a run at all, because every run judges its behaviors", async () => {
+    const other = { organization: newId("org"), project: newId("prj") };
+    const grace = newId("usr");
+    await seedOrganization(database, other.organization, [
+      { id: other.project, slug: "default" },
+    ]);
+    await seedUser(database, grace, "grace@globex.example");
+
+    const auth: AuthContext = {
+      userId: grace,
+      organizationId: other.organization,
+      projectId: other.project,
+      role: "member",
+      via: "session",
+    };
+
+    const agent = await createAgent(auth, {
+      name: "Unjudged",
+      connection: {
+        type: "retell",
+        modality: "chat",
+        config: { retellAgentId: "agent_in_retell_9" },
+        credentials: { apiKey: "a-key-for-the-unjudged-project" },
+      },
+    });
+    const persona = await createPersona(auth, {
+      name: "Sam",
+      traits: neutralTraits,
+    });
+    const test = await createTest(auth, {
+      name: "Anything at all",
+      scenario: "Their cleaning has to move.",
+      expectedBehaviors: ["confirms the new time"],
+      personaIds: [persona.id],
+    });
+
+    await expect(
+      startRun(auth, {
+        agentId: agent.id,
+        connectionId: agent.connection?.id ?? "",
+        testVersionIds: [test.versionId],
+        idempotencyKey: newId("run"),
+      }),
+    ).rejects.toBeInstanceOf(JudgeNotConfiguredError);
+
+    // Nothing was written: not the run, and not a simulation to explain.
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from run where project_id = $1",
+      [other.project],
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+
+    // And the review answers it as a state, so a page can draw it rather than
+    // meeting a refusal it cannot render.
+    const plan = await planRun(auth, {
+      agentId: agent.id,
+      connectionId: agent.connection?.id ?? "",
+      testVersionIds: [test.versionId],
+    });
+    expect(plan.judge).toEqual({ state: "needs_setup" });
+  });
+});
+
+describe("starting a run twice under one key", () => {
+  it("answers the original run rather than starting a second", async () => {
+    const key = newId("run");
+    const first = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: key,
+    });
+    const again = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: key,
+    });
+
+    expect(again.id).toBe(first.id);
+    expect(again.simulations.map((one) => one.id)).toEqual(
+      first.simulations.map((one) => one.id),
+    );
+  });
+
+  it("refuses a different selection under the same key, and writes nothing", async () => {
+    const key = newId("run");
+    const first = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: key,
+    });
+
+    await expect(
+      startRun(actingAsAcme(), {
+        agentId,
+        connectionId: measured,
+        testVersionIds: [plain, needsBargeIn],
+        idempotencyKey: key,
+      }),
+    ).rejects.toBeInstanceOf(IdempotencyConflictError);
+
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from idempotent_operation where idempotency_key = $1",
+      [key],
+    );
+    expect(Number(rows[0]?.count)).toBe(1);
+    expect((await listSimulations(actingAsAcme(), first.id))?.length).toBe(1);
+  });
+
+  it("keeps one person's key out of another's, because a key is a word somebody chose", async () => {
+    const key = "the-same-word-we-both-chose";
+    const grace = newId("usr");
+    await seedUser(database, grace, "grace@acme.example");
+
+    const mine = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: key,
+    });
+    const theirs = await startRun(
+      { ...actingAsAcme(), userId: grace },
+      {
+        agentId,
+        connectionId: measured,
+        testVersionIds: [plain],
+        idempotencyKey: key,
+      },
+    );
+
+    expect(theirs.id).not.toBe(mine.id);
+  });
+
+  it("starts a run at all without one, because egma's own fixtures have no retry to guard", async () => {
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+    });
+    expect(started.status).toBe("pending");
+  });
+});
+
+describe("who may plan and start", () => {
+  it("lets a viewer read the builder's inputs and refuses their start", async () => {
+    const plan = await planRun(actingAsAcme("viewer"), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+    });
+    expect(plan.groups).toHaveLength(1);
+
+    await expect(
+      startRun(actingAsAcme("viewer"), {
+        agentId,
+        connectionId: measured,
+        testVersionIds: [plain],
+        idempotencyKey: newId("run"),
+      }),
+    ).rejects.toBeInstanceOf(NotPermittedError);
+  });
+});
+
+describe("archiving a judge credential", () => {
+  it("is refused while a project points at it, and names the project", async () => {
+    const credential = await createJudgeCredential(actingAsAcme("admin"), {
+      label: "Pointed at",
+      provider: "openai",
+      key: "sk-a-real-looking-openai-key-0002",
+    });
+    await setProjectJudge(actingAsAcme("admin"), {
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      source: credential.id,
+    });
+
+    const refused = await archiveJudgeCredential(
+      actingAsAcme("admin"),
+      credential.id,
+    ).catch((cause: unknown) => cause);
+
+    expect(refused).toBeInstanceOf(JudgeCredentialInUseError);
+    expect((refused as JudgeCredentialInUseError).uses).toContainEqual({
+      kind: "project",
+      id: acme.project,
+    });
+  });
+
+  it("is refused while a run's frozen plan still names it, and names the run", async () => {
+    const credential = await createJudgeCredential(actingAsAcme("admin"), {
+      label: "Frozen into a plan",
+      provider: "openai",
+      key: "sk-a-real-looking-openai-key-0003",
+    });
+    await setProjectJudge(actingAsAcme("admin"), {
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      source: credential.id,
+    });
+
+    const started = await startRun(actingAsAcme(), {
+      agentId,
+      connectionId: measured,
+      testVersionIds: [plain],
+      idempotencyKey: newId("run"),
+    });
+
+    // Point the project somewhere else, so the only thing left holding this
+    // credential is the frozen plan of a run still conducting.
+    await setProjectJudge(actingAsAcme("admin"), {
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      source: (
+        await createJudgeCredential(actingAsAcme("admin"), {
+          label: "Somewhere else",
+          provider: "openai",
+          key: "sk-a-real-looking-openai-key-0004",
+        })
+      ).id,
+    });
+
+    const refused = await archiveJudgeCredential(
+      actingAsAcme("admin"),
+      credential.id,
+    ).catch((cause: unknown) => cause);
+
+    expect(refused).toBeInstanceOf(JudgeCredentialInUseError);
+    expect((refused as JudgeCredentialInUseError).uses).toContainEqual({
+      kind: "run",
+      id: started.id,
+    });
+  });
+
+  it("succeeds once nothing needs it, and the plans that named it stay readable", async () => {
+    const credential = await createJudgeCredential(actingAsAcme("admin"), {
+      label: "Nothing needs it",
+      provider: "openai",
+      key: "sk-a-real-looking-openai-key-0005",
+    });
+
+    const archived = await archiveJudgeCredential(
+      actingAsAcme("admin"),
+      credential.id,
+    );
+    expect(archived?.id).toBe(credential.id);
+    // The row stays: a plan frozen under it has to keep naming something
+    // readable, which is the difference between archiving and deleting.
+    const { rows } = await database.sql<{ count: string }>(
+      "select count(*) as count from judge_credential where id = $1",
+      [credential.id],
+    );
+    expect(Number(rows[0]?.count)).toBe(1);
+  });
+
+  it("is refused to anybody but an admin", async () => {
+    const credential = await createJudgeCredential(actingAsAcme("admin"), {
+      label: "Not a member's to remove",
+      provider: "openai",
+      key: "sk-a-real-looking-openai-key-0006",
+    });
+
+    await expect(
+      archiveJudgeCredential(actingAsAcme("member"), credential.id),
+    ).rejects.toBeInstanceOf(NotPermittedError);
+  });
+});

--- a/packages/db/test/runs-claim-concurrency.test.ts
+++ b/packages/db/test/runs-claim-concurrency.test.ts
@@ -15,7 +15,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * Two simulators, one queue — the deployment's whole queue, because the claim
@@ -62,6 +62,7 @@ beforeAll(async () => {
     { id: projectId, slug: "default" },
   ]);
   await seedUser(database, ada, "ada@acme.example");
+  await seedJudge({ ...auth, role: "admin" });
 
   const created = await createAgent(auth, {
     name: "Front desk",

--- a/packages/db/test/runs-lifecycle-constraints.test.ts
+++ b/packages/db/test/runs-lifecycle-constraints.test.ts
@@ -624,6 +624,7 @@ describe("the run header", () => {
       completed_count: 0,
       failed_count: 0,
       canceled_count: 1,
+      skipped_count: 0,
     });
 
     await expect(

--- a/packages/db/test/runs.test.ts
+++ b/packages/db/test/runs.test.ts
@@ -41,7 +41,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * The whole lifecycle at the db seam, through the module: a run and its
@@ -190,6 +190,12 @@ beforeAll(async () => {
   ]);
   await seedUser(database, ada, "ada@acme.example");
   await seedUser(database, grace, "grace@globex.example");
+  // Every run needs a judge, because every run carries the judge-backed
+  // expected-behaviors built-in. Provisioning gives a real project one; these
+  // fixtures build their tenants by raw SQL, so they have to.
+  await seedJudge(actingAsAcme("admin"));
+  await seedJudge({ ...actingAsAcme("admin"), projectId: acme.outbound });
+  await seedJudge({ ...actingAsGlobex(), role: "admin" });
 
   const created = await createAgent(actingAsAcme(), {
     name: "Front desk",

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -67,6 +67,13 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   run: "run",
   run_event: "run",
   simulation: "sim",
+  // One run's frozen grading plan: what will judge each pinned test version,
+  // and whose account pays for the judging.
+  grading_plan: "gpl",
+  // The operations a client may safely send twice. Its identity is the whole
+  // five-column key rather than an id of its own, so it pins its leading
+  // column — the shape both junction tables have, for the same reason.
+  idempotent_operation: "org",
   grading_job: "gjb",
 };
 

--- a/packages/db/test/simulation-claims.test.ts
+++ b/packages/db/test/simulation-claims.test.ts
@@ -33,7 +33,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * The simulator's claim, instance-wide, and the door its credentials come
@@ -172,6 +172,8 @@ beforeAll(async () => {
   ]);
   await seedUser(database, ada, "ada@acme.example");
   await seedUser(database, grace, "grace@globex.example");
+  await seedJudge({ ...actingAsAcme(), role: "admin" });
+  await seedJudge({ ...actingAsGlobex(), role: "admin" });
 
   acmeSeed = await seedCustomer(actingAsAcme(), "retell-secret-A1B2C3D4WXYZ");
   globexSeed = await seedCustomer(actingAsGlobex(), "retell-secret-E5F6G7H8UVWX");

--- a/packages/db/test/simulation-telemetry.test.ts
+++ b/packages/db/test/simulation-telemetry.test.ts
@@ -16,7 +16,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * The standing resolver's telemetry duty: where a simulation's arriving spans
@@ -144,6 +144,8 @@ beforeAll(async () => {
   ]);
   await seedUser(database, ada, "ada@acme.example");
   await seedUser(database, grace, "grace@globex.example");
+  await seedJudge({ ...actingAsAcme(), role: "admin" });
+  await seedJudge({ ...actingAsGlobex(), role: "admin" });
 
   ours = await oneQueuedSimulation(actingAsAcme(), "ours");
   elsewhere = await oneQueuedSimulation(actingAsGlobex(), "elsewhere");

--- a/packages/db/test/support/tenancy.ts
+++ b/packages/db/test/support/tenancy.ts
@@ -1,4 +1,5 @@
 import { newId } from "@egma/ids";
+import { setJudgeConfiguration, type AuthContext } from "@egma/db";
 
 import type { MigratedDatabase } from "./database.ts";
 
@@ -34,4 +35,27 @@ export async function seedUser(
     userId,
     email,
   ]);
+}
+
+/**
+ * A judge for a seeded project, because every run needs one.
+ *
+ * These fixtures build their tenants by raw SQL rather than through signup
+ * provisioning, so they skip the transaction that gives a real project its
+ * judge. Run creation refuses a project in `needs_setup` — every run carries the
+ * judge-backed expected-behaviors built-in — so a fixture that wants to start a
+ * run has to do what provisioning would have done.
+ *
+ * It goes through the module's own door rather than by raw SQL, so the key is
+ * sealed the way a real one is and nothing here has to know the envelope's
+ * shape. The key is nonsense: nothing in these tests ever asks a model
+ * anything, and the one door to a plaintext judge key opens only for the
+ * grading engine.
+ */
+export async function seedJudge(auth: AuthContext): Promise<void> {
+  await setJudgeConfiguration(auth, {
+    provider: "openai",
+    model: "gpt-4o-mini",
+    key: "sk-fixture-judge-key",
+  });
 }

--- a/packages/db/test/sweep-concurrency.test.ts
+++ b/packages/db/test/sweep-concurrency.test.ts
@@ -18,7 +18,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "./support/database.ts";
-import { seedOrganization, seedUser } from "./support/tenancy.ts";
+import { seedJudge, seedOrganization, seedUser } from "./support/tenancy.ts";
 
 /**
  * Two sweeps, one set of orphans — racing on a real Postgres, because replica
@@ -71,6 +71,7 @@ beforeAll(async () => {
     { id: projectId, slug: "default" },
   ]);
   await seedUser(database, ada, "ada@acme.example");
+  await seedJudge({ ...auth, role: "admin" });
 
   const created = await createAgent(auth, {
     name: "Front desk",

--- a/packages/ids/src/index.ts
+++ b/packages/ids/src/index.ts
@@ -59,6 +59,14 @@ export const ID_PREFIXES = [
   "run",
   "sim",
   "gjb",
+  /**
+   * One run's frozen grading plan: which graders will judge each pinned test
+   * version, at which versions, with which judge behind them. Its own identity
+   * because it is written once beside the run and read long afterwards by the
+   * grader service, and because an archive refusal has to be able to name the
+   * plan that still needs a credential.
+   */
+  "gpl",
   "del",
   /**
    * A live resource's revision: what an edit says it was written against, and


### PR DESCRIPTION
Ticket 09 of the Product UI effort, on migration `0029`. Base is the integration branch, not `main`.

## `skipped` is a state, not a kind of failure

A **simulation** whose required capability the **connection** cannot carry is born `skipped` — terminal at birth, never claimable, never given a grading job — with `skip_reason` telling *unsupported* apart from *unknown*, and the capabilities named. `run.skipped_count` is its own column beside the other three.

That distinction is the point. A run that folds an execution problem into a grader result tells somebody their **agent** is broken when egma is, and "we could not measure this" is not "this failed". Breaking the two reasons apart fails with `expected 'required_capability_unsupported' to be 'required_capability_unknown'`.

## The plan is frozen before the run starts

A new `grading_plan` table holds one row per run: a tagged state, groups as a tagged union, items as a tagged union, and a derived credential array with a GIN index — so a judge credential's Archive can ask whether anything still depends on it and refuse rather than break a run in flight.

`POST /api/runs` requires an `idempotency_key`, keyed on organization, project, **actor**, operation and key, with a request digest. Dropping the actor from the key fails with two different runs comparing equal.

**One resolver serves both the review and the start.** `resolvePinnedVersions`, `admitTestsForAgent` and `resolvePersonaVersions` moved out of `runs.ts` into `run-plans.ts`, so there is one direction of dependency and the screen cannot show a plan the start would not honour.

## Two real bugs the tests found, not review

1. **A pool exhaustion.** `resolveRunPlan` read the project judge off the pool while inside the run's own transaction — two connections per run, so a handful of concurrent starts drained the pool and hung. Found by `apps/grader/test/two-copies.test.ts` timing out. The judge read now takes the queryable it is meant to read on.
2. **The migration's own backfill was refused by a lifecycle trigger.** `guard_run_lifecycle` freezes a finished run's header, and `skipped_count` had to be written into finished runs. Found by the installed-data migration test. The guard is lifted for that one statement and put back.

Neither would have been visible by reading.

## 22 guards, each proved by breaking it

A selection — the full table is in the branch's commit message:

| broken | failure |
|---|---|
| capability decision always runnable | `expected 'queued' to be 'skipped'` |
| all-skipped run left pending | `expected 'pending' to be 'completed'` |
| archive stops asking what needs it | `expected { …(8) } to be an instance of JudgeCredentialInUseError` |
| one idempotency key for every selection | `expected 'run:always-the-same-word' not to be 'run:always-the-same-word'` |
| plan invents a judge | `expected { state: 'configured', … } to deeply equal { state: 'needs_setup' }` |
| testless group given the built-in | `expected [ 'built_in', 'authored' ] to deeply equal [ 'authored' ]` |
| guard lifted around the backfill removed | `migration 0029… failed` (`guard_run_lifecycle` raised) |

## The cross-row trap, met head-on

Two fixes for the planning screen — the open row's history, and the open row's retry — and they are genuinely two: removing either leaves the other's test passing.

**Both tests passed under sabotage on the first attempt**, because the second row's read landed and overwrote the stale value before the assertion ran. The fix was to hold that read unanswered, opening the window a slow network opens on its own.

That is the exact trap this effort has hit four times — asserting before the thing that would contradict you has landed — met and closed rather than shipped.

## Shared components: tempted four times, touched nothing

`apps/web/ui/controls.tsx` and `system.module.css` are byte-identical to the base.

The builder wanted a **checkbox**, which the shared set does not have — the rows use a labelled bare input inside this ticket's own page. The step number, the open-row panel, the grader list and the tally strip all wanted to be shared parts and live in `builder.module.css` instead. On the judge-credentials table it added an Archive column to the existing component rather than building a second one, keeping that component's clear-on-row-open rule intact.

## Not built, and why

**Retry, run history, live progress and Cancel are ticket 10.** The Runs page says so rather than showing an empty list. The ticket's bullets do not name them and the spec puts them with run history.

**The idempotency key is required at the route and optional at the database seam.** Making it required in `NewRun` would force it on egma's own fixtures and the grader's world, which start one run inside a process they control and have no retry to guard. Every path a person or client arrives on carries one; the CLI mints one per invocation.

**A grader's judge-model override changes provider and model but keeps the project's credential.** A grader has no credential of its own, and inventing one would be egma choosing whose key to spend. Pre-existing, recorded in the plan rather than papered over.

## Verification

`drizzle-kit generate` writes nothing; `0029`'s snapshot chains to `0028`'s id; `packages/db/test/migrations.test.ts` and `apps/web/test/pages.test.ts` pass — 121 together, independently re-run here. Fast lane 3040 passed across 187 files. Rendered-page tests: 8 consecutive clean runs by the author, 6 more by me on the merged base, 319 each. Real-browser lane 25 passed. `pnpm lint` and both typechecks clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789391232&installation_model_id=431960&pr_number=110&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F110&signature=99cf1fbc3d7ee1179dd78975d788e5f5541ae849415a805a1af2655fa6ee5013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR freezes run execution and grading decisions before startup, adds capability-based skipped simulations and idempotent run creation, and protects judge credentials referenced by active work.
- Adds persisted grading plans and run-planning APIs.
- Separates skipped simulations from execution and grading failures.
- Adds actor-scoped idempotency for run creation.
- Adds guarded judge-credential archival.
- Adds the run-builder and planning-review interfaces.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the CLI still reports terminal capability-skipped simulations as queued work.

The database and API now expose `skipped` as a simulation status, but the CLI's accepted status set omits it and its decoder converts unrecognized statuses to `queued`, leaving skipped work visibly waiting.

**Files Needing Attention:** apps/cli/src/platform/runs.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/access/run-plans.ts | Centralizes resolution of pinned versions, capabilities, personas, graders, and judge choices for preview and startup. |
| packages/db/src/access/runs.ts | Persists frozen plans, creates skipped simulations, and implements idempotent run startup. |
| packages/db/migrations/0029_run_planning_and_grading_plans.sql | Introduces grading-plan storage, skipped lifecycle state and counts, credential dependencies, and migration backfills. |
| apps/api/src/routes/runs.ts | Adds the planning endpoint, requires API idempotency keys, and exposes skipped simulation metadata. |
| apps/api/src/routes/judge.ts | Adds guarded credential archival and returns structured JSON responses without exposing credential secrets. |
| apps/web/app/projects/[projectId]/runs/new/page.tsx | Adds the run-builder workflow and renders the server-resolved plan before startup. |
| apps/cli/src/platform/runs.ts | The CLI run decoder remains incomplete for the API's new terminal `skipped` simulation status. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API
  participant Planner
  participant DB
  Client->>API: GET /api/run-plan
  API->>Planner: Resolve pinned versions, capabilities, personas, graders, judge
  Planner->>DB: Read project and selected resources
  DB-->>Planner: Frozen planning inputs
  Planner-->>API: Runnable and skipped plan
  API-->>Client: Planning review
  Client->>API: POST /api/runs + idempotency key
  API->>Planner: Resolve authoritative plan
  Planner->>DB: Persist run, simulations, and grading plan
  DB-->>API: Created or idempotently existing run
  API-->>Client: Run with queued and skipped simulations
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Mint the CLI&#39;s idempotency key with Node..."](https://github.com/egma-ai/egma/commit/2409d0c0c9553e75bb34a4e589038da74da9a69d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53611080)</sub>

<!-- /greptile_comment -->