### PR TITLE
Tighten report validation and sweep logging types

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -69,8 +69,6 @@ export function reportPathFor(simulationId: string): string {
   return `/v1/simulations/${simulationId}/reports`;
 }
 
-type Body = Record<string, unknown>;
-
 /** One status event, after the contract check has vouched for its shape. */
 type StatusEvent = {
   readonly status: "running" | "completed" | "failed" | "canceled";
@@ -95,6 +93,12 @@ type StatusEvent = {
       readonly uncovered: readonly string[];
     };
   };
+};
+
+/** The part of an accepted report this route reads. */
+type AcceptedReport = {
+  readonly simulation_id: string;
+  readonly events: readonly StatusEvent[];
 };
 
 /**
@@ -223,7 +227,7 @@ export async function reportRoutes(
    */
   app.post(REPORTS_PATH, async (request, reply) => {
     const { simulationId } = request.params as { simulationId: string };
-    const document = (request.body ?? {}) as Body;
+    const document: unknown = request.body ?? {};
 
     // The contract check first, before a byte of the document is believed —
     // the same schema the simulator compiled before sending, so the
@@ -242,13 +246,17 @@ export async function reportRoutes(
       );
     }
 
+    // SAFETY: reportComplaints accepted this value against the closed report
+    // schema, which requires simulation_id and permits only status events.
+    const report = document as AcceptedReport;
+
     // A document about another simulation is refused, not rerouted: the URL
     // and the document each name the simulation, and when they disagree
     // there is no honest way to pick one.
-    if (document.simulation_id !== simulationId) {
+    if (report.simulation_id !== simulationId) {
       return invalid(
         reply,
-        `this document says it is about ${String(document.simulation_id)}, ` +
+        `this document says it is about ${report.simulation_id}, ` +
           `but it was posted to ${simulationId}. Post each report to the ` +
           `simulation its own simulation_id names.`,
       );
@@ -264,19 +272,14 @@ export async function reportRoutes(
       );
     }
 
-    const events = document.events as readonly Record<string, unknown>[];
     let lastKnownStatus: string = standing.status;
 
     // Every event here is a lifecycle transition, because the contract check
     // above has already refused anything else: a conversation's turns, tool
     // calls and measurements arrive as spans at the OTLP door, and a report
     // claiming to carry one does not validate.
-    for (const event of events) {
-      const applied = await applyStatusEvent(
-        reply,
-        simulationId,
-        event as unknown as StatusEvent,
-      );
+    for (const event of report.events) {
+      const applied = await applyStatusEvent(reply, simulationId, event);
       if (typeof applied !== "string") return applied;
       lastKnownStatus = applied;
     }

--- a/apps/api/src/simulation-sweep.ts
+++ b/apps/api/src/simulation-sweep.ts
@@ -37,14 +37,25 @@ import {
  */
 export const SWEEP_INTERVAL_MILLISECONDS = 30_000;
 
+/** The rows named when one sweep moves silent simulations to failed. */
+export type SweptSimulationsLogDetails = {
+  readonly simulationIds: readonly (SweptSimulation["id"])[];
+  readonly runIds: readonly (SweptSimulation["runId"])[];
+};
+
+/** The fault named when one sweep cannot reach its store. */
+export type OrphanSweepFailureLogDetails = {
+  readonly err: unknown;
+};
+
 /** The two things the loop ever says, shaped so a test can hand in its own. */
-type SweepLog = {
-  info(details: object, message: string): void;
-  error(details: object, message: string): void;
+export type OrphanSweepLog = {
+  info(details: SweptSimulationsLogDetails, message: string): void;
+  error(details: OrphanSweepFailureLogDetails, message: string): void;
 };
 
 export type OrphanSweepOptions = {
-  readonly log: SweepLog;
+  readonly log: OrphanSweepLog;
   /** The cadence, for a test that cannot watch a real clock. */
   readonly intervalMilliseconds?: number;
   /**

--- a/apps/api/test/simulation-sweep.test.ts
+++ b/apps/api/test/simulation-sweep.test.ts
@@ -4,6 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   startOrphanSweep,
   SWEEP_INTERVAL_MILLISECONDS,
+  type OrphanSweepFailureLogDetails,
+  type OrphanSweepLog,
+  type SweptSimulationsLogDetails,
 } from "../src/simulation-sweep.ts";
 import { createApi, type TestApi, type TestApiOptions } from "./support/api.ts";
 import {
@@ -32,22 +35,20 @@ afterEach(async () => {
 });
 
 /** What one test's loop said, in order, without a real logger in the way. */
-function capturingLog(): {
-  infos: { details: Record<string, unknown>; message: string }[];
-  errors: { details: Record<string, unknown>; message: string }[];
-  info(details: object, message: string): void;
-  error(details: object, message: string): void;
+function capturingLog(): OrphanSweepLog & {
+  infos: { details: SweptSimulationsLogDetails; message: string }[];
+  errors: { details: OrphanSweepFailureLogDetails; message: string }[];
 } {
-  const infos: { details: Record<string, unknown>; message: string }[] = [];
-  const errors: { details: Record<string, unknown>; message: string }[] = [];
+  const infos: { details: SweptSimulationsLogDetails; message: string }[] = [];
+  const errors: { details: OrphanSweepFailureLogDetails; message: string }[] = [];
   return {
     infos,
     errors,
     info(details, message) {
-      infos.push({ details: details as Record<string, unknown>, message });
+      infos.push({ details, message });
     },
     error(details, message) {
-      errors.push({ details: details as Record<string, unknown>, message });
+      errors.push({ details, message });
     },
   };
 }

--- a/packages/simulation-contract/src/documents.ts
+++ b/packages/simulation-contract/src/documents.ts
@@ -2,12 +2,11 @@ import { readFileSync } from "node:fs";
 
 import { Ajv2020, type ValidateFunction } from "ajv/dist/2020.js";
 import ajvFormats from "ajv-formats";
-import type { FormatsPlugin } from "ajv-formats";
 
 // ajv-formats ships CommonJS whose module.exports is the plugin function
-// itself; under NodeNext TypeScript types the default import as a namespace,
-// so the callable gets its name here.
-const addFormats = ajvFormats as unknown as FormatsPlugin;
+// itself. Under NodeNext, the default import is typed as its namespace and
+// the namespace's default is that callable, with its declared type intact.
+const addFormats = ajvFormats.default;
 
 /**
  * The contract's documents, as TypeScript can check them.

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from "node:url";
 
 import { Ajv2020 } from "ajv/dist/2020.js";
 import ajvFormats from "ajv-formats";
-import type { FormatsPlugin } from "ajv-formats";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -14,9 +13,9 @@ import {
 } from "@egma/simulation-contract";
 
 // ajv-formats ships CommonJS whose module.exports is the plugin function
-// itself; under NodeNext TypeScript types the default import as a namespace,
-// so the callable gets its name here.
-const addFormats = ajvFormats as unknown as FormatsPlugin;
+// itself. Under NodeNext, the default import is typed as its namespace and
+// the namespace's default is that callable, with its declared type intact.
+const addFormats = ajvFormats.default;
 
 /**
  * The simulation contract, held to its own golden fixtures.


### PR DESCRIPTION
## Summary

- trust report fields only after the report schema accepts the document
- use the typed `ajv-formats` CommonJS callable without a chained cast
- give orphan-sweep log payloads exact, named types

## Scope

This applies the three useful findings from the anti-slop audit. It does not enable the full anti-slop rule set or add a new repository gate.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
  - TypeScript: 2,623 passed, 2 optional live tests skipped
  - simulator: 612 passed, 7 optional live tests skipped
  - Python SDK: 66 passed, 1 optional live test skipped
  - fixture: 8 passed
- independent standards review: clean
- independent requirement review: clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789428288&installation_model_id=431960&pr_number=117&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F117&signature=b1819731f8b9eddde27154ee0d694048de738d4daf240624ea7c17c6088641ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves report-field trust behind successful schema validation, replaces the chained `ajv-formats` cast with its typed callable export, and gives orphan-sweep log payloads named exact types.
- Treats incoming report bodies as `unknown` until contract validation succeeds.
- Adds named types for successful and failed orphan-sweep log records.
- Removes unnecessary logging and `ajv-formats` casts from implementation and tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code failure remains.

The report route validates the unknown body before accessing schema-guaranteed fields, and the logging and module-interop edits preserve existing runtime behavior while tightening static types.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/reports.ts | Defers report field access until the closed report schema accepts the unknown request body; the asserted subset matches all subsequently read fields. |
| apps/api/src/simulation-sweep.ts | Introduces exact exported types for the sweep logger’s success and failure payloads without changing runtime behavior. |
| apps/api/test/simulation-sweep.test.ts | Updates the capturing test logger to use the new named payload and logger types while preserving its behavior. |
| packages/simulation-contract/src/documents.ts | Uses the typed callable exposed by the CommonJS `ajv-formats` namespace instead of a chained type assertion. |
| packages/simulation-contract/test/contract.test.ts | Applies the same typed `ajv-formats` callable pattern to schema fixture validation. |

<sub>Reviews (1): Last reviewed commit: ["Tighten validated report and sweep log t..."](https://github.com/egma-ai/egma/commit/f57c54c7186c9d1a5fb54ee63461a0c9f9a092b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53683714)</sub>

<!-- /greptile_comment -->