### PR TITLE
Stop a published package importing one this repository never publishes

### DIFF
--- a/packages/lint/src/index.test.ts
+++ b/packages/lint/src/index.test.ts
@@ -485,3 +485,78 @@ describe("this repository", () => {
     expect(manifest.scripts?.build).toContain("lint");
   });
 });
+
+/**
+ * A package this repository publishes may not import one it never publishes.
+ *
+ * `apps/cli` ships its source compiled rather than bundled, so an import
+ * written in `src` is still an import in the file `npx @egma/cli` runs. A
+ * `private: true` workspace package is not on npm for it to resolve, so the
+ * command installs, starts, and fails at the first line that needs it.
+ *
+ * This shipped once and the build caught it — but only because nothing had
+ * built that package first, so the module was missing at build time too. The
+ * natural repair for *that* error is to add a project reference, which makes
+ * the build pass and ships the crash. Hence a rule rather than a memory.
+ */
+describe("a published package importing one that is never published", () => {
+  async function workspace(): Promise<void> {
+    await write(
+      "packages/ids/package.json",
+      JSON.stringify({ name: "@egma/ids", private: true }),
+    );
+    await write(
+      "packages/wire/package.json",
+      JSON.stringify({ name: "@egma/wire", version: "1.2.3" }),
+    );
+  }
+
+  it("fails the build, and says what the reader would otherwise find out from a user", async () => {
+    await workspace();
+    await write(
+      "apps/cli/src/platform/runs.ts",
+      'import { newId } from "@egma/ids";\nexport const key = newId("run");\n',
+    );
+
+    const violations = await check(root);
+
+    expect(rules(violations)).toEqual(["no-private-package-in-a-published-one"]);
+    expect(violations[0]?.file).toBe("apps/cli/src/platform/runs.ts");
+    expect(violations[0]?.detail).toContain("never publishes");
+  });
+
+  it("catches a deep import of the same package", async () => {
+    await workspace();
+    await write(
+      "apps/cli/src/a.ts",
+      'import { newId } from "@egma/ids/mint.ts";\nexport { newId };\n',
+    );
+
+    expect(rules(await check(root))).toEqual([
+      "no-private-package-in-a-published-one",
+    ]);
+  });
+
+  it("allows a workspace package that is published", async () => {
+    await workspace();
+    await write(
+      "apps/cli/src/a.ts",
+      'import { ask } from "@egma/wire";\nexport { ask };\n',
+    );
+
+    expect(rules(await check(root))).toEqual([]);
+  });
+
+  it("leaves the private package alone everywhere this repository runs its own code", async () => {
+    await workspace();
+    // The API and the tests are this repository's own, installed from this
+    // repository. Only what is published has to stand on its own.
+    await write("apps/api/src/a.ts", 'import { newId } from "@egma/ids";\nexport { newId };\n');
+    await write(
+      "apps/cli/test/a.test.ts",
+      'import { newId } from "@egma/ids";\nexport { newId };\n',
+    );
+
+    expect(rules(await check(root))).toEqual([]);
+  });
+});

--- a/packages/lint/src/index.test.ts
+++ b/packages/lint/src/index.test.ts
@@ -501,6 +501,14 @@ describe("this repository", () => {
  */
 describe("a published package importing one that is never published", () => {
   async function workspace(): Promise<void> {
+    // The roots this repository actually declares. The rule reads them from
+    // here rather than holding a list of its own, which is the whole point:
+    // the first version named `packages` and `apps` and missed `fixtures` and
+    // `sdks`, where two private packages live.
+    await write(
+      "pnpm-workspace.yaml",
+      "packages:\n  - 'apps/*'\n  - 'fixtures/*'\n  - 'packages/*'\n  - 'sdks/*'\n",
+    );
     await write(
       "packages/ids/package.json",
       JSON.stringify({ name: "@egma/ids", private: true }),
@@ -508,6 +516,10 @@ describe("a published package importing one that is never published", () => {
     await write(
       "packages/wire/package.json",
       JSON.stringify({ name: "@egma/wire", version: "1.2.3" }),
+    );
+    await write(
+      "fixtures/dumb-agent/package.json",
+      JSON.stringify({ name: "@egma/dumb-agent", private: true }),
     );
   }
 
@@ -530,6 +542,18 @@ describe("a published package importing one that is never published", () => {
     await write(
       "apps/cli/src/a.ts",
       'import { newId } from "@egma/ids/mint.ts";\nexport { newId };\n',
+    );
+
+    expect(rules(await check(root))).toEqual([
+      "no-private-package-in-a-published-one",
+    ]);
+  });
+
+  it("finds a private package under a root the first version of this rule missed", async () => {
+    await workspace();
+    await write(
+      "apps/cli/src/a.ts",
+      'import { serve } from "@egma/dumb-agent";\nexport { serve };\n',
     );
 
     expect(rules(await check(root))).toEqual([

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -486,9 +486,47 @@ function workspaceNameOf(specifier: string): string | undefined {
  * listed here. A list would be one more thing to keep, and what it would be
  * forgotten about is whether a package is safe to ship.
  */
+/**
+ * The directories the workspace keeps its packages in, read from
+ * `pnpm-workspace.yaml`.
+ *
+ * Read rather than listed, for the same reason the manifests are. The first
+ * version of this rule named `packages` and `apps` and missed `fixtures` and
+ * `sdks` — where two private packages live — so a rule written against a list
+ * was already wrong on the day it was written. The workspace file is the one
+ * place that decides, so it is the one place to ask.
+ *
+ * Only the leading directory of each entry is taken: `apps/*` and any deeper
+ * glob both mean "look under `apps`", and a manifest is either directly in
+ * there or it is not a workspace package this rule can judge.
+ */
+async function workspaceRootsIn(root: string): Promise<string[]> {
+  let file: string;
+  try {
+    file = await readFile(path.join(root, "pnpm-workspace.yaml"), "utf8");
+  } catch {
+    return [];
+  }
+  const roots = new Set<string>();
+  let inPackages = false;
+  for (const line of file.split("\n")) {
+    if (/^packages:/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages && /^\S/.test(line)) break;
+    const entry = /^\s+-\s*['"]?([^'"\s]+)/.exec(line);
+    if (inPackages && entry?.[1] !== undefined) {
+      const first = entry[1].split("/")[0];
+      if (first !== undefined && first !== "" && first !== ".") roots.add(first);
+    }
+  }
+  return [...roots];
+}
+
 async function privateWorkspacePackagesIn(root: string): Promise<Set<string>> {
   const held = new Set<string>();
-  for (const where of ["packages", "apps"]) {
+  for (const where of await workspaceRootsIn(root)) {
     let entries: string[];
     try {
       entries = await readdir(path.join(root, where));

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -26,6 +26,7 @@ export const RULE_NAMES = [
   "one-place-reads-a-membership",
   "every-exported-call-carries-an-auth-context",
   "only-the-seam-knows-the-auth-provider",
+  "no-private-package-in-a-published-one",
 ] as const;
 
 export type RuleName = (typeof RULE_NAMES)[number];
@@ -225,6 +226,24 @@ const NAMES_A_CUSTOMER = /\b(organizationId|projectId)\b/;
  * than the vendor's.
  */
 const AUTH_PROVIDER_PACKAGES = ["better-auth", "@better-auth/core"];
+
+/**
+ * The packages this repository publishes, by the source they ship.
+ *
+ * **A published package's `src` may not import a workspace package that is
+ * never published.** `apps/cli` ships `dist/` unbundled, so an import written
+ * in `src` is still an import in the file `npx @egma/cli` runs — and a
+ * `private: true` workspace package is not on npm for it to resolve. The
+ * command installs, starts, and then fails at the first line that needs it, on
+ * somebody else's machine.
+ *
+ * This shipped once, as `import { newId } from "@egma/ids"` in the CLI's run
+ * client. TypeScript caught it, but only by luck: nothing built that package
+ * first, so the module was missing at build time too. **The natural repair for
+ * that build error is to add a project reference — which makes the build pass
+ * and ships the crash.** That is what this rule is for.
+ */
+const PUBLISHED_PACKAGES = ["apps/cli/src/"];
 
 /**
  * The only files that may name the auth provider.
@@ -448,6 +467,48 @@ function isDatastoreDriver(specifier: string): boolean {
   return DATASTORE_DRIVERS.some(
     (driver) => specifier === driver || specifier.startsWith(`${driver}/`),
   );
+}
+
+/**
+ * The workspace package an import names, or nothing when it names none.
+ *
+ * `@egma/ids` and `@egma/ids/mint.ts` both belong to `@egma/ids`; a relative
+ * path and an ordinary npm package belong to nobody.
+ */
+function workspaceNameOf(specifier: string): string | undefined {
+  if (!specifier.startsWith("@egma/")) return undefined;
+  const [scope, name] = specifier.split("/");
+  return name === undefined ? undefined : `${scope}/${name}`;
+}
+
+/**
+ * Every workspace package marked `private`, read from the manifests rather than
+ * listed here. A list would be one more thing to keep, and what it would be
+ * forgotten about is whether a package is safe to ship.
+ */
+async function privateWorkspacePackagesIn(root: string): Promise<Set<string>> {
+  const held = new Set<string>();
+  for (const where of ["packages", "apps"]) {
+    let entries: string[];
+    try {
+      entries = await readdir(path.join(root, where));
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      try {
+        const manifest = JSON.parse(
+          await readFile(path.join(root, where, entry, "package.json"), "utf8"),
+        ) as { name?: unknown; private?: unknown };
+        if (manifest.private === true && typeof manifest.name === "string") {
+          held.add(manifest.name);
+        }
+      } catch {
+        // A directory with no readable manifest is not a workspace package.
+      }
+    }
+  }
+  return held;
 }
 
 function isAuthProvider(specifier: string): boolean {
@@ -722,6 +783,7 @@ async function checkExportedCallShapes(root: string): Promise<Violation[]> {
 /** Every violation in the tree rooted at `root`, in file order. */
 export async function check(root: string): Promise<Violation[]> {
   const violations: Violation[] = await checkExportedCallShapes(root);
+  const privateWorkspacePackages = await privateWorkspacePackagesIn(root);
 
   for (const absolute of await collectSourceFiles(root)) {
     const file = relative(root, absolute);
@@ -733,6 +795,23 @@ export async function check(root: string): Promise<Violation[]> {
     const bypassesDeliberately = DELIBERATE_BYPASSES.includes(file);
 
     for (const record of imports) {
+      if (
+        PUBLISHED_PACKAGES.some((where) => file.startsWith(where)) &&
+        privateWorkspacePackages.has(workspaceNameOf(record.specifier) ?? "")
+      ) {
+        violations.push({
+          file,
+          line: record.line,
+          rule: "no-private-package-in-a-published-one",
+          detail:
+            `imports "${record.specifier}", which this repository never ` +
+            `publishes. This package ships its source compiled rather than ` +
+            `bundled, so the import survives into what somebody installs and ` +
+            `cannot be resolved there. Use the standard library, or what the ` +
+            `platform already sends.`,
+        });
+      }
+
       if (
         isDatastoreDriver(record.specifier) &&
         !insideModule &&


### PR DESCRIPTION
One lint rule and four tests. Base is the integration branch, not `main`.

## What nearly shipped

`apps/cli` publishes `dist/` **unbundled**, with `bin: dist/bin.js`. So an import written in `src` is still an import in the file `npx @egma/cli` runs.

`@egma/ids` is `private: true`, version `0.0.0`, and is **never published to npm**.

Ticket 09 wrote `import { newId } from "@egma/ids"` into the CLI's run client to mint an idempotency key. The command would have installed, started, and then failed at the moment somebody tried to **start a run** — on their machine, with nothing in this repository to explain it.

## Why a rule and not a fixed bug

The build caught it. **By luck.**

`tsc -b apps/cli` has no project reference to that package, so nothing built it first and the module was missing at build time too. Locally it resolved against a `dist/` an earlier build had left behind, which is why it passed on the author's machine and failed from a clean checkout.

Now consider the obvious repair for the error CI printed — `Cannot find module '@egma/ids'`. It is to add a project reference. That makes the build pass **and ships the crash**, with the near-miss now invisible.

A rule is worth more than the memory of having been lucky.

## How it decides

Which packages are private is read from the manifests, not listed in the rule. A list is one more thing to keep in step, and the thing it would fall out of step about is whether a package is safe to ship.

The violation says what a reader would otherwise learn from a user:

```
apps/cli/src/platform/runs.ts:25  no-private-package-in-a-published-one
    imports "@egma/ids", which this repository never publishes. This package
    ships its source compiled rather than bundled, so the import survives into
    what somebody installs and cannot be resolved there. Use the standard
    library, or what the platform already sends.
```

## Four tests, and what each holds

| | |
|---|---|
| the import fails the build | with the file, the line and the reason |
| a **deep** import of the same package fails | `@egma/ids/mint.ts` belongs to `@egma/ids` |
| a **published** workspace package is allowed | the rule is about publishing, not about `@egma/` |
| the API and the CLI's own **tests** are left alone | only what ships has to stand on its own |

Pointing the rule at a directory that does not exist fails the first two and leaves the other two green — so they are testing the rule rather than each other.

## Verification

`pnpm lint` clean on the tree, `pnpm typecheck` clean, `packages/lint` 40 tests passing. Reintroducing the real import into a CLI source file fails lint with the message above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWgLY7LifotBUX2Eg3LLm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789392007&installation_model_id=431960&pr_number=111&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F111&signature=d637dff43871ab296abba79baaf9eb3271386163ae2bb2198eb8bfbe0f7dc898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a lint rule preventing published, unbundled package sources from importing private workspace packages.
- Reads workspace roots from `pnpm-workspace.yaml` instead of duplicating root names.
- Derives private package names from workspace manifests.
- Checks CLI source imports, including deep imports.
- Adds coverage for private packages in all configured roots, published dependencies, and repository-only code.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/lint/src/index.ts | Adds workspace-config-driven discovery of private packages and rejects their use from published CLI source. |
| packages/lint/src/index.test.ts | Covers direct and deep private imports, configured workspace roots, published packages, and repository-only consumers. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  W[pnpm-workspace.yaml] --> R[Discover workspace roots]
  R --> M[Read package manifests]
  M --> P[Collect private package names]
  S[Published package source imports] --> C[Lint check]
  P --> C
  C -->|Imports private workspace package| V[Report violation]
  C -->|Otherwise| A[Allow import]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Read the workspace roots too, instead of..."](https://github.com/egma-ai/egma/commit/9f37bd4d898bc2288790c8454d231a60420881fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53612043)</sub>

<!-- /greptile_comment -->