### PR TITLE
Every green merge deploys, and the web ships after the API

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -39,6 +39,10 @@ permissions:
   # What lets this job prove which repository and which ref it is, to AWS,
   # without a stored key. The same posture release-cli.yml takes with npm.
   id-token: write
+  # What lets the changes job ask which commit the last successful deploy
+  # carried — the diff base below, and the reason a superseded run's work is
+  # never lost.
+  actions: read
 
 concurrency:
   # Two deployments at once would race over the same containers, and the loser
@@ -70,6 +74,16 @@ jobs:
         # that are this pipeline. The bias is broad on purpose — a too-broad
         # match costs a harmless no-op deploy, a too-narrow one misses a real
         # deploy, and only one of those pages somebody.
+        #
+        # The diff base is the commit the last successful deploy run carried,
+        # not the commit this push replaced. The queue replaces a superseded
+        # pending run, so a run that never executes must have its changes
+        # carried by whichever run executes next — and a failed deploy's
+        # changes ride along the same way. Every executed run owns the whole
+        # delta since the platform last moved. The list below has a twin in
+        # the web job's yield step; change one, change both.
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -78,14 +92,24 @@ jobs:
             echo "Dispatched by hand: the whole pipeline runs."
             exit 0
           fi
-          before="${{ github.event.before }}"
-          if [ -z "$before" ] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
+          base=$(curl -sS \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-platform.yml/runs?branch=main&status=success&per_page=1" \
+            | python3 -c 'import json,sys; runs=json.load(sys.stdin).get("workflow_runs",[]); print(runs[0]["head_sha"] if runs else "")')
+          if [ -n "$base" ]; then
+            echo "Diffing against the last successful deploy run: $base"
+          else
+            base="${{ github.event.before }}"
+            echo "No successful deploy run yet; diffing against the pushed-over commit: $base"
+          fi
+          if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
             echo "platform=true" >> "$GITHUB_OUTPUT"
             echo "web=true" >> "$GITHUB_OUTPUT"
-            echo "No usable before-commit (a new branch, or history rewritten): the whole pipeline runs."
+            echo "No usable base commit (first run, or history rewritten): the whole pipeline runs."
             exit 0
           fi
-          changed=$(git diff --name-only "$before" "${{ github.sha }}")
+          changed=$(git diff --name-only "$base" "${{ github.sha }}")
           printf 'Changed:\n%s\n' "$changed"
           platform=false
           web=false
@@ -289,11 +313,53 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Yield when a newer merge owns the hook
+        id: yield
+        # The hook deploys the latest commit of main — not necessarily this
+        # run's commit. If main has moved past this run to a commit that will
+        # itself deploy (its run is behind this one in the queue), firing now
+        # would put that newer web live before its own API: exactly the
+        # ordering this pipeline exists to prevent. So yield, and let that
+        # run fire after its deploy. If main moved by commits that deploy
+        # nothing, fire — nobody else will. The path list is the twin of the
+        # changes job's; change one, change both. If the newer run fails its
+        # gate, the hook waits for the next green run, whose diff base
+        # carries everything outstanding.
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+          head=$(git rev-parse origin/main)
+          if [ "$head" = "${{ github.sha }}" ]; then
+            echo "fire=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          deployable=false
+          while IFS= read -r path; do
+            case "$path" in
+              apps/api/*|apps/grader/*|apps/simulator/*|packages/*) deployable=true ;;
+              docker-compose.yml|docker-compose.managed.yml|.env.example) deployable=true ;;
+              pnpm-lock.yaml|pnpm-workspace.yaml|package.json|tsconfig.base.json) deployable=true ;;
+              .github/workflows/deploy-platform.yml|.github/workflows/test.yml) deployable=true ;;
+              apps/web/*|tools/*) deployable=true ;;
+            esac
+          done <<< "$(git diff --name-only "${{ github.sha }}" "$head")"
+          if [ "$deployable" = "true" ]; then
+            echo "main moved to $head with deployable changes; that run fires the hook after its own deploy."
+            echo "fire=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "main moved to $head by commits that deploy nothing; this run still owns the hook."
+            echo "fire=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Tell Vercel to ship
-        # The hook deploys the latest commit of main, which is at least this
-        # one. Auto-deploy for main is off in apps/web/vercel.json, so this
-        # call is the only road to production for the web — which is the whole
-        # point: the page can never beat the route it calls.
+        if: steps.yield.outputs.fire == 'true'
+        # Auto-deploy for main is off in apps/web/vercel.json, so this call is
+        # the only road to production for the web — which is the whole point:
+        # the page can never beat the route it calls.
         env:
           HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
         run: |

--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -1,31 +1,37 @@
 name: Deploy platform
 
-# Deploying is one deliberate act: push a tag that names the deployment.
+# Every green merge to main deploys. The complete test suite runs first, on
+# the commit main actually carries — a pull request tests its own branch
+# head, and a merge commit is a tree no pull request ever saw. Then the three
+# images build, the box replaces what it runs, the platform proves it
+# answers, and only then is Vercel told to ship the web application — so a
+# page can never go live before the route it calls. A push that touches only
+# the web ships the web at once. A push that deploys nothing exits at once.
 #
-#   git tag platform-v2 && git push origin platform-v2
-#
-# Merging to main does not deploy. That is on purpose: this workflow can
-# replace a simulator while it is conducting a simulation, and a documentation
-# fix is not a reason to drop somebody's call.
+# It used to take a tag. The tag protected simulations: a deploy could
+# replace a simulator mid-call, so a human chose safe moments — and forgot,
+# which is how a page once shipped without its route. The simulator drains
+# now (the first stop signal ends claiming, the exchanges in flight finish
+# and report, ten minutes at the most), so any merge is safe at any hour and
+# the tag is retired. `workflow_dispatch` remains the by-hand override, and
+# `deploy.sh <sha>` on the box remains the rollback.
 #
 # **There is no migration step, and there is no missing one.** The API applies
 # both stores' schemas on boot, inside its own process, so a deployment is
 # three images and a restart. The API is also started first, because it owns
-# the schema the grader reads.
+# the schema the grader reads. The rule that keeps every deploy and every
+# rollback safe lives beside the migrations: packages/db/migrations/README.md.
 #
-# **The web application is not here.** It is a Next application on Vercel,
-# which deploys itself when main moves. This workflow is the half that runs on
-# egma's own machine.
-#
-# **Nothing in this file is specific to egma's hosted platform.** Every address
-# it uses arrives as a repository variable, so a self-hoster can point it at
-# their own account and registry without editing it. The values egma's own
-# deployment uses live in a private repository, not in this one.
+# **Nothing in this file is specific to egma's hosted platform.** Every
+# address arrives as a repository variable and the web hook as a secret, so a
+# self-hoster can point it at their own account and registry without editing
+# it. The values egma's own deployment uses live in a private repository, not
+# in this one.
 
 on:
   push:
-    tags:
-      - "platform-v*"
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -36,13 +42,87 @@ permissions:
 
 concurrency:
   # Two deployments at once would race over the same containers, and the loser
-  # would be a half-replaced platform. Queue instead, and never cancel a
-  # deployment half way.
+  # would be a half-replaced platform. Queue whole runs instead — a newer
+  # queued run replaces an older queued one, and a running deployment is never
+  # cancelled half way.
   group: deploy-platform
   cancel-in-progress: false
 
 jobs:
+  changes:
+    name: What this push deploys
+    runs-on: ubuntu-latest
+    outputs:
+      platform: ${{ steps.decide.outputs.platform }}
+      web: ${{ steps.decide.outputs.web }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The whole history, because this job diffs against the commit the
+          # branch held before the push, and a one-commit clone cannot.
+          fetch-depth: 0
+
+      - name: Decide from the changed paths
+        id: decide
+        # The platform list is what the three images COPY plus what the
+        # deployment reads: the three apps, the shared packages, the compose
+        # files, the settings shape, the build inputs, and the two workflows
+        # that are this pipeline. The bias is broad on purpose — a too-broad
+        # match costs a harmless no-op deploy, a too-narrow one misses a real
+        # deploy, and only one of those pages somebody.
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "platform=true" >> "$GITHUB_OUTPUT"
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "Dispatched by hand: the whole pipeline runs."
+            exit 0
+          fi
+          before="${{ github.event.before }}"
+          if [ -z "$before" ] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
+            echo "platform=true" >> "$GITHUB_OUTPUT"
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "No usable before-commit (a new branch, or history rewritten): the whole pipeline runs."
+            exit 0
+          fi
+          changed=$(git diff --name-only "$before" "${{ github.sha }}")
+          printf 'Changed:\n%s\n' "$changed"
+          platform=false
+          web=false
+          while IFS= read -r path; do
+            case "$path" in
+              apps/api/*|apps/grader/*|apps/simulator/*|packages/*) platform=true ;;
+              docker-compose.yml|docker-compose.managed.yml|.env.example) platform=true ;;
+              pnpm-lock.yaml|pnpm-workspace.yaml|package.json|tsconfig.base.json) platform=true ;;
+              .github/workflows/deploy-platform.yml|.github/workflows/test.yml) platform=true ;;
+              apps/web/*|tools/*) web=true ;;
+            esac
+          done <<< "$changed"
+          echo "platform=$platform" >> "$GITHUB_OUTPUT"
+          echo "web=$web" >> "$GITHUB_OUTPUT"
+          if [ "$platform" = "true" ]; then
+            echo "Platform paths changed: tests, then the box, then the web."
+          elif [ "$web" = "true" ]; then
+            echo "Only the web changed: Vercel ships now, nothing else moves."
+          else
+            echo "Nothing here deploys: exiting."
+          fi
+
+  tests:
+    name: The complete proof, on main's own tree
+    needs: changes
+    if: needs.changes.outputs.platform == 'true'
+    # The same workflow every pull request runs, called with `full: true` so
+    # the browser lane and the three Python suites run regardless of what
+    # `github.base_ref` says on a push.
+    uses: ./.github/workflows/test.yml
+    with:
+      full: true
+
   deploy:
+    name: Deploy the platform
+    needs: [changes, tests]
+    if: needs.changes.outputs.platform == 'true'
     runs-on: ubuntu-latest
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
@@ -125,7 +205,9 @@ jobs:
         # The API goes first and is waited on, because it owns the schema the
         # grader reads and applies it on boot. Starting the grader against a
         # schema that has not been migrated yet is the one ordering mistake
-        # this deployment can make.
+        # this deployment can make. The simulator is replaced under its
+        # ten-minute stop grace, so a simulation in flight finishes and
+        # reports before the old container exits.
         run: |
           set -euo pipefail
           # The steps run from a script rather than from a document built here.
@@ -149,8 +231,21 @@ jobs:
             --parameters commands="aws s3 sync s3://egma-deploy-${ACCOUNT}/deployment /opt/egma/deployment --delete && bash /opt/egma/deployment/deploy.sh $GITHUB_SHA" \
             --query Command.CommandId --output text)
           echo "SSM command: $command_id"
-          aws ssm wait command-executed \
-            --command-id "$command_id" --instance-id "$INSTANCE" || true
+          # Polled by hand rather than with `aws ssm wait`, whose waiter gives
+          # up after a hundred seconds. A deploy that lands mid-simulation now
+          # legitimately holds for the simulator's drain — up to ten minutes —
+          # and a waiter that quits early would call a working deploy failed.
+          # Twenty minutes covers the drain plus the sync, the pull and the
+          # start, with room to spare.
+          for _ in $(seq 1 120); do
+            status=$(aws ssm get-command-invocation \
+              --command-id "$command_id" --instance-id "$INSTANCE" \
+              --query Status --output text 2>/dev/null || echo Pending)
+            case "$status" in
+              Success|Failed|Cancelled|TimedOut|Undeliverable|Terminated) break ;;
+            esac
+            sleep 10
+          done
           aws ssm get-command-invocation \
             --command-id "$command_id" --instance-id "$INSTANCE" \
             --query '[Status,StandardOutputContent,StandardErrorContent]' \
@@ -178,3 +273,35 @@ jobs:
           done
           echo "$url never answered 200 after the deployment." >&2
           exit 1
+
+  web:
+    name: Ship the web application
+    # After the platform when the platform moved, straight away when only the
+    # web did, never when the platform deploy failed — a failed deploy ships
+    # no web, so the two halves stay old together rather than diverging.
+    # `always()` is what lets this run when `deploy` was skipped on a
+    # web-only push; the conditions after it put the gate back.
+    needs: [changes, deploy]
+    if: >-
+      always() && (
+        (needs.changes.outputs.platform == 'true' && needs.deploy.result == 'success') ||
+        (needs.changes.outputs.platform != 'true' && needs.changes.outputs.web == 'true')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tell Vercel to ship
+        # The hook deploys the latest commit of main, which is at least this
+        # one. Auto-deploy for main is off in apps/web/vercel.json, so this
+        # call is the only road to production for the web — which is the whole
+        # point: the page can never beat the route it calls.
+        env:
+          HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HOOK" ]; then
+            echo "VERCEL_DEPLOY_HOOK_URL is not set, and apps/web/vercel.json stops Vercel deploying main on its own — so nothing would ever ship the web." >&2
+            echo "Create a Deploy Hook for main in the Vercel project and store its URL as that secret. A deployment without Vercel can delete the web job instead." >&2
+            exit 1
+          fi
+          curl -fsS -X POST "$HOOK" >/dev/null
+          echo "Vercel told to ship the web application."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ name: Tests
 # real-browser proof, the simulator tests, the Python SDK tests and the fixture
 # tests. That is the handoff gate, and nothing in it is allowed to skip.
 #
+# The deploy pipeline is the third caller: on every push to main it runs this
+# workflow with `full: true` before anything builds, because a merge commit is
+# a tree no pull request ever tested and a direct push is a tree nothing
+# tested at all. Same complete proof, one more door.
+#
 # The split is deliberate rather than thrifty. An effort lands as a dozen pull
 # requests into one integration branch and then one pull request from that
 # branch into `main`. Running the browser proof and three Python suites on each
@@ -35,6 +40,12 @@ name: Tests
 
 on:
   pull_request:
+  workflow_call:
+    inputs:
+      full:
+        description: Run the complete proof, whatever the base branch says
+        type: boolean
+        default: false
 
 concurrency:
   # A newer push to the same pull request makes the run underway pointless.
@@ -54,8 +65,11 @@ jobs:
         # for, rather than to whichever jobs happened to be enabled that day.
         env:
           BASE: ${{ github.base_ref }}
+          FULL: ${{ inputs.full }}
         run: |
-          if [ "$BASE" = "main" ]; then
+          if [ "$FULL" = "true" ]; then
+            echo "Called by the deploy pipeline — the complete proof, on the commit main actually carries."
+          elif [ "$BASE" = "main" ]; then
             echo "Into main — the complete proof: lint, typecheck, the fast lane, the browser lane, the simulator, SDK and fixture tests."
           else
             echo "Into $BASE — the cheap lane: lint, typecheck and the fast lane."
@@ -141,7 +155,7 @@ jobs:
         # Only where a skip is not allowed. The recording suites start a MinIO
         # of their own from the image the compose file deploys, so pulling it
         # through compose keeps one version in one place.
-        if: github.base_ref == 'main'
+        if: ${{ github.base_ref == 'main' || inputs.full }}
         # **Compose interpolates every service before it pulls one**, and the
         # self-hosted phone platform declares ten variables with no default —
         # the LiveKit pair, the recording store's four credentials, the auth
@@ -167,7 +181,7 @@ jobs:
           # object store could be started would report the opposite of what
           # happened. Everywhere else the skip is the promise that contributing
           # costs no new infrastructure.
-          EGMA_REQUIRE_OBJECT_STORAGE: ${{ github.base_ref == 'main' && '1' || '' }}
+          EGMA_REQUIRE_OBJECT_STORAGE: ${{ (github.base_ref == 'main' || inputs.full) && '1' || '' }}
         run: |
           node -e 'const os = require("node:os"); console.log(`Fast Lane capacity: ${os.availableParallelism()} CPUs, 2 Vitest workers`);'
           pnpm test:fast
@@ -179,7 +193,7 @@ jobs:
     # matrix here would not make it faster, it would make it wrong — see
     # `apps/api/test/support/instance.ts` and `apps/web/tools/output-lock.ts`.
     name: Browser lane (one job, never sharded)
-    if: github.base_ref == 'main'
+    if: ${{ github.base_ref == 'main' || inputs.full }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -230,7 +244,7 @@ jobs:
 
   simulator:
     name: Simulator tests
-    if: github.base_ref == 'main'
+    if: ${{ github.base_ref == 'main' || inputs.full }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -264,7 +278,7 @@ jobs:
 
   sdk:
     name: Python SDK tests
-    if: github.base_ref == 'main'
+    if: ${{ github.base_ref == 'main' || inputs.full }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -295,7 +309,7 @@ jobs:
 
   fixture:
     name: Fixture agent tests
-    if: github.base_ref == 'main'
+    if: ${{ github.base_ref == 'main' || inputs.full }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/apps/cli/src/platform/contract.ts
+++ b/apps/cli/src/platform/contract.ts
@@ -114,7 +114,7 @@ export function contractRefusal(platform: PlatformContract): string | null {
   return [
     `This Egma instance speaks repository contract ${String(REPOSITORY_CONTRACT)} and this platform speaks ${String(platform)}.`,
     behind === "egma"
-      ? "This copy of Egma is older than the platform, and it would read only part of what the platform answers. Run npx egma@latest, then run this again."
+      ? "This copy of Egma is older than the platform, and it would read only part of what the platform answers. Run npx @egma/cli@latest, then run this again."
       : "The platform is older than this copy of Egma, and it cannot answer everything a test file now records. Upgrade the platform, or use the egma that shipped with it.",
     "Nothing was read and nothing was uploaded.",
   ].join(" ");

--- a/apps/cli/test/repository-sync.test.ts
+++ b/apps/cli/test/repository-sync.test.ts
@@ -1034,7 +1034,7 @@ describe("two egmas that read different shapes", () => {
       expect(refused.code, verb).toBe(7);
       expect(factOf(refused.stdout, "status"), verb).toBe("outdated");
       expect(refused.stderr, verb).toContain("This copy of Egma is older than the platform");
-      expect(refused.stderr, verb).toContain("npx egma@latest");
+      expect(refused.stderr, verb).toContain("npx @egma/cli@latest");
       expect(refused.stderr, verb).toContain("Nothing was read and nothing was uploaded.");
     }
 
@@ -1054,6 +1054,6 @@ describe("two egmas that read different shapes", () => {
 
     expect(refused.code).toBe(7);
     expect(refused.stderr).toContain("The platform is older than this copy of Egma");
-    expect(refused.stderr).not.toContain("npx egma@latest");
+    expect(refused.stderr).not.toContain("npx @egma/cli@latest");
   });
 });

--- a/apps/simulator/src/egma_simulator/__main__.py
+++ b/apps/simulator/src/egma_simulator/__main__.py
@@ -2,9 +2,14 @@
 
 Reads its whole configuration from ``EGMA_SIMULATOR_*`` environment
 variables, installs the credential-redacting log filter, and claims work
-until told to stop. SIGTERM and SIGINT stop it the honest way: in-flight
-exchanges are torn down and nothing terminal is invented for them — the
-control plane's orphan sweep records what a disappearing simulator means.
+until told to stop. The first SIGTERM or SIGINT is the drain: claiming
+ends, the exchanges in flight finish and report, and the process exits
+when the last one has — so replacing this container drops nobody's call.
+A second signal is the hard stop of old: in-flight exchanges are torn
+down and nothing terminal is invented for them — the control plane's
+orphan sweep records what a disappearing simulator means. The compose
+file's ``stop_grace_period`` is the drain's ceiling; past it, Docker
+kills the container and the sweep speaks for whatever remained.
 """
 
 from __future__ import annotations
@@ -99,8 +104,17 @@ async def _run(config: SimulatorConfig) -> None:
     task = asyncio.ensure_future(service.run())
 
     loop = asyncio.get_running_loop()
+
+    def on_stop_signal() -> None:
+        # The first signal drains; the second is the hard stop an operator
+        # still deserves when a drain is not what they meant.
+        if service.stop_requested:
+            task.cancel()
+        else:
+            service.request_stop()
+
     for signum in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(signum, task.cancel)
+        loop.add_signal_handler(signum, on_stop_signal)
 
     try:
         await task

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -31,6 +31,7 @@ simulator itself, and never a capacity slot that no longer comes back.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Protocol
@@ -506,9 +507,32 @@ class SimulatorService:
         self._claim_failure_began = 0.0
         self._claim_failure_said_at = 0.0
         self._claim_failure_count = 0
+        self._stop = asyncio.Event()
+
+    def request_stop(self) -> None:
+        """Ask for the drain: claim nothing new, finish the work in flight.
+
+        ``run()`` returns once the last in-flight simulation has reported.
+        This is what a deploy calls (through SIGTERM) so that replacing the
+        container costs nobody their call. Cancellation remains the hard
+        stop.
+        """
+        self._stop.set()
+
+    @property
+    def stop_requested(self) -> bool:
+        return self._stop.is_set()
 
     async def run(self) -> None:
-        """Claim and conduct until cancelled. Cancellation is the only exit."""
+        """Claim and conduct until stopped or cancelled.
+
+        Two stops, meaning different things. ``request_stop()`` is the
+        drain: claiming ends, the simulations in flight finish and report,
+        and this returns when the last one has. Cancellation is the hard
+        stop it always was: in-flight exchanges are torn down and nothing
+        terminal is invented for them — the control plane's orphan sweep
+        records what a disappearing simulator means.
+        """
         config = self._config
         async with ControlPlaneClient(
             config.control_plane_url,
@@ -525,9 +549,34 @@ class SimulatorService:
                 config.control_plane_url,
                 config.capacity,
             )
+            claiming = asyncio.ensure_future(
+                self._claim_forever(client, executor)
+            )
+            stop = asyncio.ensure_future(self._stop.wait())
             try:
-                await self._claim_forever(client, executor)
+                await asyncio.wait(
+                    {claiming, stop}, return_when=asyncio.FIRST_COMPLETED
+                )
+                if claiming.done():
+                    # The loop never returns; it only ends by a fault it
+                    # could not absorb. Await it so the fault is said.
+                    await claiming
+                in_flight = config.capacity - executor.free_capacity
+                if in_flight:
+                    logger.info(
+                        "stop requested; claiming nothing new, "
+                        "%d simulation(s) finishing",
+                        in_flight,
+                    )
+                claiming.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await claiming
+                # The drain, without the cancel that used to precede it:
+                # the running tasks are the calls being finished.
+                await executor.drain()
             finally:
+                stop.cancel()
+                claiming.cancel()
                 executor.cancel_all()
                 await executor.drain()
 

--- a/apps/simulator/tests/test_acceptance.py
+++ b/apps/simulator/tests/test_acceptance.py
@@ -16,6 +16,7 @@ scripted one, which is why none of it can flake.
 from __future__ import annotations
 
 import asyncio
+import signal
 from datetime import datetime
 
 import pytest
@@ -396,6 +397,88 @@ async def test_a_killed_simulator_just_stops_heartbeating(
     assert terminal_event_for(await workbench.records(), "sim-kill-001") is None, (
         "a killed simulator reported a terminal state it could not know"
     )
+
+
+async def test_the_first_stop_signal_drains_the_exchange_in_flight(
+    workbench, start_simulator
+):
+    """SIGTERM mid-exchange: the conversation finishes and reports, the
+    spec queued behind it is never claimed, and the process exits on its
+    own. This is what lets a deploy replace the simulator at any hour."""
+    await workbench.offer(
+        scripted_spec(
+            "sim-drain-001",
+            scenario=" ".join(f"Sentence number {n}." for n in range(1, 13)),
+            turn_seconds=0.15,
+            max_turns=200,
+            max_duration_seconds=600,
+        )
+    )
+    await workbench.offer(scripted_spec("sim-drain-queued"))
+    simulator = start_simulator(workbench, capacity=1)
+
+    records = await workbench.wait_for(
+        lambda records: len(turns_for(records, "sim-drain-001")) >= 2
+    )
+    turns_at_signal = len(turns_for(records, "sim-drain-001"))
+    simulator.process.send_signal(signal.SIGTERM)
+
+    records = await workbench.wait_for(has_terminal("sim-drain-001"))
+    terminal = terminal_event_for(records, "sim-drain-001")
+    assert terminal["status"] == "completed"
+    assert len(turns_for(records, "sim-drain-001")) > turns_at_signal, (
+        "the exchange was cut rather than finished"
+    )
+
+    assert simulator.process.wait(timeout=20) == 0
+
+    # Capacity was free the moment the exchange ended, and the queued spec
+    # was there for the taking. A draining simulator does not take it.
+    later = await workbench.records()
+    assert status_events_for(later, "sim-drain-queued") == []
+
+
+async def test_a_second_stop_signal_tears_down_at_once(
+    workbench, start_simulator
+):
+    """SIGTERM twice is the hard stop of old: the exchange is torn down
+    and nothing terminal is invented for it — the sweep's territory."""
+    await workbench.offer(
+        scripted_spec(
+            "sim-drain-hard-001",
+            scenario=LONG_SCENARIO,
+            turn_seconds=0.15,
+            max_turns=200,
+            max_duration_seconds=600,
+        )
+    )
+    simulator = start_simulator(workbench)
+
+    await workbench.wait_for(
+        lambda records: len(turns_for(records, "sim-drain-hard-001")) >= 2
+    )
+    simulator.process.send_signal(signal.SIGTERM)
+    await asyncio.sleep(0.3)
+    simulator.process.send_signal(signal.SIGTERM)
+
+    simulator.process.wait(timeout=15)
+    assert (
+        terminal_event_for(await workbench.records(), "sim-drain-hard-001")
+        is None
+    ), "a torn-down simulator reported a terminal state it could not know"
+
+
+async def test_an_idle_simulator_stops_at_once_on_the_first_signal(
+    workbench, start_simulator
+):
+    """Nothing in flight: the drain is over the moment it starts. A
+    self-hoster's `compose stop` never waits on an idle simulator."""
+    simulator = start_simulator(workbench)
+    await workbench.wait_for(
+        lambda records: any(record["kind"] == "claim" for record in records)
+    )
+    simulator.process.send_signal(signal.SIGTERM)
+    assert simulator.process.wait(timeout=10) == 0
 
 
 async def test_an_over_granting_control_plane_does_not_take_the_simulator_down(

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -460,6 +460,13 @@ services:
     build:
       context: .
       dockerfile: apps/simulator/Dockerfile
+    # A stopping simulator finishes the simulations it holds before it
+    # exits: the first stop signal ends claiming, not conversations. Ten
+    # minutes is a ceiling, not a wait — an idle simulator stops at once,
+    # and no call outlives ten minutes. Past the ceiling Docker kills the
+    # container and the control plane's sweep records what remained. The
+    # default grace is ten seconds, which would kill mid-sentence.
+    stop_grace_period: 10m
     environment:
       # Where it claims, heartbeats and reports. The API and the simulator
       # meet inside this network, so this is the service name rather than

--- a/packages/db/migrations/README.md
+++ b/packages/db/migrations/README.md
@@ -1,0 +1,31 @@
+# The migration rule
+
+One rule keeps every deploy and every rollback safe, and it binds both
+stores — the Postgres files here and the ClickHouse files in
+`../clickhouse-migrations/`:
+
+**A migration may never break the code that is currently running.**
+
+The platform deploys on every green merge, and the API applies these files
+on boot, before the new code serves — so for a moment the *old* code runs
+against the *new* schema. A rollback is the same moment held open: it
+redeploys old code against a schema that stays, because applied migrations
+are immutable and are never undone. Both are survivable only while every
+migration is additive from the running code's point of view.
+
+In practice:
+
+- **Add freely.** New tables, new nullable columns, new indexes — code that
+  does not know them never sees them.
+- **Remove in two releases, not one.** Stop reading the thing first and ship
+  that; drop it in a later release than the one that stopped using it. A
+  rename is an add and a remove, in that order, never one statement.
+- **Never rewrite an applied file.** The runner refuses a changed file
+  rather than skipping it (`packages/db/src/migrate.ts`), so the history
+  here is what production actually ran.
+- **ClickHouse has no choice.** There is no transaction to wrap a file in,
+  so its migrations are additive by necessity rather than convention.
+
+A change that cannot follow the rule in one step — a type change, a backfill
+that must rewrite — ships as expand, migrate, contract across releases, and
+the contract step waits until nothing supported still reads the old shape.


### PR DESCRIPTION
Retires the `platform-v*` deploy tag and makes every green merge to main deploy the platform, with the web application shipped only after the API it calls.

## The story

The two halves deployed on different triggers, held together by a memory rule that failed within a day of hosted egma existing: on 2026-08-15, password reset merged, the page went live on Vercel, and the route behind it waited for a tag nobody pushed. The tag itself existed to protect simulations — a deploy could replace the simulator mid-call. Both problems are mechanisms now, not rules.

## What changed

**The simulator finishes its calls before it stops** (`f65dc27`). The first SIGTERM drains: claiming ends, in-flight simulations run to their natural end and report, the process exits when the last one has. A second signal is the hard stop of old. `stop_grace_period: 10m` on the simulator is the ceiling — an idle simulator still stops instantly. Three new acceptance tests drive the real child process: the drain finishes the exchange and never takes the spec queued behind it; a second signal tears down with nothing terminal invented; an idle simulator exits at once.

**The pipeline** (`1667904`). `deploy-platform.yml` now triggers on push to main (dispatch kept, tag trigger gone). A `changes` job splits three ways: platform paths → full suite (`test.yml` gains `workflow_call` with `full: true`, so the browser lane and all three Python suites run on main's own tree) → build → deploy → smoke → Vercel hook; web-only paths → hook immediately; neither → exit running nothing. Deploys queue and a running one is never cancelled. The SSM wait is polled for up to twenty minutes because a deploy landing mid-simulation now legitimately holds for the drain. `apps/web/vercel.json` stops Vercel auto-deploying main (previews untouched), and the migration rule that keeps deploys and rollbacks safe is written at `packages/db/migrations/README.md`.

**The refusal names a package that exists** (`39cac5c`). The contract refusal said `npx egma@latest`; the bare name `egma` is not on npm (similarity-filtered, appeal never filed). It now says `npx @egma/cli@latest`.

## What to watch on merge day

- `VERCEL_DEPLOY_HOOK_URL` is already stored as a repository secret (created 2026-08-17).
- Vercel's docs don't state whether a Deploy Hook fires once `git.deploymentEnabled` is false for the branch. If this merge shows the hook firing but no production deployment appearing, revert `apps/web/vercel.json` — one file, and only the ordering guarantee is lost while a better switch is found.
- A quiet extra ten minutes on the SSM step during a deploy is the drain working, not a hang.

## Evidence

Simulator suite 626 passed (three new drain tests included) + ruff clean; `repository-sync` 22 passed; `pnpm lint` and `pnpm typecheck` clean; both workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQd67ecim3uYYXsPAgQ7YG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQd67ecim3uYYXsPAgQ7YG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789530132&installation_model_id=431960&pr_number=127&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F127&signature=ff5a3755a27efc94bb7e56530aa2641245058fd0edc4bf3cdefc5bf4a9674e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes green merges deploy the platform, drains in-flight simulator work during replacement, and gates the Vercel hook behind platform deployment. The hook ownership fix still leaves a race between checking main and firing the latest-main hook.
- Adds path-aware tests, deployment, smoke checks, and web release sequencing.
- Adds graceful simulator shutdown with a ten-minute container stop ceiling.
- Disables Vercel’s automatic main deployment and corrects the CLI upgrade command.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the latest-main hook can still publish a newer web commit before its API deployment.

The workflow checks origin/main and invokes the Deploy Hook in separate steps; a platform-and-web merge arriving between them causes Vercel to deploy that newer main commit while its platform run remains queued.

**Files Needing Attention:** .github/workflows/deploy-platform.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-platform.yml | Adds the merge-driven deployment pipeline and an incomplete latest-main hook ordering guard that remains vulnerable to a check-to-hook race. |
| .github/workflows/test.yml | Makes the full test workflow callable by the deployment pipeline and enables all complete-suite lanes through the explicit input. |
| apps/simulator/src/egma_simulator/service.py | Adds a graceful stop event that ends claiming and drains active simulations before teardown. |
| apps/simulator/src/egma_simulator/__main__.py | Changes first-signal handling to request a drain while retaining second-signal cancellation. |
| apps/web/vercel.json | Disables automatic production deployment from main so releases flow through the ordered hook. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as Current workflow
    participant G as main
    participant B as Newer workflow
    participant V as Vercel
    A->>G: Fetch and check current SHA
    G-->>A: Current workflow SHA
    G->>G: New platform+web commit lands
    G->>B: Queue newer workflow
    A->>V: Fire Deploy Hook
    V->>G: Deploy latest main
    Note over V,B: New web ships while newer API workflow is queued
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fdeployment-versioning-strategy-v7jcc4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fdeployment-versioning-strategy-v7jcc4%22.%0A%0AGreploop%20egma-ai%2Fegma%20PR%20%23127%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=egma-ai%2Fegma&pr=127&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fdeployment-versioning-strategy-v7jcc4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fdeployment-versioning-strategy-v7jcc4%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fdeploy-platform.yml%3A334-335%0A**Latest-main%20race%20remains**%0A%0AIf%20a%20newer%20platform-and-web%20commit%20reaches%20%60main%60%20after%20this%20fetch%20but%20before%20the%20subsequent%20Deploy%20Hook%20request%2C%20the%20yield%20decision%20remains%20%60fire%3Dtrue%60%20and%20the%20hook%20deploys%20that%20newer%20web%20commit%2C%20causing%20it%20to%20go%20live%20while%20its%20API%20workflow%20is%20still%20queued.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=127&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fdeploy-platform.yml%3A334-335%0A**Latest-main%20race%20remains**%0A%0AIf%20a%20newer%20platform-and-web%20commit%20reaches%20%60main%60%20after%20this%20fetch%20but%20before%20the%20subsequent%20Deploy%20Hook%20request%2C%20the%20yield%20decision%20remains%20%60fire%3Dtrue%60%20and%20the%20hook%20deploys%20that%20newer%20web%20commit%2C%20causing%20it%20to%20go%20live%20while%20its%20API%20workflow%20is%20still%20queued.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=127&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Each run deploys everything since the pl..."](https://github.com/egma-ai/egma/commit/4d82f4f911c2496823e4249822f66bf2e3ca5744) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53871802)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->