### PR TITLE
A zero read off a widthless turn is two placeholders agreeing, not a measurement

### DIFF
--- a/packages/db/src/measures/from-spans.ts
+++ b/packages/db/src/measures/from-spans.ts
@@ -309,6 +309,19 @@ function derivedFromFrameworkSpans(
 
   for (const span of everySpanIn(conversation)) {
     if (span.kind === HUMAN_TURN || span.kind === AGENT_TURN) {
+      // **A turn of zero width was never timed, and nothing is read off it.**
+      // Retell publishes no per-turn timing, so its normalizer opens every turn
+      // at the production trace's own start and closes it in the same instant —
+      // placeholders, said plainly in `apps/api/src/retell/normalise.ts`. Read
+      // as geometry they describe an agent that answered instantly every time:
+      // a series of zeroes that holds any bound put to it, so a trace whose
+      // worst wait was really 2145 ms passes a two-second bound with "0
+      // milliseconds at its worst" as the rationale. It is the negative guard
+      // below, stated one step earlier — a number worked out from a turn nobody
+      // timed is not a measurement, and a wrong number is worse than a missing
+      // one. A framework that does time its turns loses nothing by it: a turn
+      // that happened has width.
+      if (BigInt(span.durationNanoseconds) === 0n) continue;
       turns.push(timed(span));
       continue;
     }

--- a/packages/db/src/measures/from-spans.ts
+++ b/packages/db/src/measures/from-spans.ts
@@ -309,19 +309,12 @@ function derivedFromFrameworkSpans(
 
   for (const span of everySpanIn(conversation)) {
     if (span.kind === HUMAN_TURN || span.kind === AGENT_TURN) {
-      // **A turn of zero width was never timed, and nothing is read off it.**
-      // Retell publishes no per-turn timing, so its normalizer opens every turn
-      // at the production trace's own start and closes it in the same instant —
-      // placeholders, said plainly in `apps/api/src/retell/normalise.ts`. Read
-      // as geometry they describe an agent that answered instantly every time:
-      // a series of zeroes that holds any bound put to it, so a trace whose
-      // worst wait was really 2145 ms passes a two-second bound with "0
-      // milliseconds at its worst" as the rationale. It is the negative guard
-      // below, stated one step earlier — a number worked out from a turn nobody
-      // timed is not a measurement, and a wrong number is worse than a missing
-      // one. A framework that does time its turns loses nothing by it: a turn
-      // that happened has width.
-      if (BigInt(span.durationNanoseconds) === 0n) continue;
+      // **Every turn joins the list, whatever its timings are worth.** What this
+      // list carries is the conversational order, and the walk below reads it
+      // for who answered whom — so a turn held out of it stops being a barrier
+      // between the turns around it, and two people's waits become one. Which
+      // measurements a turn is fit to produce is a question for the measure that
+      // produces them, one at a time, and never for membership here.
       turns.push(timed(span));
       continue;
     }
@@ -369,6 +362,22 @@ function put(
  * should have failed — a number that is wrong is worse than a measurement that
  * is missing, so the overlapping turn contributes nothing and the turns around
  * it still count.
+ *
+ * **A zero read off a turn that had no width is two placeholders agreeing, and
+ * is not kept either.** Retell publishes no per-turn timing, so its normalizer
+ * opens every turn at the production trace's own start and closes it in the
+ * same instant — placeholders, said plainly in
+ * `apps/api/src/retell/normalise.ts`. Subtract one from the next and the answer
+ * is zero, every time, for the arithmetic's own reasons and not the agent's: a
+ * series a bound cannot fail, so a trace whose worst wait was really 2145 ms
+ * holds a two-second bound with "0 milliseconds at its worst" as its rationale,
+ * which is the false pass this product exists to kill.
+ *
+ * **It is the pair that says so, and never the width alone.** A chat simulation
+ * writes turns of no width too — a typed message is one instant and there is
+ * nothing to measure a duration of — but at real, distinct instants, so the gap
+ * it answers across is observed and every sample of it stands. Only a zero
+ * whose own turn also had no width has nothing behind it on either side.
  */
 function turnResponseLatency(turns: readonly TimedSpan[]): readonly Sample[] {
   const samples: Sample[] = [];
@@ -378,6 +387,7 @@ function turnResponseLatency(turns: readonly TimedSpan[]): readonly Sample[] {
     if (answered === undefined) continue;
     const latency = milliseconds(answered.startedAt - turn.endedAt);
     if (latency < 0) continue;
+    if (latency === 0 && turn.duration === 0n) continue;
     samples.push({ value: latency, spanId: answered.spanId });
   }
   return samples;

--- a/packages/db/test/measures-from-spans.test.ts
+++ b/packages/db/test/measures-from-spans.test.ts
@@ -755,3 +755,83 @@ describe("measures derived from a recognised framework's own spans", () => {
     expect(measureIn(both, "agent_speech_duration")?.derived).toBe(true);
   });
 });
+
+/**
+ * A Retell-shaped production trace: a `conversation` root holding the whole
+ * thing's width, and turns beneath it that hold none.
+ *
+ * Exactly the rows `apps/api/src/retell/normalise.ts` writes. The provider
+ * reports no per-turn timing, so every turn opens where the trace opened and
+ * closes in the same instant, and nothing `speaking` is filed anywhere.
+ */
+async function aRetellTrace(
+  speakers: readonly ("human" | "agent")[],
+): Promise<TraceDetail> {
+  const id = traceId();
+  const root = spanId();
+  const at = BigInt(WHEN.getTime()) * 1000n;
+
+  const spans: NewSpan[] = [
+    span({
+      traceId: id,
+      spanId: root,
+      name: "retell_call",
+      kind: "conversation",
+      connectionType: "retell",
+      startedAtMicroseconds: at,
+      durationNanoseconds: 143_000_000_000n,
+    }),
+  ];
+
+  for (const speaker of speakers) {
+    spans.push(
+      span({
+        traceId: id,
+        spanId: spanId(),
+        parentSpanId: root,
+        name: speaker === "human" ? "human_turn" : "agent_turn",
+        kind: speaker === "human" ? "turn:human" : "turn:agent",
+        connectionType: "retell",
+        startedAtMicroseconds: at,
+        durationNanoseconds: 0n,
+      }),
+    );
+  }
+
+  await appendSpans(auth, spans);
+  const read = await readTrace(auth, id, { window: WINDOW });
+  if (read === undefined) throw new Error("the trace store lost the spans");
+  return read;
+}
+
+/**
+ * **A turn nobody timed measures nothing**, and this is the shape that made the
+ * rule necessary.
+ *
+ * Retell publishes no per-turn timing, so its normalizer writes placeholders and
+ * says so plainly. Read as geometry they describe an agent that answered
+ * instantly every time — a series of zeroes that holds any bound put to it, so a
+ * production trace whose worst wait was really 2145 ms passed a two-second bound
+ * with "0 milliseconds at its worst" as its rationale. A false pass is the exact
+ * false trust this product exists to kill, and it is worse than the `skipped` a
+ * provider reporting no timing has earned.
+ */
+describe("a production trace whose turns were never timed", () => {
+  it("derives nothing at all, so every measure is absent", async () => {
+    const trace = await aRetellTrace([
+      "agent",
+      "human",
+      "agent",
+      "human",
+      "agent",
+    ]);
+
+    // Nothing — not a series of zeroes. A zero here would be a measurement of a
+    // wait nobody observed, and an absent measure is the `skipped` grader that
+    // says so, which is out of the score's denominator rather than a pass.
+    expect(measuresFromSpans(trace)).toEqual([]);
+    for (const measure of SPAN_DERIVED_MEASURES) {
+      expect(measureIn(trace, measure)).toBeUndefined();
+    }
+  });
+});

--- a/packages/db/test/measures-from-spans.test.ts
+++ b/packages/db/test/measures-from-spans.test.ts
@@ -805,16 +805,23 @@ async function aRetellTrace(
 }
 
 /**
- * **A turn nobody timed measures nothing**, and this is the shape that made the
- * rule necessary.
+ * **A zero read off a turn that had no width is not a measurement**, and this is
+ * the shape that made the rule necessary.
  *
  * Retell publishes no per-turn timing, so its normalizer writes placeholders and
- * says so plainly. Read as geometry they describe an agent that answered
- * instantly every time — a series of zeroes that holds any bound put to it, so a
- * production trace whose worst wait was really 2145 ms passed a two-second bound
- * with "0 milliseconds at its worst" as its rationale. A false pass is the exact
- * false trust this product exists to kill, and it is worse than the `skipped` a
- * provider reporting no timing has earned.
+ * says so plainly. Subtract one from the next and the answer is zero every time
+ * — a series a bound cannot fail, so a production trace whose worst wait was
+ * really 2145 ms held a two-second bound with "0 milliseconds at its worst" as
+ * its rationale. A false pass is the exact false trust this product exists to
+ * kill, and it is worse than the `skipped` a provider reporting no timing has
+ * earned.
+ *
+ * **`turn_response_latency` is the whole of what is load-bearing below**, and
+ * the empty answer is stated in full only so nothing arrives here unremarked.
+ * The other two were never derivable on a Retell trace and are not evidence of
+ * this rule: `first_response_latency` needs a root, and Retell's root is filed
+ * as `conversation` while the module reads `root`. `agent_speech_duration` needs
+ * `speaking` children, and Retell reports none, so no turn here has any.
  */
 describe("a production trace whose turns were never timed", () => {
   it("derives nothing at all, so every measure is absent", async () => {
@@ -833,5 +840,58 @@ describe("a production trace whose turns were never timed", () => {
     for (const measure of SPAN_DERIVED_MEASURES) {
       expect(measureIn(trace, measure)).toBeUndefined();
     }
+  });
+});
+
+/**
+ * **A turn of no width is not the same thing as a turn nobody timed**, and the
+ * two cases below are why the rule is a pair rather than a width.
+ *
+ * A chat simulation has no duration to write — a typed message is one instant —
+ * so every turn it files is zero nanoseconds wide at a real, distinct moment.
+ * Its geometry is honestly timed and its waits are real. `apps/grader` reads
+ * exactly these numbers into the evidence a judge is shown, and the rule is
+ * pinned here as well so it lives beside the arithmetic it constrains.
+ *
+ * The stamps say `production` on these rows, as they do on every constructed
+ * tree in this file, and it changes nothing: the module cannot see which world a
+ * conversation came from, which is what the pair of describes above proves.
+ */
+describe("turns of no width at real instants", () => {
+  it("measures the gaps between them, because the gaps were observed", async () => {
+    const trace = await aLiveKitCall([
+      { who: "human", from: 0, to: 0 },
+      { who: "agent", from: 2_000, to: 2_000 },
+      { who: "human", from: 4_000, to: 4_000 },
+      { who: "agent", from: 6_000, to: 6_000 },
+    ]);
+
+    const measured = measureIn(trace, "turn_response_latency");
+    expect(measured?.derived).toBe(true);
+    // Each human turn answered 2000 ms later, which is what the instants say
+    // and what a chat simulation's evidence carries today.
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([
+      2_000, 2_000,
+    ]);
+  });
+
+  /**
+   * **A turn stays a barrier however well it was timed.** The second caller turn
+   * here has no width, and holding it out of the ordered turns would let the
+   * agent's reply answer the *first* one instead — measuring 5000 ms across the
+   * caller's own re-speaking, which nobody waited. Missing would have become
+   * wrong, so the exclusion lives on the sample and never on the list.
+   */
+  it("still separates the turns around it, so no wait is measured twice over", async () => {
+    const trace = await aLiveKitCall([
+      { who: "human", from: 0, to: 1_000 },
+      { who: "human", from: 5_000, to: 5_000 },
+      { who: "agent", from: 6_000, to: 8_000, spoke: [[6_000, 8_000]] },
+    ]);
+
+    const measured = measureIn(trace, "turn_response_latency");
+    // One sample, and it is the second turn's: 6000 − 5000. A second number
+    // here would be the first turn measured across a wait that never happened.
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([1_000]);
   });
 });


### PR DESCRIPTION
The read-time derivation computes turn_response_latency from turn-span geometry. A platform that publishes no per-turn timing files every turn at the trace's own start with zero width — honest placeholders — and the derivation read them anyway: the only guard dropped negative latencies, so a zero survived, and a latency grader passed real production traffic at "0 ms at its worst".

The fix is at sample level, not list level: every turn stays in the ordered list (membership is conversational order — a turn held out of the list stops being a barrier, and two people's waits become one), and a sample is refused when the latency is exactly zero AND the human turn it was read from carries no width. It is the pair that says so, never the width alone: chat turns are zero-width at real, distinct instants and keep measuring their real gaps.

Proven both ways in the tests: the placeholder shape derives nothing (fails with the guard removed); the chat shape keeps [2000, 2000] and the mixed shape keeps its barrier semantics (both fail with the old list-level exclusion reapplied).

Scoped runs: measures-from-spans 28/28, simulation-spans 10/10, db build clean. Full suite is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537017&installation_model_id=431960&pr_number=129&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F129&signature=74efc68e230610a5da1ed3d11a3e29b84128194157deb2307b1676f9c3b6df03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents placeholder Retell turns from producing false zero-millisecond response-latency measurements while retaining zero-width turns as conversational barriers.
- Rejects a latency sample only when it is exactly zero and its originating human turn has zero duration.
- Adds regression coverage for untimed Retell traces, valid zero-width turns at distinct timestamps, and mixed-width barrier semantics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The new guard removes only exact-zero samples originating from zero-duration human turns, while the added tests verify that nonzero gaps from instantaneous turns and conversational barrier behavior remain intact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/measures/from-spans.ts | Adds a narrowly scoped sample-level guard that suppresses placeholder zero-latency measurements without removing turns from conversational ordering. |
| packages/db/test/measures-from-spans.test.ts | Adds coverage for placeholder traces, valid instantaneous chat turns, and preservation of turn barriers. |

<sub>Reviews (1): Last reviewed commit: ["The zero and the widthless turn together..."](https://github.com/egma-ai/egma/commit/1fee4c45d164d786079fb89d018b41c04be21120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53888372)</sub>

<!-- /greptile_comment -->