### PR TITLE
Pressing Use stops being a one-way door

### DIFF
--- a/apps/api/src/routes/graders.ts
+++ b/apps/api/src/routes/graders.ts
@@ -268,6 +268,94 @@ function sampleRateIn(body: Body): WrittenRate {
   return { value: body.production_sample_rate };
 }
 
+/**
+ * What a body actually sent, for a refusal that has to name it.
+ *
+ * `typeof null` is `"object"` and `typeof []` is `"object"` too, and neither
+ * tells the person reading the sentence anything they can act on — which is the
+ * whole job of these refusals.
+ */
+function sortOf(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "a list";
+  return typeof value;
+}
+
+/** Text a body sent, refused rather than read as silence: `123` is not a name. */
+type WrittenText =
+  | { readonly value: string | undefined }
+  | { readonly refusal: string };
+
+/**
+ * A word this door takes, as a body sends it.
+ *
+ * **Refused rather than read as absent, which is the trap this replaces.** A
+ * key that arrived as a number used to be trimmed into the empty string and
+ * then read as though nobody had sent it — so `{"scope": 123}` answered 200
+ * with the copy still judging simulations, and the developer who thinks they
+ * pointed it at live traffic finds out when nothing is ever judged there. It is
+ * `production_sample_rate: "10"` again, one field along: quietly ignoring a key
+ * is how a project comes to be configured differently from what somebody wrote
+ * down, and this group's unknown-key gate exists to refuse exactly that.
+ *
+ * **Absent stays absent**, because that is what makes an edit partial. Only a
+ * key that is *there* and is not text is refused.
+ *
+ * The shape is checked here and the meaning is not: an empty name and a scope
+ * egma has never heard of are the factory's rules, refused in the factory's own
+ * words, on `sampleRateIn`'s exact terms.
+ */
+function textIn(body: Body, key: string, takes: string): WrittenText {
+  if (!(key in body) || body[key] === undefined) return { value: undefined };
+  if (typeof body[key] !== "string") {
+    return {
+      refusal: `${key} ${takes}. Send it as text, and this request sent ${sortOf(body[key])}.`,
+    };
+  }
+  return { value: body[key].trim() };
+}
+
+/**
+ * The note on a copy, which is the one field here that can be emptied.
+ *
+ * **Three answers rather than two, because "there is no note" is a thing
+ * somebody means.** Leaving the key out keeps whatever is there; sending `null`
+ * or an empty string clears it, both of them, because a form submitting a blank
+ * box and a client sending JSON's own word for nothing mean the same thing and
+ * a door that took one and refused the other would be arbitrary. Anything else
+ * present is refused — a number here used to erase the note and answer 200,
+ * which is this group's only write that ever destroyed something a person had
+ * typed.
+ */
+type WrittenNote =
+  | { readonly value: string | null | undefined }
+  | { readonly refusal: string };
+
+function descriptionIn(body: Body): WrittenNote {
+  if (!("description" in body) || body.description === undefined) {
+    return { value: undefined };
+  }
+  if (body.description === null) return { value: null };
+  if (typeof body.description !== "string") {
+    return {
+      refusal:
+        "description is a note your team leaves on this grader, saying why it " +
+        "is switched on. Send it as text, send null or an empty string to " +
+        `clear it, or leave it out to keep it — and this request sent ${sortOf(body.description)}.`,
+    };
+  }
+  const said = body.description.trim();
+  return { value: said === "" ? null : said };
+}
+
+/** What each of the three text fields takes, said once for both verbs. */
+const NAME_TAKES = "is what this project calls its copy of the grader";
+const SCOPE_TAKES =
+  "is where this grader judges — one of simulations, production or both";
+const PROJECT_TAKES =
+  "names the project this is about, as its prj_ identifier; leave it out to " +
+  "use the one this credential already acts in";
+
 export async function graderRoutes(
   app: FastifyInstance,
   options: GraderRoutesOptions,
@@ -356,20 +444,40 @@ export async function graderRoutes(
     const sampleRate = sampleRateIn(body);
     if ("refusal" in sampleRate) return unprocessable(reply, sampleRate.refusal);
 
-    const acting = await actingIn(auth, given(text(body.project)));
+    const name = textIn(body, "name", NAME_TAKES);
+    if ("refusal" in name) return unprocessable(reply, name.refusal);
+
+    const note = descriptionIn(body);
+    if ("refusal" in note) return unprocessable(reply, note.refusal);
+
+    const scope = textIn(body, "scope", SCOPE_TAKES);
+    if ("refusal" in scope) return unprocessable(reply, scope.refusal);
+
+    const project = textIn(body, "project", PROJECT_TAKES);
+    if ("refusal" in project) return unprocessable(reply, project.refusal);
+
+    const acting = await actingIn(auth, given(project.value));
     if ("refusal" in acting) return refuseActing(reply, acting);
 
     const created = await useLibraryEntry(acting.auth, {
       libraryId,
       ...(params.params === undefined ? {} : { params: params.params }),
-      ...(given(text(body.name)) === undefined ? {} : { name: text(body.name) }),
-      ...(given(text(body.description)) === undefined
+      // Absent leaves the copy named after the entry it is a copy of; an empty
+      // one is the factory's refusal to make, in the factory's own words.
+      ...(name.value === undefined ? {} : { name: name.value }),
+      // Use has nothing to clear, so the two ways of saying "no note" both
+      // arrive here as no note at all.
+      ...(note.value === undefined || note.value === null
         ? {}
-        : { description: text(body.description) }),
+        : { description: note.value }),
       ...(required.value === undefined ? {} : { required: required.value }),
-      ...(given(text(body.scope)) === undefined
+      // Cast rather than checked: `GraderScope` is a closed vocabulary and the
+      // factory's `validScope` is the gate — a word egma has never heard of is
+      // refused there, naming the three it knows, and this door holds no second
+      // opinion about the list. What is checked here is only that a word arrived.
+      ...(scope.value === undefined
         ? {}
-        : { scope: text(body.scope) as Grader["scope"] }),
+        : { scope: scope.value as Grader["scope"] }),
       ...(sampleRate.value === undefined
         ? {}
         : { productionSampleRate: sampleRate.value }),
@@ -430,21 +538,35 @@ export async function graderRoutes(
     const sampleRate = sampleRateIn(body);
     if ("refusal" in sampleRate) return unprocessable(reply, sampleRate.refusal);
 
-    const acting = await actingIn(auth, given(text(body.project)));
+    const name = textIn(body, "name", NAME_TAKES);
+    if ("refusal" in name) return unprocessable(reply, name.refusal);
+
+    const note = descriptionIn(body);
+    if ("refusal" in note) return unprocessable(reply, note.refusal);
+
+    const scope = textIn(body, "scope", SCOPE_TAKES);
+    if ("refusal" in scope) return unprocessable(reply, scope.refusal);
+
+    const project = textIn(body, "project", PROJECT_TAKES);
+    if ("refusal" in project) return unprocessable(reply, project.refusal);
+
+    const acting = await actingIn(auth, given(project.value));
     if ("refusal" in acting) return refuseActing(reply, acting);
 
     const edited = await editGrader(acting.auth, graderId, {
       ...(params.params === undefined ? {} : { params: params.params }),
-      ...(given(text(body.name)) === undefined ? {} : { name: text(body.name) }),
-      // A description is the one field an edit can empty, and `null` is how it
-      // says so — which is a different act from leaving the key out.
-      ...("description" in body
-        ? { description: given(text(body.description)) ?? null }
-        : {}),
+      // An empty name is not a rename this door drops — a copy has to be
+      // called something, and the factory says so in its own words.
+      ...(name.value === undefined ? {} : { name: name.value }),
+      // The note is the one field an edit can empty, and `null` is what both
+      // ways of saying so arrive as — a different act from leaving the key out.
+      ...(note.value === undefined ? {} : { description: note.value }),
       ...(required.value === undefined ? {} : { required: required.value }),
-      ...(given(text(body.scope)) === undefined
+      // Cast rather than checked, on the Use door's terms: `validScope` is the
+      // gate, and a word egma has never heard of is refused there.
+      ...(scope.value === undefined
         ? {}
-        : { scope: text(body.scope) as Grader["scope"] }),
+        : { scope: scope.value as Grader["scope"] }),
       ...(sampleRate.value === undefined
         ? {}
         : { productionSampleRate: sampleRate.value }),

--- a/apps/api/src/routes/graders.ts
+++ b/apps/api/src/routes/graders.ts
@@ -1,5 +1,7 @@
 import {
   authorize,
+  deleteGrader,
+  editGrader,
   listGraders,
   NotPermittedError,
   ProjectOutsideOrganizationError,
@@ -14,22 +16,47 @@ import type { FastifyInstance } from "fastify";
 import type { SessionIdentityProvider } from "../auth/seam.ts";
 import { actingIn, refuseActing } from "../http/acting.ts";
 import { credentialed, requesterOf } from "../http/credentialed.ts";
-import { invalid, notPermitted, unprocessable } from "../http/refusals.ts";
+import {
+  invalid,
+  notFound,
+  notPermitted,
+  unprocessable,
+} from "../http/refusals.ts";
 import type { RateLimit } from "../http/rate-limit.ts";
 import { given, text } from "../http/reading.ts";
 
 /**
- * The running graders: the copies a project actually judges with, and the one
- * act that makes another — pressing **Use** on a library entry.
+ * The running graders: the copies a project actually judges with, the act that
+ * makes another — pressing **Use** on a library entry — and the two that keep
+ * pressing Use from being a one-way door.
  *
- * **Two verbs, and the missing ones are the product decision.** There is no
- * create taking a type and criteria, because a grader is always a copy *of*
+ * **Four verbs, and what is still missing is the product decision.** There is
+ * no create taking a type and criteria, because a grader is always a copy *of*
  * something: the entry decides what kind of judgment it is and what the form
  * asks for, and the copy holds the answers. The custom-grader authoring surface
- * that the grading effort designed is shelved with this change — the machinery
- * behind it stays, versioning and all, and hosts egma's own two entries — so a
- * team meets a small shelf of graders that already work rather than a blank
- * form on their first day.
+ * that the grading effort designed stays shelved — the machinery behind it
+ * stays, versioning and all, and hosts egma's own two entries — so a team meets
+ * a small shelf of graders that already work rather than a blank form on their
+ * first day.
+ *
+ * **An edit is two different acts wearing one verb, and the difference is
+ * whether anything already judged is being re-interpreted.** A name, a
+ * description, `required`, a scope and a sampling rate say where a copy applies
+ * and how loudly, and none of them changes what any verdict already written
+ * meant — so they are written in place and are true everywhere the moment they
+ * return. The filled-in values are what a judgment is *made of*, so changing
+ * one mints the next version and leaves the one behind it exactly where it was:
+ * last week's verdict still names the values it was decided by. Both rules live
+ * in the factory rather than here, and this door hands the whole body down in
+ * one call so no client has to know which of them it just tripped.
+ *
+ * **Deleting is switching off, and it is the only off switch there is.** There
+ * is no enable flag and no `none` scope: a copy either exists and judges
+ * everything in its scope, or it is deleted and judges nothing from that moment
+ * on. It is a soft delete, and that is not an implementation detail — the rows
+ * it already wrote stay readable and stay interpretable, because their versions
+ * outlive it, so an old run keeps its own meaning rather than quietly losing a
+ * grader's worth of evidence.
  *
  * **A copy's definition never crosses this door.** What a read answers is the
  * pointer, the filled-in values, and where the grader applies. The judge prompt
@@ -49,6 +76,7 @@ export type GraderRoutesOptions = {
 };
 
 export const GRADERS_PATH = "/api/graders";
+export const GRADER_PATH = "/api/graders/:graderId";
 
 type Body = Record<string, unknown>;
 
@@ -69,17 +97,47 @@ const USE_KEYS = [
 ] as const;
 
 /**
+ * What an edit may carry: everything Use takes except the pointer, which is the
+ * one thing about a copy that can never move.
+ */
+const EDIT_KEYS = USE_KEYS.filter((key) => key !== "library_id");
+
+/**
  * The unknown-key gate, the agent group's for the agent group's reason — and
  * with one more of its own here: every key in this body decides what a project
  * is judged by or how loudly, so a typo quietly ignored would be a grader
  * somebody believes they configured and did not.
  */
-function unknownKeyIn(body: Body): string | undefined {
+function unknownKeyIn(
+  body: Body,
+  door: string,
+  keys: readonly string[],
+): string | undefined {
   for (const key of Object.keys(body)) {
-    if ((USE_KEYS as readonly string[]).includes(key)) continue;
-    return `Use takes no key "${key}"; it takes ${USE_KEYS.join(", ")}`;
+    if (keys.includes(key)) continue;
+    return `${door} takes no key "${key}"; it takes ${keys.join(", ")}`;
   }
   return undefined;
+}
+
+/**
+ * The one key an edit refuses in its own words rather than as an unknown one.
+ *
+ * `library_id` is not a key an edit forgot to support — it is the pointer, and
+ * every version behind this copy holds values shaped by the type that pointer
+ * decided. A copy that could be moved to another entry would be a different
+ * grader wearing the old one's history, and its verdicts would name assertion
+ * keys nothing on the new shelf can read. Saying so beats "no such key",
+ * because somebody sending it wants a copy of the other entry and Use makes one.
+ */
+function repointing(body: Body): string | undefined {
+  if (!("library_id" in body)) return undefined;
+  return (
+    "a grader cannot be moved to another library entry: its type came from " +
+    "the entry it is a copy of, and every version behind it holds values that " +
+    "type shapes. Press Use on the entry you want, which makes a second copy " +
+    "and leaves this one's history saying what it always said."
+  );
 }
 
 /**
@@ -107,6 +165,21 @@ function described(one: Grader): Record<string, unknown> {
     created_at: one.createdAt.toISOString(),
     updated_at: one.updatedAt.toISOString(),
   };
+}
+
+/**
+ * What a caller is told about a grader that is not there.
+ *
+ * One sentence for three situations — never made, already switched off, or
+ * somebody else's — because from where this caller stands those are the same
+ * thing, and telling them apart would answer a question about another project.
+ */
+function noSuchGrader(graderId: string): string {
+  return (
+    `${graderId} is not a grader running on this project. It may never have ` +
+    `existed, or it may have been switched off — read the running graders to ` +
+    `see what is judging here now.`
+  );
 }
 
 /** The filled-in values a body sent, or a refusal saying what shape they take. */
@@ -252,7 +325,7 @@ export async function graderRoutes(
     // Everything answerable without reading anything is answered first, so a
     // body that could never be written is refused before it can learn what
     // this project holds.
-    const unknown = unknownKeyIn(body);
+    const unknown = unknownKeyIn(body, "Use", USE_KEYS);
     if (unknown !== undefined) return invalid(reply, unknown);
 
     const libraryId = text(body.library_id);
@@ -293,6 +366,122 @@ export async function graderRoutes(
     });
 
     return reply.code(201).send(described(created));
+  });
+
+  /**
+   * Change a copy: what it judges by, where it applies, and how loudly.
+   *
+   * **One verb for both, and the factory decides which happened.** Sending
+   * values mints the next version, because they are what a verdict was decided
+   * by and last week's has to keep meaning what it meant; sending a scope, a
+   * rate, a name or the `required` flag writes in place, because none of them
+   * re-interprets a judgment already made. A client that had to know which was
+   * which would be holding a second copy of a rule it cannot enforce, so it
+   * sends the body and reads the version number back.
+   *
+   * **`params` is the entry's form filled in, exactly as Use takes it** — the
+   * same key, the same shape, checked against the same entry by the same code.
+   * That is why a bound the entry never asked for is refused here in the words
+   * Use refuses it in, rather than in a second opinion this door invented.
+   *
+   * What the body leaves out, the copy keeps. A grader this credential cannot
+   * see reads exactly as one that is not there, because to this caller those
+   * are the same thing.
+   */
+  app.patch(GRADER_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { graderId } = request.params as { graderId: string };
+    const body = (request.body ?? {}) as Body;
+
+    authorize(auth, "author_definitions", {
+      organizationId: auth.organizationId,
+      projectId: auth.projectId,
+    });
+
+    // Everything answerable without reading anything is answered first, so a
+    // body that could never be written is refused before it can learn what
+    // this project holds.
+    const moved = repointing(body);
+    if (moved !== undefined) return invalid(reply, moved);
+
+    const unknown = unknownKeyIn(body, "an edit", EDIT_KEYS);
+    if (unknown !== undefined) return invalid(reply, unknown);
+
+    const params = paramsIn(body);
+    if ("refusal" in params) return unprocessable(reply, params.refusal);
+
+    const required = requiredIn(body);
+    if ("refusal" in required) return unprocessable(reply, required.refusal);
+
+    const sampleRate = sampleRateIn(body);
+    if ("refusal" in sampleRate) return unprocessable(reply, sampleRate.refusal);
+
+    const acting = await actingIn(auth, given(text(body.project)));
+    if ("refusal" in acting) return refuseActing(reply, acting);
+
+    const edited = await editGrader(acting.auth, graderId, {
+      ...(params.params === undefined ? {} : { params: params.params }),
+      ...(given(text(body.name)) === undefined ? {} : { name: text(body.name) }),
+      // A description is the one field an edit can empty, and `null` is how it
+      // says so — which is a different act from leaving the key out.
+      ...("description" in body
+        ? { description: given(text(body.description)) ?? null }
+        : {}),
+      ...(required.value === undefined ? {} : { required: required.value }),
+      ...(given(text(body.scope)) === undefined
+        ? {}
+        : { scope: text(body.scope) as Grader["scope"] }),
+      ...(sampleRate.value === undefined
+        ? {}
+        : { productionSampleRate: sampleRate.value }),
+    });
+
+    if (edited === undefined) return notFound(reply, noSuchGrader(graderId));
+
+    return reply.send(described(edited));
+  });
+
+  /**
+   * Switch a copy off.
+   *
+   * **Deleting is the switching off**, and it is the only one there is: no
+   * enable flag, no `none` scope. From the moment this returns, nothing this
+   * project runs is judged by the copy — including the expected-behaviors one
+   * every project is created with, whose delete is how a team stops being
+   * judged against its own written-down expectations.
+   *
+   * **And nothing already judged moves.** The row is marked rather than
+   * removed, and its versions are not touched at all, so every verdict it wrote
+   * is still readable and still says which values decided it. An old run keeps
+   * its own meaning, which is the whole reason a soft delete is the right shape
+   * here rather than a tidier one.
+   *
+   * The library entry behind it is **not** released: a switched-off copy still
+   * points at its definition, and that definition has to outlive it for the
+   * verdicts to stay interpretable. Deleting the entry stays refused, which is
+   * what the foreign key underneath says too.
+   */
+  app.delete(GRADER_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { graderId } = request.params as { graderId: string };
+    const query = (request.query ?? {}) as Query;
+
+    authorize(auth, "author_definitions", {
+      organizationId: auth.organizationId,
+      projectId: auth.projectId,
+    });
+
+    const acting = await actingIn(auth, given(query.project));
+    if ("refusal" in acting) return refuseActing(reply, acting);
+
+    const removed = await deleteGrader(acting.auth, graderId);
+    if (removed === undefined) return notFound(reply, noSuchGrader(graderId));
+
+    return reply.send({
+      id: removed.id,
+      name: removed.name,
+      deleted_at: removed.deletedAt.toISOString(),
+    });
   });
 
   /**

--- a/apps/api/src/routes/graders.ts
+++ b/apps/api/src/routes/graders.ts
@@ -8,6 +8,7 @@ import {
   UnknownGraderLibraryEntryError,
   UnprocessableInputError,
   useLibraryEntry,
+  type FilledInForm,
   type Grader,
 } from "@egma/db";
 import { isId } from "@egma/ids";
@@ -40,15 +41,24 @@ import { given, text } from "../http/reading.ts";
  * first day.
  *
  * **An edit is two different acts wearing one verb, and the difference is
- * whether anything already judged is being re-interpreted.** A name, a
+ * whether a verdict already written is being rewritten.** A name, a
  * description, `required`, a scope and a sampling rate say where a copy applies
- * and how loudly, and none of them changes what any verdict already written
- * meant — so they are written in place and are true everywhere the moment they
- * return. The filled-in values are what a judgment is *made of*, so changing
- * one mints the next version and leaves the one behind it exactly where it was:
- * last week's verdict still names the values it was decided by. Both rules live
- * in the factory rather than here, and this door hands the whole body down in
- * one call so no client has to know which of them it just tripped.
+ * and how loudly, and none of them rewrites a row — so they are written in
+ * place and are true everywhere the moment they return. The filled-in values
+ * are what a judgment is *made of*, so changing one mints the next version and
+ * leaves the one behind it exactly where it was: last week's verdict still
+ * names the values it was decided by. Both rules live in the factory rather
+ * than here, and this door hands the whole body down in one call so no client
+ * has to know which of them it just tripped.
+ *
+ * **`required` is the one live setting that reaches a page about the past, and
+ * a client should say so.** It rewrites no verdict; it moves this copy's rows
+ * between the lane that decides a run and the lane that only reports, and the
+ * fold runs at read time — so a run that failed on this grader alone reads as
+ * passed from the moment the flag turns. That is what the flag is for. The
+ * honest sentence is "the verdicts are unchanged and what they add up to is
+ * not", and a surface that shortens it to "nothing already judged changes" is
+ * telling somebody the opposite of what they are about to see.
  *
  * **Deleting is switching off, and it is the only off switch there is.** There
  * is no enable flag and no `none` scope: a copy either exists and judges
@@ -184,7 +194,7 @@ function noSuchGrader(graderId: string): string {
 
 /** The filled-in values a body sent, or a refusal saying what shape they take. */
 type WrittenParams =
-  | { readonly params: Readonly<Record<string, unknown>> | undefined }
+  | { readonly params: FilledInForm | undefined }
   | { readonly refusal: string };
 
 function paramsIn(body: Body): WrittenParams {
@@ -200,7 +210,7 @@ function paramsIn(body: Body): WrittenParams {
         "the library entry to see what it asks for; some ask for nothing.",
     };
   }
-  return { params: params as Readonly<Record<string, unknown>> };
+  return { params: params as FilledInForm };
 }
 
 /** A flag a body sent, refused rather than coerced: `"false"` is not false. */
@@ -375,9 +385,13 @@ export async function graderRoutes(
    * values mints the next version, because they are what a verdict was decided
    * by and last week's has to keep meaning what it meant; sending a scope, a
    * rate, a name or the `required` flag writes in place, because none of them
-   * re-interprets a judgment already made. A client that had to know which was
+   * rewrites a verdict already written. A client that had to know which was
    * which would be holding a second copy of a rule it cannot enforce, so it
    * sends the body and reads the version number back.
+   *
+   * `required` still reaches the past through the fold rather than through the
+   * rows — see this group's header — so a client relaying "nothing changed" on
+   * the strength of a standing version number would be relaying the wrong half.
    *
    * **`params` is the entry's form filled in, exactly as Use takes it** — the
    * same key, the same shape, checked against the same entry by the same code.

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -1596,6 +1596,102 @@ describe("pressing Use on a second grader while the first one's form is open", (
   );
 });
 
+/**
+ * Changing a running copy and switching one off, in a real browser.
+ *
+ * **The one thing about this screen a source scan cannot prove**, and it is the
+ * same shape as the Use form's above: the edit form is drawn from the library
+ * entry and pre-filled from the copy, so what a person sees when they open it
+ * is state assembled from two answers that arrived separately. A source scan
+ * settles that the right components are wired together; only a running page
+ * settles that the values come back.
+ *
+ * It is also the only place the **forwarding rule** for a copy's own address is
+ * exercised. `/api/graders/:path*` is a rewrite this Next process resolves at
+ * build time; without it the edit would post into this app's own file routing
+ * and read Next's 404 page as though egma had refused it — and every other test
+ * in the repository would still pass, because they all speak to the API
+ * directly.
+ *
+ * It runs after the Use flow above and depends on it: that flow left a copy of
+ * `latency` running on Ada's project, which is the row this one changes and
+ * then switches off.
+ */
+describe("changing a running grader and switching it off", () => {
+  /** One running copy's button, from the table rather than the mobile list. */
+  function on(named: string, button: string) {
+    return page
+      .locator("table")
+      .getByRole("row")
+      .filter({ hasText: named })
+      .getByRole("button", { name: button });
+  }
+
+  /**
+   * The bound, which is the entry's own question — named by what it is not,
+   * because what a grader asks for is the library entry's business and a test
+   * spelling the parameter would be the copy of egma's catalog this screen
+   * exists without.
+   */
+  const theEntrysNumber = 'form input[type="number"]:not(#edit-sample-rate)';
+
+  it(
+    "saves a new value and reads it back, and turns a blocker into a diagnostic",
+    async () => {
+      await page.goto(`${origin}/graders/running`);
+      await page.waitForSelector("text=latency");
+      // Blocking, as anything switched on is unless somebody said otherwise.
+      await page.waitForSelector("text=Blocks");
+
+      await on("latency", "Edit").click();
+      await page.waitForSelector("text=Edit latency");
+
+      // Filled in from the copy, which is the half a source scan cannot see:
+      // this is what was typed when Use was pressed, come back round.
+      expect(await page.locator(theEntrysNumber).inputValue()).toBe("2000");
+
+      await page.locator(theEntrysNumber).fill("1500");
+      await page.locator("#edit-required").uncheck();
+      await page.getByRole("button", { name: "Save" }).click();
+
+      await page.waitForSelector("text=is saved");
+      // The list was read again, so the row says what the copy now says.
+      await page.waitForSelector("text=Diagnostic");
+
+      // And opening it again shows the saved value rather than the old one —
+      // which is the whole round trip: the browser wrote it, the API versioned
+      // it, and the list handed it back.
+      await on("latency", "Edit").click();
+      await page.waitForSelector("text=Edit latency");
+      expect(await page.locator(theEntrysNumber).inputValue()).toBe("1500");
+    },
+    SETTLE,
+  );
+
+  it(
+    "says what a switched-off grader keeps before it switches one off",
+    async () => {
+      await page.goto(`${origin}/graders/running`);
+      await page.waitForSelector("text=latency");
+
+      await on("latency", "Switch off").click();
+
+      // The sentence that makes the button pressable: what stops is obvious,
+      // and what stays is the thing somebody is actually worried about.
+      await page.waitForSelector("text=already judged keeps exactly what it said");
+
+      await page.getByRole("button", { name: "Switch it off" }).click();
+      await page.waitForSelector("text=is switched off");
+
+      // Gone from the list, and the copy every project is created with is
+      // still there — only the one that was named stopped judging.
+      expect(await page.locator("table").getByRole("row").count()).toBe(2);
+      await page.waitForSelector("text=expected_behaviors");
+    },
+    SETTLE,
+  );
+});
+
 describe("recovering when a page cannot load", () => {
   it(
     "shows a retry for People and for an invitation lookup",

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -1627,6 +1627,29 @@ describe("changing a running grader and switching it off", () => {
       .getByRole("button", { name: button });
   }
 
+  /** Every row of the table, the heading row included. */
+  function rows() {
+    return page.locator("table").getByRole("row");
+  }
+
+  /**
+   * **Wait for the list to say it, never for the write to say it.**
+   *
+   * The screen shows what happened the moment the request comes back, and
+   * *then* reads the list again — two commits, not one. So the sentence
+   * confirming a write is not a signal that the table has caught up, and
+   * counting rows straight after it is a race that widens under load until it
+   * loses: this file counted three rows where two were expected the first time
+   * the whole suite ran beside it.
+   *
+   * `expect.poll` is how the rest of this file waits on a list settling, and it
+   * is the right shape here for the same reason — the assertion *is* the wait,
+   * so there is no gap left between them for the screen to change in.
+   */
+  function settlesAt(howMany: number) {
+    return expect.poll(() => rows().count(), { timeout: 30_000 }).toBe(howMany);
+  }
+
   /**
    * The bound, which is the entry's own question — named by what it is not,
    * because what a grader asks for is the library entry's business and a test
@@ -1639,7 +1662,8 @@ describe("changing a running grader and switching it off", () => {
     "saves a new value and reads it back, and turns a blocker into a diagnostic",
     async () => {
       await page.goto(`${origin}/graders/running`);
-      await page.waitForSelector("text=latency");
+      // The table, settled: two graders on this project, and a heading row.
+      await settlesAt(3);
       // Blocking, as anything switched on is unless somebody said otherwise.
       await page.waitForSelector("text=Blocks");
 
@@ -1654,8 +1678,13 @@ describe("changing a running grader and switching it off", () => {
       await page.locator("#edit-required").uncheck();
       await page.getByRole("button", { name: "Save" }).click();
 
+      // What the write said, which is the sentence being asserted and **not**
+      // the moment the table is fresh.
       await page.waitForSelector("text=is saved");
-      // The list was read again, so the row says what the copy now says.
+      // And what the *list* says, which is: the row's own cell, from the read
+      // that happened after the write. This is the wait the next line depends
+      // on — the form closes with the notice, so "Diagnostic" can only be
+      // coming from the table by the time it matches.
       await page.waitForSelector("text=Diagnostic");
 
       // And opening it again shows the saved value rather than the old one —
@@ -1672,7 +1701,7 @@ describe("changing a running grader and switching it off", () => {
     "says what a switched-off grader keeps before it switches one off",
     async () => {
       await page.goto(`${origin}/graders/running`);
-      await page.waitForSelector("text=latency");
+      await settlesAt(3);
 
       await on("latency", "Switch off").click();
 
@@ -1681,11 +1710,15 @@ describe("changing a running grader and switching it off", () => {
       await page.waitForSelector("text=already judged keeps exactly what it said");
 
       await page.getByRole("button", { name: "Switch it off" }).click();
+      // What the write said — the sentence, asserted for its own sake.
       await page.waitForSelector("text=is switched off");
 
-      // Gone from the list, and the copy every project is created with is
-      // still there — only the one that was named stopped judging.
-      expect(await page.locator("table").getByRole("row").count()).toBe(2);
+      // And then what the list says, waited for rather than read straight off
+      // the back of the sentence above: the row is gone, and the copy every
+      // project is created with is still there — only the one that was named
+      // stopped judging.
+      await settlesAt(2);
+      expect(await on("latency", "Switch off").count()).toBe(0);
       await page.waitForSelector("text=expected_behaviors");
     },
     SETTLE,

--- a/apps/api/test/graders-routes.test.ts
+++ b/apps/api/test/graders-routes.test.ts
@@ -56,6 +56,8 @@ type Listed = {
   readonly type: string;
   readonly required: boolean;
   readonly scope: string;
+  readonly version: number;
+  readonly version_id: string;
   readonly config: { readonly assertions: readonly unknown[] };
 };
 
@@ -423,7 +425,7 @@ describe("changing a running copy", () => {
       production_sample_rate: 25,
       // Version 1 still: nothing a verdict was decided by moved.
       version: 1,
-      version_id: (copy as unknown as { version_id: string }).version_id,
+      version_id: copy.version_id,
       config: { assertions: [{ metric: "turn_response_latency", bound: 2000 }] },
     });
 
@@ -456,9 +458,7 @@ describe("changing a running copy", () => {
       required: true,
       scope: "simulations",
     });
-    expect(edited.body.version_id).not.toBe(
-      (copy as unknown as { version_id: string }).version_id,
-    );
+    expect(edited.body.version_id).not.toBe(copy.version_id);
   });
 
   /**
@@ -495,6 +495,38 @@ describe("changing a running copy", () => {
     expect(itemsOf(after).find((one) => one.id === copy.id)?.config).toEqual({
       assertions: [{ metric: "turn_response_latency", bound: 2000 }],
     });
+  });
+
+  /**
+   * **An empty set of answers is not "no answers".** It passes every rule about
+   * keys — there is no key the entry never asked for, and no parameter left
+   * unanswered — and would store an assertion holding nothing on a grader whose
+   * assertions are the test's own sentences. Judging is unaffected, because the
+   * engine reads the test rather than the config; the Running tab is not, and
+   * would count "1 assertion" where the honest answer is that there is nothing
+   * to fill in. The web form never sends it and this door is the only way in.
+   */
+  it("refuses an empty set of values on an entry that asks nothing", async () => {
+    api = await createApi("graders_edit_empty_params");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    const [seeded] = itemsOf(await request("GET", "/api/graders", key));
+    if (seeded === undefined) throw new Error("the project has no graders");
+
+    const edited = await request("PATCH", `/api/graders/${seeded.id}`, key, {
+      params: {},
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toContain("asks for nothing");
+
+    // Still holding nothing, which is what a correct copy of it holds forever.
+    const after = itemsOf(await request("GET", "/api/graders", key));
+    expect(after.find((one) => one.id === seeded.id)?.config).toEqual({
+      assertions: [],
+    });
+    expect(after.find((one) => one.id === seeded.id)?.version).toBe(1);
   });
 
   /** The measure rule is the same one door, said the same way, too. */
@@ -552,19 +584,39 @@ describe("changing a running copy", () => {
 
   /**
    * A grader this credential cannot see reads exactly as one that is not there,
-   * because to this caller those are the same thing.
+   * because to this caller those are the same thing — so the case needs both
+   * halves in front of it: an id nobody ever minted, and a real one belonging
+   * to somebody else. One refusal, one sentence, and nothing in either that
+   * says which of the two it was.
    */
-  it("answers a grader this project does not have as one that is not there", async () => {
+  it("answers another customer's grader exactly as one that never existed", async () => {
     api = await createApi("graders_edit_unknown");
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
-    const key = await projectKeyFor(api.app, ada);
+    const grace = await signUp(api.app, "grace@globex.example", "Globex");
+    const theirs = await projectKeyFor(api.app, ada);
+    const others = await projectKeyFor(api.app, grace);
 
-    const edited = await request("PATCH", `/api/graders/${NOBODY_HAS_THIS}`, key, {
+    const [only] = itemsOf(await request("GET", "/api/graders", theirs));
+    if (only === undefined) throw new Error("the project has no graders");
+
+    const madeUp = await request("PATCH", `/api/graders/${NOBODY_HAS_THIS}`, others, {
+      required: false,
+    });
+    const somebodyElses = await request("PATCH", `/api/graders/${only.id}`, others, {
       required: false,
     });
 
-    expect(edited.statusCode).toBe(404);
-    expect(String(edited.body.message)).toContain(NOBODY_HAS_THIS);
+    expect(madeUp.statusCode).toBe(404);
+    expect(somebodyElses.statusCode).toBe(404);
+    // The same sentence but for the id in it, so nothing about the answer says
+    // whether the row exists somewhere else.
+    expect(String(somebodyElses.body.message).replace(only.id, "")).toBe(
+      String(madeUp.body.message).replace(NOBODY_HAS_THIS, ""),
+    );
+
+    // And Acme's copy is untouched, which is the half a status code cannot say.
+    const untouched = itemsOf(await request("GET", "/api/graders", theirs));
+    expect(untouched.find((one) => one.id === only.id)?.required).toBe(true);
   });
 
   it("is refused to a viewer, per the permission table", async () => {

--- a/apps/api/test/graders-routes.test.ts
+++ b/apps/api/test/graders-routes.test.ts
@@ -12,23 +12,26 @@ import {
 
 /**
  * The running graders, over real HTTP against real Postgres: what a project
- * judges with, and the one act that adds another — pressing **Use** on a
- * library entry.
+ * judges with, the act that adds another — pressing **Use** on a library entry
+ * — and the two that keep pressing Use from being a one-way door.
  *
- * **Two verbs, and the missing ones are the contract.** There is no create
+ * **Four verbs, and what is still missing is the contract.** There is no create
  * taking a type and criteria, because a grader is always a copy *of* something:
  * the entry decides what kind of judgment it is and what the form asks for, and
  * the copy holds the answers. The custom-grader authoring surface the grading
- * effort designed is shelved with this change, and this file is where its
- * absence is checkable.
+ * effort designed stays shelved, and this file is where its absence is
+ * checkable.
  *
- * The facts worth defending here are the two the door cannot get right by
+ * The facts worth defending here are the ones the door cannot get right by
  * accident. **A project answers a grader before anybody has configured one** —
  * it was created holding a copy of `expected_behaviors`, which is what "a first
- * run is judged with zero setup" means at this altitude. And **values are
- * checked against what the entry actually asked for**, so a bound sent to an
- * entry that asks for none, or a measure egma does not compute, is refused here
- * rather than becoming a grader that is `skipped` forever.
+ * run is judged with zero setup" means at this altitude. **Values are checked
+ * against what the entry actually asked for**, so a bound sent to an entry that
+ * asks for none, or a measure egma does not compute, is refused here rather
+ * than becoming a grader that is `skipped` forever — and refused in the same
+ * words whether it arrives on a Use or on an edit, because there is one check
+ * and not two. And **an edit is two acts wearing one verb**: values mint the
+ * next version, live settings do not, and the answer says which happened.
  */
 
 let api: TestApi;
@@ -38,7 +41,7 @@ afterEach(async () => {
 });
 
 function request(
-  method: "GET" | "POST",
+  method: "GET" | "POST" | "PATCH" | "DELETE",
   url: string,
   key: string,
   body?: Record<string, unknown>,
@@ -55,6 +58,21 @@ type Listed = {
   readonly scope: string;
   readonly config: { readonly assertions: readonly unknown[] };
 };
+
+/** A latency copy on the project, which is the one v0 entry that asks anything. */
+async function aLatencyCopy(key: string): Promise<Listed> {
+  const used = await request("POST", "/api/graders", key, {
+    library_id: PREDEFINED_GRADERS.latency,
+    params: { metric: "turn_response_latency", bound: 2000 },
+    name: "Answers inside two seconds",
+    description: "The number the support team argues about",
+  });
+  expect(used.statusCode, JSON.stringify(used.body)).toBe(201);
+  return used.body as unknown as Listed;
+}
+
+/** An id shaped like a grader's that no project ever minted. */
+const NOBODY_HAS_THIS = "grd_01M01MH8KAE8ZB19B0YJ7ZZZZZ";
 
 function itemsOf(answer: Answer): readonly Listed[] {
   return answer.body.items as readonly Listed[];
@@ -374,24 +392,288 @@ describe("pressing Use on a library entry", () => {
   });
 });
 
-describe("the authoring surface that is not here", () => {
+describe("changing a running copy", () => {
   /**
-   * v0 ships a small shelf of graders egma maintains rather than a form asking
-   * a team to design judgment logic on their first day. The routes that would
-   * have edited and deleted a grader are not registered, and this is where that
-   * decision is checkable rather than merely written down.
+   * **The live settings, and none of them re-interprets anything.** Where a
+   * copy applies, whether it can fail a run, how much live traffic it judges
+   * and what it is called change what the project lets a grader do from now on;
+   * they change nothing about a judgment already made. So they are written in
+   * place, the version number stands still, and every verdict already written
+   * still points at the values that decided it.
    */
-  it("answers nothing for an edit or a delete of a grader", async () => {
-    api = await createApi("graders_no_authoring");
+  it("changes where a copy applies and how loudly, without minting a version", async () => {
+    api = await createApi("graders_edit_settings");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      name: "Watched while we tune it",
+      required: false,
+      scope: "both",
+      production_sample_rate: 25,
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(200);
+    expect(edited.body).toMatchObject({
+      id: copy.id,
+      name: "Watched while we tune it",
+      required: false,
+      scope: "both",
+      production_sample_rate: 25,
+      // Version 1 still: nothing a verdict was decided by moved.
+      version: 1,
+      version_id: (copy as unknown as { version_id: string }).version_id,
+      config: { assertions: [{ metric: "turn_response_latency", bound: 2000 }] },
+    });
+
+    const listed = itemsOf(await request("GET", "/api/graders", key));
+    expect(listed.find((one) => one.id === copy.id)?.required).toBe(false);
+  });
+
+  /**
+   * **A bound is what a verdict is made of, so changing one starts the next
+   * version.** The version behind it is untouched, which is what makes last
+   * week's verdict still mean what it meant — and the version number on this
+   * answer is how a client finds out which of the two things it just did.
+   */
+  it("mints the next version when the filled-in values change", async () => {
+    api = await createApi("graders_edit_values");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      params: { metric: "turn_response_latency", bound: 1200 },
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(200);
+    expect(edited.body).toMatchObject({
+      version: 2,
+      config: { assertions: [{ metric: "turn_response_latency", bound: 1200 }] },
+      // What the body left out, the copy kept.
+      name: copy.name,
+      required: true,
+      scope: "simulations",
+    });
+    expect(edited.body.version_id).not.toBe(
+      (copy as unknown as { version_id: string }).version_id,
+    );
+  });
+
+  /**
+   * **The same sentence, because there is one check and not two.** An edit's
+   * values go through the code Use's values go through, against the entry this
+   * copy points at, read live — so a bound the entry never asked for is refused
+   * in the same words whichever door it arrived at. Two doors holding two
+   * opinions about what a bound is would be the drift the whole two-level shape
+   * exists to prevent.
+   */
+  it("refuses values the entry never asked for, in the words Use refuses them in", async () => {
+    api = await createApi("graders_edit_same_refusal");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    const wrong = { metric: "turn_response_latency", bound: 2000, aggregation: "p90" };
+
+    const used = await request("POST", "/api/graders", key, {
+      library_id: PREDEFINED_GRADERS.latency,
+      params: wrong,
+    });
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      params: wrong,
+    });
+
+    expect(used.statusCode).toBe(422);
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toBe(String(used.body.message));
+    expect(String(edited.body.message)).toContain("aggregation");
+
+    // And nothing was written: the copy still judges by what it judged by.
+    const after = await request("GET", "/api/graders", key);
+    expect(itemsOf(after).find((one) => one.id === copy.id)?.config).toEqual({
+      assertions: [{ metric: "turn_response_latency", bound: 2000 }],
+    });
+  });
+
+  /** The measure rule is the same one door, said the same way, too. */
+  it("refuses a measure egma does not compute, in the words Use refuses it in", async () => {
+    api = await createApi("graders_edit_bad_measure");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    const used = await request("POST", "/api/graders", key, {
+      library_id: PREDEFINED_GRADERS.latency,
+      params: { metric: "turn_responze_latency", bound: 2000 },
+    });
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      params: { metric: "turn_responze_latency", bound: 2000 },
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toBe(String(used.body.message));
+  });
+
+  /**
+   * The pointer is the one thing about a copy that cannot move: every version
+   * behind it holds values shaped by the type that pointer decided, so a copy
+   * pointed somewhere else would be a different grader wearing the old one's
+   * history. Refused by name, with the act that does want a second copy.
+   */
+  it("refuses to point a copy at another library entry, and says what to do instead", async () => {
+    api = await createApi("graders_edit_repoint");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      library_id: PREDEFINED_GRADERS.expectedBehaviors,
+    });
+
+    expect(edited.statusCode).toBe(400);
+    expect(String(edited.body.message)).toContain("Use");
+  });
+
+  it("refuses a key the body has no business carrying", async () => {
+    api = await createApi("graders_edit_unknown_key");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      type: "llm_rubric",
+    });
+
+    expect(edited.statusCode).toBe(400);
+    expect(String(edited.body.message)).toContain('"type"');
+  });
+
+  /**
+   * A grader this credential cannot see reads exactly as one that is not there,
+   * because to this caller those are the same thing.
+   */
+  it("answers a grader this project does not have as one that is not there", async () => {
+    api = await createApi("graders_edit_unknown");
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
     const key = await projectKeyFor(api.app, ada);
 
-    const [only] = itemsOf(await request("GET", "/api/graders", key));
+    const edited = await request("PATCH", `/api/graders/${NOBODY_HAS_THIS}`, key, {
+      required: false,
+    });
+
+    expect(edited.statusCode).toBe(404);
+    expect(String(edited.body.message)).toContain(NOBODY_HAS_THIS);
+  });
+
+  it("is refused to a viewer, per the permission table", async () => {
+    api = await createApi("graders_edit_roles");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+    const grace = await colleagueOf(api.app, ada, "grace@acme.example", "viewer");
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, grace.secret, {
+      required: false,
+    });
+
+    expect(edited.statusCode).toBe(403);
+  });
+});
+
+describe("switching a running copy off", () => {
+  /**
+   * **Deleting is the switching off, and it is the only one there is.** No
+   * enable flag, no `none` scope: from the moment this returns, nothing the
+   * project runs is judged by the copy — and the answer says when, so a reader
+   * can tell which runs were before it.
+   */
+  it("takes the copy out of the list, and says when it stopped", async () => {
+    api = await createApi("graders_delete");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    expect(itemsOf(await request("GET", "/api/graders", key))).toHaveLength(2);
+
+    const removed = await request("DELETE", `/api/graders/${copy.id}`, key);
+
+    expect(removed.statusCode, JSON.stringify(removed.body)).toBe(200);
+    expect(removed.body).toMatchObject({ id: copy.id, name: copy.name });
+    expect(String(removed.body.deleted_at)).not.toBe("");
+
+    const left = itemsOf(await request("GET", "/api/graders", key));
+    expect(left.map((one) => one.id)).not.toContain(copy.id);
+    // The one every project is created with is still judging, because only the
+    // copy that was named was switched off.
+    expect(left).toHaveLength(1);
+  });
+
+  /**
+   * Including that one. Deleting the seeded copy is exactly how a project stops
+   * being judged against its own written-down expectations — there is no other
+   * switch, and the screen says so when the list comes back empty.
+   */
+  it("switches off the copy every project is created with, like any other", async () => {
+    api = await createApi("graders_delete_seeded");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    const [seeded] = itemsOf(await request("GET", "/api/graders", key));
+    if (seeded === undefined) throw new Error("the project has no graders");
+
+    const removed = await request("DELETE", `/api/graders/${seeded.id}`, key);
+
+    expect(removed.statusCode, JSON.stringify(removed.body)).toBe(200);
+    expect(itemsOf(await request("GET", "/api/graders", key))).toHaveLength(0);
+  });
+
+  it("answers a second delete as a grader that is not there", async () => {
+    api = await createApi("graders_delete_twice");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+
+    expect((await request("DELETE", `/api/graders/${copy.id}`, key)).statusCode).toBe(
+      200,
+    );
+
+    const again = await request("DELETE", `/api/graders/${copy.id}`, key);
+    expect(again.statusCode).toBe(404);
+    expect(String(again.body.message)).toContain("switched off");
+  });
+
+  it("is refused to a viewer, per the permission table", async () => {
+    api = await createApi("graders_delete_roles");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aLatencyCopy(key);
+    const grace = await colleagueOf(api.app, ada, "grace@acme.example", "viewer");
+
+    const removed = await request(
+      "DELETE",
+      `/api/graders/${copy.id}`,
+      grace.secret,
+    );
+
+    expect(removed.statusCode).toBe(403);
+    expect(itemsOf(await request("GET", "/api/graders", key))).toHaveLength(2);
+  });
+
+  it("shows one customer nothing of another's, and switches nothing off there", async () => {
+    api = await createApi("graders_delete_tenants");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const grace = await signUp(api.app, "grace@globex.example", "Globex");
+    const theirs = await projectKeyFor(api.app, ada);
+    const others = await projectKeyFor(api.app, grace);
+
+    const [only] = itemsOf(await request("GET", "/api/graders", theirs));
     if (only === undefined) throw new Error("the project has no graders");
 
-    for (const method of ["PATCH", "DELETE"] as const) {
-      const answered = await ask(api.app, method, `/api/graders/${only.id}`, key);
-      expect(answered.statusCode, method).toBe(404);
-    }
+    const removed = await request("DELETE", `/api/graders/${only.id}`, others);
+
+    expect(removed.statusCode).toBe(404);
+    expect(itemsOf(await request("GET", "/api/graders", theirs))).toHaveLength(1);
   });
 });

--- a/apps/api/test/graders-routes.test.ts
+++ b/apps/api/test/graders-routes.test.ts
@@ -54,6 +54,7 @@ type Listed = {
   readonly library_id: string;
   readonly name: string;
   readonly type: string;
+  readonly description: string | null;
   readonly required: boolean;
   readonly scope: string;
   readonly version: number;
@@ -631,6 +632,236 @@ describe("changing a running copy", () => {
     });
 
     expect(edited.statusCode).toBe(403);
+  });
+});
+
+/**
+ * The three fields that arrive as words, and what happens when they arrive as
+ * something else.
+ *
+ * **Refused, because the alternative is a project configured differently from
+ * what somebody wrote down.** These used to be read through a helper that turns
+ * anything but a string into the empty string, which the door then read as
+ * silence — so `{"scope": 123}` answered 200 with the copy still judging
+ * simulations, and `{"description": 123}` answered 200 having *erased* a note a
+ * person had typed. It is `production_sample_rate: "10"` one field along, and
+ * the group's own unknown-key gate exists to refuse exactly this shape of
+ * mistake.
+ *
+ * **Absent stays absent.** An edit is partial, and every case in this block
+ * that leaves a key out has to keep meaning "keep what is there" — which the
+ * settings and values cases above rely on and would fail loudly without.
+ */
+describe("the fields a body sends as words", () => {
+  /** A copy with something in every field this block is about. */
+  async function aNamedCopy(key: string): Promise<Listed> {
+    const copy = await aLatencyCopy(key);
+    expect(copy.description).toBe("The number the support team argues about");
+    return copy;
+  }
+
+  /** What the copy looks like now, read back through the list. */
+  async function nowReading(key: string, id: string): Promise<Listed> {
+    const found = itemsOf(await request("GET", "/api/graders", key)).find(
+      (one) => one.id === id,
+    );
+    if (found === undefined) throw new Error(`${id} is no longer running`);
+    return found;
+  }
+
+  it("refuses a name that is not text, and renames nothing", async () => {
+    api = await createApi("graders_edit_name_shape");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aNamedCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      name: 123,
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toContain("name");
+    expect(String(edited.body.message)).toContain("number");
+    expect((await nowReading(key, copy.id)).name).toBe(copy.name);
+  });
+
+  /**
+   * **A copy has to be called something**, so an empty name is a refusal rather
+   * than a rename this door quietly drops. It is the factory's rule and the
+   * factory's sentence: this door checks that a word arrived, not what it says.
+   */
+  it("refuses an empty name rather than ignoring it", async () => {
+    api = await createApi("graders_edit_name_empty");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aNamedCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      name: "   ",
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toContain("name");
+    expect((await nowReading(key, copy.id)).name).toBe(copy.name);
+  });
+
+  it("refuses a scope that is not text, and moves nothing", async () => {
+    api = await createApi("graders_edit_scope_shape");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aNamedCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      scope: 123,
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toContain("scope");
+    // Still judging what it was judging, which is the half a status code
+    // cannot say: a developer who believed they pointed this at live traffic
+    // would otherwise find out when nothing was ever judged there.
+    expect((await nowReading(key, copy.id)).scope).toBe("simulations");
+  });
+
+  /**
+   * **The scope's vocabulary is the factory's gate, not this door's.** The route
+   * casts the word it read into the scope union, which is safe precisely
+   * because `validScope` refuses a word egma has never heard of and names the
+   * three it knows. This is that claim checked rather than asserted.
+   */
+  it("refuses a scope egma has never heard of, naming the ones it knows", async () => {
+    api = await createApi("graders_edit_scope_word");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aNamedCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      scope: "banana",
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toContain("simulations");
+    expect((await nowReading(key, copy.id)).scope).toBe("simulations");
+  });
+
+  /**
+   * **The worst of the three, because it destroyed something.** A number here
+   * used to be read as the empty string, then as "clear it", so a request that
+   * answered 200 erased a note a person had typed and said nothing about it.
+   */
+  it("refuses a description that is not text, and leaves the note where it was", async () => {
+    api = await createApi("graders_edit_note_shape");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aNamedCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      description: 123,
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toContain("description");
+    expect((await nowReading(key, copy.id)).description).toBe(copy.description);
+  });
+
+  /**
+   * And the intent that has to keep working: there is no note. Both ways of
+   * saying it mean it — a form submitting a blank box, and a client sending
+   * JSON's own word for nothing.
+   */
+  it("clears the note for an empty string and for null alike", async () => {
+    api = await createApi("graders_edit_note_cleared");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    for (const emptied of ["", null]) {
+      const copy = await aNamedCopy(key);
+      const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+        description: emptied,
+      });
+
+      expect(edited.statusCode, JSON.stringify(edited.body)).toBe(200);
+      expect(edited.body.description).toBeNull();
+      expect((await nowReading(key, copy.id)).description).toBeNull();
+    }
+  });
+
+  /** Leaving it out is not clearing it, which is what makes an edit partial. */
+  it("keeps the note, the name and the scope when the body leaves them out", async () => {
+    api = await createApi("graders_edit_partial");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aNamedCopy(key);
+
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      required: false,
+    });
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(200);
+    expect(edited.body).toMatchObject({
+      name: copy.name,
+      description: copy.description,
+      scope: copy.scope,
+      required: false,
+    });
+  });
+
+  /**
+   * The project a write names is read the same way, and for a worse version of
+   * the same reason: a number quietly ignored is a write that lands in whatever
+   * project the credential happens to act in rather than the one the request
+   * named.
+   */
+  it("refuses a project that is not text, on either verb", async () => {
+    api = await createApi("graders_project_shape");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+    const copy = await aNamedCopy(key);
+
+    const used = await request("POST", "/api/graders", key, {
+      library_id: PREDEFINED_GRADERS.expectedBehaviors,
+      project: 123,
+    });
+    const edited = await request("PATCH", `/api/graders/${copy.id}`, key, {
+      project: 123,
+      required: false,
+    });
+
+    expect(used.statusCode, JSON.stringify(used.body)).toBe(422);
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(422);
+    expect(String(edited.body.message)).toContain("project");
+    expect((await nowReading(key, copy.id)).required).toBe(true);
+  });
+
+  /**
+   * The same three on the way in. A Use cannot erase anything — there is
+   * nothing there yet — but a `scope` that does not arrive as text would
+   * quietly become `simulations`, which is the same trap one step earlier:
+   * somebody switches a grader on for live traffic and it never judges any.
+   */
+  it("refuses each of them on the way in, and writes nothing", async () => {
+    api = await createApi("graders_use_word_shapes");
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    for (const wrong of [
+      { name: 123 },
+      { scope: 123 },
+      { description: 123 },
+    ]) {
+      const used = await request("POST", "/api/graders", key, {
+        library_id: PREDEFINED_GRADERS.latency,
+        params: { metric: "turn_response_latency", bound: 2000 },
+        ...wrong,
+      });
+
+      expect(used.statusCode, JSON.stringify(used.body)).toBe(422);
+      expect(String(used.body.message)).toContain(Object.keys(wrong)[0] ?? "");
+    }
+
+    // Nothing was switched on: the project still holds only the copy it was
+    // created with.
+    expect(itemsOf(await request("GET", "/api/graders", key))).toHaveLength(1);
   });
 });
 

--- a/apps/grader/test/edited-and-switched-off.test.ts
+++ b/apps/grader/test/edited-and-switched-off.test.ts
@@ -13,7 +13,6 @@ import {
   makeWorld,
   oneServiceAtATime,
   seedGrader,
-  verdictsOn,
   type World,
 } from "./support/world.ts";
 
@@ -76,6 +75,21 @@ async function aCopyOnTheProject(grader: UseLibraryEntry): Promise<string> {
   return graderId;
 }
 
+/**
+ * One conversation, judged to the end.
+ *
+ * **The job reaching `graded` rather than a row appearing**, and the difference
+ * is the whole reliability of this file. A row appearing says *a* grader has
+ * spoken; every case here asks what a **particular** copy said, and one of them
+ * asks what a copy did **not** say — which no count of rows can ever confirm,
+ * because the row that is missing might simply not have been written yet. The
+ * job is finished only once every verdict is stored, so it is the one signal
+ * that means there is nothing more coming.
+ */
+async function judged(simulationId: string): Promise<void> {
+  await jobFor(world, { simulationId }, "graded", 30_000);
+}
+
 /** The rows one copy wrote about one conversation, in the order they came. */
 async function rowsFrom(conversationId: string, graderId: string) {
   const read = await readVerdicts(world.auth, conversationId);
@@ -101,7 +115,7 @@ describe("editing what a copy judges by", () => {
     );
 
     const { simulationId: before } = await conductSimulation(world);
-    await verdictsOn(world, before);
+    await judged(before);
     const [passed] = await rowsFrom(before, graderId);
     expect(passed?.verdict).toBe("passed");
 
@@ -113,7 +127,7 @@ describe("editing what a copy judges by", () => {
     expect(edited?.version).toBe(2);
 
     const { simulationId: after } = await conductSimulation(world);
-    await verdictsOn(world, after);
+    await judged(after);
     const [failed] = await rowsFrom(after, graderId);
 
     // Judged by what the copy holds now, and the row names the version that
@@ -155,9 +169,9 @@ describe("switching a copy off", () => {
       aLatencyCopy({ name: "On until it is not" }),
     );
 
-    const { simulationId: judged } = await conductSimulation(world);
-    await verdictsOn(world, judged);
-    const [wrote] = await rowsFrom(judged, graderId);
+    const { simulationId: itJudged } = await conductSimulation(world);
+    await judged(itJudged);
+    const [wrote] = await rowsFrom(itJudged, graderId);
     expect(wrote?.verdict).toBe("passed");
 
     const switchedOff = await deleteGrader(world.auth, graderId);
@@ -166,7 +180,7 @@ describe("switching a copy off", () => {
     // A whole conversation later: conducted, claimed, judged and finished —
     // and this copy said nothing about it, because it was never resolved.
     const { simulationId: afterwards } = await conductSimulation(world);
-    await jobFor(world, { simulationId: afterwards }, "graded", 30_000);
+    await judged(afterwards);
 
     expect(await rowsFrom(afterwards, graderId)).toHaveLength(0);
     // Nothing judged it at all, in fact: the conversation names no test, so the
@@ -176,10 +190,10 @@ describe("switching a copy off", () => {
     expect(nothing.outcome.verdict).toBe("skipped");
 
     // And the conversation it did judge reads exactly as it read before.
-    const [kept] = await rowsFrom(judged, graderId);
+    const [kept] = await rowsFrom(itJudged, graderId);
     expect(kept?.verdict).toBe("passed");
     expect(kept?.graderVersionId).toBe(wrote?.graderVersionId);
-    expect(await readVerdicts(world.auth, judged)).toMatchObject({
+    expect(await readVerdicts(world.auth, itJudged)).toMatchObject({
       outcome: { verdict: "passed" },
     });
   });
@@ -209,7 +223,7 @@ describe("switching a copy off", () => {
     );
 
     const { simulationId } = await conductSimulation(world);
-    await verdictsOn(world, simulationId);
+    await judged(simulationId);
 
     const before = await readVerdicts(world.auth, simulationId);
     expect(before.diagnostics?.verdict).toBe("failed");

--- a/apps/grader/test/edited-and-switched-off.test.ts
+++ b/apps/grader/test/edited-and-switched-off.test.ts
@@ -1,0 +1,233 @@
+import {
+  deleteGrader,
+  editGrader,
+  readVerdicts,
+  type UseLibraryEntry,
+} from "@egma/db";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  aLatencyCopy,
+  conductSimulation,
+  jobFor,
+  makeWorld,
+  oneServiceAtATime,
+  seedGrader,
+  verdictsOn,
+  type World,
+} from "./support/world.ts";
+
+/**
+ * What an edit and a delete actually do to judging — asked of the running
+ * service, the real stores and the real fold, because that is the only place
+ * the answer lives.
+ *
+ * **Pressing Use used to be a one-way door.** A bound typed too tight made
+ * every run red for ever: there was no route to change the values, no route to
+ * turn the blocker into a diagnostic, and no route to switch the copy off. This
+ * file is the other half of opening those doors — not that the rows in Postgres
+ * changed, which the data-access suite already proves, but that the next
+ * conversation is judged differently and the last one is not judged again.
+ *
+ * **Every conversation here names no test**, so the copy every project is
+ * created with has nothing to judge it against and writes nothing. What is left
+ * is the latency copy this file switches on, and one row per conversation —
+ * which is what makes "it wrote nothing afterwards" an assertion about the
+ * delete rather than about arithmetic.
+ *
+ * The conducted conversation measures 900 and 1100 milliseconds, and the worst
+ * of those is what a bound is held against: 2000 passes, 1000 fails.
+ */
+
+let world: World;
+const service = oneServiceAtATime();
+
+/** Every copy this case switched on, so the next one starts where this did. */
+let switchedOn: string[] = [];
+
+beforeAll(async () => {
+  world = await makeWorld("grader_edited_switched_off");
+});
+
+/**
+ * The project as this file found it: the copy every project is created with,
+ * and nothing else.
+ *
+ * **Switched off through the product's own act**, which is also the point:
+ * every case here is about one copy's rows, and a copy left running from an
+ * earlier case would judge the next case's conversations and answer for
+ * something that case never mentions. Deleting is exactly how a project stops
+ * being judged by one, so the tidying and the subject are the same verb.
+ */
+afterEach(async () => {
+  const switching = switchedOn;
+  switchedOn = [];
+  for (const graderId of switching) await deleteGrader(world.auth, graderId);
+});
+
+afterAll(async () => {
+  await service.stop();
+  await world.drop();
+});
+
+async function aCopyOnTheProject(grader: UseLibraryEntry): Promise<string> {
+  const graderId = await seedGrader(world, grader);
+  switchedOn.push(graderId);
+  return graderId;
+}
+
+/** The rows one copy wrote about one conversation, in the order they came. */
+async function rowsFrom(conversationId: string, graderId: string) {
+  const read = await readVerdicts(world.auth, conversationId);
+  return read.verdicts.filter((row) => row.graderId === graderId);
+}
+
+describe("editing what a copy judges by", () => {
+  /**
+   * **The next conversation is judged by the new bound, and the last one keeps
+   * its own answer.** An edit to the values mints the next version rather than
+   * rewriting the current one, so a verdict written under version 1 still names
+   * version 1 and still says what it said. That is the whole reason the values
+   * are versioned and the live settings are not.
+   *
+   * It is also why nothing is re-judged: editing a copy changes what happens
+   * next, and there is no re-grade in the product to reach backwards with.
+   */
+  it("judges the next conversation by the new bound, and leaves the earlier one alone", async () => {
+    await service.start();
+
+    const graderId = await aCopyOnTheProject(
+      aLatencyCopy({ name: "Answers inside two seconds" }),
+    );
+
+    const { simulationId: before } = await conductSimulation(world);
+    await verdictsOn(world, before);
+    const [passed] = await rowsFrom(before, graderId);
+    expect(passed?.verdict).toBe("passed");
+
+    // The bound tightened past what this agent manages — sent as the entry's
+    // form filled in, which is the shape the edit route hands down.
+    const edited = await editGrader(world.auth, graderId, {
+      params: { metric: "turn_response_latency", bound: 1000 },
+    });
+    expect(edited?.version).toBe(2);
+
+    const { simulationId: after } = await conductSimulation(world);
+    await verdictsOn(world, after);
+    const [failed] = await rowsFrom(after, graderId);
+
+    // Judged by what the copy holds now, and the row names the version that
+    // decided it.
+    expect(failed?.verdict).toBe("failed");
+    expect(failed?.graderVersionId).toBe(edited?.versionId);
+    expect(await readVerdicts(world.auth, after)).toMatchObject({
+      outcome: { verdict: "failed" },
+    });
+
+    // And the conversation judged before the edit is untouched — same word,
+    // same version, same instant. Nothing went back for it.
+    const [still] = await rowsFrom(before, graderId);
+    expect(still?.verdict).toBe("passed");
+    expect(still?.graderVersionId).toBe(passed?.graderVersionId);
+    expect(still?.judgedAtMicroseconds).toBe(passed?.judgedAtMicroseconds);
+    expect(await readVerdicts(world.auth, before)).toMatchObject({
+      outcome: { verdict: "passed" },
+    });
+  });
+});
+
+describe("switching a copy off", () => {
+  /**
+   * **Deleting is the off switch, and this is what that has to mean at both
+   * ends.** Nothing the project runs afterwards is judged by the copy, because
+   * it stops being resolved at all; and everything it already judged still
+   * reads, because the row is marked rather than removed and its versions stay
+   * exactly where they are.
+   *
+   * The second half is what makes the first half safe to press. A team whose
+   * grader is failing every run has to be able to stop it without being asked
+   * to give up the runs they have already read.
+   */
+  it("judges nothing afterwards, and everything it already judged still reads", async () => {
+    await service.start();
+
+    const graderId = await aCopyOnTheProject(
+      aLatencyCopy({ name: "On until it is not" }),
+    );
+
+    const { simulationId: judged } = await conductSimulation(world);
+    await verdictsOn(world, judged);
+    const [wrote] = await rowsFrom(judged, graderId);
+    expect(wrote?.verdict).toBe("passed");
+
+    const switchedOff = await deleteGrader(world.auth, graderId);
+    expect(switchedOff?.id).toBe(graderId);
+
+    // A whole conversation later: conducted, claimed, judged and finished —
+    // and this copy said nothing about it, because it was never resolved.
+    const { simulationId: afterwards } = await conductSimulation(world);
+    await jobFor(world, { simulationId: afterwards }, "graded", 30_000);
+
+    expect(await rowsFrom(afterwards, graderId)).toHaveLength(0);
+    // Nothing judged it at all, in fact: the conversation names no test, so the
+    // copy the project was created with had nothing to say either.
+    const nothing = await readVerdicts(world.auth, afterwards);
+    expect(nothing.verdicts).toHaveLength(0);
+    expect(nothing.outcome.verdict).toBe("skipped");
+
+    // And the conversation it did judge reads exactly as it read before.
+    const [kept] = await rowsFrom(judged, graderId);
+    expect(kept?.verdict).toBe("passed");
+    expect(kept?.graderVersionId).toBe(wrote?.graderVersionId);
+    expect(await readVerdicts(world.auth, judged)).toMatchObject({
+      outcome: { verdict: "passed" },
+    });
+  });
+
+  /**
+   * **A switched-off diagnostic stays a diagnostic**, and this is the case that
+   * pins it.
+   *
+   * `required` is read live off the copy rather than off the row that names it,
+   * and the copy is read **without a deleted filter** — deliberately. The fold
+   * treats a grader it cannot resolve as required, which is the safe direction
+   * for a row nobody can place; but a copy somebody switched off is not
+   * unplaceable, and reading it as required would turn every failing row a
+   * diagnostic ever wrote into a run that suddenly failed, months later,
+   * because somebody tidied up. Deleting a copy says what judges from now on.
+   * It says nothing about what a past run meant.
+   */
+  it("leaves a diagnostic's old rows in the lane that only reports", async () => {
+    await service.start();
+
+    const reporting = await aCopyOnTheProject(
+      aLatencyCopy({
+        name: "Reports and never blocks",
+        required: false,
+        params: { metric: "turn_response_latency", bound: 100 },
+      }),
+    );
+
+    const { simulationId } = await conductSimulation(world);
+    await verdictsOn(world, simulationId);
+
+    const before = await readVerdicts(world.auth, simulationId);
+    expect(before.diagnostics?.verdict).toBe("failed");
+    // Nothing that can fail anything judged this conversation, so the answer is
+    // that nothing was decided — not that something failed.
+    expect(before.outcome.verdict).toBe("skipped");
+    expect(
+      before.byGrader.find((its) => its.graderId === reporting)?.required,
+    ).toBe(false);
+
+    await deleteGrader(world.auth, reporting);
+
+    const after = await readVerdicts(world.auth, simulationId);
+    expect(after.verdicts).toHaveLength(before.verdicts.length);
+    expect(after.diagnostics?.verdict).toBe("failed");
+    expect(after.outcome.verdict).toBe("skipped");
+    expect(
+      after.byGrader.find((its) => its.graderId === reporting)?.required,
+    ).toBe(false);
+  });
+});

--- a/apps/web/app/graders/running/edit-form.tsx
+++ b/apps/web/app/graders/running/edit-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { EDIT, SCOPES, SWITCH_OFF } from "../../../lib/grader-running-copy.ts";
+import { wrote } from "../../../lib/write.ts";
 import { Field, Notice, styles } from "../../ui.tsx";
 import {
   asWritten,
@@ -32,9 +33,17 @@ import {
  * **One request carries both kinds of change**, and the platform decides which
  * happened. Values are what a verdict was decided by, so changing one starts
  * the next version and leaves the one behind it alone; a name, a scope, a rate
- * and the `required` flag change nothing already judged, so they are written in
- * place. A browser page holding a copy of that rule would be a second opinion
- * about it, and the version number on the answer is how this one finds out.
+ * and the `required` flag rewrite no verdict, so they are written in place. A
+ * browser page holding a copy of that rule would be a second opinion about it,
+ * and the version number on the answer is how this one finds out.
+ *
+ * **`required` is the one that reaches a page about the past anyway**, and the
+ * form says so beside the control rather than in a tooltip. It rewrites nothing;
+ * it moves this grader's verdicts between the lane that decides a run and the
+ * lane that only reports, and that is worked out fresh every time somebody opens
+ * a result — so a run that failed on this grader alone reads as passed from the
+ * moment the box is unticked. Saying "nothing already judged changes" here would
+ * be the screen telling somebody the opposite of what they see next.
  */
 
 /** One running copy, as this screen reads one off the list. */
@@ -103,36 +112,28 @@ export function EditForm({
     setBusy(true);
     setRefusal(null);
 
-    try {
-      const answer = await fetch(`/api/graders/${copy.id}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          name,
-          // Null rather than an empty string, because emptying a note is a
-          // thing somebody means to do and the platform reads null as it.
-          description: description.trim() === "" ? null : description,
-          scope,
-          required,
-          production_sample_rate: Number(sampleRate),
-          ...(params.length === 0 ? {} : { params: asWritten(params, filled) }),
-        }),
-      });
+    const refused = await wrote({
+      url: `/api/graders/${copy.id}`,
+      method: "PATCH",
+      body: {
+        name,
+        // Null rather than an empty string, because emptying a note is a thing
+        // somebody means to do and the platform reads null as it.
+        description: description.trim() === "" ? null : description,
+        scope,
+        required,
+        production_sample_rate: Number(sampleRate),
+        ...(params.length === 0 ? {} : { params: asWritten(params, filled) }),
+      },
+      unreachable: EDIT.unreachable,
+    });
+    setBusy(false);
 
-      if (!answer.ok) {
-        const said = (await answer.json().catch(() => ({}))) as {
-          message?: string;
-        };
-        setRefusal(said.message ?? EDIT.unreachable);
-        return;
-      }
-
-      onSaved(name);
-    } catch {
-      setRefusal(EDIT.unreachable);
-    } finally {
-      setBusy(false);
+    if (refused !== null) {
+      setRefusal(refused);
+      return;
     }
+    onSaved(name);
   }
 
   return (
@@ -265,25 +266,18 @@ export function SwitchOffPanel({
     setBusy(true);
     setRefusal(null);
 
-    try {
-      const answer = await fetch(`/api/graders/${copy.id}`, {
-        method: "DELETE",
-      });
+    const refused = await wrote({
+      url: `/api/graders/${copy.id}`,
+      method: "DELETE",
+      unreachable: SWITCH_OFF.unreachable,
+    });
+    setBusy(false);
 
-      if (!answer.ok) {
-        const said = (await answer.json().catch(() => ({}))) as {
-          message?: string;
-        };
-        setRefusal(said.message ?? SWITCH_OFF.unreachable);
-        return;
-      }
-
-      onSwitchedOff(copy.name);
-    } catch {
-      setRefusal(SWITCH_OFF.unreachable);
-    } finally {
-      setBusy(false);
+    if (refused !== null) {
+      setRefusal(refused);
+      return;
     }
+    onSwitchedOff(copy.name);
   }
 
   return (

--- a/apps/web/app/graders/running/edit-form.tsx
+++ b/apps/web/app/graders/running/edit-form.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useState } from "react";
+
+import { EDIT, SCOPES, SWITCH_OFF } from "../../../lib/grader-running-copy.ts";
+import { Field, Notice, styles } from "../../ui.tsx";
+import {
+  asWritten,
+  EntryFields,
+  firstChoices,
+  type Filled,
+  type Parameter,
+} from "../use-form.tsx";
+
+/**
+ * The two acts that stop **Use** being a one-way door: changing a running copy,
+ * and switching one off.
+ *
+ * **The edit form is the Use form's controls, drawn from the same declaration.**
+ * A library entry says what filling it in asks for — latency declares a measure
+ * from egma's catalog and a bound; expected behaviors declares nothing — and
+ * both forms render that list through `EntryFields`. There is no second reading
+ * of the entry anywhere in this section, which is what stops the two screens
+ * from drifting the first time a parameter learns a new kind of control.
+ *
+ * **What lives here and not there is the live settings**, because they are only
+ * meaningful for a copy that already exists: where it applies, whether it can
+ * fail a run, and how much live traffic it judges. Pressing Use asks for the
+ * one of those a person has an opinion about before they have seen the grader
+ * run; the rest are settings somebody comes back to.
+ *
+ * **One request carries both kinds of change**, and the platform decides which
+ * happened. Values are what a verdict was decided by, so changing one starts
+ * the next version and leaves the one behind it alone; a name, a scope, a rate
+ * and the `required` flag change nothing already judged, so they are written in
+ * place. A browser page holding a copy of that rule would be a second opinion
+ * about it, and the version number on the answer is how this one finds out.
+ */
+
+/** One running copy, as this screen reads one off the list. */
+export type Copy = {
+  readonly id: string;
+  readonly library_id: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly scope: string;
+  readonly required: boolean;
+  readonly production_sample_rate: number;
+  readonly config: {
+    readonly assertions?: readonly Readonly<Record<string, unknown>>[];
+  } | null;
+};
+
+/**
+ * What this copy currently holds, as controls hold it.
+ *
+ * A dropdown's default is where an unanswered question starts, and a stored
+ * value written over it is where an answered one is — so a copy of an entry
+ * that has grown a parameter since it was made opens with that parameter's
+ * first option rather than with nothing in it.
+ */
+function filledFrom(
+  params: readonly Parameter[],
+  assertion: Readonly<Record<string, unknown>> | undefined,
+): Filled {
+  const chosen: Record<string, string> = { ...firstChoices(params) };
+  for (const parameter of params) {
+    const held = assertion?.[parameter.name];
+    if (held !== undefined && held !== null) {
+      chosen[parameter.name] = String(held);
+    }
+  }
+  return chosen;
+}
+
+export function EditForm({
+  copy,
+  params,
+  onSaved,
+  onCancel,
+}: {
+  copy: Copy;
+  /** What this copy's entry asks for, as the entry declares it. */
+  params: readonly Parameter[];
+  onSaved: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [filled, setFilled] = useState<Filled>(() =>
+    filledFrom(params, copy.config?.assertions?.[0]),
+  );
+  const [name, setName] = useState(copy.name);
+  const [description, setDescription] = useState(copy.description ?? "");
+  const [scope, setScope] = useState(copy.scope);
+  const [required, setRequired] = useState(copy.required);
+  const [sampleRate, setSampleRate] = useState(
+    String(copy.production_sample_rate),
+  );
+  const [busy, setBusy] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  async function save(event: React.FormEvent): Promise<void> {
+    event.preventDefault();
+    setBusy(true);
+    setRefusal(null);
+
+    try {
+      const answer = await fetch(`/api/graders/${copy.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name,
+          // Null rather than an empty string, because emptying a note is a
+          // thing somebody means to do and the platform reads null as it.
+          description: description.trim() === "" ? null : description,
+          scope,
+          required,
+          production_sample_rate: Number(sampleRate),
+          ...(params.length === 0 ? {} : { params: asWritten(params, filled) }),
+        }),
+      });
+
+      if (!answer.ok) {
+        const said = (await answer.json().catch(() => ({}))) as {
+          message?: string;
+        };
+        setRefusal(said.message ?? EDIT.unreachable);
+        return;
+      }
+
+      onSaved(name);
+    } catch {
+      setRefusal(EDIT.unreachable);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className={styles.form} onSubmit={(event) => void save(event)}>
+      <p className={styles.muted}>{EDIT.lead}</p>
+      {refusal === null ? null : <Notice tone="error">{refusal}</Notice>}
+
+      <Field label={EDIT.name} hint={EDIT.nameMeans} htmlFor="edit-name">
+        <input
+          className={styles.input}
+          id="edit-name"
+          type="text"
+          required
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </Field>
+
+      <Field
+        label={EDIT.description}
+        hint={EDIT.descriptionMeans}
+        htmlFor="edit-description"
+      >
+        <input
+          className={styles.input}
+          id="edit-description"
+          type="text"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+        />
+      </Field>
+
+      {/*
+        The entry's own questions, rendered by the component the Use form
+        renders them with — one declaration, one reading of it.
+      */}
+      <EntryFields
+        params={params}
+        filled={filled}
+        onFilled={(parameter, value) =>
+          setFilled((was) => ({ ...was, [parameter]: value }))
+        }
+        named="edit"
+        sentence={EDIT.asksNothing}
+      />
+
+      <Field label={EDIT.scope} hint={EDIT.scopeMeans} htmlFor="edit-scope">
+        <select
+          className={styles.select}
+          id="edit-scope"
+          value={scope}
+          onChange={(event) => setScope(event.target.value)}
+        >
+          {Object.entries(SCOPES).map(([stored, said]) => (
+            <option key={stored} value={stored}>
+              {said}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field
+        label={EDIT.required}
+        hint={required ? EDIT.requiredOn : EDIT.requiredOff}
+        htmlFor="edit-required"
+      >
+        <input
+          id="edit-required"
+          type="checkbox"
+          checked={required}
+          onChange={(event) => setRequired(event.target.checked)}
+        />
+      </Field>
+
+      <Field
+        label={EDIT.sampleRate}
+        hint={EDIT.sampleRateMeans}
+        htmlFor="edit-sample-rate"
+      >
+        <input
+          className={styles.input}
+          id="edit-sample-rate"
+          type="number"
+          min={0}
+          max={100}
+          required
+          value={sampleRate}
+          onChange={(event) => setSampleRate(event.target.value)}
+        />
+      </Field>
+
+      <div className={styles.buttonRow}>
+        <button
+          className={styles.buttonSecondary}
+          type="button"
+          onClick={onCancel}
+        >
+          {EDIT.cancel}
+        </button>
+        <button className={styles.button} type="submit" disabled={busy}>
+          {busy ? EDIT.submitting : EDIT.submit}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+/**
+ * Switching one off, and saying what that costs before anybody presses it.
+ *
+ * **Two sentences and a button, and the second sentence is the reason this is
+ * not a plain confirmation.** What stops is obvious from the word; what stays
+ * is not, and it is the thing somebody is actually worried about. A grader
+ * making every run red is a grader a team has to be able to remove without
+ * being asked to trade away the runs they have already read.
+ */
+export function SwitchOffPanel({
+  copy,
+  onSwitchedOff,
+  onCancel,
+}: {
+  copy: Copy;
+  onSwitchedOff: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  async function switchOff(): Promise<void> {
+    setBusy(true);
+    setRefusal(null);
+
+    try {
+      const answer = await fetch(`/api/graders/${copy.id}`, {
+        method: "DELETE",
+      });
+
+      if (!answer.ok) {
+        const said = (await answer.json().catch(() => ({}))) as {
+          message?: string;
+        };
+        setRefusal(said.message ?? SWITCH_OFF.unreachable);
+        return;
+      }
+
+      onSwitchedOff(copy.name);
+    } catch {
+      setRefusal(SWITCH_OFF.unreachable);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={styles.form}>
+      {refusal === null ? null : <Notice tone="error">{refusal}</Notice>}
+      <Notice>
+        <p>{SWITCH_OFF.stops}</p>
+        <p>{SWITCH_OFF.keeps}</p>
+        <p>{SWITCH_OFF.again}</p>
+      </Notice>
+
+      <div className={styles.buttonRow}>
+        <button
+          className={styles.buttonSecondary}
+          type="button"
+          onClick={onCancel}
+        >
+          {SWITCH_OFF.cancel}
+        </button>
+        <button
+          className={styles.buttonDanger}
+          type="button"
+          disabled={busy}
+          onClick={() => void switchOff()}
+        >
+          {busy ? SWITCH_OFF.confirming : SWITCH_OFF.confirm}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/graders/running/page.tsx
+++ b/apps/web/app/graders/running/page.tsx
@@ -159,6 +159,12 @@ export default function RunningGradersPage() {
     void read();
   };
 
+  // Built once for the whole table rather than once per row. It was a module
+  // constant before the last column started pressing something, and the only
+  // thing that made it a function is a setter this component owns — which does
+  // not change while it renders.
+  const columns = columnsOf(setOpen);
+
   return (
     <AppShell active="graders">
       <ProductPage wide>
@@ -222,8 +228,8 @@ export default function RunningGradersPage() {
               </div>
               <div className={styles.tableWrap}>
                 <table className={styles.dataTable}>
-                  <thead><tr>{columnsOf(setOpen).map(([heading]) => <th key={heading} scope="col">{heading}</th>)}</tr></thead>
-                  <tbody>{state.rows.map((row) => <tr key={row.id}>{columnsOf(setOpen).map(([heading, fill]) => <td key={heading}><span className={styles.tableCell}>{fill(row)}</span></td>)}</tr>)}</tbody>
+                  <thead><tr>{columns.map(([heading]) => <th key={heading} scope="col">{heading}</th>)}</tr></thead>
+                  <tbody>{state.rows.map((row) => <tr key={row.id}>{columns.map(([heading, fill]) => <td key={heading}><span className={styles.tableCell}>{fill(row)}</span></td>)}</tr>)}</tbody>
                 </table>
               </div>
               <div className={styles.mobileRows}>

--- a/apps/web/app/graders/running/page.tsx
+++ b/apps/web/app/graders/running/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 
 import {
   CONFIG,
+  EDIT,
   NOTHING,
   REQUIRED,
   RUNNING,
   RUNNING_COLUMNS,
   SCOPES,
+  SWITCH_OFF,
 } from "../../../lib/grader-running-copy.ts";
 import {
   AppShell,
@@ -19,6 +21,8 @@ import {
   styles,
 } from "../../ui.tsx";
 import { GraderTabs } from "../tabs.tsx";
+import type { Parameter } from "../use-form.tsx";
+import { EditForm, SwitchOffPanel, type Copy } from "./edit-form.tsx";
 
 /**
  * The running graders: the copies this project is actually judged by.
@@ -30,10 +34,18 @@ import { GraderTabs } from "../tabs.tsx";
  * through that pointer rather than shown here, because it lives in exactly one
  * place and this screen is not it.
  *
- * **Read-only, like its sibling, and for a different reason.** There is nothing
- * to author here because the act that makes a row is pressing Use on the
- * library screen. What this page is for is the question a developer actually
- * has: what is judging my project, does it block, and where does it apply.
+ * **Two acts, and they are the ones the shelf cannot do.** Pressing Use over
+ * there makes a copy; changing what that copy judges by and switching it off
+ * are decisions about a grader that already exists, so they belong here. Before
+ * they did, a bound typed too tight was permanent — every run red for ever,
+ * with no way back short of somebody editing the database by hand.
+ *
+ * **The edit form is drawn from the library entry, not from this page.** What a
+ * grader asks for is the entry's own declaration, so this screen reads the
+ * shelf beside the copies and hands each copy its entry's parameters. That is
+ * why there is no measure name and no bound anywhere in this file: a form
+ * written per grader would be a second copy of the platform's declaration,
+ * drifting the first time one changed.
  *
  * **It reads the first page and stops there**, which is honest for a list that
  * starts at one row and grows by however many graders a team switches on. The
@@ -47,55 +59,88 @@ import { GraderTabs } from "../tabs.tsx";
  * be.
  */
 
-type Copy = {
-  readonly id: string;
-  readonly name: string;
-  readonly scope: string;
-  readonly required: boolean;
-  readonly config: { readonly assertions?: readonly unknown[] } | null;
-};
-
 type Answer = {
   readonly items: readonly Copy[];
+};
+
+/** One entry on the shelf, read for the one thing this screen needs off it. */
+type Entry = {
+  readonly id: string;
+  readonly params?: readonly Parameter[];
+};
+
+type Shelf = {
+  readonly items: readonly Entry[];
 };
 
 type State =
   | { status: "loading" }
   | { status: "signed-out" }
   | { status: "failed"; why: string }
-  | { status: "loaded"; rows: readonly Copy[] };
+  | {
+      status: "loaded";
+      rows: readonly Copy[];
+      /** What each entry asks for, by the entry's own id. */
+      asks: ReadonlyMap<string, readonly Parameter[]>;
+    };
+
+/** Which copy has a panel open under the heading, and which panel it is. */
+type Open =
+  | { readonly act: "edit"; readonly copy: Copy }
+  | { readonly act: "switch-off"; readonly copy: Copy }
+  | null;
 
 export default function RunningGradersPage() {
   const [state, setState] = useState<State>({ status: "loading" });
+  const [open, setOpen] = useState<Open>(null);
+  /** What the last act came to, kept after the panel closes so it can be read. */
+  const [said, setSaid] = useState<string | null>(null);
+
+  /**
+   * The copies and the shelf behind them, together.
+   *
+   * Both, because a row cannot be edited without knowing what its entry asks
+   * for — and one state rather than two, because a page that had the copies and
+   * not yet their entries would draw an edit form with no controls in it and
+   * look like a grader that asks nothing.
+   */
+  const read = useCallback(async (): Promise<void> => {
+    try {
+      const [listed, shelf] = await Promise.all([
+        fetch("/api/graders"),
+        fetch("/api/grader-library"),
+      ]);
+
+      if (listed.status === 401 || shelf.status === 401) {
+        setState({ status: "signed-out" });
+        return;
+      }
+      if (!listed.ok || !shelf.ok) {
+        const refused = listed.ok ? shelf : listed;
+        const why = (await refused.json().catch(() => ({}))) as {
+          message?: string;
+        };
+        setState({ status: "failed", why: why.message ?? RUNNING.unreachable });
+        return;
+      }
+
+      const page = (await listed.json()) as Answer;
+      const entries = (await shelf.json()) as Shelf;
+      setState({
+        status: "loaded",
+        rows: page.items,
+        asks: new Map(
+          entries.items.map((entry) => [entry.id, entry.params ?? []] as const),
+        ),
+      });
+    } catch {
+      setState({ status: "failed", why: RUNNING.unreachable });
+    }
+  }, []);
 
   useEffect(() => {
-    let current = true;
-
-    void fetch("/api/graders")
-      .then(async (answer) => {
-        if (!current) return;
-        if (answer.status === 401) {
-          setState({ status: "signed-out" });
-          return;
-        }
-        if (!answer.ok) {
-          const said = (await answer.json().catch(() => ({}))) as {
-            message?: string;
-          };
-          setState({ status: "failed", why: said.message ?? RUNNING.unreachable });
-          return;
-        }
-        const page = (await answer.json()) as Answer;
-        setState({ status: "loaded", rows: page.items });
-      })
-      .catch(() => {
-        if (current) setState({ status: "failed", why: RUNNING.unreachable });
-      });
-
-    return () => {
-      current = false;
-    };
-  }, []);
+    void read();
+  }, [read]);
 
   if (state.status === "signed-out") {
     return (
@@ -108,6 +153,12 @@ export default function RunningGradersPage() {
     );
   }
 
+  const settled = (sentence: string): void => {
+    setOpen(null);
+    setSaid(sentence);
+    void read();
+  };
+
   return (
     <AppShell active="graders">
       <ProductPage wide>
@@ -115,6 +166,52 @@ export default function RunningGradersPage() {
         <GraderTabs active="running" />
         {state.status === "failed" ? <Notice tone="error">{state.why}</Notice> : null}
         {state.status === "loading" ? <Notice>{RUNNING.loading}</Notice> : null}
+
+        {/*
+          What the last act came to, and it stays until the next one. Both
+          sentences say what changed *and* what did not, because the question
+          somebody has after saving a tighter bound or switching a grader off is
+          always about the runs they have already read.
+        */}
+        {said === null ? null : <Notice tone="success">{said}</Notice>}
+
+        {/*
+          The panel, opened on one copy at a time and keyed by it — the Use
+          form's rule, for the Use form's reason. The form's state is *this*
+          copy's answers, and React keeps a component's state across a re-render
+          when only its props change, so opening a second row's form over the
+          first would draw the second grader's controls over the first grader's
+          values.
+        */}
+        {open === null ? null : (
+          <section className={styles.settingsPanel} aria-labelledby="act-title">
+            <h2 id="act-title">
+              {open.act === "edit"
+                ? EDIT.title(open.copy.name)
+                : SWITCH_OFF.title(open.copy.name)}
+            </h2>
+            {open.act === "edit" ? (
+              <EditForm
+                key={`edit-${open.copy.id}`}
+                copy={open.copy}
+                params={
+                  (state.status === "loaded"
+                    ? state.asks.get(open.copy.library_id)
+                    : undefined) ?? []
+                }
+                onCancel={() => setOpen(null)}
+                onSaved={(name) => settled(EDIT.saved(name))}
+              />
+            ) : (
+              <SwitchOffPanel
+                key={`off-${open.copy.id}`}
+                copy={open.copy}
+                onCancel={() => setOpen(null)}
+                onSwitchedOff={(name) => settled(SWITCH_OFF.done(name))}
+              />
+            )}
+          </section>
+        )}
 
         {state.status === "loaded" ? (
           state.rows.length === 0 ? <Notice tone="error">{RUNNING.empty}</Notice> : (
@@ -125,8 +222,8 @@ export default function RunningGradersPage() {
               </div>
               <div className={styles.tableWrap}>
                 <table className={styles.dataTable}>
-                  <thead><tr>{COLUMN_ORDER.map(([heading]) => <th key={heading} scope="col">{heading}</th>)}</tr></thead>
-                  <tbody>{state.rows.map((row) => <tr key={row.id}>{COLUMN_ORDER.map(([heading, fill]) => <td key={heading}><span className={styles.tableCell}>{fill(row)}</span></td>)}</tr>)}</tbody>
+                  <thead><tr>{columnsOf(setOpen).map(([heading]) => <th key={heading} scope="col">{heading}</th>)}</tr></thead>
+                  <tbody>{state.rows.map((row) => <tr key={row.id}>{columnsOf(setOpen).map(([heading, fill]) => <td key={heading}><span className={styles.tableCell}>{fill(row)}</span></td>)}</tr>)}</tbody>
                 </table>
               </div>
               <div className={styles.mobileRows}>
@@ -135,6 +232,7 @@ export default function RunningGradersPage() {
                     <span><span>{scopeOf(row)}</span><span className={styles.muted}>{requiredOf(row)}</span></span>
                     <strong>{row.name}</strong>
                     <p>{configOf(row)}</p>
+                    <Acts copy={row} onOpen={setOpen} />
                   </div>
                 ))}
               </div>
@@ -180,25 +278,68 @@ function configOf(copy: Copy): string {
 }
 
 /**
+ * The two acts on a row, side by side and both opening a panel rather than
+ * doing anything.
+ *
+ * Switching off opens one for the same reason Use does: it says what stops and
+ * what stays before anybody presses the button, and a delete that happened on
+ * the first click would be a button that quietly removed a project's judging.
+ */
+function Acts({
+  copy,
+  onOpen,
+}: {
+  copy: Copy;
+  onOpen: (open: Open) => void;
+}) {
+  return (
+    <span className={styles.buttonRow}>
+      <button
+        className={styles.buttonSecondary}
+        type="button"
+        onClick={() => onOpen({ act: "edit", copy })}
+      >
+        {EDIT.open}
+      </button>
+      <button
+        className={styles.buttonDanger}
+        type="button"
+        onClick={() => onOpen({ act: "switch-off", copy })}
+      >
+        {SWITCH_OFF.open}
+      </button>
+    </span>
+  );
+}
+
+/**
  * The columns, in the order they are shown, each beside what fills it.
  *
  * One list rather than a header row and a body row kept in step by hand — a
  * table whose third heading names its fourth value is a bug nobody sees in a
  * diff. The order is a judgement about scanning: which grader this is, then
- * where it applies, then whether it can fail a run, and what it checks last
- * because it is the widest.
+ * where it applies, then whether it can fail a run, then what it checks because
+ * it is the widest, and the buttons last where a reader's eye ends up.
+ *
+ * A function rather than a constant because the last column presses something,
+ * and what it presses belongs to the page's state rather than to this module.
  */
-const COLUMN_ORDER: readonly (readonly [string, (row: Copy) => ReactNode])[] = [
-  [RUNNING_COLUMNS.name, (row) => <strong>{row.name}</strong>],
-  [RUNNING_COLUMNS.scope, (row) => scopeOf(row)],
-  [RUNNING_COLUMNS.required, (row) => requiredOf(row)],
-  [
-    RUNNING_COLUMNS.config,
-    (row) =>
-      row.config === null ? (
-        <span className={styles.muted}>{NOTHING}</span>
-      ) : (
-        <span>{configOf(row)}</span>
-      ),
-  ],
-];
+function columnsOf(
+  onOpen: (open: Open) => void,
+): readonly (readonly [string, (row: Copy) => ReactNode])[] {
+  return [
+    [RUNNING_COLUMNS.name, (row) => <strong>{row.name}</strong>],
+    [RUNNING_COLUMNS.scope, (row) => scopeOf(row)],
+    [RUNNING_COLUMNS.required, (row) => requiredOf(row)],
+    [
+      RUNNING_COLUMNS.config,
+      (row) =>
+        row.config === null ? (
+          <span className={styles.muted}>{NOTHING}</span>
+        ) : (
+          <span>{configOf(row)}</span>
+        ),
+    ],
+    [RUNNING_COLUMNS.actions, (row) => <Acts copy={row} onOpen={onOpen} />],
+  ];
+}

--- a/apps/web/app/graders/use-form.tsx
+++ b/apps/web/app/graders/use-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { USE } from "../../lib/grader-library-copy.ts";
+import { wrote } from "../../lib/write.ts";
 import { Field, Notice, styles } from "../ui.tsx";
 
 /**
@@ -225,33 +226,23 @@ export function UseForm({
     setBusy(true);
     setRefusal(null);
 
-    try {
-      const answer = await fetch("/api/graders", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          library_id: entry.id,
-          required,
-          ...(params.length === 0
-            ? {}
-            : { params: asWritten(params, filled) }),
-        }),
-      });
+    const refused = await wrote({
+      url: "/api/graders",
+      method: "POST",
+      body: {
+        library_id: entry.id,
+        required,
+        ...(params.length === 0 ? {} : { params: asWritten(params, filled) }),
+      },
+      unreachable: USE.unreachable,
+    });
+    setBusy(false);
 
-      if (!answer.ok) {
-        const said = (await answer.json().catch(() => ({}))) as {
-          message?: string;
-        };
-        setRefusal(said.message ?? USE.unreachable);
-        return;
-      }
-
-      onStarted(entry.name);
-    } catch {
-      setRefusal(USE.unreachable);
-    } finally {
-      setBusy(false);
+    if (refused !== null) {
+      setRefusal(refused);
+      return;
     }
+    onStarted(entry.name);
   }
 
   return (

--- a/apps/web/app/graders/use-form.tsx
+++ b/apps/web/app/graders/use-form.tsx
@@ -56,7 +56,7 @@ export type UsableEntry = {
   readonly params?: readonly Parameter[];
 };
 
-type Filled = Readonly<Record<string, string>>;
+export type Filled = Readonly<Record<string, string>>;
 
 /**
  * What was typed, as the API takes it: text stays text, a number becomes one.
@@ -65,7 +65,7 @@ type Filled = Readonly<Record<string, string>>;
  * developer reads is the entry's own — "this grader needs a bound" — rather
  * than one about the empty string.
  */
-function asWritten(
+export function asWritten(
   params: readonly Parameter[],
   filled: Filled,
 ): Record<string, string | number> {
@@ -80,7 +80,7 @@ function asWritten(
 }
 
 /** The first option of a list, which is what a dropdown shows before a choice. */
-function firstChoices(params: readonly Parameter[]): Filled {
+export function firstChoices(params: readonly Parameter[]): Filled {
   const chosen: Record<string, string> = {};
   for (const parameter of params) {
     const first = parameter.options?.[0];
@@ -89,21 +89,38 @@ function firstChoices(params: readonly Parameter[]): Filled {
   return chosen;
 }
 
-export function UseForm({
-  entry,
-  onStarted,
-  onCancel,
+/**
+ * The entry's own questions, as controls — the block both forms on this section
+ * are built around.
+ *
+ * **It is one component because there is one form.** Switching a grader on and
+ * changing what it judges by ask exactly the same questions, in the same order,
+ * with the same meanings, because both are the entry's declaration rendered. A
+ * second copy of this for the edit screen would be a second reading of that
+ * declaration, and the day one of them learned a new kind of control the other
+ * would quietly go on drawing text boxes.
+ *
+ * `sentence` is the screen's own words for an entry that asks nothing, and it
+ * is a parameter rather than a constant here so each screen keeps its copy in
+ * its own file — which is what lets each screen's own test hold every word it
+ * says against the banned list.
+ *
+ * `named` prefixes the control identifiers, so two of these on one page — a
+ * form being filled in beside another — never label each other's inputs.
+ */
+export function EntryFields({
+  params,
+  filled,
+  onFilled,
+  named,
+  sentence,
 }: {
-  entry: UsableEntry;
-  onStarted: (name: string) => void;
-  onCancel: () => void;
+  params: readonly Parameter[];
+  filled: Filled;
+  onFilled: (name: string, value: string) => void;
+  named: string;
+  sentence: string;
 }) {
-  const params = entry.params ?? [];
-  const [filled, setFilled] = useState<Filled>(() => firstChoices(params));
-  const [required, setRequired] = useState(true);
-  const [busy, setBusy] = useState(false);
-  const [refusal, setRefusal] = useState<string | null>(null);
-
   /**
    * The unit a typed value is counted in: the unit of the option that was
    * chosen.
@@ -123,6 +140,85 @@ export function UseForm({
     only === undefined
       ? undefined
       : only.options?.find((option) => option.value === filled[only.name])?.unit;
+
+  if (params.length === 0) return <Notice>{sentence}</Notice>;
+
+  return (
+    <>
+      {params.map((parameter) => {
+        const control = `${named}-${parameter.name}`;
+        const chosen = filled[parameter.name] ?? "";
+
+        return (
+          <Field
+            key={parameter.name}
+            label={parameter.label}
+            hint={parameter.means}
+            htmlFor={control}
+          >
+            {parameter.options === undefined ? (
+              <>
+                <input
+                  className={styles.input}
+                  id={control}
+                  // The kind decides the control exactly as it decides the
+                  // check behind it, so what a person can type and what a
+                  // write will take are one decision made in the entry.
+                  type={parameter.kind === "number" ? "number" : "text"}
+                  required
+                  value={chosen}
+                  onChange={(event) =>
+                    onFilled(parameter.name, event.target.value)
+                  }
+                />
+                {/*
+                  The unit, beside the control and not inside it. It used to
+                  be the placeholder, which meant it vanished the instant
+                  somebody typed — exactly when knowing whether the number
+                  is milliseconds or turns starts to matter. It changes with
+                  the choice above, because the unit belongs to the measure.
+                */}
+                {unit === undefined ? null : (
+                  <span className={styles.muted}>{unit}</span>
+                )}
+              </>
+            ) : (
+              <select
+                className={styles.select}
+                id={control}
+                value={chosen}
+                onChange={(event) =>
+                  onFilled(parameter.name, event.target.value)
+                }
+              >
+                {parameter.options.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            )}
+          </Field>
+        );
+      })}
+    </>
+  );
+}
+
+export function UseForm({
+  entry,
+  onStarted,
+  onCancel,
+}: {
+  entry: UsableEntry;
+  onStarted: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const params = entry.params ?? [];
+  const [filled, setFilled] = useState<Filled>(() => firstChoices(params));
+  const [required, setRequired] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
 
   async function start(event: React.FormEvent): Promise<void> {
     event.preventDefault();
@@ -163,64 +259,15 @@ export function UseForm({
       <p className={styles.muted}>{USE.lead}</p>
       {refusal === null ? null : <Notice tone="error">{refusal}</Notice>}
 
-      {params.length === 0 ? (
-        <Notice>{USE.asksNothing}</Notice>
-      ) : (
-        params.map((parameter) => {
-          const control = `use-${parameter.name}`;
-          const chosen = filled[parameter.name] ?? "";
-          const write = (value: string): void =>
-            setFilled((was) => ({ ...was, [parameter.name]: value }));
-
-          return (
-            <Field
-              key={parameter.name}
-              label={parameter.label}
-              hint={parameter.means}
-              htmlFor={control}
-            >
-              {parameter.options === undefined ? (
-                <>
-                  <input
-                    className={styles.input}
-                    id={control}
-                    // The kind decides the control exactly as it decides the
-                    // check behind it, so what a person can type and what a
-                    // write will take are one decision made in the entry.
-                    type={parameter.kind === "number" ? "number" : "text"}
-                    required
-                    value={chosen}
-                    onChange={(event) => write(event.target.value)}
-                  />
-                  {/*
-                    The unit, beside the control and not inside it. It used to
-                    be the placeholder, which meant it vanished the instant
-                    somebody typed — exactly when knowing whether the number
-                    is milliseconds or turns starts to matter. It changes with
-                    the choice above, because the unit belongs to the measure.
-                  */}
-                  {unit === undefined ? null : (
-                    <span className={styles.muted}>{unit}</span>
-                  )}
-                </>
-              ) : (
-                <select
-                  className={styles.select}
-                  id={control}
-                  value={chosen}
-                  onChange={(event) => write(event.target.value)}
-                >
-                  {parameter.options.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </Field>
-          );
-        })
-      )}
+      <EntryFields
+        params={params}
+        filled={filled}
+        onFilled={(name, value) =>
+          setFilled((was) => ({ ...was, [name]: value }))
+        }
+        named="use"
+        sentence={USE.asksNothing}
+      />
 
       <Field
         label={USE.required}

--- a/apps/web/lib/grader-running-copy.ts
+++ b/apps/web/lib/grader-running-copy.ts
@@ -58,12 +58,18 @@ export const RUNNING_COLUMNS = {
  * Changing a running copy: every word the edit form says.
  *
  * **The one thing this copy has to make plain is that an edit is two acts.**
- * Changing a name or turning a blocker into a diagnostic changes nothing about
- * any judgment already made — it changes what the project lets a failure do,
- * from now on. Changing a filled-in value changes what the grader *is*, so it
- * starts the next version and the version behind it stays exactly as it was,
- * which is what keeps last week's result meaning what it meant. Somebody who
- * did not know that would read a tightened bound as a rewriting of history.
+ * Changing a filled-in value changes what the grader *is*, so it starts the
+ * next version and the version behind it stays exactly as it was, which is what
+ * keeps last week's result meaning what it meant. Somebody who did not know
+ * that would read a tightened bound as a rewriting of history.
+ *
+ * **And the one sentence it must not shorten is what `required` does.** Turning
+ * a blocker into a diagnostic rewrites no verdict — and it does change what
+ * those verdicts add up to, because whether a grader can fail a run is read
+ * fresh every time somebody opens the page. A run that failed on this grader
+ * alone reads as passed from the moment the flag turns. That is the flag's
+ * whole job, and "nothing already judged changes" is the tempting short version
+ * that says the opposite of what the person will see next.
  *
  * The labels and the help text for the filled-in values are **not** here: they
  * ride the library entry, and the form renders what it was handed. A list of
@@ -88,10 +94,19 @@ export const EDIT = {
   scope: "Applies to",
   scopeMeans: "Where this grader judges. Live traffic is sampled below.",
   required: "Can fail a run",
-  requiredOn: "A test cannot pass while this grader does not.",
+  /**
+   * Both positions carry the same warning, because turning the flag either way
+   * has the same reach: no verdict is rewritten, and every run already read is
+   * re-counted the next time somebody opens it.
+   */
+  requiredOn:
+    "A test cannot pass while this grader does not. Turning this off rewrites " +
+    "no verdict, and it does change what past ones add up to: a run that " +
+    "failed on this grader alone reads as passed from then on.",
   requiredOff:
     "A diagnostic: judged and shown with its fraction, and never able to fail " +
-    "anything.",
+    "anything. Turning this back on rewrites no verdict, and it does change " +
+    "what past ones add up to: a run this grader failed reads as failed again.",
   sampleRate: "Share of live traffic judged",
   sampleRateMeans:
     "A whole percentage from 0 to 100. It counts only where this grader " +
@@ -100,8 +115,15 @@ export const EDIT = {
   submit: "Save",
   submitting: "Saving…",
   cancel: "Cancel",
+  /**
+   * **Narrow on purpose.** It used to say "what has already been judged is
+   * unchanged", which is true of the verdicts and false of the runs they add
+   * up to — and it was shown at the exact moment somebody had turned `required`
+   * off, which is when it was most wrong. It now claims only what it can: no
+   * verdict was rewritten.
+   */
   saved: (name: string): string =>
-    `${name} is saved. It judges everything in its scope from here on, and what has already been judged is unchanged.`,
+    `${name} is saved. It judges everything in its scope from here on, and no verdict it has already written was rewritten.`,
   unreachable:
     "egma could not be reached, so nothing was saved. Is the API running?",
 } as const;
@@ -175,8 +197,8 @@ export const REQUIRED = {
  *
  * **An empty set of values is a complete grader, not a half-finished one**, and
  * this is the sentence that stops it reading as a gap: the expected-behaviors
- * grader checks whatever the test in front of it says, so there is nothing for
- * anybody to fill in and there never will be.
+ * grader judges whatever the test in front of it says it expects, so there is
+ * nothing for anybody to fill in and there never will be.
  */
 export const CONFIG = {
   fromTheTest: "Whatever the test says it expects",

--- a/apps/web/lib/grader-running-copy.ts
+++ b/apps/web/lib/grader-running-copy.ts
@@ -45,12 +45,101 @@ export const RUNNING = {
   order: "Newest first",
 } as const;
 
-/** The table's headings. */
+/** The table's headings. The last one is blank, because it holds the buttons. */
 export const RUNNING_COLUMNS = {
   name: "Name",
   scope: "Applies to",
   required: "Required",
   config: "Assertions",
+  actions: "",
+} as const;
+
+/**
+ * Changing a running copy: every word the edit form says.
+ *
+ * **The one thing this copy has to make plain is that an edit is two acts.**
+ * Changing a name or turning a blocker into a diagnostic changes nothing about
+ * any judgment already made — it changes what the project lets a failure do,
+ * from now on. Changing a filled-in value changes what the grader *is*, so it
+ * starts the next version and the version behind it stays exactly as it was,
+ * which is what keeps last week's result meaning what it meant. Somebody who
+ * did not know that would read a tightened bound as a rewriting of history.
+ *
+ * The labels and the help text for the filled-in values are **not** here: they
+ * ride the library entry, and the form renders what it was handed. A list of
+ * measures typed into this file would be a second copy of egma's own catalog,
+ * wrong the first time one joined or left.
+ */
+export const EDIT = {
+  open: "Edit",
+  title: (name: string): string => `Edit ${name}`,
+  lead:
+    "What this grader judges by, and where it applies. Values are what a " +
+    "verdict is made of, so changing one starts the next version and leaves " +
+    "everything already judged saying exactly what it said.",
+  /** An entry whose assertions come from the test has nothing to fill in. */
+  asksNothing:
+    "This grader has nothing to fill in. Its assertions are each test's own " +
+    "expected behaviors, read at the moment it judges.",
+  name: "Name",
+  nameMeans: "What this project calls its copy.",
+  description: "Notes",
+  descriptionMeans: "Why your team switched it on. Leave it empty for none.",
+  scope: "Applies to",
+  scopeMeans: "Where this grader judges. Live traffic is sampled below.",
+  required: "Can fail a run",
+  requiredOn: "A test cannot pass while this grader does not.",
+  requiredOff:
+    "A diagnostic: judged and shown with its fraction, and never able to fail " +
+    "anything.",
+  sampleRate: "Share of live traffic judged",
+  sampleRateMeans:
+    "A whole percentage from 0 to 100. It counts only where this grader " +
+    "reaches live traffic, and it moves forward: raising it judges sooner and " +
+    "lowering it judges later, and neither reaches back.",
+  submit: "Save",
+  submitting: "Saving…",
+  cancel: "Cancel",
+  saved: (name: string): string =>
+    `${name} is saved. It judges everything in its scope from here on, and what has already been judged is unchanged.`,
+  unreachable:
+    "egma could not be reached, so nothing was saved. Is the API running?",
+} as const;
+
+/**
+ * Switching a running copy off: every word the delete says.
+ *
+ * **Delete is the off switch, because there is no other one.** There is no
+ * enable flag and no "applies to nothing" setting — a grader either exists and
+ * judges everything in its scope, or it is gone. So this act has to read as
+ * switching off rather than as destroying something, and the two sentences
+ * below are how: one says what stops, and one says what stays.
+ *
+ * The second is the one that must never be dropped. Everything this grader
+ * already judged keeps saying exactly what it said, because the versions it
+ * judged by outlive it — so a result somebody read last week reads the same
+ * today. Without that sentence a person weighing this button is being asked to
+ * choose between a grader they cannot live with and a history they cannot lose.
+ */
+export const SWITCH_OFF = {
+  open: "Switch off",
+  title: (name: string): string => `Switch ${name} off`,
+  stops: "Nothing this project runs from now on is judged by it.",
+  keeps:
+    "Everything it has already judged keeps exactly what it said. Every " +
+    "verdict it wrote stays readable, so a run you have already read still " +
+    "reads the same.",
+  again:
+    "There is no switching it back on. Pick the same grader from the library " +
+    "and press Use, which starts a fresh copy with its own settings.",
+  confirm: "Switch it off",
+  confirming: "Switching off…",
+  cancel: "Keep it",
+  done: (name: string): string =>
+    `${name} is switched off. Nothing new is judged by it, and everything it already judged reads exactly as it did.`,
+  unreachable:
+    "egma could not be reached, so nothing was switched off. Is the API " +
+    "running?",
 } as const;
 
 /**

--- a/apps/web/lib/write.ts
+++ b/apps/web/lib/write.ts
@@ -1,0 +1,56 @@
+/**
+ * One write to egma, and the three answers a screen has to tell apart.
+ *
+ * **It exists because the three were being told apart three times.** Every form
+ * on a product page does the same four things — post, read a refusal off the
+ * body, fall back to its own sentence when the body carried none, and treat a
+ * thrown request as the platform being out of reach — and each copy is a chance
+ * to drop the third. A refusal shown as "egma could not be reached" when egma
+ * answered perfectly well and said why is the failure this shape prevents: the
+ * developer goes looking at their network and the sentence naming the field
+ * they got wrong is on the floor.
+ *
+ * **What it does not do is hold the busy flag.** Whether a button is disabled
+ * while a request is in flight is the form's own business, and a helper that
+ * reached into a caller's state to set it would be harder to read than the two
+ * lines it replaced.
+ */
+
+export type Write = {
+  readonly url: string;
+  readonly method: "POST" | "PATCH" | "DELETE";
+  /** Sent as JSON. Absent for a verb with nothing to say, like a delete. */
+  readonly body?: unknown;
+  /** What to show when egma never answered at all. */
+  readonly unreachable: string;
+};
+
+/**
+ * `null` where the write landed, and otherwise the sentence to put in front of
+ * somebody — egma's own words wherever egma sent any.
+ */
+export async function wrote(write: Write): Promise<string | null> {
+  try {
+    const answer = await fetch(write.url, {
+      method: write.method,
+      ...(write.body === undefined
+        ? {}
+        : {
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(write.body),
+          }),
+    });
+
+    if (answer.ok) return null;
+
+    // The refusal, relayed word for word: these sentences are written to be
+    // read by the person who has to fix the thing, and a screen paraphrasing
+    // one would be a second, worse copy of the contract.
+    const said = (await answer.json().catch(() => ({}))) as {
+      message?: string;
+    };
+    return said.message ?? write.unreachable;
+  } catch {
+    return write.unreachable;
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -91,10 +91,18 @@ const config: NextConfig = {
           source: "/api/grader-library",
           destination: `${api}/api/grader-library`,
         },
-        // The running copies beside the shelf. One rule and no `:path*`: the
-        // group answers a list and a Use at one address, and a second address
-        // under it would be a forwarding rule for a door that does not exist.
+        // The running copies beside the shelf: the list and Use at the group's
+        // own address, and one copy's own address beside it — where an edit
+        // changes what it judges by and a delete switches it off. Both rules,
+        // for the reason the traces pair below spells out: `:path*` is
+        // documented as matching zero segments and on the hosted deployment it
+        // did not, so the bare path is named outright rather than left to
+        // depend on how a host reads the wildcard.
         { source: "/api/graders", destination: `${api}/api/graders` },
+        {
+          source: "/api/graders/:path*",
+          destination: `${api}/api/graders/:path*`,
+        },
         { source: "/api/tests", destination: `${api}/api/tests` },
         { source: "/api/tests/:path*", destination: `${api}/api/tests/:path*` },
         {

--- a/apps/web/test/grader-library.test.ts
+++ b/apps/web/test/grader-library.test.ts
@@ -160,14 +160,23 @@ describe("getting to the Library screen", () => {
  * door checks the catalog they were built from, and neither can drift.
  */
 describe("pressing Use", () => {
+  /**
+   * The `fetch` itself moved into `lib/write.ts` when a second and third form
+   * on this section needed the same four steps — post, read egma's own refusal
+   * off the body, fall back to a sentence of its own where the body carried
+   * none, and treat a thrown request as the platform being out of reach. What
+   * this case is about is unchanged: the address and the verb, which is what
+   * the rewrite rule beside it has to match.
+   */
   it("writes the copy at the path this instance rewrites", async () => {
     const rewrites = await readFile(path.join(WEB, "next.config.ts"), "utf8");
     const form = await readFile(path.join(WEB, "app/graders/use-form.tsx"), "utf8");
 
     expect(rewrites).toContain("/api/graders");
-    expect(form).toContain('fetch("/api/graders"');
+    expect(form).toContain('url: "/api/graders"');
     expect(form).toContain('method: "POST"');
     expect(form).toContain("library_id");
+    expect(form).toContain('from "../../lib/write.ts"');
   });
 
   it("draws its controls from the entry's own declaration, and names no measure", async () => {

--- a/apps/web/test/grader-running.test.ts
+++ b/apps/web/test/grader-running.test.ts
@@ -203,3 +203,133 @@ describe("getting to the Running-graders screen", () => {
     expect(page).not.toMatch(/state\.status === "loading"[\s\S]*?return <StatePage/);
   });
 });
+
+/**
+ * The two acts this screen owns, and the ones the shelf beside it cannot do.
+ *
+ * Pressing Use makes a copy; changing what that copy judges by and switching it
+ * off are decisions about a grader that already exists. Before this screen had
+ * them, a bound typed too tight was permanent — every run red for ever, with no
+ * way back short of somebody editing the database by hand.
+ */
+describe("changing a running copy and switching one off", () => {
+  /**
+   * A path the page writes to and the config does not forward would be served
+   * by this process, which has no such route, and the screen would read Next's
+   * own 404 as though egma had refused the edit.
+   */
+  it("writes at the copy's own address, which this instance rewrites", async () => {
+    const rewrites = await readFile(path.join(WEB, "next.config.ts"), "utf8");
+    const form = await readFile(
+      path.join(WEB, "app/graders/running/edit-form.tsx"),
+      "utf8",
+    );
+
+    expect(rewrites).toContain("/api/graders/:path*");
+    expect(form).toContain("`/api/graders/${copy.id}`");
+    expect(form).toContain('method: "PATCH"');
+    expect(form).toContain('method: "DELETE"');
+  });
+
+  /**
+   * **The edit form is the Use form's controls.** What a grader asks for is the
+   * library entry's own declaration, and both forms render that one list
+   * through one component — so this file names no measure and no bound, and a
+   * parameter that learns a new kind of control learns it once. A second
+   * rendering here would be a second reading of the platform's declaration,
+   * drifting the first time one of them was changed.
+   */
+  it("draws its controls from the entry, through the form Use is drawn with", async () => {
+    const form = await readFile(
+      path.join(WEB, "app/graders/running/edit-form.tsx"),
+      "utf8",
+    );
+
+    expect(form).toContain("EntryFields");
+    expect(form).toContain('from "../use-form.tsx"');
+
+    // Not one measure name, nor the parameter names the latency entry happens
+    // to use. The comments are read past on purpose: prose explaining why the
+    // list is not here is the opposite of the list being here.
+    const running = form.replaceAll(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/gu, "");
+    for (const named of [
+      "turn_response_latency",
+      "first_response_latency",
+      "milliseconds",
+      "latency",
+      "metric",
+      "bound",
+    ]) {
+      expect(running, `the form names ${named} itself`).not.toContain(named);
+    }
+  });
+
+  /**
+   * The page needs the shelf as well as the copies: what a copy's form asks for
+   * is its entry's declaration, and a page holding the copies without their
+   * entries would draw an edit form with no controls in it — which reads as a
+   * grader that asks nothing rather than as a page still loading.
+   */
+  it("reads the shelf beside the copies, so a form can be drawn from an entry", async () => {
+    const page = await readFile(
+      path.join(WEB, "app/graders/running/page.tsx"),
+      "utf8",
+    );
+    expect(page).toContain('fetch("/api/grader-library")');
+    expect(page).toContain("library_id");
+  });
+
+  /**
+   * **The delete has to say what stays, not only what stops.**
+   *
+   * Deleting is the off switch — there is no enable flag and no scope that
+   * means nowhere — so the button removes a project's judging, and the fear it
+   * raises is about the runs already read. Every verdict the copy wrote stays
+   * readable because its versions outlive it, and saying so is what makes the
+   * button pressable by somebody whose grader is failing every run.
+   */
+  it("says plainly that what a switched-off grader already judged is unchanged", () => {
+    expect(copy.SWITCH_OFF.stops).toBeTruthy();
+    expect(copy.SWITCH_OFF.keeps.toLowerCase()).toContain("already judged");
+    expect(copy.SWITCH_OFF.done("Latency").toLowerCase()).toContain(
+      "already judged",
+    );
+    // And what pressing it cannot be undone into, since there is no other
+    // switch to put it back with.
+    expect(copy.SWITCH_OFF.again).toContain("Use");
+  });
+
+  /**
+   * An edit is two acts wearing one verb, and only one of them touches what a
+   * verdict was decided by. Somebody who did not know that would read a
+   * tightened bound as a rewriting of history.
+   */
+  it("says that changing a value starts a version and changes nothing already judged", () => {
+    expect(copy.EDIT.lead.toLowerCase()).toContain("version");
+    expect(copy.EDIT.saved("Latency").toLowerCase()).toContain("unchanged");
+  });
+
+  it("says what required means, in both positions", () => {
+    expect(copy.EDIT.requiredOn).toContain("cannot pass");
+    expect(copy.EDIT.requiredOff.toLowerCase()).toContain("diagnostic");
+  });
+
+  /**
+   * The buttons are the copy file's words like every other string on this
+   * screen, so the banned list above reaches them too.
+   */
+  it("is what the page and the form actually render", async () => {
+    const page = await readFile(
+      path.join(WEB, "app/graders/running/page.tsx"),
+      "utf8",
+    );
+    const form = await readFile(
+      path.join(WEB, "app/graders/running/edit-form.tsx"),
+      "utf8",
+    );
+
+    expect(page).toContain("EDIT.open");
+    expect(page).toContain("SWITCH_OFF.open");
+    expect(form).toContain("grader-running-copy.ts");
+  });
+});

--- a/apps/web/test/grader-running.test.ts
+++ b/apps/web/test/grader-running.test.ts
@@ -304,14 +304,41 @@ describe("changing a running copy and switching one off", () => {
    * verdict was decided by. Somebody who did not know that would read a
    * tightened bound as a rewriting of history.
    */
-  it("says that changing a value starts a version and changes nothing already judged", () => {
+  it("says that changing a value starts a version", () => {
     expect(copy.EDIT.lead.toLowerCase()).toContain("version");
-    expect(copy.EDIT.saved("Latency").toLowerCase()).toContain("unchanged");
+  });
+
+  /**
+   * **The claim after a save has to be the narrow one, and this is the case
+   * that keeps it narrow.**
+   *
+   * "What has already been judged is unchanged" is true of the verdict rows and
+   * false of the runs they add up to — and it was being shown at the exact
+   * moment somebody had turned `required` off, which is when it was most wrong.
+   * Whether a grader can fail a run is read fresh on every page, so a run that
+   * failed on this one alone reads as passed from that moment.
+   */
+  it("claims only that no verdict was rewritten, never that nothing changed", () => {
+    const saved = copy.EDIT.saved("Latency").toLowerCase();
+    expect(saved).toContain("verdict");
+    expect(saved).not.toContain("is unchanged");
+    expect(saved).not.toContain("nothing already judged");
   });
 
   it("says what required means, in both positions", () => {
     expect(copy.EDIT.requiredOn).toContain("cannot pass");
     expect(copy.EDIT.requiredOff.toLowerCase()).toContain("diagnostic");
+  });
+
+  /**
+   * And both positions warn about the one thing a live setting does reach: the
+   * verdicts stay put, and what they add up to does not.
+   */
+  it("says that turning the required flag round re-counts runs already read", () => {
+    for (const said of [copy.EDIT.requiredOn, copy.EDIT.requiredOff]) {
+      expect(said.toLowerCase()).toContain("rewrites no verdict");
+      expect(said.toLowerCase()).toContain("add up to");
+    }
   });
 
   /**

--- a/packages/db/src/access/graders.ts
+++ b/packages/db/src/access/graders.ts
@@ -59,10 +59,19 @@ import { inActingProject, within } from "./within.ts";
  * and the judge model are what a judgment is made of, so they live in immutable
  * versions and an edit mints the next one, leaving last week's run meaning
  * exactly what it meant. The `required` flag, the scope and the sampling rate
- * change nothing about any judgment already made, so they are written in place
- * and take effect everywhere at once. A developer tightening a bound and a
- * developer turning a blocker into a diagnostic are doing two different things,
- * and only one of them is rewriting history if it is versioned wrongly.
+ * rewrite no verdict already written, so they are written in place and take
+ * effect everywhere at once. A developer tightening a bound and a developer
+ * turning a blocker into a diagnostic are doing two different things, and only
+ * one of them is rewriting history if it is versioned wrongly.
+ *
+ * **`required` is the one that reaches an old page anyway, and on purpose.** It
+ * changes no row; it changes which lane a row is folded in, and the fold runs
+ * at read time — so a run that failed on this grader alone reads as passed from
+ * the moment the flag turns. That is the flag's whole job: nothing about the
+ * judgment changed, only what the project lets a failure do, and the answer has
+ * to be the one in force when somebody looks. Verdicts unchanged; what they add
+ * up to changed. The two are not the same sentence and this file does not
+ * pretend they are.
  */
 
 /**
@@ -107,9 +116,22 @@ export type GraderConfig = {
   readonly assertions: readonly GraderAssertion[];
 };
 
+/**
+ * The library entry's form filled in, before anything has checked it: the
+ * answers to whatever that entry declared, under the names it declared them.
+ *
+ * It is a name rather than a bare map because it is the shape both write doors
+ * take — **Use** creates a copy from one and an edit replaces a copy's values
+ * with one — and a primitive spelled out at each of them would be four places
+ * agreeing by coincidence. What may be in it is the entry's decision and
+ * nothing here can narrow it, which is why the values are `unknown` until
+ * `validValue` has held each against its declared parameter.
+ */
+export type FilledInForm = Readonly<Record<string, unknown>>;
+
 /** The config as a caller writes one; the same shape, before it is checked. */
 export type GraderConfigInput = {
-  readonly assertions: readonly Readonly<Record<string, unknown>>[];
+  readonly assertions: readonly FilledInForm[];
 };
 
 /**
@@ -137,7 +159,7 @@ type LiveSettings = {
  */
 export type UseLibraryEntry = LiveSettings & {
   readonly libraryId: string;
-  readonly params?: Readonly<Record<string, unknown>> | undefined;
+  readonly params?: FilledInForm | undefined;
   readonly judgeModel?: JudgeModel | undefined;
 };
 
@@ -189,7 +211,7 @@ export type GraderChanges = {
   readonly scope?: GraderScope;
   readonly productionSampleRate?: number;
   /** The entry's form filled in once, exactly as **Use** takes it. */
-  readonly params?: Readonly<Record<string, unknown>>;
+  readonly params?: FilledInForm;
   readonly config?: GraderConfigInput;
   readonly judgeModel?: JudgeModel | null;
 };
@@ -443,6 +465,22 @@ function validValue(
 }
 
 /**
+ * What an entry that asks nothing says when something arrives for it anyway.
+ *
+ * One sentence with two callers, because there are two ways to send a value to
+ * a grader that has no questions: a set carrying a key it never declared, and a
+ * set carrying no keys at all. The second reads as harmless and is not — an
+ * empty assertion is a row the Running graders screen counts, so a copy whose
+ * assertions are the test's own sentences would report holding one of its own.
+ */
+function asksNothing(definition: Definition, because: string): string {
+  return (
+    `the ${definition.name} grader asks for nothing, so ${because} — its ` +
+    `assertions are the test's own expected behaviors`
+  );
+}
+
+/**
  * One assertion's filled-in values, checked against what the entry asks for —
  * every parameter answered, and nothing answered that was never asked.
  *
@@ -464,7 +502,7 @@ function validAssertion(
   if (unexpected.length > 0) {
     throw new UnprocessableInputError(
       asked.length === 0
-        ? `the ${definition.name} grader asks for nothing, so "${unexpected.join('", "')}" has nowhere to go — its assertions are the test's own expected behaviors`
+        ? asksNothing(definition, `"${unexpected.join('", "')}" has nowhere to go`)
         : `the ${definition.name} grader does not ask for "${unexpected.join('", "')}"; it asks for "${asked.join('", "')}"`,
     );
   }
@@ -482,7 +520,11 @@ function validAssertion(
  * **An entry that asks for something needs at least one.** A latency copy with
  * no assertions reads nothing, judges nothing, and is a row on the Running
  * graders screen that says a project is checking something it is not. An entry
- * that asks nothing must have none, for the mirror-image reason.
+ * that asks nothing must have none, for the mirror-image reason: an empty set
+ * of answers passes every rule above it — there is no key that was never asked
+ * for and no parameter left unanswered — and stores an assertion holding
+ * nothing, which the screen counts and nothing ever judges. Both halves are
+ * enforced below; only the first one used to be.
  *
  * **And no measure twice, which is the rule that makes an assertion knowable.**
  * A verdict row is filed under the measure its check bounds, because a copy's
@@ -512,6 +554,15 @@ function validConfig(
       `the ${definition.name} grader needs at least one assertion — "${definition.params
         .map((parameter) => parameter.name)
         .join('", "')}" — because a copy that checks nothing can never fail`,
+    );
+  }
+
+  if (definition.params.length === 0 && assertions.length > 0) {
+    throw new UnprocessableInputError(
+      asksNothing(
+        definition,
+        "there is nothing to fill in and an empty set of answers would be stored as though there were",
+      ),
     );
   }
 
@@ -564,9 +615,7 @@ function measureNamedTwice(
  * what they were given against the entry through `validConfig` and neither
  * holds an opinion of its own about a bound.
  */
-function oneFilledInSet(
-  params: Readonly<Record<string, unknown>>,
-): GraderConfigInput {
+function oneFilledInSet(params: FilledInForm): GraderConfigInput {
   return { assertions: [params] };
 }
 
@@ -581,14 +630,23 @@ function oneFilledInSet(
 const NOTHING_TO_FILL_IN: GraderConfigInput = { assertions: [] };
 
 /**
- * The filled-in values an edit is asking for, or nothing where it is asking for
- * none — which means keep what is stored.
+ * The filled-in values an edit is asking for, and which of the two names it
+ * asked under — or nothing at all, which means keep what is stored.
  *
  * The two names are one thing said at two grains, so exactly one may be used.
  * Refusing rather than ranking them: a precedence rule would quietly decide
  * which of two lists somebody meant, and the only honest answer is to ask.
+ *
+ * Which name was used travels on, because it decides one more thing that cannot
+ * be settled until the stored config has been read — see `wouldLoseAssertions`.
  */
-function valuesIn(changes: GraderChanges): GraderConfigInput | undefined {
+type AskedValues = {
+  /** `params` is one filled-in set; `config` is the whole list. */
+  readonly under: "params" | "config";
+  readonly values: GraderConfigInput;
+};
+
+function valuesIn(changes: GraderChanges): AskedValues | undefined {
   if (changes.params !== undefined && changes.config !== undefined) {
     throw new UnprocessableInputError(
       `an edit says a grader's filled-in values once: "params" is the entry's ` +
@@ -596,8 +654,45 @@ function valuesIn(changes: GraderChanges): GraderConfigInput | undefined {
         `whichever fits and not both.`,
     );
   }
-  if (changes.params !== undefined) return oneFilledInSet(changes.params);
-  return changes.config;
+  if (changes.params !== undefined) {
+    return { under: "params", values: oneFilledInSet(changes.params) };
+  }
+  if (changes.config !== undefined) {
+    return { under: "config", values: changes.config };
+  }
+  return undefined;
+}
+
+/**
+ * Whether replacing a copy's values with **one filled-in set** would quietly
+ * drop assertions it is holding.
+ *
+ * `params` is the form asked once, so it can only ever say one assertion. On a
+ * copy that holds one — every copy the product can make today, because Use
+ * writes exactly one set or none — that is a complete replacement and nothing
+ * is lost. On a copy holding two it is a truncation, and a silent one twice
+ * over: the second bound stops being judged, *and* the edit mints a version
+ * recording the loss as though somebody had asked for it.
+ *
+ * Nothing in the product can build such a copy yet — only `config` can, and no
+ * door outside this module offers it. The refusal is here because that changes
+ * the moment either re-grade or custom authoring lands, and a screen filling
+ * one set into a two-assertion copy is exactly the shape that would then arrive.
+ * It names `config`, which is the way to say the whole list on purpose.
+ */
+function wouldLoseAssertions(
+  asked: AskedValues,
+  stored: GraderConfig,
+): string | undefined {
+  if (asked.under !== "params" || stored.assertions.length <= 1) {
+    return undefined;
+  }
+  return (
+    `this grader holds ${stored.assertions.length} assertions, and "params" ` +
+    `is the entry's form filled in once — sending it would replace all of ` +
+    `them with that one and mint a version saying the rest were never there. ` +
+    `Send "config" with every assertion this grader should keep.`
+  );
 }
 
 /**
@@ -911,7 +1006,7 @@ export async function editGrader(
   // Which of the two names carried the values is settled before anything is
   // read; what those values may hold is the entry's business and is checked
   // below, inside the transaction, by the code Use goes through.
-  const written = valuesIn(changes);
+  const asked = valuesIn(changes);
 
   return db().transaction(async (tx) => {
     const [locked] = await tx
@@ -948,12 +1043,21 @@ export async function editGrader(
       currentVersion.id,
     );
 
+    // The one refusal that needs the stored config in front of it: whether the
+    // grain this edit spoke in can say everything this copy is holding.
+    const losing =
+      asked === undefined ? undefined : wouldLoseAssertions(asked, stored);
+    if (losing !== undefined) throw new UnprocessableInputError(losing);
+
     // Omitted means unchanged, and what given values are checked against is the
     // entry this copy points at rather than anything the caller said.
     const config =
-      written === undefined
+      asked === undefined
         ? stored
-        : validConfig(await definitionOf(tx, auth, current.libraryId), written);
+        : validConfig(
+            await definitionOf(tx, auth, current.libraryId),
+            asked.values,
+          );
     const nextJudgeModel =
       judgeModel === undefined ? storedJudgeModel : judgeModel;
 

--- a/packages/db/src/access/graders.ts
+++ b/packages/db/src/access/graders.ts
@@ -173,6 +173,14 @@ export type Grader = {
  * either would leave the history holding answers to questions this grader no
  * longer asks — a different grader wearing the old one's history. Pressing Use
  * again costs one call and says what actually happened.
+ *
+ * **The values arrive by either of two names, and they mean one thing.**
+ * `params` is the entry's form filled in once — the shape **Use** takes, so a
+ * screen that drew the form to create a copy draws the same form to change it
+ * and sends the same body. `config` is the whole list, which is what a copy
+ * holding more than one assertion needs. Both go through the same check against
+ * the same entry; sending both at once is refused rather than ranked, because a
+ * precedence rule here would decide which of two things somebody meant.
  */
 export type GraderChanges = {
   readonly name?: string;
@@ -180,6 +188,8 @@ export type GraderChanges = {
   readonly required?: boolean;
   readonly scope?: GraderScope;
   readonly productionSampleRate?: number;
+  /** The entry's form filled in once, exactly as **Use** takes it. */
+  readonly params?: Readonly<Record<string, unknown>>;
   readonly config?: GraderConfigInput;
   readonly judgeModel?: JudgeModel | null;
 };
@@ -545,6 +555,52 @@ function measureNamedTwice(
 }
 
 /**
+ * A form filled in once, as the config it becomes.
+ *
+ * **One set of answers is one assertion**, because that is what the form is:
+ * the entry's questions, asked once. It is written here rather than at each
+ * door so that **Use** and an edit cannot come to disagree about what somebody
+ * filling that form in has said — which is the same reason both of them check
+ * what they were given against the entry through `validConfig` and neither
+ * holds an opinion of its own about a bound.
+ */
+function oneFilledInSet(
+  params: Readonly<Record<string, unknown>>,
+): GraderConfigInput {
+  return { assertions: [params] };
+}
+
+/**
+ * A form that asked nothing, filled in.
+ *
+ * **Empty is a complete answer, not an unfinished one**, and this is the shape
+ * a correct expected-behaviors copy keeps forever: its assertions are the
+ * test's own sentences, supplied per test at judging time, so there has never
+ * been anything here for anybody to type.
+ */
+const NOTHING_TO_FILL_IN: GraderConfigInput = { assertions: [] };
+
+/**
+ * The filled-in values an edit is asking for, or nothing where it is asking for
+ * none — which means keep what is stored.
+ *
+ * The two names are one thing said at two grains, so exactly one may be used.
+ * Refusing rather than ranking them: a precedence rule would quietly decide
+ * which of two lists somebody meant, and the only honest answer is to ask.
+ */
+function valuesIn(changes: GraderChanges): GraderConfigInput | undefined {
+  if (changes.params !== undefined && changes.config !== undefined) {
+    throw new UnprocessableInputError(
+      `an edit says a grader's filled-in values once: "params" is the entry's ` +
+        `form filled in, and "config" is the whole list of assertions. Send ` +
+        `whichever fits and not both.`,
+    );
+  }
+  if (changes.params !== undefined) return oneFilledInSet(changes.params);
+  return changes.config;
+}
+
+/**
  * The shape guard on every read. Stored jsonb comes back `unknown`, and a row
  * somebody hand-edited must fail here, loudly and naming itself, rather than
  * leak into a caller as a config that isn't one.
@@ -719,12 +775,12 @@ export async function useLibraryEntry(
 
   const written = await db().transaction(async (tx) => {
     const definition = await definitionOf(tx, auth, input.libraryId);
-    const config = validConfig(definition, {
-      // One filled-in set is one assertion, which is what the form produces.
-      // Nothing at all is an entry that asks nothing, and its copy is born with
-      // an empty list — the shape a correct expected-behaviors copy keeps.
-      assertions: input.params === undefined ? [] : [input.params],
-    });
+    const config = validConfig(
+      definition,
+      input.params === undefined
+        ? NOTHING_TO_FILL_IN
+        : oneFilledInSet(input.params),
+    );
 
     const [identity] = await tx
       .insert(grader)
@@ -852,6 +908,10 @@ export async function editGrader(
     changes.judgeModel === undefined || changes.judgeModel === null
       ? changes.judgeModel
       : validJudgeModel(changes.judgeModel);
+  // Which of the two names carried the values is settled before anything is
+  // read; what those values may hold is the entry's business and is checked
+  // below, inside the transaction, by the code Use goes through.
+  const written = valuesIn(changes);
 
   return db().transaction(async (tx) => {
     const [locked] = await tx
@@ -888,15 +948,12 @@ export async function editGrader(
       currentVersion.id,
     );
 
-    // Omitted means unchanged, and what a given config is checked against is
-    // the entry this copy points at rather than anything the caller said.
+    // Omitted means unchanged, and what given values are checked against is the
+    // entry this copy points at rather than anything the caller said.
     const config =
-      changes.config === undefined
+      written === undefined
         ? stored
-        : validConfig(
-            await definitionOf(tx, auth, current.libraryId),
-            changes.config,
-          );
+        : validConfig(await definitionOf(tx, auth, current.libraryId), written);
     const nextJudgeModel =
       judgeModel === undefined ? storedJudgeModel : judgeModel;
 
@@ -1085,6 +1142,16 @@ export type GraderFacts = {
  * — its versions outlive it so that they stay interpretable — and a diagnostic
  * that somebody switched off must not start failing a run's headline the moment
  * it goes. Whether the copy is still running is not what this question asks.
+ *
+ * That clause became load-bearing the day switching a copy off became something
+ * a person can do from a screen. The two rules it sits between pull opposite
+ * ways: an unresolvable grader is read as **required**, which is the safe
+ * direction for a row nobody can place, and a switched-off copy is perfectly
+ * placeable. Filtering it out here would hand every failing row a diagnostic
+ * ever wrote to the lane that decides — a run that passed last month turning
+ * red because somebody tidied up this morning. Deleting a copy says what judges
+ * from now on and nothing about what a past run meant, and
+ * `apps/grader/test/edited-and-switched-off.test.ts` is where that is pinned.
  *
  * **A copy this cannot see is simply absent**, and every caller reads that
  * absence the safe way: a copy it cannot see is required, and an unresolvable

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -451,6 +451,7 @@ export {
   listGraders,
   useLibraryEntry,
   type DeletedGrader,
+  type FilledInForm,
   type Grader,
   type GraderAssertion,
   type GraderChanges,

--- a/packages/db/test/graders-edit-versions.test.ts
+++ b/packages/db/test/graders-edit-versions.test.ts
@@ -29,8 +29,16 @@ import {
  * The line every test in this file draws is between what a verdict was decided
  * by and where the decision applies. Tightening a bound changes what a verdict
  * means, so it mints a version and the old one stays exactly readable; making a
- * blocker into a diagnostic changes nothing already judged, so it writes in
- * place and is true the moment it returns.
+ * blocker into a diagnostic rewrites no verdict, so it writes in place and is
+ * true the moment it returns.
+ *
+ * **"Rewrites no verdict" is the whole claim, and it is narrower than it
+ * sounds.** Turning `required` off changes what those verdicts *add up to*: the
+ * fold reads the flag as it stands, so a run that failed on one grader alone
+ * reads as passed from that moment. That is the flag's job and it is proved in
+ * `apps/grader/test/lanes.test.ts`. Nothing in this file may be read as saying
+ * a live setting cannot reach a page about the past — only that it never
+ * touches a row.
  *
  * **The filled-in values are all a copy holds, and they are checked against the
  * entry it points at** — read live, on every edit, which is the same check Use
@@ -260,6 +268,74 @@ describe("editing what a grader judges by", () => {
         params: { metric: "turn_response_latency", bound: 1500, aggregation: "p90" },
       }),
     ).rejects.toThrow(/does not ask for/);
+  });
+
+  /**
+   * **One filled-in set cannot say two assertions, so it is refused rather than
+   * allowed to truncate.**
+   *
+   * `params` is the form asked once. On a copy holding one set — every copy the
+   * product can make today — replacing is complete and nothing is lost. On a
+   * copy holding two it is a silent truncation twice over: the second bound
+   * stops being judged, and the edit mints a version recording the loss as
+   * though somebody had asked for it. Nothing outside this module can build
+   * such a copy yet, which is exactly why the door is shut now: re-grade and
+   * custom authoring are what make one arrive.
+   */
+  it("refuses one filled-in set for a copy that holds more than one assertion", async () => {
+    const created = await useLibraryEntry(actingAsAcme(), {
+      ...latency,
+      name: "Two bounds, one form",
+    });
+    const grown = await editGrader(actingAsAcme(), created.id, {
+      config: {
+        assertions: [
+          { metric: "turn_response_latency", bound: 2000 },
+          { metric: "first_response_latency", bound: 900 },
+        ],
+      },
+    });
+    expect(grown?.version).toBe(2);
+
+    await expect(
+      editGrader(actingAsAcme(), created.id, {
+        params: { metric: "turn_response_latency", bound: 1500 },
+      }),
+    ).rejects.toThrow(/config/);
+
+    // Both bounds still there, and no version minted by the refusal.
+    const fetched = await getGrader(actingAsAcme(), created.id);
+    expect(fetched?.version).toBe(2);
+    expect(fetched?.config.assertions).toHaveLength(2);
+
+    // And the whole list, said as the whole list, goes through.
+    const narrowed = await editGrader(actingAsAcme(), created.id, {
+      config: { assertions: [{ metric: "turn_response_latency", bound: 1500 }] },
+    });
+    expect(narrowed?.version).toBe(3);
+    expect(narrowed?.config.assertions).toHaveLength(1);
+  });
+
+  /**
+   * The mirror of the "needs at least one" rule, which the module promised and
+   * did not enforce: an entry that asks nothing must hold none. An empty set of
+   * answers passes every rule about keys and stores an assertion holding
+   * nothing — a row the Running graders screen counts and nothing ever judges.
+   */
+  it("refuses an empty set of values on an entry that asks nothing", async () => {
+    const behaviors = await useLibraryEntry(actingAsAcme(), {
+      libraryId: PREDEFINED_GRADERS.expectedBehaviors,
+      name: "A second opinion on the behaviors",
+    });
+    expect(behaviors.config).toEqual({ assertions: [] });
+
+    await expect(
+      editGrader(actingAsAcme(), behaviors.id, { params: {} }),
+    ).rejects.toThrow(/asks for nothing/);
+
+    const fetched = await getGrader(actingAsAcme(), behaviors.id);
+    expect(fetched?.config).toEqual({ assertions: [] });
+    expect(fetched?.version).toBe(1);
   });
 
   /**

--- a/packages/db/test/graders-edit-versions.test.ts
+++ b/packages/db/test/graders-edit-versions.test.ts
@@ -237,6 +237,50 @@ describe("editing what a grader judges by", () => {
   });
 
   /**
+   * **The form filled in once is what a screen sends, and it means what it
+   * means on a Use.** `params` is the entry's questions answered — one set,
+   * which is one assertion — so the door that made a copy and the door that
+   * changes one send the same shape and go through the same check. Anything
+   * else would be a browser page holding its own idea of what a bound is.
+   */
+  it("takes the entry's form filled in, exactly as Use takes it", async () => {
+    const created = await useLibraryEntry(actingAsAcme(), latency);
+
+    const edited = await editGrader(actingAsAcme(), created.id, {
+      params: { metric: "turn_response_latency", bound: 1500 },
+    });
+
+    expect(edited?.version).toBe(2);
+    expect(edited?.config).toEqual(boundedAt(1500));
+
+    // And it is checked against the entry this copy points at, in the entry's
+    // own words — the same refusal Use answers with.
+    await expect(
+      editGrader(actingAsAcme(), created.id, {
+        params: { metric: "turn_response_latency", bound: 1500, aggregation: "p90" },
+      }),
+    ).rejects.toThrow(/does not ask for/);
+  });
+
+  /**
+   * Two names for one thing, so exactly one may be used. Ranking them would
+   * quietly decide which of two lists somebody meant, and the only honest
+   * answer to that is to ask.
+   */
+  it("refuses an edit that says its values twice", async () => {
+    const created = await useLibraryEntry(actingAsAcme(), latency);
+
+    await expect(
+      editGrader(actingAsAcme(), created.id, {
+        params: { metric: "turn_response_latency", bound: 1500 },
+        config: boundedAt(1200),
+      }),
+    ).rejects.toThrow(/once/);
+
+    expect((await getGrader(actingAsAcme(), created.id))?.version).toBe(1);
+  });
+
+  /**
    * The pointer and the type are set at Use time and are not on the change
    * surface at all: every version behind a copy holds values its type shapes, so
    * a copy that could change either would be a different grader wearing the old


### PR DESCRIPTION
Ticket 06 of the grader-redesign effort — the first follow-up after the effort merged (#102). Ticket text in the planning repo, raised as egma-planning#27.

A developer presses **Use** on latency, types a bound, and today lives with it. There is no route to change the values, no route to change `required` or `scope`, and no route to delete the copy. A bound typed too tight makes every run red for ever, and the only way out is a hand-written `update` against Postgres. The machinery has been sitting in the data-access module since ticket 03 with no door onto it — deliberate when custom authoring was shelved, and now the one thing between a developer and an ordinary correction.

- **`PATCH /api/graders/:graderId`** changes live settings — `name`, `description`, `required`, `scope`, `production_sample_rate` — without minting a version, and changes the copy's filled-in values **with** one. Sending values that are byte-identical mints nothing either.
- Values are validated by **the same path Use validates them with**, so the two doors can never disagree about what a bound is. A bad edit is refused with the same sentence, asserted equal rather than written twice.
- **`DELETE /api/graders/:graderId`** switches a copy off: no later run is judged by it, and every verdict row it already wrote stays readable, in the lane it was already in.
- Deleting a copy does not release its library entry — an entry with a switched-off copy pointing at it is still refused deletion.
- The **Running-graders tab** can edit a copy and switch one off, rendering the entry's own fields through the same component the Use form draws them with.

### Two judgement calls worth reading

**`graderFacts` still reads `required` live, with no deleted filter, and that is deliberate.** The fold treats a grader it cannot resolve as required — the safe direction for a row nobody can place. Add a `notDeleted` filter and every switched-off copy becomes unresolvable, so every failing row a *diagnostic* ever wrote moves into the lane that decides, and a run that passed last month goes red because somebody tidied up. Proved by temporarily adding the filter and watching the new diagnostic case fail. The reasoning now sits beside the query.

**The `required` flag reaches backwards, and the screen now says so.** Flipping it rewrites no verdict, but it does change what verdicts add up to: a run that failed on one grader alone reads as passed from then on. That is intended and pinned. Review caught that five places said the opposite — the saved-message a user reads at the exact moment they untick the box, three doc comments, and a module header. All five now say the true thing: no verdict is rewritten, and what they add up to does change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789411582&installation_model_id=431960&pr_number=115&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F115&signature=7825f9f52be51b2d3395634bdc5cb5b45f37e703cefac51096f3f06c24eb3003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds editing and soft deletion for running grader copies while preserving versioned judgment inputs and historical verdicts.
- Adds authenticated PATCH and DELETE endpoints for running graders.
- Versions changed grader parameters while updating live settings in place.
- Adds edit and switch-off controls to the Running graders UI.
- Extends database, API, browser, and grading tests for editing and deletion behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/graders.ts | Adds validated PATCH and DELETE routes; the prior malformed-field handling defect is corrected by rejecting present non-text values. |
| packages/db/src/access/graders.ts | Implements grader editing and soft deletion while separating versioned parameter changes from live-setting updates. |
| apps/web/app/graders/running/edit-form.tsx | Adds the running-grader editing form using library-defined fields and existing write handling. |
| apps/web/app/graders/running/page.tsx | Adds edit and switch-off interactions and refreshes the running-grader list after successful writes. |
| apps/web/lib/grader-running-copy.ts | Adds client-side representation and handling for editable running grader copies. |
| apps/api/test/graders-routes.test.ts | Covers edit, deletion, authorization, validation, partial-update, and versioning contracts. |
| packages/db/test/graders-edit-versions.test.ts | Verifies version minting and in-place updates at the database access layer. |
| apps/grader/test/edited-and-switched-off.test.ts | Verifies that edits affect subsequent judgments and switched-off graders no longer judge new runs. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  UI[Running graders UI] -->|PATCH settings or values| API[Grader API]
  API --> Edit[editGrader]
  Edit -->|Live settings changed| InPlace[Update running copy in place]
  Edit -->|Filled values changed| Version[Mint grader version]
  UI -->|DELETE| DeleteAPI[Grader API]
  DeleteAPI --> SoftDelete[Soft-delete running copy]
  SoftDelete --> Preserve[Preserve versions and historical verdicts]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Wait for the list to say it, never for t..."](https://github.com/egma-ai/egma/commit/77c57ea1c3182cc5901a9060943b62772b0a5cf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53649332)</sub>

<!-- /greptile_comment -->