### PR TITLE
Measure a LiveKit call's latency from its own spans

### DIFF
--- a/apps/api/src/routes/trace-reads.ts
+++ b/apps/api/src/routes/trace-reads.ts
@@ -506,9 +506,20 @@ export async function traceReadRoutes(
     // the 128 bits that id carries written as hex. The two are the same number,
     // so the reader that has one can always derive the other — which is what
     // lets a transcript show what egma made of it with nothing having stored a
-    // mapping. A production trace derives to a simulation id nothing minted,
-    // and simply has no verdicts filed that way.
-    const filedUnder = simulationIdOfTrace(traceId) ?? traceId;
+    // mapping.
+    //
+    // **A production trace's verdicts are filed under the trace id itself**, and
+    // asking `detail.source` is what keeps that true. The derivation is a pure
+    // bit conversion and succeeds for *every* trace id, so a production trace
+    // would otherwise be looked up under a simulation id nothing ever minted —
+    // and the read would answer "skipped, nothing judged" while real verdict
+    // rows sat in the store under the id it was handed. A judgment egma wrote
+    // and then could not find is the exact false trust this product exists to
+    // kill, so the question is asked rather than the answer assumed.
+    const filedUnder =
+      detail.source === "simulation"
+        ? (simulationIdOfTrace(traceId) ?? traceId)
+        : traceId;
     const judged = await readVerdicts(acting, filedUnder, { projectId }).catch(
       () => undefined,
     );

--- a/apps/api/src/routes/trace-reads.ts
+++ b/apps/api/src/routes/trace-reads.ts
@@ -347,6 +347,12 @@ function describedMeasures(
     return {
       measure: measured.measure,
       unit: measured.unit,
+      // Where the number came from, so a page can say it and a client that
+      // never asked is unaffected. **Added rather than changed**: every field a
+      // consumer integrated against still means exactly what it did, and a
+      // measure timed by egma's own vocabulary carries `false` here as it
+      // always implicitly did.
+      derived: measured.derived,
       samples: measured.samples.map((sample) => sample.value),
       span_ids: measured.samples.map((sample) => sample.spanId),
       // The one number a bound is held against, and where it happened. Null is

--- a/apps/api/test/otlp-derived-measures.test.ts
+++ b/apps/api/test/otlp-derived-measures.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  readTraceOverHttp,
+  replayFixture,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * A stock LiveKit agent's real conversation, measured from its own spans.
+ *
+ * **The proof that the derivations are worth believing.** The captured trace
+ * goes in at the real door, byte for byte as the exporter sent it, lands in real
+ * ClickHouse, and comes back through the same v1 read a grader and the
+ * transcript page read — and the numbers it carries are compared against
+ * figures **hand-computed from the capture's own raw timestamps** and written
+ * down below.
+ *
+ * That last part is the whole design of this file. Expectations produced by
+ * running the derivation would grade the derivation against itself and pass for
+ * any rule at all, including a wrong one. Every number here was worked out once
+ * from the fixture's nanosecond start and end times, with the spans it came from
+ * named beside it, so this file disagrees with the code the day the code
+ * changes what it means.
+ *
+ * The unit cases — ordering, the fallback, an interruption, an unrecognised
+ * emitter, precedence — are in `packages/db/test/measures-from-spans.test.ts`.
+ * What is proved here is that a real conversation, through the real path,
+ * arrives measured.
+ */
+
+let api: TestApi;
+let acme: Customer;
+
+/**
+ * The one trace the capture is, as its spans name themselves — written down
+ * rather than discovered, because every number below was hand-computed from
+ * *this* trace's spans and would mean nothing beside another one.
+ */
+const FIXTURE_TRACE_ID = "b37987604bb2c7aa1c1fd44183afab8b";
+
+/** A window comfortably containing the capture, which happened inside a minute. */
+const WINDOW = {
+  from: "2026-08-02T18:00:00Z",
+  to: "2026-08-02T19:00:00Z",
+} as const;
+
+/**
+ * The numbers, hand-computed from the capture's raw span timestamps.
+ *
+ * Starts are held to the microsecond and durations to the nanosecond, which is
+ * what the store keeps, so every latency below is the difference of two
+ * microsecond-truncated instants. Each line names the spans it came from by
+ * their own ids.
+ *
+ * The conversation, in the order its turns began: an agent turn that greets,
+ * then five human turns, each with one or two agent turns after it — thirteen
+ * turns in all, five of them the caller's.
+ */
+const HAND_COMPUTED = {
+  /**
+   * The root `agent_session` d949924e2d5e678d began at 1785693880281989804 ns,
+   * truncated to 1785693880281989 µs. The first agent turn 0701cc09e5f3d203
+   * spoke first in `agent_speaking` 71ac2d247c9b060d, which began at
+   * 1785693889887763200 ns → 1785693889887763 µs.
+   *
+   * 1785693889887763000 − 1785693880281989000 = 9605774000 ns = 9605.774 ms.
+   */
+  first_response_latency: [9605.774],
+
+  /**
+   * One sample per human turn, in order. Three of the five run backwards — the
+   * agent began answering before the caller stopped — and a latency that runs
+   * backwards is dropped rather than kept as a negative number.
+   *
+   * 1. human 1e6796c0e195e424 ends 1785693901696743226; the next agent turn
+   *    9ac4333458575745 has no speech and starts 1785693899185629103. Backwards
+   *    by 2511 ms — the agent talked over the caller. Dropped.
+   * 2. human baac22a26a96fa9b starts 1785693902082961920 → 1785693902082961 µs,
+   *    runs 297806362 ns, so it ends at 1785693902380767362. The next agent
+   *    turn 00820fa943b873e6 has no speech and starts 1785693902382202784 →
+   *    1785693902382202 µs. 1785693902382202000 − 1785693902380767362 =
+   *    1434638 ns = 1.434638 ms.
+   * 3. human c35b92a87f8121a1 ends 1785693923116446625; agent 674743df7fe60024
+   *    starts 1785693922817568419. Backwards by 299 ms. Dropped.
+   * 4. human f88cf2a243a38318 ends 1785693942127284137; agent cfbcc2e51885f0fa
+   *    starts 1785693941270896447. Backwards by 856 ms. Dropped.
+   * 5. human 9839f5ef664bc919 starts 1785693942114222080 → 1785693942114222 µs,
+   *    runs 1980473194 ns, so it ends at 1785693944094695194. The next agent
+   *    turn fe4af349db1e440f spoke in `agent_speaking` 11a1eaca219437a9, which
+   *    began at 1785693946089613312 ns → 1785693946089613 µs.
+   *    1785693946089613000 − 1785693944094695194 = 1994917806 ns =
+   *    1994.917806 ms.
+   */
+  turn_response_latency: [1.434638, 1994.917806],
+
+  /**
+   * One sample per agent turn that spoke, and four of the eight did. Each has a
+   * single `agent_speaking` child, so the sum is that child's own duration —
+   * nanoseconds exactly, since a duration is stored to the nanosecond.
+   *
+   * - turn 0701cc09e5f3d203, speech 71ac2d247c9b060d:
+   *   1785693894451407651 − 1785693889887763200 = 4563644451 ns
+   * - turn b2444815bd74fb3b, speech 1b8cc4d1064a766d:
+   *   1785693913955073014 − 1785693904727004928 = 9228068086 ns
+   * - turn 2c8883b32dbc323c, speech 42b9d5797f17aa9d:
+   *   1785693934154724323 − 1785693924924691968 = 9230032355 ns
+   * - turn fe4af349db1e440f, speech 11a1eaca219437a9:
+   *   1785693950543834480 − 1785693946089613312 = 4454221168 ns
+   */
+  agent_speech_duration: [
+    4563.644451, 9228.068086, 9230.032355, 4454.221168,
+  ],
+} as const;
+
+type ReadMeasure = {
+  readonly measure: string;
+  readonly unit: string;
+  readonly derived: boolean;
+  readonly samples: readonly number[];
+  readonly span_ids: readonly string[];
+  readonly worst: { readonly value: number; readonly span_id: string } | null;
+};
+
+async function measuresOfTheCapture(): Promise<readonly ReadMeasure[]> {
+  const read = await readTraceOverHttp(
+    api.app,
+    acme.secret,
+    FIXTURE_TRACE_ID,
+    WINDOW,
+  );
+  expect(read.statusCode).toBe(200);
+  return (read.json() as { measures?: readonly ReadMeasure[] }).measures ?? [];
+}
+
+function measure(
+  measures: readonly ReadMeasure[],
+  named: string,
+): ReadMeasure | undefined {
+  return measures.find((one) => one.measure === named);
+}
+
+beforeAll(async () => {
+  api = await createApi("otlp_derived_measures", { traceStore: true });
+  acme = await signUp(api.app, "ada@acme.example", "Acme");
+  // The fourteen flushes, byte for byte as the exporter sent them.
+  await replayFixture(api.app, acme.secret);
+});
+
+afterAll(async () => {
+  await api?.close();
+});
+
+describe("the captured LiveKit conversation, read back through the door", () => {
+  it("carries exactly the three derived measures, and says they were derived", async () => {
+    const measures = await measuresOfTheCapture();
+
+    // In the catalog's own order, which is what a page lists them in.
+    expect(measures.map((one) => one.measure)).toEqual([
+      "first_response_latency",
+      "turn_response_latency",
+      "agent_speech_duration",
+    ]);
+    // Every one of them worked out from the framework's spans: this agent
+    // emitted no timing span of egma's own, which is the whole reason its
+    // conversations were `skipped` before.
+    expect(measures.map((one) => one.derived)).toEqual([true, true, true]);
+    expect(new Set(measures.map((one) => one.unit))).toEqual(
+      new Set(["milliseconds"]),
+    );
+  });
+
+  it("measures the first answer at the hand-computed number", async () => {
+    const measured = measure(
+      await measuresOfTheCapture(),
+      "first_response_latency",
+    );
+
+    expect(measured?.samples).toEqual(HAND_COMPUTED.first_response_latency);
+    // Citing the `agent_speaking` span the first word came out of.
+    expect(measured?.span_ids).toEqual(["71ac2d247c9b060d"]);
+  });
+
+  it("measures each answered turn's wait at the hand-computed numbers", async () => {
+    const measured = measure(
+      await measuresOfTheCapture(),
+      "turn_response_latency",
+    );
+
+    expect(measured?.samples).toEqual(HAND_COMPUTED.turn_response_latency);
+    // The agent turn that answered without speaking, then the speech that
+    // answered the last thing the caller said.
+    expect(measured?.span_ids).toEqual([
+      "00820fa943b873e6",
+      "11a1eaca219437a9",
+    ]);
+    // The worst of them is what a bound is held against, and it is the second.
+    expect(measured?.worst).toEqual({
+      value: 1994.917806,
+      span_id: "11a1eaca219437a9",
+    });
+  });
+
+  it("measures each speaking turn's speech at the hand-computed numbers", async () => {
+    const measured = measure(
+      await measuresOfTheCapture(),
+      "agent_speech_duration",
+    );
+
+    expect(measured?.samples).toEqual(HAND_COMPUTED.agent_speech_duration);
+    // One sample per agent turn that spoke, citing the turn rather than the
+    // speech inside it — the number is the turn's.
+    expect(measured?.span_ids).toEqual([
+      "0701cc09e5f3d203",
+      "b2444815bd74fb3b",
+      "2c8883b32dbc323c",
+      "fe4af349db1e440f",
+    ]);
+  });
+
+  /**
+   * The two the spec leaves out deliberately. `time_to_first_word` is defined
+   * out of audio egma does not hold for production traffic, and
+   * `persona_speech_duration` is about egma's synthetic caller, who is not in a
+   * production conversation at all. A grader naming either is honestly
+   * `skipped`, which is better than a number that means something else.
+   */
+  it("derives neither of the two measures the catalog excludes", async () => {
+    const measures = await measuresOfTheCapture();
+
+    expect(measure(measures, "time_to_first_word")).toBeUndefined();
+    expect(measure(measures, "persona_speech_duration")).toBeUndefined();
+  });
+});

--- a/apps/api/test/trace-reads-contract.test.ts
+++ b/apps/api/test/trace-reads-contract.test.ts
@@ -1,4 +1,5 @@
 import {
+  appendVerdicts,
   createAgent,
   createPersona,
   createProject,
@@ -6,6 +7,7 @@ import {
   startRun,
   type AuthContext,
 } from "@egma/db";
+import { newId } from "@egma/ids";
 import { traceIdOfSimulation } from "@egma/simulation-contract";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -1129,4 +1131,109 @@ describe("a read with no usable credential", () => {
       expect(invented.statusCode).toBe(401);
     }
   });
+});
+
+/**
+ * **What egma judged a production conversation, found where egma filed it.**
+ *
+ * A simulation's verdicts are filed under its simulation id and its spans under
+ * the same 128 bits written as hex, so the read derives one from the other. The
+ * derivation is a pure bit conversion and therefore succeeds for *every* trace
+ * id — including a customer's own production trace, which converts to a
+ * perfectly well-formed simulation id nothing ever minted.
+ *
+ * That is the bug this describes. The read looked under the phantom id, found
+ * nothing, and answered "nothing was judged" while the real verdict rows sat in
+ * the store under the trace id it had been handed. A live call caught it: a
+ * passed latency verdict, written by the grader, invisible on the transcript.
+ *
+ * A judgment egma wrote and then could not find is the exact false trust this
+ * product exists to kill, so it is pinned here, at the read, through the routes.
+ */
+describe("a production conversation egma judged", () => {
+  const JUDGED_TRACE = "cc000000000000000000000000000001";
+  const JUDGED_AT = "2026-06-01T11:00:00Z";
+  const GRADER = newId("grd");
+  const GRADER_VERSION = newId("grv");
+
+  beforeAll(async () => {
+    await ingest(
+      api.app,
+      acme.secret,
+      syntheticExport({
+        traceId: JUDGED_TRACE,
+        startedAt: new Date(JUDGED_AT),
+        humanSaid: "How long will the wait be?",
+      }),
+    );
+
+    // Written the way the grader writes one: under the **trace id**, because a
+    // production conversation is not a simulation and has no simulation id.
+    await appendVerdicts(contextFor(acme, "admin"), [
+      {
+        traceId: JUDGED_TRACE,
+        graderId: GRADER,
+        graderVersionId: GRADER_VERSION,
+        assertion: "turn_response_latency",
+        source: "production",
+        verdict: "passed",
+        score: 1,
+        rationale: "every turn was answered inside the bound.",
+        citedSpanIds: [],
+        runId: "",
+        agentId: "",
+        agentVersionId: "",
+        judgedAtMicroseconds: BigInt(Date.parse(JUDGED_AT)) * 1000n,
+      },
+    ]);
+  });
+
+  it("shows the judgment on its transcript, rather than nothing at all", async () => {
+    const read = await readTraceOverHttp(
+      api.app,
+      acme.secret,
+      JUDGED_TRACE,
+      DAY,
+    );
+    expect(read.statusCode, read.body).toBe(200);
+
+    const detail = read.json() as {
+      trace: { source: string };
+      simulation_id: string | null;
+      verdicts: readonly { assertion: string; verdict: string }[];
+      outcome: { verdict: string; counts: Record<string, number> } | null;
+    };
+
+    // A production conversation, and it names no simulation — which is exactly
+    // the case the lookup used to get wrong.
+    expect(detail.trace.source).toBe("production");
+    expect(detail.simulation_id).toBeNull();
+
+    expect(detail.verdicts).toHaveLength(1);
+    expect(detail.verdicts[0]?.assertion).toBe("turn_response_latency");
+    expect(detail.verdicts[0]?.verdict).toBe("passed");
+  });
+
+  it("folds a real outcome, and never a skipped nothing", async () => {
+    const read = await readTraceOverHttp(
+      api.app,
+      acme.secret,
+      JUDGED_TRACE,
+      DAY,
+    );
+    expect(read.statusCode, read.body).toBe(200);
+
+    const outcome = (
+      read.json() as {
+        outcome: { verdict: string; counts: Record<string, number> } | null;
+      }
+    ).outcome;
+
+    // Present, decided, and counting the row — the three things the phantom
+    // lookup destroyed, in the order somebody reading the page notices them.
+    expect(outcome).not.toBeNull();
+    expect(outcome?.verdict).toBe("passed");
+    expect(outcome?.counts.passed).toBe(1);
+  });
+
 });

--- a/apps/api/test/trace-reads.test.ts
+++ b/apps/api/test/trace-reads.test.ts
@@ -453,19 +453,27 @@ describe("the captured trace, read as a transcript", () => {
    * verdict rests on are one arithmetic, and no page can be the reason somebody
    * distrusts a judgment.
    *
-   * The captured exchange measures **nothing**, and that is the honest answer
-   * rather than a gap: LiveKit's own agent emits no timing spans, so there is
-   * nothing in this trace for a measure to be computed from. A grader asked for
-   * one answers `skipped`, which leaves the score's denominator. The day the
-   * ingest door normalises a provider's own latency attribute into a span this
-   * list grows, and nothing else has to change.
+   * The captured exchange emits no timing span of egma's own, and it is
+   * measured anyway: the three latencies are **derived** from the shapes the
+   * framework itself timed, and each says so. That is the answer to what this
+   * read used to return — an empty list, and a latency grader `skipped` on every
+   * production conversation a stock agent ever had.
+   *
+   * The numbers themselves are asserted in
+   * `apps/api/test/otlp-derived-measures.test.ts`, against figures hand-computed
+   * from the capture's raw timestamps. What is asked here is the read's shape:
+   * which measures come back, and that the answer is a present list either way.
    */
-  it("answers what the exchange measured, which for this telemetry is nothing", async () => {
+  it("answers what the exchange measured, derived from the framework's own timings", async () => {
     const detail = await transcript();
 
-    expect(detail.measures).toEqual([]);
-    // Present and empty rather than absent, so a client can tell "nothing was
-    // measured" from "this response is an older shape that never said".
+    expect(detail.measures?.map((one) => one.measure)).toEqual([
+      "first_response_latency",
+      "turn_response_latency",
+      "agent_speech_duration",
+    ]);
+    // Present rather than absent, so a client can tell "nothing was measured"
+    // from "this response is an older shape that never said".
     expect(Array.isArray(detail.measures)).toBe(true);
   });
 });

--- a/apps/grader/test/latency.test.ts
+++ b/apps/grader/test/latency.test.ts
@@ -71,6 +71,7 @@ function measured(
   return {
     measure,
     unit: "milliseconds",
+    derived: false,
     // Each measurement carries the span it happened in, which is what a
     // judgment cites — one list, so nothing here has to keep two in step.
     samples: values.map((value, at) => ({

--- a/apps/grader/test/one-grader.test.ts
+++ b/apps/grader/test/one-grader.test.ts
@@ -32,6 +32,7 @@ function conversation(overrides: Partial<Conversation> = {}): Conversation {
       {
         measure: "turn_response_latency",
         unit: "milliseconds" as const,
+        derived: false,
         samples: [{ value: 900, spanId: "0000000000000001" }],
       },
     ],
@@ -173,6 +174,7 @@ describe("a simulation that never ran", () => {
           {
             measure: "turn_response_latency",
             unit: "milliseconds" as const,
+            derived: false,
             samples: [{ value: 10, spanId: "0000000000000001" }],
           },
         ],

--- a/apps/grader/test/production.test.ts
+++ b/apps/grader/test/production.test.ts
@@ -251,14 +251,35 @@ describe("a production trace whose root span closes", () => {
       },
     ]);
 
-    // And no measures — not because this is production, but because these spans
-    // carry none. The shared measure module is handed the trace and knows
-    // nothing about who conducted it; most agents' telemetry emits no timings,
-    // so most production traces measure nothing, and a grader asked for one
-    // answers `skipped`, which leaves the score's denominator. A production
-    // trace that *does* carry timing spans measures exactly what a simulation's
-    // identical spans measure, which the case below is about.
-    expect(conversation.measures).toEqual([]);
+    // And a measure, **derived** — not because this is production, but because
+    // these spans carry the shapes a derivation reads. The shared measure module
+    // is handed the trace and knows nothing about who conducted it: this agent
+    // emitted no timing span of egma's own, and its turn latency is worked out
+    // from the turns the framework itself timed.
+    //
+    // Hand-computed from this tree: the turns are 2000 ms apart and each runs
+    // for 1000 ms, so the human turn ends 1000 ms in and the agent's turn — which
+    // carries no speech, so its own start is the answer — begins at 2000 ms.
+    expect(conversation.measures).toEqual([
+      {
+        measure: "turn_response_latency",
+        unit: "milliseconds",
+        derived: true,
+        samples: [{ value: 1_000, spanId: expect.any(String) }],
+      },
+    ]);
+    // The other two are absent, and each for a reason this tree has: nothing
+    // here spoke, so there is no speech to have measured and no first word to
+    // have waited for. A grader asked for either answers `skipped`, which leaves
+    // the score's denominator. A production trace that *does* carry egma's own
+    // timing spans measures exactly what a simulation's identical spans measure,
+    // which the case below is about.
+    expect(conversation.measures.map((one) => one.measure)).not.toContain(
+      "agent_speech_duration",
+    );
+    expect(conversation.measures.map((one) => one.measure)).not.toContain(
+      "first_response_latency",
+    );
 
     // Empty, and honestly so: a trace that arrived at the OTLP door was not
     // started by egma, so there is no run and no agent row behind it.

--- a/apps/grader/test/simulation-spans.test.ts
+++ b/apps/grader/test/simulation-spans.test.ts
@@ -326,8 +326,20 @@ describe("what the simulator measured", () => {
 
     // The number the span's start and end bracket, read back to the
     // millisecond — nothing on the span carries it a second time.
+    //
+    // **Precedence is per measure, and this list is exact so that stays true.**
+    // The timed measure keeps the timing span's own duration and is never
+    // derived beside it; the measure this conversation timed nothing for is
+    // worked out from its turns, and is named here rather than allowed to arrive
+    // unremarked. The day a derivation appends to `first_response_latency`
+    // instead of standing aside, this assertion is what says so.
+    //
+    // The derived pair is hand-computed from the conversation's own shape: four
+    // turns 2000 ms apart, each a single instant on a chat simulation, so each
+    // of the two human turns is answered 2000 ms later.
     expect(judge.asked[0]?.evidence.measures).toEqual([
       { measure: "first_response_latency", samples: [1_214] },
+      { measure: "turn_response_latency", samples: [2_000, 2_000] },
     ]);
   });
 

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -354,6 +354,12 @@ function Measures({ measured }: { measured: readonly Measured[] }) {
           </div>
         ))
       )}
+      {measured.some((one) => one.derived === true) ? (
+        <div className={styles.contextFact}>
+          <span />
+          <strong className={styles.muted}>{MEASURES.derived}</strong>
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -379,10 +385,14 @@ function measurement(one: Measured): string {
   if (one.worst === null) return DETAIL.notReported;
 
   const shown = `${String(one.worst.value)} ${one.unit}`;
-  if (one.partial === true) return `${shown} · ${MEASURES.partialWorst}`;
+  // Said on the figure itself as well as once for the panel, because a page
+  // mixing timed and worked-out numbers must let a reader tell which is which
+  // without counting rows.
+  const from = one.derived === true ? ` · ${MEASURES.derivedOne}` : "";
+  if (one.partial === true) return `${shown} · ${MEASURES.partialWorst}${from}`;
   return one.samples.length === 1
-    ? shown
-    : `${shown} · ${MEASURES.worst} of ${MEASURES.counted(one.samples.length)}`;
+    ? `${shown}${from}`
+    : `${shown} · ${MEASURES.worst} of ${MEASURES.counted(one.samples.length)}${from}`;
 }
 
 /** What was judged, in the words a tally is read in. Written once, so the two

--- a/apps/web/lib/transcript-copy.ts
+++ b/apps/web/lib/transcript-copy.ts
@@ -306,6 +306,24 @@ export const MEASURES = {
     "Nothing was measured here. Egma's own simulations time their turns; an " +
     "exchange your agent had carries whatever its telemetry emitted, which " +
     "for most frameworks is no timings at all.",
+  /**
+   * Where the numbers came from, said once and only when it applies.
+   *
+   * **A verdict's provenance must never be a surprise.** Some of these figures
+   * were not timed by anybody: Egma worked them out from the timings your
+   * agent's own framework already records. A developer whose latency check
+   * suddenly starts failing is owed that sentence on the same screen as the
+   * number, not in a document they would have to go and find.
+   *
+   * Shown only when at least one figure on this page was worked out that way.
+   * A page whose every number was timed outright says nothing here, because a
+   * caveat about something that did not happen is noise.
+   */
+  derived:
+    "Some figures here were worked out from your framework's own timings " +
+    "rather than timed by Egma. Each says which.",
+  /** The mark beside one worked-out figure, so a reader need not guess which. */
+  derivedOne: "from your framework's timings",
   /** One measurement is the number; several are the worst of them. */
   worst: "worst",
   counted: (howMany: number): string =>

--- a/apps/web/lib/transcripts.ts
+++ b/apps/web/lib/transcripts.ts
@@ -133,6 +133,14 @@ export type Outcome = {
 export type Measured = {
   readonly measure: string;
   readonly unit: string;
+  /**
+   * True when Egma worked the number out from the framework's own timings
+   * rather than reading one Egma's simulator timed itself.
+   *
+   * Optional because an answer from an older platform does not carry it, which
+   * is a page that says nothing about provenance rather than one that breaks.
+   */
+  readonly derived?: boolean;
   /** One sample, or the series a per-turn measure produced. Never empty. */
   readonly samples: readonly number[];
   /** The span each sample came off, in the same order. */

--- a/apps/web/test/transcripts.test.ts
+++ b/apps/web/test/transcripts.test.ts
@@ -988,3 +988,56 @@ describe("what the exchange measured", () => {
     expect(copy.MEASURES.none.length).toBeGreaterThan(40);
   });
 });
+
+/**
+ * Where a number came from, said on the page that shows it.
+ *
+ * **A verdict's provenance must never be a surprise.** Some figures on this
+ * page were not timed by anybody: Egma worked them out from the timings the
+ * agent's own framework already records. A developer whose latency check starts
+ * failing is owed that sentence beside the number, not in a document.
+ *
+ * And the quiet sentence for an exchange that measured nothing stays exactly as
+ * it was, because it is still exactly as true — a framework emitting nothing
+ * Egma recognises still measures nothing.
+ */
+describe("saying which numbers Egma worked out", () => {
+  it("adds a clause only when a worked-out figure is on the page", async () => {
+    const page = await readFile(path.join(WEB, DETAIL_PAGE), "utf8");
+
+    // Shown from the answer's own flag, and only when one is set — a caveat
+    // about something that did not happen is noise on every other exchange.
+    expect(page).toContain("one.derived === true");
+    expect(page).toContain("MEASURES.derived");
+    expect(copy.MEASURES.derived).toContain("your framework's own timings");
+    // Marked on the figure too, so a page mixing the two can be read without
+    // counting rows.
+    expect(copy.MEASURES.derivedOne).toContain("framework");
+  });
+
+  it("keeps the nothing-was-measured sentence exactly as it was", () => {
+    expect(copy.MEASURES.none).toBe(
+      "Nothing was measured here. Egma's own simulations time their turns; an " +
+        "exchange your agent had carries whatever its telemetry emitted, which " +
+        "for most frameworks is no timings at all.",
+    );
+  });
+
+  /**
+   * The words on the page are the product's, and three storage words are not
+   * among them: a developer reading a transcript never has to know what a span,
+   * a trace or an instrumentation scope is to understand where a number
+   * came from.
+   */
+  it("says none of it in the storage vocabulary", () => {
+    for (const said of [
+      copy.MEASURES.derived,
+      copy.MEASURES.derivedOne,
+      copy.MEASURES.none,
+    ]) {
+      expect(said.toLowerCase()).not.toContain("span");
+      expect(said.toLowerCase()).not.toContain("trace");
+      expect(said.toLowerCase()).not.toContain("scope");
+    }
+  });
+});

--- a/packages/db/src/measures/from-spans.ts
+++ b/packages/db/src/measures/from-spans.ts
@@ -422,14 +422,24 @@ function agentSpeechDuration(turns: readonly TimedSpan[]): readonly Sample[] {
  * Where the agent's answer to the human turn at `at` began.
  *
  * The next agent turn's first speech, or that turn's own start when it carried
- * none. `undefined` when the human had the last word, which is a turn nobody
- * answered rather than a turn answered slowly.
+ * none. `undefined` when nobody answered — the human had the last word, or said
+ * something else first.
+ *
+ * **An agent turn answers only the nearest human turn before it, so the walk
+ * stops at the next human turn rather than reading past it.** A caller who says
+ * "hello" and then "are you there" before the agent replies has taken two turns
+ * and been answered once, and letting the one reply count for both would file
+ * the same wait twice — the same number in the series twice over, a worse worst
+ * on a page, and, in the limit, a bound failed by a duplicate. The unanswered
+ * first turn measures nothing, which is what actually happened: the wait it
+ * would have measured ended when the caller spoke again, not when the agent did.
  */
 function answeringSpeech(
   turns: readonly TimedSpan[],
   at: number,
 ): { readonly startedAt: bigint; readonly spanId: string } | undefined {
   for (const turn of turns.slice(at + 1)) {
+    if (turn.kind === HUMAN_TURN) return undefined;
     if (turn.kind !== AGENT_TURN) continue;
     return turn.speech[0] ?? { startedAt: turn.startedAt, spanId: turn.spanId };
   }

--- a/packages/db/src/measures/from-spans.ts
+++ b/packages/db/src/measures/from-spans.ts
@@ -74,6 +74,17 @@ export type MeasuredFromSpans = {
   /** The catalog's own unit, so nothing downstream has to look it up again. */
   readonly unit: CatalogedMeasure["unit"];
   /**
+   * Whether this number was worked out from a framework's own spans rather than
+   * read off a timing span egma's vocabulary names.
+   *
+   * A fact about *this* conversation and not about the measure, which is why it
+   * rides the answer instead of sitting in the catalog: the same measure is
+   * timed on a simulation and derived on a stock LiveKit call. A page saying
+   * where a number came from is the difference between a verdict a developer
+   * trusts and one they have to go and check.
+   */
+  readonly derived: boolean;
+  /**
    * One measurement, or the whole series for a measure taken once a turn, in
    * the order they were taken.
    *
@@ -97,7 +108,26 @@ export type MeasuredFromSpans = {
  */
 const TIMING = "timing";
 
+/**
+ * The kinds a derivation reads, and the whole of why reading them is safe.
+ *
+ * **The vetting lives at the door.** `apps/api/src/otlp/normalise.ts` assigns
+ * every one of these from a table keyed by the emitting instrumentation scope;
+ * a scope that table does not know is filed as `other`, whatever its spans are
+ * called. So a span carrying one of these kinds is a span egma recognised the
+ * emitter of, and nothing here has to re-check a name a lookalike framework
+ * could have chosen. `speaking` is LiveKit's alone today; the two turn kinds
+ * are LiveKit's and egma's own simulator's, and a simulation carries timing
+ * spans, which win outright below.
+ */
+const ROOT = "root";
+const HUMAN_TURN = "turn:human";
+const AGENT_TURN = "turn:agent";
+const SPEAKING = "speaking";
+
 const NANOSECONDS_PER_MILLISECOND = 1_000_000;
+const NANOSECONDS_PER_MICROSECOND = 1_000n;
+const MICROSECONDS_PER_SECOND = 1_000_000n;
 
 /**
  * Every measure this conversation's spans carry, in the catalog's own order.
@@ -113,15 +143,32 @@ export function measuresFromSpans(
   conversation: SpannedConversation,
 ): readonly MeasuredFromSpans[] {
   const timed = timingSpansByName(conversation);
+  const derived = derivedFromFrameworkSpans(conversation);
 
   const measured: MeasuredFromSpans[] = [];
   for (const cataloged of MEASURE_CATALOG) {
     const found = samplesOf(cataloged, timed);
-    if (found.length === 0) continue;
+    if (found.length > 0) {
+      measured.push({
+        measure: cataloged.measure,
+        unit: cataloged.unit,
+        derived: false,
+        samples: found,
+      });
+      continue;
+    }
+    // **egma's own timing vocabulary wins absolutely, and this `continue` is
+    // where.** A conversation carrying both a timed measure and the shapes a
+    // derivation reads has one answer, not two averaged or two appended: the
+    // measurement somebody instrumented on purpose. Deriving beside it would
+    // double the samples of one turn and quietly move every percentile.
+    const worked = derived.get(cataloged.measure) ?? [];
+    if (worked.length === 0) continue;
     measured.push({
       measure: cataloged.measure,
       unit: cataloged.unit,
-      samples: found,
+      derived: true,
+      samples: worked,
     });
   }
   return measured;
@@ -179,12 +226,9 @@ function timingSpansByName(
       at: span.startedAt,
       // The span's own duration **is** the measurement. Nothing carries the
       // number a second time — a second copy would be free to disagree with the
-      // interval — so this conversion is the only place nanoseconds become
-      // milliseconds. Floating point on purpose: a measure is `862.5ms` and a
-      // whole-number division would quietly floor every one of them, and the
-      // counts involved are tens of seconds, nowhere near where a double stops
-      // holding a nanosecond exactly.
-      value: Number(span.durationNanoseconds) / NANOSECONDS_PER_MILLISECOND,
+      // interval — and it becomes milliseconds through the one conversion this
+      // module has, which every derived measure also goes through.
+      value: milliseconds(BigInt(span.durationNanoseconds)),
       spanId: span.spanId,
     });
   }
@@ -226,6 +270,261 @@ function samplesOf(
       return [];
     }
   }
+}
+
+/* ------------------------------------------------------------------- *
+ * The derived measures: a framework's own spans, read as the catalog's
+ * numbers.
+ * ------------------------------------------------------------------- */
+
+/**
+ * The measures egma works out from the shapes a recognised framework emits,
+ * for a conversation that timed none of them itself.
+ *
+ * **Why derive at all.** A team points a stock LiveKit agent at egma and
+ * watches real conversations arrive, and the one question monitoring exists to
+ * answer — is my agent answering fast enough — was `skipped` on every one of
+ * them, because the framework times its turns in its own vocabulary and egma
+ * only read its own. The durations were there the whole time. Reading them is
+ * what turns a polite silence into a verdict.
+ *
+ * **Read time, not write time.** Nothing new is stored and the door still
+ * writes exactly what arrived, so every conversation already in the store gains
+ * its measures on the next read rather than on the next ingest.
+ *
+ * **Recognition rides the door's scope vetting** — see the kinds above. A
+ * framework egma does not know files everything as `other`, matches none of
+ * this, and derives nothing, which is the honest answer for a conversation egma
+ * cannot read.
+ *
+ * Every rule below is written out beside its measure's name in
+ * `packages/simulation-contract/measure-catalog.md`, plainly enough that two
+ * readers compute the same number from the same spans.
+ */
+function derivedFromFrameworkSpans(
+  conversation: SpannedConversation,
+): ReadonlyMap<string, readonly Sample[]> {
+  const turns: TimedSpan[] = [];
+  let root: TimedSpan | undefined;
+
+  for (const span of everySpanIn(conversation)) {
+    if (span.kind === HUMAN_TURN || span.kind === AGENT_TURN) {
+      turns.push(timed(span));
+      continue;
+    }
+    // The earliest root, so a trace holding more than one — a flush whose
+    // parent never came — is read from where the conversation actually began.
+    if (span.kind === ROOT) {
+      const candidate = timed(span);
+      if (root === undefined || candidate.startedAt < root.startedAt) {
+        root = candidate;
+      }
+    }
+  }
+  turns.sort(byWhenItBegan);
+
+  const derived = new Map<string, readonly Sample[]>();
+  put(derived, "turn_response_latency", turnResponseLatency(turns));
+  put(derived, "first_response_latency", firstResponseLatency(root, turns));
+  put(derived, "agent_speech_duration", agentSpeechDuration(turns));
+  return derived;
+}
+
+/** A measure with no samples is absent, exactly as it is for a timed one. */
+function put(
+  derived: Map<string, readonly Sample[]>,
+  measure: string,
+  samples: readonly Sample[],
+): void {
+  if (samples.length > 0) derived.set(measure, samples);
+}
+
+/**
+ * How long the agent took to answer, once for every turn the human took.
+ *
+ * From the **human turn's end** to the moment the agent's next turn began
+ * speaking — its first `speaking` child's start, or the turn's own start for an
+ * agent turn that carried no speech, which is what a turn that answered with a
+ * tool call looks like. The next agent turn is the next one in the
+ * conversation, ordered by when each began, which is the order a transcript
+ * reads in.
+ *
+ * **A measurement that runs backwards is not a slow answer and is not kept.**
+ * The agent begins speaking before the human stops on every interruption, and
+ * on a real captured call that is five neighbouring turn pairs out of twelve. A
+ * negative latency would drag a mean below zero and make a bound pass that
+ * should have failed — a number that is wrong is worse than a measurement that
+ * is missing, so the overlapping turn contributes nothing and the turns around
+ * it still count.
+ */
+function turnResponseLatency(turns: readonly TimedSpan[]): readonly Sample[] {
+  const samples: Sample[] = [];
+  for (const [at, turn] of turns.entries()) {
+    if (turn.kind !== HUMAN_TURN) continue;
+    const answered = answeringSpeech(turns, at);
+    if (answered === undefined) continue;
+    const latency = milliseconds(answered.startedAt - turn.endedAt);
+    if (latency < 0) continue;
+    samples.push({ value: latency, spanId: answered.spanId });
+  }
+  return samples;
+}
+
+/**
+ * How long the agent took to say anything at all, from the moment the
+ * conversation began.
+ *
+ * The root span is where a conversation begins — the one span the whole thing
+ * happened inside — and the agent's first word is its first turn's first
+ * `speaking` child. A first agent turn that never spoke has no first word to
+ * have waited for, so nothing is measured rather than a start time standing in
+ * for one: this measure is taken once, and one wrong number is the whole of it.
+ */
+function firstResponseLatency(
+  root: TimedSpan | undefined,
+  turns: readonly TimedSpan[],
+): readonly Sample[] {
+  if (root === undefined) return [];
+  const first = turns.find((turn) => turn.kind === AGENT_TURN);
+  if (first === undefined) return [];
+  const spoke = first.speech[0];
+  if (spoke === undefined) return [];
+  const latency = milliseconds(spoke.startedAt - root.startedAt);
+  if (latency < 0) return [];
+  return [{ value: latency, spanId: spoke.spanId }];
+}
+
+/**
+ * How long the agent spoke for in each of its turns, silence inside the answer
+ * excluded — which is what summing the turn's `speaking` children rather than
+ * taking the turn's own duration gets: a turn that thought for two seconds and
+ * then talked for one spoke for one.
+ *
+ * One sample per agent turn **that spoke**. A turn with no speech in it did not
+ * speak for zero milliseconds; it has no speech duration at all, and a zero
+ * would be a measurement of something that never happened.
+ *
+ * The sample cites the turn rather than one of the children, because the number
+ * is the turn's and no single child holds it.
+ */
+function agentSpeechDuration(turns: readonly TimedSpan[]): readonly Sample[] {
+  const samples: Sample[] = [];
+  for (const turn of turns) {
+    if (turn.kind !== AGENT_TURN || turn.speech.length === 0) continue;
+    let spoken = 0n;
+    for (const speech of turn.speech) spoken += speech.duration;
+    samples.push({ value: milliseconds(spoken), spanId: turn.spanId });
+  }
+  return samples;
+}
+
+/**
+ * Where the agent's answer to the human turn at `at` began.
+ *
+ * The next agent turn's first speech, or that turn's own start when it carried
+ * none. `undefined` when the human had the last word, which is a turn nobody
+ * answered rather than a turn answered slowly.
+ */
+function answeringSpeech(
+  turns: readonly TimedSpan[],
+  at: number,
+): { readonly startedAt: bigint; readonly spanId: string } | undefined {
+  for (const turn of turns.slice(at + 1)) {
+    if (turn.kind !== AGENT_TURN) continue;
+    return turn.speech[0] ?? { startedAt: turn.startedAt, spanId: turn.spanId };
+  }
+  return undefined;
+}
+
+/**
+ * A span as this arithmetic needs it: nanoseconds rather than the two strings
+ * a read hands back, and its speech lifted out once rather than per measure.
+ */
+type TimedSpan = {
+  readonly spanId: string;
+  readonly kind: string;
+  readonly startedAt: bigint;
+  readonly endedAt: bigint;
+  readonly duration: bigint;
+  /** This turn's own `speaking` children, earliest first. */
+  readonly speech: readonly {
+    readonly startedAt: bigint;
+    readonly spanId: string;
+    readonly duration: bigint;
+  }[];
+};
+
+function timed(span: TraceSpan): TimedSpan {
+  const startedAt = startedAtNanoseconds(span);
+  const duration = BigInt(span.durationNanoseconds);
+  return {
+    spanId: span.spanId,
+    kind: span.kind,
+    startedAt,
+    endedAt: startedAt + duration,
+    duration,
+    speech: span.spans
+      .filter((child) => child.kind === SPEAKING)
+      .map((child) => ({
+        startedAt: startedAtNanoseconds(child),
+        spanId: child.spanId,
+        duration: BigInt(child.durationNanoseconds),
+      }))
+      .sort((left, right) =>
+        left.startedAt < right.startedAt
+          ? -1
+          : left.startedAt > right.startedAt
+            ? 1
+            : 0,
+      ),
+  };
+}
+
+/**
+ * When a span began, in nanoseconds since the epoch.
+ *
+ * The store keeps starts to the microsecond and durations to the nanosecond, so
+ * this is exactly as precise as what was written: the six fractional digits are
+ * read as digits rather than through a `Date`, which holds milliseconds and
+ * would round the last three away — and a latency is a difference of two of
+ * these, where three lost digits is three lost digits of the answer.
+ */
+function startedAtNanoseconds(span: TraceSpan): bigint {
+  const dot = span.startedAt.indexOf(".");
+  if (dot === -1) {
+    return (
+      BigInt(Math.round(Date.parse(span.startedAt) / 1000)) *
+      MICROSECONDS_PER_SECOND *
+      NANOSECONDS_PER_MICROSECOND
+    );
+  }
+  const seconds = BigInt(Math.round(Date.parse(`${span.startedAt.slice(0, dot)}Z`) / 1000));
+  const fraction = span.startedAt.slice(dot + 1).replace(/[^0-9]/g, "");
+  const microseconds = BigInt(fraction.slice(0, 6).padEnd(6, "0"));
+  return (
+    (seconds * MICROSECONDS_PER_SECOND + microseconds) *
+    NANOSECONDS_PER_MICROSECOND
+  );
+}
+
+/**
+ * Nanoseconds as the milliseconds the catalog states every latency in.
+ *
+ * Floating point on purpose, exactly as a timing span's own duration is: a
+ * measure is `862.5ms` and a whole-number division would floor every one of
+ * them.
+ */
+function milliseconds(nanoseconds: bigint): number {
+  return Number(nanoseconds) / NANOSECONDS_PER_MILLISECOND;
+}
+
+/** Earliest first, on the nanoseconds rather than on the stored strings. */
+function byWhenItBegan(left: TimedSpan, right: TimedSpan): number {
+  return left.startedAt < right.startedAt
+    ? -1
+    : left.startedAt > right.startedAt
+      ? 1
+      : 0;
 }
 
 /**

--- a/packages/db/test/measures-from-spans.test.ts
+++ b/packages/db/test/measures-from-spans.test.ts
@@ -131,23 +131,35 @@ type Measured = Readonly<Record<string, readonly number[]>>;
  * and each one's **duration is its number** — nothing carries the value a second
  * time, exactly as the span vocabulary pins it.
  */
+/**
+ * Whether the door recognised this conversation's emitter.
+ *
+ * `unrecognised` files every span as `other`, which is what the door does for a
+ * scope its table does not know — so nothing is derivable from the shape and a
+ * case can be about egma's own timing spans and nothing else. `recognised` is
+ * the ordinary LiveKit-shaped conversation, whose turns a derivation reads.
+ */
+type Framework = "recognised" | "unrecognised";
+
 function aConversation(
   measured: Measured,
   stamped: Partial<NewSpan> = {},
+  framework: Framework = "unrecognised",
 ): { readonly traceId: string; readonly spans: readonly NewSpan[] } {
   const id = traceId();
   const root = spanId();
   const at = BigInt(WHEN.getTime()) * 1000n;
+  const known = framework === "recognised";
 
   const spans: NewSpan[] = [
-    span({ ...stamped, traceId: id, spanId: root }),
+    span({ ...stamped, traceId: id, spanId: root, kind: known ? "root" : "other" }),
     span({
       ...stamped,
       traceId: id,
       spanId: spanId(),
       parentSpanId: root,
       name: "user_turn",
-      kind: "turn:human",
+      kind: known ? "turn:human" : "other",
       text: "Can you move my cleaning to Tuesday?",
       startedAtMicroseconds: at + 1_000_000n,
     }),
@@ -157,7 +169,7 @@ function aConversation(
       spanId: spanId(),
       parentSpanId: root,
       name: "agent_turn",
-      kind: "turn:agent",
+      kind: known ? "turn:agent" : "other",
       text: "Booked for Tuesday at four.",
       startedAtMicroseconds: at + 3_000_000n,
     }),
@@ -192,8 +204,9 @@ async function stored(
   measured: Measured,
   stamped: Partial<NewSpan> = {},
   customer: AuthContext = auth,
+  framework: Framework = "unrecognised",
 ): Promise<TraceDetail> {
-  const conversation = aConversation(measured, stamped);
+  const conversation = aConversation(measured, stamped, framework);
   await appendSpans(customer, conversation.spans);
   const read = await readTrace(customer, conversation.traceId, {
     window: WINDOW,
@@ -245,11 +258,14 @@ describe("one conversation's measures", () => {
       {
         measure: "first_response_latency",
         unit: "milliseconds",
+        // Timed by egma's own vocabulary, so it is read rather than worked out.
+        derived: false,
         samples: [{ value: 1_214, spanId: expect.any(String) }],
       },
       {
         measure: "turn_response_latency",
         unit: "milliseconds",
+        derived: false,
         // In the order they were taken, so a per-turn series is the
         // conversation read forwards — and the half is still here, which a
         // whole-number division would have floored away.
@@ -475,5 +491,247 @@ describe("a conversation a measure cannot be computed for", () => {
     for (const each of notFromSpans) {
       expect(measureIn(trace, each.measure)).toBeUndefined();
     }
+  });
+});
+
+/* ------------------------------------------------------------------- *
+ * The derived measures: a framework's own spans, read as these numbers.
+ * ------------------------------------------------------------------- */
+
+/**
+ * What egma works out for a conversation that timed nothing itself.
+ *
+ * **Constructed trees, and the shapes are the point.** Each case here is one
+ * arrangement of turns and speech that a rule has to answer the same way twice —
+ * turns out of order, a turn that answered without speaking, an interruption,
+ * an emitter the door did not recognise, and a conversation carrying both
+ * vocabularies. The captured LiveKit trace proves the whole path in
+ * `apps/api/test/otlp-derived-measures.test.ts`, against numbers hand-computed
+ * from its own timestamps; what is proved here is the arithmetic itself.
+ *
+ * Rows are written and read back through the real store, exactly as every case
+ * above is, so the derivation is asked the same question a grader asks.
+ */
+
+/** One turn of a constructed conversation, in whole milliseconds from the root. */
+type Turn = {
+  readonly who: "human" | "agent";
+  readonly from: number;
+  readonly to: number;
+  /** The `speaking` children the door filed inside it, if any. */
+  readonly spoke?: readonly (readonly [number, number])[];
+};
+
+const MILLISECOND = 1_000n;
+
+/**
+ * A LiveKit-shaped conversation: a root, its turns, and the speech inside them.
+ *
+ * Timing spans are the caller's to add, so a case can put both vocabularies on
+ * one conversation and ask which wins.
+ */
+async function aLiveKitCall(
+  turns: readonly Turn[],
+  timed: Measured = {},
+): Promise<TraceDetail> {
+  const id = traceId();
+  const root = spanId();
+  const at = BigInt(WHEN.getTime()) * 1000n;
+  const ends = turns.reduce((longest, turn) => Math.max(longest, turn.to), 0);
+
+  const spans: NewSpan[] = [
+    span({
+      traceId: id,
+      spanId: root,
+      name: "agent_session",
+      kind: "root",
+      startedAtMicroseconds: at,
+      durationNanoseconds: BigInt(ends) * 1_000_000n,
+    }),
+  ];
+
+  for (const turn of turns) {
+    const id_ = spanId();
+    spans.push(
+      span({
+        traceId: id,
+        spanId: id_,
+        parentSpanId: root,
+        name: turn.who === "human" ? "user_turn" : "agent_turn",
+        kind: turn.who === "human" ? "turn:human" : "turn:agent",
+        startedAtMicroseconds: at + BigInt(turn.from) * MILLISECOND,
+        durationNanoseconds: BigInt(turn.to - turn.from) * 1_000_000n,
+      }),
+    );
+    for (const [from, to] of turn.spoke ?? []) {
+      spans.push(
+        span({
+          traceId: id,
+          spanId: spanId(),
+          parentSpanId: id_,
+          name: turn.who === "human" ? "user_speaking" : "agent_speaking",
+          kind: "speaking",
+          startedAtMicroseconds: at + BigInt(from) * MILLISECOND,
+          durationNanoseconds: BigInt(to - from) * 1_000_000n,
+        }),
+      );
+    }
+  }
+
+  let taken = 0n;
+  for (const [measure, samples] of Object.entries(timed)) {
+    for (const milliseconds of samples) {
+      taken += 100_000n;
+      spans.push(
+        span({
+          traceId: id,
+          spanId: spanId(),
+          parentSpanId: root,
+          name: measure,
+          kind: "timing",
+          startedAtMicroseconds: at + taken,
+          durationNanoseconds: BigInt(Math.round(milliseconds * 1_000_000)),
+        }),
+      );
+    }
+  }
+
+  await appendSpans(auth, spans);
+  const read = await readTrace(auth, id, { window: WINDOW });
+  if (read === undefined) throw new Error("the trace store lost the spans");
+  return read;
+}
+
+describe("measures derived from a recognised framework's own spans", () => {
+  /**
+   * Two exchanges, so the series is a conversation read forwards rather than a
+   * bag of numbers — the order is what makes a percentile mean anything.
+   */
+  it("measures every human turn's wait, in the order the turns happened", async () => {
+    const trace = await aLiveKitCall([
+      { who: "human", from: 0, to: 1_000 },
+      { who: "agent", from: 1_100, to: 3_000, spoke: [[1_400, 3_000]] },
+      { who: "human", from: 4_000, to: 5_000 },
+      { who: "agent", from: 5_050, to: 7_000, spoke: [[5_600, 7_000]] },
+    ]);
+
+    const measured = measureIn(trace, "turn_response_latency");
+    expect(measured?.derived).toBe(true);
+    // 1400 − 1000, then 5600 − 5000: the human turn's end to the agent's first
+    // word, once per human turn and in that order.
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([400, 600]);
+  });
+
+  /**
+   * A turn that answered with a tool call and no speech still answered. The
+   * turn's own start stands in for the first word it never said, which is the
+   * only endpoint the trace holds.
+   */
+  it("falls back to an agent turn's own start when it never spoke", async () => {
+    const trace = await aLiveKitCall([
+      { who: "human", from: 0, to: 1_000 },
+      { who: "agent", from: 1_250, to: 2_000 },
+    ]);
+
+    const measured = measureIn(trace, "turn_response_latency");
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([250]);
+    // And a turn that never spoke has no speech duration at all — not a zero,
+    // which would measure something that did not happen.
+    expect(measureIn(trace, "agent_speech_duration")).toBeUndefined();
+  });
+
+  /**
+   * The agent talking over the caller is an interruption, not a fast answer.
+   * The measurement runs backwards, so it is dropped — and the turns around it
+   * are still measured, which is the half that matters.
+   */
+  it("drops a turn the agent interrupted, and keeps the ones it did not", async () => {
+    const trace = await aLiveKitCall([
+      { who: "human", from: 0, to: 5_000 },
+      // Begins speaking two seconds before the caller stops.
+      { who: "agent", from: 2_500, to: 6_000, spoke: [[3_000, 6_000]] },
+      { who: "human", from: 7_000, to: 8_000 },
+      { who: "agent", from: 8_100, to: 9_000, spoke: [[8_300, 9_000]] },
+    ]);
+
+    const measured = measureIn(trace, "turn_response_latency");
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([300]);
+  });
+
+  it("measures the first answer from the moment the conversation began", async () => {
+    const trace = await aLiveKitCall([
+      { who: "agent", from: 40, to: 4_000, spoke: [[1_500, 4_000]] },
+      { who: "human", from: 5_000, to: 6_000 },
+    ]);
+
+    const measured = measureIn(trace, "first_response_latency");
+    expect(measured?.derived).toBe(true);
+    // The root's start to the first agent turn's first word, and taken once.
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([1_500]);
+  });
+
+  /**
+   * Silence inside an answer is not speech. Two bursts with a gap between them
+   * sum to what was said, which is what the turn's own duration would have got
+   * wrong.
+   */
+  it("sums the speech inside each agent turn, once per turn that spoke", async () => {
+    const trace = await aLiveKitCall([
+      {
+        who: "agent",
+        from: 0,
+        to: 5_000,
+        spoke: [
+          [500, 1_500],
+          [3_000, 3_750],
+        ],
+      },
+      { who: "human", from: 6_000, to: 7_000 },
+      { who: "agent", from: 8_000, to: 9_000, spoke: [[8_100, 9_000]] },
+    ]);
+
+    const measured = measureIn(trace, "agent_speech_duration");
+    expect(measured?.derived).toBe(true);
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([
+      1_750, 900,
+    ]);
+    // The number is the turn's, so it cites the turn rather than one child.
+    expect(measured?.samples[0]?.spanId).toBe(trace.turns[0]?.spanId);
+  });
+
+  /**
+   * **The trust rule.** Recognition rides the kinds the ingest door assigns from
+   * the emitting scope, and a scope it does not know is filed as `other`. A
+   * framework egma has not been taught therefore derives nothing, however
+   * conversation-shaped its spans look.
+   */
+  it("derives nothing at all from an emitter the door did not recognise", async () => {
+    const trace = await stored({}, {}, auth, "unrecognised");
+
+    expect(measuresFromSpans(trace)).toEqual([]);
+  });
+
+  /**
+   * **egma's own timing vocabulary wins absolutely.** The conversation below
+   * carries both — turns a derivation could read and a timing span that measured
+   * the same thing — and the answer is the timed one, alone. Appending both
+   * would double one turn's samples and move every percentile a grader reduces
+   * by.
+   */
+  it("never derives a measure the conversation already timed itself", async () => {
+    const turns: readonly Turn[] = [
+      { who: "human", from: 0, to: 1_000 },
+      { who: "agent", from: 1_100, to: 3_000, spoke: [[1_400, 3_000]] },
+    ];
+    const both = await aLiveKitCall(turns, { turn_response_latency: [862.5] });
+
+    const measured = measureIn(both, "turn_response_latency");
+    expect(measured?.derived).toBe(false);
+    // The timed number, and not the 400 the same spans would have derived.
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([862.5]);
+
+    // The measures it did **not** time are still derived, so precedence is per
+    // measure rather than a switch that turns the whole conversation off.
+    expect(measureIn(both, "agent_speech_duration")?.derived).toBe(true);
   });
 });

--- a/packages/db/test/measures-from-spans.test.ts
+++ b/packages/db/test/measures-from-spans.test.ts
@@ -641,6 +641,26 @@ describe("measures derived from a recognised framework's own spans", () => {
   });
 
   /**
+   * A caller who says "hello" and then "are you there" before the agent replies
+   * has taken two turns and been answered once. Counting the one reply for both
+   * would file the same wait twice — the same number in the series twice over,
+   * a worse worst on the page, and a bound failed by a duplicate. The first turn
+   * measures nothing, because the wait it would have measured ended when the
+   * caller spoke again rather than when the agent did.
+   */
+  it("answers only the nearest human turn when the caller spoke twice", async () => {
+    const trace = await aLiveKitCall([
+      { who: "human", from: 0, to: 1_000 },
+      { who: "human", from: 2_000, to: 3_000 },
+      { who: "agent", from: 3_200, to: 5_000, spoke: [[3_500, 5_000]] },
+    ]);
+
+    const measured = measureIn(trace, "turn_response_latency");
+    // One sample, and it is the second turn's: 3500 − 3000.
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([500]);
+  });
+
+  /**
    * The agent talking over the caller is an interruption, not a fast answer.
    * The measurement runs backwards, so it is dropped — and the turns around it
    * are still measured, which is the half that matters.

--- a/packages/simulation-contract/measure-catalog.md
+++ b/packages/simulation-contract/measure-catalog.md
@@ -106,12 +106,63 @@ two counts of one call disagreeing is exactly what one shared module exists to
 prevent. `turn_count` is the pointed case: the turn spans could be counted, and
 they are deliberately not.
 
-**Nothing is derived from the shape of the transcript**, on either source. The
-obvious candidate — the gap between a human turn ending and the agent's beginning
-— comes out negative on a real captured conversation, where five of twelve
-neighbouring turn pairs overlap. A number that is wrong is worse than a measure
-that is missing, so a measure the spans do not carry is absent, and a grader
-asked for it answers `skipped`.
+## Derived measures: a framework's own spans, read as these numbers
+
+A **derived** measure is one Egma works out from a framework's own spans rather
+than reading off a timing span named for it. It is a fact about one
+conversation, not a new measure and not a new word: the same three names below
+are timed on a simulation and derived on a stock LiveKit call, and a grader
+bounding one never has to know which it got.
+
+Why they exist: a team pointing a stock LiveKit agent at Egma got `skipped` on
+every production conversation, because the framework times its turns in its own
+vocabulary and Egma read only its own. The durations were there the whole time.
+
+Three rules hold over all of them.
+
+- **Recognition rides the door's scope vetting, never a span name.** The ingest
+  door assigns `root`, `turn:human`, `turn:agent` and `speaking` from a table
+  keyed by the emitting instrumentation scope; a scope it does not know is filed
+  as `other`, whatever its spans are called. So the kinds below are already
+  evidence that Egma recognised the emitter, and a lookalike span from some
+  other framework becomes nothing.
+- **Egma's own timing vocabulary wins absolutely.** When a conversation carries
+  timing spans for a measure, no derivation for that measure runs. A
+  conversation carrying both has one answer, never two appended.
+- **A measurement that runs backwards is not kept.** The agent begins speaking
+  before the human stops on every interruption — five of twelve neighbouring
+  turn pairs on the captured call. A negative latency would drag a mean below
+  zero and pass a bound that should have failed.
+
+Derived at read time. Nothing new is stored, and every conversation already in
+the store gains these on the next read.
+
+| Measure | Derived from the LiveKit scope as | Taken |
+| --- | --- | --- |
+| `turn_response_latency` | From each `turn:human` span's **end** to the start of the next `turn:agent` span's first `speaking` child — or to that agent turn's own start when it carried no `speaking` child. The next agent turn is the next one by start time, which is the order a transcript reads in. | One sample per human turn, in conversation order. A human turn nobody answered, and one whose sample runs backwards, contribute none. |
+| `first_response_latency` | From the `root` span's start to the start of the first `turn:agent` span's first `speaking` child. A first agent turn that never spoke has no first word to have waited for, and nothing is measured. | Once. |
+| `agent_speech_duration` | The sum of a `turn:agent` span's own `speaking` children's durations — so a turn that thought for two seconds and then talked for one spoke for one. | One sample per agent turn **that spoke**. A turn with no speech in it has no speech duration; a zero would measure something that never happened. |
+
+Each sample cites the span its number came from: the span whose start closed the
+interval for a latency, and the turn itself for a duration summed over its
+children.
+
+**Two measures are deliberately not derived.**
+
+- `time_to_first_word` — defined out of audio Egma does not hold for production
+  traffic.
+- `persona_speech_duration` — Egma's synthetic caller is not in a production
+  conversation, so the measure has no production meaning.
+
+Every other framework derives nothing until an effort of its own teaches this
+document its shapes.
+
+**Nothing is derived from the shape of the transcript alone**, on either source
+— which is what the `speaking` children above are for. The obvious shortcut, the
+gap between one turn ending and the next beginning, comes out negative on a real
+captured conversation. A number that is wrong is worse than a measure that is
+missing, so a measure the spans do not carry is absent, and a grader asked for
+it answers `skipped`.
 
 ## The aggregations
 

--- a/packages/simulation-contract/measure-catalog.md
+++ b/packages/simulation-contract/measure-catalog.md
@@ -1,6 +1,6 @@
 # The measure catalog
 
-**Catalog version: 2**
+**Catalog version: 3**
 
 Every measure a conversation produces, named once and defined once, so that a
 grader references a known measure instead of guessing a string — and so that the
@@ -139,7 +139,7 @@ the store gains these on the next read.
 
 | Measure | Derived from the LiveKit scope as | Taken |
 | --- | --- | --- |
-| `turn_response_latency` | From each `turn:human` span's **end** to the start of the next `turn:agent` span's first `speaking` child — or to that agent turn's own start when it carried no `speaking` child. The next agent turn is the next one by start time, which is the order a transcript reads in. | One sample per human turn, in conversation order. A human turn nobody answered, and one whose sample runs backwards, contribute none. |
+| `turn_response_latency` | From each `turn:human` span's **end** to the start of the next `turn:agent` span's first `speaking` child — or to that agent turn's own start when it carried no `speaking` child. The next agent turn is the next one by start time, which is the order a transcript reads in. **An agent turn answers only the nearest human turn before it: a human turn followed by another human turn before any agent turn was not answered, and measures nothing.** | One sample per human turn, in conversation order. A human turn nobody answered, one the caller spoke over with a second turn, and one whose sample runs backwards contribute none. |
 | `first_response_latency` | From the `root` span's start to the start of the first `turn:agent` span's first `speaking` child. A first agent turn that never spoke has no first word to have waited for, and nothing is measured. | Once. |
 | `agent_speech_duration` | The sum of a `turn:agent` span's own `speaking` children's durations — so a turn that thought for two seconds and then talked for one spoke for one. | One sample per agent turn **that spoke**. A turn with no speech in it has no speech duration; a zero would measure something that never happened. |
 

--- a/packages/simulation-contract/src/measures.ts
+++ b/packages/simulation-contract/src/measures.ts
@@ -43,8 +43,15 @@
  * grader reads became one derived from the trace rather than one carried
  * separately. No measure joined or left; what each of them *means* is now said
  * precisely enough to compute, which is exactly what this number is for.
+ *
+ * **3** is where three of them gained a second span-level definition: computed
+ * from a recognised framework's own spans, for a conversation that timed none
+ * itself. No measure joined or left and no timed number changed, but a
+ * conversation that answered "nothing measured" at version 2 answers with
+ * three latencies at version 3 — which is a measure changing what it means to a
+ * consumer, and this number is what tells them so.
  */
-export const MEASURE_CATALOG_VERSION = 2;
+export const MEASURE_CATALOG_VERSION = 3;
 
 /**
  * How a measure is reduced to the one number a threshold is applied to.


### PR DESCRIPTION
Implements the livekit-measures ticket, one tracer bullet: a stock LiveKit agent's production conversation now carries latency measures derived from its own spans, and a production-scoped latency grader writes a real verdict on it — proven live within the hour on the standing monitoring rig, and pinned deterministically in CI.

## The derivations

- The measure catalog gains a "Derived measures" section: `turn_response_latency`, `first_response_latency`, `agent_speech_duration`, each with its exact endpoints, for the LiveKit scope only. Two deliberate exclusions documented (`time_to_first_word` needs audio egma does not hold; `persona_speech_duration` has no production meaning).
- Computed at read time in the one shared measure module — the store stays verbatim, simulations and production keep one computation, and **every already-stored conversation gains measures retroactively** (verified on the two conversations the monitoring-surface proof stored: no re-ingest, `derived: true`, span-anchored samples).
- Recognition keys on the door's scope-vetted kinds — a span merely named like LiveKit's, from an unrecognized scope, derives nothing. Egma's own timing vocabulary keeps absolute precedence; nothing double-counts.
- Negative turn latencies (interruptions — the agent starts before the caller stops) are dropped rather than allowed to drag a mean below a bound; the captured fixture itself carries three interruptions in five human turns.
- The transcript's measures panel words the provenance: "worked out from your framework's own timings rather than timed by Egma. Each says which."

## The bug the live e2e caught

With real production verdict rows finally in existence, the transcript still said `skipped 0/0`: the detail read filed its verdict lookup under a simulation id derived mechanically from **every** trace id — a phantom id for production traffic — so production verdicts have been structurally invisible since production grading shipped. Fixed (derive the simulation id only when the conversation is a simulation) and pinned by two contract tests that seed a production trace through the real door and write a verdict the way the grader does; both fail with the fix reverted.

## The live proof (recorded on the planning ticket)

Fresh call on the standing rig: 2m49s, 3 human / 7 agent turns, 91 spans. Derived measures on screen — first response 3766.868 ms, worst turn response 2404.030 ms, agent speech 22741 ms — and the production-scoped grader's verdict: **passed, score 1, 1/1 checks**, against the 15 s bound. The two earlier stored conversations also now carry passed verdicts (the redeploy re-claimed their expired grading leases with this code).

## Tests

Scoped, per the effort's instruction: 24 measure-module cases (7 new constructed trees), 16 catalog, 5 fixture-anchored derivation checks with hand-computed expected values, 45 + 16 trace-read contract/unit, 63 web — plus typecheck and lint clean. The fixture expectations were computed from raw span timestamps, not through the code under test.

## Flagged for the reviewer

- `MEASURE_CATALOG_VERSION` stays at 2: no measure changed its definition; a second *source* for existing measures was added in its own section. Arguable under the catalog's own rule — bump if you read it the other way.
- The turn-response fallback measures pickup (agent turn start) on tool-only turns rather than speech; skipping to the next speaking agent turn is a one-line catalog refinement if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789523816&installation_model_id=431960&pr_number=125&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F125&signature=1b5618b97426dcfc1b33363e8c503f0d59e9652aac43710e54ad67d92c96d497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR derives three latency measures from recognized LiveKit spans at read time and exposes their provenance through trace reads and transcript rendering.

- Adds LiveKit derivation rules for first-response latency, turn-response latency, and agent speech duration.
- Prevents one agent response from being assigned to multiple consecutive human turns.
- Bumps the measure catalog contract to version 3.
- Looks up production verdicts under their trace IDs while preserving simulation-ID lookup for simulations.
- Adds fixture-backed, contract, grader, and web coverage for the new behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/measures/from-spans.ts | Adds shared LiveKit span derivations, explicit provenance, timing-span precedence, and nearest-human response assignment. |
| apps/api/src/routes/trace-reads.ts | Exposes derived provenance and selects production versus simulation verdict filing keys from the trace source. |
| packages/simulation-contract/src/measures.ts | Bumps the measure catalog version to 3 to identify the expanded span-level computation contract. |
| packages/simulation-contract/measure-catalog.md | Documents the version-3 LiveKit derivation contract and its supported measures. |
| apps/web/lib/transcripts.ts | Carries derived-measure provenance into the transcript model. |
| apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx | Presents derived measurements and their framework-timing provenance on production transcripts. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Stored trace spans] --> B{Egma timing spans exist?}
  B -- Yes --> C[Use timing-span samples]
  B -- No --> D{Recognized LiveKit turn and speaking kinds?}
  D -- Yes --> E[Derive latency and speech samples]
  D -- No --> F[Measure absent]
  C --> G[Shared measure result]
  E --> G
  G --> H[Trace transcript]
  G --> I[Latency grader]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Say what the grader&#39;s own trees now meas..."](https://github.com/egma-ai/egma/commit/e80be46a334ca609c7cfe81797ec540c6590f37c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53857970)</sub>

<!-- /greptile_comment -->