### PR TITLE
Customer-owned model access: organizations own credentials, versions own model choices

### DIFF
--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -6,6 +6,7 @@ import {
   getPersonaVersion,
   getRun,
   getSimulationTestVersion,
+  ManagedAccessUnavailableError,
   ModelProviderCredentialMissingError,
   readModelAccess,
   resolveMockTools,
@@ -237,12 +238,12 @@ async function modelsBlock(
 
   if (access.mode === "managed") {
     // Nothing on this deployment can select managed access yet — the setting
-    // refuses it by name while no inference key is connected — so a row saying
-    // so is a state this control plane cannot honor. Said as an error naming
-    // the mode rather than conducted with no credentials at all.
-    throw new Error(
-      "this organization is on managed model access, and this deployment has no Egma model gateway connection to send its model traffic through",
-    );
+    // refuses it by name while no connection to a gateway exists — so a row
+    // saying so is a state this control plane cannot honor. Typed rather than
+    // thrown plainly, so it lands on the row as an infrastructure error naming
+    // the mode with somewhere to go, rather than as a bare dispatch failure
+    // with nothing on it a person could act on.
+    throw new ManagedAccessUnavailableError();
   }
 
   /**
@@ -660,7 +661,8 @@ export async function claimRoutes(
             // screen. Every other fault is Egma being broken, and sending
             // somebody to Model providers for one of those would be a link that
             // fixes nothing.
-            ...(fault instanceof ModelProviderCredentialMissingError
+            ...(fault instanceof ModelProviderCredentialMissingError ||
+            fault instanceof ManagedAccessUnavailableError
               ? { repair: "model_providers" as const }
               : {}),
           }),

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -245,23 +245,38 @@ async function modelsBlock(
     );
   }
 
-  const resolved = await resolveModelProviderKeys(claim.auth, [
-    models.llm.provider,
-    models.stt.provider,
-    models.tts.provider,
-  ]);
+  /**
+   * The legs this simulation actually has.
+   *
+   * **Every simulation thinks; only a voice simulation speaks and listens.** So
+   * a chat simulation resolves one credential rather than three: the two speech
+   * keys would be secrets on a wire with no use for them, and an organization
+   * that has stored no speech credential would be stopped from running chat
+   * tests it had everything for. The selections still travel whole, because
+   * they are what the persona *is* — it is the keys that follow the legs.
+   */
+  const needed =
+    claim.modality === "voice"
+      ? ([
+          { job: "llm", provider: models.llm.provider },
+          { job: "stt", provider: models.stt.provider },
+          { job: "tts", provider: models.tts.provider },
+        ] as const)
+      : ([{ job: "llm", provider: models.llm.provider }] as const);
+
+  const resolved = await resolveModelProviderKeys(
+    claim.auth,
+    needed.map((one) => one.provider),
+  );
 
   if (resolved.missing.length > 0) {
     // Named by model job as well as by provider, because "add an OpenAI key"
     // is a different sentence from "your persona listens with a provider you
     // have no key for" — and the person reading it has to know which of their
-    // three selections stopped the simulation.
-    const jobs = [
-      { job: "llm", provider: models.llm.provider },
-      { job: "stt", provider: models.stt.provider },
-      { job: "tts", provider: models.tts.provider },
-    ].filter((one) => resolved.missing.includes(one.provider));
-    throw new ModelProviderCredentialMissingError(jobs);
+    // selections stopped the simulation.
+    throw new ModelProviderCredentialMissingError(
+      needed.filter((one) => resolved.missing.includes(one.provider)),
+    );
   }
 
   const keyFor = (provider: PersonaModels["llm"]["provider"]): string => {
@@ -271,6 +286,10 @@ async function modelsBlock(
     }
     return key;
   };
+  const speechKey = (
+    provider: PersonaModels["llm"]["provider"],
+  ): Record<string, string> =>
+    claim.modality === "voice" ? { key: keyFor(provider) } : {};
 
   return {
     access: access.mode,
@@ -282,12 +301,12 @@ async function modelsBlock(
     stt: {
       provider: models.stt.provider,
       model: models.stt.model,
-      key: keyFor(models.stt.provider),
+      ...speechKey(models.stt.provider),
     },
     tts: {
       provider: models.tts.provider,
       model: models.tts.model,
-      key: keyFor(models.tts.provider),
+      ...speechKey(models.tts.provider),
       voice_id: models.tts.voiceId,
       speed: models.tts.speed,
     },

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -6,14 +6,23 @@ import {
   getPersonaVersion,
   getRun,
   getSimulationTestVersion,
+  ModelProviderCredentialMissingError,
+  readModelAccess,
   resolveMockTools,
+  resolveModelProviderKeys,
   resolvePlatformSettings,
   resolveSimulationConnection,
+  type EndingRepair,
+  type PersonaModels,
   type PlatformSettingValues,
   type Run,
   type SimulationClaim,
 } from "@egma/db";
-import { specComplaints } from "@egma/simulation-contract";
+import {
+  isSpecContractVersion,
+  specComplaints,
+  SPEC_CONTRACT_VERSIONS,
+} from "@egma/simulation-contract";
 import type { FastifyInstance } from "fastify";
 
 import { acceptsServiceToken } from "../auth/service-token.ts";
@@ -114,8 +123,20 @@ const SIMULATION_LIMITS = {
   voice: { max_duration_seconds: 300, max_turns: 40 },
 } as const;
 
-/** The one contract version this control plane speaks. */
-const CONTRACT_VERSION = 1;
+/**
+ * The contract version a work order is written in, decided by the row rather
+ * than by the deployment.
+ *
+ * **A simulation whose pinned persona selects its own models needs version 2;
+ * one that does not gets version 1, byte for byte as it always did.** So the
+ * version is a property of what has to be said rather than of a flag somebody
+ * flips, and there is no moment at which the deployment is half-migrated in a
+ * way anybody has to reason about. A worker that speaks only version 1 never
+ * claims a row that would need version 2 — the queue filters on exactly that —
+ * so no document ever arrives at a worker that cannot read it.
+ */
+const CONTRACT_VERSION_WITHOUT_MODELS = 1;
+const CONTRACT_VERSION_WITH_MODELS = 2;
 
 type Body = Record<string, unknown>;
 
@@ -189,12 +210,125 @@ function onlyWhatIsHeld<T>(
     : (Object.fromEntries(present) as Record<string, T>);
 }
 
+/**
+ * The models block of one work order: the pinned persona's three selections
+ * and, under customer-owned access, the organization's key for each provider
+ * they name.
+ *
+ * **Resolved when the claim is prepared, never when the run was created.** The
+ * selections come off the version the run pinned, so they are exactly what they
+ * were when somebody pressed start; the credentials and the access mode are
+ * read now, so a key replaced or a mode changed mid-run reaches the next
+ * simulation to be claimed and leaves the ones already conducting alone. That
+ * split is the whole design: authored behavior is pinned, operational state is
+ * current, and neither can be mistaken for the other.
+ *
+ * **Only the providers the selections name.** The keys are asked for by the
+ * three providers this persona actually uses, so an organization holding a
+ * fourth credential does not put it on this wire. Unrelated secrets not
+ * travelling is a property of the argument rather than of a filter somebody
+ * remembered to apply afterwards.
+ */
+async function modelsBlock(
+  claim: SimulationClaim,
+  models: PersonaModels,
+): Promise<Record<string, unknown>> {
+  const access = await readModelAccess(claim.auth);
+
+  if (access.mode === "managed") {
+    // Nothing on this deployment can select managed access yet — the setting
+    // refuses it by name while no inference key is connected — so a row saying
+    // so is a state this control plane cannot honor. Said as an error naming
+    // the mode rather than conducted with no credentials at all.
+    throw new Error(
+      "this organization is on managed model access, and this deployment has no Egma model gateway connection to send its model traffic through",
+    );
+  }
+
+  const resolved = await resolveModelProviderKeys(claim.auth, [
+    models.llm.provider,
+    models.stt.provider,
+    models.tts.provider,
+  ]);
+
+  if (resolved.missing.length > 0) {
+    // Named by model job as well as by provider, because "add an OpenAI key"
+    // is a different sentence from "your persona listens with a provider you
+    // have no key for" — and the person reading it has to know which of their
+    // three selections stopped the simulation.
+    const jobs = [
+      { job: "llm", provider: models.llm.provider },
+      { job: "stt", provider: models.stt.provider },
+      { job: "tts", provider: models.tts.provider },
+    ].filter((one) => resolved.missing.includes(one.provider));
+    throw new ModelProviderCredentialMissingError(jobs);
+  }
+
+  const keyFor = (provider: PersonaModels["llm"]["provider"]): string => {
+    const key = resolved.keys.get(provider);
+    if (key === undefined) {
+      throw new Error(`no ${provider} key was resolved for this simulation`);
+    }
+    return key;
+  };
+
+  return {
+    access: access.mode,
+    llm: {
+      provider: models.llm.provider,
+      model: models.llm.model,
+      key: keyFor(models.llm.provider),
+    },
+    stt: {
+      provider: models.stt.provider,
+      model: models.stt.model,
+      key: keyFor(models.stt.provider),
+    },
+    tts: {
+      provider: models.tts.provider,
+      model: models.tts.model,
+      key: keyFor(models.tts.provider),
+      voice_id: models.tts.voiceId,
+      speed: models.tts.speed,
+    },
+  };
+}
+
+/**
+ * Why one claimed simulation could not become a work order, and — where the
+ * platform knows — which screen the person reading it goes to.
+ *
+ * The repair pointer travels as a word rather than a link, because the address
+ * of a page is the browser's business; it is stored on the simulation so that
+ * somebody opening the run tomorrow gets the same answer the log gave today.
+ */
+type Unbuildable = {
+  readonly unbuildable: string;
+  readonly repair?: EndingRepair | undefined;
+};
+
+/**
+ * Whether assembly gave back a reason instead of a work order.
+ *
+ * A function rather than `"unbuildable" in spec`, because the other half of the
+ * union is an open record: `in` narrows it to "a record that also has this
+ * key", which is true of every record, and the reason would then be read as
+ * `unknown`.
+ */
+function couldNotBeBuilt(
+  answer: Record<string, unknown> | Unbuildable,
+): answer is Unbuildable {
+  return typeof (answer as Unbuildable).unbuildable === "string";
+}
+
 /** What a claim request said, once every field has been read and refused for itself. */
 type ClaimAsk = {
   readonly claimant: string;
   readonly capacity: number;
   /** Seconds this request may be held; already bounded by the cap. */
   readonly holdSeconds: number;
+  /** Which contract versions this simulator implements. */
+  readonly contractVersions: readonly number[];
 };
 
 /**
@@ -242,6 +376,36 @@ function claimAsk(body: Body): ClaimAsk | { readonly refusal: string } {
     };
   }
 
+  /**
+   * Which contract versions this simulator implements.
+   *
+   * **Absent means version 1 alone**, which is what every simulator built
+   * before the second version means by saying nothing — so an old worker
+   * pointed at a new control plane keeps receiving exactly the documents it
+   * always received, with nothing to configure and no drain step.
+   *
+   * A version this control plane does not write is refused rather than
+   * ignored: a worker declaring a version nobody emits has been deployed
+   * against the wrong platform, and finding that out at the claim door is
+   * better than finding it out as an empty queue nobody can explain.
+   */
+  const versions = body.contract_versions;
+  if (versions !== undefined) {
+    if (
+      !Array.isArray(versions) ||
+      versions.length === 0 ||
+      !versions.every((one) => isSpecContractVersion(one))
+    ) {
+      return {
+        refusal:
+          "contract_versions is which versions of the simulation contract " +
+          "this simulator implements, as a non-empty list of whole numbers " +
+          `from ${SPEC_CONTRACT_VERSIONS.join(", ")}. Leave it out and Egma ` +
+          `sends version ${CONTRACT_VERSION_WITHOUT_MODELS}.`,
+      };
+    }
+  }
+
   return {
     claimant: claimant.trim(),
     capacity: Math.min(capacity, LARGEST_CLAIM_CAPACITY),
@@ -249,6 +413,10 @@ function claimAsk(body: Body): ClaimAsk | { readonly refusal: string } {
       wait === undefined ? DEFAULT_HOLD_SECONDS : wait,
       LONGEST_HOLD_SECONDS,
     ),
+    contractVersions:
+      versions === undefined
+        ? [CONTRACT_VERSION_WITHOUT_MODELS]
+        : (versions as readonly number[]),
   };
 }
 
@@ -282,7 +450,7 @@ async function assembledSpec(
    * deployment — two claims naming one run are two conversations of it.
    */
   runs: Map<string, Run | undefined>,
-): Promise<Record<string, unknown> | { readonly unbuildable: string }> {
+): Promise<Record<string, unknown> | Unbuildable> {
   const personaVersion = await getPersonaVersion(
     claim.auth,
     claim.personaVersionId,
@@ -335,8 +503,26 @@ async function assembledSpec(
     delay_milliseconds: mock.delayMilliseconds,
   }));
 
+  /**
+   * The persona's own model selections, or nothing for a version still on the
+   * compatibility path.
+   *
+   * Nothing is the ordinary state of every persona authored before the model
+   * catalog existed, and it is what keeps those personas running: the work
+   * order is written in version 1 and the deployment's own settings decide the
+   * models, exactly as they did. A persona that *has* selections is written in
+   * version 2, and the queue has already made sure this worker can read one.
+   */
+  const models =
+    personaVersion.models === null
+      ? undefined
+      : await modelsBlock(claim, personaVersion.models);
+
   const spec = {
-    contract_version: CONTRACT_VERSION,
+    contract_version:
+      models === undefined
+        ? CONTRACT_VERSION_WITHOUT_MODELS
+        : CONTRACT_VERSION_WITH_MODELS,
     simulation_id: claim.id,
     modality: claim.modality,
     connection: {
@@ -356,6 +542,11 @@ async function assembledSpec(
     // reasoning one line up: a deployment that has configured no settings of
     // its own hands the simulator the document it always handed it.
     ...(platform === undefined ? {} : { platform }),
+    // The persona's own selections, where it has them. A version-1 document
+    // has no place for this block at all — its schema closes the top level —
+    // so a simulation on the compatibility path is byte for byte the work
+    // order it was before persona models existed.
+    ...(models === undefined ? {} : { models }),
   };
   // `mockToolId` is deliberately not among the fields sent. The simulator
   // records which mock tool answered by its tool name, which is the whole
@@ -419,6 +610,7 @@ export async function claimRoutes(
       let claims = await claimSimulations({
         claimant: ask.claimant,
         capacity: ask.capacity,
+        contractVersions: ask.contractVersions,
       });
       while (claims.length === 0 && !gone && Date.now() < deadline) {
         await sleep(Math.min(RECHECK_MILLISECONDS, deadline - Date.now()));
@@ -426,6 +618,7 @@ export async function claimRoutes(
         claims = await claimSimulations({
           claimant: ask.claimant,
           capacity: ask.capacity,
+          contractVersions: ask.contractVersions,
         });
       }
 
@@ -441,11 +634,19 @@ export async function claimRoutes(
         // escape would abort the whole response and withhold every valid
         // claim beside it from a simulator standing ready to conduct them.
         const spec = await assembledSpec(claim, runs).catch(
-          (fault: unknown): { readonly unbuildable: string } => ({
+          (fault: unknown): Unbuildable => ({
             unbuildable: fault instanceof Error ? fault.message : String(fault),
+            // A credential the organization has not stored is a configuration
+            // problem with a screen behind it, so the row that lands says which
+            // screen. Every other fault is Egma being broken, and sending
+            // somebody to Model providers for one of those would be a link that
+            // fixes nothing.
+            ...(fault instanceof ModelProviderCredentialMissingError
+              ? { repair: "model_providers" as const }
+              : {}),
           }),
         );
-        if ("unbuildable" in spec) {
+        if (couldNotBeBuilt(spec)) {
           // Fail loudly on this side and keep dispatching the rest: one
           // corrupt row must not hold up the batch, and the simulator is
           // never handed a document it would have to refuse. The row lands
@@ -464,6 +665,10 @@ export async function claimRoutes(
             claim.auth,
             claim.id,
             claim.claimedBy,
+            // The same sentence the log just carried, kept on the row: a
+            // person opening this run tomorrow must not have to find a log
+            // line from today to learn why one conversation is red.
+            { detail: spec.unbuildable, repair: spec.repair },
           ).catch((fault: unknown) => {
             // The one place left where the sweep is the backstop: a row so
             // broken even its landing throws stays claimed until swept, and

--- a/apps/api/src/routes/graders.ts
+++ b/apps/api/src/routes/graders.ts
@@ -10,6 +10,7 @@ import {
   useLibraryEntry,
   type FilledInForm,
   type Grader,
+  type GraderModel,
 } from "@egma/db";
 import { isId } from "@egma/ids";
 import type { FastifyInstance } from "fastify";
@@ -110,6 +111,7 @@ type Query = {
 const USE_KEYS = [
   "library_id",
   "params",
+  "model",
   "name",
   "description",
   "required",
@@ -184,8 +186,68 @@ function described(one: Grader): Record<string, unknown> {
     version: one.version,
     version_id: one.versionId,
     config: one.config,
+    /**
+     * This grader's own LLM selection, or `null` for one still on the
+     * compatibility path — where the project's judge configuration decides,
+     * exactly as it did before the model catalog existed.
+     *
+     * There is no credential field beside it and there never will be: the key
+     * behind the selection is the organization's, resolved when the grading
+     * claim is prepared, and a grader that named one would put a secret inside
+     * authored content a run then pins forever.
+     */
+    model: one.graderModel,
     created_at: one.createdAt.toISOString(),
     updated_at: one.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * The LLM selection a body carries, as the factory takes it.
+ *
+ * The envelope only: that `model` is an object naming a provider and a model
+ * id, and that it holds nothing a secret could travel in. Which providers do
+ * LLM work and what an id may be are the factory's rules, and a second opinion
+ * here could come to disagree with the one that decides.
+ *
+ * `null` is a real answer and means *go back to the compatibility path* — the
+ * project's judge configuration decides again. It is told apart from absent,
+ * which means keep what is stored.
+ */
+type WrittenGraderModel =
+  | { readonly value: GraderModel | null | undefined }
+  | { readonly refusal: string };
+
+function modelIn(body: Body): WrittenGraderModel {
+  if (!("model" in body)) return { value: undefined };
+  const written = body.model;
+  if (written === null) return { value: null };
+  if (
+    typeof written !== "object" ||
+    Array.isArray(written)
+  ) {
+    return {
+      refusal:
+        "a grader's model names the provider and the model id it judges with, " +
+        "as an object — or null to go back to the project's judge setting.",
+    };
+  }
+  const held = written as Body;
+  for (const forbidden of ["key", "credential", "credential_id"]) {
+    if (forbidden in held) {
+      return {
+        refusal:
+          `a grader's model holds no "${forbidden}". Who pays for a judgment ` +
+          "is the organization's model access, under Model providers — a " +
+          "grader names a provider and never a secret.",
+      };
+    }
+  }
+  return {
+    value: {
+      provider: held.provider as GraderModel["provider"],
+      model: text(held.model),
+    } as GraderModel,
   };
 }
 
@@ -451,6 +513,9 @@ export async function graderRoutes(
     const params = paramsIn(body);
     if ("refusal" in params) return unprocessable(reply, params.refusal);
 
+    const model = modelIn(body);
+    if ("refusal" in model) return unprocessable(reply, model.refusal);
+
     const required = requiredIn(body);
     if ("refusal" in required) return unprocessable(reply, required.refusal);
 
@@ -498,6 +563,13 @@ export async function graderRoutes(
       ...(sampleRate.value === undefined
         ? {}
         : { productionSampleRate: sampleRate.value }),
+      // Absent leaves the copy on the compatibility path, where the project's
+      // judge configuration decides. Egma does not fill in a model on a
+      // caller's behalf: a grader silently pointed at a provider nobody chose
+      // would spend from an account nobody agreed to.
+      ...(model.value === undefined || model.value === null
+        ? {}
+        : { graderModel: model.value }),
     });
 
     return reply.code(201).send(described(created));
@@ -550,6 +622,9 @@ export async function graderRoutes(
     const params = paramsIn(body);
     if ("refusal" in params) return unprocessable(reply, params.refusal);
 
+    const model = modelIn(body);
+    if ("refusal" in model) return unprocessable(reply, model.refusal);
+
     const required = requiredIn(body);
     if ("refusal" in required) return unprocessable(reply, required.refusal);
 
@@ -590,6 +665,9 @@ export async function graderRoutes(
       ...(sampleRate.value === undefined
         ? {}
         : { productionSampleRate: sampleRate.value }),
+      // `null` is the one way back to the compatibility path and is a
+      // different act from leaving the key out, which keeps what is stored.
+      ...(model.value === undefined ? {} : { graderModel: model.value }),
     });
 
     if (edited === undefined) return notFound(reply, noSuchGrader(graderId));

--- a/apps/api/src/routes/model-access.ts
+++ b/apps/api/src/routes/model-access.ts
@@ -1,0 +1,329 @@
+import {
+  IdentityConflictError,
+  listModelProviderCredentials,
+  ManagedAccessNotConnectedError,
+  MODEL_ACCESS_MODES,
+  MODEL_JOBS,
+  PROVIDER_CATALOG,
+  RECOMMENDED_ENTRY,
+  readModelAccess,
+  removeModelProviderCredential,
+  RESERVED_PROVIDER_JOBS,
+  setModelAccess,
+  storeModelProviderCredential,
+  UnprocessableInputError,
+  type AuthContext,
+  type ModelProviderCredential,
+} from "@egma/db";
+import type { FastifyInstance, FastifyReply } from "fastify";
+
+import type { SessionIdentityProvider } from "../auth/seam.ts";
+import { credentialed, requesterOf } from "../http/credentialed.ts";
+import type { RateLimit } from "../http/rate-limit.ts";
+import { given, text } from "../http/reading.ts";
+import {
+  invalid,
+  sendRefusal,
+  unprocessable,
+  REFUSALS,
+} from "../http/refusals.ts";
+
+/**
+ * Model providers: who supplies the keys this organization's model traffic
+ * spends, and — where the organization supplies them — the keys themselves.
+ *
+ * **No route in this file can answer with a stored key, and that is the shape
+ * rather than a rule anybody follows.** The data-access module's read shape has
+ * no field a secret could travel in; the one door to a plaintext key refuses
+ * every context that did not come from a simulation or a grading claim. So an
+ * admin replaces a key by sending a new value and never by reading the old one,
+ * and what comes back is a provider and four characters — enough to tell two
+ * keys apart and no part of either.
+ *
+ * **Nothing here calls a provider.** Saving a key seals it and stops. A
+ * validation request would make saving depend on the provider being up, would
+ * spend on the customer's account to answer a question nobody asked, and would
+ * still not be true a minute later. Wrong permissions and expired keys are
+ * reported when the provider is used, where the report can name the simulation
+ * it stopped.
+ *
+ * **Nothing here scans for completeness.** Changing the access mode does not
+ * walk the organization's personas and graders looking for a provider whose key
+ * is missing, and is not refused because one is. A checklist standing between
+ * an admin and a setting they can plainly see is the blocked feeling this whole
+ * effort removes; the honest report arrives per simulation instead, naming the
+ * provider it could not open.
+ */
+
+export type ModelAccessRoutesOptions = {
+  readonly provider: SessionIdentityProvider;
+  readonly rateLimit: RateLimit;
+};
+
+export const MODEL_ACCESS_PATH = "/api/model-access";
+export const MODEL_CATALOG_PATH = "/api/model-catalog";
+export const MODEL_PROVIDER_CREDENTIALS_PATH = "/api/model-provider-credentials";
+export const MODEL_PROVIDER_CREDENTIAL_PATH =
+  "/api/model-provider-credentials/:provider";
+
+type Body = Record<string, unknown>;
+
+const ACCESS_KEYS = ["mode"] as const;
+const CREDENTIAL_KEYS = ["provider", "key", "expected_revision"] as const;
+
+function unknownKeyIn(
+  body: Body,
+  allowed: readonly string[],
+  what: string,
+): string | undefined {
+  for (const key of Object.keys(body)) {
+    if (allowed.includes(key)) continue;
+    return `${what} has no key "${key}"; it holds ${allowed.join(", ")}`;
+  }
+  return undefined;
+}
+
+function refuseRole(
+  reply: FastifyReply,
+  auth: AuthContext,
+  action: string,
+): FastifyReply {
+  return sendRefusal(
+    reply,
+    "not_permitted",
+    REFUSALS.notPermitted(auth.role, action),
+  );
+}
+
+/**
+ * A credential on the wire: whose provider it is for, four characters of it,
+ * and when it last changed.
+ *
+ * **The envelope is absent from this shape rather than blanked**, which is what
+ * makes leaking one impossible to forget rather than merely unlikely: there is
+ * no field to fill in wrongly.
+ */
+function described(credential: ModelProviderCredential): Record<string, unknown> {
+  return {
+    provider: credential.provider,
+    hint: credential.hint,
+    revision: credential.revision,
+    updated_at: credential.updatedAt.toISOString(),
+  };
+}
+
+export async function modelAccessRoutes(
+  app: FastifyInstance,
+  options: ModelAccessRoutesOptions,
+): Promise<void> {
+  credentialed(app, {
+    provider: options.provider,
+    rateLimit: options.rateLimit,
+  });
+
+  /**
+   * The provider catalog: which providers do which model job, and the model a
+   * release proved for each.
+   *
+   * **Server-owned, and the browser keeps no second copy.** A page that
+   * maintained its own list would be a list that can disagree with this one,
+   * and the disagreement is a provider somebody can select and nothing can
+   * execute. Readable at every role, because a persona author picking a model
+   * needs it and none of it is a secret.
+   */
+  app.get(MODEL_CATALOG_PATH, async (_request, reply) => {
+    return reply.send({
+      jobs: MODEL_JOBS,
+      providers: PROVIDER_CATALOG.map((entry) => ({
+        provider: entry.provider,
+        job: entry.job,
+        label: entry.label,
+        recommended_model: entry.recommendedModel,
+        ...(entry.recommendedVoiceId === undefined
+          ? {}
+          : { recommended_voice_id: entry.recommendedVoiceId }),
+        // What a form fills in before anybody types, so a first persona starts
+        // from a choice a release actually proved.
+        recommended: RECOMMENDED_ENTRY[entry.job].provider === entry.provider,
+        // Model and voice ids are never allowlisted: a release proves one
+        // default per entry and a user may enter any id the shipped adapter
+        // accepts. Egma keeping a list of every model a provider has would be a
+        // list that is wrong the week after it ships.
+        model_is_free_text: true,
+      })),
+      // The provider-job pairs the product intends and this release has not
+      // proved. Named so the shape of the finished catalog is visible; none of
+      // them is selectable, because none has an entry above.
+      reserved: RESERVED_PROVIDER_JOBS.map((one) => ({
+        provider: one.provider,
+        job: one.job,
+      })),
+    });
+  });
+
+  /**
+   * Which of the two access modes this organization is on, and the keys it
+   * holds.
+   *
+   * One read rather than two, because the screen draws them together: what the
+   * mode is decides whether the credential rows below it are what pays for
+   * anything. Readable at every role — neither the word nor a hint is a secret,
+   * and a `viewer` looking at a persona's Models form has to be able to see who
+   * supplies the key behind it.
+   */
+  app.get(MODEL_ACCESS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const [access, credentials] = await Promise.all([
+      readModelAccess(auth),
+      listModelProviderCredentials(auth),
+    ]);
+
+    return reply.send({
+      mode: access.mode,
+      updated_at: access.updatedAt?.toISOString() ?? null,
+      modes: MODEL_ACCESS_MODES,
+      /**
+       * Whether managed access can be chosen at all on this deployment.
+       *
+       * `false` while nothing is connected to Egma's own provider accounts,
+       * which is every deployment today. A form that offered the choice anyway
+       * would be offering a setting the server refuses, and the refusal would
+       * arrive after somebody had already decided.
+       */
+      managed_available: false,
+      credentials: credentials.map(described),
+    });
+  });
+
+  app.put(MODEL_ACCESS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const body = (request.body ?? {}) as Body;
+
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "change model access");
+    }
+
+    const unknown = unknownKeyIn(body, ACCESS_KEYS, "a model access choice");
+    if (unknown !== undefined) return invalid(reply, unknown);
+
+    const mode = given(text(body.mode));
+    if (mode === undefined) {
+      return invalid(
+        reply,
+        `a model access choice names a mode: ${MODEL_ACCESS_MODES.join(" or ")}`,
+      );
+    }
+
+    try {
+      const chosen = await setModelAccess(auth, mode);
+      return reply.send({
+        mode: chosen.mode,
+        updated_at: chosen.updatedAt?.toISOString() ?? null,
+      });
+    } catch (refusal) {
+      if (refusal instanceof ManagedAccessNotConnectedError) {
+        return unprocessable(reply, refusal.message);
+      }
+      if (refusal instanceof UnprocessableInputError) {
+        return unprocessable(reply, refusal.message);
+      }
+      throw refusal;
+    }
+  });
+
+  /**
+   * Every model-provider credential the organization holds.
+   *
+   * Readable at every role, because it is what a Models form reads to say which
+   * providers are configured. What comes back is a provider and a hint.
+   */
+  app.get(MODEL_PROVIDER_CREDENTIALS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const credentials = await listModelProviderCredentials(auth);
+    return reply.send({ items: credentials.map(described) });
+  });
+
+  /**
+   * Store this organization's key for one provider, adding it or replacing it.
+   *
+   * **One verb for both**, because there is one credential per provider by
+   * construction: "add" and "replace" are the same request with the same
+   * effect, and two doors would differ only in which of them refuses when the
+   * caller guessed wrong about what is already stored.
+   */
+  app.put(MODEL_PROVIDER_CREDENTIALS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const body = (request.body ?? {}) as Body;
+
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "manage model-provider credentials");
+    }
+
+    const unknown = unknownKeyIn(
+      body,
+      CREDENTIAL_KEYS,
+      "a model-provider credential",
+    );
+    if (unknown !== undefined) return invalid(reply, unknown);
+
+    const provider = given(text(body.provider));
+    const key = given(text(body.key));
+    if (provider === undefined) {
+      return invalid(reply, "a model-provider credential names its provider");
+    }
+    if (key === undefined) {
+      return invalid(reply, "a model-provider credential needs a key");
+    }
+
+    try {
+      const stored = await storeModelProviderCredential(auth, {
+        provider,
+        key,
+        // Absent skips the check, which is what an admin adding a provider's
+        // first key means. Present is a replacement written against a read,
+        // and a stale one is told the stored key moved rather than silently
+        // landing on top of somebody else's rotation.
+        expectedRevision: given(text(body.expected_revision)),
+      });
+      return reply.send(described(stored));
+    } catch (refusal) {
+      if (refusal instanceof IdentityConflictError) {
+        return sendRefusal(reply, "conflict", refusal.message);
+      }
+      if (refusal instanceof UnprocessableInputError) {
+        return unprocessable(reply, refusal.message);
+      }
+      throw refusal;
+    }
+  });
+
+  /**
+   * Take the organization's key for one provider away.
+   *
+   * Nothing is scanned first: no frozen plan and no pinned version names this
+   * row — a persona and a grader name the *provider* — so there is no work to
+   * strand and no history to make unreadable. A simulation that then needs one
+   * lands as an infrastructure error naming the provider, which is a better
+   * answer than a credential nobody meant to keep.
+   */
+  app.delete(MODEL_PROVIDER_CREDENTIAL_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { provider } = request.params as { provider: string };
+
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "manage model-provider credentials");
+    }
+
+    try {
+      const removed = await removeModelProviderCredential(auth, provider);
+      // Removing one the organization never held is the same outcome, said
+      // without pretending a row existed.
+      return reply.send({ removed: removed !== undefined, provider });
+    } catch (refusal) {
+      if (refusal instanceof UnprocessableInputError) {
+        return unprocessable(reply, refusal.message);
+      }
+      throw refusal;
+    }
+  });
+}

--- a/apps/api/src/routes/personas.ts
+++ b/apps/api/src/routes/personas.ts
@@ -17,10 +17,14 @@ import {
   testsUsingPersona,
   UnprocessableInputError,
   VersionConflictError,
+  PROVIDER_CATALOG,
+  RECOMMENDED_PERSONA_MODELS,
+  SPEED_RANGE,
   VOICE_PROVIDERS,
   WriteAbortedError,
   type AuthContext,
   type Persona,
+  type PersonaModels,
   type PersonaTraits,
   type PersonaVersion,
 } from "@egma/db";
@@ -191,6 +195,11 @@ function describedPersona(one: Persona): Record<string, unknown> {
     version: one.version,
     version_id: one.versionId,
     traits: one.traits,
+    // What this persona thinks, listens and speaks with, or `null` for one
+    // still on the compatibility path — where the deployment's own settings
+    // decide, exactly as they did before the model catalog existed. Null is an
+    // ordinary state and a form says so; it is never a fault.
+    models: one.models,
     // The two expectations a write can name, always answered, so that reading
     // a persona is always enough to edit one.
     revision: one.revision,
@@ -208,6 +217,7 @@ function describedVersion(one: PersonaVersion): Record<string, unknown> {
     persona_id: one.personaId,
     version: one.version,
     traits: one.traits,
+    models: one.models,
     created_at: one.createdAt.toISOString(),
   };
 }
@@ -268,6 +278,84 @@ function traitsIn(value: unknown): WrittenTraits {
       ...described("backgroundNoise"),
       ...described("underFriction"),
     } as PersonaTraits,
+  };
+}
+
+/**
+ * The model selections a body carries, as the factory takes them.
+ *
+ * Almost nothing is judged here, on the traits reader's exact terms one
+ * function up: which providers do which job, what a speed may be, and which
+ * ids are non-empty are the factory's rules, and a second opinion at this door
+ * could come to disagree with the one that decides. What this owns is the
+ * envelope — that `models` is an object holding three jobs, and that a body
+ * which is not that shape is refused rather than quietly read as a persona
+ * with no selections at all.
+ *
+ * **There is no credential field and no place for one.** Who pays is the
+ * organization's model access; a persona that named a key would put a secret
+ * inside authored content that a run then pins forever.
+ */
+type WrittenModels =
+  | { readonly models: PersonaModels }
+  | { readonly refusal: string };
+
+function modelsIn(value: unknown): WrittenModels {
+  const anObject = (held: unknown): Body | undefined =>
+    typeof held === "object" && held !== null && !Array.isArray(held)
+      ? (held as Body)
+      : undefined;
+
+  const block = anObject(value);
+  if (block === undefined) {
+    return {
+      refusal:
+        "models say what the persona thinks, listens and speaks with. Send " +
+        "them as an object holding llm, stt and tts.",
+    };
+  }
+  for (const forbidden of ["key", "credential", "credential_id"]) {
+    if (forbidden in block) {
+      return {
+        refusal:
+          `a persona's models hold no "${forbidden}". Who pays for a model is ` +
+          "the organization's model access, under Model providers — a persona " +
+          "names a provider and never a secret.",
+      };
+    }
+  }
+
+  const llm = anObject(block.llm);
+  const stt = anObject(block.stt);
+  const tts = anObject(block.tts);
+  if (llm === undefined || stt === undefined || tts === undefined) {
+    return {
+      refusal:
+        "a persona's models name all three jobs: llm, stt and tts, each an " +
+        "object with a provider and a model id.",
+    };
+  }
+
+  // Handed on as they arrived: the factory names a provider Egma ships nothing
+  // for, an empty model id and a speed outside the intelligible range in its
+  // own words, and those are the words worth relaying.
+  return {
+    models: {
+      llm: {
+        provider: llm.provider as PersonaModels["llm"]["provider"],
+        model: text(llm.model),
+      },
+      stt: {
+        provider: stt.provider as PersonaModels["stt"]["provider"],
+        model: text(stt.model),
+      },
+      tts: {
+        provider: tts.provider as PersonaModels["tts"]["provider"],
+        model: text(tts.model),
+        voiceId: text(tts.voiceId ?? tts.voice_id),
+        speed: (tts.speed ?? tts.speed) as number,
+      },
+    } as PersonaModels,
   };
 }
 
@@ -361,7 +449,38 @@ export async function personaRoutes(
     const acting = await projectFor(auth, given(query.project));
     if ("refusal" in acting) return refuseActing(reply, acting);
 
-    return reply.send({ voice_providers: VOICE_PROVIDERS });
+    return reply.send({
+      voice_providers: VOICE_PROVIDERS,
+      /**
+       * The catalog a Models form draws itself from, and the selection it
+       * starts a new persona at.
+       *
+       * Here beside the voice providers rather than fetched separately,
+       * because this is the one endpoint whose job is "what does the persona
+       * editor ask for" — and a form that had to assemble itself from two
+       * calls is a form that can render half-configured.
+       *
+       * There is no credential field and there never will be: who pays is the
+       * organization's model access, and a persona that named a key would put
+       * a secret inside authored content a run then pins forever.
+       */
+      model_catalog: PROVIDER_CATALOG.map((entry) => ({
+        provider: entry.provider,
+        job: entry.job,
+        label: entry.label,
+        recommended_model: entry.recommendedModel,
+        ...(entry.recommendedVoiceId === undefined
+          ? {}
+          : { recommended_voice_id: entry.recommendedVoiceId }),
+        model_is_free_text: true,
+      })),
+      recommended_models: {
+        llm: RECOMMENDED_PERSONA_MODELS.llm,
+        stt: RECOMMENDED_PERSONA_MODELS.stt,
+        tts: RECOMMENDED_PERSONA_MODELS.tts,
+      },
+      speed_range: SPEED_RANGE,
+    });
   });
 
   /** One persona, active or archived — a detail page has to render both. */
@@ -468,6 +587,10 @@ export async function personaRoutes(
     if (refused !== undefined) return refused;
 
     const written = traitsIn(body.traits ?? {});
+    const models = "models" in body ? modelsIn(body.models) : undefined;
+    if (models !== undefined && "refusal" in models) {
+      return sendRefusal(reply, "unprocessable", models.refusal);
+    }
     if ("refusal" in written) {
       return sendRefusal(reply, "unprocessable", written.refusal);
     }
@@ -481,6 +604,7 @@ export async function personaRoutes(
         ? {}
         : { description: text(body.description) }),
       traits: written.traits,
+      ...(models === undefined ? {} : { models: models.models }),
     });
 
     return reply.code(201).send(describedPersona(created));
@@ -523,14 +647,25 @@ export async function personaRoutes(
       return sendRefusal(reply, "unprocessable", written.refusal);
     }
 
+    const models = "models" in body ? modelsIn(body.models) : undefined;
+    if (models !== undefined && "refusal" in models) {
+      return sendRefusal(reply, "unprocessable", models.refusal);
+    }
+
     const expectedVersionId = given(text(body.expected_version_id));
-    if (written !== undefined && expectedVersionId === undefined) {
+    // Both halves of a version's content are guarded the same way, because
+    // both mint one: a models edit is as much "who this persona is on the
+    // simulation it conducts" as a trait edit is.
+    if (
+      (written !== undefined || models !== undefined) &&
+      expectedVersionId === undefined
+    ) {
       return sendRefusal(
         reply,
         "unprocessable",
-        "a traits edit says which version it was written against, and this " +
-          "one named no expected_version_id. Read the persona again and send " +
-          "the version_id it names now.",
+        "an edit to a persona's traits or models says which version it was " +
+          "written against, and this one named no expected_version_id. Read " +
+          "the persona again and send the version_id it names now.",
       );
     }
 
@@ -545,6 +680,7 @@ export async function personaRoutes(
         ? { description: given(text(body.description)) ?? null }
         : {}),
       ...(written === undefined ? {} : { traits: written.traits }),
+      ...(models === undefined ? {} : { models: models.models }),
     });
 
     if (edited === undefined) return noSuchPersona(reply, personaId);

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -307,6 +307,13 @@ function describedSimulation(
     // send, decided in `http/verdicts.ts` rather than here and again there.
     verdicts: rows.map((its) => describedVerdict(its, words, diagnostic)),
     reason: one.endingReason,
+    // What the reason word cannot say on its own, where Egma has it: one
+    // sentence naming what actually went wrong, and the screen that fixes it.
+    // Null on every conversation that ran — a `dispatch_failed` row is the
+    // platform confessing it could not hand a claimed simulation over, and a
+    // person looking at a red row needs the why and somewhere to go.
+    detail: one.endingDetail,
+    repair: one.endingRepair,
     // Why egma never conducted this conversation, and which capabilities
     // decided it. Null on every conversation that actually happened — the two
     // vocabularies are separate because `reason` is how a conversation ended

--- a/apps/api/src/routes/simulations.ts
+++ b/apps/api/src/routes/simulations.ts
@@ -437,6 +437,10 @@ export async function simulationRoutes(
       score: fold.score ?? null,
       counts: fold.counts,
       reason: one.endingReason,
+      // What the reason word cannot say on its own, where Egma has it, and the
+      // screen that fixes it. Null on every conversation that ran.
+      detail: one.endingDetail,
+      repair: one.endingRepair,
       skip_reason: one.skipReason,
       skipped_capabilities:
         one.skippedCapabilities === null ? null : [...one.skippedCapabilities],

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -22,6 +22,7 @@ import { heartbeatRoutes } from "./routes/heartbeats.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { judgeRoutes } from "./routes/judge.ts";
 import { meRoutes } from "./routes/me.ts";
+import { modelAccessRoutes } from "./routes/model-access.ts";
 import { memberRoutes } from "./routes/members.ts";
 import { organizationRoutes } from "./routes/organization.ts";
 import { personaRoutes } from "./routes/personas.ts";
@@ -304,6 +305,16 @@ export function buildApi(options: ServerOptions): Api {
     ...(config.defaultJudge === undefined
       ? {}
       : { defaultJudge: config.defaultJudge }),
+  });
+
+  // Who supplies the keys this organization's model traffic spends, the keys
+  // themselves, and the catalog a persona and a grader select from. Its own
+  // group beside the judge's above and for the same reason: reading which
+  // providers are configured is anybody's, and committing the organization's
+  // provider account is an admin's.
+  void app.register(modelAccessRoutes, {
+    provider: identity.provider,
+    rateLimit,
   });
 
   // What this deployment has been configured with, as an owner reads and

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2475,13 +2475,28 @@ describe("the complete product, walked in order in a second project", () => {
       // Which mode this organization is on, said as a word rather than left to
       // be inferred from which rows are filled in.
       await saysWithin(walk, "Customer-owned");
+      // One row for each provider Egma ships, named the way the catalog names
+      // it rather than by the word it is stored under.
+      const table = walk.locator('table[aria-label="Model providers"]');
+      await table.waitFor();
+      await expect.poll(() => table.locator("tbody tr").count()).toBe(3);
+      expect(await table.innerText()).toContain("OpenAI");
+
+      // The form is opened by the row it belongs to, so exactly one labelled
+      // secret field is on screen at a time rather than one per provider.
+      expect(await walk.locator('input[type="password"]').count()).toBe(0);
+      await walk.getByRole("button", { name: "Add key" }).first().click();
 
       const key = walk.locator("#model-provider-openai");
       await key.waitFor();
       // A password field, so a shoulder cannot read what is being typed.
       expect(await key.getAttribute("type")).toBe("password");
+      expect(await walk.locator('input[type="password"]').count()).toBe(1);
       await key.fill("sk-browser-sentinel-openai-A1B2");
-      await walk.getByRole("button", { name: "Add key" }).first().click();
+      await walk
+        .getByRole("button", { name: "Add key" })
+        .last()
+        .click();
 
       // Four characters and nothing else, and the field it was typed into is
       // empty again — the form is never the one place in the product showing a
@@ -2489,7 +2504,11 @@ describe("the complete product, walked in order in a second project", () => {
       // because the badge is uppercased by the design system and reads back as
       // "CONFIGURED", which "NOT CONFIGURED" also contains.
       await expect.poll(() => walk.innerText("main")).toContain("…A1B2");
-      await expect.poll(() => key.inputValue()).toBe("");
+      // The fourth save state, said out loud: a write that landed and left
+      // nothing on screen is indistinguishable from one that never went.
+      await saysWithin(walk, "key is saved");
+      // And the field is gone with the form it belonged to.
+      await expect.poll(() => walk.locator('input[type="password"]').count()).toBe(0);
       const shown = await walk.innerText("main");
       expect(shown).not.toContain("sk-browser-sentinel-openai-A1B2");
       expect(shown).toContain("…A1B2");
@@ -3691,29 +3710,33 @@ describe("the complete product, walked in order in a second project", () => {
           await saysWithin(walk, "Customer-owned");
           // And why the other mode is not on offer, said before anybody tries.
           await saysWithin(walk, "Egma model gateway");
-          // A provider with no key is a state and not a fault, and the page
-          // says what it actually costs rather than refusing to let anybody
-          // leave until every row is filled. Read off the sentence rather than
-          // the badge, which the design system uppercases.
-          await saysWithin(walk, "stops with an error naming it");
+          // A provider with no key is a state and not a fault: the row says so
+          // and the page still lets somebody leave. The badge is uppercased by
+          // the design system, so the whole phrase is what tells it from the
+          // configured one.
+          await expect
+            .poll(() => walk.innerText("main"))
+            .toContain("NOT CONFIGURED");
 
+          await walk
+            .getByRole("button", { name: "Replace key" })
+            .first()
+            .click();
           const key = walk.locator("#model-provider-openai");
           await key.waitFor();
           // A password field, so a shoulder cannot read what is being typed.
           expect(await key.getAttribute("type")).toBe("password");
+          const save = walk.getByRole("button", { name: "Replace key" }).last();
 
-          const button = walk
-            .getByRole("button", { name: "Replace key" })
-            .first();
           if (width === 390) {
             // A pointer target on a coarse pointer is at least 44px. Checked
             // on the button somebody actually presses to store a key.
-            const box = await button.boundingBox();
+            const box = await save.boundingBox();
             expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
           }
 
           await key.fill(replacement);
-          await button.click();
+          await save.click();
 
           // The stored key is four characters and nothing else, the field it
           // was typed into is empty again, and neither the key that was there
@@ -3721,11 +3744,44 @@ describe("the complete product, walked in order in a second project", () => {
           await expect
             .poll(() => walk.innerText("main"))
             .toContain(`…${replacement.slice(-4)}`);
-          await expect.poll(() => key.inputValue()).toBe("");
+          await expect
+            .poll(() => walk.locator('input[type="password"]').count())
+            .toBe(0);
           const shown = await walk.innerText("main");
           expect(shown).not.toContain(replacement);
           expect(shown).not.toContain(THE_KEY);
         }
+      },
+      SETTLE,
+    );
+
+    it(
+      "confirms removing a key, names the provider, and says what stops",
+      async () => {
+        await walk.setViewportSize({ width: 1280, height: 900 });
+        await walk.goto(at("settings", "model-providers"));
+        await saysWithin(walk, "Model providers");
+
+        // **Nothing is removed by one click.** The stored key cannot be read
+        // back, so a stray press is unrecoverable in the product, and it stops
+        // every later simulation and grading job that selects the provider.
+        await walk.getByRole("button", { name: "Remove key" }).first().click();
+
+        const dialog = walk.getByRole("dialog");
+        await dialog.waitFor();
+        const asked = await dialog.innerText();
+        // It names the provider it is about, and says what stops rather than
+        // asking "are you sure".
+        expect(asked).toContain("OpenAI");
+        expect(asked).toContain("stops with an error naming it");
+        expect(asked).toContain("cannot be undone");
+
+        // Escape leaves it exactly where it was.
+        await walk.keyboard.press("Escape");
+        await expect.poll(() => walk.getByRole("dialog").count()).toBe(0);
+        await expect
+          .poll(() => walk.innerText("main"))
+          .toContain("CONFIGURED");
       },
       SETTLE,
     );

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2457,6 +2457,46 @@ describe("the complete product, walked in order in a second project", () => {
     SETTLE,
   );
 
+  /**
+   * The organization's own provider key, stored before anything is authored.
+   *
+   * **This is the order the product actually has.** An organization on
+   * customer-owned model access supplies the keys its personas and graders
+   * spend, and a persona authored afterwards selects a provider rather than a
+   * secret. Doing it here rather than later is what makes the run below a real
+   * one: the claim resolves this credential, and nothing further down would
+   * conduct anything without it.
+   */
+  it(
+    "stores the organization's own provider key before authoring anything",
+    async () => {
+      await walk.goto(at("settings", "model-providers"));
+      await saysWithin(walk, "Model providers");
+      // Which mode this organization is on, said as a word rather than left to
+      // be inferred from which rows are filled in.
+      await saysWithin(walk, "Customer-owned");
+
+      const key = walk.locator("#model-provider-openai");
+      await key.waitFor();
+      // A password field, so a shoulder cannot read what is being typed.
+      expect(await key.getAttribute("type")).toBe("password");
+      await key.fill("sk-browser-sentinel-openai-A1B2");
+      await walk.getByRole("button", { name: "Add key" }).first().click();
+
+      // Four characters and nothing else, and the field it was typed into is
+      // empty again — the form is never the one place in the product showing a
+      // secret. Asserted on the hint rather than on the badge beside it,
+      // because the badge is uppercased by the design system and reads back as
+      // "CONFIGURED", which "NOT CONFIGURED" also contains.
+      await expect.poll(() => walk.innerText("main")).toContain("…A1B2");
+      await expect.poll(() => key.inputValue()).toBe("");
+      const shown = await walk.innerText("main");
+      expect(shown).not.toContain("sk-browser-sentinel-openai-A1B2");
+      expect(shown).toContain("…A1B2");
+    },
+    SETTLE,
+  );
+
   it(
     "authors a persona for this project",
     async () => {
@@ -3614,6 +3654,161 @@ describe("the complete product, walked in order in a second project", () => {
   /* ------------------------------------------------------------------ *
    * A narrow screen, and no pointer at all.
    * ------------------------------------------------------------------ */
+
+  /**
+   * The three screens that decide which models run and who pays for them.
+   *
+   * **What a browser proves here and nothing else can** is that no stored key
+   * comes back out of any of them, that a persona's Models form has nowhere to
+   * put one, and that a simulation stopped by a missing key sends somebody to
+   * the exact screen that fixes it. Every one of those is a claim about what a
+   * person can see and reach, which is the only place it can be checked.
+   *
+   * At both widths, because a settings form and a persona form are where a
+   * phone is most likely to be used and most likely to be forgotten.
+   */
+  describe("model providers, and the two forms that select from them", () => {
+    /** A sentinel, so a leak anywhere is a string this test can look for. */
+    const THE_KEY = "sk-browser-sentinel-openai-A1B2";
+
+    afterAll(async () => {
+      await walk.setViewportSize({ width: 1280, height: 900 });
+    });
+
+    it(
+      "replaces a provider key and never shows either one, on a phone and on a desktop",
+      async () => {
+        for (const [width, replacement] of [
+          [390, `${THE_KEY}-phone-9ZY8`],
+          [1280, `${THE_KEY}-desk-7XW6`],
+        ] as const) {
+          await walk.setViewportSize({ width, height: 900 });
+          await walk.goto(at("settings", "model-providers"));
+          await saysWithin(walk, "Model providers");
+
+          // The mode this organization is on, said as a word rather than left
+          // to be inferred from which rows are filled in.
+          await saysWithin(walk, "Customer-owned");
+          // And why the other mode is not on offer, said before anybody tries.
+          await saysWithin(walk, "Egma model gateway");
+          // A provider with no key is a state and not a fault, and the page
+          // says what it actually costs rather than refusing to let anybody
+          // leave until every row is filled. Read off the sentence rather than
+          // the badge, which the design system uppercases.
+          await saysWithin(walk, "stops with an error naming it");
+
+          const key = walk.locator("#model-provider-openai");
+          await key.waitFor();
+          // A password field, so a shoulder cannot read what is being typed.
+          expect(await key.getAttribute("type")).toBe("password");
+
+          const button = walk
+            .getByRole("button", { name: "Replace key" })
+            .first();
+          if (width === 390) {
+            // A pointer target on a coarse pointer is at least 44px. Checked
+            // on the button somebody actually presses to store a key.
+            const box = await button.boundingBox();
+            expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+          }
+
+          await key.fill(replacement);
+          await button.click();
+
+          // The stored key is four characters and nothing else, the field it
+          // was typed into is empty again, and neither the key that was there
+          // nor the one just typed is anywhere on the page.
+          await expect
+            .poll(() => walk.innerText("main"))
+            .toContain(`…${replacement.slice(-4)}`);
+          await expect.poll(() => key.inputValue()).toBe("");
+          const shown = await walk.innerText("main");
+          expect(shown).not.toContain(replacement);
+          expect(shown).not.toContain(THE_KEY);
+        }
+      },
+      SETTLE,
+    );
+
+    it(
+      "offers a persona three model choices and nowhere to put a key",
+      async () => {
+        await walk.setViewportSize({ width: 1280, height: 900 });
+        await walk.goto(at("personas", "new"));
+        await saysWithin(walk, "New persona");
+        await saysWithin(walk, "Models");
+
+        // Three independent choices, each filled in from a default a release
+        // proved — so a first persona runs before anybody opens a provider's
+        // documentation.
+        for (const [field, expected] of [
+          ["#persona-llm-provider", "openai"],
+          ["#persona-stt-provider", "deepgram"],
+          ["#persona-tts-provider", "cartesia"],
+        ] as const) {
+          await expect.poll(() => walk.locator(field).inputValue()).toBe(expected);
+        }
+        for (const field of [
+          "#persona-llm-model",
+          "#persona-stt-model",
+          "#persona-tts-model",
+          "#persona-tts-voice",
+        ]) {
+          expect(
+            (await walk.locator(field).inputValue()).trim().length,
+            field,
+          ).toBeGreaterThan(0);
+        }
+        // A model id is free text: a model released this morning has to be
+        // nameable without shipping a new browser.
+        await walk.locator("#persona-llm-model").fill("a-model-from-this-morning");
+        expect(await walk.locator("#persona-llm-model").inputValue()).toBe(
+          "a-model-from-this-morning",
+        );
+
+        // And nowhere to put a secret, and nothing about voice activity: the
+        // first would put a key inside authored content a run pins, and the
+        // second would make internal simulator behavior a question every
+        // persona author has to answer.
+        const shown = (await walk.innerText("main")).toLowerCase();
+        expect(shown).not.toContain("silero");
+        expect(shown).not.toContain("api key");
+        expect(await walk.locator('input[type="password"]').count()).toBe(0);
+      },
+      SETTLE,
+    );
+
+    it(
+      "reaches the persona's models with the keyboard alone",
+      async () => {
+        await walk.setViewportSize({ width: 1280, height: 900 });
+        await walk.goto(at("personas", "new"));
+        await saysWithin(walk, "Models");
+
+        const model = walk.locator("#persona-stt-model");
+        await model.focus();
+        // Selected and replaced from the keyboard, because the field arrives
+        // filled in with a default a release proved — typing into it without
+        // clearing would append rather than replace.
+        await walk.keyboard.press("ControlOrMeta+a");
+        await walk.keyboard.type("nova-2-phonecall");
+
+        expect(await model.inputValue()).toBe("nova-2-phonecall");
+        // Focus is where a person put it, and visibly so.
+        expect(
+          await walk.evaluate(() => {
+            const active = (
+              Reflect.get(globalThis, "document") as {
+                readonly activeElement: { id: string } | null;
+              }
+            ).activeElement;
+            return active?.id ?? "";
+          }),
+        ).toBe("persona-stt-model");
+      },
+      SETTLE,
+    );
+  });
 
   describe("a narrow screen", () => {
     afterAll(async () => {

--- a/apps/api/test/claims-model-access.test.ts
+++ b/apps/api/test/claims-model-access.test.ts
@@ -1,0 +1,577 @@
+import { newId } from "@egma/ids";
+import {
+  createPersona,
+  editPersona,
+  getSimulation,
+  RECOMMENDED_PERSONA_MODELS,
+  storeModelProviderCredential,
+  type PersonaModels,
+} from "@egma/db";
+import { specComplaints, specComplaintsAsVersion } from "@egma/simulation-contract";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CLAIMS_PATH } from "../src/routes/claims.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * What a simulator is handed when the organization owns its own model
+ * providers, over real HTTP against real Postgres.
+ *
+ * This is the control-plane seam the whole effort turns on: the place where the
+ * *pinned* persona version meets the *current* organization credentials. Both
+ * halves of that sentence are asserted here, because getting either the wrong
+ * way round is the failure — pinned credentials would make a rotation
+ * unreachable, and a current persona would rewrite what last week's run meant.
+ *
+ * Everything is observed through the door the shipped simulator actually knocks
+ * on, and through the public read of the simulation afterwards. Nothing reaches
+ * around into a helper.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const RESCHEDULING = {
+  name: "Reschedules a booked appointment",
+  scenario:
+    "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+  expected_behaviors: ["confirms the new time back before finishing"],
+} as const;
+
+const RETELL = {
+  type: "retell",
+  modality: "chat",
+  config: { retellAgentId: "agent_in_retell_1" },
+  credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+} as const;
+
+/** Sentinels, so a leak anywhere is a string a scan can find. */
+const OPENAI_KEY = "sk-sentinel-thinking-with-A1B2";
+const DEEPGRAM_KEY = "dg-sentinel-listening-with-C3D4";
+const CARTESIA_KEY = "ct-sentinel-speaking-with-E5F6";
+/** A provider the persona does not select, so nothing may carry it. */
+const UNRELATED_KEY = "sk-sentinel-unrelated-account-G7H8";
+
+type Claimed = {
+  readonly statusCode: number;
+  readonly specs: readonly Record<string, unknown>[];
+};
+
+async function claim(
+  token: string,
+  body: Record<string, unknown>,
+): Promise<Claimed> {
+  const response = await api.app.inject({
+    method: "POST",
+    url: CLAIMS_PATH,
+    headers: { authorization: `Bearer ${token}` },
+    payload: body,
+  });
+  const answered = response.json() as { specs?: Record<string, unknown>[] };
+  return { statusCode: response.statusCode, specs: answered.specs ?? [] };
+}
+
+type World = {
+  readonly ada: Customer;
+  readonly key: string;
+  readonly connectionId: string;
+  readonly versionId: string;
+  readonly serviceToken: string;
+};
+
+/** A customer with an agent, a persona and a test — everything a run needs. */
+async function aCustomer(
+  label: string,
+  persona: { readonly models?: PersonaModels | undefined } = {},
+): Promise<World> {
+  api = await createApi(label);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await ask(api.app, "POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: RETELL,
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+  const connectionId = (registered.body.connection as { id: string }).id;
+
+  await createPersona(contextFor(ada, "member"), {
+    name: "Impatient Rita",
+    traits: NEUTRAL_TRAITS,
+    ...(persona.models === undefined ? {} : { models: persona.models }),
+  });
+
+  const pushed = await ask(api.app, "POST", "/api/tests", key, {
+    ...RESCHEDULING,
+    personas: ["Impatient Rita"],
+  });
+  expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
+
+  return {
+    ada,
+    key,
+    connectionId,
+    versionId: String(pushed.body.version_id),
+    serviceToken: api.config.simulatorServiceToken,
+  };
+}
+
+/** A run over the customer's connection, whose simulation lands queued. */
+async function aQueuedRun(world: World): Promise<{ simulationId: string }> {
+  const started = await ask(api.app, "POST", "/api/runs", world.key, {
+    connection: world.connectionId,
+    test_versions: [world.versionId],
+    idempotency_key: newId("run"),
+  });
+  expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+  const first = (started.body.simulations as { id: string }[])[0];
+  if (first === undefined) throw new Error("the run has no simulation");
+  return { simulationId: first.id };
+}
+
+async function storeTheThreeKeys(ada: Customer): Promise<void> {
+  const admin = contextFor(ada, "admin");
+  await storeModelProviderCredential(admin, {
+    provider: "openai",
+    key: OPENAI_KEY,
+  });
+  await storeModelProviderCredential(admin, {
+    provider: "deepgram",
+    key: DEEPGRAM_KEY,
+  });
+  await storeModelProviderCredential(admin, {
+    provider: "cartesia",
+    key: CARTESIA_KEY,
+  });
+}
+
+describe("a work order for a persona that selects its own models", () => {
+  it("carries the pinned selections and only the keys they name", async () => {
+    const world = await aCustomer("claims_models_customer_owned", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeTheThreeKeys(world.ada);
+    await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    expect(claimed.statusCode).toBe(200);
+    const [spec] = claimed.specs;
+    expect(spec, "a queued simulation was not claimed").toBeDefined();
+    expect(specComplaints(spec)).toEqual([]);
+    expect(spec?.contract_version).toBe(2);
+
+    expect(spec?.models).toEqual({
+      access: "customer-owned",
+      llm: {
+        provider: RECOMMENDED_PERSONA_MODELS.llm.provider,
+        model: RECOMMENDED_PERSONA_MODELS.llm.model,
+        key: OPENAI_KEY,
+      },
+      stt: {
+        provider: RECOMMENDED_PERSONA_MODELS.stt.provider,
+        model: RECOMMENDED_PERSONA_MODELS.stt.model,
+        key: DEEPGRAM_KEY,
+      },
+      tts: {
+        provider: RECOMMENDED_PERSONA_MODELS.tts.provider,
+        model: RECOMMENDED_PERSONA_MODELS.tts.model,
+        key: CARTESIA_KEY,
+        voice_id: RECOMMENDED_PERSONA_MODELS.tts.voiceId,
+        speed: RECOMMENDED_PERSONA_MODELS.tts.speed,
+      },
+    });
+  });
+
+  it("carries no inference credential, because nothing here is Egma's to spend", async () => {
+    const world = await aCustomer("claims_models_no_inference", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeTheThreeKeys(world.ada);
+    await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    const written = JSON.stringify(claimed.specs);
+    // The words a gateway credential would travel under, none of which a
+    // customer-owned work order has any business carrying.
+    for (const absent of ["inference", "gateway", "base_url"]) {
+      expect(written, `a customer-owned work order carried ${absent}`).not.toContain(
+        absent,
+      );
+    }
+  });
+
+  it("carries no key for a provider the persona does not select", async () => {
+    const world = await aCustomer("claims_models_only_what_is_named", {
+      models: {
+        ...RECOMMENDED_PERSONA_MODELS,
+        // Everything on one account, so two of the organization's three
+        // credentials are genuinely unrelated to this simulation.
+        stt: RECOMMENDED_PERSONA_MODELS.stt,
+      },
+    });
+    const admin = contextFor(world.ada, "admin");
+    await storeModelProviderCredential(admin, {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+    await storeModelProviderCredential(admin, {
+      provider: "deepgram",
+      key: DEEPGRAM_KEY,
+    });
+    await storeModelProviderCredential(admin, {
+      provider: "cartesia",
+      key: CARTESIA_KEY,
+    });
+    await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    const written = JSON.stringify(claimed.specs);
+    expect(written).toContain(OPENAI_KEY);
+    expect(written).not.toContain(UNRELATED_KEY);
+  });
+
+  it("resolves the key when the claim is prepared, so a rotation reaches the next one", async () => {
+    const world = await aCustomer("claims_models_rotation", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeTheThreeKeys(world.ada);
+    await aQueuedRun(world);
+
+    const first = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+    expect(JSON.stringify(first.specs)).toContain(OPENAI_KEY);
+
+    // The admin rotates while that conversation is in flight, and starts
+    // another run. Nothing about the persona changed, so nothing is re-pinned.
+    const rotated = "sk-sentinel-rotated-account-J9K0";
+    await storeModelProviderCredential(contextFor(world.ada, "admin"), {
+      provider: "openai",
+      key: rotated,
+    });
+    await aQueuedRun(world);
+
+    const second = await claim(world.serviceToken, {
+      claimant: "sim-2",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    const written = JSON.stringify(second.specs);
+    expect(written).toContain(rotated);
+    expect(written).not.toContain(OPENAI_KEY);
+
+    // And the persona is where it was: a rotation is operational state, and
+    // touching it must not mint a version a run would then have to mean.
+    const [spec] = second.specs;
+    expect((spec?.models as { llm: { model: string } }).llm.model).toBe(
+      RECOMMENDED_PERSONA_MODELS.llm.model,
+    );
+  });
+
+  it("pins the version the run named, not what the persona says today", async () => {
+    const world = await aCustomer("claims_models_pinned", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeTheThreeKeys(world.ada);
+    await aQueuedRun(world);
+
+    // The author changes what the persona thinks with *after* the run started.
+    // The queued simulation still names the version it was born pinned to.
+    const author = contextFor(world.ada, "member");
+    const personas = await ask(api.app, "GET", "/api/personas", world.key);
+    const rita = (personas.body.items as { id: string }[])[0];
+    if (rita === undefined) throw new Error("the persona is missing");
+    const edited = await editPersona(author, rita.id, {
+      models: {
+        ...RECOMMENDED_PERSONA_MODELS,
+        llm: { provider: "openai", model: "gpt-4o" },
+      },
+    });
+    expect(edited?.models?.llm.model).toBe("gpt-4o");
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    const [spec] = claimed.specs;
+    expect((spec?.models as { llm: { model: string } }).llm.model).toBe(
+      RECOMMENDED_PERSONA_MODELS.llm.model,
+    );
+  });
+});
+
+describe("a persona still on the compatibility path", () => {
+  it("is conducted from the contract it always was, with no models block", async () => {
+    const world = await aCustomer("claims_models_legacy");
+    await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    const [spec] = claimed.specs;
+    expect(spec, "the legacy simulation was not claimed").toBeDefined();
+    expect(spec?.contract_version).toBe(1);
+    expect(spec).not.toHaveProperty("models");
+    expect(specComplaints(spec)).toEqual([]);
+    // And the document a version-1 worker checks it against accepts it, which
+    // is the whole of what "still starts and finishes new work" means.
+    expect(specComplaintsAsVersion(1, spec)).toEqual([]);
+  });
+
+  it("needs no model-provider credential, because nothing resolves one", async () => {
+    const world = await aCustomer("claims_models_legacy_no_keys");
+    const { simulationId } = await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+    });
+
+    expect(claimed.specs).toHaveLength(1);
+    const landed = await getSimulation(
+      contextFor(world.ada, "member"),
+      simulationId,
+    );
+    expect(landed?.status).toBe("claimed");
+  });
+});
+
+describe("a worker that speaks only the old contract", () => {
+  it("is never handed a document it could not read", async () => {
+    const world = await aCustomer("claims_models_old_worker", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeTheThreeKeys(world.ada);
+    const { simulationId } = await aQueuedRun(world);
+
+    // It says nothing about versions, which is what every simulator built
+    // before the second one says.
+    const claimed = await claim(world.serviceToken, {
+      claimant: "old-sim",
+      capacity: 5,
+      wait_seconds: 0,
+    });
+
+    expect(claimed.specs).toEqual([]);
+
+    // And the row is untouched: not claimed, not failed, still waiting for a
+    // worker that can conduct it. A rollout detail must not spend somebody's
+    // simulation.
+    const waiting = await getSimulation(
+      contextFor(world.ada, "member"),
+      simulationId,
+    );
+    expect(waiting?.status).toBe("queued");
+  });
+
+  it("leaves that work for the simulator beside it that can", async () => {
+    const world = await aCustomer("claims_models_mixed_fleet", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeTheThreeKeys(world.ada);
+    await aQueuedRun(world);
+
+    const old = await claim(world.serviceToken, {
+      claimant: "old-sim",
+      capacity: 5,
+      wait_seconds: 0,
+      contract_versions: [1],
+    });
+    expect(old.specs).toEqual([]);
+
+    const upgraded = await claim(world.serviceToken, {
+      claimant: "new-sim",
+      capacity: 5,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+    expect(upgraded.specs).toHaveLength(1);
+    expect(upgraded.specs[0]?.contract_version).toBe(2);
+  });
+
+  it("is refused by name when it declares a version this platform never writes", async () => {
+    const world = await aCustomer("claims_models_unknown_version");
+
+    const response = await api.app.inject({
+      method: "POST",
+      url: CLAIMS_PATH,
+      headers: { authorization: `Bearer ${world.serviceToken}` },
+      payload: {
+        claimant: "sim-from-the-future",
+        capacity: 1,
+        wait_seconds: 0,
+        contract_versions: [7],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(String((response.json() as { message: string }).message)).toContain(
+      "contract_versions",
+    );
+  });
+});
+
+describe("a provider credential the organization has not stored", () => {
+  it("stops that simulation and says which model job named which provider", async () => {
+    const world = await aCustomer("claims_models_missing_credential", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    // Only the thinking key. The listening and speaking legs have nothing.
+    await storeModelProviderCredential(contextFor(world.ada, "admin"), {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+    const { simulationId } = await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    // Nothing was handed over: a work order with no key would fail at the
+    // provider minutes later, naming nothing about configuration.
+    expect(claimed.specs).toEqual([]);
+
+    const landed = await getSimulation(
+      contextFor(world.ada, "member"),
+      simulationId,
+    );
+    expect(landed?.status).toBe("failed");
+    // An infrastructure error, and the word says so: `dispatch_failed` is the
+    // platform's confession, never one of the ways a conversation ends badly.
+    expect(landed?.endingReason).toBe("dispatch_failed");
+    expect(landed?.endingDetail).toContain("deepgram");
+    expect(landed?.endingDetail).toContain("stt");
+    expect(landed?.endingDetail).toContain("cartesia");
+    expect(landed?.endingDetail).toContain("tts");
+    // OpenAI is stored, so it is not among what has to be added.
+    expect(landed?.endingDetail).not.toContain("openai");
+    // And the person reading it is sent somewhere they can actually fix it.
+    expect(landed?.endingRepair).toBe("model_providers");
+  });
+
+  it("says nothing a key could be read out of", async () => {
+    const world = await aCustomer("claims_models_missing_says_no_secret", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeModelProviderCredential(contextFor(world.ada, "admin"), {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+    const { simulationId } = await aQueuedRun(world);
+
+    await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    const landed = await getSimulation(
+      contextFor(world.ada, "member"),
+      simulationId,
+    );
+    expect(JSON.stringify(landed)).not.toContain(OPENAI_KEY);
+  });
+
+  it("fails only itself, and the rest of the batch is conducted", async () => {
+    // Two personas: one whose providers are all stored, one whose are not.
+    // They are claimed in the same request, which is exactly the batch a
+    // single missing key must not take down.
+    const world = await aCustomer("claims_models_one_failure_in_a_batch", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    const admin = contextFor(world.ada, "admin");
+    await storeModelProviderCredential(admin, {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+    await storeModelProviderCredential(admin, {
+      provider: "deepgram",
+      key: DEEPGRAM_KEY,
+    });
+    await storeModelProviderCredential(admin, {
+      provider: "cartesia",
+      key: CARTESIA_KEY,
+    });
+
+    // A second persona that speaks with a provider this organization is about
+    // to stop holding a key for.
+    await createPersona(contextFor(world.ada, "member"), {
+      name: "Hurried Sam",
+      traits: NEUTRAL_TRAITS,
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    const second = await ask(api.app, "POST", "/api/tests", world.key, {
+      name: "Asks for a receipt",
+      scenario: "They want last month's receipt emailed again.",
+      expected_behaviors: ["says when the email will arrive"],
+      personas: ["Hurried Sam"],
+    });
+    expect(second.statusCode, JSON.stringify(second.body)).toBe(201);
+
+    const started = await ask(api.app, "POST", "/api/runs", world.key, {
+      connection: world.connectionId,
+      test_versions: [world.versionId, String(second.body.version_id)],
+      idempotency_key: newId("run"),
+    });
+    expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+    const simulations = started.body.simulations as { id: string }[];
+    expect(simulations).toHaveLength(2);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 5,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    // Both are conducted: this is the batch working, which is what the
+    // one-failure case below is measured against.
+    expect(claimed.specs).toHaveLength(2);
+  });
+});

--- a/apps/api/test/claims-model-access.test.ts
+++ b/apps/api/test/claims-model-access.test.ts
@@ -56,6 +56,9 @@ const RETELL = {
   credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
 } as const;
 
+/** The same agent reached over a voice line, for the cases about speech legs. */
+const RETELL_VOICE = { ...RETELL, modality: "voice" } as const;
+
 /** Sentinels, so a leak anywhere is a string a scan can find. */
 const OPENAI_KEY = "sk-sentinel-thinking-with-A1B2";
 const DEEPGRAM_KEY = "dg-sentinel-listening-with-C3D4";
@@ -93,7 +96,10 @@ type World = {
 /** A customer with an agent, a persona and a test — everything a run needs. */
 async function aCustomer(
   label: string,
-  persona: { readonly models?: PersonaModels | undefined } = {},
+  persona: {
+    readonly models?: PersonaModels | undefined;
+    readonly modality?: "chat" | "voice" | undefined;
+  } = {},
 ): Promise<World> {
   api = await createApi(label);
   const ada = await signUp(api.app, "ada@acme.example", "Acme");
@@ -101,7 +107,7 @@ async function aCustomer(
 
   const registered = await ask(api.app, "POST", "/api/agents", key, {
     name: "Front desk",
-    connection: RETELL,
+    connection: persona.modality === "voice" ? RETELL_VOICE : RETELL,
   });
   expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
   const connectionId = (registered.body.connection as { id: string }).id;
@@ -177,6 +183,9 @@ describe("a work order for a persona that selects its own models", () => {
     expect(specComplaints(spec)).toEqual([]);
     expect(spec?.contract_version).toBe(2);
 
+    // A chat simulation over this connection: it thinks, and it neither speaks
+    // nor listens. The selections travel whole because they are what the
+    // persona *is*; the keys follow the legs this simulation actually has.
     expect(spec?.models).toEqual({
       access: "customer-owned",
       llm: {
@@ -187,16 +196,60 @@ describe("a work order for a persona that selects its own models", () => {
       stt: {
         provider: RECOMMENDED_PERSONA_MODELS.stt.provider,
         model: RECOMMENDED_PERSONA_MODELS.stt.model,
-        key: DEEPGRAM_KEY,
       },
       tts: {
         provider: RECOMMENDED_PERSONA_MODELS.tts.provider,
         model: RECOMMENDED_PERSONA_MODELS.tts.model,
-        key: CARTESIA_KEY,
         voice_id: RECOMMENDED_PERSONA_MODELS.tts.voiceId,
         speed: RECOMMENDED_PERSONA_MODELS.tts.speed,
       },
     });
+  });
+
+  it("carries no speech key on a chat simulation, which has no use for one", async () => {
+    const world = await aCustomer("claims_models_chat_carries_no_speech_key", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    await storeTheThreeKeys(world.ada);
+    await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    const written = JSON.stringify(claimed.specs);
+    expect(written).toContain(OPENAI_KEY);
+    // The organization holds both, and neither travels: a credential that
+    // reaches a process with no use for it is a credential that did not have
+    // to be there.
+    expect(written).not.toContain(DEEPGRAM_KEY);
+    expect(written).not.toContain(CARTESIA_KEY);
+  });
+
+  it("needs no speech credential to conduct a chat simulation at all", async () => {
+    const world = await aCustomer("claims_models_chat_needs_only_thinking", {
+      models: RECOMMENDED_PERSONA_MODELS,
+    });
+    // The thinking key alone, which under a rule that demanded all three would
+    // stop a chat test this organization had everything for.
+    await storeModelProviderCredential(contextFor(world.ada, "admin"), {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+    await aQueuedRun(world);
+
+    const claimed = await claim(world.serviceToken, {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    });
+
+    expect(claimed.specs).toHaveLength(1);
+    expect(specComplaints(claimed.specs[0])).toEqual([]);
   });
 
   it("carries no inference credential, because nothing here is Egma's to spend", async () => {
@@ -457,8 +510,10 @@ describe("a provider credential the organization has not stored", () => {
   it("stops that simulation and says which model job named which provider", async () => {
     const world = await aCustomer("claims_models_missing_credential", {
       models: RECOMMENDED_PERSONA_MODELS,
+      modality: "voice",
     });
-    // Only the thinking key. The listening and speaking legs have nothing.
+    // Only the thinking key. The listening and speaking legs have nothing, and
+    // a voice simulation needs both.
     await storeModelProviderCredential(contextFor(world.ada, "admin"), {
       provider: "openai",
       key: OPENAI_KEY,
@@ -497,6 +552,7 @@ describe("a provider credential the organization has not stored", () => {
   it("says nothing a key could be read out of", async () => {
     const world = await aCustomer("claims_models_missing_says_no_secret", {
       models: RECOMMENDED_PERSONA_MODELS,
+      modality: "voice",
     });
     await storeModelProviderCredential(contextFor(world.ada, "admin"), {
       provider: "openai",

--- a/apps/api/test/model-access-routes.test.ts
+++ b/apps/api/test/model-access-routes.test.ts
@@ -1,0 +1,421 @@
+import {
+  listModelProviderCredentials,
+  MODEL_PROVIDERS,
+  PROVIDER_CATALOG,
+} from "@egma/db";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  MODEL_ACCESS_PATH,
+  MODEL_CATALOG_PATH,
+  MODEL_PROVIDER_CREDENTIALS_PATH,
+} from "../src/routes/model-access.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  colleagueOf,
+  contextFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * Model providers, over real HTTP against real Postgres.
+ *
+ * What is asserted here is what a browser and an API client actually observe:
+ * that a stored key never comes back out of any of these doors, that only an
+ * admin may move any of it, that another organization sees none of it, and that
+ * saving reaches no provider and scans nothing for completeness.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const OPENAI_KEY = "sk-sentinel-model-provider-A1B2";
+const DEEPGRAM_KEY = "dg-sentinel-model-provider-C3D4";
+
+type World = {
+  readonly ada: Customer;
+  readonly adminKey: string;
+};
+
+async function aCustomer(label: string): Promise<World> {
+  api = await createApi(label);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  // The organization-scoped key the signup comes away with: these doors are
+  // the customer's own and name no project.
+  return { ada, adminKey: ada.secret };
+}
+
+/** A colleague at a named role, holding an organization key of their own. */
+async function aMemberOf(host: Customer): Promise<string> {
+  const colleague = await colleagueOf(
+    api.app,
+    host,
+    "bob@acme.example",
+    "member",
+  );
+  return colleague.secret;
+}
+
+describe("the provider catalog", () => {
+  it("is served by the platform, so a browser keeps no second list", async () => {
+    const { adminKey } = await aCustomer("model_catalog");
+
+    const read = await ask(api.app, "GET", MODEL_CATALOG_PATH, adminKey);
+
+    expect(read.statusCode, JSON.stringify(read.body)).toBe(200);
+    expect(read.body.jobs).toEqual(["llm", "stt", "tts"]);
+
+    const providers = read.body.providers as {
+      provider: string;
+      job: string;
+      recommended_model: string;
+      recommended_voice_id?: string;
+      model_is_free_text: boolean;
+    }[];
+    expect(providers.map((one) => `${one.job}:${one.provider}`)).toEqual(
+      PROVIDER_CATALOG.map((one) => `${one.job}:${one.provider}`),
+    );
+  });
+
+  it("recommends a proved default for each job, and lets any id be typed over it", async () => {
+    const { adminKey } = await aCustomer("model_catalog_defaults");
+
+    const read = await ask(api.app, "GET", MODEL_CATALOG_PATH, adminKey);
+    const providers = read.body.providers as {
+      provider: string;
+      job: string;
+      recommended_model: string;
+      recommended_voice_id?: string;
+      model_is_free_text: boolean;
+    }[];
+
+    const byJob = (job: string) => providers.find((one) => one.job === job);
+    expect(byJob("llm")?.provider).toBe("openai");
+    expect(byJob("stt")?.provider).toBe("deepgram");
+    expect(byJob("tts")?.provider).toBe("cartesia");
+    // The speaking entry is the only one that needs a voice, and it has one.
+    expect(byJob("tts")?.recommended_voice_id).toBeTruthy();
+    expect(byJob("llm")?.recommended_voice_id).toBeUndefined();
+
+    for (const entry of providers) {
+      expect(entry.recommended_model).toBeTruthy();
+      // Egma never allowlists a model id: a release proves one default and the
+      // provider is the authority on the rest.
+      expect(entry.model_is_free_text).toBe(true);
+    }
+  });
+
+  it("names the pairs it has not proved without making any of them selectable", async () => {
+    const { adminKey } = await aCustomer("model_catalog_reserved");
+
+    const read = await ask(api.app, "GET", MODEL_CATALOG_PATH, adminKey);
+    const reserved = read.body.reserved as { provider: string; job: string }[];
+    const shipped = (read.body.providers as { provider: string; job: string }[]).map(
+      (one) => `${one.job}:${one.provider}`,
+    );
+
+    expect(reserved.length).toBeGreaterThan(0);
+    for (const one of reserved) {
+      expect(shipped).not.toContain(`${one.job}:${one.provider}`);
+    }
+  });
+
+  it("does not offer Silero, or any voice-activity choice at all", async () => {
+    const { adminKey } = await aCustomer("model_catalog_no_vad");
+
+    const read = await ask(api.app, "GET", MODEL_CATALOG_PATH, adminKey);
+
+    // What tells the persona the agent started and stopped speaking is
+    // internal simulator behavior, not a model anybody chooses.
+    expect(JSON.stringify(read.body).toLowerCase()).not.toContain("silero");
+    expect(JSON.stringify(read.body).toLowerCase()).not.toContain("vad");
+    expect(read.body.jobs).not.toContain("vad");
+  });
+});
+
+describe("choosing who supplies the credentials", () => {
+  it("starts customer-owned, with nothing chosen and nothing stored", async () => {
+    const { adminKey } = await aCustomer("model_access_default");
+
+    const read = await ask(api.app, "GET", MODEL_ACCESS_PATH, adminKey);
+
+    expect(read.statusCode, JSON.stringify(read.body)).toBe(200);
+    expect(read.body.mode).toBe("customer-owned");
+    expect(read.body.updated_at).toBeNull();
+    expect(read.body.credentials).toEqual([]);
+    expect(read.body.modes).toEqual(["managed", "customer-owned"]);
+  });
+
+  it("refuses managed by name while nothing is connected, and says so up front", async () => {
+    const { adminKey } = await aCustomer("model_access_managed_refused");
+
+    // The read says the choice is unavailable, so a form never offers it.
+    const read = await ask(api.app, "GET", MODEL_ACCESS_PATH, adminKey);
+    expect(read.body.managed_available).toBe(false);
+
+    const chosen = await ask(api.app, "PUT", MODEL_ACCESS_PATH, adminKey, {
+      mode: "managed",
+    });
+    expect(chosen.statusCode).toBe(422);
+    expect(String(chosen.body.message)).toContain("Egma model gateway");
+    expect(String(chosen.body.message)).toContain("Customer-owned");
+
+    // And nothing moved.
+    const after = await ask(api.app, "GET", MODEL_ACCESS_PATH, adminKey);
+    expect(after.body.mode).toBe("customer-owned");
+  });
+
+  it("has no third state and no per-provider mixing to ask for", async () => {
+    const { adminKey } = await aCustomer("model_access_binary");
+
+    for (const asked of ["mixed", "per-provider", ""]) {
+      const chosen = await ask(api.app, "PUT", MODEL_ACCESS_PATH, adminKey, {
+        mode: asked,
+      });
+      expect(chosen.statusCode, asked).toBeGreaterThanOrEqual(400);
+    }
+
+    // And a body that tried to name a provider is refused for the key itself.
+    const perProvider = await ask(api.app, "PUT", MODEL_ACCESS_PATH, adminKey, {
+      mode: "customer-owned",
+      provider: "openai",
+    });
+    expect(perProvider.statusCode).toBe(400);
+    expect(String(perProvider.body.message)).toContain("provider");
+  });
+
+  it("is an admin's to change and nobody else's", async () => {
+    const { ada, adminKey } = await aCustomer("model_access_role");
+    const memberKey = await aMemberOf(ada);
+
+    const refused = await ask(api.app, "PUT", MODEL_ACCESS_PATH, memberKey, {
+      mode: "customer-owned",
+    });
+    expect(refused.statusCode).toBe(403);
+
+    // A member can still see which mode the organization is on: it is not a
+    // secret, and a persona's Models form has to be able to say who pays.
+    const read = await ask(api.app, "GET", MODEL_ACCESS_PATH, memberKey);
+    expect(read.statusCode).toBe(200);
+    expect(read.body.mode).toBe("customer-owned");
+
+    const chosen = await ask(api.app, "PUT", MODEL_ACCESS_PATH, adminKey, {
+      mode: "customer-owned",
+    });
+    expect(chosen.statusCode, JSON.stringify(chosen.body)).toBe(200);
+  });
+
+  it("scans nothing for completeness, however little is configured", async () => {
+    const { adminKey } = await aCustomer("model_access_no_scan");
+
+    // Nothing stored at all, which under customer-owned access is an
+    // organization that cannot conduct a simulation yet. The setting still
+    // lands: readiness is reported per claim, never as a checklist in front of
+    // a switch somebody can plainly see.
+    const chosen = await ask(api.app, "PUT", MODEL_ACCESS_PATH, adminKey, {
+      mode: "customer-owned",
+    });
+
+    expect(chosen.statusCode, JSON.stringify(chosen.body)).toBe(200);
+    expect(chosen.body.mode).toBe("customer-owned");
+  });
+});
+
+describe("one provider's key", () => {
+  it("is stored and comes back as a provider and four characters, never the key", async () => {
+    const { adminKey } = await aCustomer("model_credentials_stored");
+
+    const stored = await ask(
+      api.app,
+      "PUT",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      adminKey,
+      { provider: "openai", key: OPENAI_KEY },
+    );
+
+    expect(stored.statusCode, JSON.stringify(stored.body)).toBe(200);
+    expect(stored.body.provider).toBe("openai");
+    expect(stored.body.hint).toBe("A1B2");
+    expect(JSON.stringify(stored.body)).not.toContain(OPENAI_KEY);
+
+    const listed = await ask(
+      api.app,
+      "GET",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      adminKey,
+    );
+    expect(JSON.stringify(listed.body)).not.toContain(OPENAI_KEY);
+    expect((listed.body.items as { provider: string }[])[0]?.provider).toBe(
+      "openai",
+    );
+  });
+
+  it("is replaced by the same door, and there is still only one", async () => {
+    const { ada, adminKey } = await aCustomer("model_credentials_replaced");
+
+    await ask(api.app, "PUT", MODEL_PROVIDER_CREDENTIALS_PATH, adminKey, {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+    const replaced = await ask(
+      api.app,
+      "PUT",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      adminKey,
+      { provider: "openai", key: "sk-sentinel-model-provider-Z9Y8" },
+    );
+
+    expect(replaced.statusCode, JSON.stringify(replaced.body)).toBe(200);
+    expect(replaced.body.hint).toBe("Z9Y8");
+
+    const held = await listModelProviderCredentials(contextFor(ada, "admin"));
+    expect(held.filter((one) => one.provider === "openai")).toHaveLength(1);
+  });
+
+  it("is removed, and removing one that was never there says so plainly", async () => {
+    const { adminKey } = await aCustomer("model_credentials_removed");
+
+    await ask(api.app, "PUT", MODEL_PROVIDER_CREDENTIALS_PATH, adminKey, {
+      provider: "deepgram",
+      key: DEEPGRAM_KEY,
+    });
+
+    const removed = await ask(
+      api.app,
+      "DELETE",
+      `${MODEL_PROVIDER_CREDENTIALS_PATH}/deepgram`,
+      adminKey,
+    );
+    expect(removed.statusCode, JSON.stringify(removed.body)).toBe(200);
+    expect(removed.body.removed).toBe(true);
+
+    const again = await ask(
+      api.app,
+      "DELETE",
+      `${MODEL_PROVIDER_CREDENTIALS_PATH}/deepgram`,
+      adminKey,
+    );
+    expect(again.statusCode).toBe(200);
+    expect(again.body.removed).toBe(false);
+  });
+
+  it("is refused for a provider Egma ships no adapter for", async () => {
+    const { adminKey } = await aCustomer("model_credentials_unknown_provider");
+
+    const refused = await ask(
+      api.app,
+      "PUT",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      adminKey,
+      { provider: "elevenlabs", key: OPENAI_KEY },
+    );
+
+    expect(refused.statusCode).toBe(422);
+    for (const shipped of MODEL_PROVIDERS) {
+      expect(String(refused.body.message)).toContain(shipped);
+    }
+  });
+
+  it("is an admin's to manage and nobody else's", async () => {
+    const { ada, adminKey } = await aCustomer("model_credentials_role");
+    const memberKey = await aMemberOf(ada);
+
+    const refusedStore = await ask(
+      api.app,
+      "PUT",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      memberKey,
+      { provider: "openai", key: OPENAI_KEY },
+    );
+    expect(refusedStore.statusCode).toBe(403);
+
+    await ask(api.app, "PUT", MODEL_PROVIDER_CREDENTIALS_PATH, adminKey, {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+
+    const refusedRemove = await ask(
+      api.app,
+      "DELETE",
+      `${MODEL_PROVIDER_CREDENTIALS_PATH}/openai`,
+      memberKey,
+    );
+    expect(refusedRemove.statusCode).toBe(403);
+
+    // A member still sees which providers are configured, by hint alone: it is
+    // what a Models form reads to say what is set up.
+    const listed = await ask(
+      api.app,
+      "GET",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      memberKey,
+    );
+    expect(listed.statusCode).toBe(200);
+    expect((listed.body.items as { hint: string }[])[0]?.hint).toBe("A1B2");
+    expect(JSON.stringify(listed.body)).not.toContain(OPENAI_KEY);
+  });
+
+  it("belongs to one organization, and another sees and reaches none of it", async () => {
+    const { adminKey } = await aCustomer("model_credentials_isolation");
+    await ask(api.app, "PUT", MODEL_PROVIDER_CREDENTIALS_PATH, adminKey, {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+
+    const grace = await signUp(api.app, "grace@globex.example", "Globex");
+    const globexKey = grace.secret;
+
+    const listed = await ask(
+      api.app,
+      "GET",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      globexKey,
+    );
+    expect(listed.statusCode).toBe(200);
+    expect(listed.body.items).toEqual([]);
+
+    const removed = await ask(
+      api.app,
+      "DELETE",
+      `${MODEL_PROVIDER_CREDENTIALS_PATH}/openai`,
+      globexKey,
+    );
+    expect(removed.body.removed).toBe(false);
+
+    // Acme still holds what Globex was just told nothing about.
+    const acme = await ask(
+      api.app,
+      "GET",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      adminKey,
+    );
+    expect((acme.body.items as { provider: string }[])[0]?.provider).toBe(
+      "openai",
+    );
+  });
+
+  it("reaches no provider when it is saved", async () => {
+    const { adminKey } = await aCustomer("model_credentials_no_provider_call");
+
+    // A key that could not possibly authenticate anywhere. Saving it succeeds,
+    // because saving seals a value and stops: a validation request would make
+    // saving depend on the provider being up, would spend on the customer's
+    // account to answer a question nobody asked, and would still not be true a
+    // minute later.
+    const stored = await ask(
+      api.app,
+      "PUT",
+      MODEL_PROVIDER_CREDENTIALS_PATH,
+      adminKey,
+      { provider: "openai", key: "sk-this-key-was-revoked-yesterday" },
+    );
+
+    expect(stored.statusCode, JSON.stringify(stored.body)).toBe(200);
+    expect(stored.body.hint).toBe("rday");
+  });
+});

--- a/apps/api/test/persona-and-grader-models.test.ts
+++ b/apps/api/test/persona-and-grader-models.test.ts
@@ -1,0 +1,369 @@
+import {
+  getPersonaVersion,
+  PREDEFINED_GRADERS,
+  RECOMMENDED_GRADER_MODEL,
+  RECOMMENDED_PERSONA_MODELS,
+} from "@egma/db";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The two authoring surfaces that select a model, over real HTTP.
+ *
+ * What is asserted is what an author observes: that the selections are theirs
+ * to make and independent of each other, that neither form has anywhere to put
+ * a secret, that a model edit mints a version so an old run keeps its meaning,
+ * and that a persona or grader authored before any of this existed still reads
+ * and still writes.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+type World = {
+  readonly ada: Customer;
+  readonly key: string;
+};
+
+async function aCustomer(label: string): Promise<World> {
+  api = await createApi(label);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  return { ada, key: await projectKeyFor(api.app, ada) };
+}
+
+const RITA = {
+  name: "Impatient Rita",
+  traits: NEUTRAL_TRAITS,
+} as const;
+
+/** The three selections as a body writes them. */
+const SELECTIONS = {
+  llm: { provider: "openai", model: "gpt-4o-mini" },
+  stt: { provider: "deepgram", model: "nova-3-general" },
+  tts: {
+    provider: "cartesia",
+    model: "sonic-3.5",
+    voiceId: "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+    speed: 1,
+  },
+} as const;
+
+describe("the persona editor's shape", () => {
+  it("offers the catalog and a proved default for each job, filled in", async () => {
+    const { key } = await aCustomer("persona_form_models");
+
+    const form = await ask(api.app, "GET", "/api/persona-form", key);
+
+    expect(form.statusCode, JSON.stringify(form.body)).toBe(200);
+    const recommended = form.body.recommended_models as Record<
+      string,
+      { provider: string; model: string }
+    >;
+    expect(recommended.llm).toEqual(RECOMMENDED_PERSONA_MODELS.llm);
+    expect(recommended.stt).toEqual(RECOMMENDED_PERSONA_MODELS.stt);
+    expect(recommended.tts).toEqual(RECOMMENDED_PERSONA_MODELS.tts);
+
+    const catalog = form.body.model_catalog as { job: string }[];
+    expect(new Set(catalog.map((one) => one.job))).toEqual(
+      new Set(["llm", "stt", "tts"]),
+    );
+    // Speech only stays intelligible so far from natural pace, and the form is
+    // told the bounds rather than inventing them.
+    expect(form.body.speed_range).toEqual({ slowest: 0.5, fastest: 2 });
+  });
+
+  it("has no credential field and no voice-activity choice", async () => {
+    const { key } = await aCustomer("persona_form_no_secrets");
+
+    const form = await ask(api.app, "GET", "/api/persona-form", key);
+    const written = JSON.stringify(form.body).toLowerCase();
+
+    for (const absent of ["key", "credential", "silero", "vad"]) {
+      expect(written, `the persona form offered ${absent}`).not.toContain(
+        absent,
+      );
+    }
+  });
+});
+
+describe("a persona that selects its own models", () => {
+  it("stores three independent selections, each changeable on its own", async () => {
+    const { key } = await aCustomer("persona_models_independent");
+
+    const created = await ask(api.app, "POST", "/api/personas", key, {
+      ...RITA,
+      models: SELECTIONS,
+    });
+    expect(created.statusCode, JSON.stringify(created.body)).toBe(201);
+    expect(created.body.models).toEqual(SELECTIONS);
+
+    // Changing what the persona listens with leaves what it thinks and speaks
+    // with exactly where they were. That independence is the whole decision.
+    const edited = await ask(
+      api.app,
+      "PATCH",
+      `/api/personas/${String(created.body.id)}`,
+      key,
+      {
+        expected_revision: String(created.body.revision),
+        expected_version_id: String(created.body.version_id),
+        models: {
+          ...SELECTIONS,
+          stt: { provider: "deepgram", model: "nova-2-phonecall" },
+        },
+      },
+    );
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(200);
+    const models = edited.body.models as typeof SELECTIONS;
+    expect(models.stt.model).toBe("nova-2-phonecall");
+    expect(models.llm).toEqual(SELECTIONS.llm);
+    expect(models.tts).toEqual(SELECTIONS.tts);
+  });
+
+  it("mints a new version, and the old one still says what it said", async () => {
+    const { ada, key } = await aCustomer("persona_models_version");
+
+    const created = await ask(api.app, "POST", "/api/personas", key, {
+      ...RITA,
+      models: SELECTIONS,
+    });
+    const firstVersionId = String(created.body.version_id);
+
+    const edited = await ask(
+      api.app,
+      "PATCH",
+      `/api/personas/${String(created.body.id)}`,
+      key,
+      {
+        expected_revision: String(created.body.revision),
+        expected_version_id: firstVersionId,
+        models: { ...SELECTIONS, llm: { provider: "openai", model: "gpt-4o" } },
+      },
+    );
+
+    expect(edited.body.version).toBe(2);
+    expect(edited.body.version_id).not.toBe(firstVersionId);
+
+    // The version a run would have pinned still names the model it named.
+    const frozen = await getPersonaVersion(
+      contextFor(ada, "member"),
+      firstVersionId,
+    );
+    expect(frozen?.models?.llm.model).toBe("gpt-4o-mini");
+  });
+
+  it("mints nothing when the same selections are sent again", async () => {
+    const { key } = await aCustomer("persona_models_idempotent");
+
+    const created = await ask(api.app, "POST", "/api/personas", key, {
+      ...RITA,
+      models: SELECTIONS,
+    });
+
+    const resaved = await ask(
+      api.app,
+      "PATCH",
+      `/api/personas/${String(created.body.id)}`,
+      key,
+      {
+        expected_revision: String(created.body.revision),
+        expected_version_id: String(created.body.version_id),
+        models: SELECTIONS,
+      },
+    );
+
+    expect(resaved.body.version).toBe(1);
+    expect(resaved.body.version_id).toBe(created.body.version_id);
+  });
+
+  it("refuses a provider Egma ships nothing for, naming the ones it does", async () => {
+    const { key } = await aCustomer("persona_models_unknown_provider");
+
+    const refused = await ask(api.app, "POST", "/api/personas", key, {
+      ...RITA,
+      models: { ...SELECTIONS, stt: { provider: "assemblyai", model: "best" } },
+    });
+
+    expect(refused.statusCode).toBe(422);
+    expect(String(refused.body.message)).toContain("deepgram");
+  });
+
+  it("refuses a body that tried to put a key beside the selections", async () => {
+    const { key } = await aCustomer("persona_models_no_secret");
+
+    for (const smuggled of [
+      { ...SELECTIONS, key: "sk-not-here" },
+      { ...SELECTIONS, credential_id: "mpc_01K3XQ7M4E8YB2FVN0H9TZQWER" },
+    ]) {
+      const refused = await ask(api.app, "POST", "/api/personas", key, {
+        ...RITA,
+        models: smuggled,
+      });
+
+      expect(refused.statusCode).toBe(422);
+      expect(String(refused.body.message)).toContain("Model providers");
+    }
+  });
+
+  it("takes any model id, because Egma allowlists none", async () => {
+    const { key } = await aCustomer("persona_models_free_text");
+
+    const created = await ask(api.app, "POST", "/api/personas", key, {
+      ...RITA,
+      models: {
+        ...SELECTIONS,
+        llm: { provider: "openai", model: "a-model-released-this-morning" },
+      },
+    });
+
+    expect(created.statusCode, JSON.stringify(created.body)).toBe(201);
+    expect(
+      (created.body.models as typeof SELECTIONS).llm.model,
+    ).toBe("a-model-released-this-morning");
+  });
+});
+
+describe("a persona authored before any of this", () => {
+  it("reads back with no selections, which is a state and not a fault", async () => {
+    const { key } = await aCustomer("persona_models_legacy");
+
+    const created = await ask(api.app, "POST", "/api/personas", key, RITA);
+
+    expect(created.statusCode, JSON.stringify(created.body)).toBe(201);
+    expect(created.body.models).toBeNull();
+  });
+
+  it("can still be edited without being made to choose", async () => {
+    const { key } = await aCustomer("persona_models_legacy_edit");
+
+    const created = await ask(api.app, "POST", "/api/personas", key, RITA);
+    const renamed = await ask(
+      api.app,
+      "PATCH",
+      `/api/personas/${String(created.body.id)}`,
+      key,
+      { expected_revision: String(created.body.revision), name: "Rita" },
+    );
+
+    expect(renamed.statusCode, JSON.stringify(renamed.body)).toBe(200);
+    expect(renamed.body.name).toBe("Rita");
+    expect(renamed.body.models).toBeNull();
+  });
+});
+
+describe("a grader's own model", () => {
+  it("is selected per copy, independently of every persona", async () => {
+    const { key } = await aCustomer("grader_model_independent");
+
+    const library = await ask(api.app, "GET", "/api/grader-library", key);
+    const entry = (library.body.items as { id: string; key: string }[]).find(
+      (one) => one.key === PREDEFINED_GRADERS.expectedBehaviors.key,
+    );
+    expect(entry, "the predefined entry is missing").toBeDefined();
+
+    const used = await ask(api.app, "POST", "/api/graders", key, {
+      library_id: entry?.id,
+      project: (await ask(api.app, "GET", "/api/me", key)).body.project_id,
+      model: RECOMMENDED_GRADER_MODEL,
+    });
+
+    expect(used.statusCode, JSON.stringify(used.body)).toBe(201);
+    expect(used.body.model).toEqual(RECOMMENDED_GRADER_MODEL);
+  });
+
+  it("mints a version when it changes, and stays null on the copy that never chose", async () => {
+    const { key } = await aCustomer("grader_model_version");
+
+    const graders = await ask(api.app, "GET", "/api/graders", key);
+    const seeded = (
+      graders.body.items as { id: string; version: number; model: unknown }[]
+    )[0];
+    expect(seeded, "the seeded copy is missing").toBeDefined();
+
+    // Every project is created with the expected-behaviors copy, and it is on
+    // the compatibility path: the project's judge decides, exactly as before.
+    expect(seeded?.model).toBeNull();
+
+    const edited = await ask(
+      api.app,
+      "PATCH",
+      `/api/graders/${String(seeded?.id)}`,
+      key,
+      { model: { provider: "openai", model: "gpt-4o" } },
+    );
+
+    expect(edited.statusCode, JSON.stringify(edited.body)).toBe(200);
+    expect(edited.body.model).toEqual({ provider: "openai", model: "gpt-4o" });
+    expect(edited.body.version).toBe((seeded?.version ?? 0) + 1);
+  });
+
+  it("goes back to the project's judge when it is cleared", async () => {
+    const { key } = await aCustomer("grader_model_cleared");
+
+    const graders = await ask(api.app, "GET", "/api/graders", key);
+    const seeded = (graders.body.items as { id: string }[])[0];
+
+    await ask(api.app, "PATCH", `/api/graders/${String(seeded?.id)}`, key, {
+      model: { provider: "openai", model: "gpt-4o" },
+    });
+    const cleared = await ask(
+      api.app,
+      "PATCH",
+      `/api/graders/${String(seeded?.id)}`,
+      key,
+      { model: null },
+    );
+
+    expect(cleared.statusCode, JSON.stringify(cleared.body)).toBe(200);
+    expect(cleared.body.model).toBeNull();
+  });
+
+  it("has no credential field, and refuses a body that tried to give it one", async () => {
+    const { key } = await aCustomer("grader_model_no_secret");
+
+    const graders = await ask(api.app, "GET", "/api/graders", key);
+    const seeded = (graders.body.items as { id: string }[])[0];
+
+    const refused = await ask(
+      api.app,
+      "PATCH",
+      `/api/graders/${String(seeded?.id)}`,
+      key,
+      { model: { provider: "openai", model: "gpt-4o", key: "sk-not-here" } },
+    );
+
+    expect(refused.statusCode).toBe(422);
+    expect(String(refused.body.message)).toContain("Model providers");
+  });
+
+  it("refuses a provider that does no LLM work in this catalog", async () => {
+    const { key } = await aCustomer("grader_model_unknown_provider");
+
+    const graders = await ask(api.app, "GET", "/api/graders", key);
+    const seeded = (graders.body.items as { id: string }[])[0];
+
+    const refused = await ask(
+      api.app,
+      "PATCH",
+      `/api/graders/${String(seeded?.id)}`,
+      key,
+      { model: { provider: "deepgram", model: "nova-3-general" } },
+    );
+
+    expect(refused.statusCode).toBe(422);
+    expect(String(refused.body.message)).toContain("openai");
+  });
+});

--- a/apps/api/test/persona-and-grader-models.test.ts
+++ b/apps/api/test/persona-and-grader-models.test.ts
@@ -269,8 +269,8 @@ describe("a grader's own model", () => {
     const { key } = await aCustomer("grader_model_independent");
 
     const library = await ask(api.app, "GET", "/api/grader-library", key);
-    const entry = (library.body.items as { id: string; key: string }[]).find(
-      (one) => one.key === PREDEFINED_GRADERS.expectedBehaviors.key,
+    const entry = (library.body.items as { id: string }[]).find(
+      (one) => one.id === PREDEFINED_GRADERS.expectedBehaviors,
     );
     expect(entry, "the predefined entry is missing").toBeDefined();
 

--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -112,6 +112,10 @@ describe("the provider's footprint on the schema", () => {
     "membership",
     "mock_tool",
     "mock_tool_agent",
+    // Who supplies the organization's model credentials, and the credentials
+    // themselves. Both are Egma's own, and the auth provider reaches neither.
+    "model_access",
+    "model_provider_credential",
     "organization",
     "organization_settings",
     "persona",

--- a/apps/api/test/support/recordings.ts
+++ b/apps/api/test/support/recordings.ts
@@ -6,7 +6,10 @@ import {
   startSimulation,
   type AuthContext,
 } from "@egma/db";
-import { traceIdOfSimulation } from "@egma/simulation-contract";
+import {
+  SPEC_CONTRACT_VERSIONS,
+  traceIdOfSimulation,
+} from "@egma/simulation-contract";
 import type { FastifyInstance } from "fastify";
 import { expect } from "vitest";
 
@@ -280,7 +283,15 @@ export async function landOneConversationOf(
   runId: string,
   options: { readonly reference?: string } = {},
 ): Promise<string> {
-  const [first] = await claimSimulations({ claimant: CLAIMANT, capacity: 1 });
+  const [first] = await claimSimulations({
+    claimant: CLAIMANT,
+    capacity: 1,
+    // What the shipped simulator declares. This helper stands in for one, and
+    // a stand-in that declared less would silently refuse to claim every
+    // conversation whose persona selects its own models — which reads as an
+    // empty queue rather than as a version this stand-in cannot read.
+    contractVersions: [...SPEC_CONTRACT_VERSIONS],
+  });
   expect(first, "this run wrote a conversation to claim").toBeDefined();
   expect(
     first?.runId,

--- a/apps/api/test/support/traces.ts
+++ b/apps/api/test/support/traces.ts
@@ -154,7 +154,7 @@ export type Answer = {
 /** One request with a key on it, answered by the API in this process. */
 export async function request(
   app: FastifyInstance,
-  method: "GET" | "POST" | "PATCH" | "DELETE",
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
   url: string,
   key: string,
   payload?: Record<string, unknown>,

--- a/apps/grader/src/grade.ts
+++ b/apps/grader/src/grade.ts
@@ -29,7 +29,7 @@ import {
   type Judgment,
   type Reading,
 } from "./graders/index.ts";
-import { JUDGE_MAKERS, judgeOnce, type JudgeMakers } from "./judge/index.ts";
+import { JUDGE_MAKERS, judgesOnce, type JudgeMakers } from "./judge/index.ts";
 import { applicableGraders, applicableProductionGraders } from "./resolve.ts";
 
 /**
@@ -155,11 +155,14 @@ export async function gradeClaim(
 
   const makers = options.makers ?? JUDGE_MAKERS;
 
-  // The project's judge, shared by everything on this conversation that judges
-  // and resolved only if something does. Nothing here decides whether it is
-  // needed — the things that judge ask, and a conversation where none of them
-  // does never opens the envelope.
-  const judge = judgeOnce(claim.auth);
+  // The judges this conversation may be judged by, each source resolved only
+  // if something asks for it. Nothing here decides whether one is needed — the
+  // things that judge ask, and a conversation where none of them does never
+  // opens an envelope at all. Which source answers is the grader's own fact:
+  // a version that selected its model spends the organization's credential for
+  // that provider, and one that did not is judged by the project's setting
+  // exactly as it always was.
+  const judges = judgesOnce(claim.auth);
 
   // The definitions, read through the copies' pointers and remembered for the
   // length of this conversation. Two copies of one entry cost one read; nothing
@@ -183,13 +186,17 @@ export async function gradeClaim(
           await judgmentsOf(grader, await definitionOf(grader), {
             conversation,
             judging: {
-              judge,
+              judges,
               makers,
-              // This version's own judge, or null for the project's default. It
-              // is judged content, frozen on the version beside the config, so
-              // a verdict decided by it stays readable as "decided by this
-              // model" long after the project's default moved on.
-              model: grader.judgeModel,
+              // The two model fields this version froze, handed on together
+              // because which of them answers is the resolution's decision and
+              // not this file's. Both are judged content, frozen beside the
+              // config, so a verdict decided by either stays readable as
+              // "decided by this model" long after anything else moved on.
+              grader: {
+                graderModel: grader.graderModel,
+                judgeModel: grader.judgeModel,
+              },
             },
             reading,
           })

--- a/apps/grader/src/graders/contract.ts
+++ b/apps/grader/src/graders/contract.ts
@@ -6,7 +6,11 @@ import type {
 } from "@egma/db";
 
 import type { Conversation } from "../conversation.ts";
-import type { JudgeMakers, JudgeResolution } from "../judge/index.ts";
+import type {
+  ConversationJudges,
+  GraderJudging,
+  JudgeMakers,
+} from "../judge/index.ts";
 
 /**
  * What every grader is handed and what every one of them answers with.
@@ -78,27 +82,29 @@ export type Judgment = {
  */
 export type Judging = {
   /**
-   * The project's judge, resolved at most once per conversation and shared by
-   * everything on it that judges — so five judged checks cost one read of the
-   * configuration rather than five, and all of them speak with one account.
+   * The judges this conversation may be judged by, each source resolved at
+   * most once and shared by everything on it that asks — so five judged
+   * checks on one source cost one read rather than five.
    */
-  readonly judge: JudgeResolution;
+  readonly judges: ConversationJudges;
   /** How each provider is spoken to. A test hands over a scripted one. */
   readonly makers: JudgeMakers;
   /**
-   * This grader version's own judge, or `null` for the project's default.
+   * The two model fields this grader version froze.
    *
-   * The override is judged content: it lives on the immutable version beside the
-   * config, so a verdict written under it stays readable as "decided by this
-   * model" long after the project's default moved on. It names a provider and a
-   * model and never a key, so a grader cannot move a project's judging onto an
-   * account nobody configured.
+   * **Which of them answers is the resolution's decision, not an executor's.**
+   * A version carrying a `graderModel` selected its provider and model
+   * outright and spends the organization's credential for that provider; one
+   * carrying only a `judgeModel` overrides the project's judge without
+   * touching its key; one carrying neither is judged by the project's setting
+   * exactly as it always was. Both are judged content, frozen on the immutable
+   * version beside the config, so a verdict written under either stays
+   * readable as "decided by this model" long after anything else moved on.
+   * Neither names a key, so no grader can move judging onto an account nobody
+   * configured.
    */
-  readonly model: JudgeModelOverride;
+  readonly grader: GraderJudging;
 };
-
-/** What a version may insist on: a provider and a model, or the project's. */
-type JudgeModelOverride = Grader["judgeModel"];
 
 /**
  * What egma knows about *this* conversation besides its spans — what an entry

--- a/apps/grader/src/graders/expected-behaviors.ts
+++ b/apps/grader/src/graders/expected-behaviors.ts
@@ -126,14 +126,20 @@ export async function executeExpectedBehaviors(
   }
 
   // Only now, with behaviors to judge, a conversation that happened and words
-  // to ask with, is the project's key worth unsealing.
-  const configured = await execution.judging.judge();
-  if (configured instanceof NoJudge) {
-    const why = configured.message;
+  // to ask with, is a key worth unsealing. Which one is asked for — this
+  // grader's own selection, or the project's setting — is the resolution's
+  // decision, and nothing in this executor knows the difference.
+  const judge = await execution.judging.judges.judgeFor(
+    execution.judging.grader,
+    execution.judging.makers,
+  );
+  if (judge instanceof NoJudge) {
+    // An infrastructure error and never a failed verdict: a check egma could
+    // not make did not fail, and one `errored` row per behavior says so with
+    // the sentence a person can act on.
+    const why = judge.message;
     return behaviors.map((_, at) => couldNotJudge(at, why));
   }
-
-  const judge = configured.judging(execution.judging.model, execution.judging.makers);
 
   // Assembled once and shared by every call, which is what makes N judgments of
   // one conversation one read rather than N.

--- a/apps/grader/src/judge/index.ts
+++ b/apps/grader/src/judge/index.ts
@@ -1,5 +1,6 @@
 import {
   getJudgeConfiguration,
+  JUDGE_PROVIDERS,
   resolveJudgeKey,
   resolveModelProviderKeys,
   type AuthContext,
@@ -160,7 +161,9 @@ export function judgesOnce(auth: AuthContext): ConversationJudges {
   let theProjects: Promise<ProjectJudge | NoJudge> | undefined;
   const byProvider = new Map<string, Promise<string | NoJudge>>();
 
-  const keyForProvider = (provider: string): Promise<string | NoJudge> => {
+  const keyForProvider = (
+    provider: GraderModel["provider"],
+  ): Promise<string | NoJudge> => {
     const held = byProvider.get(provider);
     if (held !== undefined) return held;
     const resolving = organizationKeyFor(auth, provider);
@@ -180,15 +183,19 @@ export function judgesOnce(auth: AuthContext): ConversationJudges {
         return configured.judging(grader.judgeModel, makers);
       }
 
-      const maker = makerFor(selected.provider, makers);
-      if (maker instanceof NoJudge) return maker;
+      const asked = makerFor(selected.provider, makers);
+      if (asked instanceof NoJudge) return asked;
 
       const key = await keyForProvider(selected.provider);
       if (key instanceof NoJudge) return key;
 
       return {
-        ask: maker({
-          provider: selected.provider as JudgeProvider,
+        ask: asked.maker({
+          // The provider `makerFor` matched, rather than the one that was
+          // asked for: they are the same word, and this one is the closed type
+          // a resolved judge is made of, so nothing here has to be cast across
+          // two vocabularies that only happen to overlap.
+          provider: asked.provider,
           model: selected.model,
           key,
         }),
@@ -210,7 +217,7 @@ export function judgesOnce(auth: AuthContext): ConversationJudges {
  */
 async function organizationKeyFor(
   auth: AuthContext,
-  provider: string,
+  provider: GraderModel["provider"],
 ): Promise<string | NoJudge> {
   let resolved: Awaited<ReturnType<typeof resolveModelProviderKeys>>;
   try {
@@ -226,7 +233,7 @@ async function organizationKeyFor(
     );
   }
 
-  const key = resolved.keys.get(provider as never);
+  const key = resolved.keys.get(provider);
   if (key === undefined) {
     return new NoJudge(
       `this grader judges with ${provider}, and this organization holds no ${provider} model-provider credential; add one under Model providers in Organization settings.`,
@@ -243,16 +250,22 @@ async function organizationKeyFor(
  * maker that exists would judge a customer's conversation on a model nobody
  * chose, and the verdict would read as if they had.
  */
-function makerFor(provider: string, makers: JudgeMakers): JudgeMaker | NoJudge {
-  const known = Object.hasOwn(makers, provider)
-    ? makers[provider as JudgeProvider]
-    : undefined;
+function makerFor(
+  provider: string,
+  makers: JudgeMakers,
+): { readonly provider: JudgeProvider; readonly maker: JudgeMaker } | NoJudge {
+  // Matched against the closed list rather than looked up on the roster, so
+  // the word comes back as the type a resolved judge is made of. The model
+  // catalog's providers and the judge roster's are two closed vocabularies
+  // that overlap; finding the word in one of them is what crosses between
+  // them honestly, where an index and a cast would only assume it.
+  const known = JUDGE_PROVIDERS.find((candidate) => candidate === provider);
   if (known === undefined) {
     return new NoJudge(
-      `this grader judges with ${provider}, and this release ships no judge for it; it judges with ${Object.keys(makers).join(", ")}.`,
+      `this grader judges with ${provider}, and this release ships no judge for it; it judges with ${JUDGE_PROVIDERS.join(", ")}.`,
     );
   }
-  return known;
+  return { provider: known, maker: makers[known] };
 }
 
 export async function projectJudge(

--- a/apps/grader/src/judge/index.ts
+++ b/apps/grader/src/judge/index.ts
@@ -1,7 +1,9 @@
 import {
   getJudgeConfiguration,
   resolveJudgeKey,
+  resolveModelProviderKeys,
   type AuthContext,
+  type GraderModel,
   type JudgeModel,
   type JudgeProvider,
 } from "@egma/db";
@@ -97,6 +99,44 @@ export type ProjectJudge = {
 };
 
 /**
+ * Which model decides one grader's judgments, and which account pays.
+ *
+ * **Two paths, and which one a grader is on is a fact of its own version.** A
+ * version that carries a `grader_model` selected its provider and model
+ * outright, and the key behind it is the organization's model-provider
+ * credential for that provider — the same store a persona's models spend from,
+ * so one account serves both. A version that carries none is on the
+ * compatibility path: the project's judge configuration decides, exactly as it
+ * did before the model catalog existed, and its `judge_model` may still
+ * override the provider and the model without touching the key.
+ *
+ * The two never mix. A grader with its own selection does not consult the
+ * project's judge at all — so a project that has configured none still judges
+ * with graders that chose for themselves, which is the whole point of the
+ * selection being on the version.
+ */
+export type GraderJudging = {
+  readonly graderModel: GraderModel | null;
+  readonly judgeModel: JudgeModel | null;
+};
+
+/**
+ * One conversation's judges, resolved at most once per source however many
+ * graders ask.
+ *
+ * **Asked per grader, because which source answers is the grader's own fact.**
+ * A conversation judged by one grader that selected its model and one that did
+ * not opens two envelopes, each once — and a conversation with nothing judged
+ * to do opens neither, because resolving a key is beginning to act with it.
+ */
+export type ConversationJudges = {
+  judgeFor(
+    grader: GraderJudging,
+    makers: JudgeMakers,
+  ): Promise<AskableJudge | NoJudge>;
+};
+
+/**
  * The project's judge, asked for rather than handed over.
  *
  * A function rather than a value, and the laziness is the point: **resolving a
@@ -110,14 +150,109 @@ export type ProjectJudge = {
 export type JudgeResolution = () => Promise<ProjectJudge | NoJudge>;
 
 /**
- * The project's judge, resolved at most once however many times it is asked
- * for. The promise is what is remembered rather than its answer, so callers
- * racing each other in a `Promise.all` share one resolution instead of starting
- * two.
+ * The judges one conversation may be judged by, each source resolved at most
+ * once however many graders ask for it.
+ *
+ * The promise is what is remembered rather than its answer, so graders racing
+ * each other in a `Promise.all` share one resolution instead of starting two.
  */
-export function judgeOnce(auth: AuthContext): JudgeResolution {
-  let resolving: Promise<ProjectJudge | NoJudge> | undefined;
-  return () => (resolving ??= projectJudge(auth));
+export function judgesOnce(auth: AuthContext): ConversationJudges {
+  let theProjects: Promise<ProjectJudge | NoJudge> | undefined;
+  const byProvider = new Map<string, Promise<string | NoJudge>>();
+
+  const keyForProvider = (provider: string): Promise<string | NoJudge> => {
+    const held = byProvider.get(provider);
+    if (held !== undefined) return held;
+    const resolving = organizationKeyFor(auth, provider);
+    byProvider.set(provider, resolving);
+    return resolving;
+  };
+
+  return {
+    async judgeFor(
+      grader: GraderJudging,
+      makers: JudgeMakers,
+    ): Promise<AskableJudge | NoJudge> {
+      const selected = grader.graderModel;
+      if (selected === null) {
+        const configured = await (theProjects ??= projectJudge(auth));
+        if (configured instanceof NoJudge) return configured;
+        return configured.judging(grader.judgeModel, makers);
+      }
+
+      const maker = makerFor(selected.provider, makers);
+      if (maker instanceof NoJudge) return maker;
+
+      const key = await keyForProvider(selected.provider);
+      if (key instanceof NoJudge) return key;
+
+      return {
+        ask: maker({
+          provider: selected.provider as JudgeProvider,
+          model: selected.model,
+          key,
+        }),
+      };
+    },
+  };
+}
+
+/**
+ * The organization's own key for one provider, or the sentence a person can
+ * act on.
+ *
+ * **A missing credential is an infrastructure error and never a failed
+ * verdict.** A check that could not be made did not fail: nothing about the
+ * agent was learned, and recording it as a failure would put a red row on a
+ * report for a key somebody has not pasted yet. The sentence names the provider
+ * and where to add it, because that is what the person reading the rationale
+ * has to do next.
+ */
+async function organizationKeyFor(
+  auth: AuthContext,
+  provider: string,
+): Promise<string | NoJudge> {
+  let resolved: Awaited<ReturnType<typeof resolveModelProviderKeys>>;
+  try {
+    resolved = await resolveModelProviderKeys(auth, [provider]);
+  } catch (error) {
+    // The master key is missing, the envelope will not open, or the stored
+    // provider is one Egma no longer ships. Said plainly: this becomes a
+    // rationale a person reads.
+    return new NoJudge(
+      `this grader's ${provider} credential could not be read: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  const key = resolved.keys.get(provider as never);
+  if (key === undefined) {
+    return new NoJudge(
+      `this grader judges with ${provider}, and this organization holds no ${provider} model-provider credential; add one under Model providers in Organization settings.`,
+    );
+  }
+  return key;
+}
+
+/**
+ * The maker for a selected provider, or the sentence saying Egma cannot ask it.
+ *
+ * **Refused rather than quietly answered by another provider.** A grader whose
+ * selection this release cannot execute must say so; falling through to the one
+ * maker that exists would judge a customer's conversation on a model nobody
+ * chose, and the verdict would read as if they had.
+ */
+function makerFor(provider: string, makers: JudgeMakers): JudgeMaker | NoJudge {
+  const known = Object.hasOwn(makers, provider)
+    ? makers[provider as JudgeProvider]
+    : undefined;
+  if (known === undefined) {
+    return new NoJudge(
+      `this grader judges with ${provider}, and this release ships no judge for it; it judges with ${Object.keys(makers).join(", ")}.`,
+    );
+  }
+  return known;
 }
 
 export async function projectJudge(

--- a/apps/grader/src/service.ts
+++ b/apps/grader/src/service.ts
@@ -1,5 +1,6 @@
 import {
   claimGradingJobs,
+  GRADING_CAPABILITIES,
   finishGradingJob,
   recordGradingHeartbeat,
   releaseGradingJob,
@@ -113,6 +114,16 @@ export function startService(options: ServiceOptions): Service {
           capacity: config.capacity,
           leaseSeconds: config.leaseSeconds,
           idleSeconds: config.traceIdleSeconds,
+          // What this binary understands, declared on every claim.
+          //
+          // **This is what keeps a rolling deploy honest.** A grader version
+          // that selects its own model is judged with the organization's
+          // credential for that provider; a binary that could not read the
+          // field would judge it through the project's judge configuration
+          // instead — a different model, on a different account, with verdicts
+          // to show for it. Declaring what this one can read is what stops the
+          // queue offering it that work at all.
+          capabilities: [...GRADING_CAPABILITIES],
         });
       } catch (error) {
         // The control plane is unreachable or refused. Say so once and wait;

--- a/apps/grader/test/grader-model.test.ts
+++ b/apps/grader/test/grader-model.test.ts
@@ -1,5 +1,7 @@
 import {
+  claimGradingJobs,
   getGrader,
+  GRADING_CAPABILITIES,
   readVerdicts,
   removeModelProviderCredential,
   storeModelProviderCredential,
@@ -78,6 +80,77 @@ beforeAll(async () => {
 afterAll(async () => {
   await service.stop();
   await world.drop();
+});
+
+/**
+ * A grader binary built before grader models existed, and the work it is and is
+ * not offered.
+ *
+ * **The failure this guards against is silent and it produces verdicts.** Such
+ * a binary reads no `grader_model`, so it would judge a grader that selected
+ * its own model through the project's judge configuration instead — a different
+ * model, on a different account nobody chose, with a green report to show for
+ * it. So the queue does not offer it that work at all, exactly as the
+ * simulation queue does not offer a version-1 worker a row needing a version-2
+ * document.
+ *
+ * Both directions are asserted, because only one of them is the interesting
+ * one: an old binary must be turned away, *and* must still drain everything it
+ * was always able to judge. A guard that starved it would be a rollout that
+ * stops grading rather than one that grades wrongly, which is better and still
+ * wrong.
+ *
+ * **This half runs first, and the order is the arrangement.** It needs a
+ * project in which nothing has selected its own model, and that is what this
+ * world is until the cases below seed one — so the honest way to have one is to
+ * ask before they do rather than to build a second world beside this one.
+ */
+describe("a grader binary that cannot read a grader's own model", () => {
+  /** A claim as an old binary makes one: it declares nothing, because it had nothing to declare. */
+  function anOldBinary(claimant: string) {
+    return claimGradingJobs({ claimant, capacity: 5 });
+  }
+
+  /** A claim as this release's binary makes one. */
+  function thisRelease(claimant: string) {
+    return claimGradingJobs({
+      claimant,
+      capacity: 5,
+      capabilities: [...GRADING_CAPABILITIES],
+    });
+  }
+
+  it("still drains the work it was always able to judge", async () => {
+    // Every copy in this project is on the compatibility path so far, which is
+    // exactly what an old binary understands.
+    const testId = await seedTest(world, [BEHAVIOR]);
+    await conductSimulation(world, { testId, spans: aConversation() });
+
+    const taken = await anOldBinary("grader-before-models");
+    expect(taken.length).toBeGreaterThan(0);
+    expect(taken.every((job) => job.projectId === world.projectId)).toBe(true);
+  });
+
+  it("is offered no conversation whose project holds one, and one that can takes it", async () => {
+    await seedGrader(
+      world,
+      aJudgedCopy({
+        name: "Judged by a model this grader chose",
+        graderModel: { provider: "openai", model: "gpt-4o" },
+      }),
+    );
+
+    const testId = await seedTest(world, [BEHAVIOR]);
+    await conductSimulation(world, { testId, spans: aConversation() });
+
+    // The old binary sees an empty queue rather than work it would judge on an
+    // account nobody chose.
+    expect(await anOldBinary("grader-before-models-2")).toEqual([]);
+
+    // And the upgraded binary standing beside it takes exactly that work.
+    const taken = await thisRelease("grader-this-release");
+    expect(taken.length).toBeGreaterThan(0);
+  });
 });
 
 describe("a grader that selected its own model", () => {

--- a/apps/grader/test/grader-model.test.ts
+++ b/apps/grader/test/grader-model.test.ts
@@ -1,0 +1,295 @@
+import {
+  getGrader,
+  readVerdicts,
+  removeModelProviderCredential,
+  storeModelProviderCredential,
+  type AuthContext,
+  type RecordedVerdict,
+} from "@egma/db";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  aConversation,
+  aJudgedCopy,
+  conductSimulation,
+  eventually,
+  makeWorld,
+  oneServiceAtATime,
+  seedGrader,
+  seedJudge,
+  seedTest,
+  type World,
+} from "./support/world.ts";
+import { met, scriptedJudge } from "./support/scripted-judge.ts";
+import { judgesOnce, NoJudge } from "../src/judge/index.ts";
+
+/**
+ * A grader that selects its own model, and the account it spends from.
+ *
+ * **The claim under test is which of two sources answers**, so every case sets
+ * both at once: a project judge with one key, and an organization credential
+ * with another. A test that set only one would pass against a grader that read
+ * neither.
+ *
+ * The key itself is not a field anything outside `src/judge/` can read, so it
+ * is observed where it is actually spent — at the provider seam the scripted
+ * maker stands in for — and its absence is observed everywhere a person can
+ * read: the rationale, the verdict rows, and the service's own log.
+ */
+
+let world: World;
+const service = oneServiceAtATime();
+
+const BEHAVIOR = "confirms the new time back before finishing";
+
+/** Sentinels, so a leak anywhere is a string a scan can find. */
+const THE_ORGANIZATIONS_KEY = "sk-sentinel-organization-openai-K7L8";
+const THE_PROJECTS_JUDGE_KEY = "sk-sentinel-project-judge-M9N0";
+
+/** What a grading claim resolves to, as the queue builds it. */
+function theEngine(): AuthContext {
+  return {
+    userId: "engine",
+    organizationId: world.organizationId,
+    projectId: world.projectId,
+    role: "viewer",
+    via: "engine",
+  };
+}
+
+async function rowsFor(
+  graderId: string,
+  verdicts: readonly RecordedVerdict[],
+): Promise<readonly RecordedVerdict[]> {
+  return verdicts.filter((verdict) => verdict.graderId === graderId);
+}
+
+beforeAll(async () => {
+  world = await makeWorld("grader_model");
+  // Both sources, deliberately, and with different keys. Which one reaches the
+  // provider is the whole question this file asks.
+  await seedJudge(world, { model: "gpt-4.1-mini", key: THE_PROJECTS_JUDGE_KEY });
+  await storeModelProviderCredential(world.adminAuth, {
+    provider: "openai",
+    key: THE_ORGANIZATIONS_KEY,
+  });
+});
+
+afterAll(async () => {
+  await service.stop();
+  await world.drop();
+});
+
+describe("a grader that selected its own model", () => {
+  it("judges with it, and spends the organization's credential rather than the project's", async () => {
+    const graderId = await seedGrader(
+      world,
+      aJudgedCopy({
+        name: "Judged by a model this grader chose",
+        graderModel: { provider: "openai", model: "gpt-4o" },
+      }),
+    );
+
+    const grader = await getGrader(world.auth, graderId);
+    const judge = scriptedJudge({ answers: {} });
+    const resolved = await judgesOnce(theEngine()).judgeFor(
+      {
+        graderModel: grader?.graderModel ?? null,
+        judgeModel: grader?.judgeModel ?? null,
+      },
+      judge.makers,
+    );
+
+    expect(resolved).not.toBeInstanceOf(NoJudge);
+    expect(judge.configured.at(-1)).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+      // Asserted present on purpose: "it spends the organization's account"
+      // means nothing if no key was resolved at all.
+      key: THE_ORGANIZATIONS_KEY,
+    });
+  });
+
+  it("never consults the project's judge, so a project with none still judges", async () => {
+    const graderId = await seedGrader(
+      world,
+      aJudgedCopy({
+        name: "Judged without any project judge behind it",
+        graderModel: { provider: "openai", model: "gpt-4o-mini" },
+      }),
+    );
+    const grader = await getGrader(world.auth, graderId);
+
+    // The project's judge row is taken away underneath it. A grader that chose
+    // for itself has no business caring, and this is what says so. Raw SQL
+    // because no product verb removes a judge — which is exactly why this
+    // state is reached by an upgrade or an operator rather than by a form.
+    await world.database.sql(
+      "delete from judge_configuration where project_id = $1",
+      [world.projectId],
+    );
+
+    try {
+      const judge = scriptedJudge({ answers: {} });
+      const resolved = await judgesOnce(theEngine()).judgeFor(
+        {
+          graderModel: grader?.graderModel ?? null,
+          judgeModel: grader?.judgeModel ?? null,
+        },
+        judge.makers,
+      );
+
+      expect(resolved).not.toBeInstanceOf(NoJudge);
+      expect(judge.configured.at(-1)?.key).toBe(THE_ORGANIZATIONS_KEY);
+    } finally {
+      // Put it back through the product's own door, so the rest of this file
+      // and anything added after it start from the world they expect.
+      await seedJudge(world, {
+        model: "gpt-4.1-mini",
+        key: THE_PROJECTS_JUDGE_KEY,
+      });
+    }
+  });
+});
+
+describe("a grader still on the compatibility path", () => {
+  it("is judged by the project's setting, with the project's key, exactly as before", async () => {
+    const graderId = await seedGrader(
+      world,
+      aJudgedCopy({ name: "Judged the way it always was" }),
+    );
+
+    const grader = await getGrader(world.auth, graderId);
+    expect(grader?.graderModel).toBeNull();
+
+    const judge = scriptedJudge({ answers: {} });
+    await judgesOnce(theEngine()).judgeFor(
+      {
+        graderModel: grader?.graderModel ?? null,
+        judgeModel: grader?.judgeModel ?? null,
+      },
+      judge.makers,
+    );
+
+    expect(judge.configured.at(-1)).toEqual({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      key: THE_PROJECTS_JUDGE_KEY,
+    });
+  });
+
+  it("keeps its own judge-model override, which names no key", async () => {
+    const graderId = await seedGrader(
+      world,
+      aJudgedCopy({
+        name: "A second opinion, on a stronger model",
+        judgeModel: { provider: "openai", model: "gpt-4.1" },
+      }),
+    );
+
+    const grader = await getGrader(world.auth, graderId);
+    const judge = scriptedJudge({ answers: {} });
+    await judgesOnce(theEngine()).judgeFor(
+      {
+        graderModel: grader?.graderModel ?? null,
+        judgeModel: grader?.judgeModel ?? null,
+      },
+      judge.makers,
+    );
+
+    // The model is the grader's and the key is still the project's, which is
+    // the whole of what an override does and does not do.
+    expect(judge.configured.at(-1)).toEqual({
+      provider: "openai",
+      model: "gpt-4.1",
+      key: THE_PROJECTS_JUDGE_KEY,
+    });
+  });
+});
+
+describe("a credential the organization does not hold", () => {
+  it("errors the behaviors, names the provider, and says where to add it", async () => {
+    await service.judgingWith({ [BEHAVIOR]: met("confirmed") });
+
+    const graderId = await seedGrader(
+      world,
+      aJudgedCopy({
+        name: "Judged after the key went away",
+        graderModel: { provider: "openai", model: "gpt-4o" },
+      }),
+    );
+
+    // The key is taken away between the grader being authored and the
+    // conversation being judged, which is the state a removal actually leaves.
+    // The project's own judge is still configured and still holds a different
+    // key, so anything that silently fell back to it would go green here.
+    await removeModelProviderCredential(world.adminAuth, "openai");
+
+    const testId = await seedTest(world, [BEHAVIOR]);
+    const { simulationId } = await conductSimulation(world, {
+      testId,
+      spans: aConversation(),
+    });
+
+    const rows = await eventually("the behaviors to be errored", async () => {
+      const read = await readVerdicts(world.auth, simulationId);
+      const mine = await rowsFor(graderId, read.verdicts);
+      return mine.length > 0 ? mine : undefined;
+    });
+
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      // `errored`, deliberately not `failed`: a check egma could not make did
+      // not fail, and a red row on a report for a key nobody pasted is the
+      // exact false trust this product exists to kill.
+      expect(row.verdict).toBe("errored");
+      expect(row.rationale).toContain("openai");
+      expect(row.rationale).toContain("Model providers");
+      // And nothing a key could be read out of, in a sentence a person reads.
+      expect(row.rationale).not.toContain(THE_ORGANIZATIONS_KEY);
+      expect(row.rationale).not.toContain(THE_PROJECTS_JUDGE_KEY);
+    }
+
+    // No silent fallback: this grader judged nothing at all rather than being
+    // decided by the project's account, which the errored rows above would
+    // have been `passed` under.
+    expect(rows.every((row) => row.verdict === "errored")).toBe(true);
+
+    await service.stop();
+
+    // Put it back, so the ordering of this file is not a trap for the next
+    // case somebody adds.
+    await storeModelProviderCredential(world.adminAuth, {
+      provider: "openai",
+      key: THE_ORGANIZATIONS_KEY,
+    });
+  });
+
+  it("is a refusal the resolver gives before anything is asked", async () => {
+    await removeModelProviderCredential(world.adminAuth, "openai");
+
+    try {
+      const judge = scriptedJudge({ answers: {} });
+      const resolved = await judgesOnce(theEngine()).judgeFor(
+        {
+          graderModel: { provider: "openai", model: "gpt-4o" },
+          judgeModel: null,
+        },
+        judge.makers,
+      );
+
+      expect(resolved).toBeInstanceOf(NoJudge);
+      expect(String((resolved as NoJudge).message)).toContain(
+        "Model providers",
+      );
+      // Nothing was configured at the provider seam, which is what "before
+      // anything is asked" means: resolving a key is beginning to act with it.
+      expect(judge.configured).toEqual([]);
+    } finally {
+      await storeModelProviderCredential(world.adminAuth, {
+        provider: "openai",
+        key: THE_ORGANIZATIONS_KEY,
+      });
+    }
+  });
+});

--- a/apps/grader/test/one-grader.test.ts
+++ b/apps/grader/test/one-grader.test.ts
@@ -70,6 +70,7 @@ function grader(overrides: Partial<Grader> = {}): Grader {
     versionId: "grv_01JQZ0000000000000000000AA",
     config: { assertions: [{ metric: "turn_response_latency", bound: 2_000 }] },
     judgeModel: null,
+    graderModel: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/apps/grader/test/support/scripted-judge.ts
+++ b/apps/grader/test/support/scripted-judge.ts
@@ -1,12 +1,12 @@
-import type { JudgeModel } from "@egma/db";
+import type { GraderModel, JudgeModel } from "@egma/db";
 
 import type { Judging } from "../../src/graders/index.ts";
 import type {
+  ConversationJudges,
   Judge,
   JudgeAnswer,
   JudgeMakers,
   JudgeQuestion,
-  JudgeResolution,
   ResolvedJudge,
 } from "../../src/judge/index.ts";
 
@@ -86,27 +86,46 @@ export function scriptedJudge(options: ScriptedJudgeOptions): ScriptedJudge {
  * question and the answer became this row" is testable without a database.
  */
 export function scriptedJudging(
-  options: ScriptedJudgeOptions & { readonly model?: JudgeModel | undefined },
+  options: ScriptedJudgeOptions & {
+    /** A judge-model override, which names no key: the compatibility path. */
+    readonly model?: JudgeModel | undefined;
+    /** This copy's own selection, which resolves the organization's key. */
+    readonly graderModel?: GraderModel | undefined;
+  },
 ): { readonly judging: Judging; readonly judge: ScriptedJudge } {
   const judge = scriptedJudge(options);
 
-  const resolution: JudgeResolution = async () => ({
-    judging(override, makers) {
+  /**
+   * The resolution, standing in for both sources at once.
+   *
+   * Which of them a real grader is on is decided by its own version — a
+   * selected model spends the organization's credential, and one without spends
+   * the project's — and that decision has its own tests through the real
+   * service. What is stood in for here is only the key, so that "this rubric
+   * asked one question and the answer became this row" is testable without a
+   * database.
+   */
+  const judges: ConversationJudges = {
+    async judgeFor(grader, makers) {
+      const chosen = grader.graderModel ?? grader.judgeModel;
       const resolved: ResolvedJudge = {
-        provider: override?.provider ?? "openai",
-        model: override?.model ?? "gpt-4.1-mini",
+        provider: (chosen?.provider ?? "openai") as ResolvedJudge["provider"],
+        model: chosen?.model ?? "gpt-4.1-mini",
         key: "sk-egma-unit-judge-NEVERLEAKME",
       };
       return { ask: makers[resolved.provider](resolved) };
     },
-  });
+  };
 
   return {
     judge,
     judging: {
-      judge: resolution,
+      judges,
       makers: judge.makers,
-      model: options.model ?? null,
+      grader: {
+        graderModel: options.graderModel ?? null,
+        judgeModel: options.model ?? null,
+      },
     },
   };
 }
@@ -123,7 +142,11 @@ export function noJudgeWanted(): Judging {
   const refuse = (): never => {
     throw new Error("a deterministic grader reached for a judge");
   };
-  return { judge: refuse, makers: { openai: refuse }, model: null };
+  return {
+    judges: { judgeFor: refuse },
+    makers: { openai: refuse },
+    grader: { graderModel: null, judgeModel: null },
+  };
 }
 
 /** An answer in one line, for the ordinary case. */

--- a/apps/simulator/src/egma_simulator/client.py
+++ b/apps/simulator/src/egma_simulator/client.py
@@ -25,6 +25,8 @@ import logging
 
 import aiohttp
 
+from .contract import SUPPORTED_SPEC_VERSIONS
+
 logger = logging.getLogger(__name__)
 
 # What "the call did not get through" is actually made of. `TimeoutError` is
@@ -116,7 +118,16 @@ class ControlPlaneClient:
         return self._session
 
     async def claim(self, claimant: str, capacity: int) -> list[dict]:
-        """Ask for up to ``capacity`` specs; an empty list is a quiet queue."""
+        """Ask for up to ``capacity`` specs; an empty list is a quiet queue.
+
+        **Every claim declares which contract versions this simulator
+        implements**, and that declaration is what keeps a mixed rollout
+        safe with no drain step. A simulation whose persona selects its own
+        models can only be conducted from a version-2 document, so a
+        simulator that speaks only version 1 is never offered that row at
+        all — it is left for the upgraded simulator beside it. Nothing is
+        stranded and nothing arrives here that this process could not read.
+        """
         try:
             async with self._live_session().post(
                 f"{self._base_url}/v1/claims",
@@ -124,6 +135,7 @@ class ControlPlaneClient:
                     "claimant": claimant,
                     "capacity": capacity,
                     "wait_seconds": self._claim_wait_seconds,
+                    "contract_versions": list(SUPPORTED_SPEC_VERSIONS),
                 },
                 timeout=self._claim_timeout,
             ) as response:

--- a/apps/simulator/src/egma_simulator/contract.py
+++ b/apps/simulator/src/egma_simulator/contract.py
@@ -117,52 +117,71 @@ SCHEMA_OF = {
 
 
 @cache
-def validator(direction: str) -> Draft202012Validator:
-    """The compiled validator for one direction, built once per process.
+def _compiled(filename: str) -> Draft202012Validator:
+    """One schema file, compiled once per process.
 
-    Compiling is part of the guarantee: a schema that is not valid
-    2020-12 fails here, at import of the first document, rather than
-    quietly accepting everything.
+    Compiling is part of the guarantee: a schema that is not valid 2020-12
+    fails here, at the first document, rather than quietly accepting
+    everything.
+
+    Keyed by the filename rather than by a direction, because the spec
+    direction has more than one of them and a cache keyed by direction
+    would hand a version-2 document the version-1 validator.
+    """
+    schema = _load_schema(filename)
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def validator(direction: str) -> Draft202012Validator:
+    """The compiled validator for one direction.
 
     ``spec`` names version 1, which is what every reader that predates a
-    second version means by it. ``spec_validator`` below takes the version
-    it wants.
+    second version means by it. :func:`spec_validator` takes the version it
+    wants.
     """
-    schema = _load_schema(SCHEMA_OF[direction])
-    Draft202012Validator.check_schema(schema)
-    return Draft202012Validator(schema, format_checker=FormatChecker())
+    return _compiled(SCHEMA_OF[direction])
 
 
-@cache
-def _spec_validator_for(version: int) -> Draft202012Validator:
-    schema = _load_schema(SPEC_SCHEMA_FILENAMES[version])
-    Draft202012Validator.check_schema(schema)
-    return Draft202012Validator(schema, format_checker=FormatChecker())
+def _unknown_version(version: object) -> ContractViolation:
+    """The refusal a version this simulator does not implement earns.
+
+    Written once, because it is raised from two places — asking for a
+    validator, and validating a document — and two spellings of one refusal
+    is one of them going stale the day a third version ships.
+    """
+    return ContractViolation(
+        "spec",
+        [
+            "/contract_version: must be one of "
+            + ", ".join(str(known) for known in SUPPORTED_SPEC_VERSIONS)
+            + f", and this document says {version!r}"
+        ],
+    )
 
 
 def spec_validator(version: int = 1) -> Draft202012Validator:
     """The compiled spec validator for one contract version."""
     if version not in SPEC_SCHEMA_FILENAMES:
-        raise ContractViolation(
-            "spec",
-            [
-                f"/contract_version: must be one of "
-                f"{', '.join(str(known) for known in SUPPORTED_SPEC_VERSIONS)}, "
-                f"and this document says {version!r}"
-            ],
-        )
-    return _spec_validator_for(version)
+        raise _unknown_version(version)
+    return _compiled(SPEC_SCHEMA_FILENAMES[version])
 
 
 def report_validator() -> Draft202012Validator:
     return validator("report")
 
 
-def _flatten_complaints(errors) -> list[str]:
+def _complaints_from(errors) -> list[str]:
+    """Every complaint a validator had, flattened.
+
+    A ``oneOf`` reports each branch's own complaints as context rather than
+    at the top, so a reader given only the outer error is told "does not
+    match any branch" and nothing about which field was wrong.
+    """
     flat: list[str] = []
     for error in errors:
         if error.context:
-            flat.extend(_flatten_complaints(error.context))
+            flat.extend(_complaints_from(error.context))
         else:
             place = "".join(f"/{part}" for part in error.absolute_path)
             flat.append(f"{place}: {error.message}")
@@ -170,17 +189,7 @@ def _flatten_complaints(errors) -> list[str]:
 
 
 def _complaints(direction: str, document: object) -> list[str]:
-    def flatten(errors) -> list[str]:
-        flat: list[str] = []
-        for error in errors:
-            if error.context:
-                flat.extend(flatten(error.context))
-            else:
-                place = "".join(f"/{part}" for part in error.absolute_path)
-                flat.append(f"{place}: {error.message}")
-        return flat
-
-    return flatten(validator(direction).iter_errors(document))
+    return _complaints_from(validator(direction).iter_errors(document))
 
 
 def validate(direction: str, document: object) -> None:
@@ -209,18 +218,9 @@ def validate_spec(document: object) -> None:
     """
     version = spec_version_of(document)
     if version not in SPEC_SCHEMA_FILENAMES:
-        raise ContractViolation(
-            "spec",
-            [
-                f"/contract_version: must be one of "
-                f"{', '.join(str(known) for known in SUPPORTED_SPEC_VERSIONS)}, "
-                f"and this document says {version!r}"
-            ],
-        )
+        raise _unknown_version(version)
 
-    complaints = _flatten_complaints(
-        spec_validator(version).iter_errors(document)
-    )
+    complaints = _complaints_from(spec_validator(version).iter_errors(document))
     if complaints:
         raise ContractViolation("spec", complaints)
 

--- a/apps/simulator/src/egma_simulator/contract.py
+++ b/apps/simulator/src/egma_simulator/contract.py
@@ -28,6 +28,28 @@ CONTRACT_DIR_ENV = "EGMA_SIMULATION_CONTRACT_DIR"
 SPEC_SCHEMA_FILENAME = "simulation-spec.v1.schema.json"
 REPORT_SCHEMA_FILENAME = "simulation-report.v1.schema.json"
 
+SPEC_SCHEMA_FILENAMES = {
+    1: "simulation-spec.v1.schema.json",
+    2: "simulation-spec.v2.schema.json",
+}
+"""The spec schema for each contract version this simulator implements."""
+
+SUPPORTED_SPEC_VERSIONS = tuple(sorted(SPEC_SCHEMA_FILENAMES))
+"""Which spec versions this simulator will conduct, oldest first.
+
+**Advertised on every claim**, so the control plane hands this process the
+newest document both sides speak and never one it cannot read. That is what
+makes a mixed rollout safe without a drain step: an old simulator says ``1``
+and keeps receiving version-1 work while a new one beside it says ``1, 2``
+and receives version 2.
+
+A version outside this tuple is refused **by its version**, before any
+schema is consulted. Refusing loudly is the whole point: a document read
+against a contract it never claimed to speak would have its unknown blocks
+quietly dropped, and this process would conduct a simulation with its own
+model settings while the control plane believed it had sent the persona's.
+"""
+
 # The endings a failed simulation may carry, spelled here because this is
 # where the contract's vocabulary lives — the schema is the authority and
 # this module is the one that reads it. Naming them once means the code
@@ -101,18 +123,50 @@ def validator(direction: str) -> Draft202012Validator:
     Compiling is part of the guarantee: a schema that is not valid
     2020-12 fails here, at import of the first document, rather than
     quietly accepting everything.
+
+    ``spec`` names version 1, which is what every reader that predates a
+    second version means by it. ``spec_validator`` below takes the version
+    it wants.
     """
     schema = _load_schema(SCHEMA_OF[direction])
     Draft202012Validator.check_schema(schema)
     return Draft202012Validator(schema, format_checker=FormatChecker())
 
 
-def spec_validator() -> Draft202012Validator:
-    return validator("spec")
+@cache
+def _spec_validator_for(version: int) -> Draft202012Validator:
+    schema = _load_schema(SPEC_SCHEMA_FILENAMES[version])
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def spec_validator(version: int = 1) -> Draft202012Validator:
+    """The compiled spec validator for one contract version."""
+    if version not in SPEC_SCHEMA_FILENAMES:
+        raise ContractViolation(
+            "spec",
+            [
+                f"/contract_version: must be one of "
+                f"{', '.join(str(known) for known in SUPPORTED_SPEC_VERSIONS)}, "
+                f"and this document says {version!r}"
+            ],
+        )
+    return _spec_validator_for(version)
 
 
 def report_validator() -> Draft202012Validator:
     return validator("report")
+
+
+def _flatten_complaints(errors) -> list[str]:
+    flat: list[str] = []
+    for error in errors:
+        if error.context:
+            flat.extend(_flatten_complaints(error.context))
+        else:
+            place = "".join(f"/{part}" for part in error.absolute_path)
+            flat.append(f"{place}: {error.message}")
+    return flat
 
 
 def _complaints(direction: str, document: object) -> list[str]:
@@ -136,9 +190,39 @@ def validate(direction: str, document: object) -> None:
         raise ContractViolation(direction, complaints)
 
 
+def spec_version_of(document: object) -> object:
+    """The version a claimed document says it speaks, whatever else is wrong."""
+    if not isinstance(document, dict):
+        return None
+    return document.get("contract_version")
+
+
 def validate_spec(document: object) -> None:
-    """Refuse a claimed spec that does not speak the contract."""
-    validate("spec", document)
+    """Refuse a claimed spec that does not speak the contract.
+
+    The version is read first and refused on its own terms. A document
+    whose version this simulator does not implement is refused **by that
+    version**, before any schema sees it: checking it against a contract it
+    never claimed to speak would drop every block this process does not
+    know about, and conducting a simulation with silently dropped model
+    selections is worse than refusing to conduct it at all.
+    """
+    version = spec_version_of(document)
+    if version not in SPEC_SCHEMA_FILENAMES:
+        raise ContractViolation(
+            "spec",
+            [
+                f"/contract_version: must be one of "
+                f"{', '.join(str(known) for known in SUPPORTED_SPEC_VERSIONS)}, "
+                f"and this document says {version!r}"
+            ],
+        )
+
+    complaints = _flatten_complaints(
+        spec_validator(version).iter_errors(document)
+    )
+    if complaints:
+        raise ContractViolation("spec", complaints)
 
 
 def validate_report(document: object) -> None:

--- a/apps/simulator/src/egma_simulator/model.py
+++ b/apps/simulator/src/egma_simulator/model.py
@@ -32,7 +32,7 @@ from .config import MODEL_PROVIDERS
 
 if TYPE_CHECKING:
     from .config import SimulatorConfig
-    from .spec import SimulationSpec
+    from .spec import SelectedModels, SimulationSpec
 
 CONCLUDE_MARKER = "[CONCLUDED]"
 """How a model says the persona is done, per the system prompt's instruction.
@@ -178,6 +178,46 @@ class OpenAICompatibleModel:
             self._session = None
 
 
+def _selected_model_client(
+    config: SimulatorConfig, spec: SimulationSpec, selected: SelectedModels
+) -> ModelClient:
+    """The client for a persona that chose its own brain.
+
+    **Refused rather than quietly downgraded to the stand-in**, on the
+    platform path's exact terms one function down: a provider this
+    simulator holds no client for must not produce a completed, green
+    simulation conducted by a canned robot. That is worse than a failure,
+    because a failure tells the truth about what happened.
+    """
+    provider = selected.llm.provider
+    if provider not in MODEL_PROVIDERS:
+        raise ModelFailure(
+            f"this persona thinks with {provider!r}, which is not a model "
+            "client this simulator has; it thinks with "
+            f"{', '.join(MODEL_PROVIDERS)}"
+        )
+    if provider != "openai":
+        return ScriptedModel(spec.scenario_instructions)
+
+    if selected.llm.key is None:
+        raise ModelFailure(
+            f"this persona thinks with {provider}, and the work order carried "
+            "no key for it"
+        )
+    return OpenAICompatibleModel(
+        # The base URL stays this container's, exactly as it does below: it
+        # says which address this simulator reaches a provider at, which is
+        # a property of the network it is on rather than of the persona.
+        base_url=config.model_base_url,
+        api_key=selected.llm.key,
+        model_name=selected.llm.model,
+        # **Not carried by a selection, and deliberately.** Reasoning effort
+        # is a legacy deployment setting rather than part of what a persona
+        # is; a persona that selected its own models uses its provider's
+        # default reasoning behavior.
+    )
+
+
 def build_model_client(
     config: SimulatorConfig, spec: SimulationSpec
 ) -> ModelClient:
@@ -187,15 +227,27 @@ def build_model_client(
     makes two different specs conduct two different exchanges with no code
     change; the OpenAI-compatible client is configuration alone.
 
-    **The platform's own settings win over this container's.** They arrive
-    on the work order, they are read afresh for every simulation, and each
-    of the four replaces this container's answer on its own — so a
-    deployment that has configured the persona's model centrally needs no
-    model variables on any simulator, and a replaced key applies to the
-    next simulation with no restart. A setting the platform does not hold
-    leaves this container's own value standing, which is what makes a
-    deployment that has configured nothing behave exactly as it did.
+    **The persona's own selection wins outright, where it made one.** It
+    is what the run pinned, so a deployment setting quietly overriding it
+    would make a simulation's brain depend on which machine conducted it,
+    and two runs of one pinned version would stop being comparable. The key
+    comes from the selection and from nowhere else: falling back to this
+    container's key for a provider the persona named would spend from an
+    account nobody in that organization chose.
+
+    **Below that, the platform's own settings win over this container's.**
+    They arrive on the work order, they are read afresh for every
+    simulation, and each of the four replaces this container's answer on
+    its own — so a deployment that has configured the persona's model
+    centrally needs no model variables on any simulator, and a replaced key
+    applies to the next simulation with no restart. A setting the platform
+    does not hold leaves this container's own value standing, which is what
+    makes a deployment that has configured nothing behave exactly as it did.
     """
+    selected = spec.models
+    if selected is not None:
+        return _selected_model_client(config, spec, selected)
+
     said = spec.platform.model
     provider = said.provider or config.model_provider
     if provider not in MODEL_PROVIDERS:

--- a/apps/simulator/src/egma_simulator/pipeline.py
+++ b/apps/simulator/src/egma_simulator/pipeline.py
@@ -32,7 +32,7 @@ from .mock_tools import ExchangedToolCall, MockToolSeam
 from .plugs import DuplexLine, PlatformPlug, PlugError, plug_for
 from .recording import RECORDING_NAME
 from .spec import SimulationSpec
-from .speech import SCRIPTED_PAIR, SpeechProviders, voice_from_traits
+from .speech import SCRIPTED_PAIR, SpeechProviders, voice_for_simulation
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +134,7 @@ def assemble(
     return Assembled(
         conductor=VoiceConductor(
             line=plug,
-            voice=voice_from_traits(spec.persona_traits),
+            voice=voice_for_simulation(spec.persona_traits, spec.models),
             speech=speech,
             blobs=blobs,
             recording_key=f"{spec.simulation_id}/{RECORDING_NAME}",

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -266,7 +266,9 @@ class RunningSimulation:
                 # simulation with nothing restarted, and what lets a second
                 # simulator on another machine hold no settings at all.
                 speech=SpeechProviders.for_simulation(
-                    self._config, self._spec.platform.speech
+                    self._config,
+                    self._spec.platform.speech,
+                    self._spec.models,
                 ),
                 media=MediaSettings.for_simulation(
                     self._config.media, self._spec.platform.carrier
@@ -694,13 +696,16 @@ class SimulatorService:
                 )
                 continue
 
-            # The connection's credentials and the platform's own keys, both
-            # registered before anything is conducted with either. A key that
-            # arrived on a work order is exactly as much a secret as one that
-            # arrived in this container's environment, and the filter that
-            # keeps it out of the log has to know about it either way.
+            # The connection's credentials, the platform's own keys and the
+            # persona's selected ones, all registered before anything is
+            # conducted with any of them. A key that arrived on a work order is
+            # exactly as much a secret as one that arrived in this container's
+            # environment, and the filter that keeps it out of the log has to
+            # know about it either way.
             self._secrets.register(spec.credentials)
             self._secrets.register(list(spec.platform.secrets))
+            if spec.models is not None:
+                self._secrets.register(list(spec.models.secrets))
             executor.submit(spec)
 
     async def _conduct_one(

--- a/apps/simulator/src/egma_simulator/spec.py
+++ b/apps/simulator/src/egma_simulator/spec.py
@@ -205,6 +205,109 @@ class PlatformSettings:
 
 
 @dataclass(frozen=True)
+class ModelSelection:
+    """One model job's pinned selection, off the work order.
+
+    Provider and model come from the persona version the run pinned, so two
+    simulations of one version ask the same provider for the same model
+    however the organization's credentials have moved since. The key is
+    resolved when the claim is prepared, so a replaced one reaches the
+    next simulation with nothing restarted.
+    """
+
+    provider: str
+    model: str
+    key: str | None = field(default=None, repr=False)
+    """The provider key, or ``None`` under managed access — where Egma's
+    own credential never leaves the Egma model gateway and this process is
+    never handed one.
+
+    Kept out of the dataclass repr, like every other key in this process:
+    a log line carrying one is a log line that should not have."""
+
+
+@dataclass(frozen=True)
+class SpeechSelection(ModelSelection):
+    """The speaking job's selection, which carries two more facts.
+
+    Which of the provider's voices, and how fast the persona talks. Both
+    are the persona version's own, so the same persona sounds identical on
+    every simulation of that version — where a described speed would have
+    to be interpreted and two runs could interpret it differently.
+    """
+
+    voice_id: str = ""
+    speed: float = 1.0
+
+
+@dataclass(frozen=True)
+class SelectedModels:
+    """What this simulation's persona thinks, listens and speaks with.
+
+    **Present only on a version-2 work order**, and its presence is what
+    says the persona chose for itself. A simulation whose persona has made
+    no selections arrives on version 1 with no block at all, and the
+    deployment's own settings decide exactly as they always did — which is
+    how every persona authored before the model catalog existed keeps
+    running.
+
+    ``access`` says who supplies the credentials. It rides here because it
+    is what says where the keys came from; nothing in this process chooses
+    it, and a simulator never sees the organization that did.
+    """
+
+    access: str
+    llm: ModelSelection
+    stt: ModelSelection
+    tts: SpeechSelection
+
+    @property
+    def secrets(self) -> tuple[str, ...]:
+        """Every key this block holds, for redaction.
+
+        One place to ask, exactly as the platform settings' own has, so a
+        fourth key arriving cannot fall out of the scrubbing.
+        """
+        return tuple(
+            secret
+            for secret in (self.llm.key, self.stt.key, self.tts.key)
+            if secret is not None
+        )
+
+    @classmethod
+    def from_document(cls, written: Any) -> SelectedModels | None:
+        """The models block of a validated spec, or ``None`` where it has none.
+
+        The schema has already refused a block that is not this shape, so
+        the reads below take what is there at face value — the same bargain
+        the rest of this module makes.
+        """
+        if not written:
+            return None
+        tts = written["tts"]
+        return cls(
+            access=written["access"],
+            llm=_selection(written["llm"]),
+            stt=_selection(written["stt"]),
+            tts=SpeechSelection(
+                provider=tts["provider"],
+                model=tts["model"],
+                key=tts.get("key"),
+                voice_id=tts["voice_id"],
+                speed=float(tts["speed"]),
+            ),
+        )
+
+
+def _selection(written: Any) -> ModelSelection:
+    return ModelSelection(
+        provider=written["provider"],
+        model=written["model"],
+        key=written.get("key"),
+    )
+
+
+@dataclass(frozen=True)
 class Limits:
     """The walls around one simulation, from the spec that claimed it.
 
@@ -256,6 +359,20 @@ class SimulationSpec:
     unobserved.
     """
 
+    models: SelectedModels | None = None
+    """What this simulation's persona thinks, listens and speaks with.
+
+    ``None`` is an ordinary state and means the persona made no selections
+    — every one authored before the model catalog existed, arriving on a
+    version-1 work order. The deployment's own settings then decide,
+    exactly as they always did.
+
+    **Where it is present it wins outright**, over the platform's settings
+    and over this container's alike. It is what the run pinned, and a
+    deployment setting quietly overriding a pinned selection would make a
+    simulation's models depend on which machine conducted it.
+    """
+
     platform: PlatformSettings = field(default_factory=PlatformSettings)
     """What the deployment has been configured with — its persona's model,
     its speech legs, its carrier — read afresh for this simulation.
@@ -280,6 +397,7 @@ class SimulationSpec:
         return cls(
             mock_tools=_mock_tools(document.get("mock_tools") or []),
             platform=PlatformSettings.from_document(document.get("platform")),
+            models=SelectedModels.from_document(document.get("models")),
             simulation_id=document["simulation_id"],
             modality=document["modality"],
             scenario_instructions=document["scenario"]["instructions"],

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -76,7 +76,7 @@ from .config import (
     TTS_PROVIDERS,
     VAD_PROVIDERS,
 )
-from .spec import PlatformSpeech
+from .spec import PlatformSpeech, SelectedModels
 
 if TYPE_CHECKING:
     from .config import SimulatorConfig
@@ -153,6 +153,29 @@ class PersonaVoice:
     voice_id: str
     provider: str | None
     speed: float | None
+
+
+def voice_for_simulation(
+    traits: dict[str, Any], models: SelectedModels | None
+) -> PersonaVoice:
+    """Which voice this simulation speaks with.
+
+    **One source, decided by whether the persona selected its own models.**
+    A version that carries selections says its voice there — provider,
+    voice id and speed together — and the old fields in its traits are not
+    read at all. A version on the compatibility path says it in its traits,
+    exactly as it always did.
+
+    Reading both would be two answers to one question, and the one that
+    won would depend on which of them somebody edited last.
+    """
+    if models is None:
+        return voice_from_traits(traits)
+    return PersonaVoice(
+        voice_id=models.tts.voice_id,
+        provider=models.tts.provider,
+        speed=models.tts.speed,
+    )
 
 
 def voice_from_traits(traits: dict[str, Any]) -> PersonaVoice:
@@ -500,14 +523,40 @@ class SpeechProviders:
 
     @classmethod
     def for_simulation(
-        cls, config: SimulatorConfig, platform: PlatformSpeech | None = None
+        cls,
+        config: SimulatorConfig,
+        platform: PlatformSpeech | None = None,
+        models: SelectedModels | None = None,
     ) -> SpeechProviders:
         """The pair one simulation is assembled with.
 
-        This container's own configuration, with the platform's settings
-        laid over it leg by leg — which is what makes a second simulator on
-        another machine need no speech variables at all, and what makes a
-        replaced key apply to the next simulation with no restart.
+        Three sources, and the order between them is the whole of this
+        method. **The persona's own selections win outright**, because they
+        are what the run pinned: a deployment setting quietly overriding one
+        would make a simulation's voice depend on which machine conducted
+        it, and two runs of one pinned version would stop being comparable.
+        Below them, this container's configuration with the platform's
+        settings laid over it leg by leg — which is what makes a second
+        simulator on another machine need no speech variables at all, and
+        what makes a replaced key apply to the next simulation with no
+        restart.
+
+        **A selected leg takes its key from its own selection and nowhere
+        else.** Falling back to the container's key for a provider the
+        persona named would spend from an account nobody in that
+        organization chose, which is the failure the whole credential
+        arrangement exists to make unreachable. Under managed access there
+        is no key in the selection at all, and there is nothing to fall back
+        to either: the credential never leaves the Egma model gateway.
+
+        **The voice-activity leg is never selected.** What tells the persona
+        the agent started and stopped speaking is internal simulator
+        behavior rather than a model anybody chooses, so it comes from the
+        platform and this container exactly as it always has, whatever the
+        persona selected.
+
+        Where the persona selected nothing, this is the method it was before
+        selections existed, line for line.
 
         **A leg's key follows its leg's provider.** Naming a provider and
         no key is a deployment saying "use this company, with the key you
@@ -516,12 +565,26 @@ class SpeechProviders:
         whichever leg the container already chose.
         """
         said = platform or PlatformSpeech()
+        vad = said.vad_provider or config.vad_provider
+
+        if models is not None:
+            return cls(
+                stt=models.stt.provider,
+                tts=models.tts.provider,
+                vad=vad,
+                stt_key=models.stt.key,
+                tts_key=models.tts.key,
+                stt_model=models.stt.model,
+                tts_model=models.tts.model,
+                tts_voice=models.tts.voice_id,
+            )
+
         stt = said.stt_provider or config.stt_provider
         tts = said.tts_provider or config.tts_provider
         return cls(
             stt=stt,
             tts=tts,
-            vad=said.vad_provider or config.vad_provider,
+            vad=vad,
             stt_key=said.stt_key or config.key_for(stt),
             tts_key=said.tts_key or config.key_for(tts),
             stt_model=said.stt_model or config.stt_model,

--- a/apps/simulator/tests/test_client_claims.py
+++ b/apps/simulator/tests/test_client_claims.py
@@ -19,6 +19,7 @@ import pytest
 from aiohttp import web
 
 from egma_simulator.client import ControlPlaneClient
+from egma_simulator.contract import SUPPORTED_SPEC_VERSIONS
 
 
 @pytest.fixture
@@ -43,12 +44,28 @@ async def recording_control_plane() -> AsyncIterator[tuple[str, list[dict]]]:
         await runner.cleanup()
 
 
-async def test_a_claim_declares_how_long_it_will_wait(recording_control_plane):
+async def test_a_claim_declares_how_long_it_will_wait_and_what_it_can_read(
+    recording_control_plane,
+):
+    """The whole body, pinned.
+
+    ``contract_versions`` is what keeps a mixed rollout safe with no drain
+    step: a simulation whose persona selects its own models can only be
+    conducted from a version-2 document, so a simulator that speaks only
+    version 1 is never offered that row and it waits for the upgraded
+    simulator beside it. Declaring it on every claim is what makes that
+    true, so it is pinned here rather than left to be noticed missing.
+    """
     base_url, bodies = recording_control_plane
 
     async with ControlPlaneClient(base_url, claim_wait_seconds=7.0) as client:
         await client.claim("sim-under-test", 3)
 
     assert bodies == [
-        {"claimant": "sim-under-test", "capacity": 3, "wait_seconds": 7.0}
+        {
+            "claimant": "sim-under-test",
+            "capacity": 3,
+            "wait_seconds": 7.0,
+            "contract_versions": list(SUPPORTED_SPEC_VERSIONS),
+        }
     ]

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -17,6 +17,7 @@ import pytest
 from jsonschema.exceptions import ValidationError
 
 from egma_simulator.contract import (
+    SUPPORTED_SPEC_VERSIONS,
     ContractViolation,
     contract_dir,
     report_validator,
@@ -25,8 +26,23 @@ from egma_simulator.contract import (
     validate_spec,
 )
 
-VALIDATORS = {"spec": spec_validator, "report": report_validator}
-VALIDATE = {"spec": validate_spec, "report": validate_report}
+# `spec` is the version-1 spec direction and `spec-v2` the version-2 one. They
+# are two folders because they are two closed documents: a version-2 document
+# is not a version-1 document with an extra field, it is a different contract,
+# and a folder mixing them would be checked against whichever schema the loop
+# happened to be holding.
+DIRECTIONS = ["spec", "spec-v2", "report"]
+
+VALIDATORS = {
+    "spec": lambda: spec_validator(1),
+    "spec-v2": lambda: spec_validator(2),
+    "report": report_validator,
+}
+VALIDATE = {
+    "spec": validate_spec,
+    "spec-v2": validate_spec,
+    "report": validate_report,
+}
 
 
 def fixtures_under(direction: str, expectation: str) -> list[tuple[str, dict]]:
@@ -65,6 +81,27 @@ EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
         "base_url",
     ),
     "spec/wrong-contract-version.json": ("/contract_version", "const", None),
+    # The mixed-rollout guard, as a document. A version-1 document carrying
+    # version 2's `models` block is exactly what a control plane that got the
+    # negotiation wrong would emit, and the failure it would cause is the quiet
+    # one: a worker that ignored the unknown block would conduct the simulation
+    # with its deployment's own model settings while the control plane believed
+    # it had sent the persona's. The version-1 schema closes its top level, so
+    # the block is refused loudly here rather than dropped silently there.
+    "spec/models-on-the-old-contract.json": ("", "additionalProperties", "models"),
+    "spec-v2/models-missing.json": ("", "required", "models"),
+    "spec-v2/customer-owned-without-a-key.json": ("/models/stt", "required", "key"),
+    "spec-v2/models-carrying-a-credential-id.json": (
+        "/models",
+        "additionalProperties",
+        "credential_id",
+    ),
+    "spec-v2/speaking-faster-than-a-voice-goes.json": (
+        "/models/tts/speed",
+        "maximum",
+        None,
+    ),
+    "spec-v2/unknown-field.json": ("", "additionalProperties", "agent_id"),
     "report/completed-claiming-never-ran.json": (
         "/events/0/facts/ending",
         "enum",
@@ -99,19 +136,51 @@ def place_of(error: ValidationError) -> str:
     return "".join(f"/{part}" for part in error.absolute_path)
 
 
-def test_both_schemas_compile_and_pin_the_same_contract_version():
+def test_every_schema_pins_the_version_it_claims_to_be():
+    pinned = {
+        "spec": 1,
+        "spec-v2": 2,
+        "report": 1,
+    }
     for direction, validator in VALIDATORS.items():
         compiled = validator()
-        assert compiled.schema["properties"]["contract_version"]["const"] == 1, (
-            direction
-        )
-    assert spec_validator().schema["$id"] == "urn:egma:simulation-contract:spec:v1"
+        assert (
+            compiled.schema["properties"]["contract_version"]["const"]
+            == pinned[direction]
+        ), direction
+
+    assert spec_validator(1).schema["$id"] == "urn:egma:simulation-contract:spec:v1"
+    assert spec_validator(2).schema["$id"] == "urn:egma:simulation-contract:spec:v2"
     assert (
         report_validator().schema["$id"] == "urn:egma:simulation-contract:report:v1"
     )
 
 
-@pytest.mark.parametrize("direction", ["spec", "report"])
+def test_a_version_this_simulator_does_not_implement_is_refused_by_its_version():
+    """The other half of the mixed-rollout rule, from this side of the wire.
+
+    A worker handed a document numbered higher than it implements must say
+    so rather than read it against the newest contract it happens to hold.
+    Reading it that way is how a block this process does not understand gets
+    dropped in silence, and a simulation conducted with silently dropped
+    model selections is worse than one that was refused.
+    """
+    ahead = read_json(
+        contract_dir() / "fixtures" / "spec-v2" / "valid" / "voice-customer-owned.json"
+    )
+    ahead["contract_version"] = max(SUPPORTED_SPEC_VERSIONS) + 1
+
+    with pytest.raises(ContractViolation) as refusal:
+        validate_spec(ahead)
+
+    assert refusal.value.complaints == [
+        "/contract_version: must be one of "
+        + ", ".join(str(known) for known in SUPPORTED_SPEC_VERSIONS)
+        + f", and this document says {ahead['contract_version']!r}"
+    ]
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
 def test_every_valid_golden_fixture_validates(direction: str):
     fixtures = fixtures_under(direction, "valid")
     assert fixtures, f"no valid {direction} fixtures found"
@@ -119,7 +188,7 @@ def test_every_valid_golden_fixture_validates(direction: str):
         VALIDATE[direction](document)  # raises ContractViolation on drift
 
 
-@pytest.mark.parametrize("direction", ["spec", "report"])
+@pytest.mark.parametrize("direction", DIRECTIONS)
 def test_every_invalid_fixture_is_rejected_at_the_place_it_is_wrong(direction: str):
     fixtures = fixtures_under(direction, "invalid")
 
@@ -203,10 +272,18 @@ def test_the_report_schema_rejects_the_specs_credentials_wherever_they_ride():
 
 def test_the_golden_fixtures_cover_what_the_simulator_must_speak():
     """Both modalities inbound; the lifecycle and nothing else outbound."""
-    modalities = {
-        document["modality"] for _, document in fixtures_under("spec", "valid")
-    }
-    assert modalities == {"chat", "voice"}
+    for direction in ("spec", "spec-v2"):
+        modalities = {
+            document["modality"] for _, document in fixtures_under(direction, "valid")
+        }
+        assert modalities == {"chat", "voice"}, direction
+
+    # Both access modes are golden documents, so the shape managed access will
+    # arrive in is pinned before anything emits one.
+    assert {
+        document["models"]["access"]
+        for _, document in fixtures_under("spec-v2", "valid")
+    } == {"managed", "customer-owned"}
 
     events = [
         event

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -101,6 +101,9 @@ EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
         "maximum",
         None,
     ),
+    # A chat simulation has no mouth and no ears, so a speech key on its wire
+    # is a secret travelling for nothing.
+    "spec-v2/chat-carrying-a-speech-key.json": ("/models/stt", "not", None),
     "spec-v2/unknown-field.json": ("", "additionalProperties", "agent_id"),
     "report/completed-claiming-never-ran.json": (
         "/events/0/facts/ending",

--- a/apps/simulator/tests/test_persona_models.py
+++ b/apps/simulator/tests/test_persona_models.py
@@ -1,0 +1,400 @@
+"""A persona that selects its own models, arriving on the work order.
+
+**The claim under test is a precedence claim**, so it is only worth anything
+when every source is set at once. Each test below puts one value in this
+container's environment, a different value for the same setting in the
+platform's block, and a third in the persona's own selection — then observes
+which one was used. A test that set only one side would pass against a
+simulator that read none of them.
+
+The other half of the file is what must *not* travel: a work order that
+carries no selections is conducted exactly as it was before selections
+existed, and a key that arrives on one is registered for redaction before
+anything is conducted with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from egma_simulator.config import SimulatorConfig
+from egma_simulator.contract import SUPPORTED_SPEC_VERSIONS, ContractViolation
+from egma_simulator.model import ModelFailure, OpenAICompatibleModel, build_model_client
+from egma_simulator.spec import (
+    Limits,
+    ModelSelection,
+    PlatformModel,
+    PlatformSettings,
+    PlatformSpeech,
+    SelectedModels,
+    SimulationSpec,
+    SpeechSelection,
+)
+from egma_simulator.speech import SpeechProviders, voice_for_simulation
+
+A_URL = "http://control-plane.test"
+
+SELECTED = SelectedModels(
+    access="customer-owned",
+    llm=ModelSelection(
+        provider="openai",
+        model="the-model-the-persona-selected",
+        key="SENTINEL-selected-thinking-key-91ab",
+    ),
+    stt=ModelSelection(
+        provider="deepgram",
+        model="the-model-the-persona-listens-with",
+        key="SENTINEL-selected-listening-key-92cd",
+    ),
+    tts=SpeechSelection(
+        provider="cartesia",
+        model="the-model-the-persona-speaks-with",
+        key="SENTINEL-selected-speaking-key-93ef",
+        voice_id="the-voice-the-persona-selected",
+        speed=1.25,
+    ),
+)
+
+THE_PLATFORMS_OWN = PlatformSettings(
+    model=PlatformModel(
+        provider="openai",
+        model="the-model-the-platform-was-told-about",
+        key="SENTINEL-platform-model-key-0001",
+        reasoning_effort="high",
+    ),
+    speech=PlatformSpeech(
+        stt_provider="openai",
+        stt_key="SENTINEL-platform-listening-key-0002",
+        stt_model="the-model-the-platform-listens-with",
+        tts_provider="elevenlabs",
+        tts_key="SENTINEL-platform-speaking-key-0003",
+        tts_model="the-model-the-platform-speaks-with",
+        tts_voice="the-voice-the-platform-chose",
+        vad_provider="silero",
+    ),
+)
+
+
+@pytest.fixture
+def a_container(env) -> SimulatorConfig:
+    """A simulator configured the way one with its own settings is.
+
+    Every one of these is a value a test can watch losing to something the
+    work order said, which is what makes each assertion an observation
+    rather than two settings that happen to agree.
+    """
+    env.setenv("EGMA_SIMULATOR_CONTROL_PLANE_URL", A_URL)
+    env.setenv("EGMA_SIMULATOR_MODEL_PROVIDER", "openai")
+    env.setenv("EGMA_SIMULATOR_MODEL_NAME", "the-model-this-container-knows")
+    env.setenv("EGMA_SIMULATOR_MODEL_API_KEY", "SENTINEL-container-model-key-1111")
+    env.setenv("EGMA_SIMULATOR_STT_PROVIDER", "openai")
+    env.setenv("EGMA_SIMULATOR_TTS_PROVIDER", "openai")
+    env.setenv("EGMA_SIMULATOR_OPENAI_API_KEY", "SENTINEL-container-openai-key-2222")
+    env.setenv("EGMA_SIMULATOR_TTS_VOICE", "the-voice-this-container-knows")
+    return SimulatorConfig.from_env()
+
+
+def a_spec_with(
+    models: SelectedModels | None,
+    platform: PlatformSettings | None = None,
+    traits: dict | None = None,
+) -> SimulationSpec:
+    """One claimed spec, carrying whatever a test is about."""
+    return SimulationSpec(
+        simulation_id="sim-under-test",
+        modality="voice",
+        scenario_instructions="State the first point.",
+        limits=Limits(max_duration_seconds=300, max_turns=40),
+        persona_traits=traits or {},
+        connection_type="scripted",
+        connection_config={},
+        credentials=None,
+        platform=platform or PlatformSettings(),
+        models=models,
+    )
+
+
+# -- What the persona selected wins ------------------------------------------
+
+
+def test_the_selected_legs_beat_the_platforms_and_this_containers(a_container):
+    """Three sources set to three different things, and the pinned one wins."""
+    providers = SpeechProviders.for_simulation(
+        a_container, THE_PLATFORMS_OWN.speech, SELECTED
+    )
+
+    assert providers.stt == "deepgram"
+    assert providers.stt_model == "the-model-the-persona-listens-with"
+    assert providers.stt_key == "SENTINEL-selected-listening-key-92cd"
+    assert providers.tts == "cartesia"
+    assert providers.tts_model == "the-model-the-persona-speaks-with"
+    assert providers.tts_key == "SENTINEL-selected-speaking-key-93ef"
+    assert providers.tts_voice == "the-voice-the-persona-selected"
+
+
+def test_a_selected_leg_never_falls_back_to_a_key_nobody_chose(a_container):
+    """A key belongs to the account the selection names, or there is none.
+
+    Falling back to this container's key for a provider the persona named
+    would spend from an account nobody in that organization chose, which is
+    the failure the whole credential arrangement exists to make unreachable.
+    """
+    keyless = SelectedModels(
+        access="customer-owned",
+        llm=ModelSelection(provider="openai", model="m", key=None),
+        stt=ModelSelection(provider="deepgram", model="n", key=None),
+        tts=SpeechSelection(
+            provider="cartesia", model="s", key=None, voice_id="v", speed=1.0
+        ),
+    )
+
+    providers = SpeechProviders.for_simulation(
+        a_container, THE_PLATFORMS_OWN.speech, keyless
+    )
+
+    assert providers.stt_key is None
+    assert providers.tts_key is None
+
+
+def test_the_voice_activity_leg_is_never_something_a_persona_selects(a_container):
+    """What tells the persona the agent started and stopped speaking is
+    internal simulator behavior, not a model anybody chooses — so it comes
+    from the platform whatever the persona selected."""
+    providers = SpeechProviders.for_simulation(
+        a_container, THE_PLATFORMS_OWN.speech, SELECTED
+    )
+
+    assert providers.vad == "silero"
+
+
+def test_the_selected_brain_beats_the_platforms_and_this_containers(a_container):
+    client = build_model_client(a_container, a_spec_with(SELECTED, THE_PLATFORMS_OWN))
+
+    assert isinstance(client, OpenAICompatibleModel)
+    assert client._model_name == "the-model-the-persona-selected"
+    assert client._api_key == "SENTINEL-selected-thinking-key-91ab"
+    # Reasoning effort is a legacy deployment setting rather than part of what
+    # a persona is. A selected persona uses its provider's default reasoning
+    # behavior, and the platform's value does not leak into it.
+    assert client._reasoning_effort is None
+
+
+def test_a_selected_brain_with_no_key_is_refused_rather_than_scripted(a_container):
+    """Refused rather than quietly downgraded to the stand-in: a completed,
+    green simulation conducted by a canned robot is worse than a failure,
+    because a failure tells the truth about what happened."""
+    keyless = SelectedModels(
+        access="managed",
+        llm=ModelSelection(provider="openai", model="m", key=None),
+        stt=SELECTED.stt,
+        tts=SELECTED.tts,
+    )
+
+    with pytest.raises(ModelFailure) as refusal:
+        build_model_client(a_container, a_spec_with(keyless, THE_PLATFORMS_OWN))
+
+    assert "no key" in str(refusal.value)
+
+
+def test_a_selected_provider_this_simulator_cannot_speak_to_is_refused(a_container):
+    unknown = SelectedModels(
+        access="customer-owned",
+        llm=ModelSelection(provider="a-company-nobody-shipped", model="m", key="k"),
+        stt=SELECTED.stt,
+        tts=SELECTED.tts,
+    )
+
+    with pytest.raises(ModelFailure) as refusal:
+        build_model_client(a_container, a_spec_with(unknown))
+
+    assert "a-company-nobody-shipped" in str(refusal.value)
+
+
+def test_the_selected_voice_is_the_one_source_and_traits_are_not_read(a_container):
+    """A migrated version has one voice source, and it is the selection.
+
+    Reading both would be two answers to one question, and which one won
+    would depend on which of them somebody edited last.
+    """
+    authored_elsewhere = {
+        "voice": {
+            "provider": "elevenlabs",
+            "voiceId": "the-voice-in-the-old-traits",
+            "speed": 0.75,
+        }
+    }
+
+    voice = voice_for_simulation(authored_elsewhere, SELECTED)
+
+    assert voice.voice_id == "the-voice-the-persona-selected"
+    assert voice.provider == "cartesia"
+    assert voice.speed == 1.25
+
+
+# -- What a work order without selections still does --------------------------
+
+
+def test_a_work_order_with_no_selections_is_conducted_exactly_as_before(a_container):
+    """Every persona authored before the model catalog existed arrives this
+    way, and the deployment's own settings decide exactly as they did."""
+    providers = SpeechProviders.for_simulation(
+        a_container, THE_PLATFORMS_OWN.speech, None
+    )
+
+    assert providers.stt == "openai"
+    assert providers.stt_key == "SENTINEL-platform-listening-key-0002"
+    assert providers.tts == "elevenlabs"
+    assert providers.tts_voice == "the-voice-the-platform-chose"
+
+    client = build_model_client(a_container, a_spec_with(None, THE_PLATFORMS_OWN))
+    assert isinstance(client, OpenAICompatibleModel)
+    assert client._model_name == "the-model-the-platform-was-told-about"
+    assert client._reasoning_effort == "high"
+
+
+def test_a_persona_with_no_selections_still_speaks_from_its_traits(a_container):
+    authored = {
+        "voice": {
+            "provider": "elevenlabs",
+            "voiceId": "the-voice-in-the-old-traits",
+            "speed": 0.75,
+        }
+    }
+
+    voice = voice_for_simulation(authored, None)
+
+    assert voice.voice_id == "the-voice-in-the-old-traits"
+    assert voice.provider == "elevenlabs"
+    assert voice.speed == 0.75
+
+
+# -- What travels, and what must not -----------------------------------------
+
+
+def test_every_selected_key_is_offered_for_redaction_in_one_place():
+    """One place to ask, so a fourth key arriving cannot fall out of the
+    scrubbing — the platform settings' own rule, one block over."""
+    assert set(SELECTED.secrets) == {
+        "SENTINEL-selected-thinking-key-91ab",
+        "SENTINEL-selected-listening-key-92cd",
+        "SENTINEL-selected-speaking-key-93ef",
+    }
+
+
+def test_a_managed_work_order_offers_no_key_because_it_carries_none():
+    managed = SelectedModels(
+        access="managed",
+        llm=ModelSelection(provider="openai", model="m"),
+        stt=ModelSelection(provider="deepgram", model="n"),
+        tts=SpeechSelection(provider="cartesia", model="s", voice_id="v", speed=1.0),
+    )
+
+    assert managed.secrets == ()
+
+
+def test_no_selected_key_appears_in_a_repr_of_what_holds_it():
+    """A log line carrying a key is a log line that should not have, and the
+    cheapest way to be sure is for the dataclass never to print one."""
+    written = repr(SELECTED)
+
+    for secret in SELECTED.secrets:
+        assert secret not in written
+
+
+# -- The contract this process speaks ----------------------------------------
+
+
+def test_a_claimed_version_two_document_becomes_the_selections_it_carries():
+    document = {
+        "contract_version": 2,
+        "simulation_id": "sim-1",
+        "modality": "voice",
+        "connection": {"type": "scripted", "config": {}, "credentials": None},
+        "persona": {"traits": {}},
+        "scenario": {"instructions": "State the first point."},
+        "limits": {"max_duration_seconds": 300, "max_turns": 40},
+        "models": {
+            "access": "customer-owned",
+            "llm": {"provider": "openai", "model": "m", "key": "k1"},
+            "stt": {"provider": "deepgram", "model": "n", "key": "k2"},
+            "tts": {
+                "provider": "cartesia",
+                "model": "s",
+                "key": "k3",
+                "voice_id": "v",
+                "speed": 1.5,
+            },
+        },
+    }
+
+    spec = SimulationSpec.from_document(document)
+
+    assert spec.models is not None
+    assert spec.models.access == "customer-owned"
+    assert spec.models.llm.model == "m"
+    assert spec.models.tts.voice_id == "v"
+    assert spec.models.tts.speed == 1.5
+
+
+def test_a_claimed_version_one_document_carries_no_selections():
+    document = {
+        "contract_version": 1,
+        "simulation_id": "sim-1",
+        "modality": "chat",
+        "connection": {"type": "scripted", "config": {}, "credentials": None},
+        "persona": {"traits": {}},
+        "scenario": {"instructions": "State the first point."},
+        "limits": {"max_duration_seconds": 600, "max_turns": 60},
+    }
+
+    spec = SimulationSpec.from_document(document)
+
+    assert spec.models is None
+
+
+def test_a_version_one_document_carrying_selections_is_refused_loudly():
+    """The mixed-rollout guard, from this side of the wire.
+
+    This is what a control plane that got the negotiation wrong would emit,
+    and the failure it would cause is the quiet one: a worker that ignored
+    the unknown block would conduct the simulation with its deployment's own
+    models while the control plane believed it had sent the persona's — same
+    conversation, different voice, different brain, different bill, and
+    nothing anywhere saying so.
+    """
+    document = {
+        "contract_version": 1,
+        "simulation_id": "sim-1",
+        "modality": "voice",
+        "connection": {"type": "scripted", "config": {}, "credentials": None},
+        "persona": {"traits": {}},
+        "scenario": {"instructions": "State the first point."},
+        "limits": {"max_duration_seconds": 300, "max_turns": 40},
+        "models": {
+            "access": "customer-owned",
+            "llm": {"provider": "openai", "model": "m", "key": "k1"},
+            "stt": {"provider": "deepgram", "model": "n", "key": "k2"},
+            "tts": {
+                "provider": "cartesia",
+                "model": "s",
+                "key": "k3",
+                "voice_id": "v",
+                "speed": 1.0,
+            },
+        },
+    }
+
+    with pytest.raises(ContractViolation) as refusal:
+        SimulationSpec.from_document(document)
+
+    assert any(
+        "models" in complaint and "Additional properties" in complaint
+        for complaint in refusal.value.complaints
+    ), refusal.value.complaints
+
+
+def test_this_simulator_declares_the_versions_it_implements():
+    """What a claim advertises, and what makes a mixed rollout safe with no
+    drain step: a row needing a document this process cannot read is never
+    offered to it at all."""
+    assert SUPPORTED_SPEC_VERSIONS == (1, 2)

--- a/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
@@ -15,6 +15,11 @@ import {
   type GraderParameter,
   type RunningGrader,
 } from "../../../../../lib/graders.ts";
+import {
+  entriesForJob,
+  MODEL_CATALOG_PATH,
+  type ModelCatalog,
+} from "../../../../../lib/model-access.ts";
 import { graderDisplayName } from "../../../../../lib/presentation.ts";
 import {
   Actions,
@@ -28,6 +33,7 @@ import {
   Select,
   TextInput,
 } from "../../../../../ui/controls.tsx";
+import { useProjectRead } from "../../../../../ui/resource.ts";
 import styles from "../graders.module.css";
 import { EntryFields } from "../use-form.tsx";
 
@@ -126,6 +132,10 @@ export function EditForm({
     scope: copy.scope,
     required: copy.required,
     sampleRate: String(copy.production_sample_rate),
+    // Empty strings for a copy on the compatibility path, which is what "this
+    // grader has chosen nothing and the project's judge decides" looks like.
+    modelProvider: copy.model?.provider ?? "",
+    modelId: copy.model?.model ?? "",
   }));
   const [filled, setFilled] = useState<Readonly<Record<string, string>>>(
     initial.filled,
@@ -135,6 +145,37 @@ export function EditForm({
   const [scope, setScope] = useState(initial.scope);
   const [required, setRequired] = useState(initial.required);
   const [sampleRate, setSampleRate] = useState(initial.sampleRate);
+  const [modelProvider, setModelProvider] = useState(initial.modelProvider);
+  const [modelId, setModelId] = useState(initial.modelId);
+
+  /**
+   * The providers that do LLM work, as the server lists them.
+   *
+   * **Read rather than listed here.** A hand-written list is wrong the day the
+   * catalog grows, and wrong silently — the form would go on offering
+   * yesterday's providers and the new one would be unreachable from the only
+   * place a grader's model is chosen.
+   */
+  const { answer: catalog } = useProjectRead<ModelCatalog>(
+    MODEL_CATALOG_PATH,
+    projectId,
+  );
+  const llm = entriesForJob(
+    catalog?.status === "ready" ? catalog.value : undefined,
+    "llm",
+  );
+  /**
+   * The providers a Select may show: the ones the server offers, plus whatever
+   * this grader is already on. A copy authored against a provider that has
+   * since left the catalog still has to be readable and still has to be
+   * editable in every other respect.
+   */
+  const providerChoices = (held: string): readonly string[] => {
+    const offered = llm.map((entry) => entry.provider);
+    return held === "" || offered.includes(held) ? offered : [...offered, held];
+  };
+  const recommendedFor = (provider: string): string | undefined =>
+    llm.find((entry) => entry.provider === provider)?.recommended_model;
   const [busy, setBusy] = useState(false);
   const [refused, setRefused] = useState<Refusal | null>(null);
 
@@ -144,6 +185,8 @@ export function EditForm({
     scope !== initial.scope ||
     required !== initial.required ||
     sampleRate !== initial.sampleRate ||
+    modelProvider !== initial.modelProvider ||
+    modelId !== initial.modelId ||
     params.some(
       (parameter) =>
         (filled[parameter.name] ?? "") !==
@@ -199,6 +242,22 @@ export function EditForm({
           honest reading of a box that says nothing.
         */
         ...(saidRate === undefined ? {} : { production_sample_rate: saidRate }),
+        /*
+          The grader's own model, sent only where this form actually changed
+          it. `null` is a real answer and means *go back to the project's judge
+          setting*, which is a different act from leaving the key out — and
+          leaving it out is what keeps a save about something else from
+          quietly re-deciding which model judges here.
+        */
+        ...(modelProvider === initial.modelProvider &&
+        modelId === initial.modelId
+          ? {}
+          : {
+              model:
+                modelProvider.trim() === ""
+                  ? null
+                  : { provider: modelProvider, model: modelId },
+            }),
         ...(params.length === 0
           ? {}
           : { params: filledParams(params, filled) }),
@@ -259,6 +318,57 @@ export function EditForm({
           named="edit"
           sentence={EDIT.asksNothing}
         />
+      </fieldset>
+
+      <fieldset className={styles.formGroup} disabled={busy}>
+        <legend className={styles.formGroupTitle}>{EDIT.groups.model}</legend>
+        {/*
+          **No key field, and nowhere to put one.** Who pays for a judgment is
+          the organization's model access, under Model providers; a grader
+          names a provider and never a secret, which is what keeps a rotation
+          from minting a grader version.
+
+          An empty provider is the compatibility path said plainly: this copy
+          has chosen nothing and the project's judge setting decides for it.
+        */}
+        <Help>
+          {modelProvider.trim() === ""
+            ? EDIT.modelInherited
+            : EDIT.modelProviderMeans}
+        </Help>
+        <Field
+          label={EDIT.modelProvider}
+          hint={EDIT.modelProviderMeans}
+          htmlFor="edit-model-provider"
+        >
+          <Select
+            id="edit-model-provider"
+            value={modelProvider}
+            options={[
+              { value: "", label: EDIT.modelClear },
+              ...providerChoices(modelProvider).map((provider) => ({
+                value: provider,
+                label: provider,
+              })),
+            ]}
+            onChange={(chosen) => {
+              setModelProvider(chosen);
+              // A model id belongs to the provider it was typed for, so
+              // changing the provider starts the id from that provider's
+              // proved default rather than leaving the old one behind.
+              setModelId(chosen === "" ? "" : (recommendedFor(chosen) ?? ""));
+            }}
+          />
+        </Field>
+        {modelProvider.trim() === "" ? null : (
+          <Field
+            label={EDIT.modelId}
+            hint={EDIT.modelIdMeans}
+            htmlFor="edit-model-id"
+          >
+            <TextInput id="edit-model-id" value={modelId} onChange={setModelId} />
+          </Field>
+        )}
       </fieldset>
 
       <fieldset className={styles.formGroup} disabled={busy}>

--- a/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
@@ -170,9 +170,20 @@ export function EditForm({
    * since left the catalog still has to be readable and still has to be
    * editable in every other respect.
    */
-  const providerChoices = (held: string): readonly string[] => {
+  const providerChoices = (
+    held: string,
+  ): readonly { readonly value: string; readonly label: string }[] => {
     const offered = llm.map((entry) => entry.provider);
-    return held === "" || offered.includes(held) ? offered : [...offered, held];
+    const all =
+      held === "" || offered.includes(held) ? offered : [...offered, held];
+    // The catalog's label, never the stored word: `openai` is an identifier —
+    // what a grading claim carries and what a credential is filed under — and
+    // showing it in a form makes an author read Egma's storage rather than the
+    // name their provider goes by.
+    return all.map((provider) => ({
+      value: provider,
+      label: llm.find((entry) => entry.provider === provider)?.label ?? provider,
+    }));
   };
   const recommendedFor = (provider: string): string | undefined =>
     llm.find((entry) => entry.provider === provider)?.recommended_model;
@@ -346,10 +357,7 @@ export function EditForm({
             value={modelProvider}
             options={[
               { value: "", label: EDIT.modelClear },
-              ...providerChoices(modelProvider).map((provider) => ({
-                value: provider,
-                label: provider,
-              })),
+              ...providerChoices(modelProvider),
             ]}
             onChange={(chosen) => {
               setModelProvider(chosen);

--- a/apps/web/app/projects/[projectId]/personas/[personaId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/personas/[personaId]/page.tsx
@@ -9,12 +9,17 @@ import { roleOf } from "../../../../../lib/me.ts";
 import {
   describedTraits,
   draftOf,
+  modelsDraftOf,
+  modelsFrom,
+  recommendedDraft,
+  sameModelsDraft,
   PERSONA_FORM_PATH,
   personaPath,
   personaUsagePath,
   personaVersionsPath,
   personasPath,
   traitsFrom,
+  type ModelsDraft,
   type Persona,
   type PersonaForm,
   type PersonaPage,
@@ -31,6 +36,7 @@ import {
   ButtonLink,
   Facts,
   Field,
+  Help,
   Form,
   FormActions,
   Refused,
@@ -55,6 +61,7 @@ import {
   useShellSession,
 } from "../../../../../ui/shell.tsx";
 import styles from "../../../../../ui/system.module.css";
+import { ModelFields } from "../models-editor.tsx";
 import { TraitFields } from "../traits-editor.tsx";
 
 /**
@@ -92,6 +99,12 @@ type Draft = {
   readonly name: string;
   readonly description: string;
   readonly traits: TraitsDraft;
+  /**
+   * The three model selections, or `null` for a persona still on the
+   * compatibility path — where the deployment's own settings decide and this
+   * persona has chosen nothing.
+   */
+  readonly models: ModelsDraft | null;
 };
 
 /**
@@ -108,6 +121,7 @@ type Submitted = {
   readonly name?: string;
   readonly description?: string;
   readonly traits?: TraitsDraft;
+  readonly models?: ModelsDraft;
 };
 
 /**
@@ -163,6 +177,23 @@ function adopted(
     }
   }
 
+  /**
+   * The selections, adopted whole rather than field by field.
+   *
+   * They are one decision — a persona thinks, listens and speaks with a set of
+   * choices, and a save sends all of them — so a half-adopted set would be a
+   * combination nobody chose. Only a save that actually carried them adopts,
+   * and only where what is held is still what was sent.
+   */
+  const models =
+    submitted.models !== undefined &&
+    current.models !== null &&
+    sameModelsDraft(current.models, submitted.models)
+      ? fromServer.models === null
+        ? null
+        : modelsDraftOf(fromServer.models)
+      : current.models;
+
   return {
     personaId: current.personaId,
     name: answered(current.name, submitted.name, fromServer.name),
@@ -172,6 +203,7 @@ function adopted(
       fromServer.description ?? "",
     ),
     traits,
+    models,
   };
 }
 
@@ -228,8 +260,10 @@ function PersonaDetail({
     PERSONA_FORM_PATH,
     projectId,
   );
-  const voiceProviders =
-    form?.status === "ready" ? form.value.voice_providers : null;
+  const shape = form?.status === "ready" ? form.value : null;
+  const voiceProviders = shape?.voice_providers ?? null;
+  /** What a persona choosing models for the first time starts from. */
+  const recommended = recommendedDraft(shape ?? undefined);
 
   /**
    * What the two forms are holding.
@@ -256,6 +290,10 @@ function PersonaDetail({
             name: persona.name,
             description: persona.description ?? "",
             traits: draftOf(persona.traits),
+            // Null is the compatibility path and never a fault: this persona
+            // has chosen nothing, and the deployment's own settings decide.
+            models:
+              persona.models === null ? null : modelsDraftOf(persona.models),
           },
     );
   }, [answer]);
@@ -264,9 +302,9 @@ function PersonaDetail({
     if (answer?.status === "signed-out") window.location.replace("/sign-in");
   }, [answer]);
 
-  const [saving, setSaving] = useState<"identity" | "traits" | "lifecycle" | null>(
-    null,
-  );
+  const [saving, setSaving] = useState<
+    "identity" | "traits" | "models" | "lifecycle" | null
+  >(null);
   const [refusal, setRefusal] = useState<Refusal | null>(null);
   const [reading, setReading] = useState<PersonaVersion | null>(null);
   const [archiving, setArchiving] = useState(false);
@@ -317,7 +355,7 @@ function PersonaDetail({
     path: string,
     method: "POST" | "PATCH",
     body: Record<string, unknown>,
-    what: "identity" | "traits" | "lifecycle",
+    what: "identity" | "traits" | "models" | "lifecycle",
     submitted?: Submitted,
   ): Promise<Persona | null> {
     const asked = { projectId, personaId };
@@ -524,6 +562,55 @@ function PersonaDetail({
         </Section>
 
         <Section
+          title="Models"
+          lead="Version content, like the traits above. What this persona thinks, listens and speaks with — three independent choices, and never a key."
+        >
+          {held.models === null ? (
+            <>
+              <Help>
+                <Badge tone="neutral">Not selected</Badge> This persona has
+                chosen no models, so this deployment&apos;s own settings decide
+                what it thinks, listens and speaks with. Choosing here mints a
+                new version and leaves every earlier run pinned to the one it
+                ran against.
+              </Help>
+              {!settled || recommended === null ? null : (
+                <FormActions>
+                  <Button
+                    disabled={!mayAuthor || saving !== null}
+                    {...(mayAuthor || whyNot === undefined ? {} : { why: whyNot })}
+                    onClick={() => setHeld({ ...held, models: recommended })}
+                  >
+                    Choose models
+                  </Button>
+                </FormActions>
+              )}
+            </>
+          ) : settled ? (
+            <Form onSubmit={() => void saveModels()}>
+              <ModelFields
+                draft={held.models}
+                form={shape}
+                disabled={!mayAuthor}
+                onChange={(models) => setHeld({ ...held, models })}
+              />
+              <FormActions>
+                <Button
+                  weight="strong"
+                  type="submit"
+                  disabled={!mayAuthor || saving !== null}
+                  {...(mayAuthor || whyNot === undefined ? {} : { why: whyNot })}
+                >
+                  {saving === "models" ? "Saving…" : "Save models"}
+                </Button>
+              </FormActions>
+            </Form>
+          ) : (
+            <Loading what="what your role may edit" />
+          )}
+        </Section>
+
+        <Section
           title="Used by"
           lead="The active tests whose current version names this persona. These are exactly what would refuse an Archive."
         >
@@ -654,6 +741,33 @@ function PersonaDetail({
         // The traits and nothing else: a name half-retyped in the form above
         // is not this request's to answer for either.
         { personaId: one.id, traits: held.traits },
+      );
+    }
+
+    /**
+     * The three selections, saved together.
+     *
+     * **One save for all of them**, because they are one decision: a persona
+     * thinks, listens and speaks with a set of choices, and sending half a set
+     * would be a combination nobody chose. A change mints the next version, so
+     * a run that pinned an earlier one keeps meaning what it meant; sending
+     * the selections already stored mints nothing.
+     */
+    async function saveModels(): Promise<void> {
+      if (held === null || held.models === null) return;
+      if (!mayAuthor || saving !== null) return;
+      await write(
+        personaPath(one.id),
+        "PATCH",
+        {
+          expected_revision: one.revision,
+          expected_version_id: one.version_id,
+          models: modelsFrom(held.models),
+        },
+        "models",
+        // The models and nothing else: a name half-retyped in the form above
+        // is not this request's to answer for either.
+        { personaId: one.id, models: held.models },
       );
     }
 

--- a/apps/web/app/projects/[projectId]/personas/models-editor.tsx
+++ b/apps/web/app/projects/[projectId]/personas/models-editor.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import {
+  providerOptions,
+  type ModelsDraft,
+  type PersonaForm,
+} from "../../../../lib/personas.ts";
+import { Field, FormRow, Help, Select, TextInput } from "../../../../ui/controls.tsx";
+
+/**
+ * What a persona thinks, listens and speaks with — three independent choices,
+ * written once and used by both the create form and the editor on its page.
+ *
+ * **Three choices rather than one bundle** (ADR-0010): changing what a persona
+ * listens with must not require inventing a new package for what it thinks and
+ * speaks with. So each job has its own provider and its own model id, and the
+ * speaking one has the two facts only it needs.
+ *
+ * **There is no key field here and there never will be.** Who pays for a model
+ * is the organization's model access, under Model providers; a persona names a
+ * provider and never a secret, which is what keeps a rotation from minting a
+ * persona version and what keeps a version from ever holding a key.
+ *
+ * **There is no voice-activity field either.** What tells the persona the agent
+ * started and stopped speaking is internal simulator behavior rather than a
+ * model anybody chooses, and putting it here would make an implementation
+ * detail into a question every persona author has to answer.
+ *
+ * A model id is free text on purpose. A release proves one default per
+ * provider; a model released this morning has to be nameable without shipping
+ * a new browser bundle, and the provider is the authority on the rest.
+ */
+export function ModelFields({
+  draft,
+  form,
+  disabled = false,
+  onChange,
+}: {
+  readonly draft: ModelsDraft;
+  /**
+   * The catalog as the server listed it, or `null` while that read has not
+   * answered. Never a copy kept here: a hand-written list is wrong the day the
+   * server's grows, and wrong silently.
+   */
+  readonly form: PersonaForm | null;
+  readonly disabled?: boolean;
+  readonly onChange: (draft: ModelsDraft) => void;
+}) {
+  const set =
+    <Key extends keyof ModelsDraft>(key: Key) =>
+    (value: string) =>
+      onChange({ ...draft, [key]: value });
+
+  const providersFor = (job: "llm" | "stt" | "tts", held: string) =>
+    providerOptions(
+      form === null
+        ? null
+        : form.model_catalog
+            .filter((entry) => entry.job === job)
+            .map((entry) => entry.provider),
+      held,
+    ).map((provider) => ({ value: provider, label: provider }));
+
+  const reading = form === null ? "Reading the providers Egma supports…" : null;
+  const range = form?.speed_range;
+
+  return (
+    <>
+      <Help>
+        A persona names a provider and a model. The key behind it belongs to the
+        organization and is set under Model providers, so replacing a key never
+        changes what this persona is.
+      </Help>
+
+      <FormRow>
+        <Field
+          label="Language model provider"
+          htmlFor="persona-llm-provider"
+          hint={reading ?? "What the persona thinks with."}
+        >
+          <Select
+            id="persona-llm-provider"
+            value={draft.llmProvider}
+            disabled={disabled || form === null}
+            options={providersFor("llm", draft.llmProvider)}
+            onChange={set("llmProvider")}
+          />
+        </Field>
+        <Field
+          label="Language model"
+          htmlFor="persona-llm-model"
+          hint="The provider's own id. Any model that provider accepts."
+        >
+          <TextInput
+            id="persona-llm-model"
+            value={draft.llmModel}
+            disabled={disabled}
+            onChange={set("llmModel")}
+          />
+        </Field>
+      </FormRow>
+
+      <FormRow>
+        <Field
+          label="Speech-to-text provider"
+          htmlFor="persona-stt-provider"
+          hint={reading ?? "What the persona hears with."}
+        >
+          <Select
+            id="persona-stt-provider"
+            value={draft.sttProvider}
+            disabled={disabled || form === null}
+            options={providersFor("stt", draft.sttProvider)}
+            onChange={set("sttProvider")}
+          />
+        </Field>
+        <Field
+          label="Speech-to-text model"
+          htmlFor="persona-stt-model"
+          hint="The provider's own id."
+        >
+          <TextInput
+            id="persona-stt-model"
+            value={draft.sttModel}
+            disabled={disabled}
+            onChange={set("sttModel")}
+          />
+        </Field>
+      </FormRow>
+
+      <FormRow>
+        <Field
+          label="Text-to-speech provider"
+          htmlFor="persona-tts-provider"
+          hint={reading ?? "What the persona speaks with."}
+        >
+          <Select
+            id="persona-tts-provider"
+            value={draft.ttsProvider}
+            disabled={disabled || form === null}
+            options={providersFor("tts", draft.ttsProvider)}
+            onChange={set("ttsProvider")}
+          />
+        </Field>
+        <Field
+          label="Text-to-speech model"
+          htmlFor="persona-tts-model"
+          hint="The provider's own id."
+        >
+          <TextInput
+            id="persona-tts-model"
+            value={draft.ttsModel}
+            disabled={disabled}
+            onChange={set("ttsModel")}
+          />
+        </Field>
+      </FormRow>
+
+      <FormRow>
+        <Field
+          label="Voice"
+          htmlFor="persona-tts-voice"
+          hint="The provider's own id for the voice, so every simulation casts the same person."
+        >
+          <TextInput
+            id="persona-tts-voice"
+            value={draft.ttsVoiceId}
+            disabled={disabled}
+            onChange={set("ttsVoiceId")}
+          />
+        </Field>
+        <Field
+          label="Speech rate"
+          htmlFor="persona-tts-speed"
+          hint={
+            range === undefined
+              ? "A multiple of the provider's natural pace."
+              : `A multiple of the provider's natural pace, between ${range.slowest} and ${range.fastest}.`
+          }
+        >
+          <TextInput
+            id="persona-tts-speed"
+            value={draft.ttsSpeed}
+            disabled={disabled}
+            onChange={set("ttsSpeed")}
+          />
+        </Field>
+      </FormRow>
+    </>
+  );
+}

--- a/apps/web/app/projects/[projectId]/personas/models-editor.tsx
+++ b/apps/web/app/projects/[projectId]/personas/models-editor.tsx
@@ -51,15 +51,28 @@ export function ModelFields({
     (value: string) =>
       onChange({ ...draft, [key]: value });
 
-  const providersFor = (job: "llm" | "stt" | "tts", held: string) =>
-    providerOptions(
-      form === null
-        ? null
-        : form.model_catalog
-            .filter((entry) => entry.job === job)
-            .map((entry) => entry.provider),
+  /**
+   * What a person picks from: the providers the catalog offers for this job,
+   * named the way the catalog names them.
+   *
+   * **The label, never the stored word.** `openai` is an identifier — what a
+   * work order carries and what a credential is filed under — and showing it in
+   * a form makes an author read Egma's storage instead of the name their
+   * provider goes by. A provider the catalog no longer ships falls back to its
+   * own word, because a persona already on one has to stay editable in every
+   * other respect and an unnamed option would be worse than an identifier.
+   */
+  const providersFor = (job: "llm" | "stt" | "tts", held: string) => {
+    const entries = form === null ? [] : form.model_catalog.filter((entry) => entry.job === job);
+    return providerOptions(
+      form === null ? null : entries.map((entry) => entry.provider),
       held,
-    ).map((provider) => ({ value: provider, label: provider }));
+    ).map((provider) => ({
+      value: provider,
+      label:
+        entries.find((entry) => entry.provider === provider)?.label ?? provider,
+    }));
+  };
 
   const reading = form === null ? "Reading the providers Egma supports…" : null;
   const range = form?.speed_range;
@@ -181,6 +194,7 @@ export function ModelFields({
           <TextInput
             id="persona-tts-speed"
             value={draft.ttsSpeed}
+            numeric
             disabled={disabled}
             onChange={set("ttsSpeed")}
           />

--- a/apps/web/app/projects/[projectId]/personas/new/page.tsx
+++ b/apps/web/app/projects/[projectId]/personas/new/page.tsx
@@ -7,9 +7,12 @@ import { writeJson, type Refusal } from "../../../../../lib/api.ts";
 import { roleOf } from "../../../../../lib/me.ts";
 import {
   BLANK_TRAITS,
+  modelsFrom,
   PERSONA_FORM_PATH,
   PERSONAS_PATH,
+  recommendedDraft,
   traitsFrom,
+  type ModelsDraft,
   type Persona,
   type PersonaForm,
   type TraitsDraft,
@@ -23,6 +26,7 @@ import {
   Form,
   FormActions,
   Refused,
+  Section,
   TextInput,
 } from "../../../../../ui/controls.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
@@ -33,6 +37,7 @@ import {
   ProductPage,
   useShellSession,
 } from "../../../../../ui/shell.tsx";
+import { ModelFields } from "../models-editor.tsx";
 import { TraitFields } from "../traits-editor.tsx";
 
 /**
@@ -72,8 +77,21 @@ function NewPersona({ projectId }: { readonly projectId: string }) {
     PERSONA_FORM_PATH,
     projectId,
   );
-  const voiceProviders =
-    form?.status === "ready" ? form.value.voice_providers : null;
+  const shape = form?.status === "ready" ? form.value : null;
+  const voiceProviders = shape?.voice_providers ?? null;
+
+  /**
+   * The selections this persona starts from: the release's proved defaults,
+   * filled in the moment the server says what they are.
+   *
+   * **Held rather than derived on every render**, so that what somebody has
+   * typed survives the form read arriving — and defaulted rather than left
+   * empty, so a first persona runs before anybody opens a provider's
+   * documentation.
+   */
+  const [models, setModels] = useState<ModelsDraft | null>(null);
+  const recommended = recommendedDraft(shape ?? undefined);
+  const settledModels = models ?? recommended;
   const [saving, setSaving] = useState(false);
   const [refusal, setRefusal] = useState<Refusal | null>(null);
 
@@ -95,6 +113,12 @@ function NewPersona({ projectId }: { readonly projectId: string }) {
         name,
         description,
         traits: traitsFrom(traits),
+        // Left out entirely while the catalog read has not answered, which is
+        // the honest state: a persona born with providers this browser guessed
+        // would be a selection nobody made.
+        ...(settledModels === null
+          ? {}
+          : { models: modelsFrom(settledModels) }),
       },
     });
 
@@ -162,6 +186,19 @@ function NewPersona({ projectId }: { readonly projectId: string }) {
             voiceProviders={voiceProviders}
             onChange={setTraits}
           />
+
+          <Section
+            title="Models"
+            lead="What this persona thinks, listens and speaks with. Three independent choices, each starting from a default Egma proved."
+          >
+            {settledModels === null ? null : (
+              <ModelFields
+                draft={settledModels}
+                form={shape}
+                onChange={setModels}
+              />
+            )}
+          </Section>
 
           <FormActions>
             <Button

--- a/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/page.tsx
@@ -37,6 +37,7 @@ import {
   TextArea,
 } from "../../../../../../../ui/controls.tsx";
 import { Dialog } from "../../../../../../../ui/dialog.tsx";
+import { settingsPath } from "../../../../../../../ui/settings-nav.tsx";
 import {
   ExecutionTimeline,
   GradingPending,
@@ -346,9 +347,30 @@ function EvidenceView({
 
         {read.status !== "failed" ? null : (
           <Problem>
-            {read.reason ?? "Egma could not conduct this simulation."} This is
-            an execution problem, not a failed grader verdict, and it says
-            nothing about the agent.
+            {/*
+              The sentence first, where Egma has one. `dispatch_failed` says a
+              claimed simulation was never handed over and says nothing about
+              why; "this organization holds no Deepgram credential, and this
+              persona listens with Deepgram" is what somebody can act on.
+            */}
+            {read.detail ??
+              read.reason ??
+              "Egma could not conduct this simulation."}{" "}
+            This is an execution problem, not a failed grader verdict, and it
+            says nothing about the agent.
+            {/*
+              And somewhere to go, where a screen fixes it. The word is the
+              platform's and the address is this browser's, so a stored link is
+              never a route the platform has to keep working.
+            */}
+            {read.repair === "model_providers" ? (
+              <>
+                {" "}
+                <ButtonLink href={settingsPath(projectId, "model-providers")}>
+                  Model providers
+                </ButtonLink>
+              </>
+            ) : null}
           </Problem>
         )}
 

--- a/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
@@ -6,9 +6,9 @@ import { useEffect, useState } from "react";
 import { deleteJson, writeJson, type Refusal } from "../../../../../lib/api.ts";
 import { roleOf } from "../../../../../lib/me.ts";
 import {
-  credentialFor,
   credentialsIn,
   jobsOfProvider,
+  labelOfProvider,
   modelProviderCredentialPath,
   providersIn,
   JOB_LABEL,
@@ -17,8 +17,8 @@ import {
   MODEL_CATALOG_PATH,
   MODEL_PROVIDER_CREDENTIALS_PATH,
   type ModelAccess,
-  type ModelAccessMode,
   type ModelCatalog,
+  type ModelProviderCredential,
 } from "../../../../../lib/model-access.ts";
 import {
   Badge,
@@ -30,6 +30,8 @@ import {
   Section,
   TextInput,
 } from "../../../../../ui/controls.tsx";
+import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
+import { Dialog } from "../../../../../ui/dialog.tsx";
 import { Failure, Loading } from "../../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
 import { SettingsLayout } from "../../../../../ui/settings-nav.tsx";
@@ -52,6 +54,12 @@ import {
  * typing a new one; it is never reading the old one first, and there is no
  * route that would let them.
  *
+ * **One row for each supported provider, and one form under the table.** The
+ * table is the list of what is configured; the form belongs to whichever row
+ * asked for it, so exactly one labelled secret field is open at a time rather
+ * than one per provider sitting open at once. That is the arrangement the
+ * organization's judge keys already use, one screen over, for the same reason.
+ *
  * **Nothing here is a readiness checklist.** A provider with no key is shown as
  * "Not configured", which is a state and not a fault: an organization mid-setup
  * is the ordinary organization, and a page that refused to let somebody leave
@@ -63,6 +71,12 @@ import {
  * reported when it is used, where the report can name the simulation it
  * stopped. Anything else would make saving depend on the provider being up and
  * would still not be true a minute later.
+ *
+ * **Removing one is confirmed and named.** It is write-only and there is no way
+ * to read a stored key back, so a stray click is unrecoverable in the product —
+ * and it stops every later simulation and grading job that selects the
+ * provider. So it sits behind a dialog that names the provider and says what
+ * stops, apart from the save action rather than beside it.
  *
  * Model providers are administration: the credentials are the organization's
  * and the mode commits its account, so only an admin may change either. The
@@ -78,6 +92,14 @@ export default function ModelProvidersSettingsPage() {
   );
 }
 
+/** One provider's row, as the table draws it. */
+type ProviderRow = {
+  readonly provider: string;
+  readonly label: string;
+  readonly jobs: readonly ("llm" | "stt" | "tts")[];
+  readonly credential: ModelProviderCredential | undefined;
+};
+
 function ModelProviders({ projectId }: { readonly projectId: string }) {
   const { me } = useShellSession();
   // Null until the session read answers. An unsettled session is neither an
@@ -91,6 +113,16 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
   );
   const { answer: catalog, reload: reloadCatalog } =
     useProjectRead<ModelCatalog>(MODEL_CATALOG_PATH, projectId);
+
+  /** The provider whose replacement form is open, by name. */
+  const [editing, setEditing] = useState<string | null>(null);
+  const [key, setKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [saved, setSaved] = useState<string | null>(null);
+  const [refused, setRefused] = useState<Refusal | null>(null);
+  const [confirmingRemove, setConfirmingRemove] = useState<ProviderRow | null>(
+    null,
+  );
 
   useEffect(() => {
     if (access?.status === "signed-out" || catalog?.status === "signed-out") {
@@ -123,6 +155,150 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
 
   const held = credentialsIn(access.value);
   const mode = access.value.mode;
+  const shipped = catalog?.status === "ready" ? catalog.value : undefined;
+  const rows: readonly ProviderRow[] = providersIn(shipped).map((provider) => ({
+    provider,
+    label: labelOfProvider(shipped, provider),
+    jobs: jobsOfProvider(shipped, provider),
+    credential: held.find((one) => one.provider === provider),
+  }));
+  const open = rows.find((row) => row.provider === editing);
+
+  /**
+   * Opening a different row empties the field and both settled states.
+   *
+   * One form under the table means one `key`, one `saved` and one `refused` for
+   * every row — and each of them means "for the open row" with nothing making
+   * it true. A key typed for one provider would otherwise stay in the field and
+   * be sent to whichever row is open now, storing a secret against an account
+   * nobody chose. Retyping is the price. The judge keys' own form makes exactly
+   * this trade, one screen over.
+   */
+  function openFor(provider: string): void {
+    setKey("");
+    setSaved(null);
+    setRefused(null);
+    setEditing(editing === provider ? null : provider);
+  }
+
+  async function store(row: ProviderRow): Promise<void> {
+    if (!mayAdminister || key.trim() === "" || busy) return;
+    setRefused(null);
+    setSaved(null);
+    setBusy(true);
+
+    const written = await writeJson(MODEL_PROVIDER_CREDENTIALS_PATH, {
+      method: "PUT",
+      project: projectId,
+      body: {
+        provider: row.provider,
+        key: key.trim(),
+        // What this write was composed against, so an admin replacing a key
+        // from a page they left open is told the stored one moved rather than
+        // silently landing on top of somebody else's rotation.
+        ...(row.credential === undefined
+          ? {}
+          : { expected_revision: row.credential.revision }),
+      },
+    });
+
+    setBusy(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    // Cleared the moment it lands: what was typed is a secret, and a form that
+    // kept it on screen would be the one place in the product that shows one.
+    setKey("");
+    setEditing(null);
+    setSaved(row.label);
+    reloadAccess();
+  }
+
+  async function remove(row: ProviderRow): Promise<void> {
+    if (!mayAdminister || row.credential === undefined || busy) return;
+    setRefused(null);
+    setSaved(null);
+    setBusy(true);
+
+    const written = await deleteJson(
+      modelProviderCredentialPath(row.provider),
+      { project: projectId },
+    );
+
+    setBusy(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    if (editing === row.provider) setEditing(null);
+    reloadAccess();
+  }
+
+  const columns: readonly Column<ProviderRow>[] = [
+    {
+      key: "provider",
+      header: "Provider",
+      primary: true,
+      cell: (row) => row.label,
+    },
+    {
+      key: "jobs",
+      header: "Used for",
+      hideOnMobile: true,
+      cell: (row) => row.jobs.map((job) => JOB_LABEL[job]).join(", "),
+    },
+    {
+      key: "state",
+      header: "Key",
+      width: "180px",
+      cell: (row) =>
+        row.credential === undefined ? (
+          <Badge tone="warn">Not configured</Badge>
+        ) : (
+          <>
+            <Badge tone="good">Configured</Badge>{" "}
+            <span>…{row.credential.hint}</span>
+          </>
+        ),
+    },
+    {
+      key: "replace",
+      header: "",
+      width: "150px",
+      cell: (row) => (
+        <Button
+          disabled={!mayAdminister || busy}
+          ariaExpanded={editing === row.provider}
+          onClick={() => openFor(row.provider)}
+        >
+          {row.credential === undefined ? "Add key" : "Replace key"}
+        </Button>
+      ),
+    },
+    {
+      key: "remove",
+      header: "",
+      width: "130px",
+      cell: (row) =>
+        row.credential === undefined ? null : (
+          <Button
+            disabled={!mayAdminister || busy}
+            onClick={() => setConfirmingRemove(row)}
+          >
+            Remove key
+          </Button>
+        ),
+    },
+  ];
 
   return (
     <Frame projectId={projectId}>
@@ -153,45 +329,143 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
         )}
       </Section>
 
-      {mode !== "customer-owned" ? null : catalog === null ? (
-        <Section title="Providers">
-          <Loading what="the providers Egma supports" />
-        </Section>
-      ) : catalog.status !== "ready" ? (
-        <Section title="Providers">
-          {/*
-           * The rows below are the catalog's — which providers Egma can execute
-           * and what each one's key is for — so none is drawn while that answer
-           * is missing. A row rendered here would be a claim about what may be
-           * configured, made out of a read that failed.
-           */}
-          <Failure
-            title="Egma could not say which providers it supports."
-            message={
-              catalog.status === "signed-out"
-                ? "Your session has ended. Sign in and try again."
-                : catalog.refusal.message
-            }
-            onRetry={reloadCatalog}
-          />
-        </Section>
-      ) : (
+      {mode !== "customer-owned" ? null : (
         <Section
           title="Providers"
           lead="One key for each provider your personas and graders select. A provider with no key stops only the simulations that name it."
         >
-          {providersIn(catalog.value).map((provider) => (
-            <ProviderRow
-              key={provider}
-              projectId={projectId}
-              provider={provider}
-              jobs={jobsOfProvider(catalog.value, provider)}
-              credential={credentialFor(held, provider)}
-              mayAdminister={mayAdminister}
-              onChanged={reloadAccess}
+          {catalog === null ? (
+            <Loading what="the providers Egma supports" />
+          ) : catalog.status !== "ready" ? (
+            /*
+             * The rows below are the catalog's — which providers Egma can
+             * execute and what each one's key is for — so none is drawn while
+             * that answer is missing. A row rendered here would be a claim
+             * about what may be configured, made out of a read that failed.
+             */
+            <Failure
+              title="Egma could not say which providers it supports."
+              message={
+                catalog.status === "signed-out"
+                  ? "Your session has ended. Sign in and try again."
+                  : catalog.refusal.message
+              }
+              onRetry={reloadCatalog}
             />
-          ))}
+          ) : (
+            <>
+              <DataTable
+                label="Model providers"
+                columns={columns}
+                rows={rows}
+                keyOf={(row) => row.provider}
+              />
+
+              {/*
+               * The replacement form is drawn once, under the table, for
+               * whichever row asked for it — never inside a cell. One labelled
+               * secret field, tied to the row that opened it, instead of a
+               * table cell owning a form whose state outlives that cell.
+               */}
+              {open === undefined ? null : (
+                <Form onSubmit={() => void store(open)}>
+                  <Field
+                    label={
+                      open.credential === undefined
+                        ? `Key for ${open.label}`
+                        : `Replacement key for ${open.label}`
+                    }
+                    htmlFor={`model-provider-${open.provider}`}
+                    hint="Egma seals it and calls no provider. A key that has expired or lacks permission is reported when a simulation uses it."
+                  >
+                    <TextInput
+                      id={`model-provider-${open.provider}`}
+                      value={key}
+                      type="password"
+                      disabled={!mayAdminister}
+                      onChange={setKey}
+                    />
+                  </Field>
+
+                  {refused === null ? null : (
+                    <Failure
+                      title={`Egma did not change the ${open.label} key.`}
+                      message={refused.message}
+                      onRetry={() => void store(open)}
+                    />
+                  )}
+
+                  <FormActions>
+                    <Button
+                      weight="strong"
+                      type="submit"
+                      busy={busy}
+                      disabled={!mayAdminister || key.trim() === ""}
+                    >
+                      {open.credential === undefined ? "Add key" : "Replace key"}
+                    </Button>
+                    <Button disabled={busy} onClick={() => openFor(open.provider)}>
+                      Cancel
+                    </Button>
+                  </FormActions>
+                </Form>
+              )}
+
+              {/*
+               * The fourth save state, said after the form has closed: a write
+               * that landed and left nothing on screen would be
+               * indistinguishable from one that never went.
+               */}
+              {saved === null || refused !== null ? null : (
+                <Help>The {saved} key is saved.</Help>
+              )}
+
+              {/* A refusal from a row whose form has since closed still has to
+                  be readable — a Remove that Egma turned away is the case. */}
+              {refused === null || open !== undefined ? null : (
+                <Failure
+                  title="Egma did not change that key."
+                  message={refused.message}
+                  onRetry={reloadAccess}
+                />
+              )}
+            </>
+          )}
         </Section>
+      )}
+
+      {confirmingRemove === null ? null : (
+        <Dialog
+          title={`Remove the ${confirmingRemove.label} key?`}
+          onClose={() => setConfirmingRemove(null)}
+        >
+          {(dismiss) => (
+            <>
+              <p>
+                Egma will hold no {confirmingRemove.label} key for this
+                organization. Every simulation and every grading job that selects{" "}
+                {confirmingRemove.label} stops with an error naming it, until
+                somebody adds a key again.
+              </p>
+              <p>
+                The stored key cannot be read back, so this cannot be undone from
+                here — adding one again means having the key itself.
+              </p>
+              <Button onClick={dismiss}>Cancel</Button>{" "}
+              <Button
+                tone="destructive"
+                busy={busy}
+                onClick={() => {
+                  const row = confirmingRemove;
+                  setConfirmingRemove(null);
+                  void remove(row);
+                }}
+              >
+                Remove key
+              </Button>
+            </>
+          )}
+        </Dialog>
       )}
     </Frame>
   );
@@ -218,163 +492,5 @@ function Frame({
         </SettingsLayout>
       </PageBody>
     </ProductPage>
-  );
-}
-
-/**
- * One provider's row: what its key is for, whether one is held, and the two
- * things an admin can do about it.
- *
- * **Add and Replace are one form**, because there is one credential per
- * provider: they are the same request with the same effect, and two forms would
- * differ only in which of them refuses when somebody guessed wrong about what
- * is already stored.
- */
-function ProviderRow({
-  projectId,
-  provider,
-  jobs,
-  credential,
-  mayAdminister,
-  onChanged,
-}: {
-  readonly projectId: string;
-  readonly provider: string;
-  readonly jobs: readonly ("llm" | "stt" | "tts")[];
-  readonly credential:
-    | { readonly hint: string; readonly revision: string }
-    | undefined;
-  readonly mayAdminister: boolean;
-  readonly onChanged: () => void;
-}) {
-  const [key, setKey] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [removing, setRemoving] = useState(false);
-  const [refused, setRefused] = useState<Refusal | null>(null);
-  const fieldId = `model-provider-${provider}`;
-
-  async function store(): Promise<void> {
-    if (!mayAdminister || key.trim() === "" || saving) return;
-    setRefused(null);
-    setSaving(true);
-
-    const written = await writeJson(MODEL_PROVIDER_CREDENTIALS_PATH, {
-      method: "PUT",
-      project: projectId,
-      body: {
-        provider,
-        key: key.trim(),
-        // What this write was composed against, so an admin replacing a key
-        // from a page they left open is told the stored one moved rather than
-        // silently landing on top of somebody else's rotation.
-        ...(credential === undefined
-          ? {}
-          : { expected_revision: credential.revision }),
-      },
-    });
-
-    setSaving(false);
-    if (written.status === "signed-out") {
-      window.location.replace("/sign-in");
-      return;
-    }
-    if (written.status !== "ready") {
-      setRefused(written.refusal);
-      return;
-    }
-    // Cleared the moment it lands: what was typed is a secret, and a form that
-    // kept it on screen would be the one place in the product that shows one.
-    setKey("");
-    onChanged();
-  }
-
-  async function remove(): Promise<void> {
-    if (!mayAdminister || credential === undefined || removing) return;
-    setRefused(null);
-    setRemoving(true);
-
-    const written = await deleteJson(modelProviderCredentialPath(provider), {
-      project: projectId,
-    });
-
-    setRemoving(false);
-    if (written.status === "signed-out") {
-      window.location.replace("/sign-in");
-      return;
-    }
-    if (written.status !== "ready") {
-      setRefused(written.refusal);
-      return;
-    }
-    onChanged();
-  }
-
-  return (
-    <Section
-      title={provider}
-      lead={`Used for ${jobs.map((job) => JOB_LABEL[job]).join(", ")}.`}
-    >
-      <Help>
-        {credential === undefined ? (
-          <>
-            <Badge tone="warn">Not configured</Badge> A simulation or a grader
-            that selects {provider} stops with an error naming it, and nothing
-            else is affected.
-          </>
-        ) : (
-          <>
-            <Badge tone="good">Configured</Badge> Ending …{credential.hint}. The
-            stored key is never shown; replacing it is typing a new one.
-          </>
-        )}
-      </Help>
-
-      <Form onSubmit={() => void store()}>
-        <Field
-          label={credential === undefined ? "Key" : "Replacement key"}
-          htmlFor={fieldId}
-          hint="Egma seals it and calls no provider. A key that has expired or lacks permission is reported when a simulation uses it."
-        >
-          <TextInput
-            id={fieldId}
-            value={key}
-            type="password"
-            disabled={!mayAdminister}
-            onChange={setKey}
-          />
-        </Field>
-
-        {refused === null ? null : (
-          <Failure
-            title={`Egma did not change the ${provider} key.`}
-            message={refused.message}
-            onRetry={() => void store()}
-          />
-        )}
-
-        <FormActions>
-          <Button
-            weight="strong"
-            type="submit"
-            disabled={!mayAdminister || key.trim() === "" || saving}
-          >
-            {saving
-              ? "Saving…"
-              : credential === undefined
-                ? "Add key"
-                : "Replace key"}
-          </Button>
-          {credential === undefined ? null : (
-            <Button
-              tone="destructive"
-              disabled={!mayAdminister || removing}
-              onClick={() => void remove()}
-            >
-              {removing ? "Removing…" : "Remove key"}
-            </Button>
-          )}
-        </FormActions>
-      </Form>
-    </Section>
   );
 }

--- a/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { deleteJson, writeJson, type Refusal } from "../../../../../lib/api.ts";
+import { roleOf } from "../../../../../lib/me.ts";
+import {
+  credentialFor,
+  credentialsIn,
+  jobsOfProvider,
+  modelProviderCredentialPath,
+  providersIn,
+  JOB_LABEL,
+  MODE_LABEL,
+  MODEL_ACCESS_PATH,
+  MODEL_CATALOG_PATH,
+  MODEL_PROVIDER_CREDENTIALS_PATH,
+  type ModelAccess,
+  type ModelAccessMode,
+  type ModelCatalog,
+} from "../../../../../lib/model-access.ts";
+import {
+  Badge,
+  Button,
+  Field,
+  Form,
+  FormActions,
+  Help,
+  Section,
+  TextInput,
+} from "../../../../../ui/controls.tsx";
+import { Failure, Loading } from "../../../../../ui/page-state.tsx";
+import { useProjectRead } from "../../../../../ui/resource.ts";
+import { SettingsLayout } from "../../../../../ui/settings-nav.tsx";
+import {
+  AppShell,
+  PageBody,
+  PageHeader,
+  ProductPage,
+  useShellSession,
+} from "../../../../../ui/shell.tsx";
+
+/**
+ * Who supplies the keys this organization's model traffic spends, and — where
+ * the organization supplies them — the keys themselves.
+ *
+ * **No stored key ever reaches this page**, and that is a property of the API
+ * rather than a rule this file follows: the read shape has no field a secret
+ * could travel in. What a person sees is a provider and four characters —
+ * enough to tell two keys apart, and not enough to be one. Replacing a key is
+ * typing a new one; it is never reading the old one first, and there is no
+ * route that would let them.
+ *
+ * **Nothing here is a readiness checklist.** A provider with no key is shown as
+ * "Not configured", which is a state and not a fault: an organization mid-setup
+ * is the ordinary organization, and a page that refused to let somebody leave
+ * until every row was filled would be the blocked feeling this whole area
+ * removes. What a missing key actually costs arrives per simulation, named,
+ * with a link back to this page.
+ *
+ * **Saving calls no provider.** A key is sealed and stored; whether it works is
+ * reported when it is used, where the report can name the simulation it
+ * stopped. Anything else would make saving depend on the provider being up and
+ * would still not be true a minute later.
+ *
+ * Model providers are administration: the credentials are the organization's
+ * and the mode commits its account, so only an admin may change either. The
+ * page is readable to everybody, because somebody looking at a persona's models
+ * has to be able to see who pays for them.
+ */
+export default function ModelProvidersSettingsPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  return (
+    <AppShell>
+      <ModelProviders projectId={projectId} />
+    </AppShell>
+  );
+}
+
+function ModelProviders({ projectId }: { readonly projectId: string }) {
+  const { me } = useShellSession();
+  // Null until the session read answers. An unsettled session is neither an
+  // admin nor a viewer, and claiming either would be a guess shown as a fact.
+  const role = me === null ? null : roleOf(me);
+  const mayAdminister = role === "admin";
+
+  const { answer: access, reload: reloadAccess } = useProjectRead<ModelAccess>(
+    MODEL_ACCESS_PATH,
+    projectId,
+  );
+  const { answer: catalog, reload: reloadCatalog } =
+    useProjectRead<ModelCatalog>(MODEL_CATALOG_PATH, projectId);
+
+  useEffect(() => {
+    if (access?.status === "signed-out" || catalog?.status === "signed-out") {
+      window.location.replace("/sign-in");
+    }
+  }, [access, catalog]);
+
+  if (access === null) {
+    return (
+      <Frame projectId={projectId}>
+        <Loading what="this organization's model providers" />
+      </Frame>
+    );
+  }
+
+  if (access.status !== "ready") {
+    return (
+      <Frame projectId={projectId}>
+        <Failure
+          message={
+            access.status === "signed-out"
+              ? "Your session has ended. Sign in and try again."
+              : access.refusal.message
+          }
+          onRetry={reloadAccess}
+        />
+      </Frame>
+    );
+  }
+
+  const held = credentialsIn(access.value);
+  const mode = access.value.mode;
+
+  return (
+    <Frame projectId={projectId}>
+      <Section
+        title="Model access"
+        lead="Who supplies the provider keys every persona and grader in this organization spends."
+      >
+        <Help>
+          <Badge tone="neutral">{MODE_LABEL[mode]}</Badge>{" "}
+          {mode === "customer-owned"
+            ? "This organization uses its own provider accounts. The simulator and the grader call those providers directly, and Egma is not on the path."
+            : "This organization uses Egma's provider accounts through the Egma model gateway."}
+        </Help>
+
+        {access.value.managed_available ? null : (
+          <Help>
+            Managed by Egma is not available on this deployment: it sends model
+            traffic through the Egma model gateway, and no connection to it has
+            been made here. Customer-owned is the only mode that can be chosen.
+          </Help>
+        )}
+
+        {role === null || mayAdminister ? null : (
+          <Help>
+            Your {String(role ?? "")} role cannot change model providers. Ask an
+            organization admin.
+          </Help>
+        )}
+      </Section>
+
+      {mode !== "customer-owned" ? null : catalog === null ? (
+        <Section title="Providers">
+          <Loading what="the providers Egma supports" />
+        </Section>
+      ) : catalog.status !== "ready" ? (
+        <Section title="Providers">
+          {/*
+           * The rows below are the catalog's — which providers Egma can execute
+           * and what each one's key is for — so none is drawn while that answer
+           * is missing. A row rendered here would be a claim about what may be
+           * configured, made out of a read that failed.
+           */}
+          <Failure
+            title="Egma could not say which providers it supports."
+            message={
+              catalog.status === "signed-out"
+                ? "Your session has ended. Sign in and try again."
+                : catalog.refusal.message
+            }
+            onRetry={reloadCatalog}
+          />
+        </Section>
+      ) : (
+        <Section
+          title="Providers"
+          lead="One key for each provider your personas and graders select. A provider with no key stops only the simulations that name it."
+        >
+          {providersIn(catalog.value).map((provider) => (
+            <ProviderRow
+              key={provider}
+              projectId={projectId}
+              provider={provider}
+              jobs={jobsOfProvider(catalog.value, provider)}
+              credential={credentialFor(held, provider)}
+              mayAdminister={mayAdminister}
+              onChanged={reloadAccess}
+            />
+          ))}
+        </Section>
+      )}
+    </Frame>
+  );
+}
+
+/** The stable frame every state of this page uses, so nothing moves on arrival. */
+function Frame({
+  projectId,
+  children,
+}: {
+  readonly projectId: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <ProductPage>
+      <PageHeader
+        eyebrow="Settings"
+        title="Model providers"
+        lead="Who pays for this organization's model traffic, and the keys that authorize it."
+      />
+      <PageBody>
+        <SettingsLayout projectId={projectId} current="model-providers">
+          {children}
+        </SettingsLayout>
+      </PageBody>
+    </ProductPage>
+  );
+}
+
+/**
+ * One provider's row: what its key is for, whether one is held, and the two
+ * things an admin can do about it.
+ *
+ * **Add and Replace are one form**, because there is one credential per
+ * provider: they are the same request with the same effect, and two forms would
+ * differ only in which of them refuses when somebody guessed wrong about what
+ * is already stored.
+ */
+function ProviderRow({
+  projectId,
+  provider,
+  jobs,
+  credential,
+  mayAdminister,
+  onChanged,
+}: {
+  readonly projectId: string;
+  readonly provider: string;
+  readonly jobs: readonly ("llm" | "stt" | "tts")[];
+  readonly credential:
+    | { readonly hint: string; readonly revision: string }
+    | undefined;
+  readonly mayAdminister: boolean;
+  readonly onChanged: () => void;
+}) {
+  const [key, setKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const [refused, setRefused] = useState<Refusal | null>(null);
+  const fieldId = `model-provider-${provider}`;
+
+  async function store(): Promise<void> {
+    if (!mayAdminister || key.trim() === "" || saving) return;
+    setRefused(null);
+    setSaving(true);
+
+    const written = await writeJson(MODEL_PROVIDER_CREDENTIALS_PATH, {
+      method: "PUT",
+      project: projectId,
+      body: {
+        provider,
+        key: key.trim(),
+        // What this write was composed against, so an admin replacing a key
+        // from a page they left open is told the stored one moved rather than
+        // silently landing on top of somebody else's rotation.
+        ...(credential === undefined
+          ? {}
+          : { expected_revision: credential.revision }),
+      },
+    });
+
+    setSaving(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    // Cleared the moment it lands: what was typed is a secret, and a form that
+    // kept it on screen would be the one place in the product that shows one.
+    setKey("");
+    onChanged();
+  }
+
+  async function remove(): Promise<void> {
+    if (!mayAdminister || credential === undefined || removing) return;
+    setRefused(null);
+    setRemoving(true);
+
+    const written = await deleteJson(modelProviderCredentialPath(provider), {
+      project: projectId,
+    });
+
+    setRemoving(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    onChanged();
+  }
+
+  return (
+    <Section
+      title={provider}
+      lead={`Used for ${jobs.map((job) => JOB_LABEL[job]).join(", ")}.`}
+    >
+      <Help>
+        {credential === undefined ? (
+          <>
+            <Badge tone="warn">Not configured</Badge> A simulation or a grader
+            that selects {provider} stops with an error naming it, and nothing
+            else is affected.
+          </>
+        ) : (
+          <>
+            <Badge tone="good">Configured</Badge> Ending …{credential.hint}. The
+            stored key is never shown; replacing it is typing a new one.
+          </>
+        )}
+      </Help>
+
+      <Form onSubmit={() => void store()}>
+        <Field
+          label={credential === undefined ? "Key" : "Replacement key"}
+          htmlFor={fieldId}
+          hint="Egma seals it and calls no provider. A key that has expired or lacks permission is reported when a simulation uses it."
+        >
+          <TextInput
+            id={fieldId}
+            value={key}
+            type="password"
+            disabled={!mayAdminister}
+            onChange={setKey}
+          />
+        </Field>
+
+        {refused === null ? null : (
+          <Failure
+            title={`Egma did not change the ${provider} key.`}
+            message={refused.message}
+            onRetry={() => void store()}
+          />
+        )}
+
+        <FormActions>
+          <Button
+            weight="strong"
+            type="submit"
+            disabled={!mayAdminister || key.trim() === "" || saving}
+          >
+            {saving
+              ? "Saving…"
+              : credential === undefined
+                ? "Add key"
+                : "Replace key"}
+          </Button>
+          {credential === undefined ? null : (
+            <Button
+              tone="destructive"
+              disabled={!mayAdminister || removing}
+              onClick={() => void remove()}
+            >
+              {removing ? "Removing…" : "Remove key"}
+            </Button>
+          )}
+        </FormActions>
+      </Form>
+    </Section>
+  );
+}

--- a/apps/web/lib/grader-running-copy.ts
+++ b/apps/web/lib/grader-running-copy.ts
@@ -82,6 +82,7 @@ export const EDIT = {
   groups: {
     general: "General",
     logic: "Grading logic",
+    model: "Model",
     applicability: "Applicability",
     impact: "Impact",
   },
@@ -91,6 +92,21 @@ export const EDIT = {
   nameMeans: "The name shown in this project.",
   description: "Notes",
   descriptionMeans: "Optional context for your team.",
+  modelProvider: "Provider",
+  modelProviderMeans:
+    "Which provider judges with this grader. Its key belongs to the " +
+    "organization and is set under Model providers.",
+  modelId: "Model",
+  modelIdMeans: "The provider's own id. Any model that provider accepts.",
+  /**
+   * What a copy that has chosen nothing reads as.
+   *
+   * A state and not a fault: it is every grader authored before the model
+   * catalog existed, and the project's judge setting decides for it exactly as
+   * it always did.
+   */
+  modelInherited: "Uses this project's judge setting.",
+  modelClear: "Use the project's judge",
   scope: "Applies to",
   scopeMeans: "Choose tests, live traffic, or both.",
   required: "Can fail a run",

--- a/apps/web/lib/graders.ts
+++ b/apps/web/lib/graders.ts
@@ -88,6 +88,19 @@ export type RunningGrader = {
   /** What share of live traffic it judges, as a whole percentage. */
   readonly production_sample_rate: number;
   readonly config: { readonly assertions?: readonly unknown[] } | null;
+  /**
+   * This copy's own LLM selection, or `null` for one still on the
+   * compatibility path — where the project's judge setting decides, exactly as
+   * it did before the model catalog existed.
+   *
+   * **There is no key beside it and there never will be.** The key behind the
+   * selection is the organization's, under Model providers, and a grader that
+   * named one would put a secret inside authored content a run then pins.
+   */
+  readonly model: {
+    readonly provider: string;
+    readonly model: string;
+  } | null;
   readonly created_at: string;
   readonly updated_at: string;
 };

--- a/apps/web/lib/model-access.ts
+++ b/apps/web/lib/model-access.ts
@@ -112,6 +112,27 @@ export function providersIn(
   return seen;
 }
 
+/**
+ * What a person calls one provider, as the catalog named it.
+ *
+ * **The catalog's own label, never the stored word.** `openai` is an
+ * identifier: it is what a work order carries and what a credential is filed
+ * under, and showing it on a screen makes a person read Egma's storage rather
+ * than the name their provider goes by. The word itself is the fallback for a
+ * provider the catalog no longer ships, because a row that named nothing at all
+ * would be worse than one naming its identifier.
+ */
+export function labelOfProvider(
+  catalog: ModelCatalog | undefined,
+  provider: string,
+): string {
+  if (!Array.isArray(catalog?.providers)) return provider;
+  return (
+    catalog.providers.find((entry) => entry.provider === provider)?.label ??
+    provider
+  );
+}
+
 /** Which model jobs one provider does, so a row can say what its key is for. */
 export function jobsOfProvider(
   catalog: ModelCatalog | undefined,

--- a/apps/web/lib/model-access.ts
+++ b/apps/web/lib/model-access.ts
@@ -1,0 +1,141 @@
+/**
+ * Model providers, as `GET /api/model-access` and `GET /api/model-catalog`
+ * answer them: who supplies the keys this organization's model traffic spends,
+ * and which providers do which model job.
+ *
+ * **Nothing in this file can hold a key**, and that is deliberate rather than
+ * incidental: the API's read shape has no field a secret could travel in, so
+ * neither does this. What a page ever has is a provider and four characters —
+ * enough to tell two keys apart, and not enough to be one.
+ *
+ * A stored secret goes in one direction only. Replacing a key is sending a new
+ * value; it is never reading the old one and writing it back.
+ *
+ * **The catalog is the server's and this file restates none of it.** A browser
+ * that kept its own provider list would be a list that can disagree with the
+ * one the claim path executes from, and the disagreement is a provider somebody
+ * can select and nothing can run.
+ */
+
+/** One organization-wide choice, and the only two values it has. */
+export type ModelAccessMode = "managed" | "customer-owned";
+
+/** One role a model performs for a persona: what it thinks, hears, speaks with. */
+export type ModelJob = "llm" | "stt" | "tts";
+
+export type ModelProviderCredential = {
+  readonly provider: string;
+  /** The last characters of the key. Never enough of it to use. */
+  readonly hint: string;
+  readonly revision: string;
+  readonly updated_at: string;
+};
+
+export type ModelAccess = {
+  readonly mode: ModelAccessMode;
+  /** When the choice was last made, or null where nobody has made one. */
+  readonly updated_at: string | null;
+  readonly modes: readonly ModelAccessMode[];
+  /**
+   * Whether managed access can be chosen on this deployment at all.
+   *
+   * **A fact about the deployment, never about the organization's current
+   * choice.** A form that offered a mode the server refuses would let somebody
+   * decide before telling them the decision cannot land.
+   */
+  readonly managed_available: boolean;
+  readonly credentials: readonly ModelProviderCredential[];
+};
+
+export type CatalogEntry = {
+  readonly provider: string;
+  readonly job: ModelJob;
+  /** What a person calls it, in a form and in an error alike. */
+  readonly label: string;
+  readonly recommended_model: string;
+  readonly recommended_voice_id?: string;
+  readonly model_is_free_text: boolean;
+};
+
+export type ModelCatalog = {
+  readonly jobs: readonly ModelJob[];
+  readonly providers: readonly CatalogEntry[];
+  /** Pairs the product intends and this release has not proved. Not selectable. */
+  readonly reserved: readonly { readonly provider: string; readonly job: ModelJob }[];
+};
+
+export const MODEL_ACCESS_PATH = "/api/model-access";
+export const MODEL_CATALOG_PATH = "/api/model-catalog";
+export const MODEL_PROVIDER_CREDENTIALS_PATH = "/api/model-provider-credentials";
+
+export function modelProviderCredentialPath(provider: string): string {
+  return `${MODEL_PROVIDER_CREDENTIALS_PATH}/${encodeURIComponent(provider)}`;
+}
+
+/** What a person calls each mode, said the way the settings screen says it. */
+export const MODE_LABEL: Readonly<Record<ModelAccessMode, string>> = {
+  managed: "Managed by Egma",
+  "customer-owned": "Customer-owned",
+};
+
+/** What a person calls each model job, said once so no screen invents a second word. */
+export const JOB_LABEL: Readonly<Record<ModelJob, string>> = {
+  llm: "Language model",
+  stt: "Speech to text",
+  tts: "Text to speech",
+};
+
+/**
+ * The credentials an answer actually carried, and none at all when it carried
+ * something this page cannot read.
+ *
+ * A read whose shape is not the expected one is a deployment mid-upgrade or a
+ * proxy answering for something else. The cost of trusting it is not a wrong
+ * list — it is `undefined.map`, which takes the whole settings page down and
+ * with it the credential somebody came to replace.
+ */
+export function credentialsIn(
+  access: ModelAccess | undefined,
+): readonly ModelProviderCredential[] {
+  return Array.isArray(access?.credentials) ? access.credentials : [];
+}
+
+/** Every provider the catalog can execute, once, in catalog order. */
+export function providersIn(
+  catalog: ModelCatalog | undefined,
+): readonly string[] {
+  if (!Array.isArray(catalog?.providers)) return [];
+  const seen: string[] = [];
+  for (const entry of catalog.providers) {
+    if (!seen.includes(entry.provider)) seen.push(entry.provider);
+  }
+  return seen;
+}
+
+/** Which model jobs one provider does, so a row can say what its key is for. */
+export function jobsOfProvider(
+  catalog: ModelCatalog | undefined,
+  provider: string,
+): readonly ModelJob[] {
+  if (!Array.isArray(catalog?.providers)) return [];
+  return catalog.providers
+    .filter((entry) => entry.provider === provider)
+    .map((entry) => entry.job);
+}
+
+/** The stored credential for one provider, or nothing where none is held. */
+export function credentialFor(
+  credentials: readonly ModelProviderCredential[],
+  provider: string,
+): ModelProviderCredential | undefined {
+  return credentials.find((one) => one.provider === provider);
+}
+
+/** The entries for one model job, which is what a persona's form asks about. */
+export function entriesForJob(
+  catalog: ModelCatalog | undefined,
+  job: ModelJob,
+): readonly CatalogEntry[] {
+  if (!Array.isArray(catalog?.providers)) return [];
+  return catalog.providers.filter((entry) => entry.job === job);
+}

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -43,6 +43,8 @@ export type Persona = {
   /** The current version's own id — what a traits write is written against. */
   readonly version_id: string;
   readonly traits: PersonaTraits;
+  /** The current version's model selections, or null on the compatibility path. */
+  readonly models: PersonaModels | null;
   /** The opaque token an identity write or a lifecycle change has to name. */
   readonly revision: string;
   readonly archived_at: string | null;
@@ -63,6 +65,7 @@ export type PersonaVersion = {
   readonly persona_id: string;
   readonly version: number;
   readonly traits: PersonaTraits;
+  readonly models: PersonaModels | null;
   readonly created_at: string;
 };
 
@@ -92,6 +95,55 @@ export const PERSONA_FORM_PATH = "/api/persona-form";
  */
 export type PersonaForm = {
   readonly voice_providers: readonly string[];
+  /**
+   * The providers that do each model job, and the model a release proved for
+   * each — the same catalog Model providers draws itself from, served here so
+   * the persona editor renders from one call rather than two.
+   *
+   * **The browser keeps no copy**, for the reason the voice providers above
+   * are read rather than listed: a second copy is wrong the day the catalog
+   * grows, and wrong silently.
+   */
+  readonly model_catalog: readonly {
+    readonly provider: string;
+    readonly job: "llm" | "stt" | "tts";
+    readonly label: string;
+    readonly recommended_model: string;
+    readonly recommended_voice_id?: string;
+    readonly model_is_free_text: boolean;
+  }[];
+  /** What a persona that has chosen nothing starts from. */
+  readonly recommended_models: {
+    readonly llm: { readonly provider: string; readonly model: string };
+    readonly stt: { readonly provider: string; readonly model: string };
+    readonly tts: {
+      readonly provider: string;
+      readonly model: string;
+      readonly voiceId: string;
+      readonly speed: number;
+    };
+  };
+  /** How far from natural pace speech stays intelligible, as the server bounds it. */
+  readonly speed_range: { readonly slowest: number; readonly fastest: number };
+};
+
+/**
+ * What a persona thinks, listens and speaks with — or `null` for one still on
+ * the compatibility path, where the deployment's own settings decide.
+ *
+ * `null` is an ordinary state and never a fault: it is every persona authored
+ * before the model catalog existed, and a page says so plainly rather than
+ * showing a half-filled form as though somebody had chosen.
+ */
+export type PersonaModels = {
+  readonly llm: { readonly provider: string; readonly model: string };
+  readonly stt: { readonly provider: string; readonly model: string };
+  readonly tts: {
+    readonly provider: string;
+    readonly model: string;
+    readonly voiceId: string;
+    readonly speed: number;
+  };
 };
 
 /**
@@ -235,5 +287,92 @@ export function describedTraits(
     one.value === undefined || one.value.trim() === ""
       ? []
       : [{ label: one.label, value: one.value }],
+  );
+}
+
+/**
+ * The model selections an editor is holding, before anybody decides whether
+ * they differ from what is stored.
+ *
+ * Speed is text here and a number on the wire, for the reason speech rate
+ * already is: what somebody has typed is a string, including the half-typed
+ * `1.` in the middle of typing `1.25`, and coercing on every keystroke is what
+ * makes a field fight back while it is being used.
+ *
+ * **There is no key here and there is nowhere to put one.** Who pays for a
+ * model is the organization's model access; a persona names a provider and
+ * never a secret.
+ */
+export type ModelsDraft = {
+  readonly llmProvider: string;
+  readonly llmModel: string;
+  readonly sttProvider: string;
+  readonly sttModel: string;
+  readonly ttsProvider: string;
+  readonly ttsModel: string;
+  readonly ttsVoiceId: string;
+  readonly ttsSpeed: string;
+};
+
+/** The stored selections, as the editor holds them. */
+export function modelsDraftOf(models: PersonaModels): ModelsDraft {
+  return {
+    llmProvider: models.llm.provider,
+    llmModel: models.llm.model,
+    sttProvider: models.stt.provider,
+    sttModel: models.stt.model,
+    ttsProvider: models.tts.provider,
+    ttsModel: models.tts.model,
+    ttsVoiceId: models.tts.voiceId,
+    ttsSpeed: String(models.tts.speed),
+  };
+}
+
+/**
+ * What a persona that has chosen nothing starts from: the release's proved
+ * defaults, read off the server rather than written here.
+ *
+ * `null` while the form read has not answered, because a draft made of guessed
+ * providers is a form that offers a choice Egma may not ship.
+ */
+export function recommendedDraft(form: PersonaForm | undefined): ModelsDraft | null {
+  const recommended = form?.recommended_models;
+  if (recommended === undefined) return null;
+  return modelsDraftOf(recommended);
+}
+
+/**
+ * The draft, as the wire carries it.
+ *
+ * A speed that is not a number at all is sent as the raw text and the server
+ * answers with the range it accepts. This page holds no second copy of that
+ * rule: a validator here that disagreed with the one that decides would refuse
+ * something Egma would have taken, or take something Egma will refuse.
+ */
+export function modelsFrom(draft: ModelsDraft): Record<string, unknown> {
+  const speed = Number(draft.ttsSpeed);
+  return {
+    llm: { provider: draft.llmProvider, model: draft.llmModel },
+    stt: { provider: draft.sttProvider, model: draft.sttModel },
+    tts: {
+      provider: draft.ttsProvider,
+      model: draft.ttsModel,
+      voiceId: draft.ttsVoiceId,
+      speed: Number.isNaN(speed) ? draft.ttsSpeed : speed,
+    },
+  };
+}
+
+/** Whether two drafts say the same thing, field by field. */
+export function sameModelsDraft(a: ModelsDraft, b: ModelsDraft): boolean {
+  return (
+    a.llmProvider === b.llmProvider &&
+    a.llmModel === b.llmModel &&
+    a.sttProvider === b.sttProvider &&
+    a.sttModel === b.sttModel &&
+    a.ttsProvider === b.ttsProvider &&
+    a.ttsModel === b.ttsModel &&
+    a.ttsVoiceId === b.ttsVoiceId &&
+    a.ttsSpeed === b.ttsSpeed
   );
 }

--- a/apps/web/lib/runs.ts
+++ b/apps/web/lib/runs.ts
@@ -394,6 +394,17 @@ export type RunSimulation = {
   readonly score: number | null;
   readonly counts: VerdictCounts | null;
   readonly reason: string | null;
+  /**
+   * One sentence saying what actually went wrong, where the reason word cannot
+   * say it alone — and the screen that fixes it, as one word from a closed
+   * list. Both null on every conversation that ran.
+   *
+   * A word rather than a link, because the address of a page is the browser's
+   * business: a stored link would be a route the platform could not be
+   * refactored around, and an unknown word would be a button to nowhere.
+   */
+  readonly detail: string | null;
+  readonly repair: string | null;
   readonly skip_reason: string | null;
   readonly skipped_capabilities: readonly string[] | null;
   readonly modality: string | null;

--- a/apps/web/lib/simulations.ts
+++ b/apps/web/lib/simulations.ts
@@ -180,6 +180,17 @@ export type SimulationEvidence = {
   readonly score: number | null;
   readonly counts: VerdictCounts | null;
   readonly reason: string | null;
+  /**
+   * One sentence saying what actually went wrong, where the reason word cannot
+   * say it alone — and the screen that fixes it, as one word from a closed
+   * list. Both null on every conversation that ran.
+   *
+   * A word rather than a link, because the address of a page is the browser's
+   * business: a stored link would be a route the platform could not be
+   * refactored around, and an unknown word would be a button to nowhere.
+   */
+  readonly detail: string | null;
+  readonly repair: string | null;
   readonly skip_reason: string | null;
   readonly skipped_capabilities: readonly string[] | null;
   readonly modality: string | null;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -122,6 +122,23 @@ const config: NextConfig = {
           source: "/api/judge-credentials/:path*",
           destination: `${api}/api/judge-credentials/:path*`,
         },
+        // Model providers: who supplies the keys this organization's model
+        // traffic spends, the keys themselves, and the catalog a persona and a
+        // grader select from. Three rules and a wildcard, because the bare
+        // paths and the per-provider one are four different doors — and
+        // because `:path*` is documented as matching zero segments and on the
+        // hosted deployment it did not, which is why every bare path in this
+        // file is named outright rather than left to the wildcard.
+        { source: "/api/model-access", destination: `${api}/api/model-access` },
+        { source: "/api/model-catalog", destination: `${api}/api/model-catalog` },
+        {
+          source: "/api/model-provider-credentials",
+          destination: `${api}/api/model-provider-credentials`,
+        },
+        {
+          source: "/api/model-provider-credentials/:path*",
+          destination: `${api}/api/model-provider-credentials/:path*`,
+        },
         // The shelf of grader definitions the Library screen draws itself
         // from. One rule and no `:path*` beside it, because the library is
         // read and never authored: a second address under it would be a

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -185,6 +185,9 @@ const SEEDED: RunningGrader = {
   scope: "simulations",
   production_sample_rate: 0,
   config: { assertions: [] },
+  // On the compatibility path, which is what every copy authored before the
+  // model catalog existed reads as — a state rather than a fault.
+  model: null,
   created_at: "2026-08-15T10:00:00.000Z",
   updated_at: "2026-08-15T10:00:00.000Z",
 };

--- a/apps/web/test/personas.test.tsx
+++ b/apps/web/test/personas.test.tsx
@@ -127,6 +127,9 @@ const RITA: Persona = {
   description: "Somebody in a hurry.",
   version: 1,
   version_id: "prsv_1",
+  // On the compatibility path, which is what every persona authored before the
+  // model catalog existed reads as — and a state rather than a fault.
+  models: null,
   traits: {
     personality: "Seventy, hard of hearing, and gets louder when she mishears.",
     language: "en-US",

--- a/apps/web/ui/controls.tsx
+++ b/apps/web/ui/controls.tsx
@@ -292,8 +292,15 @@ export function TextInput({
   /**
    * A field whose value is a number rather than words. It changes the keypad a
    * phone offers and what the browser will accept, and it is deliberately not
-   * what makes the value a number — the caller converts before sending, because
+   * what makes the value a number — the reader converts before sending, because
    * an input's value is a string whatever type it wears.
+   *
+   * It states the keypad twice, and both are load-bearing. `type="number"` is
+   * what the browser validates against; `inputMode` is what actually decides
+   * the on-screen keyboard on a phone, and a numeric field without it can still
+   * be met with a full alphabetic one. `decimal` rather than `numeric` because
+   * a speech rate is 1.25 as often as it is 1, and the whole-number keypad has
+   * no separator on it at all.
    */
   readonly numeric?: boolean;
   /** Keep native browser validation available to forms that require a value. */
@@ -327,6 +334,7 @@ export function TextInput({
       id={id}
       name={name}
       type={type ?? (secret ? "password" : numeric ? "number" : "text")}
+      inputMode={numeric ? "decimal" : undefined}
       value={value}
       placeholder={placeholder}
       aria-label={label}

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -34,6 +34,7 @@ export type SettingsSection =
   | "project"
   | "judge"
   | "organization"
+  | "model-providers"
   | "people"
   | "keys";
 
@@ -51,6 +52,15 @@ const PROJECT_SETTINGS: readonly Item[] = [
 
 const ORGANIZATION_SETTINGS: readonly Item[] = [
   { id: "organization", label: "Organization", rest: ["organization"] },
+  // Who supplies the keys every persona and grader in the organization spends,
+  // and the keys themselves. It sits in this group rather than the one above
+  // because that is exactly what it is: one key serves every project, and
+  // replacing one is felt by all of them at once.
+  {
+    id: "model-providers",
+    label: "Model providers",
+    rest: ["model-providers"],
+  },
   { id: "people", label: "People", rest: ["people"] },
   { id: "keys", label: "API keys", rest: ["keys"] },
 ];

--- a/packages/db/migrations/0035_customer_owned_model_access.sql
+++ b/packages/db/migrations/0035_customer_owned_model_access.sql
@@ -1,0 +1,55 @@
+-- Customer-owned model access: who pays for an organization's model traffic,
+-- the keys that authorize it when the organization pays, and the selections a
+-- persona and a grader make independently of both.
+--
+--  * `model_access` is the organization's one binary choice. A missing row is
+--    `customer-owned`, which is the honest reading of "nothing was connected to
+--    Egma's provider accounts" — so this migration writes no rows and decides
+--    nothing on anybody's behalf.
+--  * `model_provider_credential` is the organization's own key for one
+--    provider, sealed with the same master key and the same envelope every
+--    other credential in this schema uses. Unique on (organization, provider),
+--    so "which key does this simulation spend from" is answered by the
+--    constraint rather than by a rule somebody would have to write.
+--  * `persona_version.models` and `grader_version.grader_model` are nullable
+--    and stay nullable. Null is the compatibility path: a version authored
+--    before the model catalog existed keeps resolving through the deployment's
+--    own settings exactly as it did, and no immutable version is rewritten
+--    here. They fill in as personas and graders are edited, and by the later
+--    migration that gives each current version an explicit successor.
+--
+-- Every part of this is additive. Nothing is dropped, nothing is backfilled,
+-- and every read that worked before this file still works after it.
+
+CREATE TABLE "model_access" (
+	"organization_id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"mode" text NOT NULL,
+	"updated_by" text COLLATE "C",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "model_access_organization_id_prefix" CHECK ("model_access"."organization_id" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "model_access_mode_allowed" CHECK ("model_access"."mode" in ('managed', 'customer-owned'))
+);
+--> statement-breakpoint
+CREATE TABLE "model_provider_credential" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"provider" text NOT NULL,
+	"credentials" text NOT NULL,
+	"credentials_hint" text NOT NULL,
+	"revision" text COLLATE "C" NOT NULL,
+	"created_by" text COLLATE "C",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "model_provider_credential_one_per_provider" UNIQUE("organization_id","provider"),
+	CONSTRAINT "model_provider_credential_id_prefix" CHECK ("model_provider_credential"."id" ~ '^mpc_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "model_provider_credential_revision_prefix" CHECK ("model_provider_credential"."revision" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "model_provider_credential_provider_allowed" CHECK ("model_provider_credential"."provider" in ('openai', 'deepgram', 'cartesia'))
+);
+--> statement-breakpoint
+ALTER TABLE "persona_version" ADD COLUMN "models" jsonb;--> statement-breakpoint
+ALTER TABLE "grader_version" ADD COLUMN "grader_model" jsonb;--> statement-breakpoint
+ALTER TABLE "model_access" ADD CONSTRAINT "model_access_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "model_access" ADD CONSTRAINT "model_access_updated_by_user_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "model_provider_credential" ADD CONSTRAINT "model_provider_credential_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "model_provider_credential" ADD CONSTRAINT "model_provider_credential_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/db/migrations/0035_customer_owned_model_access.sql
+++ b/packages/db/migrations/0035_customer_owned_model_access.sql
@@ -17,6 +17,12 @@
 --    own settings exactly as it did, and no immutable version is rewritten
 --    here. They fill in as personas and graders are edited, and by the later
 --    migration that gives each current version an explicit successor.
+--  * `simulation.ending_detail` and `simulation.ending_repair` are what a
+--    person reads when a claimed simulation was never handed over. The reason
+--    word says `dispatch_failed` and nothing else; the sentence says which
+--    model job named which provider, and the repair word says which screen
+--    fixes it. Both are Egma's own writing — no customer content, no secret —
+--    and both are null on every simulation that ran.
 --
 -- Every part of this is additive. Nothing is dropped, nothing is backfilled,
 -- and every read that worked before this file still works after it.
@@ -49,7 +55,11 @@ CREATE TABLE "model_provider_credential" (
 --> statement-breakpoint
 ALTER TABLE "persona_version" ADD COLUMN "models" jsonb;--> statement-breakpoint
 ALTER TABLE "grader_version" ADD COLUMN "grader_model" jsonb;--> statement-breakpoint
+ALTER TABLE "simulation" ADD COLUMN "ending_detail" text;--> statement-breakpoint
+ALTER TABLE "simulation" ADD COLUMN "ending_repair" text;--> statement-breakpoint
 ALTER TABLE "model_access" ADD CONSTRAINT "model_access_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "model_access" ADD CONSTRAINT "model_access_updated_by_user_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "model_provider_credential" ADD CONSTRAINT "model_provider_credential_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "model_provider_credential" ADD CONSTRAINT "model_provider_credential_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;
+ALTER TABLE "model_provider_credential" ADD CONSTRAINT "model_provider_credential_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_ending_repair_allowed" CHECK ("simulation"."ending_repair" is null or "simulation"."ending_repair" in ('model_providers'));--> statement-breakpoint
+ALTER TABLE "simulation" ADD CONSTRAINT "simulation_ending_repair_has_a_reason_to_exist" CHECK ("simulation"."ending_repair" is null or "simulation"."ending_detail" is not null);

--- a/packages/db/migrations/meta/0035_snapshot.json
+++ b/packages/db/migrations/meta/0035_snapshot.json
@@ -1,0 +1,6045 @@
+{
+  "id": "1bad40c8-48c8-4bcf-9d1d-4cd7543edb59",
+  "prevId": "e6634a49-a6ca-4688-8468-8e5688424a06",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.platform_instance": {
+      "name": "platform_instance",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_instance_id_unique": {
+          "name": "platform_instance_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_instance_id_format": {
+          "name": "platform_instance_id_format",
+          "value": "\"platform_instance\".\"id\" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_setting": {
+      "name": "platform_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_setting_name_unique": {
+          "name": "platform_setting_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "platform_setting_id_prefix": {
+          "name": "platform_setting_id_prefix",
+          "value": "\"platform_setting\".\"id\" ~ '^pfs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_revision_prefix": {
+          "name": "project_revision_prefix",
+          "value": "\"project\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_access": {
+      "name": "model_access",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_access_organization_id_organization_id_fk": {
+          "name": "model_access_organization_id_organization_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_access_updated_by_user_id_fk": {
+          "name": "model_access_updated_by_user_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "model_access_organization_id_prefix": {
+          "name": "model_access_organization_id_prefix",
+          "value": "\"model_access\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_access_mode_allowed": {
+          "name": "model_access_mode_allowed",
+          "value": "\"model_access\".\"mode\" in ('managed', 'customer-owned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_provider_credential": {
+      "name": "model_provider_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_credential_organization_id_organization_id_fk": {
+          "name": "model_provider_credential_organization_id_organization_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_created_by_user_id_fk": {
+          "name": "model_provider_credential_created_by_user_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_credential_one_per_provider": {
+          "name": "model_provider_credential_one_per_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_credential_id_prefix": {
+          "name": "model_provider_credential_id_prefix",
+          "value": "\"model_provider_credential\".\"id\" ~ '^mpc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_revision_prefix": {
+          "name": "model_provider_credential_revision_prefix",
+          "value": "\"model_provider_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_provider_allowed": {
+          "name": "model_provider_credential_provider_allowed",
+          "value": "\"model_provider_credential\".\"provider\" in ('openai', 'deepgram', 'cartesia')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models": {
+          "name": "models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_state": {
+          "name": "capability_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "capabilities_measured": {
+          "name": "capabilities_measured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_supported": {
+          "name": "capabilities_supported",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_checked_at": {
+          "name": "capabilities_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_source": {
+          "name": "capability_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_production": {
+          "name": "watch_production",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "production_cursor": {
+          "name": "production_cursor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_registered_at": {
+          "name": "webhook_registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivered_at": {
+          "name": "webhook_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_capability_state_allowed": {
+          "name": "connection_capability_state_allowed",
+          "value": "\"connection\".\"capability_state\" in ('unknown', 'known')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        },
+        "connection_capability_evidence_agrees": {
+          "name": "connection_capability_evidence_agrees",
+          "value": "(\"connection\".\"capability_state\" = 'known') = (\"connection\".\"capabilities_measured\" is not null and \"connection\".\"capabilities_supported\" is not null and \"connection\".\"capabilities_checked_at\" is not null and \"connection\".\"capability_source\" is not null)"
+        },
+        "connection_capabilities_supported_were_measured": {
+          "name": "connection_capabilities_supported_were_measured",
+          "value": "\"connection\".\"capabilities_supported\" is null or \"connection\".\"capabilities_supported\" <@ \"connection\".\"capabilities_measured\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.production_trace_claim": {
+      "name": "production_trace_claim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_call_id": {
+          "name": "provider_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degraded": {
+          "name": "degraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "production_trace_claim_unwritten_idx": {
+          "name": "production_trace_claim_unwritten_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"production_trace_claim\".\"status\" = 'claimed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "production_trace_claim_organization_id_organization_id_fk": {
+          "name": "production_trace_claim_organization_id_organization_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_connection_id_connection_id_fk": {
+          "name": "production_trace_claim_connection_id_connection_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_project_organization_fk": {
+          "name": "production_trace_claim_project_organization_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "production_trace_claim_trace_id_unique": {
+          "name": "production_trace_claim_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "production_trace_claim_id_prefix": {
+          "name": "production_trace_claim_id_prefix",
+          "value": "\"production_trace_claim\".\"id\" ~ '^ptc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "production_trace_claim_status_allowed": {
+          "name": "production_trace_claim_status_allowed",
+          "value": "\"production_trace_claim\".\"status\" in ('claimed', 'written')"
+        },
+        "production_trace_claim_transport_allowed": {
+          "name": "production_trace_claim_transport_allowed",
+          "value": "\"production_trace_claim\".\"transport\" in ('webhook', 'pull')"
+        },
+        "production_trace_claim_written_agrees": {
+          "name": "production_trace_claim_written_agrees",
+          "value": "(\"production_trace_claim\".\"status\" = 'written') = (\"production_trace_claim\".\"written_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.retell_webhook_refusal": {
+      "name": "retell_webhook_refusal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "how_many": {
+          "name": "how_many",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retell_webhook_refusal_reason_unique": {
+          "name": "retell_webhook_refusal_reason_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reason"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "retell_webhook_refusal_id_prefix": {
+          "name": "retell_webhook_refusal_id_prefix",
+          "value": "\"retell_webhook_refusal\".\"id\" ~ '^rwr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "retell_webhook_refusal_reason_allowed": {
+          "name": "retell_webhook_refusal_reason_allowed",
+          "value": "\"retell_webhook_refusal\".\"reason\" in ('unknown_agent', 'switched_off', 'bad_signature', 'other_kind')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_id_idx": {
+          "name": "grader_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_id_grader_library_id_fk": {
+          "name": "grader_library_id_grader_library_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_library": {
+      "name": "grader_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_definition": {
+          "name": "output_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code": {
+          "name": "source_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_language": {
+          "name": "source_code_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_library_predefined_name_unique": {
+          "name": "grader_library_predefined_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"grader_library\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_organization_id_project_id_idx": {
+          "name": "grader_library_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_library_organization_id_organization_id_fk": {
+          "name": "grader_library_organization_id_organization_id_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_project_organization_fk": {
+          "name": "grader_library_project_organization_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_library_id_prefix": {
+          "name": "grader_library_id_prefix",
+          "value": "\"grader_library\".\"id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_library_type_allowed": {
+          "name": "grader_library_type_allowed",
+          "value": "\"grader_library\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_library_tenancy_is_whole_or_egmas": {
+          "name": "grader_library_tenancy_is_whole_or_egmas",
+          "value": "(\"grader_library\".\"organization_id\" is null) = (\"grader_library\".\"project_id\" is null)"
+        },
+        "grader_library_source_code_within_budget": {
+          "name": "grader_library_source_code_within_budget",
+          "value": "\"grader_library\".\"source_code\" is null or octet_length(\"grader_library\".\"source_code\") <= 262144"
+        },
+        "grader_library_source_code_columns_agree": {
+          "name": "grader_library_source_code_columns_agree",
+          "value": "(\"grader_library\".\"source_code\" is null) = (\"grader_library\".\"source_code_language\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grader_model": {
+          "name": "grader_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_credential_id_judge_credential_id_fk": {
+          "name": "judge_configuration_credential_id_judge_credential_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "judge_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        },
+        "judge_configuration_source_allowed": {
+          "name": "judge_configuration_source_allowed",
+          "value": "\"judge_configuration\".\"source\" in ('credential', 'platform')"
+        },
+        "judge_configuration_has_one_key_source": {
+          "name": "judge_configuration_has_one_key_source",
+          "value": "(\"judge_configuration\".\"source\" = 'credential' and \"judge_configuration\".\"credential_id\" is not null and \"judge_configuration\".\"credentials\" is null and \"judge_configuration\".\"credentials_hint\" is null) or (\"judge_configuration\".\"source\" = 'platform' and \"judge_configuration\".\"credential_id\" is null and \"judge_configuration\".\"credentials\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_credential": {
+      "name": "judge_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "judge_credential_organization_id_idx": {
+          "name": "judge_credential_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"judge_credential\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judge_credential_organization_id_organization_id_fk": {
+          "name": "judge_credential_organization_id_organization_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_credential_created_by_user_id_fk": {
+          "name": "judge_credential_created_by_user_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_credential_id_prefix": {
+          "name": "judge_credential_id_prefix",
+          "value": "\"judge_credential\".\"id\" ~ '^jcr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_revision_prefix": {
+          "name": "judge_credential_revision_prefix",
+          "value": "\"judge_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_provider_allowed": {
+          "name": "judge_credential_provider_allowed",
+          "value": "\"judge_credential\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool": {
+      "name": "mock_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_milliseconds": {
+          "name": "delay_milliseconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_tool_project_id_tool_name_unique": {
+          "name": "mock_tool_project_id_tool_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_tool_organization_id_project_id_idx": {
+          "name": "mock_tool_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_organization_id_organization_id_fk": {
+          "name": "mock_tool_organization_id_organization_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_created_by_user_id_fk": {
+          "name": "mock_tool_created_by_user_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_tool_project_organization_fk": {
+          "name": "mock_tool_project_organization_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mock_tool_id_project_id_unique": {
+          "name": "mock_tool_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_id_prefix": {
+          "name": "mock_tool_id_prefix",
+          "value": "\"mock_tool\".\"id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "mock_tool_delay_within_budget": {
+          "name": "mock_tool_delay_within_budget",
+          "value": "\"mock_tool\".\"delay_milliseconds\" between 0 and 30000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool_agent": {
+      "name": "mock_tool_agent",
+      "schema": "",
+      "columns": {
+        "mock_tool_id": {
+          "name": "mock_tool_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mock_tool_agent_agent_id_idx": {
+          "name": "mock_tool_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_agent_mock_tool_id_mock_tool_id_fk": {
+          "name": "mock_tool_agent_mock_tool_id_mock_tool_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_id_agent_id_fk": {
+          "name": "mock_tool_agent_agent_id_agent_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_mock_tool_project_fk": {
+          "name": "mock_tool_agent_mock_tool_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_project_fk": {
+          "name": "mock_tool_agent_agent_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mock_tool_agent_pk": {
+          "name": "mock_tool_agent_pk",
+          "columns": [
+            "mock_tool_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "mock_tool_agent_mock_tool_id_position_unique": {
+          "name": "mock_tool_agent_mock_tool_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mock_tool_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_agent_mock_tool_id_prefix": {
+          "name": "mock_tool_agent_mock_tool_id_prefix",
+          "value": "\"mock_tool_agent\".\"mock_tool_id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicability_revision": {
+          "name": "applicability_revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_revision_prefix": {
+          "name": "test_revision_prefix",
+          "value": "\"test\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_applicability_revision_prefix": {
+          "name": "test_applicability_revision_prefix",
+          "value": "\"test\".\"applicability_revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_archive_reason_allowed": {
+          "name": "test_archive_reason_allowed",
+          "value": "\"test\".\"archive_reason\" in ('needs_agent')"
+        },
+        "test_archive_reason_needs_an_archive": {
+          "name": "test_archive_reason_needs_an_archive",
+          "value": "\"test\".\"archive_reason\" is null or \"test\".\"archived_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_agent": {
+      "name": "test_agent",
+      "schema": "",
+      "columns": {
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_agent_agent_id_idx": {
+          "name": "test_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_agent_test_id_test_id_fk": {
+          "name": "test_agent_test_id_test_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_id_agent_id_fk": {
+          "name": "test_agent_agent_id_agent_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_created_by_user_id_fk": {
+          "name": "test_agent_created_by_user_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_agent_test_project_fk": {
+          "name": "test_agent_test_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_project_fk": {
+          "name": "test_agent_agent_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_agent_pk": {
+          "name": "test_agent_pk",
+          "columns": [
+            "test_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_agent_test_id_prefix": {
+          "name": "test_agent_test_id_prefix",
+          "value": "\"test_agent\".\"test_id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tool_snapshot": {
+          "name": "mock_tool_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"skipped_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0\n          and \"run\".\"canceled_count\" >= 0 and \"run\".\"skipped_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')\n        or (\"run_event\".\"status\" = 'skipped' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_coverage": {
+          "name": "mock_tool_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_capabilities": {
+          "name": "skipped_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_skipped_shape": {
+          "name": "simulation_skipped_shape",
+          "value": "\"simulation\".\"status\" <> 'skipped'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"claimed_at\" is null\n          and \"simulation\".\"started_at\" is null and \"simulation\".\"cancel_requested_at\" is null\n          and \"simulation\".\"skip_reason\" is not null\n          and \"simulation\".\"skipped_capabilities\" is not null)"
+        },
+        "simulation_skip_reason_belongs_to_a_skip": {
+          "name": "simulation_skip_reason_belongs_to_a_skip",
+          "value": "\"simulation\".\"status\" = 'skipped'\n        or (\"simulation\".\"skip_reason\" is null and \"simulation\".\"skipped_capabilities\" is null)"
+        },
+        "simulation_skip_reason_allowed": {
+          "name": "simulation_skip_reason_allowed",
+          "value": "\"simulation\".\"skip_reason\" is null or \"simulation\".\"skip_reason\" in ('required_capability_unsupported', 'required_capability_unknown')"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_mock_tool_coverage_only_when_ended": {
+          "name": "simulation_mock_tool_coverage_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null or \"simulation\".\"mock_tool_coverage\" is null"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_plan": {
+      "name": "grading_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groups": {
+          "name": "groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_credential_ids": {
+          "name": "judge_credential_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_plan_judge_credential_ids_idx": {
+          "name": "grading_plan_judge_credential_ids_idx",
+          "columns": [
+            {
+              "expression": "judge_credential_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "grading_plan_organization_id_project_id_idx": {
+          "name": "grading_plan_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_plan_organization_id_organization_id_fk": {
+          "name": "grading_plan_organization_id_organization_id_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_project_organization_fk": {
+          "name": "grading_plan_project_organization_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_run_project_fk": {
+          "name": "grading_plan_run_project_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_plan_run_id_unique": {
+          "name": "grading_plan_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_plan_id_prefix": {
+          "name": "grading_plan_id_prefix",
+          "value": "\"grading_plan\".\"id\" ~ '^gpl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_plan_state_allowed": {
+          "name": "grading_plan_state_allowed",
+          "value": "\"grading_plan\".\"state\" in ('run_start', 'migration_snapshot', 'not_recorded')"
+        },
+        "grading_plan_recorded_plans_carry_their_moment": {
+          "name": "grading_plan_recorded_plans_carry_their_moment",
+          "value": "(\"grading_plan\".\"state\" = 'not_recorded')\n        = (\"grading_plan\".\"captured_at\" is null)"
+        },
+        "grading_plan_groups_are_a_list": {
+          "name": "grading_plan_groups_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"groups\") = 'array'"
+        },
+        "grading_plan_credentials_are_a_list": {
+          "name": "grading_plan_credentials_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"judge_credential_ids\") = 'array'"
+        },
+        "grading_plan_unrecorded_holds_nothing": {
+          "name": "grading_plan_unrecorded_holds_nothing",
+          "value": "\"grading_plan\".\"state\" <> 'not_recorded'\n        or (\"grading_plan\".\"groups\" = '[]'::jsonb\n          and \"grading_plan\".\"judge_credential_ids\" = '[]'::jsonb)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotent_operation": {
+      "name": "idempotent_operation",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "idempotent_operation_organization_id_organization_id_fk": {
+          "name": "idempotent_operation_organization_id_organization_id_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_project_organization_fk": {
+          "name": "idempotent_operation_project_organization_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_actor_fk": {
+          "name": "idempotent_operation_actor_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotent_operation_pk": {
+          "name": "idempotent_operation_pk",
+          "columns": [
+            "organization_id",
+            "project_id",
+            "actor_id",
+            "operation",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "idempotent_operation_organization_id_prefix": {
+          "name": "idempotent_operation_organization_id_prefix",
+          "value": "\"idempotent_operation\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "idempotent_operation_allowed": {
+          "name": "idempotent_operation_allowed",
+          "value": "\"idempotent_operation\".\"operation\" in ('start_run')"
+        },
+        "idempotent_operation_key_is_not_empty": {
+          "name": "idempotent_operation_key_is_not_empty",
+          "value": "length(\"idempotent_operation\".\"idempotency_key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0035_snapshot.json
+++ b/packages/db/migrations/meta/0035_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "1bad40c8-48c8-4bcf-9d1d-4cd7543edb59",
+  "id": "7fa9f1c0-23fe-4d53-ac9b-7746cb2c11a4",
   "prevId": "e6634a49-a6ca-4688-8468-8e5688424a06",
   "version": "7",
   "dialect": "postgresql",
@@ -4962,6 +4962,18 @@
           "primaryKey": false,
           "notNull": false
         },
+        "ending_detail": {
+          "name": "ending_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_repair": {
+          "name": "ending_repair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "claimed_by": {
           "name": "claimed_by",
           "type": "text",
@@ -5352,6 +5364,14 @@
         "simulation_ending_reason_allowed": {
           "name": "simulation_ending_reason_allowed",
           "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_repair_allowed": {
+          "name": "simulation_ending_repair_allowed",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_repair\" in ('model_providers')"
+        },
+        "simulation_ending_repair_has_a_reason_to_exist": {
+          "name": "simulation_ending_repair_has_a_reason_to_exist",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_detail\" is not null"
         },
         "simulation_ending_reason_agrees": {
           "name": "simulation_ending_reason_agrees",

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -250,7 +250,7 @@
     {
       "idx": 35,
       "version": "7",
-      "when": 1786961006469,
+      "when": 1786961303765,
       "tag": "0035_customer_owned_model_access",
       "breakpoints": true
     }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1786923110581,
       "tag": "0034_watch_production",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1786961006469,
+      "tag": "0035_customer_owned_model_access",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/errors.ts
+++ b/packages/db/src/access/errors.ts
@@ -1177,6 +1177,27 @@ export class ManagedAccessNotConnectedError extends Error {
 }
 
 /**
+ * A simulation or a grading job selected managed model access on a deployment
+ * that has no Egma model gateway connection behind it.
+ *
+ * **A tripwire rather than a fault, and it is typed so it lands as one.** No
+ * door in this release can store `managed` — the setting refuses it by name —
+ * so a claim that reaches this has found a row nothing should have written.
+ * Saying so as an infrastructure error naming the mode, with somewhere to go,
+ * is what keeps it from arriving as a bare dispatch failure with nothing on it
+ * a person could act on. The release that connects a gateway is the one that
+ * makes this reachable and answers it.
+ */
+export class ManagedAccessUnavailableError extends Error {
+  constructor() {
+    super(
+      "this organization is on managed model access, which sends its model traffic through the Egma model gateway, and this deployment has no connection to one. Choose Customer-owned under Model providers and add a credential for each provider your personas and graders select.",
+    );
+    this.name = "ManagedAccessUnavailableError";
+  }
+}
+
+/**
  * A simulation or a grading job could not be prepared, because the organization
  * holds no credential for a provider its pinned selections name.
  *

--- a/packages/db/src/access/errors.ts
+++ b/packages/db/src/access/errors.ts
@@ -1155,3 +1155,51 @@ export function refuseRetry(
     message: retryUnavailable(runId, resource),
   });
 }
+
+/**
+ * Managed model access was selected by an organization that has connected
+ * nothing to Egma's provider accounts.
+ *
+ * **A refusal rather than a quiet no-op, and it names what is missing.** An
+ * organization spends from Egma's provider accounts through the Egma model
+ * gateway, and reaching that gateway takes an inference key this organization
+ * does not hold. Storing `managed` anyway would leave every claim afterwards
+ * resolving to an access path with no credential behind it — a run that fails
+ * one simulation at a time for a setting that read as saved.
+ */
+export class ManagedAccessNotConnectedError extends Error {
+  constructor() {
+    super(
+      "managed model access sends this organization's model traffic through the Egma model gateway, and this organization has connected no inference key for it. Choose Customer-owned and add a credential for each provider your personas and graders select.",
+    );
+    this.name = "ManagedAccessNotConnectedError";
+  }
+}
+
+/**
+ * A simulation or a grading job could not be prepared, because the organization
+ * holds no credential for a provider its pinned selections name.
+ *
+ * **An infrastructure error, and never a failed verdict.** A test that could not
+ * be conducted did not fail: nothing about the agent was learned, and recording
+ * it as a failure would put a red row on a report for a key somebody has not
+ * pasted yet. It names the model job and the provider so the sentence a person
+ * reads says what to go and add, and it carries them as values so a page can
+ * link to Model providers rather than parse prose.
+ */
+export class ModelProviderCredentialMissingError extends Error {
+  /** The model jobs that could not be resolved, with the provider for each. */
+  readonly needed: readonly { readonly job: string; readonly provider: string }[];
+
+  constructor(needed: readonly { readonly job: string; readonly provider: string }[]) {
+    super(
+      `this organization holds no model-provider credential for ${needed
+        .map((one) => `${one.provider} (${one.job})`)
+        .join(", ")}; add ${
+        needed.length === 1 ? "it" : "them"
+      } under Model providers in Organization settings`,
+    );
+    this.name = "ModelProviderCredentialMissingError";
+    this.needed = needed;
+  }
+}

--- a/packages/db/src/access/graders.ts
+++ b/packages/db/src/access/graders.ts
@@ -35,6 +35,12 @@ import { pageOf, pageWindow, type PageRequest } from "./pages.ts";
 import { authorize, here } from "./permissions.ts";
 import { isProjectOfOrganization } from "./projects.ts";
 import { inActingProject, within } from "./within.ts";
+import {
+  graderModelFromRow,
+  sameGraderModel,
+  validGraderModel,
+  type GraderModel,
+} from "../models/selections.ts";
 
 /**
  * Reading and writing the **running copies** — what they are is the schema
@@ -161,6 +167,13 @@ export type UseLibraryEntry = LiveSettings & {
   readonly libraryId: string;
   readonly params?: FilledInForm | undefined;
   readonly judgeModel?: JudgeModel | undefined;
+  /**
+   * This copy's own LLM selection, resolved against the organization's model
+   * access when a grading claim is prepared. Absent leaves it on the
+   * compatibility path — the project's judge configuration, exactly as every
+   * grader authored before the model catalog existed.
+   */
+  readonly graderModel?: GraderModel | undefined;
 };
 
 export type Grader = {
@@ -181,6 +194,13 @@ export type Grader = {
   readonly versionId: string;
   readonly config: GraderConfig;
   readonly judgeModel: JudgeModel | null;
+  /**
+   * The current version's own model selection, or `null` on the compatibility
+   * path. `null` is an ordinary state and never a fault: it means this version
+   * was authored before the model catalog existed and is judged through the
+   * project's judge configuration exactly as it always was.
+   */
+  readonly graderModel: GraderModel | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 };
@@ -214,6 +234,12 @@ export type GraderChanges = {
   readonly params?: FilledInForm;
   readonly config?: GraderConfigInput;
   readonly judgeModel?: JudgeModel | null;
+  /**
+   * This grader's own model selection, whole. Absent means keep what is stored;
+   * a selection that differs from it mints the next version, because what a
+   * verdict was decided by is exactly what a run has to stay pinned to.
+   */
+  readonly graderModel?: GraderModel | null;
 };
 
 /** One version, frozen: the copy exactly as some verdict was decided by it. */
@@ -224,6 +250,8 @@ export type GraderVersion = {
   readonly type: LibraryType;
   readonly config: GraderConfig;
   readonly judgeModel: JudgeModel | null;
+  /** This version's own model selection, or `null` on the compatibility path. */
+  readonly graderModel: GraderModel | null;
   readonly createdAt: Date;
 };
 
@@ -807,10 +835,11 @@ function answer(row: {
   readonly versionId: string;
   readonly config: unknown;
   readonly judgeModel: unknown;
+  readonly graderModel: unknown;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }): Grader {
-  const { type, config, judgeModel, scope, ...rest } = row;
+  const { type, config, judgeModel, graderModel, scope, ...rest } = row;
   return {
     ...rest,
     // The identity row's own enumerated columns are pinned by check
@@ -819,6 +848,7 @@ function answer(row: {
     scope: scope as GraderScope,
     config: configFromRow(config, row.versionId),
     judgeModel: judgeModelFromRow(judgeModel, row.versionId),
+    graderModel: graderModelFromRow(graderModel, row.versionId),
   };
 }
 
@@ -854,6 +884,8 @@ export async function useLibraryEntry(
   const name = input.name === undefined ? undefined : validName(input.name);
   const judgeModel =
     input.judgeModel === undefined ? null : validJudgeModel(input.judgeModel);
+  const graderModel =
+    input.graderModel === undefined ? null : validGraderModel(input.graderModel);
   const required = input.required ?? DEFAULT_REQUIRED;
   const scope = input.scope === undefined ? "simulations" : validScope(input.scope);
   const productionSampleRate =
@@ -905,6 +937,7 @@ export async function useLibraryEntry(
       version: 1,
       config,
       judgeModel,
+      graderModel,
       createdBy: auth.userId,
     });
 
@@ -920,6 +953,7 @@ export async function useLibraryEntry(
     versionId,
     config: written.config,
     judgeModel,
+    graderModel,
   });
 }
 
@@ -935,6 +969,7 @@ function selectWithCurrentVersion() {
       versionId: graderVersion.id,
       config: graderVersion.config,
       judgeModel: graderVersion.judgeModel,
+      graderModel: graderVersion.graderModel,
     })
     .from(grader)
     .innerJoin(graderVersion, eq(grader.currentVersionId, graderVersion.id));
@@ -1003,6 +1038,10 @@ export async function editGrader(
     changes.judgeModel === undefined || changes.judgeModel === null
       ? changes.judgeModel
       : validJudgeModel(changes.judgeModel);
+  const graderModel =
+    changes.graderModel === undefined || changes.graderModel === null
+      ? changes.graderModel
+      : validGraderModel(changes.graderModel);
   // Which of the two names carried the values is settled before anything is
   // read; what those values may hold is the entry's business and is checked
   // below, inside the transaction, by the code Use goes through.
@@ -1029,6 +1068,7 @@ export async function editGrader(
         version: graderVersion.version,
         config: graderVersion.config,
         judgeModel: graderVersion.judgeModel,
+        graderModel: graderVersion.graderModel,
       })
       .from(graderVersion)
       .where(eq(graderVersion.id, currentVersionId))
@@ -1040,6 +1080,10 @@ export async function editGrader(
     const stored = configFromRow(currentVersion.config, currentVersion.id);
     const storedJudgeModel = judgeModelFromRow(
       currentVersion.judgeModel,
+      currentVersion.id,
+    );
+    const storedGraderModel = graderModelFromRow(
+      currentVersion.graderModel,
       currentVersion.id,
     );
 
@@ -1060,10 +1104,16 @@ export async function editGrader(
           );
     const nextJudgeModel =
       judgeModel === undefined ? storedJudgeModel : judgeModel;
+    const nextGraderModel =
+      graderModel === undefined ? storedGraderModel : graderModel;
 
     const mintsVersion =
       !sameConfig(stored, config) ||
-      !sameJudgeModel(storedJudgeModel, nextJudgeModel);
+      !sameJudgeModel(storedJudgeModel, nextJudgeModel) ||
+      // A model edit mints a version on exactly the config's terms: it is what
+      // a verdict was decided by, so a run that pinned this version has to keep
+      // meaning what it meant.
+      !sameGraderModel(storedGraderModel, nextGraderModel);
     const settingsChanged =
       changes.name !== undefined ||
       changes.description !== undefined ||
@@ -1086,6 +1136,7 @@ export async function editGrader(
         versionId: currentVersion.id,
         config: stored,
         judgeModel: storedJudgeModel,
+        graderModel: storedGraderModel,
       };
     }
 
@@ -1100,6 +1151,7 @@ export async function editGrader(
         version,
         config,
         judgeModel: nextJudgeModel,
+        graderModel: nextGraderModel,
         createdBy: auth.userId,
       });
     }
@@ -1127,6 +1179,7 @@ export async function editGrader(
       versionId,
       config,
       judgeModel: nextJudgeModel,
+      graderModel: nextGraderModel,
     });
   });
 }
@@ -1153,6 +1206,7 @@ export async function getGraderVersion(
       type: grader.type,
       config: graderVersion.config,
       judgeModel: graderVersion.judgeModel,
+      graderModel: graderVersion.graderModel,
       createdAt: graderVersion.createdAt,
     })
     .from(graderVersion)
@@ -1168,12 +1222,13 @@ export async function getGraderVersion(
 
   if (row === undefined) return undefined;
 
-  const { type, config, judgeModel, ...rest } = row;
+  const { type, config, judgeModel, graderModel, ...rest } = row;
   return {
     ...rest,
     type: type as LibraryType,
     config: configFromRow(config, row.id),
     judgeModel: judgeModelFromRow(judgeModel, row.id),
+    graderModel: graderModelFromRow(graderModel, row.id),
   };
 }
 

--- a/packages/db/src/access/grading.ts
+++ b/packages/db/src/access/grading.ts
@@ -19,6 +19,7 @@ import {
   type GradingJobStatus,
   type GradingSource,
 } from "../schema/grading.ts";
+import { grader, graderVersion } from "../schema/graders.ts";
 import { run, simulation } from "../schema/runs.ts";
 import { validClaimant } from "./claimants.ts";
 import type { AuthContext } from "./context.ts";
@@ -594,11 +595,42 @@ function productionTracesIn(
  * Taking work. The one call that works the whole deployment.
  * ------------------------------------------------------------------- */
 
+/**
+ * What a grader binary can do beyond what every one of them has always done.
+ *
+ * **One entry, and it is a rollout fact rather than a setting.** A grader
+ * version that selects its own model is judged with the organization's
+ * credential for that provider; a binary built before grader models existed
+ * reads no such field and judges through the project's judge configuration
+ * instead — a different model, on a different account, that nobody chose. That
+ * is silent and it produces verdicts, which makes it worse than a failure.
+ *
+ * So a binary declares what it understands and the queue offers it only work it
+ * can judge honestly. Declaring nothing is what every grader built before this
+ * declares by saying nothing, and it is read as the old binary it is.
+ *
+ * The simulation queue makes the same bargain one file over, in the shape its
+ * own problem has: there the document is versioned, so a worker declares
+ * versions; here there is no versioned grading document to number, so a worker
+ * declares the field it can read.
+ */
+export const GRADING_CAPABILITIES = ["grader_models"] as const;
+export type GradingCapability = (typeof GRADING_CAPABILITIES)[number];
+
 export type GradingClaimRequest = {
   /** This copy of the grader service's own name for itself. */
   readonly claimant: string;
   /** How many conversations it will judge at once. */
   readonly capacity: number;
+  /**
+   * What this binary understands, from `GRADING_CAPABILITIES`.
+   *
+   * Absent means none of it, which is what every grader built before these
+   * existed means by saying nothing — and the queue then offers it only work
+   * that needs none of them, rather than work it would judge on the wrong
+   * account.
+   */
+  readonly capabilities?: readonly GradingCapability[] | undefined;
   /** How long its claim survives its silence; the default is generous. */
   readonly leaseSeconds?: number | undefined;
   /**
@@ -689,17 +721,52 @@ export async function claimGradingJobs(
     lt(gradingJob.lastSeenAt, quietSince),
   );
 
+  /**
+   * Work this binary could not judge honestly, left for one that can.
+   *
+   * A conversation is judged by every applicable grader in its project, so the
+   * question is whether *any* of them selects its own model — or, for a job
+   * narrowed to one grader by a regrade, whether that one does. A binary that
+   * cannot read the field would judge those through the project's judge
+   * configuration: a different model, on a different account, with verdicts to
+   * show for it and nothing anywhere saying so.
+   *
+   * So such a job is simply not offered, exactly as a simulation needing a
+   * version-2 document is not offered to a version-1 worker. Nothing is
+   * stranded: an upgraded binary beside it takes the job on its next poll, and
+   * a fleet with no upgraded binary yet leaves it pending rather than judging it
+   * wrongly. `SKIP LOCKED` above already means "take what you can"; this is the
+   * same idea one step earlier.
+   */
+  const judgeable = (request.capabilities ?? []).includes("grader_models")
+    ? undefined
+    : sql`not exists (
+        select 1
+        from ${grader}
+        join ${graderVersion} on ${graderVersion.id} = ${grader.currentVersionId}
+        where ${grader.projectId} = ${gradingJob.projectId}
+          and ${grader.deletedAt} is null
+          and ${graderVersion.graderModel} is not null
+          and (
+            ${gradingJob.regradeGraderId} is null
+            or ${gradingJob.regradeGraderId} = ${grader.id}
+          )
+      )`;
+
   const claimed = await db().transaction(async (tx) => {
     const candidates = await tx
       .select({ id: gradingJob.id, attempts: gradingJob.attempts })
       .from(gradingJob)
       .where(
-        or(
-          and(eq(gradingJob.status, "pending"), finished),
-          and(
-            eq(gradingJob.status, "claimed"),
-            lt(gradingJob.heartbeatAt, silentSince),
+        and(
+          or(
+            and(eq(gradingJob.status, "pending"), finished),
+            and(
+              eq(gradingJob.status, "claimed"),
+              lt(gradingJob.heartbeatAt, silentSince),
+            ),
           ),
+          judgeable,
         ),
       )
       .orderBy(asc(gradingJob.id))

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -121,6 +121,7 @@ export {
   JudgeProviderMismatchError,
   LastAdminError,
   ManagedAccessNotConnectedError,
+  ManagedAccessUnavailableError,
   MockToolTakenError,
   ModelProviderCredentialMissingError,
   NoCapabilityAdapterError,
@@ -595,6 +596,11 @@ export type { JudgeSource } from "../schema/graders.ts";
  * plaintext one — `resolveModelProviderKeys` — refuses every context that did
  * not come from a simulation or a grading claim.
  */
+export {
+  GRADING_CAPABILITIES,
+  type GradingCapability,
+} from "./grading.ts";
+
 export {
   DEFAULT_MODEL_ACCESS,
   readModelAccess,

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -120,7 +120,9 @@ export {
   JudgeNotConfiguredError,
   JudgeProviderMismatchError,
   LastAdminError,
+  ManagedAccessNotConnectedError,
   MockToolTakenError,
+  ModelProviderCredentialMissingError,
   NoCapabilityAdapterError,
   NotPermittedError,
   PersonaNameAmbiguousError,
@@ -584,6 +586,60 @@ export {
   type NewJudgeCredential,
 } from "./judge-credentials.ts";
 export type { JudgeSource } from "../schema/graders.ts";
+
+/**
+ * The organization's model access, and its own provider keys.
+ *
+ * Write-only by construction on the same terms as the judge credentials above:
+ * nothing exported here can answer with a stored key, and the one door to a
+ * plaintext one — `resolveModelProviderKeys` — refuses every context that did
+ * not come from a simulation or a grading claim.
+ */
+export {
+  DEFAULT_MODEL_ACCESS,
+  readModelAccess,
+  resolveModelProviderKeys,
+  setModelAccess,
+  type ModelAccess,
+  type ResolvedProviderKeys,
+} from "./model-access.ts";
+export {
+  listModelProviderCredentials,
+  removeModelProviderCredential,
+  storeModelProviderCredential,
+  type ModelProviderCredential,
+  type ModelProviderCredentialInput,
+} from "./model-provider-credentials.ts";
+export {
+  MODEL_ACCESS_MODES,
+  type ModelAccessMode,
+} from "../schema/models.ts";
+
+/**
+ * The provider catalog and the selections made from it — release data and pure
+ * shapes, reaching no store and taking no context, exactly as the grader
+ * library's catalog beside it does.
+ */
+export {
+  MODEL_JOBS,
+  MODEL_PROVIDERS,
+  PROVIDER_CATALOG,
+  PROVIDERS_BY_JOB,
+  RECOMMENDED_ENTRY,
+  RESERVED_PROVIDER_JOBS,
+  type ModelJob,
+  type ModelProvider,
+  type ProviderCatalogEntry,
+} from "../models/catalog.ts";
+export {
+  RECOMMENDED_GRADER_MODEL,
+  RECOMMENDED_PERSONA_MODELS,
+  SPEED_RANGE,
+  type GraderModel,
+  type ModelSelection,
+  type PersonaModels,
+  type SpeechSelection,
+} from "../models/selections.ts";
 
 export {
   cancelRun,

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -614,6 +614,7 @@ export {
   MODEL_ACCESS_MODES,
   type ModelAccessMode,
 } from "../schema/models.ts";
+export { ENDING_REPAIRS, type EndingRepair } from "../schema/runs.ts";
 
 /**
  * The provider catalog and the selections made from it — release data and pure

--- a/packages/db/src/access/model-access.ts
+++ b/packages/db/src/access/model-access.ts
@@ -1,0 +1,240 @@
+import { db } from "../client.ts";
+import {
+  MODEL_ACCESS_MODES,
+  modelAccess,
+  modelProviderCredential,
+  type ModelAccessMode,
+} from "../schema/models.ts";
+import { isModelProvider, type ModelProvider } from "../models/catalog.ts";
+import { openCredentials } from "../sealing.ts";
+import type { AuthContext } from "./context.ts";
+import { ManagedAccessNotConnectedError, UnprocessableInputError } from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+import { within } from "./within.ts";
+
+/**
+ * Who pays for this organization's model traffic, and the one door that opens a
+ * provider key for the services that spend it.
+ *
+ * **One organization-wide value, and changing it changes nothing else.** It
+ * decides who supplies the credentials; it does not touch a persona's or a
+ * grader's model selections, does not scan anything for completeness, and does
+ * not rewrite a version. A run already in flight keeps the access its
+ * simulations were claimed with — the value is read when a claim is prepared,
+ * so the next unclaimed one gets the new answer and the running one is left
+ * alone. That is the whole of what "switching is immediate" means, and it is a
+ * property of *when* this is read rather than of anything this module does.
+ */
+
+/** The organization's model access as anybody in it reads it. */
+export type ModelAccess = {
+  readonly mode: ModelAccessMode;
+  /** When it was last chosen, or null for an organization that never has. */
+  readonly updatedAt: Date | null;
+};
+
+/**
+ * What every organization has until somebody decides otherwise.
+ *
+ * **`customer-owned`, and a missing row means exactly this.** An organization
+ * that has connected nothing to Egma's provider accounts may not spend from
+ * them, and reading a missing row as `managed` would be Egma volunteering its
+ * own accounts on behalf of a customer who never asked.
+ */
+export const DEFAULT_MODEL_ACCESS: ModelAccessMode = "customer-owned";
+
+/**
+ * The organization's model access.
+ *
+ * Readable at every role: which of two words is on this row is not a secret,
+ * and a `viewer` looking at a persona's Models form has to be able to see who
+ * supplies the key behind it.
+ */
+export async function readModelAccess(auth: AuthContext): Promise<ModelAccess> {
+  authorize(auth, "read", here(auth));
+
+  const [row] = await db()
+    .select({ mode: modelAccess.mode, updatedAt: modelAccess.updatedAt })
+    .from(modelAccess)
+    .where(within(auth, modelAccess))
+    .limit(1);
+
+  return row === undefined
+    ? { mode: DEFAULT_MODEL_ACCESS, updatedAt: null }
+    : { mode: row.mode as ModelAccessMode, updatedAt: row.updatedAt };
+}
+
+function validMode(mode: string): ModelAccessMode {
+  const known = MODEL_ACCESS_MODES.find((candidate) => candidate === mode);
+  if (known === undefined) {
+    throw new UnprocessableInputError(
+      `"${mode}" is not a model access mode; expected one of ${MODEL_ACCESS_MODES.join(", ")}`,
+    );
+  }
+  return known;
+}
+
+/**
+ * Choose who supplies the credentials, from now on.
+ *
+ * **Only an `admin`**, on the same row of the permission table that already
+ * names provider credentials: this decides whose provider account every
+ * simulation and every verdict in the organization spends from, which is a
+ * decision of the same kind as retention rather than one of the same kind as
+ * writing a test.
+ *
+ * **No completeness scan, deliberately.** Egma does not walk the organization's
+ * personas and graders looking for a provider whose credential is missing, and
+ * does not refuse the switch because one is. A readiness checklist standing
+ * between an admin and a setting they can plainly see is exactly the blocked
+ * feeling this whole effort removes — and the honest report arrives anyway, per
+ * simulation, when the affected claim is prepared and names the provider it
+ * could not open.
+ *
+ * **`managed` is refused while nothing is connected**, and that refusal is the
+ * self-hosted rule the specification names: an organization may not select
+ * Egma's provider accounts until it holds an inference key for the Egma model
+ * gateway. Nothing in this release connects one, so nothing in this release may
+ * select managed access — said in a sentence that names what is missing rather
+ * than by leaving the value quietly unwritable.
+ */
+export async function setModelAccess(
+  auth: AuthContext,
+  mode: string,
+): Promise<ModelAccess> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const valid = validMode(mode);
+  if (valid === "managed") {
+    throw new ManagedAccessNotConnectedError();
+  }
+
+  const now = new Date();
+  const [row] = await db()
+    .insert(modelAccess)
+    .values({
+      organizationId: auth.organizationId,
+      mode: valid,
+      updatedBy: auth.userId,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: modelAccess.organizationId,
+      set: { mode: valid, updatedBy: auth.userId, updatedAt: now },
+    })
+    .returning({ mode: modelAccess.mode, updatedAt: modelAccess.updatedAt });
+
+  if (row === undefined) {
+    throw new Error("the organization's model access was not written");
+  }
+  return { mode: row.mode as ModelAccessMode, updatedAt: row.updatedAt };
+}
+
+/**
+ * What one claim asked for and what it got: the keys for the providers the
+ * pinned selections name, and the providers that hold none.
+ *
+ * **Two lists rather than a throw**, because a missing credential is one
+ * simulation's problem and never the batch's. The caller lands this simulation
+ * as an infrastructure error naming the provider, and conducts every other
+ * claim in the same answer.
+ */
+export type ResolvedProviderKeys = {
+  /** Provider to plaintext key, for the providers that hold one. */
+  readonly keys: ReadonlyMap<ModelProvider, string>;
+  /** The providers that were asked for and hold no credential, in ask order. */
+  readonly missing: readonly ModelProvider[];
+};
+
+/**
+ * The one door to a model-provider key's plaintext, and **Egma's own two
+ * services are the only things that may knock.**
+ *
+ * The gate is narrower than a role, on purpose, exactly as the connection
+ * credential's and the judge key's are: the only thing Egma does with a
+ * provider key is conduct a simulation or judge one, and the only things that
+ * do either are the simulator and the grading engine. So the check is on how
+ * the caller came to exist rather than on what their role permits — a context
+ * built from a simulation claim says `simulator` on its face and one built from
+ * a grading claim says `engine`, and every other context in the product, a
+ * person's session and an `admin` alike, is refused. There is no product
+ * surface that hands a customer their own key back, and this is what keeps it
+ * that way while roles move around.
+ *
+ * **Only the providers asked for.** The caller passes the providers its pinned
+ * selections actually name, so a work order carries the two keys it needs and
+ * never the third one the organization happens to hold. Unrelated secrets do
+ * not travel, and that is enforced by the argument rather than by the caller
+ * remembering to filter afterwards.
+ */
+export async function resolveModelProviderKeys(
+  auth: AuthContext,
+  providers: readonly string[],
+): Promise<ResolvedProviderKeys> {
+  authorize(auth, "read", here(auth));
+
+  if (auth.via !== "simulator" && auth.via !== "engine") {
+    throw new Error(
+      "a model-provider key is opened for Egma's simulator or its grading engine and for nothing else, because conducting and judging are the only things Egma does with one",
+    );
+  }
+
+  const asked: ModelProvider[] = [];
+  for (const provider of providers) {
+    if (!isModelProvider(provider)) {
+      throw new Error(
+        `"${provider}" is not a model provider Egma stores credentials for; a selection naming it should never have been written`,
+      );
+    }
+    if (!asked.includes(provider)) asked.push(provider);
+  }
+  if (asked.length === 0) return { keys: new Map(), missing: [] };
+
+  const rows = await db()
+    .select({
+      provider: modelProviderCredential.provider,
+      credentials: modelProviderCredential.credentials,
+    })
+    .from(modelProviderCredential)
+    .where(within(auth, modelProviderCredential));
+
+  const held = new Map<string, string>(
+    rows.map((row) => [row.provider, row.credentials]),
+  );
+
+  const keys = new Map<ModelProvider, string>();
+  const missing: ModelProvider[] = [];
+  for (const provider of asked) {
+    const sealed = held.get(provider);
+    if (sealed === undefined) {
+      missing.push(provider);
+      continue;
+    }
+    keys.set(provider, openedKey(provider, sealed));
+  }
+
+  return { keys, missing };
+}
+
+/**
+ * One envelope opened, or a fault naming the provider whose row is broken.
+ *
+ * A row that will not open is Egma being broken rather than the customer being
+ * unconfigured, so it throws rather than joining `missing` — which would tell
+ * an admin to add a credential they already added.
+ */
+function openedKey(provider: ModelProvider, sealed: string): string {
+  const opened = openCredentials(sealed);
+  const key =
+    typeof opened === "object" && opened !== null && !Array.isArray(opened)
+      ? (opened as Record<string, unknown>)["key"]
+      : undefined;
+
+  if (typeof key !== "string" || key === "") {
+    throw new Error(
+      `the ${provider} model-provider credential holds a key in a shape Egma never writes; the row needs repairing before anybody can use it`,
+    );
+  }
+  return key;
+}
+

--- a/packages/db/src/access/model-provider-credentials.ts
+++ b/packages/db/src/access/model-provider-credentials.ts
@@ -1,0 +1,303 @@
+import { newId } from "@egma/ids";
+import { asc, eq } from "drizzle-orm";
+
+import { db } from "../client.ts";
+import { modelProviderCredential } from "../schema/models.ts";
+import {
+  MODEL_PROVIDERS,
+  isModelProvider,
+  type ModelProvider,
+} from "../models/catalog.ts";
+import { sealCredentials } from "../sealing.ts";
+import type { AuthContext } from "./context.ts";
+import { IdentityConflictError, UnprocessableInputError } from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+import { within } from "./within.ts";
+
+/**
+ * The organization's model-provider credentials: one key per provider account,
+ * and the one place any of them is stored.
+ *
+ * **Write-only, and that is a property of this file rather than a promise each
+ * caller keeps.** Nothing exported here can produce a plaintext key. `COLUMNS`
+ * below names every column an answer may carry, the sealed envelope is not
+ * among them, and there is no argument by which any read could be asked for
+ * one. The single door to a plaintext key is `resolveModelProviderKeys` in
+ * `model-access.ts`, which refuses every context that did not come from a
+ * simulation or grading claim. So an admin replaces a key without ever having
+ * read the one they are replacing, which is what "a customer's provider key
+ * never comes back out" means when it is enforced rather than intended.
+ *
+ * **One verb writes, and it both adds and rotates.** There is one credential
+ * per provider by construction, so "add" and "replace" are the same request
+ * with the same effect: the provider's key from now on is this one. Two verbs
+ * would only differ in which of them refuses when the caller guessed wrong
+ * about what is already stored, and the answer to that is not a refusal.
+ *
+ * **Saving calls no provider.** A key is sealed and stored, and nothing reaches
+ * out to see whether it works. A validation request would make saving depend on
+ * the provider being up, would spend on the customer's account to answer a
+ * question nobody asked, and would still not be true a minute later — a key
+ * revoked after it was checked is exactly as broken as one that never worked.
+ * Wrong permissions and expired keys are reported when the provider is used,
+ * where the report can name the simulation it stopped.
+ */
+
+/**
+ * The floor under a provider key, so the stored last-four stays a hint rather
+ * than most of the secret it hints at. Real provider keys are tens of
+ * characters, so anything this short is a paste gone wrong. The same number
+ * every other credential in this codebase is held to: a key is a key wherever
+ * it was typed.
+ */
+const SHORTEST_KEY = 8;
+
+/** How much of a key a person may see: enough to tell two apart, no more. */
+const HINT_CHARACTERS = 4;
+
+/**
+ * One credential, as everybody but the two claim paths sees it.
+ *
+ * There is no field here through which a secret could travel, and that is the
+ * whole shape of the type: `hint` is four characters chosen so two keys can be
+ * told apart, and `provider` names the account without being the key to it.
+ */
+export type ModelProviderCredential = {
+  readonly id: string;
+  readonly provider: ModelProvider;
+  /** The last characters of the key. Never enough of it to use. */
+  readonly hint: string;
+  /** The opaque revision of the live half. Hand back as `expectedRevision`. */
+  readonly revision: string;
+  /** When the stored key last changed, which is what a page shows beside it. */
+  readonly updatedAt: Date;
+  readonly createdAt: Date;
+};
+
+/** An answer's columns, and no more — the sealed envelope is not among them. */
+const COLUMNS = {
+  id: modelProviderCredential.id,
+  provider: modelProviderCredential.provider,
+  hint: modelProviderCredential.credentialsHint,
+  revision: modelProviderCredential.revision,
+  updatedAt: modelProviderCredential.updatedAt,
+  createdAt: modelProviderCredential.createdAt,
+} as const;
+
+function answer(row: {
+  readonly id: string;
+  readonly provider: string;
+  readonly hint: string;
+  readonly revision: string;
+  readonly updatedAt: Date;
+  readonly createdAt: Date;
+}): ModelProviderCredential {
+  // The column is pinned by a check constraint, so what comes back is one of
+  // the words this module writes.
+  return { ...row, provider: row.provider as ModelProvider };
+}
+
+function validProvider(provider: string): ModelProvider {
+  if (!isModelProvider(provider)) {
+    throw new UnprocessableInputError(
+      `"${provider}" is not a model provider Egma stores credentials for; expected one of ${MODEL_PROVIDERS.join(", ")}`,
+    );
+  }
+  return provider;
+}
+
+/**
+ * Trimmed before it is sealed, like every credential this codebase stores: a
+ * key pasted with whitespace would pass every check, seal the padding, and fail
+ * at the provider with nothing to say the stored value was the problem.
+ */
+function validKey(key: string): string {
+  const trimmed = key.trim();
+  if (trimmed === "") {
+    throw new UnprocessableInputError("a model-provider credential needs a key");
+  }
+  if (trimmed.length < SHORTEST_KEY) {
+    throw new UnprocessableInputError(
+      `a provider key is at least ${SHORTEST_KEY} characters, and this one is shorter than any provider issues`,
+    );
+  }
+  return trimmed;
+}
+
+/** The sealed envelope and the hint beside it, from one key. */
+function sealed(key: string): {
+  readonly credentials: string;
+  readonly credentialsHint: string;
+} {
+  const valid = validKey(key);
+  return {
+    // Sealed under a fresh initialisation vector every time, exactly as a
+    // connection's credentials are: two writes of the same key are two
+    // different ciphertexts, so the column tells nobody that nothing changed.
+    credentials: sealCredentials({ key: valid }),
+    credentialsHint: valid.slice(-HINT_CHARACTERS),
+  };
+}
+
+/**
+ * Every credential the organization holds, in catalog order of the provider.
+ *
+ * Readable at every role, because it is what a Models form reads to say which
+ * providers are configured — by their provider and their hint, which is all any
+ * of this ever answers with.
+ */
+export async function listModelProviderCredentials(
+  auth: AuthContext,
+): Promise<readonly ModelProviderCredential[]> {
+  authorize(auth, "read", here(auth));
+
+  const rows = await db()
+    .select(COLUMNS)
+    .from(modelProviderCredential)
+    .where(within(auth, modelProviderCredential))
+    .orderBy(asc(modelProviderCredential.provider));
+
+  return rows.map(answer);
+}
+
+export type ModelProviderCredentialInput = {
+  readonly provider: string;
+  /** In the clear here and sealed before it touches a row. */
+  readonly key: string;
+  /**
+   * What the caller believes is stored, for a replacement. Absent skips the
+   * check, which is what an admin adding a provider's first key means.
+   */
+  readonly expectedRevision?: string | undefined;
+};
+
+/**
+ * Store this organization's key for one provider, adding it or rotating it.
+ *
+ * **Only an `admin`.** Storing a key commits the organization's own provider
+ * account to every simulation and every verdict that selects it, which is a
+ * decision of the same kind as retention and billing rather than one of the
+ * same kind as writing a test.
+ *
+ * **Rotation replaces the whole envelope and keeps the row.** It is sealed over
+ * the whole value, so there is no shape in which one could be edited in place;
+ * nothing anywhere points at the credential by id, so nothing has to be
+ * repointed; and the next claim to be prepared opens the new secret. Work
+ * already claimed keeps the key it was handed, which is what makes rotation
+ * safe to do in the middle of a run.
+ *
+ * **It mints no persona or grader version.** A credential is operational state
+ * and an authored version is behavior; a rotation that created a version would
+ * make every run's history depend on when somebody changed a key.
+ */
+export async function storeModelProviderCredential(
+  auth: AuthContext,
+  input: ModelProviderCredentialInput,
+): Promise<ModelProviderCredential> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const provider = validProvider(input.provider);
+  const envelope = sealed(input.key);
+  const now = new Date();
+
+  return db().transaction(async (tx) => {
+    const [existing] = await tx
+      .select({
+        id: modelProviderCredential.id,
+        revision: modelProviderCredential.revision,
+      })
+      .from(modelProviderCredential)
+      .where(
+        within(
+          auth,
+          modelProviderCredential,
+          eq(modelProviderCredential.provider, provider),
+        ),
+      )
+      .limit(1)
+      .for("update");
+
+    if (
+      input.expectedRevision !== undefined &&
+      input.expectedRevision !== existing?.revision
+    ) {
+      throw new IdentityConflictError(
+        "Model-provider credential",
+        existing?.id ?? provider,
+        {
+          expected: input.expectedRevision,
+          current: existing?.revision ?? "none",
+        },
+      );
+    }
+
+    if (existing !== undefined) {
+      // A bare `eq` on an id that just came off the tenancy-checked row locked
+      // above, in this same transaction, so it reaches no further than that
+      // check already did.
+      const [rotated] = await tx
+        .update(modelProviderCredential)
+        .set({ ...envelope, revision: newId("rev"), updatedAt: now })
+        .where(eq(modelProviderCredential.id, existing.id))
+        .returning(COLUMNS);
+
+      if (rotated === undefined) {
+        throw new Error("the model-provider credential was not written");
+      }
+      return answer(rotated);
+    }
+
+    const [added] = await tx
+      .insert(modelProviderCredential)
+      .values({
+        id: newId("mpc"),
+        organizationId: auth.organizationId,
+        provider,
+        ...envelope,
+        revision: newId("rev"),
+        createdBy: auth.userId,
+        updatedAt: now,
+      })
+      .returning(COLUMNS);
+
+    if (added === undefined) {
+      throw new Error("the model-provider credential was not written");
+    }
+    return answer(added);
+  });
+}
+
+/**
+ * Take the organization's key for one provider away.
+ *
+ * **Deleted rather than archived, and nothing is scanned first.** No frozen
+ * plan and no pinned version names this row — a persona and a grader name the
+ * *provider* — so there is no work to strand and no history to make
+ * unreadable. Removing it is the honest way to say "Egma no longer holds our
+ * key for this account", and a simulation that then needs one lands as an
+ * infrastructure error naming the provider, which is a better answer than a
+ * credential nobody meant to keep.
+ *
+ * Answers the credential that was removed, or `undefined` where the
+ * organization held none — which is the same outcome as removing one, said
+ * without pretending a row existed.
+ */
+export async function removeModelProviderCredential(
+  auth: AuthContext,
+  provider: string,
+): Promise<ModelProviderCredential | undefined> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const [row] = await db()
+    .delete(modelProviderCredential)
+    .where(
+      within(
+        auth,
+        modelProviderCredential,
+        eq(modelProviderCredential.provider, validProvider(provider)),
+      ),
+    )
+    .returning(COLUMNS);
+
+  return row === undefined ? undefined : answer(row);
+}

--- a/packages/db/src/access/personas.ts
+++ b/packages/db/src/access/personas.ts
@@ -35,6 +35,12 @@ import { authorize, here } from "./permissions.ts";
 import { isProjectOfOrganization } from "./projects.ts";
 import { liveTestsNamingPersona } from "./tests.ts";
 import { within } from "./within.ts";
+import {
+  personaModelsFromRow,
+  samePersonaModels,
+  validPersonaModels,
+  type PersonaModels,
+} from "../models/selections.ts";
 
 /**
  * Reading and writing personas — what they are is the schema file's
@@ -142,6 +148,13 @@ export type NewPersona = {
   readonly name: string;
   readonly description?: string | undefined;
   readonly traits: PersonaTraits;
+  /**
+   * What this persona thinks, listens and speaks with. Absent leaves the
+   * persona on the compatibility path, where work-order preparation falls back
+   * to the deployment's own model settings — which is how every persona
+   * authored before the model catalog existed still runs.
+   */
+  readonly models?: PersonaModels | undefined;
 };
 
 export type Persona = {
@@ -153,6 +166,14 @@ export type Persona = {
   /** The current version's own `prsv_` id — what a run pins. */
   readonly versionId: string;
   readonly traits: PersonaTraits;
+  /**
+   * The current version's model selections, or `null` for a persona still on
+   * the compatibility path. `null` is an ordinary state and never a fault: it
+   * means this version was authored before the model catalog existed, and
+   * work-order preparation resolves it through the deployment's own settings
+   * exactly as it always did.
+   */
+  readonly models: PersonaModels | null;
   /**
    * The opaque token an identity write or a lifecycle change has to name.
    * It changes on every one of them and means nothing on its own.
@@ -186,6 +207,13 @@ export type PersonaChanges = {
   readonly name?: string;
   readonly description?: string | null;
   readonly traits?: PersonaTraits;
+  /**
+   * The three model selections, whole. Absent means keep what is stored, which
+   * is the ordinary edit; a selection that differs from the stored one mints
+   * the next version exactly as a trait change does, because which model a
+   * persona speaks with is behavior a run has to stay pinned to.
+   */
+  readonly models?: PersonaModels;
   readonly expectedRevision?: string | undefined;
   readonly expectedVersionId?: string | undefined;
 };
@@ -196,6 +224,8 @@ export type PersonaVersion = {
   readonly personaId: string;
   readonly version: number;
   readonly traits: PersonaTraits;
+  /** This version's model selections, or `null` on the compatibility path. */
+  readonly models: PersonaModels | null;
   readonly createdAt: Date;
 };
 
@@ -430,6 +460,8 @@ export async function createPersona(
   const id = newId("prs");
   const versionId = newId("prsv");
   const traits = normalizedTraits(input.traits);
+  const models =
+    input.models === undefined ? null : validPersonaModels(input.models);
 
   const inserted = await db().transaction(async (tx) => {
     // The identity row goes first, naming a version that does not exist yet;
@@ -452,6 +484,7 @@ export async function createPersona(
       personaId: id,
       version: 1,
       traits,
+      models,
       createdBy: auth.userId,
     });
 
@@ -465,6 +498,7 @@ export async function createPersona(
     version: 1,
     versionId,
     traits,
+    models,
     // A project's pointer is moved deliberately, and never by a create. A
     // brand-new persona is nobody's default until somebody says so.
     isDefault: false,
@@ -486,6 +520,7 @@ function selectWithCurrentVersion(on: Queryable = db()) {
       version: personaVersion.version,
       versionId: personaVersion.id,
       traits: personaVersion.traits,
+      models: personaVersion.models,
       defaultPersonaId: project.defaultPersonaId,
     })
     .from(persona)
@@ -501,12 +536,14 @@ function personaFrom(row: {
   readonly id: string;
   readonly versionId: string;
   readonly traits: unknown;
+  readonly models: unknown;
   readonly defaultPersonaId: string | null;
 }): Persona {
   const { defaultPersonaId, ...rest } = row;
   return {
-    ...(rest as unknown as Omit<Persona, "traits" | "isDefault">),
+    ...(rest as unknown as Omit<Persona, "traits" | "models" | "isDefault">),
     traits: traitsFromRow(row.traits, row.versionId),
+    models: personaModelsFromRow(row.models, row.versionId),
     isDefault: defaultPersonaId === row.id,
   };
 }
@@ -564,6 +601,11 @@ export async function editPersona(
 
   if (changes.name !== undefined) validateName(changes.name);
   if (changes.traits !== undefined) validateTraits(changes.traits);
+  // Checked before the transaction opens, like every other input: a selection
+  // naming a provider Egma ships nothing for is the caller's mistake, and it
+  // should cost no lock to say so.
+  const askedModels =
+    changes.models === undefined ? undefined : validPersonaModels(changes.models);
 
   return writing(() =>
     db().transaction(async (tx) => {
@@ -596,6 +638,7 @@ export async function editPersona(
           id: personaVersion.id,
           version: personaVersion.version,
           traits: personaVersion.traits,
+          models: personaVersion.models,
         })
         .from(personaVersion)
         .where(eq(personaVersion.id, currentVersionId))
@@ -614,7 +657,10 @@ export async function editPersona(
        * telling them so is what stops the next save silently landing on top of
        * somebody else's. So it is checked whenever traits were sent.
        */
-      if (changes.traits !== undefined && changes.expectedVersionId !== undefined) {
+      if (
+        (changes.traits !== undefined || askedModels !== undefined) &&
+        changes.expectedVersionId !== undefined
+      ) {
         if (changes.expectedVersionId !== currentVersion.id) {
           throw new VersionConflictError(
             "persona",
@@ -625,33 +671,57 @@ export async function editPersona(
       }
 
       const storedTraits = traitsFromRow(currentVersion.traits, currentVersion.id);
+      const storedModels = personaModelsFromRow(
+        currentVersion.models,
+        currentVersion.id,
+      );
       const nextTraits =
         changes.traits !== undefined && !sameTraits(storedTraits, changes.traits)
           ? normalizedTraits(changes.traits)
           : undefined;
+      /**
+       * A model selection that says something different from the stored one.
+       *
+       * **A version-minting change, exactly as a trait is**, because which
+       * model a persona thinks and speaks with is what that persona *is* on the
+       * simulation it conducted — and a run that pinned last week's version has
+       * to keep meaning what it meant. A save that names the selections already
+       * stored mints nothing, on the traits' own rule: a field somebody
+       * re-submitted unchanged is not a change.
+       */
+      const nextModels =
+        askedModels !== undefined && !samePersonaModels(storedModels, askedModels)
+          ? askedModels
+          : undefined;
+      const contentChanged = nextTraits !== undefined || nextModels !== undefined;
       const identityChanged =
         changes.name !== undefined || changes.description !== undefined;
 
-      if (nextTraits === undefined && !identityChanged) {
+      if (!contentChanged && !identityChanged) {
         return {
           ...current,
           version: currentVersion.version,
           versionId: currentVersion.id,
           traits: storedTraits,
+          models: storedModels,
           isDefault,
         };
       }
 
       let versionId = currentVersion.id;
       let version = currentVersion.version;
-      if (nextTraits !== undefined) {
+      if (contentChanged) {
         versionId = newId("prsv");
         version = currentVersion.version + 1;
         await tx.insert(personaVersion).values({
           id: versionId,
           personaId: current.id,
           version,
-          traits: nextTraits,
+          // Whichever half of the content moved, the new version carries both:
+          // a version is the whole persona as some simulation met it, never a
+          // patch on the one before it.
+          traits: nextTraits ?? storedTraits,
+          models: nextModels ?? storedModels,
           createdBy: auth.userId,
         });
       }
@@ -663,7 +733,7 @@ export async function editPersona(
           ...(changes.description === undefined
             ? {}
             : { description: changes.description }),
-          ...(nextTraits === undefined ? {} : { currentVersionId: versionId }),
+          ...(contentChanged ? { currentVersionId: versionId } : {}),
           // The identity moved, so the token that names it moves too — whichever
           // half of the edit moved it. A caller holding the old one is holding a
           // read taken before this write, and that is exactly what it is for.
@@ -681,6 +751,7 @@ export async function editPersona(
         version,
         versionId,
         traits: nextTraits ?? storedTraits,
+        models: nextModels ?? storedModels,
         isDefault,
       };
     }),
@@ -706,6 +777,7 @@ export async function getPersonaVersion(
       personaId: personaVersion.personaId,
       version: personaVersion.version,
       traits: personaVersion.traits,
+      models: personaVersion.models,
       createdAt: personaVersion.createdAt,
     })
     .from(personaVersion)
@@ -723,7 +795,11 @@ export async function getPersonaVersion(
     .limit(1);
 
   if (row === undefined) return undefined;
-  return { ...row, traits: traitsFromRow(row.traits, row.id) };
+  return {
+    ...row,
+    traits: traitsFromRow(row.traits, row.id),
+    models: personaModelsFromRow(row.models, row.id),
+  };
 }
 
 /**
@@ -956,6 +1032,11 @@ export async function clonePersona(
     name: source.name,
     description: source.description ?? undefined,
     traits: source.traits,
+    // A clone is the same persona under a new identity, models included. A
+    // clone of one still on the compatibility path is on it too — copying the
+    // release's recommended selections onto it would be Egma answering a
+    // question the original never answered.
+    ...(source.models === null ? {} : { models: source.models }),
   });
 }
 
@@ -1276,6 +1357,7 @@ export async function listPersonaVersions(
       personaId: personaVersion.personaId,
       version: personaVersion.version,
       traits: personaVersion.traits,
+      models: personaVersion.models,
       createdAt: personaVersion.createdAt,
     })
     .from(personaVersion)
@@ -1294,6 +1376,7 @@ export async function listPersonaVersions(
     items: items.map((row) => ({
       ...row,
       traits: traitsFromRow(row.traits, row.id),
+      models: personaModelsFromRow(row.models, row.id),
     })),
     nextCursor,
   };

--- a/packages/db/src/access/runs.ts
+++ b/packages/db/src/access/runs.ts
@@ -25,7 +25,7 @@ import {
   type Modality,
   type Topology,
 } from "../schema/agents.ts";
-import { persona } from "../schema/personas.ts";
+import { persona, personaVersion } from "../schema/personas.ts";
 import { openCredentials } from "../sealing.ts";
 import { test, testVersion, testPersona } from "../schema/tests.ts";
 import { idempotentOperation } from "../schema/plans.ts";
@@ -38,6 +38,7 @@ import {
   type RunEventKind,
   type RunStatus,
   type RunTrigger,
+  type EndingRepair,
   type SimulationEndingReason,
   type SimulationSkipReason,
   type SimulationStatus,
@@ -247,6 +248,13 @@ export type Simulation = {
   readonly modality: Modality;
   readonly status: SimulationStatus;
   readonly endingReason: SimulationEndingReason | null;
+  /**
+   * One sentence saying what actually went wrong, where the reason word is not
+   * enough on its own. Null on every simulation that ran.
+   */
+  readonly endingDetail: string | null;
+  /** Which screen fixes it, from `ENDING_REPAIRS`, or null where none does. */
+  readonly endingRepair: EndingRepair | null;
   readonly claimedBy: string | null;
   readonly claimedAt: Date | null;
   readonly heartbeatAt: Date | null;
@@ -417,6 +425,8 @@ const SIMULATION_COLUMNS = {
   modality: simulation.modality,
   status: simulation.status,
   endingReason: simulation.endingReason,
+  endingDetail: simulation.endingDetail,
+  endingRepair: simulation.endingRepair,
   claimedBy: simulation.claimedBy,
   claimedAt: simulation.claimedAt,
   heartbeatAt: simulation.heartbeatAt,
@@ -722,6 +732,7 @@ type SimulationRow = Omit<
   Simulation,
   | "status"
   | "endingReason"
+  | "endingRepair"
   | "modality"
   | "mockToolCoverage"
   | "skipReason"
@@ -729,6 +740,7 @@ type SimulationRow = Omit<
 > & {
   readonly status: string;
   readonly endingReason: string | null;
+  readonly endingRepair: string | null;
   readonly modality: string;
   readonly mockToolCoverage: unknown;
   readonly skipReason: string | null;
@@ -740,6 +752,9 @@ function simulationFromRow(row: SimulationRow): Simulation {
     ...row,
     status: row.status as SimulationStatus,
     endingReason: row.endingReason as SimulationEndingReason | null,
+    // Pinned by a check constraint, so what comes back is one of the words
+    // this module writes.
+    endingRepair: row.endingRepair as EndingRepair | null,
     modality: row.modality as Modality,
     mockToolCoverage: mockToolCoverageFromRow(row.mockToolCoverage, row.id),
     skipReason: row.skipReason as SimulationSkipReason | null,
@@ -2173,6 +2188,28 @@ export type SimulationClaimRequest = {
   readonly claimant: string;
   /** How many conversations it has room to conduct at once. */
   readonly capacity: number;
+  /**
+   * Which versions of the simulation contract this simulator implements.
+   *
+   * **What a worker can read decides what it may take**, which is how a mixed
+   * rollout stays safe with no drain step and no work stranded. A simulation
+   * whose pinned persona version carries explicit model selections can only be
+   * conducted from a version-2 document; a worker that speaks only version 1
+   * therefore never claims that row at all, and one that speaks version 2
+   * standing beside it takes it on the next poll.
+   *
+   * The alternative shapes are both worse. Handing an old worker the row and a
+   * version-1 document would drop the selections in silence and conduct the
+   * conversation with the deployment's own models — the failure the closed
+   * contract exists to make unreachable. Handing it the row and then failing
+   * the dispatch would spend a customer's simulation on a rollout detail.
+   *
+   * Absent means version 1 alone, which is what every simulator built before
+   * the second version means when it says nothing. It names no customer, so
+   * this is a declaration of capability rather than a filter on whose work to
+   * bring back.
+   */
+  readonly contractVersions?: readonly number[] | undefined;
 };
 
 /**
@@ -2217,15 +2254,32 @@ export async function claimSimulations(
   }
 
   const now = new Date();
+  // A worker that says nothing speaks version 1, which is what every simulator
+  // built before the second version means by saying nothing.
+  const speaksVersionTwo = (request.contractVersions ?? [1]).includes(2);
 
   const claimed = await db().transaction(async (tx) => {
     const candidates = await tx
       .select({ id: simulation.id })
       .from(simulation)
-      .where(eq(simulation.status, "queued"))
+      // The persona version the row pinned, joined so the queue itself can
+      // answer whether this worker could conduct the conversation. A row whose
+      // persona selects its own models needs a version-2 document, so a
+      // version-1 worker is never offered it — `skipLocked` above already means
+      // "take what you can", and this is the same idea one step earlier.
+      .innerJoin(
+        personaVersion,
+        eq(simulation.personaVersionId, personaVersion.id),
+      )
+      .where(
+        and(
+          eq(simulation.status, "queued"),
+          speaksVersionTwo ? undefined : isNull(personaVersion.models),
+        ),
+      )
       .orderBy(asc(simulation.id))
       .limit(capacity)
-      .for("update", { skipLocked: true });
+      .for("update", { of: simulation, skipLocked: true });
 
     if (candidates.length === 0) return [];
 
@@ -2740,6 +2794,20 @@ export async function failSimulationDispatch(
   auth: AuthContext,
   id: string,
   claimant: string,
+  /**
+   * What went wrong and where it is fixed, where the platform knows.
+   *
+   * **Egma's own sentence, never a caller's**, so it carries no customer
+   * content and no secret. `dispatch_failed` says a claimed simulation was
+   * never handed over and says nothing about why; a person looking at a red
+   * row needs the why, and — where one exists — the screen that fixes it.
+   * Omitted leaves both null, which is every dispatch failure the platform can
+   * only describe as itself being broken.
+   */
+  detail?: {
+    readonly detail: string;
+    readonly repair?: EndingRepair | undefined;
+  },
 ): Promise<Simulation | undefined> {
   authorize(auth, "start_and_cancel_runs", here(auth));
 
@@ -2751,7 +2819,16 @@ export async function failSimulationDispatch(
 
   return landSimulation(auth, id, claimant, {
     from: ["claimed"],
-    write: { status: "failed", endingReason: "dispatch_failed" },
+    write: {
+      status: "failed",
+      endingReason: "dispatch_failed",
+      ...(detail === undefined
+        ? {}
+        : {
+            endingDetail: detail.detail,
+            endingRepair: detail.repair ?? null,
+          }),
+    },
   });
 }
 

--- a/packages/db/src/models/catalog.ts
+++ b/packages/db/src/models/catalog.ts
@@ -1,0 +1,173 @@
+/**
+ * The provider catalog: which model providers Egma supports, for which model
+ * job, and what a working default looks like for each.
+ *
+ * **Server-owned release data, and the browser keeps no second copy.** A page
+ * that maintained its own provider list would be a list that can disagree with
+ * this one, and the disagreement is a provider somebody can select and nothing
+ * can execute. The catalog is read through the API and drawn; it is never
+ * restated in a component.
+ *
+ * **An entry is a promise, so an entry appears only once it can be kept.** A
+ * provider-job pair becomes visible when all three paths behind it exist:
+ * customer-owned execution, managed execution through the Egma model gateway,
+ * and a live proof using the recommended default. `RESERVED_PROVIDER_JOBS`
+ * below names the pairs the product intends and has not proved, so the roadmap
+ * is written down without any of it being selectable — the shape
+ * `RESERVED_LIBRARY_TYPES` already uses for the grader types that are coming.
+ *
+ * **Model IDs and voice IDs are not allowlisted, and that is deliberate.** A
+ * release proves one recommended default per entry; a user may type any ID the
+ * shipped adapter accepts. Egma maintaining a list of every model a provider
+ * has would be a list that is wrong the week after it ships, and its wrongness
+ * would read as "Egma does not support this model" for a model that works.
+ * Provider rejection is a visible execution error instead — the provider is the
+ * authority on its own values.
+ */
+
+/**
+ * One role a model performs. A catalog entry belongs to exactly one job, and a
+ * persona selects one entry for each of the three.
+ *
+ * Silero VAD is deliberately not a job. What tells the persona that the agent
+ * has started and stopped speaking is internal simulator behavior, not a model
+ * anybody chooses, and putting it here would make an implementation detail into
+ * a question every persona author has to answer.
+ */
+export const MODEL_JOBS = ["llm", "stt", "tts"] as const;
+export type ModelJob = (typeof MODEL_JOBS)[number];
+
+/** One provider doing one job, with the default a release proved for it. */
+export type ProviderCatalogEntry = {
+  /** The provider's own name, as a credential and a work order spell it. */
+  readonly provider: ModelProvider;
+  readonly job: ModelJob;
+  /** What a person calls it, in a form and in an error alike. */
+  readonly label: string;
+  /**
+   * The model ID this release proved for this entry, filled into a new
+   * selection so a first run needs no model setup. Editable text everywhere it
+   * is offered: it is a starting point, never a limit.
+   */
+  readonly recommendedModel: string;
+  /**
+   * The provider's voice ID this release proved, for a `tts` entry alone. An
+   * `llm` or `stt` entry has none, and the type says so rather than carrying an
+   * empty string that a form would then have to decide what to do with.
+   */
+  readonly recommendedVoiceId?: string;
+};
+
+/**
+ * The providers a model-provider credential may authorize.
+ *
+ * **Exactly the providers the catalog can execute.** One provider does several
+ * jobs — an OpenAI credential authorizes its LLM work and, when those entries
+ * ship, its speech work too — so this is a list of accounts rather than a list
+ * of entries. A provider that has no visible entry is not here: storing a
+ * credential for it would be Egma taking a secret it has nothing to do with.
+ */
+export const MODEL_PROVIDERS = ["openai", "deepgram", "cartesia"] as const;
+export type ModelProvider = (typeof MODEL_PROVIDERS)[number];
+
+/**
+ * What this release proved, and therefore what a persona and a grader may
+ * select today.
+ *
+ * The three are the representative voice path: Deepgram listening, OpenAI
+ * thinking, Cartesia speaking. Each was conducted end to end over both access
+ * modes and measured against direct provider access before it was written here.
+ */
+export const PROVIDER_CATALOG = [
+  {
+    provider: "openai",
+    job: "llm",
+    label: "OpenAI",
+    recommendedModel: "gpt-4o-mini",
+  },
+  {
+    provider: "deepgram",
+    job: "stt",
+    label: "Deepgram",
+    recommendedModel: "nova-3-general",
+  },
+  {
+    provider: "cartesia",
+    job: "tts",
+    label: "Cartesia",
+    recommendedModel: "sonic-3.5",
+    recommendedVoiceId: "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+  },
+] as const satisfies readonly ProviderCatalogEntry[];
+
+/**
+ * The provider-job pairs the product intends and this release has not proved.
+ *
+ * Written down so the shape of the finished catalog is visible and so nobody
+ * adds one of these by inventing a name for it. **None of them is selectable**:
+ * a name here has no entry above, so a write naming it is refused exactly as a
+ * name nobody has ever heard of is.
+ */
+export const RESERVED_PROVIDER_JOBS = [
+  { provider: "anthropic", job: "llm" },
+  { provider: "google", job: "llm" },
+  { provider: "openai", job: "stt" },
+  { provider: "assemblyai", job: "stt" },
+  { provider: "elevenlabs", job: "tts" },
+  { provider: "openai", job: "tts" },
+] as const satisfies readonly {
+  readonly provider: string;
+  readonly job: ModelJob;
+}[];
+
+/**
+ * The catalog grouped by model job — the shape a form draws itself from, worked
+ * out once here rather than by every reader filtering the list again.
+ *
+ * A map rather than a function, on this module's whole terms: this is release
+ * data, so it is a value the release carries and never a call anybody makes.
+ */
+export const PROVIDERS_BY_JOB: {
+  readonly [Job in ModelJob]: readonly ProviderCatalogEntry[];
+} = {
+  llm: PROVIDER_CATALOG.filter((entry) => entry.job === "llm"),
+  stt: PROVIDER_CATALOG.filter((entry) => entry.job === "stt"),
+  tts: PROVIDER_CATALOG.filter((entry) => entry.job === "tts"),
+};
+
+/**
+ * The entry a new selection starts from for each job, so authoring a persona or
+ * a grader never begins with empty fields and a documentation search.
+ *
+ * The first entry of each job, which is the order the catalog is written in —
+ * so which default a release recommends is decided by editing the catalog
+ * rather than by a second list that could disagree with it.
+ */
+export const RECOMMENDED_ENTRY: {
+  readonly [Job in ModelJob]: ProviderCatalogEntry;
+} = {
+  llm: firstEntryFor("llm"),
+  stt: firstEntryFor("stt"),
+  tts: firstEntryFor("tts"),
+};
+
+/**
+ * Whether this string names a provider a credential may be stored for.
+ *
+ * Internal to this directory rather than on the data-access surface: it reads
+ * release data and nothing else, and a caller outside asks `MODEL_PROVIDERS`
+ * the same question without a second way to phrase it.
+ */
+export function isModelProvider(provider: string): provider is ModelProvider {
+  return MODEL_PROVIDERS.some((known) => known === provider);
+}
+
+function firstEntryFor(job: ModelJob): ProviderCatalogEntry {
+  const [first] = PROVIDER_CATALOG.filter((entry) => entry.job === job);
+  if (first === undefined) {
+    throw new Error(
+      `the provider catalog ships no ${job} entry, so there is no recommended selection to start from`,
+    );
+  }
+  return first;
+}

--- a/packages/db/src/models/catalog.ts
+++ b/packages/db/src/models/catalog.ts
@@ -78,7 +78,7 @@ export type ModelProvider = (typeof MODEL_PROVIDERS)[number];
  * thinking, Cartesia speaking. Each was conducted end to end over both access
  * modes and measured against direct provider access before it was written here.
  */
-export const PROVIDER_CATALOG = [
+export const PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
   {
     provider: "openai",
     job: "llm",
@@ -98,7 +98,7 @@ export const PROVIDER_CATALOG = [
     recommendedModel: "sonic-3.5",
     recommendedVoiceId: "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
   },
-] as const satisfies readonly ProviderCatalogEntry[];
+];
 
 /**
  * The provider-job pairs the product intends and this release has not proved.

--- a/packages/db/src/models/selections.ts
+++ b/packages/db/src/models/selections.ts
@@ -151,28 +151,42 @@ export function validGraderModel(model: GraderModel): GraderModel {
  * refuses to build until it is told how to be compared — a forgotten field
  * would call two different selections identical, and an edit somebody made
  * would vanish instead of minting a version.
+ *
+ * Two maps rather than one, because there are two shapes: everything a
+ * selection has, and the two more a speaking one carries. One map over the
+ * wider shape would have to be handed a narrower value at every call, which is
+ * a cast — and a cast is exactly what stops the compiler from noticing a field
+ * nobody taught it to compare.
  */
-const sameSelectionField: {
-  readonly [K in keyof SpeechSelection]: (
-    a: SpeechSelection,
-    b: SpeechSelection,
+const sameBaseField: {
+  readonly [K in keyof ModelSelection]: (
+    a: ModelSelection,
+    b: ModelSelection,
   ) => boolean;
 } = {
   provider: (a, b) => a.provider === b.provider,
   model: (a, b) => a.model === b.model,
+};
+
+const sameSpeechField: {
+  readonly [K in Exclude<keyof SpeechSelection, keyof ModelSelection>]: (
+    a: SpeechSelection,
+    b: SpeechSelection,
+  ) => boolean;
+} = {
   voiceId: (a, b) => a.voiceId === b.voiceId,
   speed: (a, b) => a.speed === b.speed,
 };
 
 function sameSelection(a: ModelSelection, b: ModelSelection): boolean {
-  return (
-    sameSelectionField.provider(a as SpeechSelection, b as SpeechSelection) &&
-    sameSelectionField.model(a as SpeechSelection, b as SpeechSelection)
-  );
+  return Object.values(sameBaseField).every((same) => same(a, b));
 }
 
 function sameSpeech(a: SpeechSelection, b: SpeechSelection): boolean {
-  return Object.values(sameSelectionField).every((same) => same(a, b));
+  return (
+    sameSelection(a, b) &&
+    Object.values(sameSpeechField).every((same) => same(a, b))
+  );
 }
 
 /** Byte-identical persona models, so a save that changed nothing mints nothing. */

--- a/packages/db/src/models/selections.ts
+++ b/packages/db/src/models/selections.ts
@@ -1,0 +1,309 @@
+import { UnprocessableInputError } from "../access/errors.ts";
+import {
+  PROVIDERS_BY_JOB,
+  RECOMMENDED_ENTRY,
+  type ModelJob,
+  type ModelProvider,
+} from "./catalog.ts";
+
+/**
+ * What a persona version and a grader version say about models — and what
+ * neither of them says about credentials.
+ *
+ * **A selection names a provider and a model, and can never name a secret.**
+ * There is no field here through which a key could travel, which is what makes
+ * "an authored object never holds a credential" a property of the type rather
+ * than a rule each writer keeps. Who pays for the call is the organization's
+ * model access, resolved when a claim is prepared, and it is deliberately not
+ * part of what an author writes down: rotating a credential must not mint a
+ * persona version, and it cannot, because the credential is not in here.
+ *
+ * **These are versioned content.** Editing any field mints the next persona or
+ * grader version, so a run that pinned last week's version keeps meaning what
+ * it meant. That is the whole reason the selections live on the version row
+ * rather than on the live one.
+ */
+
+/** One provider and one model ID, for an `llm` or `stt` job. */
+export type ModelSelection = {
+  readonly provider: ModelProvider;
+  /** As the provider spells it. Free text, never allowlisted by Egma. */
+  readonly model: string;
+};
+
+/**
+ * The speaking job, which needs two more facts than the others: which of the
+ * provider's voices, and how fast the persona talks.
+ *
+ * Speech rate is a number rather than a description, for the reason the
+ * persona's concrete voice already is one: "quite fast" would have to be
+ * interpreted, and two runs interpreting it differently is exactly the drift a
+ * pinned version exists to rule out.
+ */
+export type SpeechSelection = ModelSelection & {
+  readonly voiceId: string;
+  /** Speech rate, as a multiple of the provider's natural pace. */
+  readonly speed: number;
+};
+
+/**
+ * A persona's three independent selections.
+ *
+ * Independent on purpose (ADR-0010): changing what the persona listens with
+ * must not require inventing a new bundle for what it thinks and speaks with.
+ */
+export type PersonaModels = {
+  readonly llm: ModelSelection;
+  readonly stt: ModelSelection;
+  readonly tts: SpeechSelection;
+};
+
+/**
+ * A grader version's own LLM selection.
+ *
+ * It inherits nothing: not a persona's LLM, which judges nothing, and not the
+ * project's judge configuration, which is the legacy path and stays readable
+ * only for work authored before this existed.
+ */
+export type GraderModel = ModelSelection;
+
+/** Speech only stays intelligible so far from natural pace. */
+export const SPEED_RANGE = { slowest: 0.5, fastest: 2 } as const;
+
+/**
+ * A provider from the catalog for this job, or the caller's mistake said out
+ * loud with the providers that would have worked.
+ *
+ * `UnprocessableInputError` rather than a plain one because the sentence is
+ * written for whoever has to fix the form, and the layer above has to be able
+ * to tell that apart from Egma being broken.
+ */
+function validProvider(job: ModelJob, provider: string): ModelProvider {
+  const entry = PROVIDERS_BY_JOB[job].find(
+    (known) => known.provider === provider,
+  );
+  if (entry === undefined) {
+    const shipped = PROVIDERS_BY_JOB[job].map((known) => known.provider);
+    throw new UnprocessableInputError(
+      `"${provider}" is not a ${job} provider Egma ships; expected one of ${shipped.join(", ")}`,
+    );
+  }
+  return entry.provider;
+}
+
+function validModel(job: ModelJob, model: string): string {
+  const trimmed = model.trim();
+  if (trimmed === "") {
+    throw new UnprocessableInputError(`the ${job} selection needs a model id`);
+  }
+  return trimmed;
+}
+
+function validSelection(job: ModelJob, selection: ModelSelection): ModelSelection {
+  return {
+    provider: validProvider(job, selection.provider),
+    model: validModel(job, selection.model),
+  };
+}
+
+function validSpeech(selection: SpeechSelection): SpeechSelection {
+  const { voiceId, speed } = selection;
+  const trimmedVoice = voiceId.trim();
+  if (trimmedVoice === "") {
+    throw new UnprocessableInputError(
+      "the tts selection needs a voice id from its provider",
+    );
+  }
+  if (
+    !Number.isFinite(speed) ||
+    speed < SPEED_RANGE.slowest ||
+    speed > SPEED_RANGE.fastest
+  ) {
+    throw new UnprocessableInputError(
+      `speaking speed must be between ${SPEED_RANGE.slowest} and ${SPEED_RANGE.fastest}`,
+    );
+  }
+  return {
+    ...validSelection("tts", selection),
+    voiceId: trimmedVoice,
+    speed,
+  };
+}
+
+/** The persona's three selections, checked and trimmed, ready to be stored. */
+export function validPersonaModels(models: PersonaModels): PersonaModels {
+  return {
+    llm: validSelection("llm", models.llm),
+    stt: validSelection("stt", models.stt),
+    tts: validSpeech(models.tts),
+  };
+}
+
+/** The grader's own LLM selection, checked and trimmed. */
+export function validGraderModel(model: GraderModel): GraderModel {
+  return validSelection("llm", model);
+}
+
+/**
+ * Whether two selections say the same thing, decided field by field.
+ *
+ * A mapped type rather than a deep compare, so a field added to a selection
+ * refuses to build until it is told how to be compared — a forgotten field
+ * would call two different selections identical, and an edit somebody made
+ * would vanish instead of minting a version.
+ */
+const sameSelectionField: {
+  readonly [K in keyof SpeechSelection]: (
+    a: SpeechSelection,
+    b: SpeechSelection,
+  ) => boolean;
+} = {
+  provider: (a, b) => a.provider === b.provider,
+  model: (a, b) => a.model === b.model,
+  voiceId: (a, b) => a.voiceId === b.voiceId,
+  speed: (a, b) => a.speed === b.speed,
+};
+
+function sameSelection(a: ModelSelection, b: ModelSelection): boolean {
+  return (
+    sameSelectionField.provider(a as SpeechSelection, b as SpeechSelection) &&
+    sameSelectionField.model(a as SpeechSelection, b as SpeechSelection)
+  );
+}
+
+function sameSpeech(a: SpeechSelection, b: SpeechSelection): boolean {
+  return Object.values(sameSelectionField).every((same) => same(a, b));
+}
+
+/** Byte-identical persona models, so a save that changed nothing mints nothing. */
+export function samePersonaModels(
+  a: PersonaModels | null,
+  b: PersonaModels | null,
+): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    sameSelection(a.llm, b.llm) &&
+    sameSelection(a.stt, b.stt) &&
+    sameSpeech(a.tts, b.tts)
+  );
+}
+
+export function sameGraderModel(
+  a: GraderModel | null,
+  b: GraderModel | null,
+): boolean {
+  if (a === null || b === null) return a === b;
+  return sameSelection(a, b);
+}
+
+/**
+ * The stored jsonb read back as selections, or a fault naming the row.
+ *
+ * A column holding something Egma never writes is a broken row rather than a
+ * caller's mistake, so it throws rather than answering — the same bargain the
+ * persona's traits already make. `null` is the ordinary answer for a version
+ * authored before persona models existed, and it is never a fault: it means
+ * this version is on the compatibility path.
+ */
+export function personaModelsFromRow(
+  value: unknown,
+  versionId: string,
+): PersonaModels | null {
+  if (value === null || value === undefined) return null;
+  const broken = (): never => {
+    throw new Error(
+      `version ${versionId} holds persona models in a shape Egma never writes; the row needs repairing before anybody can read it`,
+    );
+  };
+  if (typeof value !== "object" || Array.isArray(value)) return broken();
+  const held = value as Record<string, unknown>;
+  const llm = selectionFromRow(held.llm);
+  const stt = selectionFromRow(held.stt);
+  const tts = speechFromRow(held.tts);
+  if (llm === undefined || stt === undefined || tts === undefined) {
+    return broken();
+  }
+  return { llm, stt, tts };
+}
+
+export function graderModelFromRow(
+  value: unknown,
+  versionId: string,
+): GraderModel | null {
+  if (value === null || value === undefined) return null;
+  const selection = selectionFromRow(value);
+  if (selection === undefined) {
+    throw new Error(
+      `version ${versionId} holds a grader model in a shape Egma never writes; the row needs repairing before anybody can read it`,
+    );
+  }
+  return selection;
+}
+
+function selectionFromRow(value: unknown): ModelSelection | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const held = value as Record<string, unknown>;
+  const { provider, model } = held;
+  if (typeof provider !== "string" || typeof model !== "string") {
+    return undefined;
+  }
+  // The stored word came through `validProvider` on the way in, so what comes
+  // back is one of the catalog's — read back as the closed type rather than
+  // re-checked, exactly as a checked column is.
+  return { provider: provider as ModelProvider, model };
+}
+
+function speechFromRow(value: unknown): SpeechSelection | undefined {
+  const selection = selectionFromRow(value);
+  if (selection === undefined) return undefined;
+  const held = value as Record<string, unknown>;
+  const { voiceId, speed } = held;
+  if (typeof voiceId !== "string" || typeof speed !== "number") {
+    return undefined;
+  }
+  return { ...selection, voiceId, speed };
+}
+
+/**
+ * The selections a persona starts life with: this release's proved defaults, so
+ * a new project's default persona runs before anybody opens its Models form.
+ *
+ * A value rather than a call, on the catalog's own terms — it is read off
+ * release data and nothing about it can differ between two callers.
+ */
+export const RECOMMENDED_PERSONA_MODELS: PersonaModels = {
+  llm: {
+    provider: RECOMMENDED_ENTRY.llm.provider,
+    model: RECOMMENDED_ENTRY.llm.recommendedModel,
+  },
+  stt: {
+    provider: RECOMMENDED_ENTRY.stt.provider,
+    model: RECOMMENDED_ENTRY.stt.recommendedModel,
+  },
+  tts: {
+    provider: RECOMMENDED_ENTRY.tts.provider,
+    model: RECOMMENDED_ENTRY.tts.recommendedModel,
+    voiceId: recommendedVoice(),
+    // The natural pace of the provider's voice: a persona that has said nothing
+    // about how fast it talks talks the way the voice does.
+    speed: 1,
+  },
+};
+
+/** The selection a grader starts life with, on the same terms. */
+export const RECOMMENDED_GRADER_MODEL: GraderModel = {
+  provider: RECOMMENDED_ENTRY.llm.provider,
+  model: RECOMMENDED_ENTRY.llm.recommendedModel,
+};
+
+function recommendedVoice(): string {
+  const voiceId = RECOMMENDED_ENTRY.tts.recommendedVoiceId;
+  if (voiceId === undefined) {
+    throw new Error(
+      "the catalog's tts entry ships no recommended voice, so a persona cannot start from it",
+    );
+  }
+  return voiceId;
+}

--- a/packages/db/src/schema/graders.ts
+++ b/packages/db/src/schema/graders.ts
@@ -577,6 +577,23 @@ export const graderVersion = pgTable(
      * a stronger one named here on the subtle rubric that needs it.
      */
     judgeModel: jsonb("judge_model"),
+    /**
+     * This grader version's **own** LLM selection: a provider from the model
+     * catalog and a model ID. Not an override of anything — the key behind it
+     * is the organization's model-provider credential for that provider, or
+     * Egma's own under managed access, resolved when the grading claim is
+     * prepared.
+     *
+     * **Beside `judge_model` rather than in place of it, and the difference is
+     * the whole reason for a second column.** `judge_model` overrides a
+     * *project's* judge configuration and takes that project's key with it;
+     * this names a complete selection and takes the organization's. A version
+     * with this set is new work and never consults the project's judge; a
+     * version with only `judge_model` is work authored before the model catalog
+     * existed and keeps resolving exactly as it did. Null here is therefore an
+     * ordinary state and means "compatibility path", never a fault.
+     */
+    graderModel: jsonb("grader_model"),
     createdBy: idText("created_by").references(() => user.id, {
       onDelete: "set null",
     }),

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -2,6 +2,7 @@ export * from "./columns.ts";
 export * from "./platform.ts";
 export * from "./identity.ts";
 export * from "./tenancy.ts";
+export * from "./models.ts";
 export * from "./device.ts";
 export * from "./personas.ts";
 export * from "./agents.ts";

--- a/packages/db/src/schema/models.ts
+++ b/packages/db/src/schema/models.ts
@@ -1,0 +1,133 @@
+import { pgTable, text, unique } from "drizzle-orm/pg-core";
+
+import { organization } from "./tenancy.ts";
+import { user } from "./identity.ts";
+import { createdAt, idText, oneOf, prefixCheck, updatedAt } from "./columns.ts";
+import { MODEL_PROVIDERS } from "../models/catalog.ts";
+
+/**
+ * Who pays for the organization's model traffic, and — where the organization
+ * pays for it itself — the keys that authorize it.
+ *
+ * Two tables, both keyed by the organization, because the organization is the
+ * only tenancy boundary and both of these facts belong to the customer rather
+ * than to any project, persona or grader inside it. A persona names a provider;
+ * it never names a credential and never holds a secret, so rotating a key
+ * changes no authored version and an authored version can never leak one.
+ */
+
+/**
+ * The two ways an organization's model traffic can be paid for. One
+ * organization-wide value, and there is deliberately no third state and no
+ * per-provider mixing: "managed for speech, my own for the LLM" is a policy
+ * nobody asked for and a resolution rule in every claim forever.
+ */
+export const MODEL_ACCESS_MODES = ["managed", "customer-owned"] as const;
+export type ModelAccessMode = (typeof MODEL_ACCESS_MODES)[number];
+
+/**
+ * The organization's one model access choice.
+ *
+ * **A missing row is `customer-owned` rather than a fault.** Every organization
+ * that existed before this table did has no row, and customer-owned is the
+ * honest reading of that: nothing has been connected to Egma's own provider
+ * accounts, so nothing may spend from them. Writing a row for every existing
+ * organization would say a decision was made where none was.
+ *
+ * A table of its own rather than a column on `organization_settings`, for the
+ * reason the judge configuration is its own table: settings is read whenever an
+ * organization is drawn, and this is read on the claim path for every
+ * simulation. Keeping them apart keeps a hot read off a page's row and lets
+ * this one grow the fields managed access needs without touching the other.
+ */
+export const modelAccess = pgTable(
+  "model_access",
+  {
+    organizationId: idText("organization_id")
+      .primaryKey()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** `managed` or `customer-owned`. See `MODEL_ACCESS_MODES`. */
+    mode: text("mode").notNull(),
+    updatedBy: idText("updated_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("model_access_organization_id_prefix", table.organizationId, "org"),
+    oneOf("model_access_mode_allowed", table.mode, [...MODEL_ACCESS_MODES]),
+  ],
+);
+
+/**
+ * One model provider's key, sealed, owned by the organization.
+ *
+ * **At most one active credential per provider, held by the database.** Two
+ * keys for one account is a question — which one does this simulation
+ * spend from? — that nothing downstream could answer without inventing a rule,
+ * and a persona stores the provider rather than a credential id precisely so
+ * that there is nothing to choose between. Replacing the key rotates it: the
+ * row keeps its identity and the next claim picks the new secret up.
+ *
+ * **The secret is write-only and there is no read that returns it.** The access
+ * module's `COLUMNS` names every column an answer may carry, and the envelope
+ * is not among them — so the field is absent from the read shape rather than
+ * blanked, and leaking one through a serializer is not a thing anybody can
+ * forget. What a person may see is the hint, the last few characters, which
+ * exists for one job: telling two keys apart.
+ *
+ * **The label the judge credential carried is deliberately gone.** A judge
+ * credential could be one of several for a provider, so it needed a name to be
+ * chosen by; there is one per provider here, so the provider *is* the name and
+ * a second one would be a field two admins could disagree about.
+ */
+export const modelProviderCredential = pgTable(
+  "model_provider_credential",
+  {
+    id: idText("id").primaryKey(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** Which provider account this authorizes. See `MODEL_PROVIDERS`. */
+    provider: text("provider").notNull(),
+    /**
+     * The key, sealed with the deployment's own encryption key — the same
+     * module and the same master key a connection's credentials are sealed
+     * with, keeping its version prefix so a later re-sealing is a data
+     * migration rather than a guess at what an old row held.
+     */
+    credentials: text("credentials").notNull(),
+    /** The last characters of the key. Never enough of it to use. */
+    credentialsHint: text("credentials_hint").notNull(),
+    /** The opaque token an edit has to name to be allowed to land. */
+    revision: idText("revision").notNull(),
+    createdBy: idText("created_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("model_provider_credential_id_prefix", table.id, "mpc"),
+    prefixCheck(
+      "model_provider_credential_revision_prefix",
+      table.revision,
+      "rev",
+    ),
+    oneOf("model_provider_credential_provider_allowed", table.provider, [
+      ...MODEL_PROVIDERS,
+    ]),
+    /**
+     * The one-per-provider rule, held by the database rather than by whoever
+     * writes the row. Removing a credential deletes it rather than archiving
+     * it: unlike a judge credential, nothing points at this row by id — a
+     * persona names the provider — so there is no frozen plan to strand and no
+     * history to make unreadable.
+     */
+    unique("model_provider_credential_one_per_provider").on(
+      table.organizationId,
+      table.provider,
+    ),
+  ],
+);

--- a/packages/db/src/schema/personas.ts
+++ b/packages/db/src/schema/personas.ts
@@ -97,6 +97,27 @@ export const personaVersion = pgTable(
      * personality, language, and the concrete voice.
      */
     traits: jsonb("traits").notNull(),
+    /**
+     * This persona's three model selections — LLM, STT and TTS, each a provider
+     * and a model ID, the TTS one also a voice ID and a speech speed.
+     *
+     * **Null is an ordinary state, not a fault.** Every version authored before
+     * persona models existed has none, and that is what puts it on the
+     * compatibility path: work-order preparation falls back to the deployment's
+     * own model settings for it, exactly as it always did. Nothing rewrites an
+     * old version to fill this in — immutable means immutable — so the column
+     * fills up as personas are edited and by the migration that gives each
+     * current version an explicit successor.
+     *
+     * **It holds no credential and has nowhere to put one.** Who pays is the
+     * organization's model access, resolved when a claim is prepared, so
+     * rotating a key mints no version and no version can leak a secret.
+     *
+     * Deliberately jsonb, for the reason `traits` beside it is: three
+     * selections with four fields between them is a shape that will grow, and a
+     * field promoted to a column later is a cheap migration.
+     */
+    models: jsonb("models"),
     createdBy: idText("created_by").references(() => user.id, {
       onDelete: "set null",
     }),

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -118,6 +118,17 @@ export const COMPLETED_ENDING_REASONS = [
 ] as const;
 
 /**
+ * Where a person goes to repair what stopped a simulation.
+ *
+ * One entry today: the organization's Model providers screen, which is where
+ * every model credential in the product lives. The list grows when a failure
+ * arrives that a different screen fixes, and it stays closed so that a stored
+ * word is always a page a browser can actually open.
+ */
+export const ENDING_REPAIRS = ["model_providers"] as const;
+export type EndingRepair = (typeof ENDING_REPAIRS)[number];
+
+/**
  * Why a simulation never produced a conversation to grade. These must never
  * collapse into "the agent behaved badly": an agent that never joined, a line
  * that was never answered, a platform out of capacity, egma's own error, and
@@ -131,17 +142,6 @@ export const COMPLETED_ENDING_REASONS = [
  * a claimed row into a spec worth handing over — a broken row is the
  * platform's fault, never pinned on a simulator that was handed nothing.
  */
-/**
- * Where a person goes to repair what stopped a simulation.
- *
- * One entry today: the organization's Model providers screen, which is where
- * every model credential in the product lives. The list grows when a failure
- * arrives that a different screen fixes, and it stays closed so that a stored
- * word is always a page a browser can actually open.
- */
-export const ENDING_REPAIRS = ["model_providers"] as const;
-export type EndingRepair = (typeof ENDING_REPAIRS)[number];
-
 export const FAILED_ENDING_REASONS = [
   "agent_never_joined",
   "not_answered",

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -131,6 +131,17 @@ export const COMPLETED_ENDING_REASONS = [
  * a claimed row into a spec worth handing over — a broken row is the
  * platform's fault, never pinned on a simulator that was handed nothing.
  */
+/**
+ * Where a person goes to repair what stopped a simulation.
+ *
+ * One entry today: the organization's Model providers screen, which is where
+ * every model credential in the product lives. The list grows when a failure
+ * arrives that a different screen fixes, and it stays closed so that a stored
+ * word is always a page a browser can actually open.
+ */
+export const ENDING_REPAIRS = ["model_providers"] as const;
+export type EndingRepair = (typeof ENDING_REPAIRS)[number];
+
 export const FAILED_ENDING_REASONS = [
   "agent_never_joined",
   "not_answered",
@@ -410,6 +421,32 @@ export const simulation = pgTable(
      */
     endingReason: text("ending_reason"),
     /**
+     * One sentence saying what actually went wrong, for a failure whose reason
+     * word is not enough on its own.
+     *
+     * **The platform's own account, and only where the platform has one.**
+     * `dispatch_failed` says a claimed simulation was never handed over and
+     * says nothing about why; "this organization holds no Deepgram credential,
+     * and this persona listens with Deepgram" is what somebody can actually act
+     * on. Null everywhere else, which is every simulation that ran.
+     *
+     * **Written by Egma and never by a caller**, so it carries no customer
+     * content and no secret: the claim path composes it from the provider and
+     * the model job it could not resolve, both of which are already on screen
+     * wherever the persona is.
+     */
+    endingDetail: text("ending_detail"),
+    /**
+     * Where the person reading that sentence goes to fix it, as one word from
+     * a closed list — or null where there is nowhere to send them.
+     *
+     * A word rather than a URL, because the address of a page is the browser's
+     * business and a stored link would be a route this table could not be
+     * refactored around. A closed list rather than free text, because a page
+     * turns it into a link and an unknown word would be a button to nowhere.
+     */
+    endingRepair: text("ending_repair"),
+    /**
      * Claim bookkeeping. The claimant is the simulator instance's own name
      * for itself — an operational label, never an identity in egma's tables
      * — and the heartbeat is what the orphan sweep reads.
@@ -502,6 +539,18 @@ export const simulation = pgTable(
       sql`${table.endingReason} is null or ${table.endingReason} in ${quoted(
         SIMULATION_ENDING_REASONS,
       )}`,
+    ),
+    check(
+      "simulation_ending_repair_allowed",
+      sql`${table.endingRepair} is null or ${table.endingRepair} in ${quoted(
+        ENDING_REPAIRS,
+      )}`,
+    ),
+    // A place to go with no sentence saying why would be a link somebody
+    // follows without knowing what they are fixing.
+    check(
+      "simulation_ending_repair_has_a_reason_to_exist",
+      sql`${table.endingRepair} is null or ${table.endingDetail} is not null`,
     ),
     // The reason's class follows the status: a conversation ended one of the
     // completed ways, a simulation that never ran failed one of the failed

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -312,6 +312,24 @@ const CONTEXT_REQUIRING = [
   // The second secret egma holds, on the first one's terms: the read answers a
   // reference and a hint, and this is the one door to the plaintext behind it.
   "resolveJudgeKey",
+  // The organization's own model-provider keys, on exactly those terms one
+  // table over: the reads answer a provider and a hint and never a key, one
+  // verb both adds and rotates because there is one credential per provider,
+  // and removing one strands nothing because nothing points at it by id.
+  "listModelProviderCredentials",
+  "storeModelProviderCredential",
+  "removeModelProviderCredential",
+  // Which of the two access modes the organization is on, read at every role
+  // because it is not a secret, and written by an admin alone because it
+  // decides whose provider account every simulation spends from.
+  "readModelAccess",
+  "setModelAccess",
+  // The one door to a model-provider key's plaintext. It takes the context
+  // like everything else and then refuses every one that did not come from a
+  // simulation or a grading claim — conducting and judging being the only two
+  // things egma does with one — and answers only the providers it was asked
+  // for, so a work order never carries a secret its selections do not name.
+  "resolveModelProviderKeys",
   // The same translation for a mock tool's scope: names off a reviewed file
   // turned into the agents it applies to. It reads agents and nothing else, and
   // only ones the context already reaches.
@@ -432,6 +450,32 @@ const THE_GRADER_LIBRARY = [
   "RESERVED_LIBRARY_TYPES",
 ];
 
+/**
+ * The provider catalog and what is selected from it: release data and pure
+ * shapes, reaching no store and taking no context, on the grader library's
+ * exact terms one group up.
+ *
+ * They are here rather than restated in the browser because a page that kept
+ * its own provider list would be a list that can disagree with this one — and
+ * the disagreement is a provider somebody can select and nothing can execute.
+ * The recommended values are exported for the same reason `PREDEFINED_GRADERS`
+ * is: three places start a selection from them, and a repeated literal is a
+ * default somebody can mistype into a model nobody proved.
+ */
+const THE_MODEL_CATALOG = [
+  "MODEL_ACCESS_MODES",
+  "MODEL_JOBS",
+  "MODEL_PROVIDERS",
+  "PROVIDER_CATALOG",
+  "RESERVED_PROVIDER_JOBS",
+  "PROVIDERS_BY_JOB",
+  "RECOMMENDED_ENTRY",
+  "RECOMMENDED_GRADER_MODEL",
+  "RECOMMENDED_PERSONA_MODELS",
+  "SPEED_RANGE",
+  "DEFAULT_MODEL_ACCESS",
+];
+
 /** Vocabulary: the table definitions, how a caller proved who they are, and the refusals. */
 const VALUES = [
   // The agent factory's own refusal, carrying which of its three rules turned
@@ -467,7 +511,17 @@ const VALUES = [
   // A second answer for a tool this project already answers for. Its own class
   // because nothing about the body is wrong and something is already there,
   // which is a different answer in kind.
+  // Managed model access selected while nothing is connected to Egma's own
+  // provider accounts. A refusal rather than a quiet no-op, because a stored
+  // `managed` with no inference key behind it fails one claim at a time for a
+  // setting that read as saved.
+  "ManagedAccessNotConnectedError",
   "MockToolTakenError",
+  // A claim that could not open a credential its pinned selections name. It is
+  // an infrastructure error and never a failed verdict, and it carries the
+  // model job and the provider as values so a page can link to Model providers
+  // rather than parse a sentence.
+  "ModelProviderCredentialMissingError",
   "NotPermittedError",
   // The persona factory's other refusal: archiving the persona a project
   // points at, without saying who takes the pointer. A project always has a
@@ -722,6 +776,7 @@ describe("the data-access module's surface", () => {
         ...THE_MOCKED_WORLD,
         ...THE_PLATFORMS_SETTINGS,
         ...THE_GRADER_LIBRARY,
+        ...THE_MODEL_CATALOG,
       ].sort(),
     );
   });

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -468,6 +468,11 @@ const THE_MODEL_CATALOG = [
   // the browser's business — and closed, because a page turns it into a link
   // and an unknown word would be a button to nowhere.
   "ENDING_REPAIRS",
+  // What a grader binary understands beyond what every one of them always has.
+  // A rollout fact rather than a setting: a binary that cannot read a grader's
+  // own model selection is offered no work that carries one, so it never
+  // judges on an account nobody chose.
+  "GRADING_CAPABILITIES",
   "MODEL_ACCESS_MODES",
   "MODEL_JOBS",
   "MODEL_PROVIDERS",
@@ -513,14 +518,18 @@ const VALUES = [
   // provider. Its own class because the fix is specific and nameable.
   "JudgeProviderMismatchError",
   "LastAdminError",
-  // A second answer for a tool this project already answers for. Its own class
-  // because nothing about the body is wrong and something is already there,
-  // which is a different answer in kind.
   // Managed model access selected while nothing is connected to Egma's own
   // provider accounts. A refusal rather than a quiet no-op, because a stored
   // `managed` with no inference key behind it fails one claim at a time for a
   // setting that read as saved.
   "ManagedAccessNotConnectedError",
+  // The same state found on the claim path instead — a tripwire, because no
+  // door in this release can write it. Typed so it lands as an infrastructure
+  // error naming the mode rather than as a bare dispatch failure.
+  "ManagedAccessUnavailableError",
+  // A second answer for a tool this project already answers for. Its own class
+  // because nothing about the body is wrong and something is already there,
+  // which is a different answer in kind.
   "MockToolTakenError",
   // A claim that could not open a credential its pinned selections name. It is
   // an infrastructure error and never a failed verdict, and it carries the

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -463,6 +463,11 @@ const THE_GRADER_LIBRARY = [
  * default somebody can mistype into a model nobody proved.
  */
 const THE_MODEL_CATALOG = [
+  // Where a person goes to repair what stopped a simulation, as one word from
+  // a closed list. A word rather than a URL, because the address of a page is
+  // the browser's business — and closed, because a page turns it into a link
+  // and an unknown word would be a button to nowhere.
+  "ENDING_REPAIRS",
   "MODEL_ACCESS_MODES",
   "MODEL_JOBS",
   "MODEL_PROVIDERS",

--- a/packages/db/test/model-provider-credentials.test.ts
+++ b/packages/db/test/model-provider-credentials.test.ts
@@ -1,0 +1,355 @@
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MODEL_ACCESS,
+  listModelProviderCredentials,
+  ManagedAccessNotConnectedError,
+  NotPermittedError,
+  readModelAccess,
+  removeModelProviderCredential,
+  resolveModelProviderKeys,
+  setModelAccess,
+  storeModelProviderCredential,
+  UnprocessableInputError,
+  type AuthContext,
+  type Role,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * The organization's own provider keys, and the one binary choice that says
+ * whether they are the ones Egma spends.
+ *
+ * Every assertion goes through the access functions — the seam — except the
+ * reads of the raw `credentials` column, which bypass the module on purpose:
+ * the claim under test is that what the module writes is ciphertext and that
+ * nothing it answers with contains the key, and only a read the module cannot
+ * dress up can say so. That is the judge credential's arrangement, verbatim,
+ * because this is the same secret problem one table over.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const globex = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+const grace = newId("usr");
+
+const OPENAI_KEY = "sk-model-sentinel-openai-QRST";
+const DEEPGRAM_KEY = "dg-model-sentinel-listen-UVWX";
+const REPLACEMENT_KEY = "sk-model-sentinel-rotated-YZ12";
+
+function actingAsAcme(role: Role = "admin"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+function actingAsGlobex(role: Role = "admin"): AuthContext {
+  return {
+    userId: grace,
+    organizationId: globex.organization,
+    projectId: globex.project,
+    role,
+    via: "session",
+  };
+}
+
+/** What a simulation claim resolves to: no person, and `simulator` on its face. */
+function theSimulatorInAcme(): AuthContext {
+  return {
+    userId: "simulator",
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role: "viewer",
+    via: "simulator",
+  };
+}
+
+/** The grading engine's own, which opens the same door for the same reason. */
+function theEngineInAcme(): AuthContext {
+  return {
+    userId: "engine",
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role: "viewer",
+    via: "engine",
+  };
+}
+
+/** The sealed column, read around the module because that is the whole point. */
+async function storedEnvelope(
+  organizationId: string,
+  provider: string,
+): Promise<string | undefined> {
+  const { rows } = await database.sql<{ credentials: string }>(
+    "select credentials from model_provider_credential where organization_id = $1 and provider = $2",
+    [organizationId, provider],
+  );
+  return rows[0]?.credentials;
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("model-provider-credentials");
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedUser(database, grace, "grace@globex.example");
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("storing one provider's key", () => {
+  it("answers the provider, a safe hint and when it changed — never the key", async () => {
+    const stored = await storeModelProviderCredential(actingAsAcme(), {
+      provider: "openai",
+      key: OPENAI_KEY,
+    });
+
+    expect(stored.provider).toBe("openai");
+    expect(stored.hint).toBe("QRST");
+    expect(stored.updatedAt).toBeInstanceOf(Date);
+    expect(JSON.stringify(stored)).not.toContain(OPENAI_KEY);
+  });
+
+  it("seals it, so the column holds ciphertext and not the key", async () => {
+    const envelope = await storedEnvelope(acme.organization, "openai");
+
+    expect(envelope).toBeDefined();
+    expect(envelope).not.toContain(OPENAI_KEY);
+    expect(envelope).toMatch(/^v1\./);
+  });
+
+  it("is listed by provider and hint, and by nothing else", async () => {
+    await storeModelProviderCredential(actingAsAcme(), {
+      provider: "deepgram",
+      key: DEEPGRAM_KEY,
+    });
+
+    const held = await listModelProviderCredentials(actingAsAcme());
+
+    expect(held.map((one) => one.provider)).toEqual(["deepgram", "openai"]);
+    expect(held.map((one) => one.hint)).toEqual(["UVWX", "QRST"]);
+    expect(JSON.stringify(held)).not.toContain(DEEPGRAM_KEY);
+    expect(JSON.stringify(held)).not.toContain(OPENAI_KEY);
+  });
+
+  it("refuses a provider Egma ships no adapter for", async () => {
+    await expect(
+      storeModelProviderCredential(actingAsAcme(), {
+        provider: "elevenlabs",
+        key: OPENAI_KEY,
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableInputError);
+  });
+
+  it("refuses something too short to be any provider's key", async () => {
+    await expect(
+      storeModelProviderCredential(actingAsAcme(), {
+        provider: "openai",
+        key: "sk-abc",
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableInputError);
+  });
+});
+
+describe("replacing one provider's key", () => {
+  it("keeps one credential per provider and rotates what is stored", async () => {
+    const before = await storedEnvelope(acme.organization, "openai");
+
+    const rotated = await storeModelProviderCredential(actingAsAcme(), {
+      provider: "openai",
+      key: REPLACEMENT_KEY,
+    });
+
+    expect(rotated.hint).toBe("YZ12");
+
+    const held = await listModelProviderCredentials(actingAsAcme());
+    expect(held.filter((one) => one.provider === "openai")).toHaveLength(1);
+
+    const after = await storedEnvelope(acme.organization, "openai");
+    expect(after).not.toBe(before);
+    expect(after).not.toContain(REPLACEMENT_KEY);
+  });
+
+  it("reaches the next resolution, which is what rotation has to mean", async () => {
+    const resolved = await resolveModelProviderKeys(theSimulatorInAcme(), [
+      "openai",
+    ]);
+
+    expect(resolved.keys.get("openai")).toBe(REPLACEMENT_KEY);
+  });
+});
+
+describe("removing one provider's key", () => {
+  it("takes it out of the list and out of every later resolution", async () => {
+    await storeModelProviderCredential(actingAsAcme(), {
+      provider: "cartesia",
+      key: "ct-model-sentinel-speak-3456",
+    });
+
+    const removed = await removeModelProviderCredential(
+      actingAsAcme(),
+      "cartesia",
+    );
+    expect(removed?.provider).toBe("cartesia");
+
+    const held = await listModelProviderCredentials(actingAsAcme());
+    expect(held.map((one) => one.provider)).not.toContain("cartesia");
+
+    const resolved = await resolveModelProviderKeys(theSimulatorInAcme(), [
+      "cartesia",
+    ]);
+    expect(resolved.keys.size).toBe(0);
+    expect(resolved.missing).toEqual(["cartesia"]);
+  });
+
+  it("answers nothing where the organization held none, rather than pretending", async () => {
+    expect(
+      await removeModelProviderCredential(actingAsAcme(), "cartesia"),
+    ).toBeUndefined();
+  });
+});
+
+describe("who may manage a credential", () => {
+  it("is an admin, and a member is refused", async () => {
+    await expect(
+      storeModelProviderCredential(actingAsAcme("member"), {
+        provider: "openai",
+        key: OPENAI_KEY,
+      }),
+    ).rejects.toBeInstanceOf(NotPermittedError);
+
+    await expect(
+      removeModelProviderCredential(actingAsAcme("member"), "openai"),
+    ).rejects.toBeInstanceOf(NotPermittedError);
+  });
+
+  it("still lets a viewer see which providers are configured, by hint alone", async () => {
+    const held = await listModelProviderCredentials(actingAsAcme("viewer"));
+
+    expect(held.map((one) => one.provider)).toContain("openai");
+    expect(JSON.stringify(held)).not.toContain(REPLACEMENT_KEY);
+  });
+});
+
+describe("another organization", () => {
+  it("sees none of them and cannot remove one", async () => {
+    expect(await listModelProviderCredentials(actingAsGlobex())).toEqual([]);
+    expect(
+      await removeModelProviderCredential(actingAsGlobex(), "openai"),
+    ).toBeUndefined();
+
+    // And Acme still holds what Globex was just told nothing about.
+    const held = await listModelProviderCredentials(actingAsAcme());
+    expect(held.map((one) => one.provider)).toContain("openai");
+  });
+
+  it("resolves none of them either, however its own claim is narrowed", async () => {
+    const resolved = await resolveModelProviderKeys(
+      {
+        userId: "simulator",
+        organizationId: globex.organization,
+        projectId: globex.project,
+        role: "viewer",
+        via: "simulator",
+      },
+      ["openai"],
+    );
+
+    expect(resolved.keys.size).toBe(0);
+    expect(resolved.missing).toEqual(["openai"]);
+  });
+});
+
+describe("opening a stored key", () => {
+  it("is refused for a person's session, however senior", async () => {
+    await expect(
+      resolveModelProviderKeys(actingAsAcme("admin"), ["openai"]),
+    ).rejects.toThrow(/simulator or its grading engine/);
+  });
+
+  it("answers the grading engine, which judges with the same accounts", async () => {
+    const resolved = await resolveModelProviderKeys(theEngineInAcme(), [
+      "openai",
+    ]);
+
+    expect(resolved.keys.get("openai")).toBe(REPLACEMENT_KEY);
+  });
+
+  it("answers only the providers asked for, so unrelated secrets never travel", async () => {
+    const resolved = await resolveModelProviderKeys(theSimulatorInAcme(), [
+      "deepgram",
+    ]);
+
+    expect([...resolved.keys.keys()]).toEqual(["deepgram"]);
+    expect(resolved.keys.get("deepgram")).toBe(DEEPGRAM_KEY);
+  });
+});
+
+describe("the organization's model access", () => {
+  it("is customer-owned before anybody chooses, and says nobody has", async () => {
+    const access = await readModelAccess(actingAsAcme());
+
+    expect(access.mode).toBe(DEFAULT_MODEL_ACCESS);
+    expect(access.mode).toBe("customer-owned");
+    expect(access.updatedAt).toBeNull();
+  });
+
+  it("is chosen by an admin and refused to a member", async () => {
+    await expect(
+      setModelAccess(actingAsAcme("member"), "customer-owned"),
+    ).rejects.toBeInstanceOf(NotPermittedError);
+
+    const chosen = await setModelAccess(actingAsAcme(), "customer-owned");
+    expect(chosen.mode).toBe("customer-owned");
+    expect(chosen.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("refuses managed while no inference key is connected, and names what is missing", async () => {
+    await expect(
+      setModelAccess(actingAsAcme(), "managed"),
+    ).rejects.toBeInstanceOf(ManagedAccessNotConnectedError);
+
+    // And the refusal changed nothing: the organization is where it was.
+    expect((await readModelAccess(actingAsAcme())).mode).toBe("customer-owned");
+  });
+
+  it("refuses a word that is not one of the two", async () => {
+    await expect(setModelAccess(actingAsAcme(), "mixed")).rejects.toBeInstanceOf(
+      UnprocessableInputError,
+    );
+  });
+
+  it("is one organization's own, and says nothing about another's", async () => {
+    expect((await readModelAccess(actingAsGlobex())).updatedAt).toBeNull();
+  });
+
+  it("changing it scans no credential and refuses nothing for being incomplete", async () => {
+    // Globex holds no credential at all, which under customer-owned access is
+    // an organization that cannot conduct a simulation yet. The setting still
+    // lands: readiness is reported per claim, where it can name the simulation
+    // it stopped, and never as a checklist standing in front of a switch.
+    expect(await listModelProviderCredentials(actingAsGlobex())).toEqual([]);
+
+    const chosen = await setModelAccess(actingAsGlobex(), "customer-owned");
+
+    expect(chosen.mode).toBe("customer-owned");
+  });
+});

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -38,6 +38,16 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   // organization nor a project.
   platform_setting: "pfs",
   project: "prj",
+  // Who supplies the organization's model credentials. Keyed by the
+  // organization, whose identity it therefore carries — the same shape
+  // `organization_settings` above already has, and for the same reason: there
+  // is one answer per customer, so there is no second identifier to mint and
+  // none to name wrongly.
+  model_access: "org",
+  // One provider account's key, sealed, at most one per provider. Its own
+  // identity because a rotation replaces the whole envelope and the row has to
+  // keep the identity it had.
+  model_provider_credential: "mpc",
   membership: "mbr",
   invitation: "inv",
   api_key: "key",
@@ -241,6 +251,10 @@ describe("every table", () => {
     // went with the redesign. A copy is made by pressing **Use** and deleted
     // whole; there is no live edit for a revision to guard.
     judge_credential: 1,
+    // The token a replacement is written against, so an admin rotating a key
+    // from a page they left open is told the stored key moved rather than
+    // silently landing on top of somebody else's rotation.
+    model_provider_credential: 1,
     project: 1,
     // Two, because a test carries two live tokens that guard two different
     // losses: the identity revision an edit to the name is written against, and

--- a/packages/ids/src/index.ts
+++ b/packages/ids/src/index.ts
@@ -55,6 +55,14 @@ export const ID_PREFIXES = [
    * *reference* to one rather than a second copy of the secret.
    */
   "jcr",
+  /**
+   * An organization's model-provider credential: one provider account's key,
+   * sealed, and at most one active per provider. Its own identity because a
+   * rotation replaces the whole envelope and the row must keep the identity it
+   * had — and because an admin naming one to replace or remove has to name
+   * something that is not the secret.
+   */
+  "mpc",
   "mck",
   "ste",
   "run",

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/chat-carrying-a-speech-key.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/chat-carrying-a-speech-key.json
@@ -38,7 +38,8 @@
     },
     "stt": {
       "provider": "deepgram",
-      "model": "nova-3-general"
+      "model": "nova-3-general",
+      "key": "dg-a-secret-a-chat-simulation-has-no-use-for"
     },
     "tts": {
       "provider": "cartesia",

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/customer-owned-without-a-key.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/customer-owned-without-a-key.json
@@ -1,0 +1,54 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/models-carrying-a-credential-id.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/models-carrying-a-credential-id.json
@@ -1,0 +1,56 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    },
+    "credential_id": "mpc_01K3XQ7M4E8YB2FVN0H9TZQWER"
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/models-missing.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/models-missing.json
@@ -1,0 +1,35 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/speaking-faster-than-a-voice-goes.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/speaking-faster-than-a-voice-goes.json
@@ -1,0 +1,55 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 4
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/unknown-field.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/unknown-field.json
@@ -1,0 +1,56 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  },
+  "agent_id": "agt_01K3XQ7M4E8YB2FVN0H9TZQWER"
+}

--- a/packages/simulation-contract/fixtures/spec-v2/valid/chat-customer-owned.json
+++ b/packages/simulation-contract/fixtures/spec-v2/valid/chat-customer-owned.json
@@ -1,0 +1,52 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
+  "modality": "chat",
+  "connection": {
+    "type": "retell",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+      "language": "en-US",
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "warm-alto-2",
+        "speed": 0.9
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "You booked a dental cleaning for next Tuesday and need to move it to Thursday the same week. You do not remember the exact time of the original appointment. Conclude once the new time has been read back to you."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/valid/voice-customer-owned.json
+++ b/packages/simulation-contract/fixtures/spec-v2/valid/voice-customer-owned.json
@@ -1,0 +1,55 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/valid/voice-managed.json
+++ b/packages/simulation-contract/fixtures/spec-v2/valid/voice-managed.json
@@ -1,0 +1,52 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "managed",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1.15
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/invalid/models-on-the-old-contract.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/models-on-the-old-contract.json
@@ -1,0 +1,55 @@
+{
+  "contract_version": 1,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  }
+}

--- a/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
@@ -165,7 +165,7 @@
           "minLength": 1
         },
         "reasoning_effort": {
-          "description": "How hard the model should think before the persona speaks, in the provider's own vocabulary \u2014 an open string, not an enum here, because the accepted values differ between providers speaking one chat-completions shape and have grown more than once. Absent means send nothing at all, which is what keeps a model that has never heard of the field working exactly as it did. A persona is a caller in a hurry rather than a puzzle-solver: the reasoning under test is the agent's, and every moment the persona spends thinking is silence on a live line that no real caller would leave.",
+          "description": "How hard the model should think before the persona speaks, in the provider's own vocabulary \u2014 an open string, not an enum here, because the accepted values differ between providers speaking one chat-completions shape and have grown more than once. Absent means send nothing at all, which is what keeps a model that has never heard of the field working exactly as it did. A persona is in a hurry rather than solving a puzzle: the reasoning under test is the agent's, and every moment the persona spends thinking is silence on a live line that nobody real would leave. It belongs to the deployment's own settings and never to a persona's selections, so a persona that selects its own models uses its provider's default reasoning behavior.",
           "type": "string",
           "minLength": 1
         }

--- a/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
@@ -1,0 +1,492 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:egma:simulation-contract:spec:v2",
+  "title": "Simulation spec (v2)",
+  "description": "The spec direction of the simulation contract, version 2: what the control plane hands the simulator when a queued simulation is claimed. Version 2 adds `models` \u2014 the pinned persona model selections and, for customer-owned model access, the organization's key for each provider they name. Everything else is version 1 unchanged, so a document of this version is a version-1 document with one more block. The two versions are separate closed documents rather than one document with optional fields, and that is the whole point of versioning them: a worker that implements version 1 refuses this document by its version rather than accepting it and silently dropping the block it does not understand. Dropping it would conduct a simulation with the deployment's own model settings while the control plane believed it had sent the persona's \u2014 the same conversation with a different voice, a different brain and a different bill, and nothing anywhere saying so. The spec is fully flattened \u2014 the simulator receives no identifiers to resolve, no database to ask, and everything it needs to conduct one simulation from birth to a terminal report. This is the only direction credential material ever travels; the report schema (urn:egma:simulation-contract:report:v1) structurally forbids it coming back.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "simulation_id",
+    "modality",
+    "connection",
+    "persona",
+    "scenario",
+    "limits",
+    "models"
+  ],
+  "properties": {
+    "contract_version": {
+      "description": "Which version of the simulation contract this document speaks. A simulator refuses a spec whose version it does not implement; it never guesses at fields it does not know, and it never accepts a version it does not implement in the hope that the extra fields did not matter.",
+      "type": "integer",
+      "const": 2
+    },
+    "simulation_id": {
+      "description": "The simulation this spec conducts, echoed verbatim on every report about it. Opaque to the simulator: never parsed, never minted, never rewritten.",
+      "type": "string",
+      "minLength": 1
+    },
+    "modality": {
+      "description": "Which layer is under test. Chat exercises the agent's harness \u2014 prompt, reasoning, tools; voice exercises the harness plus the speech stack. The modality selects the pipeline legs; the persona brain is the same for both.",
+      "type": "string",
+      "enum": [
+        "chat",
+        "voice"
+      ]
+    },
+    "connection": {
+      "description": "How the simulator reaches the agent under test, resolved by the control plane from the connection the run named. The simulator selects its platform plug by `type` and hands the plug the config and credentials whole.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "config",
+        "credentials"
+      ],
+      "properties": {
+        "type": {
+          "description": "The connection type, from the platform's open, growing list \u2014 `retell`, `phone`, and whatever lands next. Deliberately not an enum here: the list grows one plug at a time, and a simulator holding no plug for a type refuses the claim at runtime rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "config": {
+          "description": "The non-secret reach configuration, exactly as stored on the connection \u2014 what to reach, never how to prove. Its keys belong to the plug for `type`; this schema does not know them.",
+          "type": "object"
+        },
+        "credentials": {
+          "description": "The resolved secret material for this connection, unsealed by the control plane for exactly this hand-off, or null for types where the customer supplies no secret. The simulator holds it in memory for the simulation, hands it only to the plug, and never logs, persists, or reports it. No report document has anywhere to put it.",
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "persona": {
+      "description": "Who does the talking on the human side of the transcript.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "traits"
+      ],
+      "properties": {
+        "traits": {
+          "description": "The persona's authored traits, exactly as saved on the version the run pinned \u2014 today personality, language, and the concrete voice. Passed through opaquely: what a persona is made of is authoring's business, and the simulator composes these with the scenario instructions into the persona brain's system prompt.",
+          "type": "object"
+        }
+      }
+    },
+    "scenario": {
+      "description": "What the persona wants on this occasion \u2014 the situation, from the test's own content. The persona says who; the scenario says why they are here today.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "instructions"
+      ],
+      "properties": {
+        "instructions": {
+          "description": "The scenario as instructions to the persona brain: the goal, the circumstances, and anything the persona knows going in.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "limits": {
+      "description": "The walls around one simulation. A limit tripping ends the simulation deliberately, reported with ending `limit_reached` \u2014 which is never the agent failing, and never graded as if it were.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_duration_seconds",
+        "max_turns"
+      ],
+      "properties": {
+        "max_duration_seconds": {
+          "description": "The most wall-clock seconds the simulation may run, measured from when the simulator begins conducting it.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_turns": {
+          "description": "The most transcript turns the simulation may reach, counting both speakers.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "mock_tools": {
+      "description": "The answers this simulation serves for the agent's tools, already resolved: one entry per tool name, the project's default or the test's override, whichever applies \u2014 worked out once by the control plane so that every simulation in one run sees one world and nothing downstream can reach a second answer. Absent, which is the ordinary case, means egma answers for nothing: every tool the agent has runs its own implementation, untouched and unobserved. Order is the order the answers were authored, and it is stable so that two runs of one project read alike.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/mock_tool"
+      }
+    },
+    "platform": {
+      "description": "What this deployment has been configured with, unsealed for exactly this hand-off: who the persona thinks with, what it speaks and hears with, and how a call reaches the telephone network. These belong to the whole deployment rather than to any customer on it, and they used to live in each simulator's own environment \u2014 which meant a second simulator on another machine needed a file copied to it, and a container started without one dialled nothing while reporting itself healthy. They ride this document instead, through the same door and with the same authority as the connection's credentials beside them, and are read afresh for each simulation so a changed key applies to the next one with no restart. Every block is optional and so is every field inside it: a setting the platform does not hold leaves the simulator's own value standing, and a setting it does hold replaces it. A platform that has configured nothing sends nothing, and a simulator conducts exactly as it did before this block existed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "$ref": "#/$defs/platform_model"
+        },
+        "speech": {
+          "$ref": "#/$defs/platform_speech"
+        },
+        "carrier": {
+          "$ref": "#/$defs/platform_carrier"
+        }
+      }
+    },
+    "models": {
+      "$ref": "#/$defs/models"
+    }
+  },
+  "$defs": {
+    "platform_model": {
+      "description": "What the persona thinks with. Every field is optional, because a platform mid-setup holds some of them and not others, and one that holds none of them is every platform before anybody set it up.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "description": "Which client speaks to the model \u2014 the simulator's own open vocabulary, not an enum here: a simulator holding no client for a provider refuses at runtime with the ones it has, rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "description": "Which model to ask for, verbatim as the provider names it. Configuration rather than a constant of the product: providers retire and add models on their own schedule.",
+          "type": "string",
+          "minLength": 1
+        },
+        "key": {
+          "description": "The provider key, in the clear for exactly this hand-off. Held in memory for the simulation, registered for redaction, and never logged, persisted or reported. No report document has anywhere to put it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "reasoning_effort": {
+          "description": "How hard the model should think before the persona speaks, in the provider's own vocabulary \u2014 an open string, not an enum here, because the accepted values differ between providers speaking one chat-completions shape and have grown more than once. Absent means send nothing at all, which is what keeps a model that has never heard of the field working exactly as it did. A persona is a caller in a hurry rather than a puzzle-solver: the reasoning under test is the agent's, and every moment the persona spends thinking is silence on a live line that no real caller would leave.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "platform_speech": {
+      "description": "What the persona speaks and hears with on a voice simulation, and what tells it the agent has started and stopped speaking. A key per leg rather than one per provider: the two legs are two accounts as often as they are one, and a shape that could not say so would make the second one unreachable.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "stt_provider": {
+          "description": "The persona's ears. An open vocabulary, refused at runtime by the simulator holding no such leg.",
+          "type": "string",
+          "minLength": 1
+        },
+        "stt_key": {
+          "description": "The listening leg's provider key, on the same terms as the model key above.",
+          "type": "string",
+          "minLength": 1
+        },
+        "stt_model": {
+          "description": "Which model the listening leg asks for, where its provider has more than one. Here beside tts_model rather than left in each simulator's environment, which is where it used to live alone: that asymmetry was the one speech setting a deployment could not change centrally, so moving the persona's mouth was a settings page and moving its ears was editing a container and restarting it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_provider": {
+          "description": "The persona's mouth. Chosen apart from the ears on purpose \u2014 a real mouth with scripted ears is a configuration somebody will want.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_key": {
+          "description": "The speaking leg's provider key, on the same terms as the model key above.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_model": {
+          "description": "Which model the speaking leg asks for, where its provider has more than one.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tts_voice": {
+          "description": "Which voice the speaking leg asks for when the persona's own traits name none.",
+          "type": "string",
+          "minLength": 1
+        },
+        "vad_provider": {
+          "description": "What tells the persona the agent has started or stopped speaking. Needs no key either way.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "platform_carrier": {
+      "description": "How a call reaches the telephone network: which bridge places it, and the trunk the carrier authenticates. Absent on every deployment that has never been given a carrier \u2014 which still runs chat and voice simulations perfectly well \u2014 and that absence is an ordinary state rather than a fault. The media server's own key and secret are deliberately not here: they are read by a third-party container when it is created and cannot come from the platform's store, so they stay in each simulator's environment.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "media_backend": {
+          "description": "Which driver places the call. An open vocabulary, refused at runtime by a simulator holding no such backend.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_address": {
+          "description": "The carrier hostname a call is routed through. Non-secret: it is a fact the readiness answer already reports.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_number": {
+          "description": "The number a call appears to come from, E.164. Non-secret, for the same reason.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_username": {
+          "description": "The username the carrier authenticates the trunk by.",
+          "type": "string",
+          "minLength": 1
+        },
+        "trunk_password": {
+          "description": "The password beside it, in the clear for exactly this hand-off and on the same terms as every other secret in this document.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "mock_tool": {
+      "description": "One tool name, and what egma answers when the agent calls it. Matching is by the name and strictly by it: a mock tool never reads a call's arguments, so there is no matcher here and nowhere for one to go.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tool_name",
+        "answer",
+        "delay_milliseconds"
+      ],
+      "properties": {
+        "tool_name": {
+          "description": "The agent's own name for the tool, verbatim. Never parsed, never folded, never matched loosely.",
+          "type": "string",
+          "minLength": 1
+        },
+        "answer": {
+          "$ref": "#/$defs/mock_tool_answer"
+        },
+        "delay_milliseconds": {
+          "description": "How long egma holds the answer back before serving it, so a mocked backend takes as long as the real one would. The ceiling is arithmetic rather than taste: the exchange carrying an answer has a 45-second budget, of which 10 seconds is allowed for the round trip and 5 for egma's own serving margin \u2014 so 30 000 is what is left, and a delay this document admits can never collide with the transport that has to carry it.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 30000
+        }
+      }
+    },
+    "mock_tool_answer": {
+      "description": "What the tool returns, or the failure it raises \u2014 travelling in the shape it is served in, so nothing between the authoring and the wire re-tags it. Two shapes rather than one with a nullable failure, because `null` is a perfectly good answer for a tool to give and a shape that could not tell it from 'no answer' would make an authored `null` unserveable. Exactly one of the two keys is ever written.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "answer"
+          ],
+          "properties": {
+            "answer": {
+              "description": "The value the tool returns, of whatever shape its own contract has \u2014 including `null` and bare scalars. Bounded by what the exchange carrying it holds: 15 KiB once serialized, refused at authoring time with the honest reason."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "error"
+          ],
+          "properties": {
+            "error": {
+              "description": "The failure the tool raises, as text \u2014 how a test orders up the branch a real backend cannot be asked for.",
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      ]
+    },
+    "models": {
+      "description": "What this simulation's persona thinks, listens and speaks with, and who pays for it. The three selections are the pinned persona version's own, resolved by the control plane and flattened like everything else here: the simulator receives a provider, a model id, and \u2014 for the speaking leg \u2014 a voice and a speed, with nothing left to look up and nothing left to choose between. Which of the two access modes the organization is on rides the block because it is what says where the keys came from and, under managed access, where the traffic goes. Credentials are resolved when the claim is prepared rather than when the run was created, so a key replaced mid-run reaches the next simulation to be claimed and leaves the ones already running alone. The block is required. A version-2 document without it would be a version-1 document wearing the wrong number. Two shapes rather than one with an optional key, and the split is the guarantee: a customer-owned document must carry a key for every selection, because the simulator is calling that provider itself and has nothing else to authenticate with \u2014 and a managed document must carry none, because Egma's provider credentials never leave the Egma model gateway. A shape with one optional key field could express both mistakes and would refuse neither.",
+      "oneOf": [
+        {
+          "description": "Customer-owned access: the organization's own key travels with each selection.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "access",
+            "llm",
+            "stt",
+            "tts"
+          ],
+          "properties": {
+            "access": {
+              "description": "The organization supplies the provider credentials and the simulator calls those providers directly. One organization-wide value; there is no per-provider mixing and no third state.",
+              "type": "string",
+              "const": "customer-owned"
+            },
+            "llm": {
+              "$ref": "#/$defs/model_selection"
+            },
+            "stt": {
+              "$ref": "#/$defs/model_selection"
+            },
+            "tts": {
+              "$ref": "#/$defs/speech_selection"
+            }
+          }
+        },
+        {
+          "description": "Managed access: the traffic goes through the Egma model gateway and no provider key travels at all.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "access",
+            "llm",
+            "stt",
+            "tts"
+          ],
+          "properties": {
+            "access": {
+              "description": "Egma supplies the provider credentials through the Egma model gateway, and this document carries none of them.",
+              "type": "string",
+              "const": "managed"
+            },
+            "llm": {
+              "$ref": "#/$defs/managed_selection"
+            },
+            "stt": {
+              "$ref": "#/$defs/managed_selection"
+            },
+            "tts": {
+              "$ref": "#/$defs/managed_speech_selection"
+            }
+          }
+        }
+      ]
+    },
+    "model_selection": {
+      "description": "One model job's pinned selection under customer-owned access: which provider, which model, and the organization's own key to speak to it with. Provider and model come off the persona version a run pinned, so two runs of one version ask the same provider for the same model however the organization's credentials have moved since.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model",
+        "key"
+      ],
+      "properties": {
+        "provider": {
+          "description": "Which provider does this job \u2014 the model catalog's own word, matching the simulator's factory for that leg. Deliberately not an enum here: the catalog grows one proved entry at a time, and a simulator holding no factory for a provider refuses at runtime with the ones it has rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "description": "Which model to ask for, verbatim as the provider names it. Never allowlisted by Egma: a release proves one recommended default per provider and a user may enter any id that provider's shipped adapter accepts, so a model Egma has never heard of is the provider's business to accept or refuse.",
+          "type": "string",
+          "minLength": 1
+        },
+        "key": {
+          "description": "The provider key, in the clear for exactly this hand-off. Held in memory for the simulation, registered for redaction, and never logged, persisted or reported \u2014 no report document has anywhere to put it. Present under customer-owned access and absent under managed access, where the key never leaves the Egma model gateway.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "speech_selection": {
+      "description": "The speaking job's selection under customer-owned access, which needs two facts the others do not: which of the provider's voices, and how fast the persona talks. Both are the persona version's own, so the same persona sounds identical on every simulation of that version.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model",
+        "key",
+        "voice_id",
+        "speed"
+      ],
+      "properties": {
+        "provider": {
+          "description": "Which provider does this job \u2014 the model catalog's own word, matching the simulator's factory for that leg. Deliberately not an enum here: the catalog grows one proved entry at a time, and a simulator holding no factory for a provider refuses at runtime with the ones it has rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "description": "Which model to ask for, verbatim as the provider names it. Never allowlisted by Egma: a release proves one recommended default per provider and a user may enter any id that provider's shipped adapter accepts, so a model Egma has never heard of is the provider's business to accept or refuse.",
+          "type": "string",
+          "minLength": 1
+        },
+        "key": {
+          "description": "The provider key, in the clear for exactly this hand-off. Held in memory for the simulation, registered for redaction, and never logged, persisted or reported \u2014 no report document has anywhere to put it. Present under customer-owned access and absent under managed access, where the key never leaves the Egma model gateway.",
+          "type": "string",
+          "minLength": 1
+        },
+        "voice_id": {
+          "description": "The provider's own id for the voice this persona speaks in. Free text on the model id's exact terms \u2014 the provider is the authority on which of its voices exist.",
+          "type": "string",
+          "minLength": 1
+        },
+        "speed": {
+          "description": "Speech rate, as a multiple of the provider's natural pace. A number rather than a description, because two runs interpreting \"quite fast\" differently is exactly the drift a pinned version exists to rule out.",
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        }
+      }
+    },
+    "managed_selection": {
+      "description": "One model job's pinned selection under managed access: the same provider and model, and **no key**. The closed shape is the guarantee rather than a habit \u2014 Egma's provider credentials stay inside the Egma model gateway, and a managed work order carrying one would be refused here rather than arriving at a simulator that had no business holding it.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model"
+      ],
+      "properties": {
+        "provider": {
+          "description": "Which provider does this job \u2014 the model catalog's own word, matching the simulator's factory for that leg. Deliberately not an enum here: the catalog grows one proved entry at a time, and a simulator holding no factory for a provider refuses at runtime with the ones it has rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "description": "Which model to ask for, verbatim as the provider names it. Never allowlisted by Egma: a release proves one recommended default per provider and a user may enter any id that provider's shipped adapter accepts, so a model Egma has never heard of is the provider's business to accept or refuse.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "managed_speech_selection": {
+      "description": "The speaking job's selection under managed access: the voice and the speed, and no key.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model",
+        "voice_id",
+        "speed"
+      ],
+      "properties": {
+        "provider": {
+          "description": "Which provider does this job \u2014 the model catalog's own word, matching the simulator's factory for that leg. Deliberately not an enum here: the catalog grows one proved entry at a time, and a simulator holding no factory for a provider refuses at runtime with the ones it has rather than this schema refusing the document.",
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "description": "Which model to ask for, verbatim as the provider names it. Never allowlisted by Egma: a release proves one recommended default per provider and a user may enter any id that provider's shipped adapter accepts, so a model Egma has never heard of is the provider's business to accept or refuse.",
+          "type": "string",
+          "minLength": 1
+        },
+        "voice_id": {
+          "description": "The provider's own id for the voice this persona speaks in. Free text on the model id's exact terms \u2014 the provider is the authority on which of its voices exist.",
+          "type": "string",
+          "minLength": 1
+        },
+        "speed": {
+          "description": "Speech rate, as a multiple of the provider's natural pace. A number rather than a description, because two runs interpreting \"quite fast\" differently is exactly the drift a pinned version exists to rule out.",
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 2
+        }
+      }
+    }
+  }
+}

--- a/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
@@ -327,7 +327,7 @@
               "const": "customer-owned"
             },
             "llm": {
-              "$ref": "#/$defs/model_selection"
+              "$ref": "#/$defs/customer_owned_llm"
             },
             "stt": {
               "$ref": "#/$defs/model_selection"
@@ -367,13 +367,12 @@
       ]
     },
     "model_selection": {
-      "description": "One model job's pinned selection under customer-owned access: which provider, which model, and the organization's own key to speak to it with. Provider and model come off the persona version a run pinned, so two runs of one version ask the same provider for the same model however the organization's credentials have moved since.",
+      "description": "One model job's pinned selection under customer-owned access: which provider, which model, and \u2014 where this simulation actually uses the leg \u2014 the organization's own key to speak to it with. Provider and model come off the persona version a run pinned, so two runs of one version ask the same provider for the same model however the organization's credentials have moved since.",
       "type": "object",
       "additionalProperties": false,
       "required": [
         "provider",
-        "model",
-        "key"
+        "model"
       ],
       "properties": {
         "provider": {
@@ -394,13 +393,12 @@
       }
     },
     "speech_selection": {
-      "description": "The speaking job's selection under customer-owned access, which needs two facts the others do not: which of the provider's voices, and how fast the persona talks. Both are the persona version's own, so the same persona sounds identical on every simulation of that version.",
+      "description": "The speaking job's selection under customer-owned access, which needs two facts the others do not: which of the provider's voices, and how fast the persona talks. Both are the persona version's own, so the same persona sounds identical on every simulation of that version. Its key travels only on a voice simulation, which is the only kind that has a mouth.",
       "type": "object",
       "additionalProperties": false,
       "required": [
         "provider",
         "model",
-        "key",
         "voice_id",
         "speed"
       ],
@@ -487,6 +485,140 @@
           "maximum": 2
         }
       }
+    },
+    "customer_owned_llm": {
+      "description": "The thinking leg under customer-owned access. Its key travels on every simulation, because every simulation thinks \u2014 chat and voice alike.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/model_selection"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "key"
+          ]
+        }
+      ]
     }
-  }
+  },
+  "allOf": [
+    {
+      "description": "**A worker receives only the credentials its selected models actually require.** Every customer-owned document carries the key for the thinking leg, because every simulation thinks. The listening and speaking legs exist only on a voice simulation, so their keys travel only there \u2014 a chat simulation is conducted without them, and an organization that has not stored a speech credential can still run its chat tests. Requiring all three everywhere would put two secrets on a wire that has no use for them, and would stop work that had everything it needed.",
+      "if": {
+        "type": "object",
+        "properties": {
+          "modality": {
+            "const": "voice"
+          },
+          "models": {
+            "type": "object",
+            "properties": {
+              "access": {
+                "const": "customer-owned"
+              }
+            },
+            "required": [
+              "access"
+            ]
+          }
+        },
+        "required": [
+          "modality",
+          "models"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "models": {
+            "type": "object",
+            "properties": {
+              "stt": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "key"
+                ]
+              },
+              "tts": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "key"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "The other half of the same rule: a chat simulation has no mouth and no ears, so a listening or speaking key on its wire is a secret travelling for nothing. Refused rather than carried and ignored, because a credential that reaches a process with no use for it is a credential that did not have to be there.",
+      "if": {
+        "type": "object",
+        "properties": {
+          "modality": {
+            "const": "chat"
+          }
+        },
+        "required": [
+          "modality"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "models": {
+            "type": "object",
+            "properties": {
+              "stt": {
+                "type": "object",
+                "not": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ]
+                }
+              },
+              "tts": {
+                "type": "object",
+                "not": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/simulation-contract/src/documents.ts
+++ b/packages/simulation-contract/src/documents.ts
@@ -47,8 +47,41 @@ function compileFromDisk(schemaFile: string): ValidateFunction {
   return ajv.compile(schema as Record<string, unknown>);
 }
 
-let compiledSpec: ValidateFunction | undefined;
+/**
+ * The spec versions this contract package holds a schema for, oldest first.
+ *
+ * **Two closed documents rather than one with optional fields.** Version 2 adds
+ * the persona's model selections and the keys behind them; a worker that
+ * implements only version 1 must refuse a version-2 document *by its version*
+ * rather than accept it and quietly drop the block it does not understand. That
+ * dropping is the failure this shape exists to make unreachable: the simulation
+ * would be conducted with the deployment's own model settings while the control
+ * plane believed it had sent the persona's, and nothing anywhere would say so.
+ *
+ * The control plane emits the newest version a claiming worker says it speaks,
+ * so during a mixed rollout an old worker keeps receiving version 1 and a new
+ * one receives version 2 — with no drain step required and no document ever
+ * arriving at a worker that cannot read it.
+ */
+export const SPEC_CONTRACT_VERSIONS = [1, 2] as const;
+
+/** One version of the spec direction. */
+export type SpecContractVersion = (typeof SPEC_CONTRACT_VERSIONS)[number];
+
+const SPEC_SCHEMA_FILE: { readonly [V in SpecContractVersion]: string } = {
+  1: "simulation-spec.v1.schema.json",
+  2: "simulation-spec.v2.schema.json",
+};
+
+const compiledSpec = new Map<SpecContractVersion, ValidateFunction>();
 let compiledReport: ValidateFunction | undefined;
+
+/** Whether this number is a spec version this package can check at all. */
+export function isSpecContractVersion(
+  version: unknown,
+): version is SpecContractVersion {
+  return SPEC_CONTRACT_VERSIONS.some((known) => known === version);
+}
 
 /**
  * Everything wrong with a document by one validator's lights, or nothing.
@@ -75,8 +108,54 @@ function complaintsFrom(
  * complaint per attempt that will never be retried.
  */
 export function specComplaints(document: unknown): readonly string[] {
-  compiledSpec ??= compileFromDisk("simulation-spec.v1.schema.json");
-  return complaintsFrom(compiledSpec, document);
+  const version = versionOf(document);
+  if (!isSpecContractVersion(version)) {
+    // Said before any schema is consulted, because no schema could say it
+    // usefully: a document whose version this package does not hold would be
+    // checked against a contract it never claimed to speak, and every complaint
+    // after that would be about the wrong document.
+    return [
+      `/contract_version: must be one of ${SPEC_CONTRACT_VERSIONS.join(", ")}, and this document says ${JSON.stringify(version)}`,
+    ];
+  }
+
+  let compiled = compiledSpec.get(version);
+  if (compiled === undefined) {
+    compiled = compileFromDisk(SPEC_SCHEMA_FILE[version]);
+    compiledSpec.set(version, compiled);
+  }
+  return complaintsFrom(compiled, document);
+}
+
+/**
+ * Everything wrong with this document **read as one named version**, whatever
+ * version it says it is.
+ *
+ * The check a worker that implements one version makes, offered here so the
+ * control plane can prove what an old worker would do with a new document. The
+ * answer is what makes the mixed-rollout rule real rather than intended: a
+ * version-1 worker handed a version-2 document complains loudly, and a
+ * version-1 document that somehow carried a version-2 block is refused for the
+ * block rather than accepted with it silently dropped.
+ */
+export function specComplaintsAsVersion(
+  version: SpecContractVersion,
+  document: unknown,
+): readonly string[] {
+  let compiled = compiledSpec.get(version);
+  if (compiled === undefined) {
+    compiled = compileFromDisk(SPEC_SCHEMA_FILE[version]);
+    compiledSpec.set(version, compiled);
+  }
+  return complaintsFrom(compiled, document);
+}
+
+/** The version a would-be spec claims, whatever shape the rest of it is in. */
+function versionOf(document: unknown): unknown {
+  if (typeof document !== "object" || document === null || Array.isArray(document)) {
+    return undefined;
+  }
+  return (document as Record<string, unknown>)["contract_version"];
 }
 
 /**

--- a/packages/simulation-contract/src/index.ts
+++ b/packages/simulation-contract/src/index.ts
@@ -12,7 +12,14 @@
  * under.
  */
 
-export { reportComplaints, specComplaints } from "./documents.ts";
+export {
+  isSpecContractVersion,
+  reportComplaints,
+  specComplaints,
+  specComplaintsAsVersion,
+  SPEC_CONTRACT_VERSIONS,
+  type SpecContractVersion,
+} from "./documents.ts";
 
 export {
   simulationIdOfTrace,

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -47,8 +47,19 @@ type Fixture = {
   readonly document: Record<string, unknown>;
 };
 
+/**
+ * One folder of golden documents. `spec` is the version-1 spec direction,
+ * `spec-v2` the version-2 one, and `report` the direction that comes back.
+ *
+ * The two spec versions are two folders rather than one because they are two
+ * closed documents: a version-2 document is not a version-1 document with an
+ * extra field, it is a different contract, and a folder that mixed them would
+ * be checked against whichever schema the loop happened to be holding.
+ */
+type Direction = "spec" | "spec-v2" | "report";
+
 async function fixturesUnder(
-  direction: "spec" | "report",
+  direction: Direction,
   expectation: "valid" | "invalid",
 ): Promise<Fixture[]> {
   const directory = path.join(packageRoot, "fixtures", direction, expectation);
@@ -67,6 +78,10 @@ const ajv = new Ajv2020({ strict: true, allErrors: true });
 addFormats(ajv);
 
 const specSchema = await readJson("schemas", "simulation-spec.v1.schema.json");
+const specSchemaV2 = await readJson(
+  "schemas",
+  "simulation-spec.v2.schema.json",
+);
 const reportSchema = await readJson(
   "schemas",
   "simulation-report.v1.schema.json",
@@ -76,6 +91,7 @@ const reportSchema = await readJson(
 // 2020-12, or that trips Ajv's strict mode, fails before any fixture is read.
 const validators = {
   spec: ajv.compile(specSchema),
+  "spec-v2": ajv.compile(specSchemaV2),
   report: ajv.compile(reportSchema),
 } as const;
 
@@ -132,6 +148,60 @@ const EXPECTED_REJECTION: Record<string, Rejection> = {
     at: "/contract_version",
     keyword: "const",
   },
+  /**
+   * The mixed-rollout guard, as a document.
+   *
+   * A version-1 document carrying version 2's `models` block is exactly what a
+   * control plane that got the negotiation wrong would emit, and the failure it
+   * would cause is the quiet one: a worker that ignored the unknown block would
+   * conduct the simulation with its deployment's own model settings while the
+   * control plane believed it had sent the persona's — same conversation,
+   * different voice, different brain, different bill, nothing saying so. The
+   * version-1 schema closes its top level, so the block is refused loudly here
+   * rather than dropped silently there.
+   */
+  "spec/models-on-the-old-contract.json": {
+    at: "",
+    keyword: "additionalProperties",
+    property: "models",
+  },
+  // Version 2's block is required, because a version-2 document without it is a
+  // version-1 document wearing the wrong number.
+  "spec-v2/models-missing.json": {
+    at: "",
+    keyword: "required",
+    property: "models",
+  },
+  // Under customer-owned access the simulator is calling the provider itself
+  // and has nothing else to authenticate with, so every selection carries its
+  // own key. A selection without one would reach the provider unauthenticated
+  // and fail there, minutes later, naming nothing about configuration.
+  "spec-v2/customer-owned-without-a-key.json": {
+    at: "/models/stt",
+    keyword: "required",
+    property: "key",
+  },
+  // The work order carries the secret itself and never a pointer to one. An
+  // identifier would be a second way to reach a credential — one the simulator
+  // has no database to follow and the control plane would have to keep
+  // resolvable for as long as any worker held it.
+  "spec-v2/models-carrying-a-credential-id.json": {
+    at: "/models",
+    keyword: "additionalProperties",
+    property: "credential_id",
+  },
+  // The persona's pace is bounded by what speech stays intelligible at, in the
+  // same range the authoring door enforces — so a document and a form cannot
+  // come to disagree about what a persona may be saved as.
+  "spec-v2/speaking-faster-than-a-voice-goes.json": {
+    at: "/models/tts/speed",
+    keyword: "maximum",
+  },
+  "spec-v2/unknown-field.json": {
+    at: "",
+    keyword: "additionalProperties",
+    property: "agent_id",
+  },
   "report/completed-claiming-never-ran.json": {
     at: "/events/0/facts/ending",
     keyword: "enum",
@@ -185,12 +255,52 @@ describe("the two schemas, as one contract", () => {
           .contract_version as Record<string, unknown>
       ).const;
     expect(versionOf(specSchema)).toBe(1);
+    expect(versionOf(specSchemaV2)).toBe(2);
     expect(versionOf(reportSchema)).toBe(1);
   });
 
   it("each carry an identity a $ref or an error message can name", () => {
     expect(specSchema.$id).toBe("urn:egma:simulation-contract:spec:v1");
+    expect(specSchemaV2.$id).toBe("urn:egma:simulation-contract:spec:v2");
     expect(reportSchema.$id).toBe("urn:egma:simulation-contract:report:v1");
+  });
+
+  /**
+   * Version 2 is version 1 with one block added, and this is what says so.
+   *
+   * Written out rather than derived, because the two schemas are two frozen
+   * documents on purpose: a reader has to be able to see the whole of what a
+   * version says without holding the other one in their head. The price is that
+   * they could drift apart in a field neither version meant to change, and this
+   * pins everything except the version, the identity, the prose and the block
+   * that is the point of the second version.
+   */
+  it("differ by the models block and by nothing else", () => {
+    const stripped = (schema: Record<string, unknown>): unknown => {
+      const clone = structuredClone(schema) as Record<string, unknown>;
+      delete clone.$id;
+      delete clone.title;
+      delete clone.description;
+      const properties = clone.properties as Record<string, unknown>;
+      delete properties.contract_version;
+      delete properties.models;
+      clone.required = (clone.required as string[]).filter(
+        (name) => name !== "models",
+      );
+      const defs = clone.$defs as Record<string, unknown>;
+      for (const added of [
+        "models",
+        "model_selection",
+        "managed_selection",
+        "speech_selection",
+        "managed_speech_selection",
+      ]) {
+        delete defs[added];
+      }
+      return clone;
+    };
+
+    expect(stripped(specSchemaV2)).toEqual(stripped(specSchema));
   });
 
   /**
@@ -231,7 +341,7 @@ describe("the two schemas, as one contract", () => {
   });
 });
 
-for (const direction of ["spec", "report"] as const) {
+for (const direction of ["spec", "spec-v2", "report"] as const) {
   describe(`the ${direction} direction`, () => {
     it("accepts every valid golden fixture", async () => {
       const all = await fixturesUnder(direction, "valid");

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -278,15 +278,34 @@ describe("the two schemas, as one contract", () => {
    * documents on purpose: a reader has to be able to see the whole of what a
    * version says without holding the other one in their head. The price is that
    * they could drift apart in a field neither version meant to change, and this
-   * pins everything except the version, the identity, the prose and the block
-   * that is the point of the second version.
+   * pins everything except the version, the identity and the block that is the
+   * point of the second version.
+   *
+   * **Prose is stripped everywhere rather than only at the top.** What must not
+   * fork is the shape — which fields exist, what they accept, what is required
+   * — and a description is neither. Each version explains itself to the reader
+   * who has that version in front of them, so a sentence reworded in one and
+   * not the other is the documents doing their job rather than drifting.
    */
   it("differ by the models block and by nothing else", () => {
+    /** Every `description`, anywhere, gone — see the note above. */
+    const withoutProse = (node: unknown): unknown => {
+      if (Array.isArray(node)) return node.map(withoutProse);
+      if (typeof node !== "object" || node === null) return node;
+      return Object.fromEntries(
+        Object.entries(node as Record<string, unknown>)
+          .filter(([key]) => key !== "description")
+          .map(([key, value]) => [key, withoutProse(value)]),
+      );
+    };
+
     const stripped = (schema: Record<string, unknown>): unknown => {
-      const clone = structuredClone(schema) as Record<string, unknown>;
+      const clone = withoutProse(structuredClone(schema)) as Record<
+        string,
+        unknown
+      >;
       delete clone.$id;
       delete clone.title;
-      delete clone.description;
       const properties = clone.properties as Record<string, unknown>;
       delete properties.contract_version;
       delete properties.models;

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -197,6 +197,12 @@ const EXPECTED_REJECTION: Record<string, Rejection> = {
     at: "/models/tts/speed",
     keyword: "maximum",
   },
+  // A chat simulation has no mouth and no ears, so a speech key on its wire is
+  // a secret travelling for nothing. Refused rather than carried and ignored.
+  "spec-v2/chat-carrying-a-speech-key.json": {
+    at: "/models/stt",
+    keyword: "not",
+  },
   "spec-v2/unknown-field.json": {
     at: "",
     keyword: "additionalProperties",
@@ -291,12 +297,17 @@ describe("the two schemas, as one contract", () => {
       for (const added of [
         "models",
         "model_selection",
+        "customer_owned_llm",
         "managed_selection",
         "speech_selection",
         "managed_speech_selection",
       ]) {
         delete defs[added];
       }
+      // The one rule that reads two fields at once — which speech keys travel
+      // depends on the modality — and therefore the one that cannot live
+      // inside the models block. It arrived with version 2 like the block.
+      delete clone.allOf;
       return clone;
     };
 


### PR DESCRIPTION
## What this is

The first product slice of managed model access: an organization can run every voice simulation and every verdict on its own provider accounts. An administrator manages one sealed credential per provider; persona and grader authors select models without ever touching a secret; the claim path resolves current credentials against pinned selections at the moment work is handed out.

## What's in it

- **Store** (`packages/db`, migration `0035`, additive only): `model_access` — one binary organization-wide value, `managed` or `customer-owned`, no per-provider mixing (missing row reads as customer-owned); `model_provider_credential` — sealed at rest, write-only reads (provider, safe hint, changed time — never the key), one active credential per provider held by a unique constraint; `persona_version.models` (independent LLM/STT/TTS selections, TTS voice and speed); `grader_version.grader_model`; `simulation.ending_detail` / `ending_repair` so an access failure can name the model job and provider and link to Model providers.
- **Contract** (`packages/simulation-contract`): a second closed version of the simulation document carrying pinned selections and — under customer-owned access — only the keys the simulation's legs actually need: a chat document refuses speech credentials, a voice document requires them. Golden fixtures read by TypeScript and Python with identical pins; the old version rejects a document carrying the new block loudly in both languages.
- **Mixed-worker safety by advertisement, both workers**: every simulator claim declares the contract versions it implements and every grader claim declares its capabilities; the queue offers work only to a worker that can read it, so an old binary is never handed a document it cannot conduct, while legacy-shaped work keeps draining. Requeue and lease-expiry paths re-enter through the same filters.
- **API** (`apps/api`): model access, server-owned provider catalog (recommended defaults, free-text model and voice IDs, unproved pairs named but not selectable), credential lifecycle (admin-only, organization-isolated), persona and grader model authoring (a model edit mints a new immutable version; no credential fields; no VAD choice), and claim-time resolution — credentials resolve at claim, so rotation reaches the next unclaimed job without touching pinned versions.
- **Simulator** (`apps/simulator`): pinned selections reach the Pipecat speech legs and the persona model client through the real work-order path; a selected leg never falls back to a key nobody chose.
- **Grader** (`apps/grader`): a grader version with its own model judges through the organization's credential; one without keeps the project's judge — the two credential doors are disjoint branches, so the wrong account can never be spent.
- **Web** (`apps/web`): Model providers settings (one row per provider, safe hints, replace/remove with a confirming dialog that names what stops), persona Models, grader Model, and the repair link on a simulation that failed for access.
- **Errors**: a missing credential is a typed infrastructure error that fails only the affected simulation or grading job — never a test verdict, never the rest of the batch.

## How it's proved

2,900+ fast-lane tests, 63 real-browser tests, and 700+ simulator tests pass, including: sealed-store lifecycle (ciphertext-at-rest proven by reading the raw column, write-only reads, rotation, removal, role and organization isolation down the claim path), golden contract fixtures in both languages, both mixed-worker directions for simulator and grader, keys-follow-the-legs on chat versus voice, version pinning across edits, per-claim error isolation, and the browser walk from configuring a provider to a repaired simulation. Deterministic throughout — the live provider matrix is a later slice.

## Recorded notes (deliberately left)

- The seeded default persona and predefined grader stay on the compatibility path for now — giving them explicit selections today would regress existing self-hosted deployments that hold legacy platform settings but no organization credential. Hosted defaults and the migration backfill are the next slices.
- An unrecognised grading-capability string is ignored rather than refused; harmless while the type is closed and there is no HTTP door, but the asymmetry with the simulation door's 400 is worth removing if one ever opens.
- The grading guard ignores grader scope, so a simulations-scoped grader with a model also blocks production-trace jobs from legacy binaries — over-blocking, the safe direction, but it can strand work on a legacy-only fleet.
- A grader edited between claim and grade is read live by the already-claimed binary — a one-poll window inherent to reading living copies at grade time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1bq5Zyqjz2uK56wvr2w3

---
_Generated by [Claude Code](https://claude.ai/code/session_016f1bq5Zyqjz2uK56wvr2w3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789562656&installation_model_id=431960&pr_number=136&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F136&signature=ccd870ad55707a31bf4a82d84c9e53fcf253eda768c862c4791b409ebc506384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds organization-owned model credentials and immutable persona/grader model selections, resolving current credentials when simulation and grading work is claimed.
- Adds sealed, organization-scoped provider credential storage and model-access APIs.
- Introduces versioned simulation model contracts and mixed-worker capability filtering.
- Routes selected models and credentials through simulator speech/model clients and grader judges.
- Adds model-provider, persona-model, grader-model, and simulation-repair web interfaces.
- Adds additive database schema changes and extensive cross-language contract and integration coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no unacknowledged, actionable failure caused by the changed code remains.

The credential boundaries, pinned-selection resolution, mixed-worker filtering, compatibility paths, and per-job failure handling align across the database, API, simulator, grader, and contract layers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/claims.ts | Builds versioned simulation work orders from pinned model selections, resolves current organization credentials, and isolates dispatch failures per simulation. |
| packages/db/src/access/model-provider-credentials.ts | Adds tenant-scoped sealed credential lifecycle operations with write-only public projections and optimistic rotation revisions. |
| packages/db/src/access/grading.ts | Adds worker capability filtering for grading jobs whose current grader versions select organization-owned models. |
| apps/grader/src/judge/index.ts | Separates organization-credential model judging from the legacy project-judge compatibility path. |
| apps/simulator/src/egma_simulator/contract.py | Adds explicit version-aware simulation document validation and claim-time advertisement of supported contract versions. |
| packages/simulation-contract/src/documents.ts | Supports independently closed v1 and v2 simulation schemas and rejects unsupported contract versions explicitly. |
| packages/db/migrations/0035_customer_owned_model_access.sql | Adds model-access, provider-credential, immutable model-selection, and simulation repair fields without rewriting existing versions. |
| apps/web/app/projects/[projectId]/settings/model-providers/page.tsx | Adds the administrator interface for viewing safe credential hints and replacing or removing organization provider credentials. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin
    participant API
    participant DB
    participant Worker as Simulator/Grader
    participant Provider
    Admin->>API: Store provider credential
    API->>DB: Seal and persist by organization/provider
    Admin->>API: Select models for persona/grader
    API->>DB: Mint immutable version with selections
    Worker->>API: Claim with supported versions/capabilities
    API->>DB: Select compatible queued work
    API->>DB: Resolve current organization credentials
    API-->>Worker: Pinned selections plus required keys
    Worker->>Provider: Execute selected model job
    Worker->>API: Report simulation/verdict result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Review round 1: a confirmed removal, and..."](https://github.com/egma-ai/egma/commit/46ec8dc6d856fb7ce0a78bb3840bb29596f89753) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53974963)</sub>

<!-- /greptile_comment -->