### PR TITLE
Two browser-walk races: hold the delivery, click until the address answers

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -838,8 +838,35 @@ describe("what a project recorded in production", () => {
       await page.evaluate(() => {
         Reflect.set(globalThis, "__egma_same_document_navigation", true);
       });
-      await page.getByRole("link", { name: "Tests", exact: true }).first().click();
-      await page.waitForURL(new RegExp(`/projects/${project}/tests$`));
+      // Clicked until the address answers. The shell has just re-rendered
+      // around the Settings page, and a click can land on a link node the
+      // re-render is replacing — dispatched at something already detached,
+      // handled by nobody, navigating nowhere; that is how this step once
+      // timed out with the click reported delivered. Each poll turn clicks
+      // again unless the address already moved, so the settled node gets
+      // the next attempt. The marker above still proves what this test
+      // exists to prove: retried clicks never reload the document, and a
+      // product that did reload would wipe the marker and fail below
+      // exactly as before.
+      const atTests = new RegExp(`/projects/${project}/tests$`);
+      await expect
+        .poll(
+          async () => {
+            if (!atTests.test(page.url())) {
+              await page
+                .getByRole("link", { name: "Tests", exact: true })
+                .first()
+                .click({ timeout: 2_000 })
+                .catch(() => undefined);
+              await page
+                .waitForURL(atTests, { timeout: 2_000 })
+                .catch(() => undefined);
+            }
+            return page.url();
+          },
+          { timeout: 30_000 },
+        )
+        .toMatch(atTests);
 
       expect(
         await page.evaluate(() =>

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -1650,7 +1650,12 @@ describe.skipIf(!storage.available)("hearing a recording from a run", () => {
           )
           .toBe(75);
       } finally {
-        await page.unroute(`${running.store.publicUrl}/**`);
+        // Removed with `behavior: "wait"`, not the default: the player keeps
+        // fetching the store while it plays, so a handler can be mid-continue
+        // at exactly this moment, and a default removal races it over one
+        // request. This is the page's only route here, so removing all of
+        // them is the same removal with the safe semantics.
+        await page.unrouteAll({ behavior: "wait" });
       }
 
       // The other conversation of the same run never connected, so it wrote no
@@ -3690,8 +3695,18 @@ describe("the complete product, walked in order in a second project", () => {
           const theAgentsRead = (asked: URL) =>
             asked.pathname === "/api/agents";
           await walk.route(theAgentsRead, async (route) => {
+            // The real answer is fetched at once; only its delivery is held.
+            // The shorter spelling — await the gate, then `route.continue()`
+            // — parks the request itself across the release and removal
+            // below, and a continue that loses that race kills the fetch. A
+            // killed fetch carries no error for the page to react to, so it
+            // renders as "Loading agents…" until the poll gives up — which
+            // is exactly how this step once failed on a tree that passed
+            // this same suite twice. Fetch-then-fulfil parks nothing: one
+            // pending request until `release()`, then one delivery.
+            const answer = await route.fetch();
             await held;
-            return route.continue();
+            return route.fulfill({ response: answer });
           });
           try {
             await walk.goto(at("agents"));
@@ -3700,9 +3715,8 @@ describe("the complete product, walked in order in a second project", () => {
               .toContain("Loading");
           } finally {
             release();
-            // Wait for the held handler to finish before removing it. The
-            // default removal can continue the request itself, after which the
-            // released handler tries to continue the same route a second time.
+            // Wait for the handler to finish its delivery before removing it
+            // — a removal mid-delivery would strand the request it holds.
             await walk.unrouteAll({ behavior: "wait" });
           }
           await saysWithin(walk, "The Support line");


### PR DESCRIPTION
Fixes the flake that held the #128 merge behind a red gate for eighteen minutes, and a second race that repeat-running the suite shook out while proving the first fix.

## The held-request race (`0cb6956`)

The walk's loading step parked the `/api/agents` request behind a gate and `route.continue()`d it on release — one parked request, two movers (the released continue and the removal behind it). When the removal won, the fetch was stranded: never finished, never errored, so the page said "Loading agents…" until the poll gave up. That is how run 7 failed on bytes that passed the same suite twice.

Now the handler `route.fetch()`es the real answer at once and the gate holds only the `fulfill` — nothing parked, nothing left to race. The recording-expiry stub had the same class in miniature (a default `unroute` while the player still fetches the store) and now removes with `behavior: "wait"`. The two retry stubs sequence their removals behind settled pages and are untouched.

## The navigation race (`a181e25`)

Found by running the suite in a loop: the same-document-navigation step clicked the Tests link, the click reported delivered, and the URL never changed — a click dispatched at a link node the shell's re-render was replacing. The step now uses the file's own staple, `expect.poll`: click unless the address already moved, so the settled node gets the next attempt. The reload marker keeps its meaning — retried clicks never reload the document, and a product that did reload would still wipe the marker and fail.

The twin click idiom later in the file starts from a settled page and has never been seen failing; it stays as written until it is. Same policy for the file's other ~35 navigation waits: the retry idiom is recorded for the next observed instance, not sprayed on evidence-free sites.

## Evidence

Four full local runs of the suite today on this tree: 58/58, 58/58, then 57/58 (the navigation race, pre-fix — the held-request step passed all three), then 58/58 with both fixes. `pnpm typecheck` clean. CI's own rerun of the unfixed held-request step also passed on identical bytes, confirming nondeterminism in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQd67ecim3uYYXsPAgQ7YG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQd67ecim3uYYXsPAgQ7YG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537417&installation_model_id=431960&pr_number=131&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F131&signature=d0c7fce54ffcd2b655d8136c680b3bc98416b296de145b9cb05c4fef730c3141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens browser-walk synchronization against two observed races.
- Fetches the agents response immediately while delaying only its delivery, then waits for route teardown.
- Waits for in-flight recording route handlers before removing interception.
- Retries Tests-link activation until the expected same-document URL is reached.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable regressions identified.

The changed synchronization keeps the agents request pending from the page’s perspective until fulfillment, safely waits for active route handlers during teardown, and preserves the same-document navigation assertion while retrying a lost click.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/test/browser.test.ts | Reworks route lifecycle and navigation synchronization in browser tests without introducing an actionable defect. |

<sub>Reviews (1): Last reviewed commit: ["Click until the address answers"](https://github.com/egma-ai/egma/commit/a181e25dc724a7d8938ad3b679379d09218ba0f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53889300)</sub>

<!-- /greptile_comment -->