### PR TITLE
The measure module gains its final source: what the platform itself reported

### DIFF
--- a/apps/api/src/routes/trace-reads.ts
+++ b/apps/api/src/routes/trace-reads.ts
@@ -333,7 +333,10 @@ function describedSpan(span: TraceSpan): Record<string, unknown> {
  * the worst of the part egma holds and not of the call — the worst turn of a
  * long conversation is as likely to be past the cut as before it. The grading
  * engine refuses such a trace outright; a display is allowed to show what there
- * is, and is not allowed to show it as though it were the whole call.
+ * is, and is not allowed to show it as though it were the whole call. A measure
+ * the platform reported is the exception and is never partial: it is one row's
+ * account of the whole conversation rather than a series reduced over spans, so
+ * the cap cannot have cut anything off it.
  *
  * The unit rides each measure because the catalog owns it — a client that named
  * one of its own would be a second opinion about something already written
@@ -353,14 +356,13 @@ function describedMeasures(
       // measure timed by egma's own vocabulary carries `false` here as it
       // always implicitly did.
       //
-      // **The module now says which of three sources measured, and this field
-      // stays the boolean it has always been.** A client that integrated
-      // against "true means egma worked it out rather than reading its own
-      // timing span" is told exactly that, and a reported measure is not a
-      // measure egma timed — so `true` is the honest answer for it too. Which
-      // of the two non-timed sources it was is `reported_by` below, where a
-      // reader who wants the distinction can have it without every existing
-      // reader's meaning shifting under them.
+      // **The module now names three sources, and this field stays the boolean
+      // it has always been: false means egma timed it, true means egma did
+      // not.** That is all it has ever been able to say. Which of the two
+      // untimed sources it was — a derivation off the framework's own spans, or
+      // a number the platform handed egma — is `reported_by` below, present
+      // only on the second. A reader wanting the distinction asks that field;
+      // no existing reader's meaning shifts under them.
       derived: measured.origin !== "timed",
       // **Only on a measure a platform reported, and absent everywhere else.**
       // Simulation traffic is byte-for-byte what it was before this field
@@ -380,7 +382,14 @@ function describedMeasures(
         worst === undefined
           ? null
           : { value: worst.value, span_id: worst.spanId },
-      partial: detail.truncated,
+      // **A reported measure is never partial, however much of the trace was
+      // dropped.** The flag says "this number was reduced over a prefix of the
+      // conversation" — true of a series taken off spans when the read stopped
+      // at the cap, and false of a block, which is one platform's account of
+      // the whole conversation written on one row that either arrived or did
+      // not. Stamping the truncation on it would tell a page the worst
+      // measurement might be past the cut when there is no cut it could be past.
+      partial: measured.origin === "reported" ? false : detail.truncated,
     };
   });
 }

--- a/apps/api/src/routes/trace-reads.ts
+++ b/apps/api/src/routes/trace-reads.ts
@@ -352,7 +352,24 @@ function describedMeasures(
       // consumer integrated against still means exactly what it did, and a
       // measure timed by egma's own vocabulary carries `false` here as it
       // always implicitly did.
-      derived: measured.derived,
+      //
+      // **The module now says which of three sources measured, and this field
+      // stays the boolean it has always been.** A client that integrated
+      // against "true means egma worked it out rather than reading its own
+      // timing span" is told exactly that, and a reported measure is not a
+      // measure egma timed — so `true` is the honest answer for it too. Which
+      // of the two non-timed sources it was is `reported_by` below, where a
+      // reader who wants the distinction can have it without every existing
+      // reader's meaning shifting under them.
+      derived: measured.origin !== "timed",
+      // **Only on a measure a platform reported, and absent everywhere else.**
+      // Simulation traffic is byte-for-byte what it was before this field
+      // existed, which is the criterion this branch exists to hold: a field
+      // present-but-empty on every simulation would be a wire change on traffic
+      // nothing new happened to. Present, it names the platform that measured.
+      ...(measured.origin === "reported"
+        ? { reported_by: measured.reportedBy }
+        : {}),
       samples: measured.samples.map((sample) => sample.value),
       span_ids: measured.samples.map((sample) => sample.spanId),
       // The one number a bound is held against, and where it happened. Null is

--- a/apps/api/test/support/traces.ts
+++ b/apps/api/test/support/traces.ts
@@ -357,6 +357,14 @@ export type DetailSpan = {
 export type DetailMeasure = {
   readonly measure: string;
   readonly unit: string;
+  /** True when Egma did not time this itself. Absent on an older answer. */
+  readonly derived?: boolean;
+  /**
+   * The agent platform that measured this, on the figures a platform reported
+   * rather than Egma measured — and **absent on every other measure**, which is
+   * the whole of what keeps simulation traffic what it always was.
+   */
+  readonly reported_by?: string;
   readonly samples: readonly number[];
   readonly span_ids: readonly string[];
   /**

--- a/apps/api/test/trace-reads.test.ts
+++ b/apps/api/test/trace-reads.test.ts
@@ -1,14 +1,22 @@
+import {
+  appendSpans,
+  REPORTED_MEASUREMENTS_PAYLOAD_KEY,
+  reportedMeasurementsPayload,
+  type NewSpan,
+} from "@egma/db";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { createApi, type TestApi } from "./support/api.ts";
 import { FIXTURE_PROVIDER_CALL_ID, FIXTURE_TRACE } from "./support/fixture.ts";
 import {
+  contextFor,
   everySpan,
   listTracesOverHttp,
   readTraceOverHttp,
   replayFixture,
   signUp,
   type Customer,
+  type DetailMeasure,
   type DetailSpan,
   type ListedPage,
   type TraceDetailBody,
@@ -475,5 +483,191 @@ describe("the captured trace, read as a transcript", () => {
     // Present rather than absent, so a client can tell "nothing was measured"
     // from "this response is an older shape that never said".
     expect(Array.isArray(detail.measures)).toBe(true);
+  });
+});
+
+/**
+ * **What one measure looks like on the wire, field by field.**
+ *
+ * The acceptance criterion this pins is "simulation traffic is byte-for-byte
+ * unchanged", and it is a claim about the serialized object rather than about
+ * the arithmetic behind it — so it is asked here, over HTTP, by pinning the
+ * keys themselves. A field that appeared on every measure would be a wire
+ * change on traffic nothing new happened to, and no assertion about numbers
+ * would have noticed.
+ *
+ * **Its own day, deliberately.** These two traces are written straight into the
+ * store, and putting them in the capture's own window would make every other
+ * case in this file depend on the order the describes happen to run in.
+ */
+describe("what one measure looks like on the wire", () => {
+  const SIMULATED = "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a";
+  const REPORTED = "1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b";
+
+  /** A day of its own, holding nothing the rest of this file reads. */
+  const THE_NEXT_DAY = {
+    from: "2026-08-03T00:00:00Z",
+    to: "2026-08-04T00:00:00Z",
+  } as const;
+  const AT = BigInt(Date.parse("2026-08-03T09:00:00Z")) * 1_000n;
+
+  /** Every column stated, so a case says only what it is about. */
+  function span(over: Partial<NewSpan>): NewSpan {
+    return {
+      traceId: "",
+      spanId: "",
+      parentSpanId: "",
+      source: "production",
+      emitter: "agent",
+      environment: "default",
+      startedAtMicroseconds: AT,
+      durationNanoseconds: 1_000_000_000n,
+      name: "agent_session",
+      kind: "root",
+      status: "unset",
+      text: "",
+      audioUrl: "",
+      toolName: "",
+      toolArguments: "",
+      toolResult: "",
+      providerCallId: "room-wire",
+      connectionType: "livekit",
+      audioSampleRateHz: 0,
+      audioEncoding: "",
+      runId: "",
+      agentId: "",
+      agentVersionId: "",
+      testVersionId: "",
+      personaVersionId: "",
+      payload: "{}",
+      ...over,
+    };
+  }
+
+  async function measureOf(traceId: string): Promise<DetailMeasure> {
+    const response = await readTraceOverHttp(
+      api.app,
+      acme.secret,
+      traceId,
+      THE_NEXT_DAY,
+    );
+    expect(response.statusCode, response.body).toBe(200);
+    const body = response.json() as TraceDetailBody;
+    const only = body.measures[0];
+    if (only === undefined) throw new Error("the read measured nothing");
+    return only;
+  }
+
+  beforeAll(async () => {
+    const auth = contextFor(acme, "admin");
+
+    // A simulation, timing its own turn the way egma's simulator does.
+    await appendSpans(auth, [
+      span({
+        traceId: SIMULATED,
+        spanId: "5100000000000001",
+        source: "simulation",
+        emitter: "egma-runtime",
+        connectionType: "",
+        runId: "run_01JQZ0000000000000000000AA",
+        agentId: "agt_01JQZ0000000000000000000AA",
+      }),
+      span({
+        traceId: SIMULATED,
+        spanId: "5100000000000002",
+        parentSpanId: "5100000000000001",
+        source: "simulation",
+        emitter: "egma-runtime",
+        connectionType: "",
+        runId: "run_01JQZ0000000000000000000AA",
+        agentId: "agt_01JQZ0000000000000000000AA",
+        name: "turn_response_latency",
+        kind: "timing",
+        startedAtMicroseconds: AT + 1_000_000n,
+        durationNanoseconds: 1_100_000_000n,
+      }),
+    ]);
+
+    // And a managed platform's conversation: no turns, no timings, and the
+    // block on the root — written through the contract's own writer, so this
+    // spells it exactly as a normalizer does.
+    await appendSpans(auth, [
+      span({
+        traceId: REPORTED,
+        spanId: "5200000000000001",
+        name: "retell_call",
+        kind: "conversation",
+        connectionType: "retell",
+        providerCallId: "call_wire",
+        payload: JSON.stringify({
+          call_id: "call_wire",
+          egma_normalised: {
+            degraded: false,
+            [REPORTED_MEASUREMENTS_PAYLOAD_KEY]: reportedMeasurementsPayload(
+              "retell",
+              [
+                {
+                  measure: "turn_response_latency",
+                  unit: "milliseconds",
+                  values: [517, 2145],
+                },
+              ],
+            ),
+          },
+        }),
+      }),
+    ]);
+  });
+
+  it("carries no platform field at all on a simulation's own measure", async () => {
+    const only = await measureOf(SIMULATED);
+
+    // The exact shape, pinned: a client integrated against this answer sees
+    // precisely the fields it always saw.
+    expect(Object.keys(only).sort()).toEqual([
+      "derived",
+      "measure",
+      "partial",
+      "samples",
+      "span_ids",
+      "unit",
+      "worst",
+    ]);
+    expect(only.derived).toBe(false);
+    // Absent, not empty and not null — there is nothing on the wire to have to
+    // interpret.
+    expect("reported_by" in only).toBe(false);
+  });
+
+  it("adds the platform's name, and only there, on a measure it reported", async () => {
+    const only = await measureOf(REPORTED);
+
+    expect(Object.keys(only).sort()).toEqual([
+      "derived",
+      "measure",
+      "partial",
+      "reported_by",
+      "samples",
+      "span_ids",
+      "unit",
+      "worst",
+    ]);
+    // `derived` says what it has always said — egma did not time this — and the
+    // new field says which of the two untimed sources it was.
+    expect(only.derived).toBe(true);
+    expect(only.reported_by).toBe("retell");
+    expect(only.samples).toEqual([517, 2145]);
+    expect(only.worst).toEqual({ value: 2145, span_id: "5200000000000001" });
+  });
+
+  /**
+   * **A block is never a prefix.** `partial` says the figure was reduced over
+   * the first part of a conversation the read had to stop somewhere in. A
+   * platform's block is one row's account of the whole conversation, so there
+   * is no cut its worst measurement could be past — and saying otherwise would
+   * have a page disclaim a number that needs no disclaimer.
+   */
+  it("never calls a reported measure partial", async () => {
+    expect((await measureOf(REPORTED)).partial).toBe(false);
   });
 });

--- a/apps/grader/src/graders/latency.ts
+++ b/apps/grader/src/graders/latency.ts
@@ -34,6 +34,14 @@ import type { Execution, Judgment } from "./contract.ts";
  * made — and the rationale says which measurement decided, so nobody has to
  * guess.
  *
+ * **And it says who measured, when that was not egma.** The measure module
+ * reads three sources — egma's own timing spans, a derivation off a recognised
+ * framework's spans, and the block an agent platform reported about its own
+ * conversation — and a verdict decided by the third names the platform in its
+ * rationale. The bound is applied identically whoever took the number; what
+ * changes is that the record does not let a platform's account of its own agent
+ * pass silently as egma's observation of it.
+ *
  * ## What it says when it cannot say anything
  *
  * - **The conversation's spans do not carry the measure.** `skipped`, out of
@@ -246,6 +254,10 @@ function boundIn(entry: Readonly<Record<string, string | number>>): Bounded | un
  * because "the worst of eleven turns was 2.4 seconds" and "the one turn took 2.4
  * seconds" are different things to go and look at, and a rationale that hid the
  * difference would leave a developer opening the wrong transcript.
+ *
+ * And it says **who measured, when it was not egma** — see `whoMeasured` below.
+ * The two sentence shapes are otherwise the ones they have always been, word
+ * for word, so a verdict on a conversation egma timed reads exactly as it did.
  */
 function rationaleFor(
   asked: Bounded,
@@ -257,9 +269,31 @@ function rationaleFor(
     measured.samples.length === 1
       ? `was ${worst} ${measured.unit}`
       : `was ${worst} ${measured.unit} at its worst, across ${measured.samples.length} measurements`;
-  return held
-    ? `${asked.metric} ${taken}, within the bound of ${asked.bound}.`
-    : `${asked.metric} ${taken}, over the bound of ${asked.bound}.`;
+  const against = held
+    ? `within the bound of ${asked.bound}`
+    : `over the bound of ${asked.bound}`;
+  return `${asked.metric} ${taken}, ${against}${whoMeasured(measured)}.`;
+}
+
+/**
+ * The clause that names the platform, on a verdict decided by a number egma did
+ * not take.
+ *
+ * **A verdict computed from what a platform reported has to say so.** The
+ * number is real and the bound is real, but the evidence is the platform's
+ * account of its own agent rather than something egma watched happen — and the
+ * two are not the same kind of fact. A developer deciding whether to believe a
+ * failing check needs to know which one they are holding, and a rationale is the
+ * only place on a verdict row where that can be said in words a person reads.
+ *
+ * Nothing at all for a measure egma timed or derived, so those rationales are
+ * byte-for-byte what they were. The empty reporter is guarded too: the contract
+ * refuses a block without one, and a clause reading "as reported by" with
+ * nothing after it would be worse than the silence.
+ */
+function whoMeasured(measured: MeasuredFromSpans): string {
+  if (measured.origin !== "reported" || measured.reportedBy === "") return "";
+  return `, as reported by ${measured.reportedBy} — the platform's own measurement, not Egma's observation`;
 }
 
 /** egma could not make this check. Never `failed`: nothing is said about the agent. */

--- a/apps/grader/test/latency.test.ts
+++ b/apps/grader/test/latency.test.ts
@@ -71,7 +71,8 @@ function measured(
   return {
     measure,
     unit: "milliseconds",
-    derived: false,
+    origin: "timed",
+    reportedBy: "",
     // Each measurement carries the span it happened in, which is what a
     // judgment cites — one list, so nothing here has to keep two in step.
     samples: values.map((value, at) => ({
@@ -80,6 +81,30 @@ function measured(
     })),
   };
 }
+
+/**
+ * The same series, as the platform reported it rather than as egma measured it.
+ *
+ * Every sample cites the root span, which is what the measure module does with
+ * a block: an aggregate describes the whole conversation and happened at no
+ * moment inside it.
+ */
+function asReportedBy(
+  platform: string,
+  measure: string,
+  values: readonly number[],
+): MeasuredFromSpans {
+  return {
+    measure,
+    unit: "milliseconds",
+    origin: "reported",
+    reportedBy: platform,
+    samples: values.map((value) => ({ value, spanId: ROOT_SPAN })),
+  };
+}
+
+/** The root span a reported measurement rides in on. */
+const ROOT_SPAN = "00000000000000ff";
 
 function execution(
   entries: readonly Readonly<Record<string, string | number>>[],
@@ -162,6 +187,74 @@ describe("one config entry, one assertion", () => {
     );
 
     expect(only).toMatchObject({ verdict: "passed", score: 1 });
+  });
+});
+
+/**
+ * **A verdict decided by a number the platform reported, rather than one egma
+ * took.**
+ *
+ * The bound is applied identically — the platform's measurements are raw
+ * samples, so "every measurement holds the bound, the worst decides" means what
+ * it always meant. What changes is the record: the rationale names the
+ * platform, so nobody reading a failing check has to go and work out whose
+ * measurement it rests on.
+ *
+ * The numbers are the live proof's own: a Retell production conversation whose
+ * worst turn took 2145 ms, over the two-second bound the project already had
+ * wired, with nothing to say so until the block was read.
+ */
+describe("a verdict computed from what the platform reported", () => {
+  it("fails the bound the platform's own worst measurement missed, and names it", () => {
+    const [only] = executeLatency(
+      execution([{ metric: "turn_response_latency", bound: 2_000 }], {
+        source: "production",
+        measures: [
+          asReportedBy("retell", "turn_response_latency", [517, 2_145]),
+        ],
+      }),
+    );
+
+    expect(only).toMatchObject({
+      assertion: "turn_response_latency",
+      verdict: "failed",
+      score: 0,
+    });
+    expect(only?.rationale).toBe(
+      "turn_response_latency was 2145 milliseconds at its worst, across 2 measurements, over the bound of 2000, as reported by retell — the platform's own measurement, not Egma's observation.",
+    );
+    // The root span the block rode in on, which is the only span an aggregate
+    // over the whole conversation can honestly cite.
+    expect(only?.citedSpanIds).toEqual([ROOT_SPAN]);
+  });
+
+  it("passes a fast conversation, and still says whose measurement it was", () => {
+    const [only] = executeLatency(
+      execution([{ metric: "turn_response_latency", bound: 2_000 }], {
+        source: "production",
+        measures: [asReportedBy("retell", "turn_response_latency", [412, 517])],
+      }),
+    );
+
+    expect(only).toMatchObject({ verdict: "passed", score: 1 });
+    expect(only?.rationale).toBe(
+      "turn_response_latency was 517 milliseconds at its worst, across 2 measurements, within the bound of 2000, as reported by retell — the platform's own measurement, not Egma's observation.",
+    );
+  });
+
+  /**
+   * The clause is the reported measure's alone. A verdict on a number egma
+   * timed reads exactly as it did before there was a third source — which is
+   * what keeps this addition from rewriting every rationale already on a page.
+   */
+  it("says nothing about a platform on a measure egma measured itself", () => {
+    const [only] = executeLatency(
+      execution([{ metric: "turn_response_latency", bound: 2_000 }]),
+    );
+
+    expect(only?.rationale).toBe(
+      "turn_response_latency was 1100 milliseconds at its worst, across 2 measurements, within the bound of 2000.",
+    );
   });
 });
 

--- a/apps/grader/test/one-grader.test.ts
+++ b/apps/grader/test/one-grader.test.ts
@@ -32,7 +32,8 @@ function conversation(overrides: Partial<Conversation> = {}): Conversation {
       {
         measure: "turn_response_latency",
         unit: "milliseconds" as const,
-        derived: false,
+        origin: "timed" as const,
+        reportedBy: "",
         samples: [{ value: 900, spanId: "0000000000000001" }],
       },
     ],
@@ -174,7 +175,8 @@ describe("a simulation that never ran", () => {
           {
             measure: "turn_response_latency",
             unit: "milliseconds" as const,
-            derived: false,
+            origin: "timed" as const,
+            reportedBy: "",
             samples: [{ value: 10, spanId: "0000000000000001" }],
           },
         ],

--- a/apps/grader/test/production.test.ts
+++ b/apps/grader/test/production.test.ts
@@ -264,7 +264,8 @@ describe("a production trace whose root span closes", () => {
       {
         measure: "turn_response_latency",
         unit: "milliseconds",
-        derived: true,
+        origin: "derived",
+        reportedBy: "",
         samples: [{ value: 1_000, spanId: expect.any(String) }],
       },
     ]);

--- a/apps/grader/test/production.test.ts
+++ b/apps/grader/test/production.test.ts
@@ -392,6 +392,80 @@ describe("a production trace whose root span closes", () => {
   });
 });
 
+/**
+ * **The acceptance criterion, end to end and through everything.** A managed
+ * platform's conversation is stored the way its normalizer stores one — zero-
+ * width placeholder turns, and the platform's own raw measurements in the block
+ * on the root span — and it comes out the far side as a real verdict.
+ *
+ * This is the whole reason the ticket exists. The live proof of 2026-08-17
+ * captured a Retell conversation whose worst turn took 2145 ms, over the
+ * two-second bound the project already had wired, and no verdict said so: the
+ * trace carried no timing spans, its turns had no width to derive from, and
+ * the numbers Retell itself published were sitting unread on a payload. Nothing
+ * below is mocked between the store and the verdict row.
+ */
+describe("a production trace whose platform reported its own latency", () => {
+  const AS_RETELL_MEASURED = (values: readonly number[]) => ({
+    by: "retell",
+    measurements: [
+      { measure: "turn_response_latency", unit: "milliseconds", values },
+    ],
+  });
+
+  it("fails the bound the platform's own worst measurement missed, and says whose it was", async () => {
+    const graderId = await seedGrader(
+      world,
+      aLatencyCopy({ name: "Two seconds in the wild", scope: "production" }),
+    );
+
+    const { traceId } = await conductProductionTrace(world, {
+      reportedByPlatform: AS_RETELL_MEASURED([517, 2_145]),
+    });
+
+    const mine = (await verdictsOn(world, traceId, 1)).find(
+      (verdict) => verdict.graderId === graderId,
+    );
+
+    // A verdict, and not the `skipped` this conversation used to get — the one
+    // sentence the whole ticket is about.
+    expect(mine).toMatchObject({
+      source: "production",
+      assertion: "turn_response_latency",
+      verdict: "failed",
+      score: 0,
+    });
+    expect(mine?.rationale).toContain("2145 milliseconds at its worst");
+    expect(mine?.rationale).toContain("over the bound of 2000");
+    // And the record says whose measurement decided it, because a platform's
+    // account of its own agent is not egma's observation of it.
+    expect(mine?.rationale).toContain("as reported by retell");
+    expect(mine?.rationale).toContain("not Egma's observation");
+    // Cited on the root span the block rode in on, which is the only span an
+    // aggregate over the whole conversation can honestly point at.
+    expect(mine?.citedSpanIds).toHaveLength(1);
+  });
+
+  it("passes a fast conversation the same way", async () => {
+    const graderId = await seedGrader(
+      world,
+      aLatencyCopy({ name: "Two seconds, and it was quick", scope: "production" }),
+    );
+
+    const { traceId } = await conductProductionTrace(world, {
+      reportedByPlatform: AS_RETELL_MEASURED([412, 517]),
+    });
+
+    const mine = (await verdictsOn(world, traceId, 1)).find(
+      (verdict) => verdict.graderId === graderId,
+    );
+
+    expect(mine).toMatchObject({ verdict: "passed", score: 1 });
+    expect(mine?.rationale).toContain("517 milliseconds at its worst");
+    expect(mine?.rationale).toContain("as reported by retell");
+  });
+});
+
 describe("a production trace whose root span never closes", () => {
   it("is completed by the idle window, and still only judged once", async () => {
     const patient = runService(

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -18,6 +18,8 @@ import {
   readVerdicts,
   recordProductionTraces,
   PREDEFINED_GRADERS,
+  REPORTED_MEASUREMENTS_PAYLOAD_KEY,
+  reportedMeasurementsPayload,
   seedGraderLibrary,
   seedRunningGraders,
   setJudgeConfiguration,
@@ -28,6 +30,7 @@ import {
   type ExpectedBehavior,
   type GradingJob,
   type NewSpan,
+  type ReportedMeasurement,
   type UseLibraryEntry,
   type RecordedVerdict,
   type Simulation,
@@ -711,6 +714,26 @@ export async function conductProductionTrace(
      * decision to take, and the day it does, these rows are what arrive.
      */
     readonly measured?: Readonly<Record<string, readonly number[]>> | undefined;
+    /**
+     * What the **agent platform** measured about this conversation, filed the
+     * way a managed platform's normalizer files it: the neutral block on the
+     * root span's payload, and turns of zero width beside it.
+     *
+     * **The two go together because on a real platform they always do.** Retell
+     * publishes no per-turn timing, so its normalizer opens every turn where the
+     * trace opened and closes it in the same instant — placeholders — and the
+     * reason the block exists at all is that there is nothing else to measure
+     * from. A harness that wrote the block onto turns egma could read the
+     * geometry of would be testing a conversation no platform produces, and the
+     * derivation would answer first, so the case would prove nothing about the
+     * source it names.
+     */
+    readonly reportedByPlatform?:
+      | {
+          readonly by: string;
+          readonly measurements: readonly ReportedMeasurement[];
+        }
+      | undefined;
   } = {},
 ): Promise<ConductedTrace> {
   nextTraceOrdinal += 1;
@@ -733,6 +756,8 @@ export async function conductProductionTrace(
       ...over,
     });
 
+  const reportedByPlatform = conducting.reportedByPlatform;
+
   said.forEach((turn, at) => {
     const turnSpan = spanning({
       name: turn.speaker === "human" ? "user_turn" : "agent_turn",
@@ -740,6 +765,11 @@ export async function conductProductionTrace(
       text: turn.text,
       startedAtMicroseconds:
         BigInt(startedAt.getTime()) * 1_000n + BigInt(at) * 2_000_000n,
+      // A platform that reports its own numbers publishes no per-turn timing,
+      // so its turns are placeholders of no width — see the option above.
+      ...(reportedByPlatform === undefined
+        ? {}
+        : { durationNanoseconds: 0n }),
     });
     spans.push(turnSpan);
 
@@ -791,6 +821,25 @@ export async function conductProductionTrace(
         name: "agent_session",
         kind: "root",
         durationNanoseconds: 20_000_000_000n,
+        // The block rides here, under the egma-owned corner of a payload that
+        // is otherwise the vendor's own document — written through the
+        // contract's own writer, so this harness cannot spell it differently
+        // from the normalizer it stands in for.
+        ...(reportedByPlatform === undefined
+          ? {}
+          : {
+              payload: JSON.stringify({
+                call_id: `platform-${traceId.slice(-6)}`,
+                egma_normalised: {
+                  degraded: false,
+                  [REPORTED_MEASUREMENTS_PAYLOAD_KEY]:
+                    reportedMeasurementsPayload(
+                      reportedByPlatform.by,
+                      reportedByPlatform.measurements,
+                    ),
+                },
+              }),
+            }),
       }),
     ]);
   }

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -354,14 +354,45 @@ function Measures({ measured }: { measured: readonly Measured[] }) {
           </div>
         ))
       )}
-      {measured.some((one) => one.derived === true) ? (
+      {measured.some(
+        (one) => one.derived === true && one.reported_by === undefined,
+      ) ? (
         <div className={styles.contextFact}>
           <span />
           <strong className={styles.muted}>{MEASURES.derived}</strong>
         </div>
       ) : null}
+      {reportingPlatform(measured) === undefined ? null : (
+        <div className={styles.contextFact}>
+          <span />
+          <strong className={styles.muted}>
+            {MEASURES.reported(reportingPlatform(measured) ?? "")}
+          </strong>
+        </div>
+      )}
     </section>
   );
+}
+
+/**
+ * The agent platform that reported figures on this page, or nothing where none
+ * did.
+ *
+ * One name rather than a list, because there is only ever one to have: the
+ * figures a platform reports ride the one span that opens the exchange, written
+ * by the one platform the exchange happened on. Reading the first is therefore
+ * reading the only one, and a page that listed them would be dressing a
+ * certainty up as a set.
+ */
+function reportingPlatform(
+  measured: readonly Measured[],
+): string | undefined {
+  for (const one of measured) {
+    if (one.reported_by !== undefined && one.reported_by !== "") {
+      return one.reported_by;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -388,7 +419,16 @@ function measurement(one: Measured): string {
   // Said on the figure itself as well as once for the panel, because a page
   // mixing timed and worked-out numbers must let a reader tell which is which
   // without counting rows.
-  const from = one.derived === true ? ` · ${MEASURES.derivedOne}` : "";
+  //
+  // **The platform's mark is asked for first, and it is not the other one
+  // reworded.** A figure a platform reported was not worked out from anything;
+  // saying it was would be this page inventing an observation Egma never made.
+  const from =
+    one.reported_by !== undefined && one.reported_by !== ""
+      ? ` · ${MEASURES.reportedOne(one.reported_by)}`
+      : one.derived === true
+        ? ` · ${MEASURES.derivedOne}`
+        : "";
   if (one.partial === true) return `${shown} · ${MEASURES.partialWorst}${from}`;
   return one.samples.length === 1
     ? `${shown}${from}`

--- a/apps/web/lib/transcript-copy.ts
+++ b/apps/web/lib/transcript-copy.ts
@@ -324,6 +324,26 @@ export const MEASURES = {
     "rather than timed by Egma. Each says which.",
   /** The mark beside one worked-out figure, so a reader need not guess which. */
   derivedOne: "from your framework's timings",
+  /**
+   * Where a number the **platform** measured came from — a different sentence
+   * from the one above, deliberately.
+   *
+   * **These figures were not worked out by Egma at all.** Retell publishes no
+   * per-turn timing, so there is nothing for Egma to work anything out from;
+   * what there is, is Retell's own measurement of its own agent, handed over
+   * and judged as it stands. Saying "worked out from your framework's timings"
+   * about it would claim Egma observed something it never saw — a caveat that
+   * is itself untrue is worse than none, because it is the sentence a developer
+   * decides how much to believe the verdict on.
+   *
+   * The platform's name is filled in from the answer rather than written here:
+   * this page never hardcodes which platforms exist.
+   */
+  reported: (platform: string): string =>
+    `Some figures here were measured by ${platform} and reported to Egma, ` +
+    `not observed by Egma. Each says which.`,
+  /** The mark beside one such figure, so a reader need not guess which. */
+  reportedOne: (platform: string): string => `as reported by ${platform}`,
   /** One measurement is the number; several are the worst of them. */
   worst: "worst",
   counted: (howMany: number): string =>

--- a/apps/web/lib/transcripts.ts
+++ b/apps/web/lib/transcripts.ts
@@ -134,13 +134,25 @@ export type Measured = {
   readonly measure: string;
   readonly unit: string;
   /**
-   * True when Egma worked the number out from the framework's own timings
-   * rather than reading one Egma's simulator timed itself.
+   * True when Egma did not time the number itself — either it worked the figure
+   * out from the framework's own timings, or the agent platform handed it over.
+   * `reported_by` beside this is what tells the two apart.
    *
    * Optional because an answer from an older platform does not carry it, which
    * is a page that says nothing about provenance rather than one that breaks.
    */
   readonly derived?: boolean;
+  /**
+   * The agent platform that measured this figure — `retell` — on the figures a
+   * platform reported rather than Egma measured.
+   *
+   * **Absent on everything else, and that absence is the whole signal.** Egma
+   * working a number out from your framework's spans and a platform reporting
+   * its own number are different claims, and the page must not word one as the
+   * other: `derived` alone cannot tell them apart, so a figure carrying this
+   * field is said differently from one that does not.
+   */
+  readonly reported_by?: string;
   /** One sample, or the series a per-turn measure produced. Never empty. */
   readonly samples: readonly number[];
   /** The span each sample came off, in the same order. */

--- a/apps/web/test/transcripts.test.ts
+++ b/apps/web/test/transcripts.test.ts
@@ -1015,6 +1015,45 @@ describe("saying which numbers Egma worked out", () => {
     expect(copy.MEASURES.derivedOne).toContain("framework");
   });
 
+  /**
+   * **A figure the agent platform measured is said differently, and the
+   * difference is not decoration.** Retell publishes no per-turn timing, so
+   * there is nothing for Egma to have worked anything out from: the number is
+   * Retell's own measurement of its own agent, handed over and judged as it
+   * stands. The sentence above would claim Egma observed it, and a caveat that
+   * is itself untrue is worse than none — it is the sentence a developer
+   * decides how far to believe a failing check on.
+   */
+  it("says a platform-reported figure in its own words, never the worked-out ones", async () => {
+    const page = await readFile(path.join(WEB, DETAIL_PAGE), "utf8");
+
+    expect(page).toContain("one.reported_by");
+    expect(page).toContain("MEASURES.reported");
+    expect(page).toContain("MEASURES.reportedOne");
+
+    const said = copy.MEASURES.reported("retell");
+    expect(said).toContain("retell");
+    expect(said).toContain("not observed by Egma");
+    // And none of the worked-out wording, which is the whole point of there
+    // being two sentences rather than one.
+    expect(said).not.toContain("worked out");
+    expect(said).not.toContain("framework");
+
+    // Marked on the figure too, in the words the verdict's own rationale uses.
+    expect(copy.MEASURES.reportedOne("retell")).toBe("as reported by retell");
+  });
+
+  /**
+   * The two caveats never speak for each other. A page whose only untimed
+   * figures were reported by a platform must not also say Egma worked
+   * something out from a framework's timings, because it did not.
+   */
+  it("does not show the worked-out caveat for a figure a platform reported", async () => {
+    const page = await readFile(path.join(WEB, DETAIL_PAGE), "utf8");
+
+    expect(page).toContain("one.reported_by === undefined");
+  });
+
   it("keeps the nothing-was-measured sentence exactly as it was", () => {
     expect(copy.MEASURES.none).toBe(
       "Nothing was measured here. Egma's own simulations time their turns; an " +
@@ -1033,6 +1072,8 @@ describe("saying which numbers Egma worked out", () => {
     for (const said of [
       copy.MEASURES.derived,
       copy.MEASURES.derivedOne,
+      copy.MEASURES.reported("retell"),
+      copy.MEASURES.reportedOne("retell"),
       copy.MEASURES.none,
     ]) {
       expect(said.toLowerCase()).not.toContain("span");

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -281,6 +281,7 @@ export {
   MAXIMUM_WINDOW_MILLISECONDS,
   type ListTracesOptions,
   type ReadTraceOptions,
+  type ReportedOnTrace,
   type TimeWindow,
   type TraceDetail,
   type TraceFacts,

--- a/packages/db/src/access/traces.ts
+++ b/packages/db/src/access/traces.ts
@@ -1,5 +1,6 @@
 import { traceStore } from "../clickhouse/client.ts";
 import {
+  REPORTED_MEASUREMENTS_PAYLOAD_KEY,
   REPORTED_MEASUREMENTS_PAYLOAD_PATH,
   reportedMeasurementsOf,
   type ReportedMeasurement,
@@ -79,19 +80,20 @@ const SPANS_TABLE = "spans";
 const TURNS_TABLE = "turns";
 
 /**
- * Where the reported-measurements block rides, as the two payload keys a read
- * has to walk to reach it.
+ * The outer of the two payload keys reaching the block walks — the egma-owned
+ * corner of an otherwise vendor-owned document.
  *
- * Split from the path the contract itself exports rather than written out a
- * second time here: the normalizers write to
- * `REPORTED_MEASUREMENTS_PAYLOAD_PATH` and this is that same string read
- * backwards, so a writer's spelling and this reader's cannot come apart. The
- * defaults cover a path that is not two segments — which a literal constant
- * cannot become, and which would otherwise have this asking the store for a key
- * called `undefined`.
+ * Taken off the path the contract exports rather than written out a second time
+ * here, so a normalizer's spelling and this reader's cannot come apart. The
+ * inner key needs no such derivation: the contract exports it as
+ * `REPORTED_MEASUREMENTS_PAYLOAD_KEY` and this file uses that constant itself.
+ *
+ * The `= ""` is not a case that can arise. Indexing is strictly typed here, so
+ * the first element of a split is `string | undefined` however literal the
+ * string being split was, and a default is how that is answered rather than
+ * asserted away.
  */
-const [NORMALISED_KEY = "", REPORTED_KEY = ""] =
-  REPORTED_MEASUREMENTS_PAYLOAD_PATH.split(".");
+const [NORMALISED_KEY = ""] = REPORTED_MEASUREMENTS_PAYLOAD_PATH.split(".");
 
 /**
  * A window of time, closed at the start and open at the end, counted in
@@ -239,12 +241,13 @@ export type TraceSpan = {
  */
 export type ReportedOnTrace = {
   /**
-   * The root span the block was written on.
+   * The parentless row this block rode in on — the root, as its own platform
+   * wrote it.
    *
    * An aggregate describes the whole trace and happened at no single moment
-   * inside it, so the root is the only span a measurement taken from this block
-   * can honestly cite. Carried here rather than looked up again later, because
-   * the row that held the block is the row that knows.
+   * inside it, so this is the only span a measurement taken from the block can
+   * honestly cite. Carried here rather than looked up again later, because the
+   * row that held the block is the row that knows.
    */
   readonly spanId: string;
   /** The platform that measured — `retell`. Provenance, and the word a
@@ -901,15 +904,24 @@ export async function readTrace(
       parameters,
     ),
     rowsOf<RootSliceRow>(
-      // **The egma-owned slice of one root's payload, and never the payload.**
-      // A root is the span that named no parent — the door normalises an
-      // unusable one to `''`, and every normalizer writes its root that way —
-      // so this asks for the parentless rows and keeps the earliest, exactly as
-      // the measure module's own derivation picks its root: a trace holding more
-      // than one is a flush whose parent never came, and the conversation began
-      // at the first of them. The span id is the tie-break the row order already uses,
-      // so two readings of one trace answer with one span rather than with
-      // whichever row came back first.
+      // **The egma-owned slice of one parentless row's payload, and never the
+      // payload.** Every normalizer writes its root naming no parent, and the
+      // block is written on that row — so what this selects is the parentless
+      // rows, earliest first, and keeps one. Selected by the parent and
+      // deliberately not by a kind: a root wears whatever word its platform
+      // uses, `root` on egma's own traces and `conversation` on a Retell one,
+      // and a reader that named kinds would have to learn a new one per
+      // platform.
+      //
+      // The same predicate also catches a span whose unusable parent id
+      // normalised away at the door — the orphan `transcriptOf` files at the
+      // top, below — so this is honestly *the first parentless row* and not
+      // "the root" by any stronger claim. Nothing is lost by it: a block only
+      // ever rides the row a normalizer wrote it on, and a trace holding
+      // several parentless rows is a flush whose parent never came, which
+      // began at the earliest of them. The span id breaks a tie exactly as the
+      // row order above does, so two readings of one trace answer with one span
+      // rather than with whichever row came back first.
       `select
        span_id,
        JSONExtractRaw(payload, '${NORMALISED_KEY}') as normalised
@@ -971,7 +983,7 @@ function reportedOn(row: RootSliceRow | undefined): ReportedOnTrace | undefined 
   }
 
   const block = reportedMeasurementsOf(
-    (slice as Record<string, unknown>)[REPORTED_KEY],
+    (slice as Record<string, unknown>)[REPORTED_MEASUREMENTS_PAYLOAD_KEY],
   );
   if (block === undefined) return undefined;
   return {

--- a/packages/db/src/access/traces.ts
+++ b/packages/db/src/access/traces.ts
@@ -1,4 +1,9 @@
 import { traceStore } from "../clickhouse/client.ts";
+import {
+  REPORTED_MEASUREMENTS_PAYLOAD_PATH,
+  reportedMeasurementsOf,
+  type ReportedMeasurement,
+} from "../measures/reported.ts";
 import type { AuthContext } from "./context.ts";
 import { UnreadableTraceQueryError } from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
@@ -72,6 +77,21 @@ export const MAXIMUM_SPANS_PER_TRACE = 10_000;
 
 const SPANS_TABLE = "spans";
 const TURNS_TABLE = "turns";
+
+/**
+ * Where the reported-measurements block rides, as the two payload keys a read
+ * has to walk to reach it.
+ *
+ * Split from the path the contract itself exports rather than written out a
+ * second time here: the normalizers write to
+ * `REPORTED_MEASUREMENTS_PAYLOAD_PATH` and this is that same string read
+ * backwards, so a writer's spelling and this reader's cannot come apart. The
+ * defaults cover a path that is not two segments — which a literal constant
+ * cannot become, and which would otherwise have this asking the store for a key
+ * called `undefined`.
+ */
+const [NORMALISED_KEY = "", REPORTED_KEY = ""] =
+  REPORTED_MEASUREMENTS_PAYLOAD_PATH.split(".");
 
 /**
  * A window of time, closed at the start and open at the end, counted in
@@ -208,6 +228,31 @@ export type TraceSpan = {
   readonly spans: readonly TraceSpan[];
 };
 
+/**
+ * What the agent platform measured about this trace, as the root span carried
+ * it.
+ *
+ * The block itself is `packages/db/src/measures/reported.ts` — one neutral
+ * shape every platform's normalizer writes and nothing downstream has to know a
+ * vendor to read. What this adds is the one fact a reader of the payload has
+ * and a reader of the block does not: **which span it rode in on**.
+ */
+export type ReportedOnTrace = {
+  /**
+   * The root span the block was written on.
+   *
+   * An aggregate describes the whole trace and happened at no single moment
+   * inside it, so the root is the only span a measurement taken from this block
+   * can honestly cite. Carried here rather than looked up again later, because
+   * the row that held the block is the row that knows.
+   */
+  readonly spanId: string;
+  /** The platform that measured — `retell`. Provenance, and the word a
+   * rationale prints. */
+  readonly reportedBy: string;
+  readonly measurements: readonly ReportedMeasurement[];
+};
+
 export type TraceDetail = TraceFacts & {
   /**
    * The transcript in the order it happened: every `turn:` span, each carrying
@@ -232,6 +277,22 @@ export type TraceDetail = TraceFacts & {
    * the transcript is.
    */
   readonly truncated: boolean;
+  /**
+   * What the platform reported about this trace, when its root span carries a
+   * block that reads.
+   *
+   * **Absent is the ordinary answer, and never an error.** A simulation has no
+   * platform to report anything; a platform egma reads no numbers from reports
+   * nothing; and a root that never arrived, a payload with no egma-owned corner
+   * in it, and a block that is malformed all land here the same way, because a
+   * trace is still a trace whatever a vendor wrote in one key of one row.
+   *
+   * The numbers are read by the shared measure module and by nothing else: a
+   * display and a verdict both reach them through that one arithmetic rather
+   * than through this field, so provenance and priority are decided in one
+   * place for every source.
+   */
+  readonly reported?: ReportedOnTrace | undefined;
 };
 
 /* ------------------------------------------------------------------- *
@@ -767,6 +828,17 @@ function isTurn(kind: string): boolean {
  * not build, because nothing consumes it yet and an endpoint with no caller is a
  * contract nobody has checked.
  *
+ * **One key of one row is the exception, and it is the narrow consumer that
+ * paragraph said did not exist yet.** The reported-measurements block rides the
+ * root span's payload, so the third query below reads
+ * `JSONExtractRaw(payload, 'egma_normalised')` off the earliest root and
+ * nothing beside it: one row, and only the corner of it egma itself wrote. The
+ * extraction happens in ClickHouse rather than here, so the vendor's own
+ * document never crosses the wire at all — which is what keeps the paragraph
+ * above true in the shape that mattered, rather than merely in its letter. A
+ * trace whose platform reported nothing pays one cheap lookup for an empty
+ * string.
+ *
  * Absent when the window holds no span of that trace for this customer — which is
  * also the answer another customer gets for a trace id they guessed correctly,
  * because the organization leads the filing order and their query never reaches
@@ -788,14 +860,17 @@ export async function readTrace(
        and trace_id = {trace_id:String}`;
   const parameters = { ...tenancy.parameters, trace_id: traceId };
 
-  // Two reads of the same window, and the second is not the first's leftovers.
+  // Three reads of the same window, and none of them is another's leftovers.
   // The rows build the tree and stop at the cap; the aggregate counts the whole
   // trace, so that a transcript which had to stop somewhere still reports what
   // it stopped short of. It is the list's own aggregate, scoped to one trace,
   // over a window the sort key has already pruned to this organization, this
-  // project and these minutes — one cheap pass, and asked in parallel with the
-  // rows because neither answer is the other's input.
-  const [summaries, rows] = await Promise.all([
+  // project and these minutes — one cheap pass. The third reads the block the
+  // platform reported, off one row and one key of it. All three are asked in
+  // parallel because no answer is another's input, and all three carry the same
+  // tenancy and the same window, so the third can no more reach another
+  // customer's row than the first two can.
+  const [summaries, rows, roots] = await Promise.all([
     rowsOf<SummaryRow>(
       `select
        trace_id,
@@ -825,6 +900,26 @@ export async function readTrace(
      limit ${MAXIMUM_SPANS_PER_TRACE + 1}`,
       parameters,
     ),
+    rowsOf<RootSliceRow>(
+      // **The egma-owned slice of one root's payload, and never the payload.**
+      // A root is the span that named no parent — the door normalises an
+      // unusable one to `''`, and every normalizer writes its root that way —
+      // so this asks for the parentless rows and keeps the earliest, exactly as
+      // the measure module's own derivation picks its root: a trace holding more
+      // than one is a flush whose parent never came, and the conversation began
+      // at the first of them. The span id is the tie-break the row order already uses,
+      // so two readings of one trace answer with one span rather than with
+      // whichever row came back first.
+      `select
+       span_id,
+       JSONExtractRaw(payload, '${NORMALISED_KEY}') as normalised
+     from ${SPANS_TABLE}
+     where ${where}
+       and parent_span_id = ''
+     order by started_at asc, span_id asc
+     limit 1`,
+      parameters,
+    ),
   ]);
 
   const facts = summaries[0];
@@ -833,7 +928,57 @@ export async function readTrace(
   const truncated = rows.length > MAXIMUM_SPANS_PER_TRACE;
   const kept = truncated ? rows.slice(0, MAXIMUM_SPANS_PER_TRACE) : rows;
 
-  return { ...factsOf(traceId, facts), ...transcriptOf(kept), truncated };
+  return {
+    ...factsOf(traceId, facts),
+    ...transcriptOf(kept),
+    truncated,
+    reported: reportedOn(roots[0]),
+  };
+}
+
+/** The root span's id, and the egma-owned slice of its payload as raw JSON. */
+type RootSliceRow = {
+  readonly span_id: string;
+  readonly normalised: string;
+};
+
+/**
+ * The reported-measurements block off the trace's root, or nothing at all.
+ *
+ * **Nothing at all is a first-class answer here and is never an error.** No
+ * root row, no egma-owned slice, no block inside it, a slice that is not JSON,
+ * a block of a version this code predates — every one of them is a trace that
+ * reported nothing, which is what almost every trace in the store is. A read
+ * that threw on any of them would turn one bad write by one vendor into a
+ * transcript nobody can open, and the transcript is the part that was never in
+ * doubt.
+ *
+ * The parse of the block itself is `reportedMeasurementsOf` and is deliberately
+ * not repeated here: this walks two payload keys and hands over what it found,
+ * and the contract decides what a block is.
+ */
+function reportedOn(row: RootSliceRow | undefined): ReportedOnTrace | undefined {
+  if (row === undefined || row.normalised === "") return undefined;
+
+  let slice: unknown;
+  try {
+    slice = JSON.parse(row.normalised);
+  } catch {
+    return undefined;
+  }
+  if (typeof slice !== "object" || slice === null || Array.isArray(slice)) {
+    return undefined;
+  }
+
+  const block = reportedMeasurementsOf(
+    (slice as Record<string, unknown>)[REPORTED_KEY],
+  );
+  if (block === undefined) return undefined;
+  return {
+    spanId: row.span_id,
+    reportedBy: block.reportedBy,
+    measurements: block.measurements,
+  };
 }
 
 /**

--- a/packages/db/src/measures/from-spans.ts
+++ b/packages/db/src/measures/from-spans.ts
@@ -375,6 +375,12 @@ function reportedSamplesOf(
   cataloged: CatalogedMeasure,
   reported: ReportedOnTrace,
 ): readonly Sample[] {
+  // The first match wins where a block somehow names one measure twice in one
+  // unit. A normalizer maps each of its own stages once, so nothing writes such
+  // a block — and the reader stays lenient rather than refusing, exactly as the
+  // contract's parse does: a duplicate is one platform's bookkeeping mistake,
+  // and answering with the first of two identical-looking series beats
+  // answering a customer with nothing.
   const said = reported.measurements.find(
     (measurement) =>
       measurement.measure === cataloged.measure &&

--- a/packages/db/src/measures/from-spans.ts
+++ b/packages/db/src/measures/from-spans.ts
@@ -3,11 +3,19 @@ import {
   type CatalogedMeasure,
 } from "@egma/simulation-contract";
 
-import type { TraceSpan } from "../access/traces.ts";
+import type { ReportedOnTrace, TraceSpan } from "../access/traces.ts";
 
 /**
- * The shared measure module: a conversation's spans in, the measure catalog's
- * numbers out.
+ * The shared measure module: a conversation in, the measure catalog's numbers
+ * out.
+ *
+ * **Three sources, one answer per measure.** A measure egma timed itself wins;
+ * a measure worked out from a recognised framework's own spans comes next; what
+ * the agent platform reported about its own conversation comes last. Every step
+ * of the chain is absolute — nothing is averaged with anything and nothing is
+ * appended to anything — and every number says which step it came from, because
+ * a developer reading a verdict is entitled to know whether egma watched it
+ * happen or was told about it.
  *
  * **One computation, and that is the whole reason this file exists.** The
  * metrics display reads through it and so does the grader that bounds a
@@ -19,12 +27,15 @@ import type { TraceSpan } from "../access/traces.ts";
  * settle the disagreement against, which is precisely the false trust this
  * product exists to kill.
  *
- * **The source is not an input, and cannot become one.** What goes in is spans;
- * what comes out is what those spans carry. A simulation's telemetry and a real
- * caller's arrive at the same OTLP door and land in the same table, so
- * "identical spans, identical numbers" is a property of this function's
- * signature rather than a promise somebody has to keep — there is nowhere here
- * for `source` to be read even by a caller who wanted to.
+ * **The source is not an input, and cannot become one.** What goes in is a
+ * conversation's spans, and what a platform reported about it; what comes out is
+ * what those carry. A simulation's telemetry and a real caller's arrive at the
+ * same OTLP door and land in the same table, so "identical input, identical
+ * numbers" is a property of this function's signature rather than a promise
+ * somebody has to keep — there is nowhere here for `source` to be read even by a
+ * caller who wanted to. The reported block is not a way in for it: it is what a
+ * platform said about one conversation, read on its own terms and last of the
+ * three, and a simulation carrying one would be read exactly the same way.
  *
  * **The catalog decides what is computed and how.** Every measure carries its
  * span-level definition beside its name
@@ -41,10 +52,10 @@ import type { TraceSpan } from "../access/traces.ts";
 
 /**
  * The part of a trace this reads: its spans, however they were arranged for a
- * transcript.
+ * transcript, and what its platform reported about it.
  *
  * Structural rather than `TraceDetail` itself, so a caller holding a trace hands
- * it straight over and a test can hand over the two lists — and so that adding a
+ * it straight over and a test can hand over the lists — and so that adding a
  * fact to a trace read is not a change to this arithmetic. A trace read hands
  * back the turns lifted out for the transcript and everything filed beside them,
  * with children hanging beneath both; every span is under one of the two, once.
@@ -52,6 +63,20 @@ import type { TraceSpan } from "../access/traces.ts";
 export type SpannedConversation = {
   readonly turns: readonly TraceSpan[];
   readonly spans: readonly TraceSpan[];
+  /**
+   * What the platform measured about this conversation itself, when the trace
+   * read found a block on its root span.
+   *
+   * **Not spans, and that is the honest shape.** These numbers were never
+   * events egma watched happen; they are what somebody else says happened, and
+   * dressing them as spans would fabricate a granularity the platform never
+   * gave. So they arrive beside the spans rather than among them, they are read
+   * last, and every number worked out from them says so.
+   *
+   * Optional, because a conversation is a conversation without one — every
+   * simulation, and every platform egma reads no numbers from.
+   */
+  readonly reported?: ReportedOnTrace | undefined;
 };
 
 /**
@@ -74,16 +99,33 @@ export type MeasuredFromSpans = {
   /** The catalog's own unit, so nothing downstream has to look it up again. */
   readonly unit: CatalogedMeasure["unit"];
   /**
-   * Whether this number was worked out from a framework's own spans rather than
-   * read off a timing span egma's vocabulary names.
+   * Which of the three sources this number came from: a timing span egma's own
+   * vocabulary names, a derivation off a recognised framework's own spans, or
+   * the platform's own reported block.
    *
    * A fact about *this* conversation and not about the measure, which is why it
    * rides the answer instead of sitting in the catalog: the same measure is
-   * timed on a simulation and derived on a stock LiveKit call. A page saying
-   * where a number came from is the difference between a verdict a developer
-   * trusts and one they have to go and check.
+   * timed on a simulation, derived on a stock LiveKit call, and reported on a
+   * Retell one. A page saying where a number came from is the difference
+   * between a verdict a developer trusts and one they have to go and check —
+   * and `reported` is the value that most needs saying out loud, because a
+   * platform's measurement of its own agent is a different kind of evidence
+   * from egma's observation of it.
+   *
+   * Not the catalog's own `origin`, which says where a measure arrives from in
+   * general — a timing span or a terminal fact. This says who measured this
+   * one, on this conversation.
    */
-  readonly derived: boolean;
+  readonly origin: "timed" | "derived" | "reported";
+  /**
+   * Who reported it — `retell`, exactly as the connection type names the
+   * platform — and the empty string for every measure egma measured itself.
+   *
+   * Empty rather than absent, so that reading it is never a narrowing: anything
+   * printing a platform's name asks `origin === "reported"` first, and there is
+   * one question to ask rather than two that could come to disagree.
+   */
+  readonly reportedBy: string;
   /**
    * One measurement, or the whole series for a measure taken once a turn, in
    * the order they were taken.
@@ -144,6 +186,7 @@ export function measuresFromSpans(
 ): readonly MeasuredFromSpans[] {
   const timed = timingSpansByName(conversation);
   const derived = derivedFromFrameworkSpans(conversation);
+  const reported = conversation.reported;
 
   const measured: MeasuredFromSpans[] = [];
   for (const cataloged of MEASURE_CATALOG) {
@@ -152,7 +195,8 @@ export function measuresFromSpans(
       measured.push({
         measure: cataloged.measure,
         unit: cataloged.unit,
-        derived: false,
+        origin: "timed",
+        reportedBy: "",
         samples: found,
       });
       continue;
@@ -163,12 +207,32 @@ export function measuresFromSpans(
     // measurement somebody instrumented on purpose. Deriving beside it would
     // double the samples of one turn and quietly move every percentile.
     const worked = derived.get(cataloged.measure) ?? [];
-    if (worked.length === 0) continue;
+    if (worked.length > 0) {
+      measured.push({
+        measure: cataloged.measure,
+        unit: cataloged.unit,
+        origin: "derived",
+        reportedBy: "",
+        samples: worked,
+      });
+      continue;
+    }
+    // **And the platform's own numbers are last, for the same reason and by the
+    // same absolute rule.** egma watching the conversation outranks the
+    // platform grading its own homework, so a measure egma timed or derived is
+    // never joined by what the platform said about it: one answer per measure,
+    // never averaged and never appended. Last is not least — for a Retell trace
+    // it is the only source there is, and the whole difference between a
+    // production conversation with a verdict and one with a polite silence.
+    if (reported === undefined) continue;
+    const said = reportedSamplesOf(cataloged, reported);
+    if (said.length === 0) continue;
     measured.push({
       measure: cataloged.measure,
       unit: cataloged.unit,
-      derived: true,
-      samples: worked,
+      origin: "reported",
+      reportedBy: reported.reportedBy,
+      samples: said,
     });
   }
   return measured;
@@ -270,6 +334,54 @@ function samplesOf(
       return [];
     }
   }
+}
+
+/* ------------------------------------------------------------------- *
+ * The reported measures: what the platform said, read as the catalog's
+ * numbers.
+ * ------------------------------------------------------------------- */
+
+/**
+ * One cataloged measure's samples out of the platform's reported block, or
+ * nothing where the block does not hold that measure.
+ *
+ * **The name and the unit both have to match, and the unit is not a
+ * formality.** A platform that reports its end-to-end latency in seconds under
+ * the catalog's own name is reporting something real; reading `2.145` as
+ * milliseconds would hand a grader a conversation that answered in two
+ * milliseconds, and a two-second bound would pass what it exists to fail. A
+ * number in the wrong unit is worse than no number, so such a measurement is
+ * skipped in silence and the measure comes back absent — which is a `skipped`
+ * check rather than a false pass, and the difference the verdict vocabulary is
+ * built on. Converting it instead would be egma inventing a fact about a unit
+ * nobody in this repository declared.
+ *
+ * **A platform-prefixed name never matches**, because no catalog measure is
+ * called `retell/llm_latency`. Those entries stay in the block for the day a
+ * display asks for them, and are deliberately not folded into the catalog
+ * answer beside a stage that means something else.
+ *
+ * **Every sample cites the root span the block rode in on.** These numbers
+ * describe the whole conversation and happened at no single moment inside it,
+ * so the root is the only span that can honestly be pointed at — and a verdict
+ * citing it opens the trace the measurement is about rather than a turn picked
+ * to look precise.
+ *
+ * The order is the platform's own, exactly as a timed series is the order it
+ * was taken in: the block carries raw measurements rather than a summary, so
+ * read forwards it is the conversation read forwards.
+ */
+function reportedSamplesOf(
+  cataloged: CatalogedMeasure,
+  reported: ReportedOnTrace,
+): readonly Sample[] {
+  const said = reported.measurements.find(
+    (measurement) =>
+      measurement.measure === cataloged.measure &&
+      measurement.unit === cataloged.unit,
+  );
+  if (said === undefined) return [];
+  return said.values.map((value) => ({ value, spanId: reported.spanId }));
 }
 
 /* ------------------------------------------------------------------- *

--- a/packages/db/test/measures-from-spans.test.ts
+++ b/packages/db/test/measures-from-spans.test.ts
@@ -4,10 +4,12 @@ import {
   disconnectClickHouse,
   measuresFromSpans,
   readTrace,
+  reportedMeasurementsPayload,
   worstSampleOf,
   type AuthContext,
   type MeasuredFromSpans,
   type NewSpan,
+  type ReportedMeasurement,
   type TraceDetail,
 } from "@egma/db";
 import { newId } from "@egma/ids";
@@ -258,14 +260,17 @@ describe("one conversation's measures", () => {
       {
         measure: "first_response_latency",
         unit: "milliseconds",
-        // Timed by egma's own vocabulary, so it is read rather than worked out.
-        derived: false,
+        // Timed by egma's own vocabulary, so it is read rather than worked out,
+        // and reported by nobody.
+        origin: "timed",
+        reportedBy: "",
         samples: [{ value: 1_214, spanId: expect.any(String) }],
       },
       {
         measure: "turn_response_latency",
         unit: "milliseconds",
-        derived: false,
+        origin: "timed",
+        reportedBy: "",
         // In the order they were taken, so a per-turn series is the
         // conversation read forwards — and the half is still here, which a
         // whole-number division would have floored away.
@@ -616,7 +621,7 @@ describe("measures derived from a recognised framework's own spans", () => {
     ]);
 
     const measured = measureIn(trace, "turn_response_latency");
-    expect(measured?.derived).toBe(true);
+    expect(measured?.origin).toBe("derived");
     // 1400 − 1000, then 5600 − 5000: the human turn's end to the agent's first
     // word, once per human turn and in that order.
     expect(measured === undefined ? [] : valuesOf(measured)).toEqual([400, 600]);
@@ -685,7 +690,7 @@ describe("measures derived from a recognised framework's own spans", () => {
     ]);
 
     const measured = measureIn(trace, "first_response_latency");
-    expect(measured?.derived).toBe(true);
+    expect(measured?.origin).toBe("derived");
     // The root's start to the first agent turn's first word, and taken once.
     expect(measured === undefined ? [] : valuesOf(measured)).toEqual([1_500]);
   });
@@ -711,7 +716,7 @@ describe("measures derived from a recognised framework's own spans", () => {
     ]);
 
     const measured = measureIn(trace, "agent_speech_duration");
-    expect(measured?.derived).toBe(true);
+    expect(measured?.origin).toBe("derived");
     expect(measured === undefined ? [] : valuesOf(measured)).toEqual([
       1_750, 900,
     ]);
@@ -746,12 +751,265 @@ describe("measures derived from a recognised framework's own spans", () => {
     const both = await aLiveKitCall(turns, { turn_response_latency: [862.5] });
 
     const measured = measureIn(both, "turn_response_latency");
-    expect(measured?.derived).toBe(false);
+    expect(measured?.origin).toBe("timed");
     // The timed number, and not the 400 the same spans would have derived.
     expect(measured === undefined ? [] : valuesOf(measured)).toEqual([862.5]);
 
     // The measures it did **not** time are still derived, so precedence is per
     // measure rather than a switch that turns the whole conversation off.
-    expect(measureIn(both, "agent_speech_duration")?.derived).toBe(true);
+    expect(measureIn(both, "agent_speech_duration")?.origin).toBe("derived");
+  });
+});
+
+/* ------------------------------------------------------------------- *
+ * The reported measures: what the agent platform measured about its own
+ * conversation.
+ * ------------------------------------------------------------------- */
+
+/**
+ * The last source in the chain, and for a managed platform the only one there
+ * is.
+ *
+ * A Retell production trace carries no timing spans, because Retell publishes
+ * no per-turn timing and the store never writes a span nobody observed. What it
+ * does carry is Retell's own raw measurements, translated at the ingest door
+ * into the neutral block and written on the root span's payload. These cases
+ * store that payload, read it back through the same trace read a grader reads
+ * through, and ask what the shared measure module makes of it.
+ *
+ * **Deliberately without turn spans of any kind.** What a zero-width turn
+ * derives is a separate question with its own fix, and a case here that leaned
+ * on it would be proving two things at once and failing for either.
+ */
+
+/** Where the block rides, in the payload's own words rather than a constant's.
+ * A rename then has to be a deliberate change in two places, which is what a
+ * wire shape deserves. */
+function payloadReporting(
+  reportedBy: string,
+  measurements: readonly ReportedMeasurement[],
+): string {
+  return JSON.stringify({
+    call_id: "call_c0ffee",
+    egma_normalised: {
+      degraded: false,
+      // Built by the contract's own writer, so the block's inner casing is the
+      // normalizers' and cannot drift from what the reader parses.
+      reported_measurements: reportedMeasurementsPayload(
+        reportedBy,
+        measurements,
+      ),
+    },
+  });
+}
+
+/**
+ * A conversation as a managed platform filed it: one root span carrying the
+ * block, and nothing else unless a case asks for it.
+ *
+ * The root's kind is the platform normalizer's own — `conversation`, not
+ * `root` — which is exactly why the read finds the block by the parent nobody
+ * named rather than by a kind.
+ */
+async function aReportedCall(
+  measurements: readonly ReportedMeasurement[],
+  timed: Measured = {},
+  reportedBy = "retell",
+): Promise<TraceDetail> {
+  const id = traceId();
+  const root = spanId();
+  const at = BigInt(WHEN.getTime()) * 1000n;
+
+  const spans: NewSpan[] = [
+    span({
+      traceId: id,
+      spanId: root,
+      parentSpanId: "",
+      name: "retell_call",
+      kind: "conversation",
+      connectionType: "retell",
+      providerCallId: "call_c0ffee",
+      startedAtMicroseconds: at,
+      durationNanoseconds: 42_000_000_000n,
+      payload: payloadReporting(reportedBy, measurements),
+    }),
+  ];
+
+  let taken = 0n;
+  for (const [measure, samples] of Object.entries(timed)) {
+    for (const milliseconds of samples) {
+      taken += 100_000n;
+      spans.push(
+        span({
+          traceId: id,
+          spanId: spanId(),
+          parentSpanId: root,
+          name: measure,
+          kind: "timing",
+          startedAtMicroseconds: at + taken,
+          durationNanoseconds: BigInt(Math.round(milliseconds * 1_000_000)),
+        }),
+      );
+    }
+  }
+
+  await appendSpans(auth, spans);
+  const read = await readTrace(auth, id, { window: WINDOW });
+  if (read === undefined) throw new Error("the trace store lost the spans");
+  return read;
+}
+
+/** The live proof's own numbers: one fast turn, and the 2145 ms one that is
+ * over the two-second bound nothing said a word about. */
+const AS_RETELL_MEASURED: readonly ReportedMeasurement[] = [
+  {
+    measure: "turn_response_latency",
+    unit: "milliseconds",
+    values: [517, 2_145],
+  },
+  {
+    measure: "retell/llm_latency",
+    unit: "milliseconds",
+    values: [220, 310],
+  },
+];
+
+describe("measures an agent platform reported about its own conversation", () => {
+  /**
+   * **The bridge, end to end.** No timing spans, no turns, nothing to derive
+   * from — and the conversation still measures its response latency, because
+   * the platform measured it and said so in the block.
+   */
+  it("reads the block off the root when the trace carries nothing else", async () => {
+    const trace = await aReportedCall(AS_RETELL_MEASURED);
+    const root = trace.spans[0];
+
+    expect(measuresFromSpans(trace)).toEqual([
+      {
+        measure: "turn_response_latency",
+        unit: "milliseconds",
+        // The platform measured, and the answer says whose measurement it is.
+        origin: "reported",
+        reportedBy: "retell",
+        // Retell's raw series in Retell's own order, every sample citing the
+        // root the block rode in on — an aggregate describes the whole
+        // conversation and happened at no moment inside it.
+        samples: [
+          { value: 517, spanId: root?.spanId },
+          { value: 2_145, spanId: root?.spanId },
+        ],
+      },
+    ]);
+
+    // And the worst measurement is the one the live proof found: 2145 ms,
+    // which is what a two-second bound is held against.
+    const measured = measureIn(trace, "turn_response_latency");
+    expect(measured === undefined ? undefined : worstSampleOf(measured)).toEqual(
+      { value: 2_145, spanId: root?.spanId },
+    );
+  });
+
+  /**
+   * A provider stage with no counterpart in the catalog keeps its
+   * platform-prefixed name and stays in the block. Folding it into a catalog
+   * answer would put a stage that means something else beside the numbers a
+   * grader bounds; it is captured now and surfaced the day a display asks.
+   */
+  it("does not answer a platform-prefixed name as a measure", async () => {
+    const trace = await aReportedCall(AS_RETELL_MEASURED);
+
+    for (const one of measuresFromSpans(trace)) {
+      expect(one.measure.startsWith("retell/")).toBe(false);
+    }
+    expect(measureIn(trace, "retell/llm_latency")).toBeUndefined();
+  });
+
+  /**
+   * **A number in the wrong unit is worse than no number.** Two point one
+   * four five seconds read as milliseconds is a conversation that answered
+   * instantly, and a two-second bound would pass exactly the turn it exists to
+   * fail. So the measurement is skipped and the measure is absent — a `skipped`
+   * check rather than a false pass.
+   */
+  it("skips a measurement stated in a unit the catalog does not use", async () => {
+    const trace = await aReportedCall([
+      { measure: "turn_response_latency", unit: "seconds", values: [2.145] },
+    ]);
+
+    expect(measureIn(trace, "turn_response_latency")).toBeUndefined();
+    expect(measuresFromSpans(trace)).toEqual([]);
+  });
+
+  /**
+   * **egma's own observation outranks the platform's account of itself**, by
+   * the same absolute rule that puts a timed measure over a derived one. The
+   * conversation below carries both, and the answer is the timed one alone —
+   * never the two appended, which would file one turn's wait twice and move
+   * every percentile.
+   */
+  it("lets a measure egma timed itself win over the one the platform reported", async () => {
+    const trace = await aReportedCall(AS_RETELL_MEASURED, {
+      turn_response_latency: [862.5],
+    });
+
+    const measured = measureIn(trace, "turn_response_latency");
+    expect(measured?.origin).toBe("timed");
+    expect(measured?.reportedBy).toBe("");
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([862.5]);
+  });
+
+  /**
+   * A trace whose root carries no block at all, which is nearly every trace in
+   * the store. Nothing is reported, nothing is answered, and nothing throws.
+   */
+  it("answers nothing for a conversation whose platform reported nothing", async () => {
+    const trace = await aReportedCall([]);
+
+    expect(trace.reported).toBeUndefined();
+    expect(measuresFromSpans(trace)).toEqual([]);
+  });
+});
+
+/**
+ * **Simulation traffic is unchanged, at the level this module decides it.**
+ *
+ * A simulation carries its own timing spans and no platform reports anything
+ * about it, so every number it produces comes from the first source in the
+ * chain and the answer is the one this module always gave. The same claim about
+ * the wire — the `derived` boolean a client integrated against — is asked where
+ * the wire is, over HTTP, in the API's own suite.
+ */
+describe("a simulation, after the platform's numbers joined the chain", () => {
+  it("answers exactly what it answered before there was a third source", async () => {
+    const trace = await stored(
+      {
+        first_response_latency: [1_214],
+        turn_response_latency: [862.5, 1_100],
+      },
+      AS_A_SIMULATION,
+    );
+
+    // Nothing reported anything about it, so there is no block to have read.
+    expect(trace.reported).toBeUndefined();
+
+    expect(measuresFromSpans(trace)).toEqual([
+      {
+        measure: "first_response_latency",
+        unit: "milliseconds",
+        origin: "timed",
+        reportedBy: "",
+        samples: [{ value: 1_214, spanId: expect.any(String) }],
+      },
+      {
+        measure: "turn_response_latency",
+        unit: "milliseconds",
+        origin: "timed",
+        reportedBy: "",
+        samples: [
+          { value: 862.5, spanId: expect.any(String) },
+          { value: 1_100, spanId: expect.any(String) },
+        ],
+      },
+    ]);
   });
 });

--- a/packages/db/test/measures-from-spans.test.ts
+++ b/packages/db/test/measures-from-spans.test.ts
@@ -538,6 +538,7 @@ const MILLISECOND = 1_000n;
 async function aLiveKitCall(
   turns: readonly Turn[],
   timed: Measured = {},
+  reported: readonly ReportedMeasurement[] = [],
 ): Promise<TraceDetail> {
   const id = traceId();
   const root = spanId();
@@ -552,6 +553,11 @@ async function aLiveKitCall(
       kind: "root",
       startedAtMicroseconds: at,
       durationNanoseconds: BigInt(ends) * 1_000_000n,
+      // A block on a framework-shaped trace, for the case that asks which of
+      // the two sources wins. Empty by default, which is every other case.
+      ...(reported.length === 0
+        ? {}
+        : { payload: payloadReporting("retell", reported) }),
     }),
   ];
 
@@ -804,19 +810,20 @@ function payloadReporting(
 }
 
 /**
- * A conversation as a managed platform filed it: one root span carrying the
- * block, and nothing else unless a case asks for it.
+ * A trace as a managed platform filed it: one root span carrying the block, and
+ * nothing else unless a case asks for it.
  *
  * The root's kind is the platform normalizer's own — `conversation`, not
  * `root` — which is exactly why the read finds the block by the parent nobody
  * named rather than by a kind.
  */
-async function aReportedCall(
+async function aReportedTrace(
   measurements: readonly ReportedMeasurement[],
   timed: Measured = {},
   reportedBy = "retell",
+  customer: AuthContext = auth,
+  id: string = traceId(),
 ): Promise<TraceDetail> {
-  const id = traceId();
   const root = spanId();
   const at = BigInt(WHEN.getTime()) * 1000n;
 
@@ -853,8 +860,8 @@ async function aReportedCall(
     }
   }
 
-  await appendSpans(auth, spans);
-  const read = await readTrace(auth, id, { window: WINDOW });
+  await appendSpans(customer, spans);
+  const read = await readTrace(customer, id, { window: WINDOW });
   if (read === undefined) throw new Error("the trace store lost the spans");
   return read;
 }
@@ -881,7 +888,7 @@ describe("measures an agent platform reported about its own conversation", () =>
    * the platform measured it and said so in the block.
    */
   it("reads the block off the root when the trace carries nothing else", async () => {
-    const trace = await aReportedCall(AS_RETELL_MEASURED);
+    const trace = await aReportedTrace(AS_RETELL_MEASURED);
     const root = trace.spans[0];
 
     expect(measuresFromSpans(trace)).toEqual([
@@ -916,7 +923,7 @@ describe("measures an agent platform reported about its own conversation", () =>
    * grader bounds; it is captured now and surfaced the day a display asks.
    */
   it("does not answer a platform-prefixed name as a measure", async () => {
-    const trace = await aReportedCall(AS_RETELL_MEASURED);
+    const trace = await aReportedTrace(AS_RETELL_MEASURED);
 
     for (const one of measuresFromSpans(trace)) {
       expect(one.measure.startsWith("retell/")).toBe(false);
@@ -932,7 +939,7 @@ describe("measures an agent platform reported about its own conversation", () =>
    * check rather than a false pass.
    */
   it("skips a measurement stated in a unit the catalog does not use", async () => {
-    const trace = await aReportedCall([
+    const trace = await aReportedTrace([
       { measure: "turn_response_latency", unit: "seconds", values: [2.145] },
     ]);
 
@@ -948,7 +955,7 @@ describe("measures an agent platform reported about its own conversation", () =>
    * every percentile.
    */
   it("lets a measure egma timed itself win over the one the platform reported", async () => {
-    const trace = await aReportedCall(AS_RETELL_MEASURED, {
+    const trace = await aReportedTrace(AS_RETELL_MEASURED, {
       turn_response_latency: [862.5],
     });
 
@@ -959,11 +966,74 @@ describe("measures an agent platform reported about its own conversation", () =>
   });
 
   /**
+   * **Derived beats reported, exactly as timed beats both.** The trace below is
+   * LiveKit-shaped — turns egma can read the geometry of — and its root also
+   * carries a block naming the same measure. egma working a number out from
+   * spans it can see outranks the platform's account of itself, so the answer
+   * is the derived one and the block is not appended to it.
+   */
+  it("lets a measure egma derived win over the one the platform reported", async () => {
+    const trace = await aLiveKitCall(
+      [
+        { who: "human", from: 0, to: 1_000 },
+        { who: "agent", from: 1_100, to: 3_000, spoke: [[1_400, 3_000]] },
+      ],
+      {},
+      [
+        {
+          measure: "turn_response_latency",
+          unit: "milliseconds",
+          values: [517, 2_145],
+        },
+      ],
+    );
+
+    // The block really was read — this is a precedence case, not an absence one.
+    expect(trace.reported?.reportedBy).toBe("retell");
+
+    const measured = measureIn(trace, "turn_response_latency");
+    expect(measured?.origin).toBe("derived");
+    expect(measured?.reportedBy).toBe("");
+    // 1400 − 1000, worked out from the turns, and not the platform's series.
+    expect(measured === undefined ? [] : valuesOf(measured)).toEqual([400]);
+  });
+
+  /**
+   * **The block sits behind the same tenancy wall every other read does.**
+   *
+   * Two customers and one trace id, in one window — the only arrangement that
+   * can tell a real predicate from a lucky one. Without the shared id the wrong
+   * customer's read finds no rows at all and answers `undefined` for a reason
+   * that has nothing to do with the block's own query. Here their read
+   * succeeds on their own rows, and the question is whether somebody else's
+   * block came back with it.
+   */
+  it("never hands one customer the block another customer's trace carries", async () => {
+    const shared = traceId();
+
+    const theirs = await aReportedTrace(
+      AS_RETELL_MEASURED,
+      {},
+      "retell",
+      elsewhere,
+      shared,
+    );
+    expect(theirs.reported?.reportedBy).toBe("retell");
+
+    // The same id, this customer's own rows, and no block written on them.
+    const ours = await aReportedTrace([], {}, "retell", auth, shared);
+
+    expect(ours.traceId).toBe(theirs.traceId);
+    expect(ours.reported).toBeUndefined();
+    expect(measuresFromSpans(ours)).toEqual([]);
+  });
+
+  /**
    * A trace whose root carries no block at all, which is nearly every trace in
    * the store. Nothing is reported, nothing is answered, and nothing throws.
    */
   it("answers nothing for a conversation whose platform reported nothing", async () => {
-    const trace = await aReportedCall([]);
+    const trace = await aReportedTrace([]);
 
     expect(trace.reported).toBeUndefined();
     expect(measuresFromSpans(trace)).toEqual([]);

--- a/packages/db/test/trace-reads.test.ts
+++ b/packages/db/test/trace-reads.test.ts
@@ -613,6 +613,121 @@ describe("a duration that the reading arithmetic cannot hold", () => {
   });
 });
 
+/**
+ * The reported-measurements block, which is the one thing a read takes off a
+ * payload.
+ *
+ * Everything else about the payload is deliberately not returned — it is the
+ * largest column on the row and nothing renders it — so what is asked here is
+ * that the exception stays the size it was argued to be: one root row, one
+ * egma-owned key, and an answer of `undefined` for every shape that is not a
+ * block. Never a throw, because a vendor's bad write must not cost a customer
+ * their transcript.
+ */
+describe("the block a platform reported on the root span", () => {
+  const REPORTED = "0a0a1111111111111111111111111111";
+  const UNREPORTED = "0b0b1111111111111111111111111111";
+  const MALFORMED = "0c0c1111111111111111111111111111";
+
+  /** A root the way a platform normalizer files one: parentless, and carrying
+   * the egma-owned corner of an otherwise vendor-owned payload. */
+  function aReportedRoot(traceId: string, normalised: unknown): NewSpan {
+    return span({
+      traceId,
+      spanId: spanId(),
+      parentSpanId: "",
+      name: "retell_call",
+      kind: "conversation",
+      payload: JSON.stringify({
+        call_id: "call_c0ffee",
+        recording_url: "https://example.invalid/one.wav",
+        egma_normalised: normalised,
+      }),
+    });
+  }
+
+  beforeAll(async () => {
+    await appendSpans(at(acme, SUPPORT), [
+      aReportedRoot(REPORTED, {
+        degraded: false,
+        reported_measurements: {
+          version: 1,
+          reported_by: "retell",
+          measurements: [
+            {
+              measure: "turn_response_latency",
+              unit: "milliseconds",
+              values: [517, 2145],
+            },
+          ],
+        },
+      }),
+      // The same payload corner without a block in it, which is every trace
+      // filed before a platform reported anything.
+      aReportedRoot(UNREPORTED, { degraded: false }),
+      // And a block of a version this code has never seen, which is the shape a
+      // reader has to be able to tell from a block it simply predates.
+      aReportedRoot(MALFORMED, {
+        reported_measurements: { version: 99, reported_by: "", measurements: 7 },
+      }),
+    ]);
+  });
+
+  it("is read back with the root span it rode in on", async () => {
+    const detail = await readTrace(at(acme, SUPPORT), REPORTED, {
+      window: WINDOW,
+    });
+
+    expect(detail?.reported).toEqual({
+      spanId: detail?.spans[0]?.spanId,
+      reportedBy: "retell",
+      measurements: [
+        {
+          measure: "turn_response_latency",
+          unit: "milliseconds",
+          values: [517, 2145],
+        },
+      ],
+    });
+  });
+
+  it("is absent on a root that carries no block, and the trace reads as ever", async () => {
+    const detail = await readTrace(at(acme, SUPPORT), UNREPORTED, {
+      window: WINDOW,
+    });
+
+    expect(detail?.spanCount).toBe(1);
+    expect(detail?.reported).toBeUndefined();
+  });
+
+  it("is absent rather than fatal when the block is one nothing can read", async () => {
+    const detail = await readTrace(at(acme, SUPPORT), MALFORMED, {
+      window: WINDOW,
+    });
+
+    // The transcript is unharmed, which is the half that was never in doubt.
+    expect(detail?.spanCount).toBe(1);
+    expect(detail?.reported).toBeUndefined();
+  });
+
+  /**
+   * The payload itself is still not returned. One key of one row is the whole
+   * exception, and a span in the transcript carries no payload at all — which
+   * is what keeps a trace read from shipping megabytes of a vendor's own
+   * document to a page that renders none of it.
+   */
+  it("does not put the payload on a span, block or no block", async () => {
+    const detail = await readTrace(at(acme, SUPPORT), REPORTED, {
+      window: WINDOW,
+    });
+
+    for (const each of everySpanOf(detail)) {
+      expect(Object.keys(each)).not.toContain("payload");
+      expect(JSON.stringify(each)).not.toContain("recording_url");
+    }
+  });
+});
+
 describe("a page token", () => {
   it("survives a round trip and resumes exactly where the page stopped", async () => {
     const context = at(acme, undefined);


### PR DESCRIPTION
A managed platform's production trace carries no timing spans and no per-turn geometry, so until now the one question monitoring exists to answer was silent on it. This is the read half of the bridge: the trace read fetches the reported-measurements block off the parentless row's payload — the egma-owned slice only, never the payload whole — and the shared measure module folds it in as the last source in an absolute chain: timed by egma wins, then derived from framework spans, then reported by the platform. One answer per measure, never averaged.

Provenance is now three-valued end to end. Internally a measure says how it was known — timed, derived, or reported, and by whom; on the wire simulation traffic is byte-for-byte unchanged (the new field appears only on reported measures, pinned key-by-key in the API suite); a verdict computed from reported values says so in its rationale ("as reported by retell — the platform's own measurement, not Egma's observation"); and the transcript page words a reported figure as the platform's own, never as framework timing.

Folding requires the catalog's exact name and exact unit — a number in the wrong unit is worse than absent — and every reported sample cites the parentless row it rode in on. Tenancy holds on the new read (proven by a two-customers-one-trace-id case that goes red when the clause is removed). The acceptance path runs whole in the grader suite: stored block, real read, real verdict rows — 2145 ms failing a 2000 ms bound with the platform named, 517 ms passing it.

Scoped runs: 191 tests across db, api, grader and web suites; all builds, lint, and web typecheck clean. Full suite is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789538054&installation_model_id=431960&pr_number=132&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F132&signature=9253dae98afa490a002800d765071769f758adf871e1a75cf6774e9bd4aa945d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends trace measurement reads and latency grading to consume measurements reported by managed platforms while preserving timed and span-derived measurements as higher-priority sources.
- Reads the Egma-owned reported-measurement block from a tenant-scoped trace root payload.
- Applies timed → derived → reported precedence through the shared measure module.
- Carries reported provenance through API responses, grader rationales, and transcript presentation.
- Adds database, API, grader, and web coverage for parsing, precedence, tenancy, grading, and display behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/access/traces.ts | Adds a tenant- and window-scoped read of the normalized payload slice and exposes validated reported measurements on trace details. |
| packages/db/src/measures/from-spans.ts | Extends the shared measurement fold with explicit timed, derived, and reported origins and deterministic source precedence. |
| apps/api/src/routes/trace-reads.ts | Serializes reported provenance while preserving the existing measure shape for timed and derived traffic. |
| apps/grader/src/graders/latency.ts | Includes platform provenance in rationales when a latency verdict relies on reported measurements. |
| apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx | Distinguishes platform-reported figures from measurements derived from framework timing spans. |
| apps/web/lib/transcripts.ts | Extends the transcript measure contract with optional platform provenance. |
| apps/web/lib/transcript-copy.ts | Adds user-facing copy that accurately labels platform-reported measurements. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Trace spans] --> B[Shared measure module]
  R[Root reported-measurement block] --> B
  B -->|1. timed| P[One value series per measure]
  B -->|2. derived fallback| P
  B -->|3. reported fallback| P
  P --> API[Trace-read API]
  P --> G[Latency grader]
  API --> W[Transcript measurement display]
  G --> V[Verdict with provenance rationale]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["An empty commit, so the review workflow ..."](https://github.com/egma-ai/egma/commit/f03176e53a0e7ca7836571d988d36b1e1312108e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53890787)</sub>

<!-- /greptile_comment -->