### PR TITLE
The Retell normalizer translates the platform's own latency into the reported block

### DIFF
--- a/apps/api/src/retell/normalise.ts
+++ b/apps/api/src/retell/normalise.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 
-import type { NewSpan } from "@egma/db";
+import {
+  reportedMeasurementsPayload,
+  type NewSpan,
+  type ReportedMeasurement,
+} from "@egma/db";
 
 /**
  * One Retell call object, as spans. The single place that reading happens.
@@ -286,18 +290,90 @@ function turnsIn(call: RetellCall): {
 /**
  * What Retell measured about the whole conversation, gathered onto the root.
  *
- * These are aggregates — a p50, a p90, a maximum — and they describe the call
- * rather than any moment in it, so the root span is the only honest place for
- * them. Kept as the vendor's own names inside the root's payload, which is
- * where a reader who knows Retell will look; egma reads no meaning into them
- * here, because a measure egma computes is computed from spans by the one
- * shared measure module and never copied off a vendor's summary.
+ * Retell reports one object per stage — `e2e`, `llm`, `tts` and the rest — each
+ * holding its own summary (`p50`, `p90`, `p95`, `p99`, `min`, `max`, `num`)
+ * beside `values`, the individual measurements the summary was worked out from.
+ * They describe the call rather than any moment in it, so the root span is the
+ * only honest place for them. This keeps the whole object under the vendor's
+ * own names, verbatim, which is where a reader who knows Retell will look; the
+ * translation into egma's vocabulary is `reportedLatencyOf` below and reads the
+ * samples alone.
  */
 function latencyOf(call: RetellCall): Record<string, unknown> {
   const held = call["latency"];
   return typeof held === "object" && held !== null && !Array.isArray(held)
     ? (held as Record<string, unknown>)
     : {};
+}
+
+/** What Retell counts its latency in, and the catalog's word for it too. */
+const MILLISECONDS = "milliseconds";
+
+/**
+ * Which of Retell's latency stages is which measure, and the only place that
+ * mapping is written down.
+ *
+ * **Same meaning, same name.** Retell's `e2e` is what the measure catalog calls
+ * `turn_response_latency` — how long the agent took to answer — so it is
+ * reported under the catalog's own name and the graders a developer already
+ * configured judge Retell traffic unchanged. A stage the catalog has no
+ * counterpart for keeps a platform-prefixed name rather than a forced fit: the
+ * numbers are captured now, surfaced when a display asks for them, and promoted
+ * to a catalog name the day a second platform proves the general shape.
+ *
+ * Ordered, because the block's bytes are: the order here is the order the
+ * measurements are written in, and a replay has to produce the identical batch.
+ */
+const REPORTED_LATENCY_MEASURES: readonly (readonly [string, string])[] = [
+  ["e2e", "turn_response_latency"],
+  ["llm", "retell/llm_latency"],
+  ["tts", "retell/tts_latency"],
+  ["asr", "retell/asr_latency"],
+  ["knowledge_base", "retell/knowledge_base_latency"],
+];
+
+/**
+ * Retell's own measurements as the neutral reported-measurements block, or
+ * `undefined` where Retell reported none worth carrying.
+ *
+ * **This is the only code that knows Retell's shape.** The block it builds is
+ * one contract for every platform, so the shared measure module reads a single
+ * shape forever and the next platform is one more mapping table in its own
+ * normalizer rather than a second parser under the arithmetic every verdict
+ * rests on.
+ *
+ * **The samples, never the summary.** Each stage's `values` are the individual
+ * measurements, so "every measurement holds the bound, the worst turn decides"
+ * stays truthful and percentile math stays egma's own. A p50 carried as a
+ * sample would let one summarised turn pass a bound a real turn failed.
+ *
+ * Read defensively, because this is a vendor document: a stage that is missing,
+ * a `values` that is not a list, and an entry inside one that is not a finite
+ * number are each simply not there. A stage left with nothing is dropped by the
+ * block itself, and a call whose every stage is dropped writes no block at all
+ * — absence being the honest shape for a conversation nobody measured.
+ */
+function reportedLatencyOf(call: RetellCall): Record<string, unknown> | undefined {
+  const stages = latencyOf(call);
+  const measurements: ReportedMeasurement[] = [];
+
+  for (const [stage, measure] of REPORTED_LATENCY_MEASURES) {
+    const held = stages[stage];
+    if (typeof held !== "object" || held === null || Array.isArray(held)) continue;
+    const values = (held as Record<string, unknown>)["values"];
+    if (!Array.isArray(values)) continue;
+    measurements.push({
+      measure,
+      unit: MILLISECONDS,
+      // In the order Retell reported them, which is the order they happened in.
+      values: values.filter(
+        (value): value is number =>
+          typeof value === "number" && Number.isFinite(value),
+      ),
+    });
+  }
+
+  return reportedMeasurementsPayload("retell", measurements);
 }
 
 /** One span with every field stated, including the empty ones. */
@@ -356,6 +432,7 @@ export function normaliseRetellCall(
   const startedAt = microseconds(times.startedAt);
   const endedAt = microseconds(times.endedAt);
   const environment = into.environment ?? "default";
+  const reported = reportedLatencyOf(call);
 
   const shared = {
     traceId,
@@ -392,6 +469,10 @@ export function normaliseRetellCall(
           degraded,
           disconnection_reason: text(call["disconnection_reason"]),
           latency: latencyOf(call),
+          // Absent rather than empty where Retell measured nothing, so a
+          // reader meets the same shape a payload nobody wrote has — and so a
+          // replay of this call writes the identical bytes.
+          ...(reported === undefined ? {} : { reported_measurements: reported }),
         },
       }),
     }),

--- a/apps/api/src/retell/normalise.ts
+++ b/apps/api/src/retell/normalise.ts
@@ -298,8 +298,8 @@ function turnsIn(call: RetellCall): {
  * They describe the call rather than any moment in it, so the root span is the
  * only honest place for them. This keeps the whole object under the vendor's
  * own names, verbatim, which is where a reader who knows Retell will look; the
- * translation into egma's vocabulary is `reportedLatencyOf` below and reads the
- * samples alone.
+ * translation into egma's vocabulary is `reportedLatencyOf` below, and it reads
+ * `values` alone.
  */
 function latencyOf(call: RetellCall): Record<string, unknown> {
   const held = call["latency"];
@@ -384,10 +384,11 @@ const REPORTED_LATENCY_MEASURES: readonly (readonly [
  * platform is one more mapping table in its own normalizer rather than a second
  * parser under the arithmetic every verdict rests on.
  *
- * **The samples, never the summary.** Each stage's `values` are the individual
- * measurements, so "every measurement holds the bound, the worst turn decides"
- * stays truthful and percentile math stays egma's own. A p50 carried as a
- * sample would let one summarised turn pass a bound a real turn failed.
+ * **The individual measurements, never the summary.** Each stage's `values` are
+ * the measurements themselves, so "every measurement holds the bound, the worst
+ * turn decides" stays truthful and percentile math stays egma's own. A p50
+ * carried as a measurement would let one summarised turn pass a bound a real
+ * turn failed.
  *
  * Read defensively, because this is a vendor document: a stage that is missing,
  * a `values` that is not a list, and an entry inside one that is not a finite
@@ -395,13 +396,13 @@ const REPORTED_LATENCY_MEASURES: readonly (readonly [
  * call whose every stage is dropped writes no block at all — absence being the
  * honest shape for a conversation nobody measured.
  *
- * **A sample that is not a number is dropped silently, and that is the
+ * **A measurement that is not a number is dropped silently, and that is the
  * deliberate line.** `degraded` is raised for a payload egma could not read as
  * a conversation — no id, contradictory instants, a transcript that is not one
  * — because that is a trace somebody has to look at. One unreadable entry in a
- * measurement series is not: the other samples are still true, the vendor's
- * whole document is still on the row verbatim, and flagging the trace would
- * spend somebody's attention on a number egma never needed.
+ * stage's list is not: the rest of the list is still true, the vendor's whole
+ * document is still on the row verbatim, and flagging the trace would spend
+ * somebody's attention on a number egma never needed.
  */
 function reportedLatencyOf(
   call: RetellCall,
@@ -415,20 +416,20 @@ function reportedLatencyOf(
     const values = (held as Record<string, unknown>)["values"];
     if (!Array.isArray(values)) continue;
     // In the order Retell reported them, which is the order they happened in.
-    const samples = values.filter(
+    const kept = values.filter(
       (value): value is number =>
         typeof value === "number" && Number.isFinite(value),
     );
-    // Never an empty series: the contract says a measurement holds at least one
-    // sample, and a stage that reported none is a stage nobody reported.
-    if (samples.length === 0) continue;
+    // Never an empty list: the contract says a measurement holds at least one
+    // number, and a stage that reported none is a stage nobody reported.
+    if (kept.length === 0) continue;
     measurements.push({
       measure,
-      // The catalog's own unit for a measure it names, so a bound and a sample
-      // are read in one unit; the platform's honest word for a stage it does
-      // not name.
+      // The catalog's own unit for a measure it names, so a bound and a
+      // measurement are read in one unit; the platform's honest word for a
+      // stage it does not name.
       unit: catalogedMeasure(measure)?.unit ?? MILLISECONDS,
-      values: samples,
+      values: kept,
     });
   }
 

--- a/apps/api/src/retell/normalise.ts
+++ b/apps/api/src/retell/normalise.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 
 import {
+  REPORTED_MEASUREMENTS_PAYLOAD_KEY,
   reportedMeasurementsPayload,
   type NewSpan,
   type ReportedMeasurement,
 } from "@egma/db";
+import { catalogedMeasure, isSpanDerivedMeasure } from "@egma/simulation-contract";
 
 /**
  * One Retell call object, as spans. The single place that reading happens.
@@ -306,8 +308,44 @@ function latencyOf(call: RetellCall): Record<string, unknown> {
     : {};
 }
 
-/** What Retell counts its latency in, and the catalog's word for it too. */
+/**
+ * What this platform is called wherever egma names it: the connection type on
+ * every row it files, the prefix on a measure only Retell has a word for, and
+ * the reporter's name on the block. One spelling, in one place.
+ */
+const RETELL = "retell";
+
+/**
+ * What a stage egma has no catalog name for is counted in.
+ *
+ * The fallback only. A measure the catalog names takes the catalog's own unit,
+ * below, because a unit stated twice is a unit that comes to disagree — and a
+ * bound is read in whichever one the reader believed.
+ */
 const MILLISECONDS = "milliseconds";
+
+/**
+ * A catalog name, refused if the catalog has stopped saying it.
+ *
+ * The measure catalog owns the names egma computes and judges by, and this
+ * table is the one place a vendor's word is bound to one of them. A rename in
+ * the catalog with no rename here would leave Retell's numbers stored under a
+ * measure nothing reads — green, silent, and wrong, which is the exact failure
+ * the catalog exists to prevent. The sibling OTLP normalizer takes the same
+ * rule the other way round, by reading its span names out of the catalog rather
+ * than listing them again; a mapping cannot do that, so it says so instead, at
+ * the moment the table is built and loudly enough to stop a build.
+ */
+function catalogNamed(measure: string): string {
+  if (!isSpanDerivedMeasure(measure)) {
+    throw new Error(
+      `the measure catalog no longer names \`${measure}\`, so Retell's own ` +
+        `measurements would be reported under a measure nothing computes or ` +
+        `judges — rename it here in the same breath as the catalog`,
+    );
+  }
+  return measure;
+}
 
 /**
  * Which of Retell's latency stages is which measure, and the only place that
@@ -315,21 +353,25 @@ const MILLISECONDS = "milliseconds";
  *
  * **Same meaning, same name.** Retell's `e2e` is what the measure catalog calls
  * `turn_response_latency` — how long the agent took to answer — so it is
- * reported under the catalog's own name and the graders a developer already
- * configured judge Retell traffic unchanged. A stage the catalog has no
- * counterpart for keeps a platform-prefixed name rather than a forced fit: the
- * numbers are captured now, surfaced when a display asks for them, and promoted
- * to a catalog name the day a second platform proves the general shape.
+ * reported under the catalog's own name, and the day the measure module reads
+ * this block a developer's existing latency grader judges Retell traffic with
+ * nothing reconfigured. A stage the catalog has no counterpart for keeps a
+ * platform-prefixed name rather than a forced fit: the numbers are captured
+ * now, surfaced when a display asks for them, and promoted to a catalog name
+ * the day a second platform proves the general shape.
  *
  * Ordered, because the block's bytes are: the order here is the order the
  * measurements are written in, and a replay has to produce the identical batch.
  */
-const REPORTED_LATENCY_MEASURES: readonly (readonly [string, string])[] = [
-  ["e2e", "turn_response_latency"],
-  ["llm", "retell/llm_latency"],
-  ["tts", "retell/tts_latency"],
-  ["asr", "retell/asr_latency"],
-  ["knowledge_base", "retell/knowledge_base_latency"],
+const REPORTED_LATENCY_MEASURES: readonly (readonly [
+  stage: string,
+  measure: string,
+])[] = [
+  ["e2e", catalogNamed("turn_response_latency")],
+  ["llm", `${RETELL}/llm_latency`],
+  ["tts", `${RETELL}/tts_latency`],
+  ["asr", `${RETELL}/asr_latency`],
+  ["knowledge_base", `${RETELL}/knowledge_base_latency`],
 ];
 
 /**
@@ -337,10 +379,10 @@ const REPORTED_LATENCY_MEASURES: readonly (readonly [string, string])[] = [
  * `undefined` where Retell reported none worth carrying.
  *
  * **This is the only code that knows Retell's shape.** The block it builds is
- * one contract for every platform, so the shared measure module reads a single
- * shape forever and the next platform is one more mapping table in its own
- * normalizer rather than a second parser under the arithmetic every verdict
- * rests on.
+ * one contract for every platform, so the shared measure module — on the day it
+ * reads this block — reads a single shape for all of them, and the next
+ * platform is one more mapping table in its own normalizer rather than a second
+ * parser under the arithmetic every verdict rests on.
  *
  * **The samples, never the summary.** Each stage's `values` are the individual
  * measurements, so "every measurement holds the bound, the worst turn decides"
@@ -349,11 +391,21 @@ const REPORTED_LATENCY_MEASURES: readonly (readonly [string, string])[] = [
  *
  * Read defensively, because this is a vendor document: a stage that is missing,
  * a `values` that is not a list, and an entry inside one that is not a finite
- * number are each simply not there. A stage left with nothing is dropped by the
- * block itself, and a call whose every stage is dropped writes no block at all
- * — absence being the honest shape for a conversation nobody measured.
+ * number are each simply not there. A stage left with nothing is dropped, and a
+ * call whose every stage is dropped writes no block at all — absence being the
+ * honest shape for a conversation nobody measured.
+ *
+ * **A sample that is not a number is dropped silently, and that is the
+ * deliberate line.** `degraded` is raised for a payload egma could not read as
+ * a conversation — no id, contradictory instants, a transcript that is not one
+ * — because that is a trace somebody has to look at. One unreadable entry in a
+ * measurement series is not: the other samples are still true, the vendor's
+ * whole document is still on the row verbatim, and flagging the trace would
+ * spend somebody's attention on a number egma never needed.
  */
-function reportedLatencyOf(call: RetellCall): Record<string, unknown> | undefined {
+function reportedLatencyOf(
+  call: RetellCall,
+): Record<string, unknown> | undefined {
   const stages = latencyOf(call);
   const measurements: ReportedMeasurement[] = [];
 
@@ -362,18 +414,25 @@ function reportedLatencyOf(call: RetellCall): Record<string, unknown> | undefine
     if (typeof held !== "object" || held === null || Array.isArray(held)) continue;
     const values = (held as Record<string, unknown>)["values"];
     if (!Array.isArray(values)) continue;
+    // In the order Retell reported them, which is the order they happened in.
+    const samples = values.filter(
+      (value): value is number =>
+        typeof value === "number" && Number.isFinite(value),
+    );
+    // Never an empty series: the contract says a measurement holds at least one
+    // sample, and a stage that reported none is a stage nobody reported.
+    if (samples.length === 0) continue;
     measurements.push({
       measure,
-      unit: MILLISECONDS,
-      // In the order Retell reported them, which is the order they happened in.
-      values: values.filter(
-        (value): value is number =>
-          typeof value === "number" && Number.isFinite(value),
-      ),
+      // The catalog's own unit for a measure it names, so a bound and a sample
+      // are read in one unit; the platform's honest word for a stage it does
+      // not name.
+      unit: catalogedMeasure(measure)?.unit ?? MILLISECONDS,
+      values: samples,
     });
   }
 
-  return reportedMeasurementsPayload("retell", measurements);
+  return reportedMeasurementsPayload(RETELL, measurements);
 }
 
 /** One span with every field stated, including the empty ones. */
@@ -469,10 +528,13 @@ export function normaliseRetellCall(
           degraded,
           disconnection_reason: text(call["disconnection_reason"]),
           latency: latencyOf(call),
-          // Absent rather than empty where Retell measured nothing, so a
-          // reader meets the same shape a payload nobody wrote has — and so a
-          // replay of this call writes the identical bytes.
-          ...(reported === undefined ? {} : { reported_measurements: reported }),
+          // Under the contract's own key, never a spelling of egma's own: the
+          // read side looks the block up by the same constant. Absent rather
+          // than empty where Retell measured nothing, so a reader meets the
+          // same shape a payload nobody wrote has.
+          ...(reported === undefined
+            ? {}
+            : { [REPORTED_MEASUREMENTS_PAYLOAD_KEY]: reported }),
         },
       }),
     }),

--- a/apps/api/test/retell-normalise.test.ts
+++ b/apps/api/test/retell-normalise.test.ts
@@ -1,3 +1,4 @@
+import { REPORTED_MEASUREMENTS_VERSION } from "@egma/db";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -58,9 +59,63 @@ export function capturedCall(overrides: Partial<RetellCall> = {}): RetellCall {
         ],
       },
     ],
+    // One object per stage, exactly as Retell reports one: the summary it
+    // worked out, and `values`, the individual measurements it worked the
+    // summary out from. The 2145 ms sample is the live proof's own — the turn
+    // that beat a two-second bound with no verdict to say so.
     latency: {
-      e2e: { p50: 820, p90: 1310, max: 1900 },
-      llm: { p50: 410, p90: 700 },
+      e2e: {
+        p50: 820,
+        p90: 2010,
+        p95: 2100,
+        p99: 2140,
+        max: 2145,
+        min: 517,
+        num: 4,
+        values: [517, 820, 1704, 2145],
+      },
+      llm: {
+        p50: 410,
+        p90: 700,
+        max: 780,
+        min: 260,
+        num: 4,
+        values: [260, 410, 700, 780],
+      },
+      tts: {
+        p50: 190,
+        p90: 250,
+        max: 260,
+        min: 150,
+        num: 4,
+        values: [150, 190, 240, 260],
+      },
+      asr: {
+        p50: 90,
+        p90: 145,
+        max: 150,
+        min: 70,
+        num: 4,
+        values: [70, 90, 140, 150],
+      },
+      knowledge_base: {
+        p50: 300,
+        p90: 370,
+        max: 380,
+        min: 280,
+        num: 3,
+        values: [280, 300, 380],
+      },
+      // A stage egma maps to nothing. It stays in the verbatim payload and out
+      // of the block, which is what "only the mapped stages" has to be checked
+      // against.
+      llm_websocket_network_rtt: {
+        p50: 40,
+        max: 61,
+        min: 22,
+        num: 3,
+        values: [22, 40, 61],
+      },
     },
     // Nothing reads this. That is the point of the verbatim rule.
     call_analysis: { user_sentiment: "Positive", call_successful: true },
@@ -161,10 +216,9 @@ describe("the spans a captured payload becomes", () => {
     expect(root?.text).toBe("agent_hangup");
     const held = JSON.parse(root?.payload ?? "{}") as Record<string, unknown>;
     const normalisedBlock = held["egma_normalised"] as Record<string, unknown>;
-    expect(normalisedBlock["latency"]).toEqual({
-      e2e: { p50: 820, p90: 1310, max: 1900 },
-      llm: { p50: 410, p90: 700 },
-    });
+    // Retell's whole latency object, under Retell's own names, untouched — the
+    // summary included, because a reader who knows Retell looks for it here.
+    expect(normalisedBlock["latency"]).toEqual(capturedCall()["latency"]);
     // The whole conversation's extent, from Retell's own two instants.
     expect(root?.durationNanoseconds).toBe(74_000n * 1_000_000n);
   });
@@ -185,6 +239,126 @@ describe("the spans a captured payload becomes", () => {
     expect(held["transcript"]).toBe(
       "Agent: Hello. User: I would like to reschedule.",
     );
+  });
+});
+
+/** The egma-owned corner of the root span's payload, as a reader holds it. */
+function normalisedCornerOf(call: RetellCall): Record<string, unknown> {
+  const [root] = normaliseRetellCall(call, FILED_INTO, NOW).spans;
+  const payload = JSON.parse(root?.payload ?? "{}") as Record<string, unknown>;
+  return payload["egma_normalised"] as Record<string, unknown>;
+}
+
+/**
+ * What Retell measured, translated into egma's own vocabulary at the door.
+ *
+ * This file is the only code in egma that knows Retell's latency shape, so this
+ * is the only place that translation can be checked — everything downstream
+ * reads the neutral block and would read the identical one from any platform.
+ */
+describe("the reported-measurements block", () => {
+  it("maps each stage Retell reports to the measure it means", () => {
+    expect(normalisedCornerOf(capturedCall())["reported_measurements"]).toEqual({
+      version: REPORTED_MEASUREMENTS_VERSION,
+      reported_by: "retell",
+      measurements: [
+        {
+          // Retell's `e2e` is what the catalog calls `turn_response_latency`:
+          // same meaning, same name, so the latency grader a developer already
+          // configured judges this trace with nothing changed.
+          measure: "turn_response_latency",
+          unit: "milliseconds",
+          values: [517, 820, 1704, 2145],
+        },
+        {
+          measure: "retell/llm_latency",
+          unit: "milliseconds",
+          values: [260, 410, 700, 780],
+        },
+        {
+          measure: "retell/tts_latency",
+          unit: "milliseconds",
+          values: [150, 190, 240, 260],
+        },
+        {
+          measure: "retell/asr_latency",
+          unit: "milliseconds",
+          values: [70, 90, 140, 150],
+        },
+        {
+          measure: "retell/knowledge_base_latency",
+          unit: "milliseconds",
+          values: [280, 300, 380],
+        },
+      ],
+    });
+  });
+
+  it("carries the samples, and leaves the summary to the vendor's own block", () => {
+    const corner = normalisedCornerOf(capturedCall());
+    const block = corner["reported_measurements"] as {
+      measurements: readonly { measure: string; values: readonly number[] }[];
+    };
+    // The individual measurements — never a p50 wearing a sample's clothes,
+    // which would let one summarised turn pass a bound a real turn failed.
+    expect(block.measurements[0]?.values).toEqual([517, 820, 1704, 2145]);
+    // And Retell's own aggregates are still there, under Retell's own names.
+    expect((corner["latency"] as Record<string, unknown>)["e2e"]).toEqual(
+      (capturedCall()["latency"] as Record<string, unknown>)["e2e"],
+    );
+  });
+
+  it("writes nothing at all where Retell measured nothing", () => {
+    for (const latency of [
+      undefined,
+      {},
+      "sometimes a payload is not the shape it was",
+      { e2e: null },
+      // A summary with no samples under it. The percentiles are Retell's own
+      // arithmetic, and egma reports no measurement it was not handed.
+      { e2e: { p50: 820, p90: 2010, num: 4 } },
+      { e2e: { values: [] } },
+      { e2e: { values: "1704" } },
+      { e2e: { values: [null, "1704"] } },
+      // A stage nothing maps to, alone, is a stage nobody reported.
+      { llm_websocket_network_rtt: { values: [22, 40, 61] } },
+    ]) {
+      const corner = normalisedCornerOf(capturedCall({ latency }));
+      expect(
+        Object.hasOwn(corner, "reported_measurements"),
+        JSON.stringify(latency),
+      ).toBe(false);
+      // The vendor's own key stays exactly where it was, empty object and all.
+      expect(Object.hasOwn(corner, "latency")).toBe(true);
+    }
+  });
+
+  it("keeps the numbers Retell reported and drops what is not one", () => {
+    const corner = normalisedCornerOf(
+      capturedCall({
+        latency: { e2e: { values: [517, "1704", null, 2145, Number.NaN] } },
+      }),
+    );
+    expect(corner["reported_measurements"]).toEqual({
+      version: REPORTED_MEASUREMENTS_VERSION,
+      reported_by: "retell",
+      measurements: [
+        {
+          measure: "turn_response_latency",
+          unit: "milliseconds",
+          values: [517, 2145],
+        },
+      ],
+    });
+  });
+
+  it("is the same bytes twice, which is what a replay rests on", () => {
+    const once = normaliseRetellCall(capturedCall(), FILED_INTO, NOW);
+    const again = normaliseRetellCall(capturedCall(), FILED_INTO, NOW);
+    // The root payload holds the block, so its own bytes are the property the
+    // store's insert dedup recognises a replayed batch by.
+    expect(once.spans[0]?.payload).toBe(again.spans[0]?.payload);
+    expect(asBytes(once.spans)).toBe(asBytes(again.spans));
   });
 });
 

--- a/apps/api/test/retell-normalise.test.ts
+++ b/apps/api/test/retell-normalise.test.ts
@@ -59,10 +59,13 @@ export function capturedCall(overrides: Partial<RetellCall> = {}): RetellCall {
         ],
       },
     ],
-    // One object per stage, exactly as Retell reports one: the summary it
-    // worked out, and `values`, the individual measurements it worked the
-    // summary out from. The 2145 ms sample is the live proof's own — the turn
-    // that beat a two-second bound with no verdict to say so.
+    // One object per stage, as Retell's documentation shapes one: the summary
+    // it worked out, and `values`, the individual measurements it worked the
+    // summary out from. This is the documented shape and not a captured
+    // payload — no live Retell document is checked in yet — so the stage names
+    // are held here to be settled by the next live capture. The 2145 ms sample
+    // is the live proof's own reading: the turn that beat a two-second bound
+    // with no verdict to say so.
     latency: {
       e2e: {
         p50: 820,
@@ -216,9 +219,35 @@ describe("the spans a captured payload becomes", () => {
     expect(root?.text).toBe("agent_hangup");
     const held = JSON.parse(root?.payload ?? "{}") as Record<string, unknown>;
     const normalisedBlock = held["egma_normalised"] as Record<string, unknown>;
-    // Retell's whole latency object, under Retell's own names, untouched — the
-    // summary included, because a reader who knows Retell looks for it here.
-    expect(normalisedBlock["latency"]).toEqual(capturedCall()["latency"]);
+    // Retell's own latency object, under Retell's own names, untouched — the
+    // summary included, because a reader who knows Retell looks for it here,
+    // and the stages egma maps to nothing included for the same reason.
+    const latency = normalisedBlock["latency"] as Record<string, unknown>;
+    expect(latency["e2e"]).toEqual({
+      p50: 820,
+      p90: 2010,
+      p95: 2100,
+      p99: 2140,
+      max: 2145,
+      min: 517,
+      num: 4,
+      values: [517, 820, 1704, 2145],
+    });
+    expect(latency["llm_websocket_network_rtt"]).toEqual({
+      p50: 40,
+      max: 61,
+      min: 22,
+      num: 3,
+      values: [22, 40, 61],
+    });
+    expect(Object.keys(latency)).toEqual([
+      "e2e",
+      "llm",
+      "tts",
+      "asr",
+      "knowledge_base",
+      "llm_websocket_network_rtt",
+    ]);
     // The whole conversation's extent, from Retell's own two instants.
     expect(root?.durationNanoseconds).toBe(74_000n * 1_000_000n);
   });
@@ -253,8 +282,9 @@ function normalisedCornerOf(call: RetellCall): Record<string, unknown> {
  * What Retell measured, translated into egma's own vocabulary at the door.
  *
  * This file is the only code in egma that knows Retell's latency shape, so this
- * is the only place that translation can be checked — everything downstream
- * reads the neutral block and would read the identical one from any platform.
+ * is the only place that translation can be proved — a reader downstream will
+ * meet the neutral block alone, and would meet the identical one from any
+ * platform.
  */
 describe("the reported-measurements block", () => {
   it("maps each stage Retell reports to the measure it means", () => {
@@ -264,9 +294,11 @@ describe("the reported-measurements block", () => {
       measurements: [
         {
           // Retell's `e2e` is what the catalog calls `turn_response_latency`:
-          // same meaning, same name, so the latency grader a developer already
-          // configured judges this trace with nothing changed.
+          // same meaning, same name, so the day the measure module reads this
+          // block, the latency grader a developer already configured judges
+          // this trace with nothing reconfigured.
           measure: "turn_response_latency",
+          // The catalog's own unit for that measure, not a word chosen here.
           unit: "milliseconds",
           values: [517, 820, 1704, 2145],
         },
@@ -292,6 +324,16 @@ describe("the reported-measurements block", () => {
         },
       ],
     });
+  });
+
+  it("names the reporter exactly as the row names the platform", () => {
+    const { spans } = normaliseRetellCall(capturedCall(), FILED_INTO, NOW);
+    const block = normalisedCornerOf(capturedCall())["reported_measurements"] as {
+      reported_by: string;
+    };
+    // Provenance, and the word a rationale will print: one spelling of this
+    // platform, on the block and on the row it rides alike.
+    expect(block.reported_by).toBe(spans[0]?.connectionType);
   });
 
   it("carries the samples, and leaves the summary to the vendor's own block", () => {
@@ -356,9 +398,9 @@ describe("the reported-measurements block", () => {
     const once = normaliseRetellCall(capturedCall(), FILED_INTO, NOW);
     const again = normaliseRetellCall(capturedCall(), FILED_INTO, NOW);
     // The root payload holds the block, so its own bytes are the property the
-    // store's insert dedup recognises a replayed batch by.
+    // store's insert dedup recognises a replayed batch by. The whole batch's
+    // bytes are the identity suite's own check, above.
     expect(once.spans[0]?.payload).toBe(again.spans[0]?.payload);
-    expect(asBytes(once.spans)).toBe(asBytes(again.spans));
   });
 });
 

--- a/apps/api/test/retell-normalise.test.ts
+++ b/apps/api/test/retell-normalise.test.ts
@@ -336,7 +336,7 @@ describe("the reported-measurements block", () => {
     expect(block.reported_by).toBe(spans[0]?.connectionType);
   });
 
-  it("carries the samples, and leaves the summary to the vendor's own block", () => {
+  it("carries the measurements, and leaves the summary to the vendor's own block", () => {
     const corner = normalisedCornerOf(capturedCall());
     const block = corner["reported_measurements"] as {
       measurements: readonly { measure: string; values: readonly number[] }[];
@@ -356,7 +356,7 @@ describe("the reported-measurements block", () => {
       {},
       "sometimes a payload is not the shape it was",
       { e2e: null },
-      // A summary with no samples under it. The percentiles are Retell's own
+      // A summary with no measurements under it. The percentiles are Retell's own
       // arithmetic, and egma reports no measurement it was not handed.
       { e2e: { p50: 820, p90: 2010, num: 4 } },
       { e2e: { values: [] } },


### PR DESCRIPTION
Retell measures its own production traffic — raw per-stage sample arrays riding the call record — and until now egma stored those numbers verbatim and read them nowhere. This teaches the one place that knows Retell's shape, its normalizer, to translate them into the neutral reported-measurements block the measure module will read: same-meaning stages under the catalog's own name (e2e is turn_response_latency, unit read from the catalog, with a build-time guard that fails loudly if the catalog stops naming it), platform-only stages under retell/-prefixed names, raw values only — percentile math stays egma's own.

The block rides the root span's payload under the contract's exported key, entirely absent when the platform reported nothing valid. Attribution is fixed by the normalizer that ran, never read off a row. Normalising the same call twice stays byte-identical, which the exactly-once replay protocol rests on.

The test fixture is Retell's documented shape, said honestly in its comment — no live capture is checked in yet; the next live capture settles the stage names.

Scoped runs: retell-normalise + retell-watch 57/57, data-access surface 4/4, api build and lint clean. Full suite is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537075&installation_model_id=431960&pr_number=130&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F130&signature=3fb5c10f8ad38f303cff330dc6abbe98d7c90c7b01f4ed322338f862c22cd481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR translates valid Retell latency sample arrays into the platform-neutral reported-measurements payload stored on the root span.
- Maps documented Retell stages to catalog or `retell/`-prefixed measure names.
- Preserves the original vendor latency object while filtering malformed samples from the normalized block.
- Adds coverage for mapping, omission, filtering, provenance, and deterministic replay behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/retell/normalise.ts | Adds deterministic translation of mapped Retell latency arrays into the exported reported-measurements payload contract. |
| apps/api/test/retell-normalise.test.ts | Expands the documented Retell fixture and verifies mapping, filtering, omission, provenance, payload preservation, and replay stability. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Retell call latency object] --> B[Retell normalizer]
  B --> C[Preserved vendor latency payload]
  B --> D[Filter mapped stages and finite samples]
  D --> E[Reported measurements payload]
  C --> F[Root span payload]
  E --> F
```
</details>

<sub>Reviews (2): Last reviewed commit: ["The normalizer stops borrowing the measu..."](https://github.com/egma-ai/egma/commit/c097555e9ad857373008c724556bb04fc1587a55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53888512)</sub>

<!-- /greptile_comment -->