### PR TITLE
Managed by Egma: inference keys, a key-checking gateway verifier, and the zero-setup first run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,36 @@ EGMA_ENCRYPTION_KEY=
 # everything after the port. The startup message names the part to remove.
 EGMA_BASE_URL=
 
+# ── Managed model access ─────────────────────────────────────────────────────
+#
+# Every organization has one model access choice. **Customer-owned** means it
+# supplies a key for each model provider its personas and graders use, and Egma
+# is not on the model traffic path at all — that is the default and needs none
+# of the three below. **Managed by Egma** means its model traffic goes through
+# the Egma model gateway on Egma's provider accounts.
+#
+# To use Managed by Egma on your own deployment: create an inference key in
+# Egma Cloud, paste it under Settings → Model providers, and set the gateway's
+# address here. Nothing else.
+
+# Where the Egma model gateway answers. Unset until you connect managed access.
+EGMA_MODEL_GATEWAY_URL=
+
+# Where Egma Cloud is asked whether a pasted inference key is good and whose it
+# is. One content-free request, made when somebody connects a key and never
+# again. Leave it unset unless you are pointing at a different Egma Cloud.
+EGMA_CLOUD_URL=
+
+# Whether this deployment *is* Egma Cloud. Almost certainly not: it means this
+# deployment operates the Egma model gateway and mints the inference keys other
+# deployments connect. Leave it off.
+EGMA_HOSTED=false
+
+# The key hosted Egma signs its own gateway credentials with. Only meaningful
+# with EGMA_HOSTED on; a deployment that connects an inference key presents
+# that key instead and needs nothing here.
+EGMA_GATEWAY_INTERNAL_KEY=
+
 # One organization on this deployment, and the first person to sign up claims
 # it and becomes its admin. Everyone after them arrives by invitation. Turn it
 # off only for a deployment that holds many customers.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,8 @@
     "protobufjs": "^8.7.1"
   },
   "devDependencies": {
-    "@types/nodemailer": "^8.0.1"
+    "@types/nodemailer": "^8.0.1",
+    "@types/ws": "^8.18.1",
+    "ws": "^8.21.2"
   }
 }

--- a/apps/api/src/auth/egma-cloud.ts
+++ b/apps/api/src/auth/egma-cloud.ts
@@ -1,0 +1,83 @@
+import { INFERENCE_KEY_HEADER } from "./inference-key.ts";
+import type { ManagedValidation } from "../routes/model-access.ts";
+
+/**
+ * The one request this deployment makes to Egma Cloud on a person's behalf, and
+ * everything that is deliberately not in it.
+ *
+ * When an administrator pastes an inference key, the deployment asks Egma Cloud
+ * one question — is this key good, and which organization owns it — and stores
+ * nothing until it has an answer. That is what "Connected only after
+ * organization-bound validation" means, and it is the only outbound call the
+ * product makes here.
+ *
+ * **Content-free, and the shape is what keeps it that way.** The credential
+ * travels in its own header and there is no body at all, so there is no field
+ * anybody could later put a simulation, a persona or a model into. The answer
+ * is an organization identifier and a key identifier.
+ *
+ * **Not an exchange.** Nothing here comes back that a later connection uses:
+ * the key that was pasted is the credential every gateway connection presents,
+ * and no provider credential and no per-simulation grant is issued by either
+ * side.
+ */
+
+/**
+ * How long the ask may take before this deployment says it does not know.
+ *
+ * An administrator is watching a form, so it is short. Ten seconds is far
+ * longer than a control plane takes to hash a string and read one row, and
+ * short enough that Egma Cloud being down looks like Egma Cloud being down
+ * rather than like a page that hangs.
+ */
+const VALIDATION_TIMEOUT_MS = 10_000;
+
+export const INFERENCE_KEY_VALIDATION_PATH = "/v1/inference-keys/validation";
+
+/**
+ * Where Egma Cloud answers. A deployment may point this elsewhere — a staging
+ * Egma Cloud, or the deterministic suite's own — and one that names nothing
+ * reports every paste as unreachable rather than quietly connecting it.
+ */
+export function validateAtEgmaCloud(
+  cloudOrigin: string | undefined,
+  request: typeof fetch = fetch,
+): (key: string) => Promise<ManagedValidation> {
+  return async (key: string): Promise<ManagedValidation> => {
+    if (cloudOrigin === undefined || cloudOrigin === "") {
+      return { outcome: "unreachable" };
+    }
+
+    let answer: Response;
+    try {
+      answer = await request(
+        `${cloudOrigin.replace(/\/+$/, "")}${INFERENCE_KEY_VALIDATION_PATH}`,
+        {
+          method: "POST",
+          headers: { [INFERENCE_KEY_HEADER]: key, "content-length": "0" },
+          signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+        },
+      );
+    } catch {
+      return { outcome: "unreachable" };
+    }
+
+    if (answer.status === 401 || answer.status === 403) return { outcome: "refused" };
+    if (!answer.ok) return { outcome: "unreachable" };
+
+    let said: { organization_id?: unknown };
+    try {
+      said = (await answer.json()) as { organization_id?: unknown };
+    } catch {
+      return { outcome: "unreachable" };
+    }
+
+    const organizationId = said.organization_id;
+    if (typeof organizationId !== "string" || organizationId === "") {
+      // An answer this deployment cannot read is not a refusal: the key may be
+      // perfectly good and the thing on the other end may not be Egma Cloud.
+      return { outcome: "unreachable" };
+    }
+    return { outcome: "valid", organizationId };
+  };
+}

--- a/apps/api/src/auth/inference-key.ts
+++ b/apps/api/src/auth/inference-key.ts
@@ -1,0 +1,85 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import type { IncomingHttpHeaders } from "node:http";
+
+/**
+ * The secret a self-hosted deployment presents at the Egma model gateway, and
+ * how a request carrying one is read.
+ *
+ * The sibling of `api-key.ts`, and the whole of the difference is what the
+ * secret opens. A product key resolves to a person, their current role and a
+ * project, and every ordinary Egma door takes one. This one resolves to an
+ * organization and opens exactly one thing.
+ *
+ * **A different prefix and a different table, which is what makes the two
+ * unmixable.** `apiKeySecretOn` requires `egma_sk_` and looks in `api_key`;
+ * this requires `egma_ik_` and looks in `inference_key`. So an inference key
+ * offered at a product route is not refused by a rule somebody wrote — it is
+ * not found, because nothing there ever looks where it lives.
+ */
+
+/**
+ * The static prefix every inference key starts with.
+ *
+ * It exists for `egma_sk_`'s reason: a fixed shape is what lets a
+ * secret-scanning service recognise a leaked Egma credential in a repository, a
+ * log or a paste. `ik` for inference key, one letter apart from `sk` in the
+ * name and a whole table apart in what it opens.
+ */
+export const INFERENCE_KEY_SECRET_PREFIX = "egma_ik_";
+
+/**
+ * The header an inference key travels in, from a self-hosted deployment and
+ * from the gateway alike.
+ *
+ * The same name the gateway's own slot uses, so there is exactly one spelling
+ * of "here is an inference key" anywhere in Egma. Deliberately not
+ * `Authorization: Bearer`: that header is the product's, an inference key is
+ * not a product credential, and a value in the product's slot is a value some
+ * later door might try to resolve.
+ */
+export const INFERENCE_KEY_HEADER = "egma-inference-key";
+
+/** 256 bits of randomness. A single SHA-256 over it, for `api-key.ts`'s reason. */
+const SECRET_BYTES = 32;
+
+/** Enough of the tail to tell two keys apart in a list, and no more. */
+const DISPLAY_SUFFIX_LENGTH = 4;
+
+export type MintedInferenceKey = {
+  /** Handed over once, at the moment of creation, and never stored. */
+  readonly secret: string;
+  /** What goes in the table instead. */
+  readonly hash: string;
+  readonly prefix: string;
+  readonly displaySuffix: string;
+};
+
+export function mintInferenceKeySecret(): MintedInferenceKey {
+  const secret = `${INFERENCE_KEY_SECRET_PREFIX}${randomBytes(SECRET_BYTES).toString("base64url")}`;
+  return {
+    secret,
+    hash: hashInferenceKeySecret(secret),
+    prefix: INFERENCE_KEY_SECRET_PREFIX,
+    displaySuffix: secret.slice(-DISPLAY_SUFFIX_LENGTH),
+  };
+}
+
+export function hashInferenceKeySecret(secret: string): string {
+  return createHash("sha256").update(secret, "utf8").digest("hex");
+}
+
+/**
+ * The inference key on a request, if it carries one in the one slot it may.
+ *
+ * A value that is not shaped like one answers `null` rather than being tried:
+ * a product key sent here is somebody pointing the wrong credential at the
+ * right door, and hashing it to look it up in a table it is not in would be
+ * spending a query to reach the same answer.
+ */
+export function inferenceKeySecretOn(headers: IncomingHttpHeaders): string | null {
+  const offered = headers[INFERENCE_KEY_HEADER];
+  const written = typeof offered === "string" ? offered.trim() : "";
+  if (written === "") return null;
+  return written.startsWith(INFERENCE_KEY_SECRET_PREFIX) ? written : null;
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,4 +1,4 @@
-import type { PlatformSettingValues } from "@egma/db";
+import { securely, type PlatformSettingValues } from "@egma/db";
 
 import { SERVICE_TOKEN_PREFIX } from "./auth/service-token.ts";
 import type { SmtpSettings } from "./auth/email.ts";
@@ -217,6 +217,7 @@ function smtpSettings(
  */
 const DEFAULT_EGMA_CLOUD_URL = "https://app.egma.ai";
 
+
 export function loadConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): Config {
@@ -356,7 +357,10 @@ export function loadConfig(
     baseUrl,
     authSecret,
     encryptionKey,
-    egmaCloudOrigin: environment.EGMA_CLOUD_URL?.trim() || DEFAULT_EGMA_CLOUD_URL,
+    egmaCloudOrigin: securely(
+      "EGMA_CLOUD_URL",
+      environment.EGMA_CLOUD_URL?.trim() || DEFAULT_EGMA_CLOUD_URL,
+    ),
     singleOrganization: flag(environment, "EGMA_SINGLE_ORGANIZATION", true),
     trustProxy: flag(environment, "EGMA_TRUST_PROXY", false),
     rateLimitPerMinute,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -70,6 +70,16 @@ export type Config = {
    */
   readonly rateLimitPerMinute: number;
   /**
+   * Where Egma Cloud answers when this deployment validates an inference key.
+   *
+   * A deployment setting rather than something an administrator types beside
+   * the key, because pointing one installation at a stranger's Egma Cloud is
+   * not a per-organization choice — and because a self-hoster who never uses
+   * managed access sets none of this. `undefined` means every paste is reported
+   * as unreachable rather than quietly connected.
+   */
+  readonly egmaCloudOrigin: string | undefined;
+  /**
    * What the simulator shows this API to claim simulation work — `egma_st_`
    * and then a secret, the same value both containers read. Absent means the
    * service will not start: the claim answers carry customers' live provider
@@ -197,6 +207,16 @@ function smtpSettings(
  * The service refuses to start rather than run misconfigured, so a bad
  * self-host is loud instead of silent.
  */
+/**
+ * Where Egma Cloud answers, for a deployment that names none.
+ *
+ * The same address the CLI falls back to and for the same reason: hosted Egma
+ * is at one place, everybody who connects managed access is connecting to that
+ * place, and a self-hoster who never uses managed access never notices this
+ * value. A deployment pointing at a staging Egma Cloud sets `EGMA_CLOUD_URL`.
+ */
+const DEFAULT_EGMA_CLOUD_URL = "https://app.egma.ai";
+
 export function loadConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): Config {
@@ -336,6 +356,7 @@ export function loadConfig(
     baseUrl,
     authSecret,
     encryptionKey,
+    egmaCloudOrigin: environment.EGMA_CLOUD_URL?.trim() || DEFAULT_EGMA_CLOUD_URL,
     singleOrganization: flag(environment, "EGMA_SINGLE_ORGANIZATION", true),
     trustProxy: flag(environment, "EGMA_TRUST_PROXY", false),
     rateLimitPerMinute,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import {
   connectClickHouse,
   disconnect,
   disconnectClickHouse,
+  managedDeploymentFrom,
   runClickHouseMigrations,
   runMigrations,
   seedDefaultJudge,
@@ -27,6 +28,11 @@ const traceMigrations = await runClickHouseMigrations(config.clickhouseUrl);
 connect({
   databaseUrl: config.databaseUrl,
   encryptionKey: config.encryptionKey,
+  // What kind of deployment this is, and where its managed model traffic goes.
+  // Read through the shared reader rather than out of this file's own config,
+  // so that the grading engine beside it cannot spell a name differently and
+  // end up disagreeing about who Egma is.
+  managedDeployment: managedDeploymentFrom(process.env),
 });
 connectClickHouse({ clickhouseUrl: config.clickhouseUrl });
 

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -6,10 +6,12 @@ import {
   getPersonaVersion,
   getRun,
   getSimulationTestVersion,
+  ManagedAccessNotConnectedError,
   ManagedAccessUnavailableError,
   ModelProviderCredentialMissingError,
   readModelAccess,
   resolveMockTools,
+  resolveManagedAccess,
   resolveModelProviderKeys,
   resolvePlatformSettings,
   resolveSimulationConnection,
@@ -237,13 +239,40 @@ async function modelsBlock(
   const access = await readModelAccess(claim.auth);
 
   if (access.mode === "managed") {
-    // Nothing on this deployment can select managed access yet — the setting
-    // refuses it by name while no connection to a gateway exists — so a row
-    // saying so is a state this control plane cannot honor. Typed rather than
-    // thrown plainly, so it lands on the row as an infrastructure error naming
-    // the mode with somewhere to go, rather than as a bare dispatch failure
-    // with nothing on it a person could act on.
-    throw new ManagedAccessUnavailableError();
+    /**
+     * **The whole managed answer is two values, and neither is a provider
+     * secret.** Where the traffic goes, and what authorizes it at the door —
+     * hosted Egma's own signed credential, or the inference key this
+     * deployment connected. Egma's provider credentials never leave the
+     * gateway, so there is no path from here to one and the closed contract
+     * shape refuses a document that carried one anyway.
+     *
+     * Resolved now rather than when the run was created, exactly as the
+     * customer-owned keys below are: a reconnected key reaches the next
+     * simulation to be claimed and leaves the ones already conducting alone.
+     *
+     * A deployment with no gateway address, or an organization on managed
+     * access with nothing connected, throws typed and lands on the row as an
+     * infrastructure error with somewhere to go. Neither falls back to calling
+     * a provider directly: a simulation quietly conducted on an account nobody
+     * chose is worse than one that stopped and said why.
+     */
+    const managed = await resolveManagedAccess(claim.auth);
+    return {
+      access: access.mode,
+      gateway: {
+        address: managed.gatewayAddress,
+        credential: managed.credential,
+      },
+      llm: { provider: models.llm.provider, model: models.llm.model },
+      stt: { provider: models.stt.provider, model: models.stt.model },
+      tts: {
+        provider: models.tts.provider,
+        model: models.tts.model,
+        voice_id: models.tts.voiceId,
+        speed: models.tts.speed,
+      },
+    };
   }
 
   /**
@@ -656,13 +685,15 @@ export async function claimRoutes(
         const spec = await assembledSpec(claim, runs).catch(
           (fault: unknown): Unbuildable => ({
             unbuildable: fault instanceof Error ? fault.message : String(fault),
-            // A credential the organization has not stored is a configuration
-            // problem with a screen behind it, so the row that lands says which
-            // screen. Every other fault is Egma being broken, and sending
-            // somebody to Model providers for one of those would be a link that
-            // fixes nothing.
+            // A credential the organization has not stored, and an inference
+            // key nobody has connected, are configuration problems with a
+            // screen behind them — so the row that lands says which screen.
+            // `ManagedAccessUnavailableError` is deliberately not here: a
+            // deployment that was never told where its gateway is, is Egma
+            // misconfigured, and sending an administrator to Model providers
+            // for that would be a link that fixes nothing.
             ...(fault instanceof ModelProviderCredentialMissingError ||
-            fault instanceof ManagedAccessUnavailableError
+            fault instanceof ManagedAccessNotConnectedError
               ? { repair: "model_providers" as const }
               : {}),
           }),

--- a/apps/api/src/routes/inference-keys.ts
+++ b/apps/api/src/routes/inference-keys.ts
@@ -1,0 +1,269 @@
+import {
+  createInferenceKey,
+  listInferenceKeys,
+  managedDeployment,
+  NotPermittedError,
+  resolveInferenceKey,
+  revokeInferenceKey,
+  UnprocessableInputError,
+  type AuthContext,
+  type InferenceKey,
+} from "@egma/db";
+import type { FastifyInstance, FastifyReply } from "fastify";
+
+import {
+  hashInferenceKeySecret,
+  INFERENCE_KEY_HEADER,
+  inferenceKeySecretOn,
+  mintInferenceKeySecret,
+} from "../auth/inference-key.ts";
+import type { SessionIdentityProvider } from "../auth/seam.ts";
+import { credentialed, requesterOf } from "../http/credentialed.ts";
+import type { RateLimit } from "../http/rate-limit.ts";
+import { given, text } from "../http/reading.ts";
+import { invalid, sendRefusal, unprocessable, REFUSALS } from "../http/refusals.ts";
+
+/**
+ * Inference keys: the credentials a self-hosted deployment presents at the Egma
+ * model gateway, minted here and stored as a hash.
+ *
+ * **Two doors that look alike and are nothing like each other.** The management
+ * routes are ordinary product routes: a person's session or a product key opens
+ * them, only an `admin` may use them, and no route can answer with a stored key
+ * because the store has none to answer with. The validation route below is the
+ * *only* door in Egma an inference key itself opens, and it answers one fact —
+ * which organization the key belongs to.
+ *
+ * **These routes exist on hosted Egma and nowhere else.** Egma operates the
+ * gateway and keeps the provider accounts behind it, so Egma is the only
+ * deployment that can say what an inference key means. A self-hosted
+ * installation answers `404` here, which is the honest shape: there is nothing
+ * at this address on that deployment rather than something an administrator is
+ * failing to reach.
+ */
+
+export type InferenceKeyRoutesOptions = {
+  readonly provider: SessionIdentityProvider;
+  readonly rateLimit: RateLimit;
+};
+
+export const INFERENCE_KEYS_PATH = "/api/inference-keys";
+export const INFERENCE_KEY_PATH = "/api/inference-keys/:inferenceKeyId";
+export const INFERENCE_KEY_VALIDATION_PATH = "/v1/inference-keys/validation";
+
+type Body = Record<string, unknown>;
+
+/** A key as a list is allowed to describe it. Never the secret. */
+function described(key: InferenceKey): Record<string, unknown> {
+  return {
+    id: key.id,
+    name: key.name,
+    // Enough to tell one key from another, and not enough to be one.
+    looks_like: key.looksLike,
+    created_at: key.createdAt.toISOString(),
+    created_by_user_id: key.createdByUserId,
+    last_used_at: key.lastUsedAt?.toISOString() ?? null,
+    revoked_at: key.revokedAt?.toISOString() ?? null,
+  };
+}
+
+function refuseRole(
+  reply: FastifyReply,
+  auth: AuthContext,
+  action: string,
+): FastifyReply {
+  return sendRefusal(reply, "not_permitted", REFUSALS.notPermitted(auth.role, action));
+}
+
+/**
+ * Not here on this deployment.
+ *
+ * A `404` rather than a refusal, because a refusal would say "you may not do
+ * this" about something nobody on a self-hosted deployment could ever do. The
+ * sentence says where the thing actually is.
+ */
+function notHosted(reply: FastifyReply): FastifyReply {
+  return reply.code(404).send({
+    error: "not_found",
+    message:
+      "inference keys are created in Egma Cloud, which operates the Egma model gateway and the provider accounts behind it. This deployment connects one; it does not mint them.",
+  });
+}
+
+export async function inferenceKeyRoutes(
+  app: FastifyInstance,
+  options: InferenceKeyRoutesOptions,
+): Promise<void> {
+  /**
+   * The one door an inference key opens, and the reason it is registered before
+   * the credentialed hook rather than inside it.
+   *
+   * **An inference key is refused by every normal Egma product interface**, and
+   * that is a property of where secrets are looked up rather than a rule a door
+   * remembers: the product's resolver reads the `api_key` table, and an
+   * inference key is not in it. This route reads the other table, answers one
+   * fact, and establishes no context at all — there is no `AuthContext` here for
+   * anything to widen.
+   *
+   * **Content-free.** No body is read and none is expected. What comes back is
+   * an organization identifier and a key identifier: enough for a self-hosted
+   * deployment to bind itself and for the gateway to know whose connection this
+   * is, and nothing about anybody's simulations, personas or models.
+   *
+   * The budget is keyed on where the request came from rather than on an
+   * organization, because a request that fails to resolve one has no
+   * organization to charge. It bounds guessing without letting a stranger spend
+   * a customer's allowance.
+   */
+  app.post(INFERENCE_KEY_VALIDATION_PATH, async (request, reply) => {
+    if (!managedDeployment().hosted) return notHosted(reply);
+
+    const verdict = options.rateLimit.reached(`inference-validation:${request.ip}`);
+    if (!verdict.allowed) {
+      return reply
+        .code(429)
+        .header("retry-after", String(verdict.retryAfterSeconds))
+        .send({
+          error: "too_many_requests",
+          message: "too many inference-key validations from this address",
+        });
+    }
+
+    const secret = inferenceKeySecretOn(request.headers);
+    if (secret === null) {
+      return reply.code(401).send({
+        error: "no_inference_key",
+        message: `this request carried no inference key; send it as ${INFERENCE_KEY_HEADER}`,
+      });
+    }
+
+    const resolved = await resolveInferenceKey(hashInferenceKeySecret(secret));
+    if (resolved === undefined) {
+      // One sentence for "never existed" and "revoked" alike. Which of the two
+      // it is would tell somebody holding a guessed key that they had guessed
+      // one that once existed.
+      return reply.code(401).send({
+        error: "inference_key_refused",
+        message: "this inference key does not authorize managed model access",
+      });
+    }
+
+    return reply.send({
+      organization_id: resolved.organizationId,
+      inference_key_id: resolved.inferenceKeyId,
+    });
+  });
+
+  /**
+   * The management routes, inside their own scope.
+   *
+   * Encapsulated rather than registered beside the validation route above,
+   * because `credentialed` is a hook on a scope: a route in the same scope
+   * would be behind it whatever order it was declared in. The validation door
+   * takes no session and no product key, so it has to be outside — and a scope
+   * is what makes "outside" a structural fact rather than a line ordering
+   * somebody could move.
+   */
+  void app.register(async (scope) => {
+    credentialed(scope, {
+      provider: options.provider,
+      rateLimit: options.rateLimit,
+    });
+    await managementRoutes(scope, options);
+  });
+}
+
+async function managementRoutes(
+  app: FastifyInstance,
+  options: InferenceKeyRoutesOptions,
+): Promise<void> {
+  app.get(INFERENCE_KEYS_PATH, async (request, reply) => {
+    if (!managedDeployment().hosted) return notHosted(reply);
+    const { auth } = requesterOf(request);
+
+    try {
+      const keys = await listInferenceKeys(auth);
+      return reply.send({ keys: keys.map(described) });
+    } catch (refusal) {
+      if (refusal instanceof NotPermittedError) {
+        return refuseRole(reply, auth, "see this organization's inference keys");
+      }
+      throw refusal;
+    }
+  });
+
+  /**
+   * Mint one. **The plaintext is in this response and in no other, ever.**
+   *
+   * There is no route that reads it back and no column it could be read out of:
+   * the store is handed a hash, a prefix and four characters, and never the
+   * secret itself. An administrator who loses it creates another and revokes
+   * this one, which is also how rotation works.
+   */
+  app.post(INFERENCE_KEYS_PATH, async (request, reply) => {
+    if (!managedDeployment().hosted) return notHosted(reply);
+    const { auth } = requesterOf(request);
+    const body = (request.body ?? {}) as Body;
+
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "create an inference key");
+    }
+
+    const name = given(text(body.name));
+    if (name === undefined) {
+      return invalid(
+        reply,
+        "an inference key needs a name — which installation it is for — so that a list of several says which one to revoke",
+      );
+    }
+
+    const minted = mintInferenceKeySecret();
+    try {
+      const created = await createInferenceKey(auth, {
+        name,
+        hash: minted.hash,
+        prefix: minted.prefix,
+        displaySuffix: minted.displaySuffix,
+      });
+      return reply.code(201).send({
+        ...described(created),
+        // Shown once, here, and nowhere again.
+        key: minted.secret,
+      });
+    } catch (refusal) {
+      if (refusal instanceof UnprocessableInputError) {
+        return unprocessable(reply, refusal.message);
+      }
+      throw refusal;
+    }
+  });
+
+  /**
+   * Retire one, effective on the next connection the gateway opens.
+   *
+   * Not a replacement: create the new key first, connect it where it is needed,
+   * and revoke this one afterwards. That order is what makes rotation overlap
+   * safely, and it is why an organization may hold several active keys at once.
+   */
+  app.delete(INFERENCE_KEY_PATH, async (request, reply) => {
+    if (!managedDeployment().hosted) return notHosted(reply);
+    const { auth } = requesterOf(request);
+    const { inferenceKeyId } = request.params as { inferenceKeyId: string };
+
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "revoke an inference key");
+    }
+
+    const revoked = await revokeInferenceKey(auth, inferenceKeyId);
+    if (revoked === undefined) {
+      // One answer for a key that was never here, one that belongs to somebody
+      // else, and one already revoked. Telling them apart would answer a
+      // question about another customer's account.
+      return reply.code(404).send({
+        error: "not_found",
+        message: "no active inference key of that identifier is in this organization",
+      });
+    }
+    return reply.send(described(revoked));
+  });
+}

--- a/apps/api/src/routes/model-access.ts
+++ b/apps/api/src/routes/model-access.ts
@@ -1,11 +1,17 @@
 import {
+  connectManagedAccess,
+  disconnectManagedAccess,
   IdentityConflictError,
   listModelProviderCredentials,
+  managedAccessAvailable,
+  managedDeployment,
+  ManagedAccessBoundElsewhereError,
   ManagedAccessNotConnectedError,
   MODEL_ACCESS_MODES,
   MODEL_JOBS,
   PROVIDER_CATALOG,
   RECOMMENDED_ENTRY,
+  readManagedAccessConnection,
   readModelAccess,
   removeModelProviderCredential,
   RESERVED_PROVIDER_JOBS,
@@ -55,21 +61,68 @@ import {
  * provider it could not open.
  */
 
+/**
+ * What one content-free validation request answered.
+ *
+ * Three outcomes rather than two, for the reason the gateway keeps three: a key
+ * Egma Cloud could not be asked about is not a bad key, and telling an
+ * administrator to check the value they just pasted when Egma Cloud was down
+ * would send them looking in the wrong place.
+ */
+export type ManagedValidation =
+  | { readonly outcome: "valid"; readonly organizationId: string }
+  | { readonly outcome: "refused" }
+  | { readonly outcome: "unreachable" };
+
+const VALIDATION_REFUSAL: Readonly<Record<"refused" | "unreachable", string>> = {
+  refused:
+    "Egma Cloud does not recognise this inference key. Create one under Inference keys in Egma Cloud and paste the value it shows you; a key that was revoked cannot be connected again.",
+  unreachable:
+    "Egma Cloud could not be reached, so this key was neither accepted nor refused. Nothing has changed here; try again when it answers.",
+};
+
 export type ModelAccessRoutesOptions = {
   readonly provider: SessionIdentityProvider;
   readonly rateLimit: RateLimit;
+  /**
+   * The one content-free ask, as a seam.
+   *
+   * A seam rather than a call written inline, because this is the one place the
+   * product reaches out of the deployment on a person's behalf — and the
+   * deterministic suite has to be able to stand a real Egma Cloud in front of it
+   * without a network. What crosses is a key and what comes back is an
+   * organization identifier: no simulation, no persona, no model, no payload.
+   */
+  readonly validate: (key: string) => Promise<ManagedValidation>;
 };
+
+/**
+ * Hosted Egma has nothing to connect, and says where the answer really lives.
+ *
+ * A `404` rather than a refusal, for the reason the inference-key routes answer
+ * one on a self-hosted deployment: there is nothing at this address here, and a
+ * "you may not" would suggest somebody with more authority could.
+ */
+function managedIsInternal(reply: FastifyReply): FastifyReply {
+  return reply.code(404).send({
+    error: "not_found",
+    message:
+      "this deployment supplies managed model access internally, so there is no inference key to connect. Managed by Egma is available under Model access.",
+  });
+}
 
 export const MODEL_ACCESS_PATH = "/api/model-access";
 export const MODEL_CATALOG_PATH = "/api/model-catalog";
 export const MODEL_PROVIDER_CREDENTIALS_PATH = "/api/model-provider-credentials";
 export const MODEL_PROVIDER_CREDENTIAL_PATH =
   "/api/model-provider-credentials/:provider";
+export const MANAGED_ACCESS_PATH = "/api/managed-access";
 
 type Body = Record<string, unknown>;
 
 const ACCESS_KEYS = ["mode"] as const;
 const CREDENTIAL_KEYS = ["provider", "key", "expected_revision"] as const;
+const MANAGED_KEYS = ["key"] as const;
 
 function unknownKeyIn(
   body: Body,
@@ -173,9 +226,11 @@ export async function modelAccessRoutes(
    */
   app.get(MODEL_ACCESS_PATH, async (request, reply) => {
     const { auth } = requesterOf(request);
-    const [access, credentials] = await Promise.all([
+    const [access, credentials, connection, available] = await Promise.all([
       readModelAccess(auth),
       listModelProviderCredentials(auth),
+      readManagedAccessConnection(auth),
+      managedAccessAvailable(auth),
     ]);
 
     return reply.send({
@@ -183,14 +238,29 @@ export async function modelAccessRoutes(
       updated_at: access.updatedAt?.toISOString() ?? null,
       modes: MODEL_ACCESS_MODES,
       /**
-       * Whether managed access can be chosen at all on this deployment.
+       * Whether managed access can be chosen at all right now.
        *
-       * `false` while nothing is connected to Egma's own provider accounts,
-       * which is every deployment today. A form that offered the choice anyway
-       * would be offering a setting the server refuses, and the refusal would
-       * arrive after somebody had already decided.
+       * Always true on hosted Egma, which operates the gateway and signs its
+       * own credentials, so there is nothing to connect. On a self-hosted
+       * deployment it is true once an inference key is connected. A form that
+       * offered the choice otherwise would be offering a setting the server
+       * refuses, and the refusal would arrive after somebody had decided.
        */
-      managed_available: false,
+      managed_available: available,
+      /**
+       * Which of the two managed stories this deployment tells.
+       *
+       * A fact about the deployment rather than about the organization, and the
+       * screen needs it to know which shape to draw: hosted managed access is a
+       * state to read, and self-hosted managed access is a key to connect.
+       */
+      hosted: managedDeployment().hosted,
+      managed: {
+        connected: connection.connected,
+        hint: connection.hint,
+        cloud_organization_id: connection.cloudOrganizationId,
+        connected_at: connection.updatedAt?.toISOString() ?? null,
+      },
       credentials: credentials.map(described),
     });
   });
@@ -229,6 +299,94 @@ export async function modelAccessRoutes(
       }
       throw refusal;
     }
+  });
+
+  /**
+   * Connect the inference key this deployment presents at the Egma model
+   * gateway, or replace the one it presents now.
+   *
+   * **One content-free validation request stands between the paste and
+   * Connected**, and it is the whole reason this route is not just a write.
+   * Egma Cloud is asked whether the key is good and which organization owns it;
+   * only then is anything stored, and what is stored includes that answer — so
+   * a key belonging to another Egma Cloud organization is refused next time
+   * rather than silently moving this deployment's spend onto somebody else's
+   * account.
+   *
+   * **The key is not exchanged for anything.** What comes back is an identifier,
+   * not a grant and not a provider credential; the key itself is what every
+   * later connection presents. There is no per-simulation round trip here or
+   * anywhere else.
+   *
+   * Hosted Egma answers `404`: it signs its own credentials and has nothing to
+   * connect, so a route that accepted a pasted key there would be a second
+   * authentication story nobody asked for.
+   */
+  app.put(MANAGED_ACCESS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const body = (request.body ?? {}) as Body;
+
+    if (managedDeployment().hosted) return managedIsInternal(reply);
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "connect managed model access");
+    }
+
+    const unknown = unknownKeyIn(body, MANAGED_KEYS, "a managed access connection");
+    if (unknown !== undefined) return invalid(reply, unknown);
+
+    const key = given(text(body.key));
+    if (key === undefined) {
+      return invalid(
+        reply,
+        "connecting managed access needs the inference key Egma Cloud showed you when you created it",
+      );
+    }
+
+    const validated = await options.validate(key);
+    if (validated.outcome !== "valid") {
+      return unprocessable(reply, VALIDATION_REFUSAL[validated.outcome]);
+    }
+
+    try {
+      const connected = await connectManagedAccess(auth, {
+        key,
+        cloudOrganizationId: validated.organizationId,
+      });
+      return reply.send({
+        connected: connected.connected,
+        hint: connected.hint,
+        cloud_organization_id: connected.cloudOrganizationId,
+        connected_at: connected.updatedAt?.toISOString() ?? null,
+      });
+    } catch (refusal) {
+      if (refusal instanceof ManagedAccessBoundElsewhereError) {
+        return sendRefusal(reply, "conflict", refusal.message);
+      }
+      if (refusal instanceof UnprocessableInputError) {
+        return unprocessable(reply, refusal.message);
+      }
+      throw refusal;
+    }
+  });
+
+  /**
+   * Disconnect it.
+   *
+   * The access mode is deliberately left alone. An organization that is on
+   * managed access and disconnects lands its next claim as a visible
+   * infrastructure error naming what to reconnect, which is a better answer
+   * than this route quietly choosing somebody's access mode for them.
+   */
+  app.delete(MANAGED_ACCESS_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+
+    if (managedDeployment().hosted) return managedIsInternal(reply);
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "disconnect managed model access");
+    }
+
+    const removed = await disconnectManagedAccess(auth);
+    return reply.send({ disconnected: removed });
   });
 
   /**

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -22,7 +22,12 @@ import { heartbeatRoutes } from "./routes/heartbeats.ts";
 import { invitationRoutes } from "./routes/invitations.ts";
 import { judgeRoutes } from "./routes/judge.ts";
 import { meRoutes } from "./routes/me.ts";
-import { modelAccessRoutes } from "./routes/model-access.ts";
+import { validateAtEgmaCloud } from "./auth/egma-cloud.ts";
+import { inferenceKeyRoutes } from "./routes/inference-keys.ts";
+import {
+  modelAccessRoutes,
+  type ModelAccessRoutesOptions,
+} from "./routes/model-access.ts";
 import { memberRoutes } from "./routes/members.ts";
 import { organizationRoutes } from "./routes/organization.ts";
 import { personaRoutes } from "./routes/personas.ts";
@@ -98,6 +103,13 @@ export type ServerOptions = {
   readonly retellReach?: RetellReach;
   /** Test-only device-flow pace; a production server uses five seconds. */
   readonly deviceAuthorizationInterval?: IdentityOptions["deviceAuthorizationInterval"];
+  /**
+   * How an inference key is validated at Egma Cloud when an administrator
+   * connects one. Absent reaches the real Egma Cloud over the network; the
+   * deterministic suite hands in one pointed at a real API of its own, so the
+   * self-hosted half of the four-way matrix is proved without a network.
+   */
+  readonly validateInferenceKey?: ModelAccessRoutesOptions["validate"];
 };
 
 export type Api = {
@@ -313,6 +325,19 @@ export function buildApi(options: ServerOptions): Api {
   // providers are configured is anybody's, and committing the organization's
   // provider account is an admin's.
   void app.register(modelAccessRoutes, {
+    provider: identity.provider,
+    rateLimit,
+    // The one outbound ask this product makes on a person's behalf, handed in
+    // rather than reached for, so the deterministic suite can stand a real Egma
+    // Cloud in front of it with no network.
+    validate: options.validateInferenceKey ?? validateAtEgmaCloud(config.egmaCloudOrigin),
+  });
+
+  // The inference keys hosted Egma mints, and the one door an inference key
+  // itself opens. Its own group because half of it is not a product route at
+  // all: the validation door establishes no context, takes no session and no
+  // product key, and answers one fact about one credential.
+  void app.register(inferenceKeyRoutes, {
     provider: identity.provider,
     rateLimit,
   });

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -59,6 +59,16 @@ import {
  * product in.
  */
 
+/**
+ * The inference key this walk pastes, and the Egma Cloud organization it
+ * belongs to.
+ *
+ * A sentinel, so a leak anywhere on any of these pages is a string this file
+ * can look for — and it is looked for, on every screen the arc passes.
+ */
+const MANAGED_ACCESS_KEY = "egma_ik_browser-sentinel-managed-access-Q7R8";
+const EGMA_CLOUD_ORGANIZATION = "org_01K3XQ7M4E8YB2FVN0H9TZQWER";
+
 let instance: Instance;
 let browser: Browser;
 let page: Page;
@@ -84,6 +94,20 @@ beforeAll(async () => {
   instance = await startInstance("browser", {
     traces: true,
     ...(storage.available ? { blob: storage.store } : {}),
+    /**
+     * The one outbound ask managed access makes, standing in.
+     *
+     * Everything else in the Connect Egma arc below is real — the routes, the
+     * Postgres, the sealing, the binding — and this is the only part that
+     * cannot be: it leaves the deployment, and no test may reach Egma Cloud.
+     * What it stands in for is exactly the contract: a key Egma Cloud
+     * recognises answers which organization owns it, and one it does not is
+     * refused.
+     */
+    validateInferenceKey: async (key: string) =>
+      key === MANAGED_ACCESS_KEY
+        ? { outcome: "valid", organizationId: EGMA_CLOUD_ORGANIZATION }
+        : { outcome: "refused" },
   });
   origin = instance.origin;
 
@@ -3782,6 +3806,149 @@ describe("the complete product, walked in order in a second project", () => {
         await expect
           .poll(() => walk.innerText("main"))
           .toContain("CONFIGURED");
+      },
+      SETTLE,
+    );
+
+    /**
+     * The Managed by Egma arc, clicked through on the deployment that has one:
+     * a self-hosted installation with an inference key to connect.
+     *
+     * **Every state the specification names, in the order somebody meets
+     * them** — Connect Egma, Connected, Replace, Disconnect — plus the mode
+     * switch above them and the refusal a key Egma Cloud does not recognise
+     * earns. What is checked on every screen is the same two things: that the
+     * state is said in words rather than implied by which controls are lit,
+     * and that the key is nowhere on the page.
+     *
+     * Hosted Egma's own state is a different deployment and cannot be a second
+     * instance in this lane; its `Available` shape is read in
+     * `apps/web/test/model-providers.test.tsx`.
+     */
+    it(
+      "connects, replaces and disconnects Egma, and never shows the key",
+      async () => {
+        await walk.setViewportSize({ width: 1280, height: 900 });
+        await walk.goto(at("settings", "model-providers"));
+        await saysWithin(walk, "Managed by Egma");
+
+        // Nothing connected: the state is a word, and the sentence says what
+        // has to happen before Managed by Egma can be chosen at all.
+        //
+        // Read as the design system renders it — badges are uppercased, so the
+        // legible text is "NOT CONNECTED" — and paired with prose, because
+        // "CONNECTED" is a substring of it and a badge assertion alone could
+        // not tell the two states apart.
+        await saysWithin(walk, "NOT CONNECTED");
+        await saysWithin(walk, "Create an inference key in Egma Cloud");
+        await saysWithin(walk, "connected no inference key for it");
+
+        // The mode switch is a radio group, so a keyboard reaches it and a
+        // screen reader announces which of the two is current.
+        const managed = walk.getByRole("radio", { name: "Managed by Egma" });
+        await managed.waitFor();
+        expect(await managed.getAttribute("aria-checked")).toBe("false");
+
+        // A key Egma Cloud does not recognise is refused, and connects
+        // nothing — said in words that send somebody to Egma Cloud rather
+        // than blaming the field they typed into.
+        await walk.getByRole("button", { name: "Connect Egma" }).click();
+        const field = walk.locator("#managed-access-key");
+        await field.waitFor();
+        expect(await field.getAttribute("type")).toBe("password");
+        await field.fill("egma_ik_browser-sentinel-never-issued-S9T0");
+        await walk.getByRole("button", { name: "Connect Egma" }).last().click();
+        await saysWithin(walk, "does not recognise this inference key");
+        await saysWithin(walk, "NOT CONNECTED");
+
+        // And the real one connects.
+        await field.fill(MANAGED_ACCESS_KEY);
+        await walk.getByRole("button", { name: "Connect Egma" }).last().click();
+
+        // Asserted on the prose and the hint rather than on the badge, for the
+        // reason above: "CONNECTED" is a substring of "NOT CONNECTED", so the
+        // badge alone cannot say which of the two states this is.
+        await saysWithin(walk, "present this key at the Egma model gateway");
+        // Four characters, which is the whole of what a connected key ever
+        // shows — and the field it was typed into is gone with its form.
+        await saysWithin(walk, `…${MANAGED_ACCESS_KEY.slice(-4)}`);
+        expect(await walk.innerText("main")).not.toContain("NOT CONNECTED");
+        await expect
+          .poll(() => walk.locator('input[type="password"]').count())
+          .toBe(0);
+        expect(await walk.innerText("main")).not.toContain(MANAGED_ACCESS_KEY);
+
+        // Now the mode can be chosen, which is the point of connecting.
+        await walk.getByRole("radio", { name: "Managed by Egma" }).click();
+        await expect
+          .poll(() =>
+            walk
+              .getByRole("radio", { name: "Managed by Egma" })
+              .getAttribute("aria-checked"),
+          )
+          .toBe("true");
+        await saysWithin(walk, "Egma's provider accounts through the Egma model gateway");
+
+        // Replace is the same one field, opened by the row that owns it.
+        await walk.getByRole("button", { name: "Replace key" }).first().click();
+        await walk.locator("#managed-access-key").waitFor();
+        expect(await walk.locator('input[type="password"]').count()).toBe(1);
+        await walk.getByRole("button", { name: "Cancel" }).last().click();
+        await expect
+          .poll(() => walk.locator('input[type="password"]').count())
+          .toBe(0);
+
+        // **Nothing is disconnected by one click**, and the dialog names the
+        // key it is about — the safe hint being the only part of a connected
+        // key anybody can see, and exactly enough to tell two apart.
+        await walk.getByRole("button", { name: "Disconnect" }).click();
+        const dialog = walk.getByRole("dialog");
+        await dialog.waitFor();
+        const asked = await dialog.innerText();
+        expect(asked).toContain(MANAGED_ACCESS_KEY.slice(-4));
+        expect(asked).toContain("stops with an error");
+        expect(asked).not.toContain(MANAGED_ACCESS_KEY);
+
+        // Escape leaves it exactly where it was.
+        await walk.keyboard.press("Escape");
+        await expect.poll(() => walk.getByRole("dialog").count()).toBe(0);
+        await saysWithin(walk, "present this key at the Egma model gateway");
+
+        // And confirming really disconnects.
+        await walk.getByRole("button", { name: "Disconnect" }).click();
+        await walk.getByRole("dialog").waitFor();
+        await walk
+          .getByRole("dialog")
+          .getByRole("button", { name: "Disconnect" })
+          .click();
+        await saysWithin(walk, "NOT CONNECTED");
+        expect(await walk.innerText("main")).not.toContain(MANAGED_ACCESS_KEY);
+      },
+      SETTLE,
+    );
+
+    it(
+      "connects Egma on a phone, where the whole arc has to fit in one column",
+      async () => {
+        await walk.setViewportSize({ width: 390, height: 844 });
+        await walk.goto(at("settings", "model-providers"));
+        await saysWithin(walk, "Managed by Egma");
+
+        await walk.getByRole("button", { name: "Connect Egma" }).click();
+        const field = walk.locator("#managed-access-key");
+        await field.waitFor();
+
+        // A pointer target somebody can actually hit with a thumb.
+        const connect = walk.getByRole("button", { name: "Connect Egma" }).last();
+        const box = await connect.boundingBox();
+        expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+
+        await field.fill(MANAGED_ACCESS_KEY);
+        await connect.click();
+        await saysWithin(walk, "present this key at the Egma model gateway");
+        expect(await walk.innerText("main")).not.toContain(MANAGED_ACCESS_KEY);
+
+        await walk.setViewportSize({ width: 1280, height: 900 });
       },
       SETTLE,
     );

--- a/apps/api/test/inference-keys.test.ts
+++ b/apps/api/test/inference-keys.test.ts
@@ -145,9 +145,15 @@ describe("the one door an inference key opens", () => {
       headers: { [INFERENCE_KEY_HEADER]: secret },
     });
 
-    const listed = (await ask(api.app, "GET", INFERENCE_KEYS_PATH, adminKey))
-      .body["keys"] as Record<string, unknown>[];
-    expect(listed[0]?.["last_used_at"]).not.toBeNull();
+    // The stamp is written without the connection waiting for it, so the read
+    // that observes it waits here instead.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const listed = (await ask(api.app, "GET", INFERENCE_KEYS_PATH, adminKey))
+        .body["keys"] as Record<string, unknown>[];
+      if (listed[0]?.["last_used_at"] !== null) return;
+      await new Promise((settle) => setTimeout(settle, 10));
+    }
+    throw new Error("the use stamp never landed");
   });
 
   it("refuses a revoked key on the very next ask", async () => {

--- a/apps/api/test/inference-keys.test.ts
+++ b/apps/api/test/inference-keys.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { INFERENCE_KEY_HEADER } from "../src/auth/inference-key.ts";
+import {
+  INFERENCE_KEYS_PATH,
+  INFERENCE_KEY_VALIDATION_PATH,
+} from "../src/routes/inference-keys.ts";
+import { MANAGED_ACCESS_PATH, MODEL_ACCESS_PATH } from "../src/routes/model-access.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import { request as ask, signUp, colleagueOf, type Customer } from "./support/traces.ts";
+
+/**
+ * Inference keys, over real HTTP against real Postgres.
+ *
+ * Two claims are asserted here and they are the two the product actually makes
+ * about this credential. **It is shown once**: the one response that carries it
+ * is the one that minted it, and no later read has a field for it. And **it
+ * opens exactly one door**: the validation route answers which organization it
+ * belongs to, and every ordinary Egma product interface refuses it — not by a
+ * rule anybody wrote, but because a product route looks the credential up in a
+ * table this key is not in.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const HOSTED = {
+  hosted: true,
+  gatewayAddress: "https://gateway.egma.example",
+  internalGatewayKey: "sentinel-internal-gateway-signing-Xy7Zk2",
+} as const;
+
+const SELF_HOSTED = {
+  hosted: false,
+  gatewayAddress: "https://gateway.egma.example",
+  internalGatewayKey: undefined,
+} as const;
+
+type World = { readonly ada: Customer; readonly adminKey: string };
+
+async function hostedEgma(label: string): Promise<World> {
+  api = await createApi(label, { managedDeployment: HOSTED });
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  return { ada, adminKey: ada.secret };
+}
+
+async function created(
+  adminKey: string,
+  name: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const answered = await ask(api.app, "POST", INFERENCE_KEYS_PATH, adminKey, {
+    name,
+  });
+  return { status: answered.statusCode, body: answered.body };
+}
+
+describe("creating one", () => {
+  it("shows the key once, and shows it nowhere again", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_shown_once");
+
+    const minted = await created(adminKey, "Lakeside self-hosted");
+    expect(minted.status).toBe(201);
+    const secret = minted.body["key"] as string;
+    expect(secret.startsWith("egma_ik_")).toBe(true);
+    expect(minted.body["looks_like"]).toBe(`egma_ik_…${secret.slice(-4)}`);
+
+    const listed = await ask(api.app, "GET", INFERENCE_KEYS_PATH, adminKey);
+    expect(listed.statusCode).toBe(200);
+    expect(JSON.stringify(listed.body)).not.toContain(secret);
+    const keys = listed.body["keys"] as Record<string, unknown>[];
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).not.toHaveProperty("key");
+    expect(keys[0]?.["name"]).toBe("Lakeside self-hosted");
+    expect(keys[0]?.["revoked_at"]).toBeNull();
+  });
+
+  it("is an admin's, and everybody else is told so by their role", async () => {
+    const { ada, adminKey } = await hostedEgma("inference_keys_admin_only");
+    const grace = await colleagueOf(api.app, ada, "grace@acme.example", "member");
+
+    const refused = await ask(api.app, "POST", INFERENCE_KEYS_PATH, grace.secret, {
+      name: "not mine to make",
+    });
+    expect(refused.statusCode).toBe(403);
+    expect(refused.body["error"]).toBe("not_permitted");
+
+    expect((await created(adminKey, "mine")).status).toBe(201);
+  });
+
+  it("needs a name, so a list of several says which one to revoke", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_named");
+
+    const refused = await ask(api.app, "POST", INFERENCE_KEYS_PATH, adminKey, {});
+    expect(refused.statusCode).toBe(400);
+  });
+
+  it("is not a thing a self-hosted deployment does at all", async () => {
+    api = await createApi("inference_keys_not_here", {
+      managedDeployment: SELF_HOSTED,
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+    const answered = await ask(api.app, "POST", INFERENCE_KEYS_PATH, ada.secret, {
+      name: "nope",
+    });
+    expect(answered.statusCode).toBe(404);
+    expect(String(answered.body["message"])).toContain("Egma Cloud");
+  });
+});
+
+describe("the one door an inference key opens", () => {
+  it("answers which organization it acts for, and nothing else", async () => {
+    const { ada, adminKey } = await hostedEgma("inference_keys_validation");
+    const minted = await created(adminKey, "Lakeside");
+    const secret = minted.body["key"] as string;
+
+    const answered = await api.app.inject({
+      method: "POST",
+      url: INFERENCE_KEY_VALIDATION_PATH,
+      headers: { [INFERENCE_KEY_HEADER]: secret },
+    });
+
+    expect(answered.statusCode).toBe(200);
+    const said = JSON.parse(answered.body) as Record<string, unknown>;
+    expect(said["organization_id"]).toBe(ada.organizationId);
+    expect(said["inference_key_id"]).toBe(minted.body["id"]);
+    // Nothing about the customer beyond which one it is: no project, no role,
+    // no person, and no provider credential.
+    expect(Object.keys(said).sort()).toEqual([
+      "inference_key_id",
+      "organization_id",
+    ]);
+  });
+
+  it("marks the key used, so a key nobody needs is visible as one", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_last_used");
+    const secret = (await created(adminKey, "Lakeside")).body["key"] as string;
+
+    await api.app.inject({
+      method: "POST",
+      url: INFERENCE_KEY_VALIDATION_PATH,
+      headers: { [INFERENCE_KEY_HEADER]: secret },
+    });
+
+    const listed = (await ask(api.app, "GET", INFERENCE_KEYS_PATH, adminKey))
+      .body["keys"] as Record<string, unknown>[];
+    expect(listed[0]?.["last_used_at"]).not.toBeNull();
+  });
+
+  it("refuses a revoked key on the very next ask", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_revoked");
+    const minted = await created(adminKey, "Retired");
+    const secret = minted.body["key"] as string;
+
+    const revoked = await ask(
+      api.app,
+      "DELETE",
+      `${INFERENCE_KEYS_PATH}/${String(minted.body["id"])}`,
+      adminKey,
+    );
+    expect(revoked.statusCode).toBe(200);
+    expect(revoked.body["revoked_at"]).not.toBeNull();
+
+    const answered = await api.app.inject({
+      method: "POST",
+      url: INFERENCE_KEY_VALIDATION_PATH,
+      headers: { [INFERENCE_KEY_HEADER]: secret },
+    });
+    expect(answered.statusCode).toBe(401);
+  });
+
+  it("leaves a replacement working, which is what makes rotation overlap", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_rotation");
+    const older = await created(adminKey, "Before rotation");
+    const newer = await created(adminKey, "After rotation");
+
+    await ask(
+      api.app,
+      "DELETE",
+      `${INFERENCE_KEYS_PATH}/${String(older.body["id"])}`,
+      adminKey,
+    );
+
+    const stillGood = await api.app.inject({
+      method: "POST",
+      url: INFERENCE_KEY_VALIDATION_PATH,
+      headers: { [INFERENCE_KEY_HEADER]: newer.body["key"] as string },
+    });
+    expect(stillGood.statusCode).toBe(200);
+  });
+
+  it("refuses an ordinary Egma product key, which is not one of these", async () => {
+    const { ada } = await hostedEgma("inference_keys_not_a_product_key");
+
+    const answered = await api.app.inject({
+      method: "POST",
+      url: INFERENCE_KEY_VALIDATION_PATH,
+      headers: { [INFERENCE_KEY_HEADER]: ada.secret },
+    });
+    expect(answered.statusCode).toBe(401);
+  });
+});
+
+describe("an inference key at an ordinary product door", () => {
+  it("is nobody, whichever slot it is offered in", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_refused_by_product");
+    const secret = (await created(adminKey, "Lakeside")).body["key"] as string;
+
+    // The product's own slot: `Authorization: Bearer`, which is where every
+    // real Egma credential goes. There is no table this resolves in.
+    for (const path of [MODEL_ACCESS_PATH, INFERENCE_KEYS_PATH, "/api/me"]) {
+      const answered = await api.app.inject({
+        method: "GET",
+        url: path,
+        headers: { authorization: `Bearer ${secret}` },
+      });
+      expect(answered.statusCode, path).toBe(401);
+    }
+
+    // And the gateway's own slot, which product doors do not read at all.
+    const other = await api.app.inject({
+      method: "GET",
+      url: MODEL_ACCESS_PATH,
+      headers: { [INFERENCE_KEY_HEADER]: secret },
+    });
+    expect(other.statusCode).toBe(401);
+  });
+
+  it("cannot write anything either, so a leaked one changes nothing in the product", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_cannot_write");
+    const secret = (await created(adminKey, "Lakeside")).body["key"] as string;
+
+    const answered = await api.app.inject({
+      method: "PUT",
+      url: MODEL_ACCESS_PATH,
+      headers: {
+        authorization: `Bearer ${secret}`,
+        "content-type": "application/json",
+      },
+      payload: { mode: "managed" },
+    });
+    expect(answered.statusCode).toBe(401);
+  });
+});
+
+describe("a self-hosted deployment connecting one", () => {
+  /**
+   * Two real instances: one hosted Egma that mints the key, one self-hosted
+   * deployment that pastes it. The validation between them is the real route on
+   * the real hosted API, reached through the seam rather than over a network —
+   * which is exactly what the deterministic suite is allowed to do and exactly
+   * what makes this the real path rather than a stand-in for it.
+   */
+  /**
+   * Two deployments, one at a time.
+   *
+   * A process holds one database connection and one deployment identity, so
+   * hosted Egma and a self-hosted installation cannot both be up here — which
+   * is also true in the world. So the key is minted on the real hosted API and
+   * its real validation route is asked the real question; that answer is
+   * carried across, and the self-hosted instance connects on it. The route that
+   * answered is the shipped one, above and again here.
+   */
+  it("reaches Connected only after Egma Cloud confirms the organization", async () => {
+    api = await createApi("inference_keys_cloud", { managedDeployment: HOSTED });
+    const cloudAda = await signUp(api.app, "ada@acme.example", "Acme");
+    const secret = (
+      await ask(api.app, "POST", INFERENCE_KEYS_PATH, cloudAda.secret, {
+        name: "Lakeside self-hosted",
+      })
+    ).body["key"] as string;
+
+    const confirmed = await api.app.inject({
+      method: "POST",
+      url: INFERENCE_KEY_VALIDATION_PATH,
+      headers: { [INFERENCE_KEY_HEADER]: secret },
+    });
+    expect(confirmed.statusCode).toBe(200);
+    const cloudOrganizationId = (
+      JSON.parse(confirmed.body) as { organization_id: string }
+    ).organization_id;
+    expect(cloudOrganizationId).toBe(cloudAda.organizationId);
+
+    await api.close();
+
+    api = await createApi("inference_keys_self_hosted", {
+      managedDeployment: SELF_HOSTED,
+      validateInferenceKey: async (key) =>
+        key === secret
+          ? { outcome: "valid", organizationId: cloudOrganizationId }
+          : { outcome: "refused" },
+    });
+    const local = await signUp(api.app, "grace@lakeside.example", "Lakeside");
+
+    // Before anything is connected: not connected, and managed access cannot
+    // even be chosen.
+    const before = (await ask(api.app, "GET", MODEL_ACCESS_PATH, local.secret))
+      .body;
+    expect(before["managed_available"]).toBe(false);
+    expect((before["managed"] as Record<string, unknown>)["connected"]).toBe(false);
+    expect(
+      (await ask(api.app, "PUT", MODEL_ACCESS_PATH, local.secret, { mode: "managed" }))
+        .statusCode,
+    ).toBe(422);
+
+    const connected = await ask(api.app, "PUT", MANAGED_ACCESS_PATH, local.secret, {
+      key: secret,
+    });
+    expect(connected.statusCode).toBe(200);
+    expect(connected.body["connected"]).toBe(true);
+    expect(connected.body["hint"]).toBe(secret.slice(-4));
+    expect(connected.body["cloud_organization_id"]).toBe(cloudOrganizationId);
+    expect(JSON.stringify(connected.body)).not.toContain(secret);
+
+    const after = (await ask(api.app, "GET", MODEL_ACCESS_PATH, local.secret)).body;
+    expect(after["managed_available"]).toBe(true);
+    expect(after["hosted"]).toBe(false);
+    // The read carries Connected and a hint and no key at all.
+    expect(JSON.stringify(after)).not.toContain(secret);
+
+    // And now managed access is a choice the server accepts.
+    const chosen = await ask(api.app, "PUT", MODEL_ACCESS_PATH, local.secret, {
+      mode: "managed",
+    });
+    expect(chosen.statusCode).toBe(200);
+    expect(chosen.body["mode"]).toBe("managed");
+  });
+
+  it("refuses a key Egma Cloud does not recognise, and connects nothing", async () => {
+    api = await createApi("inference_keys_refused_paste", {
+      managedDeployment: SELF_HOSTED,
+      validateInferenceKey: async () => ({ outcome: "refused" }),
+    });
+    const local = await signUp(api.app, "grace@lakeside.example", "Lakeside");
+
+    const answered = await ask(api.app, "PUT", MANAGED_ACCESS_PATH, local.secret, {
+      key: "egma_ik_sentinel-never-issued-Qq4Rt8",
+    });
+    expect(answered.statusCode).toBe(422);
+    expect(String(answered.body["message"])).toContain("does not recognise");
+
+    const read = (await ask(api.app, "GET", MODEL_ACCESS_PATH, local.secret)).body;
+    expect((read["managed"] as Record<string, unknown>)["connected"]).toBe(false);
+  });
+
+  it("says Egma Cloud could not be asked, rather than blaming the key", async () => {
+    api = await createApi("inference_keys_cloud_down", {
+      managedDeployment: SELF_HOSTED,
+      validateInferenceKey: async () => ({ outcome: "unreachable" }),
+    });
+    const local = await signUp(api.app, "grace@lakeside.example", "Lakeside");
+
+    const answered = await ask(api.app, "PUT", MANAGED_ACCESS_PATH, local.secret, {
+      key: "egma_ik_sentinel-fine-key-cloud-down-Vv6Ww1",
+    });
+    expect(answered.statusCode).toBe(422);
+    expect(String(answered.body["message"])).toContain("could not be reached");
+    expect(String(answered.body["message"])).toContain("Nothing has changed");
+  });
+
+  it("refuses a key from another Egma Cloud organization while the binding stands", async () => {
+    let whose = "org_01K3XQ7M4E8YB2FVN0H9TZQWER";
+    api = await createApi("inference_keys_bound", {
+      managedDeployment: SELF_HOSTED,
+      validateInferenceKey: async () => ({ outcome: "valid", organizationId: whose }),
+    });
+    const local = await signUp(api.app, "grace@lakeside.example", "Lakeside");
+
+    expect(
+      (
+        await ask(api.app, "PUT", MANAGED_ACCESS_PATH, local.secret, {
+          key: "egma_ik_sentinel-first-binding-Aa1Bb2",
+        })
+      ).statusCode,
+    ).toBe(200);
+
+    whose = "org_01K3XQ7M4E8YB2FVN0H9TZQZZZ";
+    const refused = await ask(api.app, "PUT", MANAGED_ACCESS_PATH, local.secret, {
+      key: "egma_ik_sentinel-somebody-elses-Cc3Dd4",
+    });
+    expect(refused.statusCode).toBe(409);
+    expect(String(refused.body["message"])).toContain("Disconnect managed access");
+
+    // Disconnect deliberately, and the other organization's key is accepted.
+    expect(
+      (await ask(api.app, "DELETE", MANAGED_ACCESS_PATH, local.secret)).statusCode,
+    ).toBe(200);
+    expect(
+      (
+        await ask(api.app, "PUT", MANAGED_ACCESS_PATH, local.secret, {
+          key: "egma_ik_sentinel-somebody-elses-Cc3Dd4",
+        })
+      ).statusCode,
+    ).toBe(200);
+  });
+
+  it("is an admin's to connect and to disconnect", async () => {
+    api = await createApi("inference_keys_connect_admin", {
+      managedDeployment: SELF_HOSTED,
+      validateInferenceKey: async () => ({
+        outcome: "valid",
+        organizationId: "org_01K3XQ7M4E8YB2FVN0H9TZQWER",
+      }),
+    });
+    const ada = await signUp(api.app, "ada@lakeside.example", "Lakeside");
+    const grace = await colleagueOf(api.app, ada, "grace@lakeside.example", "member");
+
+    expect(
+      (
+        await ask(api.app, "PUT", MANAGED_ACCESS_PATH, grace.secret, {
+          key: "egma_ik_sentinel-not-mine-Ee5Ff6",
+        })
+      ).statusCode,
+    ).toBe(403);
+    expect(
+      (await ask(api.app, "DELETE", MANAGED_ACCESS_PATH, grace.secret)).statusCode,
+    ).toBe(403);
+  });
+
+  it("is not a thing hosted Egma does, because it connects nothing", async () => {
+    const { adminKey } = await hostedEgma("inference_keys_hosted_connects_nothing");
+
+    const answered = await ask(api.app, "PUT", MANAGED_ACCESS_PATH, adminKey, {
+      key: "egma_ik_sentinel-nothing-to-connect-Gg7Hh8",
+    });
+    expect(answered.statusCode).toBe(404);
+
+    const read = (await ask(api.app, "GET", MODEL_ACCESS_PATH, adminKey)).body;
+    expect(read["hosted"]).toBe(true);
+    // Available with nothing connected, because there is nothing to connect.
+    expect(read["managed_available"]).toBe(true);
+    expect((read["managed"] as Record<string, unknown>)["connected"]).toBe(false);
+  });
+});

--- a/apps/api/test/managed-model-access.test.ts
+++ b/apps/api/test/managed-model-access.test.ts
@@ -1,0 +1,646 @@
+import { newId } from "@egma/ids";
+import {
+  connectManagedAccess,
+  createPersona,
+  getSimulation,
+  RECOMMENDED_PERSONA_MODELS,
+  storeModelProviderCredential,
+  type ManagedDeployment,
+} from "@egma/db";
+import { specComplaints } from "@egma/simulation-contract";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+
+import { startLocalGateway, type LocalGateway } from "../../gateway/src/host/node.ts";
+import { makeLog } from "../../gateway/src/record.ts";
+import { startEgmaCloudDoor } from "../../gateway/test/support/egma-cloud.ts";
+import {
+  EGMA_PROVIDER_KEY,
+  startHttpUpstream,
+  startSocketUpstream,
+  type HttpUpstream,
+  type SocketUpstream,
+} from "../../gateway/test/support/upstreams.ts";
+import { INFERENCE_KEY_HEADER } from "../src/auth/inference-key.ts";
+import { CLAIMS_PATH } from "../src/routes/claims.ts";
+import { INFERENCE_KEYS_PATH } from "../src/routes/inference-keys.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  NEUTRAL_TRAITS,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * The four ways an organization can pay for its model traffic, each conducted
+ * for real.
+ *
+ * **hosted-managed, hosted-customer-owned, self-hosted-managed,
+ * self-hosted-customer-owned.** Deployment type must not change what the
+ * product can do, and neither must who supplies the credential — so all four
+ * are set up through the real product interfaces, claimed from the real claim
+ * door, and then *conducted*: the work order's own address and its own
+ * credential are used to talk to the providers exactly as the simulator's
+ * shipped adapters would.
+ *
+ * **The managed cells go through the real Egma model gateway application**,
+ * started in this process against strict local provider servers, with the real
+ * verifier — hosted Egma's signature checked on the spot, a self-hosted
+ * installation's inference key asked about at the real hosted validation route.
+ * The customer-owned cells call the same provider servers directly. What the
+ * provider servers saw is what settles the question that matters: under managed
+ * access they were shown *Egma's* credential and the work order carried none,
+ * and under customer-owned access they were shown the organization's own.
+ *
+ * Nothing here reaches around into a helper to make a work order. Every one is
+ * the document a simulator would have been handed.
+ */
+
+let api: TestApi;
+let gateway: LocalGateway | undefined;
+let openai: HttpUpstream | undefined;
+let deepgram: SocketUpstream | undefined;
+let cartesia: SocketUpstream | undefined;
+
+afterEach(async () => {
+  await api?.close();
+  await gateway?.stop();
+  await Promise.all([openai?.stop(), deepgram?.stop(), cartesia?.stop()]);
+  gateway = undefined;
+  openai = undefined;
+  deepgram = undefined;
+  cartesia = undefined;
+});
+
+/** Sentinels, so a leak anywhere is a string a scan can find. */
+const CUSTOMER_KEY = {
+  openai: "sk-sentinel-matrix-customer-openai-A1B2",
+  deepgram: "dg-sentinel-matrix-customer-deepgram-C3D4",
+  cartesia: "ct-sentinel-matrix-customer-cartesia-E5F6",
+} as const;
+
+const INTERNAL_KEY = "sentinel-matrix-internal-gateway-signing-G7H8";
+
+const RETELL_VOICE = {
+  type: "retell",
+  modality: "voice",
+  config: { retellAgentId: "agent_in_retell_1" },
+  credentials: { apiKey: "retell-sentinel-matrix-J9K0" },
+} as const;
+
+const RESCHEDULING = {
+  name: "Reschedules a booked appointment",
+  scenario:
+    "Their cleaning is booked for Thursday morning and has to move to any afternoon next week.",
+  expected_behaviors: ["confirms the new time back before finishing"],
+} as const;
+
+/**
+ * The three provider-shaped servers, and the real gateway in front of them.
+ *
+ * Started before the API, because the API has to be told the gateway's address
+ * and a deployment learns that at boot. The gateway is handed the provider
+ * homes so its fixed routes reach these servers instead of the real providers —
+ * deployment configuration, exactly as the shipped one takes it, and never
+ * anything a caller can name.
+ */
+async function standUpProviders(
+  validationUrl: string | undefined,
+): Promise<string> {
+  openai = await startHttpUpstream({
+    path: "/v1/chat/completions",
+    expectAuthorization: `Bearer ${EGMA_PROVIDER_KEY.openai}`,
+    chunks: ['{"choices":[{"message":{"content":"hello"}}]}'],
+  });
+  deepgram = await startSocketUpstream({
+    path: "/v1/listen",
+    expect: {
+      at: "header",
+      name: "authorization",
+      value: `Token ${EGMA_PROVIDER_KEY.deepgram}`,
+    },
+    echo: true,
+  });
+  cartesia = await startSocketUpstream({
+    path: "/tts/websocket",
+    expect: { at: "query", name: "api_key", value: EGMA_PROVIDER_KEY.cartesia },
+    echo: true,
+  });
+
+  gateway = await startLocalGateway(
+    {
+      EGMA_GATEWAY_INTERNAL_KEY: INTERNAL_KEY,
+      ...(validationUrl === undefined
+        ? {}
+        : { EGMA_GATEWAY_VALIDATION_URL: validationUrl }),
+      EGMA_GATEWAY_DEEPGRAM_KEY: EGMA_PROVIDER_KEY.deepgram,
+      EGMA_GATEWAY_OPENAI_KEY: EGMA_PROVIDER_KEY.openai,
+      EGMA_GATEWAY_CARTESIA_KEY: EGMA_PROVIDER_KEY.cartesia,
+      EGMA_GATEWAY_DEEPGRAM_HOME: deepgram.origin,
+      EGMA_GATEWAY_OPENAI_HOME: openai.origin,
+      EGMA_GATEWAY_CARTESIA_HOME: cartesia.origin,
+    },
+    { log: makeLog("ERROR", () => undefined) },
+  );
+  return gateway.origin;
+}
+
+/**
+ * Provider servers with no gateway in front of them, for the customer-owned
+ * cells: the organization's own key travels, and Egma is not on the path.
+ */
+async function standUpDirectProviders(): Promise<void> {
+  openai = await startHttpUpstream({
+    path: "/v1/chat/completions",
+    expectAuthorization: `Bearer ${CUSTOMER_KEY.openai}`,
+    chunks: ['{"choices":[{"message":{"content":"hello"}}]}'],
+  });
+  deepgram = await startSocketUpstream({
+    path: "/v1/listen",
+    expect: {
+      at: "header",
+      name: "authorization",
+      value: `Token ${CUSTOMER_KEY.deepgram}`,
+    },
+    echo: true,
+  });
+  cartesia = await startSocketUpstream({
+    path: "/tts/websocket",
+    expect: { at: "query", name: "api_key", value: CUSTOMER_KEY.cartesia },
+    echo: true,
+  });
+}
+
+type World = {
+  readonly ada: Customer;
+  readonly key: string;
+  readonly connectionId: string;
+  readonly versionId: string;
+  readonly serviceToken: string;
+};
+
+/** A customer with a voice agent, a persona that selected its models, and a test. */
+async function aCustomer(
+  label: string,
+  deployment: ManagedDeployment,
+  options: { readonly validateInferenceKey?: (key: string) => Promise<never> } = {},
+): Promise<World> {
+  api = await createApi(label, {
+    managedDeployment: deployment,
+    ...options,
+  });
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await ask(api.app, "POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: RETELL_VOICE,
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+
+  await createPersona(contextFor(ada, "member"), {
+    name: "Impatient Rita",
+    traits: NEUTRAL_TRAITS,
+    models: RECOMMENDED_PERSONA_MODELS,
+  });
+
+  const pushed = await ask(api.app, "POST", "/api/tests", key, {
+    ...RESCHEDULING,
+    personas: ["Impatient Rita"],
+  });
+  expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
+
+  return {
+    ada,
+    key,
+    connectionId: (registered.body.connection as { id: string }).id,
+    versionId: String(pushed.body.version_id),
+    serviceToken: api.config.simulatorServiceToken,
+  };
+}
+
+/** One work order, off the door the shipped simulator knocks on. */
+async function oneWorkOrder(world: World): Promise<Record<string, unknown>> {
+  const started = await ask(api.app, "POST", "/api/runs", world.key, {
+    connection: world.connectionId,
+    test_versions: [world.versionId],
+    idempotency_key: newId("run"),
+  });
+  expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+
+  const claimed = await api.app.inject({
+    method: "POST",
+    url: CLAIMS_PATH,
+    headers: { authorization: `Bearer ${world.serviceToken}` },
+    payload: {
+      claimant: "sim-1",
+      capacity: 1,
+      wait_seconds: 0,
+      contract_versions: [1, 2],
+    },
+  });
+  const specs = (claimed.json() as { specs?: Record<string, unknown>[] }).specs ?? [];
+  const [spec] = specs;
+  expect(spec, `no work order was claimed: ${claimed.body}`).toBeDefined();
+  return spec as Record<string, unknown>;
+}
+
+type Models = {
+  readonly access: string;
+  readonly gateway?: { readonly address: string; readonly credential: string };
+  readonly llm: { readonly provider: string; readonly model: string; readonly key?: string };
+  readonly stt: { readonly provider: string; readonly model: string; readonly key?: string };
+  readonly tts: { readonly provider: string; readonly model: string; readonly key?: string };
+};
+
+/**
+ * The three legs, conducted from the work order and from nothing else.
+ *
+ * This is the simulator's own arithmetic: under managed access each leg is told
+ * the gateway's route for its provider and handed the gateway's credential in
+ * the slot the shipped adapter puts a provider key in; under customer-owned
+ * access it reaches the provider's own address with the organization's key. The
+ * request is the same either way, which is the whole claim.
+ */
+async function conductEveryLeg(
+  models: Models,
+  direct: { readonly openai: string; readonly deepgram: string; readonly cartesia: string },
+): Promise<{ readonly thought: number }> {
+  const managed = models.gateway;
+
+  const chat = managed === undefined ? `${direct.openai}/v1` : `${managed.address}/openai/v1`;
+  const thinking = managed?.credential ?? models.llm.key;
+  const thought = await fetch(`${chat}/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${String(thinking)}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ model: models.llm.model, messages: [] }),
+  });
+
+  await listenAndSpeak(models, direct, managed);
+  return { thought: thought.status };
+}
+
+async function listenAndSpeak(
+  models: Models,
+  direct: { readonly deepgram: string; readonly cartesia: string },
+  managed: Models["gateway"],
+): Promise<void> {
+  const ears =
+    managed === undefined
+      ? `${direct.deepgram.replace(/^http/, "ws")}/v1/listen?model=${models.stt.model}`
+      : `${managed.address.replace(/^http/, "ws")}/deepgram/v1/listen?model=${models.stt.model}`;
+  await opened(
+    new WebSocket(ears, {
+      headers: {
+        authorization: `Token ${String(managed?.credential ?? models.stt.key)}`,
+      },
+    }),
+  );
+
+  const credential = String(managed?.credential ?? models.tts.key);
+  const mouth =
+    managed === undefined
+      ? `${direct.cartesia.replace(/^http/, "ws")}/tts/websocket?api_key=${credential}`
+      : `${managed.address.replace(/^http/, "ws")}/cartesia/tts/websocket?api_key=${credential}`;
+  await opened(new WebSocket(mouth));
+}
+
+function opened(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.on("open", () => {
+      socket.close(1000, "done");
+      resolve();
+    });
+    socket.on("error", reject);
+    socket.on(
+      "unexpected-response",
+      (_request: unknown, response: { statusCode?: number | undefined }) =>
+        reject(new Error(`the socket was refused with ${String(response.statusCode)}`)),
+    );
+  });
+}
+
+const HOSTED = (gatewayAddress: string): ManagedDeployment => ({
+  hosted: true,
+  gatewayAddress,
+  internalGatewayKey: INTERNAL_KEY,
+});
+
+const SELF_HOSTED = (gatewayAddress: string | undefined): ManagedDeployment => ({
+  hosted: false,
+  gatewayAddress,
+  internalGatewayKey: undefined,
+});
+
+async function storeTheThreeKeys(ada: Customer): Promise<void> {
+  const admin = contextFor(ada, "admin");
+  for (const [provider, key] of Object.entries(CUSTOMER_KEY)) {
+    await storeModelProviderCredential(admin, { provider, key });
+  }
+}
+
+describe("hosted Egma, managed by Egma", () => {
+  it("conducts every leg through the real gateway and carries no provider key", async () => {
+    const address = await standUpProviders(undefined);
+    const world = await aCustomer("matrix_hosted_managed", HOSTED(address));
+
+    const spec = await oneWorkOrder(world);
+    expect(specComplaints(spec)).toEqual([]);
+    const models = spec.models as Models;
+
+    expect(models.access).toBe("managed");
+    expect(models.gateway?.address).toBe(address);
+    expect(models.gateway?.credential.startsWith("egma_ig_")).toBe(true);
+    // Nothing to paste, and nothing was pasted: this organization connected no
+    // inference key and never will.
+    expect(models.llm.key).toBeUndefined();
+    expect(models.stt.key).toBeUndefined();
+    expect(models.tts.key).toBeUndefined();
+    // The selections are the pinned ones, untouched by who pays.
+    expect(models.llm.model).toBe(RECOMMENDED_PERSONA_MODELS.llm.model);
+    expect(models.stt.model).toBe(RECOMMENDED_PERSONA_MODELS.stt.model);
+
+    const conducted = await conductEveryLeg(models, {
+      openai: openai?.origin ?? "",
+      deepgram: deepgram?.origin ?? "",
+      cartesia: cartesia?.origin ?? "",
+    });
+    expect(conducted.thought).toBe(200);
+
+    // What the providers saw: Egma's own credentials, put on by the gateway,
+    // and never anything the work order carried.
+    expect(openai?.seen[0]?.headers["authorization"]).toBe(
+      `Bearer ${EGMA_PROVIDER_KEY.openai}`,
+    );
+    expect(deepgram?.seen[0]?.headers["authorization"]).toBe(
+      `Token ${EGMA_PROVIDER_KEY.deepgram}`,
+    );
+    expect(cartesia?.seen[0]?.query.get("api_key")).toBe(
+      EGMA_PROVIDER_KEY.cartesia,
+    );
+    // The gateway credential stopped at the gateway.
+    expect(JSON.stringify(openai?.seen)).not.toContain(
+      models.gateway?.credential,
+    );
+  });
+
+  it("starts a new project managed, so its seeded persona and grader need no setup", async () => {
+    const address = await standUpProviders(undefined);
+    const world = await aCustomer("matrix_hosted_defaults", HOSTED(address));
+
+    const read = await ask(api.app, "GET", "/api/model-access", world.key);
+    expect(read.body["mode"]).toBe("managed");
+    expect(read.body["managed_available"]).toBe(true);
+    // And nothing at all was configured to get there.
+    expect(read.body["credentials"]).toEqual([]);
+  });
+});
+
+describe("hosted Egma, customer-owned", () => {
+  it("calls the providers directly with the organization's own keys", async () => {
+    await standUpDirectProviders();
+    const world = await aCustomer(
+      "matrix_hosted_customer_owned",
+      SELF_HOSTED(undefined),
+    );
+    await storeTheThreeKeys(world.ada);
+    await ask(api.app, "PUT", "/api/model-access", world.key, {
+      mode: "customer-owned",
+    });
+
+    const spec = await oneWorkOrder(world);
+    expect(specComplaints(spec)).toEqual([]);
+    const models = spec.models as Models;
+
+    expect(models.access).toBe("customer-owned");
+    // No gateway address and no gateway credential: Egma is not on this path.
+    expect(models.gateway).toBeUndefined();
+    expect(models.llm.key).toBe(CUSTOMER_KEY.openai);
+
+    const conducted = await conductEveryLeg(models, {
+      openai: openai?.origin ?? "",
+      deepgram: deepgram?.origin ?? "",
+      cartesia: cartesia?.origin ?? "",
+    });
+    expect(conducted.thought).toBe(200);
+    expect(openai?.seen[0]?.headers["authorization"]).toBe(
+      `Bearer ${CUSTOMER_KEY.openai}`,
+    );
+  });
+});
+
+describe("a self-hosted deployment, managed by Egma", () => {
+  it("conducts every leg on the key it pasted, validated at the real hosted door", async () => {
+    /**
+     * The two deployments, one at a time, exactly as `inference-keys.test.ts`
+     * takes them: a process holds one database and one identity. The key is
+     * minted on the real hosted API and its real validation route answers the
+     * real question; the self-hosted instance then connects on that answer, and
+     * the *gateway* asks the same question again on every connection — of a
+     * door that answers with the same contract.
+     */
+    api = await createApi("matrix_self_hosted_cloud", {
+      managedDeployment: HOSTED("https://unused.example"),
+    });
+    const cloudAda = await signUp(api.app, "ada@egma.example", "Egma");
+    const secret = (
+      await ask(api.app, "POST", INFERENCE_KEYS_PATH, cloudAda.secret, {
+        name: "Lakeside self-hosted",
+      })
+    ).body["key"] as string;
+    const cloudOrganizationId = cloudAda.organizationId;
+    await api.close();
+
+    // A door speaking the validation contract, holding the key hosted Egma
+    // really minted. It is what the gateway asks on every connection.
+    const cloud = await startEgmaCloudDoor();
+    cloud.issue(secret, cloudOrganizationId, "ifk_01K3XQ7M4E8YB2FVN0H9TZQWER");
+
+    try {
+      const address = await standUpProviders(cloud.validationUrl);
+      const world = await aCustomer(
+        "matrix_self_hosted_managed",
+        SELF_HOSTED(address),
+      );
+
+      await connectManagedAccess(contextFor(world.ada, "admin"), {
+        key: secret,
+        cloudOrganizationId,
+      });
+      const chosen = await ask(api.app, "PUT", "/api/model-access", world.key, {
+        mode: "managed",
+      });
+      expect(chosen.statusCode).toBe(200);
+
+      const spec = await oneWorkOrder(world);
+      expect(specComplaints(spec)).toEqual([]);
+      const models = spec.models as Models;
+
+      expect(models.access).toBe("managed");
+      expect(models.gateway?.address).toBe(address);
+      // The pasted key itself, opened only here — never a per-simulation grant
+      // and never a provider credential.
+      expect(models.gateway?.credential).toBe(secret);
+      expect(models.llm.key).toBeUndefined();
+
+      const conducted = await conductEveryLeg(models, {
+        openai: openai?.origin ?? "",
+        deepgram: deepgram?.origin ?? "",
+        cartesia: cartesia?.origin ?? "",
+      });
+      expect(conducted.thought).toBe(200);
+      expect(openai?.seen[0]?.headers["authorization"]).toBe(
+        `Bearer ${EGMA_PROVIDER_KEY.openai}`,
+      );
+      // Asked once per connection, and content-free every time.
+      expect(cloud.asks.length).toBeGreaterThan(0);
+      for (const asked of cloud.asks) {
+        expect(asked.body).toBe("");
+        expect(asked.credential).toBe(secret);
+      }
+    } finally {
+      await cloud.stop();
+    }
+  });
+});
+
+describe("a self-hosted deployment, customer-owned", () => {
+  it("calls the providers directly and carries no gateway credential", async () => {
+    await standUpDirectProviders();
+    const world = await aCustomer(
+      "matrix_self_hosted_customer_owned",
+      SELF_HOSTED(undefined),
+    );
+    await storeTheThreeKeys(world.ada);
+
+    const spec = await oneWorkOrder(world);
+    expect(specComplaints(spec)).toEqual([]);
+    const models = spec.models as Models;
+
+    // Self-hosted starts here without anybody choosing, because nothing is
+    // connected to Egma's provider accounts and nothing may spend from them.
+    expect(models.access).toBe("customer-owned");
+    expect(models.gateway).toBeUndefined();
+
+    const conducted = await conductEveryLeg(models, {
+      openai: openai?.origin ?? "",
+      deepgram: deepgram?.origin ?? "",
+      cartesia: cartesia?.origin ?? "",
+    });
+    expect(conducted.thought).toBe(200);
+    expect(deepgram?.seen[0]?.headers["authorization"]).toBe(
+      `Token ${CUSTOMER_KEY.deepgram}`,
+    );
+  });
+});
+
+describe("when managed access cannot be prepared or cannot be used", () => {
+  it("stops the simulation with a reason and never a verdict, when nothing is connected", async () => {
+    const address = await standUpProviders(undefined);
+    const world = await aCustomer(
+      "matrix_managed_not_connected",
+      SELF_HOSTED(address),
+    );
+
+    // Connected, chosen, then disconnected: the mode stays, deliberately, so
+    // the next claim lands as a visible error naming what to reconnect.
+    await connectManagedAccess(contextFor(world.ada, "admin"), {
+      key: "egma_ik_sentinel-about-to-be-disconnected-L1M2",
+      cloudOrganizationId: newId("org"),
+    });
+    await ask(api.app, "PUT", "/api/model-access", world.key, { mode: "managed" });
+    await ask(api.app, "DELETE", "/api/managed-access", world.key);
+
+    const started = await ask(api.app, "POST", "/api/runs", world.key, {
+      connection: world.connectionId,
+      test_versions: [world.versionId],
+      idempotency_key: newId("run"),
+    });
+    const simulationId = (started.body.simulations as { id: string }[])[0]?.id;
+
+    const claimed = await api.app.inject({
+      method: "POST",
+      url: CLAIMS_PATH,
+      headers: { authorization: `Bearer ${world.serviceToken}` },
+      payload: { claimant: "sim-1", capacity: 1, wait_seconds: 0, contract_versions: [2] },
+    });
+    // Nothing is handed over: a work order with nowhere for the traffic to go
+    // must not reach a simulator that would fall back to a provider.
+    expect((claimed.json() as { specs: unknown[] }).specs).toEqual([]);
+
+    const landed = await getSimulation(
+      contextFor(world.ada, "member"),
+      String(simulationId),
+    );
+    // An infrastructure error, and the word says so: `dispatch_failed` is the
+    // platform's confession, never one of the ways a conversation ends badly
+    // and never a verdict about the agent.
+    expect(landed?.status).toBe("failed");
+    expect(landed?.endingReason).toBe("dispatch_failed");
+    expect(landed?.endingDetail).toContain("inference key");
+    // And the person reading it is sent somewhere they can actually fix it.
+    expect(landed?.endingRepair).toBe("model_providers");
+  });
+
+  it("refuses a revoked inference key at the gateway, on the very next connection", async () => {
+    const cloud = await startEgmaCloudDoor();
+    const key = "egma_ik_sentinel-matrix-revocable-N3P4";
+    cloud.issue(key, "org_01K3XQ7M4E8YB2FVN0H9TZQWER", "ifk_01K3XQ7M4E8YB2FVN0H9TZQWER");
+
+    try {
+      const address = await standUpProviders(cloud.validationUrl);
+
+      const asked = async (): Promise<number> =>
+        (
+          await fetch(`${address}/openai/v1/chat/completions`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              [INFERENCE_KEY_HEADER]: key,
+            },
+            body: JSON.stringify({ model: "m", messages: [] }),
+          })
+        ).status;
+
+      expect(await asked()).toBe(200);
+      cloud.revoke(key);
+      expect(await asked()).toBe(401);
+    } finally {
+      await cloud.stop();
+    }
+  });
+
+  it("says the gateway could not be reached, rather than blaming a key", async () => {
+    const cloud = await startEgmaCloudDoor();
+    cloud.goDown();
+
+    try {
+      const address = await standUpProviders(cloud.validationUrl);
+
+      const answered = await fetch(`${address}/openai/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [INFERENCE_KEY_HEADER]: "egma_ik_sentinel-matrix-fine-key-Q5R6",
+        },
+        body: JSON.stringify({ model: "m", messages: [] }),
+      });
+
+      expect(answered.status).toBe(503);
+      expect(
+        ((await answered.json()) as { error: { code: string } }).error.code,
+      ).toBe("gateway_authentication_unavailable");
+      // The provider was never asked, so nothing was spent on a connection
+      // nobody could authorize.
+      expect(openai?.attempts()).toBe(0);
+    } finally {
+      await cloud.stop();
+    }
+  });
+});

--- a/apps/api/test/managed-model-access.test.ts
+++ b/apps/api/test/managed-model-access.test.ts
@@ -3,6 +3,7 @@ import {
   connectManagedAccess,
   createPersona,
   getSimulation,
+  RECOMMENDED_GRADER_MODEL,
   RECOMMENDED_PERSONA_MODELS,
   storeModelProviderCredential,
   type ManagedDeployment,
@@ -13,6 +14,8 @@ import { WebSocket } from "ws";
 
 import { startLocalGateway, type LocalGateway } from "../../gateway/src/host/node.ts";
 import { makeLog } from "../../gateway/src/record.ts";
+import { judgesOnce, NoJudge } from "../../grader/src/judge/index.ts";
+import { scriptedJudge } from "../../grader/test/support/scripted-judge.ts";
 import { startEgmaCloudDoor } from "../../gateway/test/support/egma-cloud.ts";
 import {
   EGMA_PROVIDER_KEY,
@@ -253,7 +256,13 @@ type Models = {
   readonly gateway?: { readonly address: string; readonly credential: string };
   readonly llm: { readonly provider: string; readonly model: string; readonly key?: string };
   readonly stt: { readonly provider: string; readonly model: string; readonly key?: string };
-  readonly tts: { readonly provider: string; readonly model: string; readonly key?: string };
+  readonly tts: {
+    readonly provider: string;
+    readonly model: string;
+    readonly key?: string;
+    readonly voice_id: string;
+    readonly speed: number;
+  };
 };
 
 /**
@@ -390,15 +399,106 @@ describe("hosted Egma, managed by Egma", () => {
     );
   });
 
-  it("starts a new project managed, so its seeded persona and grader need no setup", async () => {
+  /**
+   * The zero-setup first run, from a project nobody has touched.
+   *
+   * **Nothing in this case authors a persona or a grader.** It signs up,
+   * registers an agent, writes one test naming nobody, and starts a run — so
+   * the persona and the grader that execute are the ones project creation
+   * seeded. That is the promise the whole effort is for, and it is the only
+   * case here that would still pass if every Models form were deleted.
+   */
+  it("completes a first run on its seeded persona and grader, with nothing configured", async () => {
     const address = await standUpProviders(undefined);
-    const world = await aCustomer("matrix_hosted_defaults", HOSTED(address));
+    api = await createApi("matrix_hosted_first_run", {
+      managedDeployment: HOSTED(address),
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
 
-    const read = await ask(api.app, "GET", "/api/model-access", world.key);
-    expect(read.body["mode"]).toBe("managed");
-    expect(read.body["managed_available"]).toBe(true);
-    // And nothing at all was configured to get there.
-    expect(read.body["credentials"]).toEqual([]);
+    // Managed by Egma before anybody opens a settings screen, and no
+    // credential stored anywhere.
+    const access = await ask(api.app, "GET", "/api/model-access", key);
+    expect(access.body["mode"]).toBe("managed");
+    expect(access.body["managed_available"]).toBe(true);
+    expect(access.body["credentials"]).toEqual([]);
+
+    const registered = await ask(api.app, "POST", "/api/agents", key, {
+      name: "Front desk",
+      connection: RETELL_VOICE,
+    });
+    expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+
+    // A test that names no persona, which is what makes the seeded one the
+    // one that runs.
+    const pushed = await ask(api.app, "POST", "/api/tests", key, RESCHEDULING);
+    expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
+
+    const spec = await oneWorkOrder({
+      ada,
+      key,
+      connectionId: (registered.body.connection as { id: string }).id,
+      versionId: String(pushed.body.version_id),
+      serviceToken: api.config.simulatorServiceToken,
+    });
+    expect(specComplaints(spec)).toEqual([]);
+    const models = spec.models as Models;
+
+    // The seeded persona chose for itself, so the work order carries its
+    // selections rather than falling back to deployment settings hosted Egma
+    // does not have.
+    expect(models.access).toBe("managed");
+    expect(models.gateway?.address).toBe(address);
+    expect(models.llm.provider).toBe(RECOMMENDED_PERSONA_MODELS.llm.provider);
+    expect(models.stt.model).toBe(RECOMMENDED_PERSONA_MODELS.stt.model);
+    expect(models.tts.voice_id).toBe(RECOMMENDED_PERSONA_MODELS.tts.voiceId);
+    expect(models.llm.key).toBeUndefined();
+
+    // And every leg of it really conducts, through the real gateway, on Egma's
+    // own provider accounts.
+    expect(
+      (
+        await conductEveryLeg(models, {
+          openai: openai?.origin ?? "",
+          deepgram: deepgram?.origin ?? "",
+          cartesia: cartesia?.origin ?? "",
+        })
+      ).thought,
+    ).toBe(200);
+    expect(openai?.seen[0]?.headers["authorization"]).toBe(
+      `Bearer ${EGMA_PROVIDER_KEY.openai}`,
+    );
+
+    // The seeded grader has chosen its judge model too, so a verdict needs no
+    // setup either — resolved through the engine's own door, which is the seam
+    // the grading service reaches it by. The maker is a recorder rather than a
+    // real provider: what is being asked here is which account and which
+    // address a seeded grader is pointed at, not what a model says.
+    const recorder = scriptedJudge({ answers: {} });
+    const judged = await judgesOnce({
+      userId: "engine",
+      organizationId: ada.organizationId,
+      projectId: ada.projectId,
+      role: "viewer",
+      via: "engine",
+    }).judgeFor(
+      { graderModel: RECOMMENDED_GRADER_MODEL, judgeModel: null },
+      recorder.makers,
+    );
+
+    expect(judged).not.toBeInstanceOf(NoJudge);
+    const asked = recorder.configured.at(-1) as {
+      provider: string;
+      model: string;
+      key: string;
+      endpoint: string;
+    };
+    expect(asked.provider).toBe(RECOMMENDED_GRADER_MODEL.provider);
+    expect(asked.model).toBe(RECOMMENDED_GRADER_MODEL.model);
+    // Egma's own signed credential and the gateway's route for it — never an
+    // organization credential, because none was ever stored.
+    expect(asked.key.startsWith("egma_ig_")).toBe(true);
+    expect(asked.endpoint).toBe(`${address}/openai/v1`);
   });
 });
 

--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -106,9 +106,15 @@ describe("the provider's footprint on the schema", () => {
     "grading_job",
     "grading_plan",
     "idempotent_operation",
+    // The two halves of one inference key: hosted Egma's hash of it, and a
+    // self-hosted deployment's sealed copy. Both are Egma's own, and the auth
+    // provider reaches neither.
+    "inference_key",
     "invitation",
     "judge_configuration",
     "judge_credential",
+    // A self-hosted deployment's sealed copy of the inference key it connected.
+    "managed_access_key",
     "membership",
     "mock_tool",
     "mock_tool_agent",

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -5,6 +5,7 @@ import {
   disconnectClickHouse,
   seedGraderLibrary,
   seedPlatformSettings,
+  type ManagedDeployment,
 } from "@egma/db";
 import type { FastifyInstance } from "fastify";
 
@@ -147,6 +148,22 @@ export type TestApiOptions = {
    * not read the log has no reason to collect one.
    */
   readonly logTo?: { write(line: string): void };
+  /**
+   * What kind of deployment this instance is, where its managed model traffic
+   * goes, and the key it signs its own gateway credentials with.
+   *
+   * Off by default, which is the ordinary self-hosted deployment with nothing
+   * connected. A test that is about managed access says which of the two
+   * deployments it is standing in, because that is the difference the whole
+   * area turns on.
+   */
+  readonly managedDeployment?: ManagedDeployment;
+  /**
+   * How this instance validates a pasted inference key. A test hands in one
+   * pointed at a real Egma Cloud of its own, so the self-hosted managed path is
+   * proved over a real door with no network.
+   */
+  readonly validateInferenceKey?: ServerOptions["validateInferenceKey"];
 };
 
 export function testConfig(overrides: Partial<Config> = {}): Config {
@@ -172,6 +189,11 @@ export async function createApi(
     databaseUrl: database.url,
     maxConnections: 4,
     encryptionKey: TEST_ENCRYPTION_KEY,
+    managedDeployment: options.managedDeployment ?? {
+      hosted: false,
+      gatewayAddress: undefined,
+      internalGatewayKey: undefined,
+    },
   });
 
   const traceStore =
@@ -232,6 +254,9 @@ export async function createApi(
     ...(options.retellReach === undefined
       ? {}
       : { retellReach: options.retellReach }),
+    ...(options.validateInferenceKey === undefined
+      ? {}
+      : { validateInferenceKey: options.validateInferenceKey }),
     // The production sweep's loop is never wanted in a route test: a suite that
     // wants one drives `runProductionSweep` itself, where it can say when a
     // tick happens instead of waiting for one.

--- a/apps/api/test/support/instance.ts
+++ b/apps/api/test/support/instance.ts
@@ -8,6 +8,7 @@ import {
   disconnect,
   disconnectClickHouse,
   seedGraderLibrary,
+  type ManagedDeployment,
 } from "@egma/db";
 import type { FastifyInstance } from "fastify";
 
@@ -94,6 +95,18 @@ export type InstanceOptions = {
    */
   readonly web?: boolean;
   /**
+   * How this instance validates a pasted inference key, and what kind of
+   * deployment it is.
+   *
+   * Absent is the ordinary self-hosted instance: nothing connected, and a
+   * paste that reaches the real Egma Cloud, which no test may do. A browser
+   * walk that drives the Connect Egma states hands one in, so the arc it
+   * clicks through is the real one — real routes, real Postgres, real sealing
+   * — with only the outbound ask standing in.
+   */
+  readonly validateInferenceKey?: ServerOptions["validateInferenceKey"];
+  readonly managedDeployment?: ManagedDeployment;
+  /**
    * The object store recordings are resolved against, where the caller has one
    * running. Absent by default, because most of what a browser does here has
    * nothing to do with audio — and because the one flow that does must skip
@@ -177,6 +190,11 @@ export async function startInstance(
     databaseUrl: database.url,
     maxConnections: 4,
     encryptionKey: TEST_ENCRYPTION_KEY,
+    managedDeployment: options.managedDeployment ?? {
+      hosted: false,
+      gatewayAddress: undefined,
+      internalGatewayKey: undefined,
+    },
   });
   connectClickHouse({ clickhouseUrl: traceStore.url, maxOpenConnections: 4 });
 
@@ -217,6 +235,9 @@ export async function startInstance(
     ...(options.deviceAuthorizationInterval === undefined
       ? {}
       : { deviceAuthorizationInterval: options.deviceAuthorizationInterval }),
+    ...(options.validateInferenceKey === undefined
+      ? {}
+      : { validateInferenceKey: options.validateInferenceKey }),
   });
   if (options.observeRequest !== undefined) {
     // `prependListener` puts this before Fastify's own request listener. A

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -41,9 +41,32 @@ different base address and nothing else:
 
 The gateway takes one credential per connection and asks one question of it:
 does this authorize a connection, and which organization is it. That question is
-answered by a **verifier**, which is a replaceable interface
-(`src/verify.ts`) — the shipped implementation compares one
-organization-scoped secret held in deployment configuration.
+answered by a **verifier**, which is a replaceable interface (`src/verify.ts`).
+Two shipped answers sit behind it, tried in that order:
+
+- an **internal gateway credential** — `egma_ig_<payload>.<signature>`, where
+  the payload names the organization and when the credential stops being good,
+  and the signature is made with a key only Egma's control plane and this
+  gateway hold. It is checked here, with no network and no store. The
+  organization travels *inside* the signature, which is what keeps it out of a
+  caller's hands: edit it and the signature stops matching, hold no signing key
+  and you cannot name an organization at all;
+- an **inference key** — an organization's own credential for managed model
+  access. The gateway keeps no key store and holds no copy of anybody's key: it
+  asks Egma Cloud, where the key was minted and hashed, whether it is still good
+  and whose it is. One small request when a connection opens, never per audio
+  frame.
+
+Two things follow from asking rather than caching, and both are promises this
+product makes. **Revocation is effective for the very next connection**, because
+there is nothing to wait out. And **no Cloudflare storage product is part of
+authentication at all**, so swapping one changes nothing here.
+
+The cost is honest: a connection cannot open while Egma Cloud is unreachable.
+That is answered `503 gateway_authentication_unavailable` rather than `401`,
+because a credential Egma could not look up is not a bad credential — and
+telling a customer to rotate a key that was fine would hide an Egma outage
+inside a sentence about their configuration.
 
 The credential may arrive in either of two places:
 
@@ -167,12 +190,20 @@ except where a default is written below.
 
 | Name | Secret | What it is |
 | --- | --- | --- |
-| `EGMA_GATEWAY_ORGANIZATION_SECRET` | **yes** | The organization-scoped credential the shipped verifier accepts |
-| `EGMA_GATEWAY_ORGANIZATION_ID` | no | The organization that credential stands for |
-| `EGMA_GATEWAY_INFERENCE_KEY_ID` | no | The identifier recorded against connections it opens |
 | `EGMA_GATEWAY_DEEPGRAM_KEY` | **yes** | Egma's Deepgram credential |
 | `EGMA_GATEWAY_OPENAI_KEY` | **yes** | Egma's OpenAI credential |
 | `EGMA_GATEWAY_CARTESIA_KEY` | **yes** | Egma's Cartesia credential |
+
+### Authentication
+
+Optional, each on its own, because a deployment may honestly hold only one of
+the two answers. Absent means that answer is not accepted from anybody.
+
+| Name | Secret | What it is |
+| --- | --- | --- |
+| `EGMA_GATEWAY_INTERNAL_KEY` | **yes** | The key hosted Egma signs its own gateway credentials with |
+| `EGMA_GATEWAY_VALIDATION_URL` | no | Where Egma Cloud answers whether an inference key is good and whose it is |
+| `EGMA_GATEWAY_VALIDATION_TIMEOUT_MS` | no | How long that one ask may take before the answer is "nobody knows". Default `5000` |
 
 ### Optional
 
@@ -195,6 +226,13 @@ The three `_HOME` names are **deployment configuration and never a caller's**.
 They exist so the deterministic suite can point a route at a strict local server
 standing in for a provider. A deployment reaching the real providers sets none
 of them.
+
+**The two authentication names are optional on their own, and neither is a
+default worth having.** A gateway with a signing key and no validation address
+serves hosted Egma alone; one with a validation address and no signing key
+serves self-hosted installations alone. A gateway with neither authenticates
+nobody — every connection is refused, and nothing is silently open. Egma's own
+deployment sets both.
 
 A missing required name stops the gateway at startup, in a sentence naming it.
 
@@ -236,9 +274,8 @@ production deployment.
 
 ```sh
 pnpm --filter @egma/gateway build
-EGMA_GATEWAY_ORGANIZATION_SECRET=… \
-EGMA_GATEWAY_ORGANIZATION_ID=org_… \
-EGMA_GATEWAY_INFERENCE_KEY_ID=… \
+EGMA_GATEWAY_INTERNAL_KEY=… \
+EGMA_GATEWAY_VALIDATION_URL=https://app.example/v1/inference-keys/validation \
 EGMA_GATEWAY_DEEPGRAM_KEY=… EGMA_GATEWAY_OPENAI_KEY=… EGMA_GATEWAY_CARTESIA_KEY=… \
 EGMA_GATEWAY_PORT=8787 \
 pnpm --filter @egma/gateway start

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -51,11 +51,18 @@ Two shipped answers sit behind it, tried in that order:
   organization travels *inside* the signature, which is what keeps it out of a
   caller's hands: edit it and the signature stops matching, hold no signing key
   and you cannot name an organization at all;
-- an **inference key** — an organization's own credential for managed model
-  access. The gateway keeps no key store and holds no copy of anybody's key: it
-  asks Egma Cloud, where the key was minted and hashed, whether it is still good
-  and whose it is. One small request when a connection opens, never per audio
-  frame.
+- an **inference key** — `egma_ik_…`, an organization's own credential for
+  managed model access. The gateway keeps no key store and holds no copy of
+  anybody's key: it asks Egma Cloud, where the key was minted and hashed,
+  whether it is still good and whose it is. One small request when a connection
+  opens, never per audio frame.
+
+**A credential that could not be an inference key is refused without Egma Cloud
+being asked.** A forged internal credential, an ordinary Egma product key
+(`egma_sk_…`), a provider key pasted into the wrong field — none is a value Egma
+Cloud could recognise. Asking would spend a round trip to be told so, would make
+every one of them read as "nobody could say" on a day Egma Cloud is down, and
+would turn the validation door into a free oracle for arbitrary strings.
 
 Two things follow from asking rather than caching, and both are promises this
 product makes. **Revocation is effective for the very next connection**, because

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -118,23 +118,41 @@ const DEFAULT_MAX_BUFFERED_BYTES = 4_194_304;
  */
 const DEFAULT_BUFFER_DRAIN_MS = 10_000;
 
+/**
+ * How long the one validation ask may take before the answer is "nobody knows".
+ *
+ * It happens once, when a connection opens, and a voice caller is already
+ * waiting on it — so it is short. Five seconds is far longer than a control
+ * plane takes to hash a string and read one row, and short enough that a
+ * simulator hearing nothing gets a clear infrastructure error rather than a
+ * hang.
+ */
+const DEFAULT_VALIDATION_TIMEOUT_MS = 5_000;
+
 export type Config = {
   /**
-   * The organization-scoped secret the preview verifier accepts, the
-   * organization it stands for, and the inference-key identifier recorded
-   * against it.
+   * The key hosted Egma signs its own gateway credentials with.
    *
-   * **This is the preview's whole authentication story and it is deliberately
-   * one secret.** Real inference keys — created, shown once, hashed, revoked —
-   * are stored work that belongs to the managed-access ticket that builds the
-   * store. What the gateway needs from that store is one answer: does this
-   * credential authorize a connection, and which organization is it. So the
-   * gateway takes a verifier, this is the verifier a preview deploys, and the
-   * store arrives later behind the same interface with nothing else changing.
+   * **Shared with the control plane and with nobody else.** It is what lets the
+   * gateway check, on its own and without asking anybody, that a connection
+   * claiming to act for an organization was really opened by Egma's own
+   * simulator or grading engine. It is never sent anywhere, never returned, and
+   * never appears in a credential — only a signature made with it does.
    */
-  readonly organizationSecret: string;
-  readonly organizationId: string;
-  readonly inferenceKeyId: string;
+  readonly internalCredentialKey: string | undefined;
+
+  /**
+   * Where Egma Cloud answers whether an inference key is good and whose it is.
+   *
+   * **The gateway keeps no key store, so it asks the one that does.** That is
+   * what makes revocation effective for the next connection — there is no cache
+   * to wait out — and what keeps this application uncoupled from any Cloudflare
+   * storage product. A connection cannot open while that door is unreachable,
+   * which the gateway says as an infrastructure error rather than as a refusal.
+   */
+  readonly validationUrl: string | undefined;
+  /** How long that one ask may take before the answer is "nobody knows". */
+  readonly validationTimeoutMs: number;
 
   /** Egma's own provider credentials, one per shipped provider. */
   readonly providerCredentials: Readonly<Record<Provider, string>>;
@@ -153,9 +171,6 @@ export type Config = {
 
 /** Every name a deployment must supply a value for. */
 export const REQUIRED_NAMES = [
-  "EGMA_GATEWAY_ORGANIZATION_SECRET",
-  "EGMA_GATEWAY_ORGANIZATION_ID",
-  "EGMA_GATEWAY_INFERENCE_KEY_ID",
   "EGMA_GATEWAY_DEEPGRAM_KEY",
   "EGMA_GATEWAY_OPENAI_KEY",
   "EGMA_GATEWAY_CARTESIA_KEY",
@@ -163,6 +178,19 @@ export const REQUIRED_NAMES = [
 
 /** Every name a deployment may supply, and which nothing breaks without. */
 export const OPTIONAL_NAMES = [
+  /**
+   * The two halves of authentication, and each is optional on its own because a
+   * deployment may honestly hold only one.
+   *
+   * A gateway with a signing key and no validation address serves hosted Egma
+   * alone; one with a validation address and no signing key serves self-hosted
+   * installations alone. A gateway with neither authenticates nobody, which is
+   * a strange thing to deploy and not a broken one — every connection is
+   * refused and nothing is silently open. Egma's own deployment sets both.
+   */
+  "EGMA_GATEWAY_INTERNAL_KEY",
+  "EGMA_GATEWAY_VALIDATION_URL",
+  "EGMA_GATEWAY_VALIDATION_TIMEOUT_MS",
   "EGMA_GATEWAY_DEEPGRAM_HOME",
   "EGMA_GATEWAY_OPENAI_HOME",
   "EGMA_GATEWAY_CARTESIA_HOME",
@@ -192,7 +220,7 @@ export const OPTIONAL_NAMES = [
  * and the record writer, which must never be handed one.
  */
 export const SECRET_NAMES = [
-  "EGMA_GATEWAY_ORGANIZATION_SECRET",
+  "EGMA_GATEWAY_INTERNAL_KEY",
   "EGMA_GATEWAY_DEEPGRAM_KEY",
   "EGMA_GATEWAY_OPENAI_KEY",
   "EGMA_GATEWAY_CARTESIA_KEY",
@@ -208,6 +236,38 @@ function required(environment: Environment, name: string): string {
     );
   }
   return value;
+}
+
+function optional(environment: Environment, name: string): string | undefined {
+  const value = environment[name]?.trim();
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/**
+ * Where Egma Cloud is asked about an inference key, checked at boot.
+ *
+ * Checked here rather than at first use, for the provider home's reason: a
+ * value that is not an address would otherwise be discovered by a connection
+ * that fails as "nobody could say whether your key is good", which reads as
+ * Egma Cloud being down.
+ */
+function validationUrl(environment: Environment): string | undefined {
+  const written = optional(environment, "EGMA_GATEWAY_VALIDATION_URL");
+  if (written === undefined) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(written);
+  } catch {
+    throw new ConfigurationFault(
+      `EGMA_GATEWAY_VALIDATION_URL must be an absolute address, and "${written}" is not`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ConfigurationFault(
+      `EGMA_GATEWAY_VALIDATION_URL must be an http or https address, and "${written}" is not`,
+    );
+  }
+  return written;
 }
 
 function positiveWholeNumber(
@@ -267,9 +327,13 @@ function logLevel(environment: Environment): LogLevel {
 
 export function loadConfig(environment: Environment): Config {
   const config: Config = {
-    organizationSecret: required(environment, "EGMA_GATEWAY_ORGANIZATION_SECRET"),
-    organizationId: required(environment, "EGMA_GATEWAY_ORGANIZATION_ID"),
-    inferenceKeyId: required(environment, "EGMA_GATEWAY_INFERENCE_KEY_ID"),
+    internalCredentialKey: optional(environment, "EGMA_GATEWAY_INTERNAL_KEY"),
+    validationUrl: validationUrl(environment),
+    validationTimeoutMs: positiveWholeNumber(
+      environment,
+      "EGMA_GATEWAY_VALIDATION_TIMEOUT_MS",
+      DEFAULT_VALIDATION_TIMEOUT_MS,
+    ),
     providerCredentials: {
       deepgram: required(environment, "EGMA_GATEWAY_DEEPGRAM_KEY"),
       openai: required(environment, "EGMA_GATEWAY_OPENAI_KEY"),

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -262,12 +262,30 @@ function validationUrl(environment: Environment): string | undefined {
       `EGMA_GATEWAY_VALIDATION_URL must be an absolute address, and "${written}" is not`,
     );
   }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new ConfigurationFault(
-      `EGMA_GATEWAY_VALIDATION_URL must be an http or https address, and "${written}" is not`,
-    );
-  }
-  return written;
+  /**
+   * **`https:` unless it is loopback**, and both halves are deliberate.
+   *
+   * The credential a caller presented travels to this address on every
+   * connection open. A plain-text address puts every customer's inference key
+   * on the wire for anybody on the path — and a deployment that fell back to
+   * `http:` by a typo would leak them silently rather than fail. Loopback is
+   * carved out because the deterministic suite stands a real Egma Cloud on
+   * `127.0.0.1` over real sockets, and a test that needed a certificate to
+   * prove a verifier would be proving TLS setup instead.
+   */
+  if (parsed.protocol === "https:") return written;
+  // Anchored at both ends: a prefix test on `127.` would call
+  // `127.0.0.1.attacker.example` loopback, and a host somebody else controls
+  // would become a legal plain-text destination for every customer's key.
+  const bare = parsed.hostname.replace(/^\[|\]$/g, "");
+  const loopback =
+    bare === "localhost" ||
+    bare === "::1" ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(bare);
+  if (parsed.protocol === "http:" && loopback) return written;
+  throw new ConfigurationFault(
+    `EGMA_GATEWAY_VALIDATION_URL must be an https address — every customer's inference key travels to it — and "${written}" is not. Only a loopback address may be http:, which is what the deterministic suite uses.`,
+  );
 }
 
 function positiveWholeNumber(

--- a/apps/gateway/src/gateway.ts
+++ b/apps/gateway/src/gateway.ts
@@ -183,6 +183,24 @@ export async function handle(request: Request, host: GatewayHost): Promise<Respo
 
   const verified = await host.verifier.verify(offeredCredential(url, request.headers, route));
   if (!isAuthenticated(verified)) {
+    /**
+     * Three answers rather than two, and the third is the one worth having.
+     *
+     * A credential Egma could not look up is not a bad credential. Answering
+     * 401 when the store is unreachable would send a customer to rotate a key
+     * that was fine, and would hide an Egma outage inside a sentence about
+     * their configuration. So "nobody could say" is a 503 with its own word on
+     * it, and only a store that answered gets to refuse anybody.
+     */
+    if (verified.refused === "unavailable") {
+      write("authentication-unavailable", { provider: route.provider, job: route.job });
+      return refusalResponse({
+        status: 503,
+        code: "gateway_authentication_unavailable",
+        message:
+          "the Egma model gateway could not reach Egma Cloud to check this inference credential, so it does not know whether it is good",
+      });
+    }
     write("refused", { provider: route.provider, job: route.job });
     return refusalResponse({
       status: 401,

--- a/apps/gateway/src/host/node.ts
+++ b/apps/gateway/src/host/node.ts
@@ -12,7 +12,7 @@ import {
   type SocketHost,
   UpstreamHandshakeRefused,
 } from "../socket.ts";
-import { staticSecretVerifier } from "../verify.ts";
+import { deployedVerifier } from "../verify.ts";
 
 /**
  * The local host: the same application, on a developer's machine.
@@ -147,7 +147,7 @@ export function startLocalGateway(
 ): Promise<LocalGateway> {
   const config = loadConfig(environment);
   const log = overrides.log ?? makeLog(config.logLevel);
-  const verifier = overrides.verifier ?? staticSecretVerifier(config);
+  const verifier = overrides.verifier ?? deployedVerifier(config);
   const port = Number(environment["EGMA_GATEWAY_PORT"] ?? 0);
 
   const origin = (): string => `http://127.0.0.1:${(server.address() as { port: number }).port}`;

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -38,6 +38,7 @@ export {
   cloudInferenceKeyVerifier,
   deployedVerifier,
   eitherVerifier,
+  INFERENCE_KEY_PREFIX,
   internalCredentialVerifier,
   INTERNAL_CREDENTIAL_ID,
   INTERNAL_CREDENTIAL_PREFIX,

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -35,8 +35,13 @@ export { HEALTH_PATH, matchRoute, type Route, ROUTES, type Transport } from "./r
 export { type Duplex, type SocketHost, UpstreamHandshakeRefused } from "./socket.ts";
 export {
   type Authenticated,
+  cloudInferenceKeyVerifier,
+  deployedVerifier,
+  eitherVerifier,
+  internalCredentialVerifier,
+  INTERNAL_CREDENTIAL_ID,
+  INTERNAL_CREDENTIAL_PREFIX,
   isAuthenticated,
-  staticSecretVerifier,
   type Verified,
   type Verifier,
 } from "./verify.ts";

--- a/apps/gateway/src/record.ts
+++ b/apps/gateway/src/record.ts
@@ -44,6 +44,16 @@ export const STATUS_CLASSES = [
   "timed-out",
   /** The provider could not be reached at all. */
   "unreachable",
+  /**
+   * Egma Cloud could not be asked whether the credential is good, so this
+   * connection was neither authorized nor refused.
+   *
+   * Its own class rather than folded into `refused`, for the reason the 503 is
+   * its own answer: a reader counting refusals is counting customers with a
+   * configuration problem, and an outage of Egma's own would otherwise arrive
+   * in that number and look like a hundred people mistyping a key at once.
+   */
+  "authentication-unavailable",
 ] as const;
 export type StatusClass = (typeof STATUS_CLASSES)[number];
 

--- a/apps/gateway/src/verify.ts
+++ b/apps/gateway/src/verify.ts
@@ -5,10 +5,11 @@ import type { Config } from "./config.ts";
  *
  * **The gateway asks one question and takes one answer: does this credential
  * authorize a connection, and which organization is it.** Everything about how
- * that answer is reached — a static secret today, a hashed inference key in a
- * store tomorrow, a signed service assertion for hosted egma beside it — sits
+ * that answer is reached — a signature this deployment can check without asking
+ * anybody, a hashed inference key that only Egma Cloud can recognise — sits
  * behind this interface, which is what keeps the public application from being
- * coupled to one Cloudflare storage product.
+ * coupled to any one Cloudflare storage product. It is coupled to none: the
+ * gateway stores no keys at all.
  *
  * The answer names the organization. **Nothing else in the gateway may.** A
  * header, a query value, a path or a body can no more change it than they can
@@ -27,8 +28,19 @@ export type Authenticated = {
   readonly inferenceKeyId: string;
 };
 
-/** Why a credential did not authorize a connection. Never the credential itself. */
-export type Refusal = { readonly refused: "absent" | "not-recognized" };
+/**
+ * Why a credential did not authorize a connection. Never the credential itself.
+ *
+ * **`unavailable` is a third answer rather than a kind of refusal, and keeping
+ * it apart is the point.** A gateway that cannot reach the store where keys
+ * live knows nothing about the credential it was handed — and telling a
+ * customer their key is invalid because Egma could not look it up sends them to
+ * rotate a key that was fine. One is a 401 and something to fix; the other is a
+ * 503 and something to wait out.
+ */
+export type Refusal = {
+  readonly refused: "absent" | "not-recognized" | "unavailable";
+};
 
 export type Verified = Authenticated | Refusal;
 
@@ -66,27 +78,235 @@ function sameSecret(offered: string, expected: string): boolean {
 }
 
 /**
- * The verifier a preview deploys: one organization-scoped secret, held in the
- * deployment's own secret store and compared against what the caller offered.
+ * The static prefix an internal gateway credential starts with.
  *
- * **It stores nothing and issues nothing.** Creating, showing, hashing and
- * revoking inference keys is the store the managed-access work builds later,
- * and building half of it here would be a second place keys live. What this
- * proves is the shape: the gateway authenticates per connection, derives the
- * organization from the credential and from nowhere else, and refuses without
- * saying anything about what it holds.
+ * Written here and in the control plane's own `managed-deployment.ts`, which is
+ * the one duplication in this format and an unavoidable one: the two halves are
+ * two deployables, one of which runs on Cloudflare Workers and cannot import a
+ * package that speaks to Postgres. The deterministic suite mints with one and
+ * checks with the other, which is what keeps the two spellings honest.
  */
-export function staticSecretVerifier(config: Config): Verifier {
+export const INTERNAL_CREDENTIAL_PREFIX = "egma_ig_";
+
+/** The identifier an internal credential is recorded under. Never a key. */
+export const INTERNAL_CREDENTIAL_ID = "egma-internal";
+
+function base64urlToBytes(value: string): Uint8Array | null {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  try {
+    const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+    const bytes = new Uint8Array(binary.length);
+    for (let at = 0; at < binary.length; at += 1) bytes[at] = binary.charCodeAt(at);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+function bytesToBase64url(bytes: ArrayBuffer): string {
+  let binary = "";
+  for (const byte of new Uint8Array(bytes)) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Hosted Egma's own credential: **the organization, and a signature over it
+ * made with a key only the control plane and this gateway hold.**
+ *
+ * `egma_ig_<payload>.<signature>`, where the payload names the organization and
+ * the second the credential stops being good.
+ *
+ * **The organization travels inside the signature, which is what keeps it out
+ * of a caller's hands.** The rule the whole design rests on is that no header,
+ * query value, path or body may say which organization a connection acts for.
+ * This does not bend it: what a caller presents is one opaque credential, and
+ * an organization is read out of it only after the signature has proved this
+ * deployment wrote it. Edit the organization and the signature stops matching;
+ * hold no signing key and there is no organization you can name at all.
+ *
+ * **Nothing is exchanged and nothing is stored.** There is no round trip to get
+ * one and no row per organization to keep — which is exactly why a hosted user
+ * pastes nothing, and why this is not a per-simulation grant: it authenticates
+ * the connection and hands back no provider credential, because it has none.
+ */
+export function internalCredentialVerifier(config: Config): Verifier {
   return {
     async verify(credential: string | null): Promise<Verified> {
       if (credential === null || credential === "") return { refused: "absent" };
-      if (!sameSecret(credential, config.organizationSecret)) {
+      if (!credential.startsWith(INTERNAL_CREDENTIAL_PREFIX)) {
         return { refused: "not-recognized" };
       }
-      return {
-        organizationId: config.organizationId,
-        inferenceKeyId: config.inferenceKeyId,
-      };
+      const secret = config.internalCredentialKey;
+      if (secret === undefined) return { refused: "not-recognized" };
+
+      const [encoded, signature] = credential
+        .slice(INTERNAL_CREDENTIAL_PREFIX.length)
+        .split(".");
+      if (encoded === undefined || signature === undefined) {
+        return { refused: "not-recognized" };
+      }
+
+      const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const expected = bytesToBase64url(
+        await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(encoded)),
+      );
+      if (!sameSecret(signature, expected)) return { refused: "not-recognized" };
+
+      const bytes = base64urlToBytes(encoded);
+      if (bytes === null) return { refused: "not-recognized" };
+      let payload: unknown;
+      try {
+        payload = JSON.parse(new TextDecoder().decode(bytes));
+      } catch {
+        return { refused: "not-recognized" };
+      }
+      if (typeof payload !== "object" || payload === null) {
+        return { refused: "not-recognized" };
+      }
+
+      const said = payload as Record<string, unknown>;
+      const organizationId = said["o"];
+      const expires = said["x"];
+      if (typeof organizationId !== "string" || organizationId === "") {
+        return { refused: "not-recognized" };
+      }
+      // Expiry is checked *after* the signature, deliberately: a caller must not
+      // be able to learn anything about the shape of a payload they could not
+      // have signed.
+      if (typeof expires !== "number" || expires * 1000 <= Date.now()) {
+        return { refused: "not-recognized" };
+      }
+
+      return { organizationId, inferenceKeyId: INTERNAL_CREDENTIAL_ID };
     },
   };
+}
+
+/** What Egma Cloud answers when it recognises an inference key. */
+type Validated = {
+  readonly organization_id?: unknown;
+  readonly inference_key_id?: unknown;
+};
+
+/**
+ * A real inference key, validated where inference keys actually live.
+ *
+ * **The gateway keeps no key store, and this is the decision that says so.**
+ * Egma Cloud minted the key, hashed it and holds its lifecycle, so Egma Cloud
+ * is asked whether it is still good — one small request when a connection
+ * opens, never per audio frame. Two things fall out of that and both are
+ * promises this product makes. There is no cache, so **revocation is effective
+ * for the very next connection**. And there is no copy of anybody's key in
+ * Cloudflare, so no Cloudflare storage product is part of the authentication
+ * story and swapping one changes nothing here.
+ *
+ * The cost is honest and worth writing down: a connection cannot open while
+ * Egma Cloud is unreachable. That is answered as `unavailable` rather than as a
+ * refusal, so a customer is told to wait rather than told their key is bad.
+ */
+export function cloudInferenceKeyVerifier(
+  config: Config,
+  /** Injected so a test can drive the real verifier against a real local door. */
+  request: typeof fetch = fetch,
+): Verifier {
+  return {
+    async verify(credential: string | null): Promise<Verified> {
+      if (credential === null || credential === "") return { refused: "absent" };
+      const where = config.validationUrl;
+      if (where === undefined) return { refused: "unavailable" };
+
+      let answer: Response;
+      try {
+        answer = await request(where, {
+          method: "POST",
+          headers: {
+            // The credential travels in the same header it arrived in, so there
+            // is exactly one name for it on both sides of Egma.
+            "egma-inference-key": credential,
+            // No body at all: validation is content-free. Egma Cloud is asked
+            // whether a credential is good and whose it is, and is told nothing
+            // about the simulation, the persona or the model behind the ask.
+            "content-length": "0",
+          },
+          signal: AbortSignal.timeout(config.validationTimeoutMs),
+        });
+      } catch {
+        return { refused: "unavailable" };
+      }
+
+      if (answer.status === 401 || answer.status === 403) {
+        return { refused: "not-recognized" };
+      }
+      if (!answer.ok) return { refused: "unavailable" };
+
+      let said: Validated;
+      try {
+        said = (await answer.json()) as Validated;
+      } catch {
+        return { refused: "unavailable" };
+      }
+
+      const organizationId = said.organization_id;
+      const inferenceKeyId = said.inference_key_id;
+      if (
+        typeof organizationId !== "string" ||
+        organizationId === "" ||
+        typeof inferenceKeyId !== "string" ||
+        inferenceKeyId === ""
+      ) {
+        return { refused: "unavailable" };
+      }
+      return { organizationId, inferenceKeyId };
+    },
+  };
+}
+
+/**
+ * The two authentication stories, asked in order, as one verifier.
+ *
+ * **Cheapest and most certain first.** An internal credential is a signature
+ * this deployment can check on its own, so it costs nothing and cannot be
+ * confused with anything else — its prefix says what it is. Anything that is
+ * not one is an inference key, and that is the ask that leaves the isolate.
+ *
+ * `unavailable` outranks `not-recognized` in the composed answer, for the
+ * reason it exists at all: if any verifier could not find out, the honest
+ * answer about the credential is that nobody knows.
+ */
+export function eitherVerifier(verifiers: readonly Verifier[]): Verifier {
+  return {
+    async verify(credential: string | null): Promise<Verified> {
+      let worst: Refusal = { refused: "absent" };
+      for (const verifier of verifiers) {
+        const verified = await verifier.verify(credential);
+        if (isAuthenticated(verified)) return verified;
+        if (verified.refused === "unavailable") worst = verified;
+        else if (worst.refused === "absent") worst = verified;
+      }
+      return worst;
+    },
+  };
+}
+
+/**
+ * The verifier a deployment runs: hosted Egma's own signed credentials, and
+ * every organization's inference keys.
+ *
+ * One function rather than a choice each host makes, because both hosts run one
+ * gateway and a difference between them would be a difference nobody tests.
+ */
+export function deployedVerifier(
+  config: Config,
+  request: typeof fetch = fetch,
+): Verifier {
+  return eitherVerifier([
+    internalCredentialVerifier(config),
+    cloudInferenceKeyVerifier(config, request),
+  ]);
 }

--- a/apps/gateway/src/verify.ts
+++ b/apps/gateway/src/verify.ts
@@ -88,6 +88,19 @@ function sameSecret(offered: string, expected: string): boolean {
  */
 export const INTERNAL_CREDENTIAL_PREFIX = "egma_ig_";
 
+/**
+ * The static prefix every inference key starts with.
+ *
+ * Here for a sharper reason than tidiness: **the gateway does not ask Egma
+ * Cloud about a value that could not be an inference key.** A forged internal
+ * credential, an ordinary Egma product key, a provider key somebody pasted into
+ * the wrong field — none of those is a key Egma Cloud could recognise, and
+ * asking about them would spend a round trip to be told so, would make every
+ * one of them read as "nobody could say" whenever Egma Cloud is down, and would
+ * turn the validation door into a free oracle for arbitrary strings.
+ */
+export const INFERENCE_KEY_PREFIX = "egma_ik_";
+
 /** The identifier an internal credential is recorded under. Never a key. */
 export const INTERNAL_CREDENTIAL_ID = "egma-internal";
 
@@ -218,6 +231,13 @@ export function cloudInferenceKeyVerifier(
   return {
     async verify(credential: string | null): Promise<Verified> {
       if (credential === null || credential === "") return { refused: "absent" };
+      // Refused here rather than asked about. See `INFERENCE_KEY_PREFIX`: a
+      // value that is not shaped like an inference key is one Egma Cloud could
+      // not recognise, and a refusal is both the honest answer and the cheap
+      // one — it stays right when Egma Cloud is unreachable.
+      if (!credential.startsWith(INFERENCE_KEY_PREFIX)) {
+        return { refused: "not-recognized" };
+      }
       const where = config.validationUrl;
       if (where === undefined) return { refused: "unavailable" };
 

--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -7,7 +7,7 @@ import {
   type SocketHost,
   UpstreamHandshakeRefused,
 } from "./socket.ts";
-import { staticSecretVerifier } from "./verify.ts";
+import { deployedVerifier } from "./verify.ts";
 
 /**
  * The deployed host: the Egma model gateway as a Cloudflare Worker.
@@ -143,7 +143,7 @@ export default {
     const build = env.EGMA_GATEWAY_VERSION;
     return handle(request, {
       config,
-      verifier: staticSecretVerifier(config),
+      verifier: deployedVerifier(config),
       log: makeLog(config.logLevel),
       socketHostFor: () => socketHostFor(),
       waitUntil: (work) => ctx.waitUntil(work),

--- a/apps/gateway/test/authentication.test.ts
+++ b/apps/gateway/test/authentication.test.ts
@@ -502,12 +502,6 @@ describe("an inference key", () => {
     }
   });
 
-  it("refuses an ordinary Egma product key, because a product key is not one of these", async () => {
-    // Never issued in Egma Cloud's inference-key store, because a product key
-    // lives in a different table entirely. The gateway learns that by asking.
-    const productKey = "egma_sk_sentinel-a-product-key-not-an-inference-one";
-    expect((await ask({ "egma-inference-key": productKey })).status).toBe(401);
-  });
 });
 
 describe("an Egma Cloud that cannot be reached", () => {
@@ -563,6 +557,52 @@ describe("an Egma Cloud that cannot be reached", () => {
       );
 
       expect(answered.status).toBe(200);
+    } finally {
+      await world.world.stop();
+    }
+  });
+});
+
+describe("a credential that could not be an inference key", () => {
+  it("is refused without Egma Cloud being asked about it at all", async () => {
+    const before = standing.cloud.asks.length;
+
+    for (const offered of [
+      // An internal credential whose signature does not hold. It is
+      // unambiguously one of ours and unambiguously wrong; nobody else could
+      // settle that.
+      `${INTERNAL_CREDENTIAL_PREFIX}bm90LWEtcGF5bG9hZA.bm90LWEtc2lnbmF0dXJl`,
+      // An ordinary Egma product key. It lives in a different table entirely.
+      "egma_sk_sentinel-a-product-key-not-an-inference-one",
+      // A provider key somebody pasted into the wrong field.
+      "sk-sentinel-a-provider-key-in-the-wrong-slot",
+    ]) {
+      expect((await ask({ "egma-inference-key": offered })).status, offered).toBe(401);
+    }
+
+    // Not one round trip spent, and — the reason that matters — not one of
+    // these reads as "nobody could say" on a day Egma Cloud is down.
+    expect(standing.cloud.asks.length).toBe(before);
+  });
+
+  it("stays refused while Egma Cloud is unreachable, because nothing was in doubt", async () => {
+    const world = await standUp();
+    try {
+      world.cloud.goDown();
+
+      const answered = await fetch(
+        `${world.world.origin}/openai/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "egma-inference-key": "egma_sk_sentinel-a-product-key-Zz9Yy8",
+          },
+          body: JSON.stringify({ model: "m", messages: [] }),
+        },
+      );
+
+      expect(answered.status).toBe(401);
     } finally {
       await world.world.stop();
     }

--- a/apps/gateway/test/authentication.test.ts
+++ b/apps/gateway/test/authentication.test.ts
@@ -342,39 +342,42 @@ describe("the organization a connection acts in", () => {
 
 describe("a credential that stops being good", () => {
   /**
-   * The static verifier a preview deploys cannot revoke, so this is proved with
-   * one of the test's own — which is the point of there being a verifier seam
-   * at all. The store that arrives with real inference keys plugs in here and
-   * this behavior comes with it.
+   * Revocation on the WebSocket transport, against the **real** verifier and a
+   * real revocation.
+   *
+   * The HTTP case one describe down proves the same rule on the same door; this
+   * is the transport where getting it wrong would be invisible, because a
+   * socket that authenticated once could plausibly never be asked again. So the
+   * key is really issued in the Egma Cloud stand-in and really revoked there,
+   * and what is observed is that the connection already open is untouched and
+   * the next one is refused.
    */
   it("keeps an open connection and refuses the next one", async () => {
-    let live = true;
-    const revocable: Verifier = {
-      verify: async (credential): Promise<Verified> =>
-        credential === GATEWAY_SECRET && live
-          ? { organizationId: ORGANIZATION, inferenceKeyId: INFERENCE_KEY_ID }
-          : { refused: "not-recognized" },
-    };
-    const world = await standUp({ verifier: revocable });
+    const world = await standUp();
+    const retired = "egma_ik_sentinel-revocable-on-a-socket-Tt5Uu6";
+    world.cloud.issue(retired, ORGANIZATION, INFERENCE_KEY_ID);
     try {
       const socket = openSocket(world.world, "/deepgram/v1/listen", {
-        headers: { "egma-inference-key": GATEWAY_SECRET },
+        headers: { "egma-inference-key": retired },
       });
       const seen = watch(socket);
       await seen.opened;
 
-      live = false;
+      world.cloud.revoke(retired);
 
       // The open one is untouched: authentication happened when it opened, and
-      // an audio frame does not re-ask.
+      // an audio frame does not re-ask. Nothing was asked of Egma Cloud for
+      // this frame either, which is the same claim from the other side.
+      const askedBefore = world.cloud.asks.length;
       socket.send("still-listening");
       const provider = await world.deepgram.opened();
       await eventually(() => (provider.frames.length > 0 ? provider.frames : undefined));
       expect(provider.frames).toContain("still-listening");
+      expect(world.cloud.asks.length).toBe(askedBefore);
 
-      // The next one is refused.
+      // The next one is refused, with no cache to wait out.
       const again = openSocket(world.world, "/deepgram/v1/listen", {
-        headers: { "egma-inference-key": GATEWAY_SECRET },
+        headers: { "egma-inference-key": retired },
       });
       await expect(watch(again).opened).rejects.toThrow(/401/);
 

--- a/apps/gateway/test/authentication.test.ts
+++ b/apps/gateway/test/authentication.test.ts
@@ -1,12 +1,19 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { isAuthenticated, type Verified, type Verifier } from "../src/verify.ts";
+import {
+  INTERNAL_CREDENTIAL_ID,
+  INTERNAL_CREDENTIAL_PREFIX,
+  isAuthenticated,
+  type Verified,
+  type Verifier,
+} from "../src/verify.ts";
 import {
   CALLER_PROVIDER_KEY,
   EGMA_PROVIDER_KEY,
   eventually,
   GATEWAY_SECRET,
   INFERENCE_KEY_ID,
+  INTERNAL_KEY,
   openSocket,
   ORGANIZATION,
   records,
@@ -38,6 +45,49 @@ beforeAll(async () => {
 afterAll(async () => {
   await standing.world.stop();
 });
+
+/**
+ * One internal gateway credential, minted the way the control plane mints one.
+ *
+ * Written out here rather than imported from the control plane on purpose: this
+ * format is the one thing the two deployables have to agree about across a
+ * boundary that cannot be crossed by an import — the gateway runs on Cloudflare
+ * Workers and cannot load a package that speaks to Postgres. So one side mints
+ * and the other checks, and the deterministic suite is where they meet.
+ */
+async function internalCredential(
+  organizationId: string,
+  livesForSeconds = 3600,
+): Promise<string> {
+  const payload = btoa(
+    JSON.stringify({
+      o: organizationId,
+      x: Math.floor(Date.now() / 1000) + livesForSeconds,
+    }),
+  )
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(INTERNAL_KEY),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signed = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  let binary = "";
+  for (const byte of new Uint8Array(signed)) binary += String.fromCharCode(byte);
+  const signature = binary === "" ? "" : btoa(binary);
+  return `${INTERNAL_CREDENTIAL_PREFIX}${payload}.${signature
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")}`;
+}
 
 /** One relayed LLM request, with whatever authentication the test wants to try. */
 async function ask(
@@ -348,5 +398,173 @@ describe("a credential that stops being good", () => {
     const bad = await verifier.verify("bad");
     expect(isAuthenticated(bad)).toBe(false);
     expect(JSON.stringify(bad)).not.toContain("bad");
+  });
+});
+
+/**
+ * The two shipped answers, driven the way a simulator and a grader drive them:
+ * real credentials over real sockets, against the real Egma Cloud door on
+ * loopback. Nothing here hands the gateway a verifier of its own — that seam is
+ * exercised above, and what is left to prove is that the answers a deployment
+ * actually runs behave the way the product promises.
+ */
+describe("hosted Egma's own credential", () => {
+  it("opens a connection without asking Egma Cloud anything at all", async () => {
+    const before = standing.cloud.asks.length;
+
+    const answered = await ask({
+      "egma-inference-key": await internalCredential(ORGANIZATION),
+    });
+
+    expect(answered.status).toBe(200);
+    // The whole point of signing rather than storing: hosted managed traffic
+    // pays no round trip, and Egma Cloud never hears about it.
+    expect(standing.cloud.asks.length).toBe(before);
+  });
+
+  it("acts for the organization inside its signature and for no other", async () => {
+    const another = "org_01K3XQ7M4E8YB2FVN0H9TZQZZZ";
+    const answered = await ask({
+      "egma-inference-key": await internalCredential(another),
+    });
+    expect(answered.status).toBe(200);
+
+    const filed = await eventually(() =>
+      records(standing.world)
+        .reverse()
+        .find((line) => line["organizationId"] === another),
+    );
+    expect(filed["inferenceKeyId"]).toBe(INTERNAL_CREDENTIAL_ID);
+  });
+
+  it("is refused once its own signature is edited", async () => {
+    const credential = await internalCredential(ORGANIZATION);
+    const [payload, signature] = credential
+      .slice(INTERNAL_CREDENTIAL_PREFIX.length)
+      .split(".");
+    // The organization swapped for another, with the signature left as it was:
+    // the exact move the whole shape exists to make useless.
+    const forged = `${INTERNAL_CREDENTIAL_PREFIX}${btoa(
+      JSON.stringify({ o: "org_somebody_else", x: Math.floor(Date.now() / 1000) + 60 }),
+    )
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "")}.${signature}`;
+    expect(payload).toBeDefined();
+
+    expect((await ask({ "egma-inference-key": forged })).status).toBe(401);
+  });
+
+  it("is refused once it has expired, however good its signature is", async () => {
+    const expired = await internalCredential(ORGANIZATION, -60);
+    expect((await ask({ "egma-inference-key": expired })).status).toBe(401);
+  });
+});
+
+describe("an inference key", () => {
+  it("is validated at Egma Cloud, content-free, once per connection", async () => {
+    const before = standing.cloud.asks.length;
+
+    expect((await ask({ "egma-inference-key": GATEWAY_SECRET })).status).toBe(200);
+
+    const asked = standing.cloud.asks.slice(before);
+    expect(asked).toHaveLength(1);
+    expect(asked[0]?.method).toBe("POST");
+    expect(asked[0]?.credential).toBe(GATEWAY_SECRET);
+    // Content-free: the ask carries the credential and nothing about the
+    // simulation, the persona, the model or the payload behind it.
+    expect(asked[0]?.body).toBe("");
+  });
+
+  it("stops working on the next connection once Egma Cloud revokes it", async () => {
+    const world = await standUp();
+    try {
+      const retired = "egma_ik_sentinel-about-to-be-revoked-Mn3Qr7";
+      world.cloud.issue(retired, ORGANIZATION, "ifk_01K3XQ7M4E8YB2FVN0H9TZQWET");
+
+      const first = await fetch(`${world.world.origin}/openai/v1/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "egma-inference-key": retired },
+        body: JSON.stringify({ model: "m", messages: [] }),
+      });
+      expect(first.status).toBe(200);
+
+      world.cloud.revoke(retired);
+
+      const next = await fetch(`${world.world.origin}/openai/v1/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "egma-inference-key": retired },
+        body: JSON.stringify({ model: "m", messages: [] }),
+      });
+      expect(next.status).toBe(401);
+    } finally {
+      await world.world.stop();
+    }
+  });
+
+  it("refuses an ordinary Egma product key, because a product key is not one of these", async () => {
+    // Never issued in Egma Cloud's inference-key store, because a product key
+    // lives in a different table entirely. The gateway learns that by asking.
+    const productKey = "egma_sk_sentinel-a-product-key-not-an-inference-one";
+    expect((await ask({ "egma-inference-key": productKey })).status).toBe(401);
+  });
+});
+
+describe("an Egma Cloud that cannot be reached", () => {
+  it("says so, rather than telling a customer their key is bad", async () => {
+    const world = await standUp();
+    try {
+      world.cloud.goDown();
+
+      const answered = await fetch(
+        `${world.world.origin}/openai/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "egma-inference-key": GATEWAY_SECRET,
+          },
+          body: JSON.stringify({ model: "m", messages: [] }),
+        },
+      );
+
+      expect(answered.status).toBe(503);
+      expect(
+        ((await answered.json()) as { error: { code: string } }).error.code,
+      ).toBe("gateway_authentication_unavailable");
+      // Filed as its own thing, so an Egma outage does not arrive in the count
+      // of customers who mistyped a key.
+      const filed = await eventually(() =>
+        records(world.world).find(
+          (line) => line["statusClass"] === "authentication-unavailable",
+        ),
+      );
+      expect(filed["organizationId"]).toBeUndefined();
+    } finally {
+      await world.world.stop();
+    }
+  });
+
+  it("still lets hosted Egma's own credential through, because nothing is asked for it", async () => {
+    const world = await standUp();
+    try {
+      world.cloud.goDown();
+
+      const answered = await fetch(
+        `${world.world.origin}/openai/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "egma-inference-key": await internalCredential(ORGANIZATION),
+          },
+          body: JSON.stringify({ model: "m", messages: [] }),
+        },
+      );
+
+      expect(answered.status).toBe(200);
+    } finally {
+      await world.world.stop();
+    }
   });
 });

--- a/apps/gateway/test/routes-agree.test.ts
+++ b/apps/gateway/test/routes-agree.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+
+import { GATEWAY_ROUTE } from "@egma/db";
+import { describe, expect, it } from "vitest";
+
+import { ROUTES } from "../src/routes.ts";
+
+/**
+ * The one list three things have to agree about.
+ *
+ * The gateway's route table is the authority: it is what actually answers, and
+ * a path it does not carry is a `404` from Egma that whoever sees it reads as
+ * the provider being wrong. Two other places hold a copy — the control plane's
+ * `GATEWAY_ROUTE`, which the grader's judge makers read, and the simulator's
+ * own in `spec.py`, which its speech legs read — because neither can import
+ * this application: one speaks to Postgres and this one runs on Cloudflare
+ * Workers.
+ *
+ * So the copies are checked against the authority here rather than trusted.
+ * **What is checked is that each copy's suffix is a prefix of a real route's
+ * path**, not that the two are equal: a suffix deliberately stops where the
+ * shipped provider adapter starts appending, which is a different place for
+ * every provider.
+ */
+
+describe("where each provider is reached through this gateway", () => {
+  it("is a prefix of a route this gateway actually carries, in the control plane's copy", () => {
+    for (const [provider, jobs] of Object.entries(GATEWAY_ROUTE)) {
+      for (const [job, suffix] of Object.entries(jobs)) {
+        const carried = ROUTES.find(
+          (route) =>
+            route.provider === provider &&
+            route.job === job &&
+            route.path.startsWith(suffix),
+        );
+        expect(carried, `${provider}/${job} → ${suffix}`).toBeDefined();
+      }
+    }
+  });
+
+  it("is the same list the simulator holds, read out of its own source", () => {
+    // A text read rather than a Python import, for the reason the deployment
+    // check in `egma-cloud` is a text scan: this must give the same answer on a
+    // runner with no Python toolchain as it does on a developer's machine.
+    const source = readFileSync(
+      new URL("../../simulator/src/egma_simulator/spec.py", import.meta.url),
+      "utf8",
+    );
+    const written = /GATEWAY_ROUTE: dict\[str, dict\[str, str\]\] = \{(.*?)\n\}/s.exec(
+      source,
+    );
+    expect(written, "the simulator no longer declares GATEWAY_ROUTE as a literal").not
+      .toBeNull();
+
+    const held = new Map<string, string>();
+    for (const [, provider, job, suffix] of (written?.[1] ?? "").matchAll(
+      /"([a-z]+)": \{"([a-z]+)": "([^"]+)"\}/g,
+    )) {
+      held.set(`${provider}/${job}`, suffix as string);
+    }
+
+    const expected = new Map<string, string>();
+    for (const [provider, jobs] of Object.entries(GATEWAY_ROUTE)) {
+      for (const [job, suffix] of Object.entries(jobs)) {
+        expected.set(`${provider}/${job}`, suffix);
+      }
+    }
+
+    expect([...held.entries()].sort()).toEqual([...expected.entries()].sort());
+  });
+});

--- a/apps/gateway/test/routes-agree.test.ts
+++ b/apps/gateway/test/routes-agree.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 
-import { GATEWAY_ROUTE } from "@egma/db";
+import { GATEWAY_ROUTE, PROVIDER_CATALOG } from "@egma/db";
 import { describe, expect, it } from "vitest";
 
 import { ROUTES } from "../src/routes.ts";
@@ -24,6 +24,43 @@ import { ROUTES } from "../src/routes.ts";
  */
 
 describe("where each provider is reached through this gateway", () => {
+  /**
+   * The direction that was missing, and the one that matters as the catalog
+   * grows.
+   *
+   * Every other check here walks from a route or a copy *outward* and asks
+   * whether the gateway carries it — which is true of a shrinking list and
+   * says nothing about a growing one. **This walks from the product catalog
+   * in.** A provider-job pair a persona or a grader can select and the
+   * gateway has no route for is the pair that arms the leak: the leg is
+   * handed an Egma credential and no address, and a builder reading a missing
+   * address as "the provider's own" would put that credential on a third
+   * party's wire.
+   *
+   * The simulator refuses that at build time and the grader answers
+   * `NoJudge`, so the failure is contained either way — but a visible
+   * catalog entry nothing can execute is a broken promise, and the
+   * specification says so out loud: an entry cannot become visible until
+   * managed execution exists for it. This is that rule, as a test.
+   */
+  it("exists for every provider-job pair the product catalog offers", () => {
+    for (const entry of PROVIDER_CATALOG) {
+      const suffix = GATEWAY_ROUTE[entry.provider]?.[entry.job];
+      expect(
+        suffix,
+        `the catalog offers ${entry.provider} for ${entry.job} and the Egma model gateway carries no route for it, so managed access cannot execute a selection the product lets somebody make`,
+      ).toBeDefined();
+
+      const carried = ROUTES.find(
+        (route) =>
+          route.provider === entry.provider &&
+          route.job === entry.job &&
+          route.path.startsWith(suffix ?? "\u0000"),
+      );
+      expect(carried, `${entry.provider}/${entry.job}`).toBeDefined();
+    }
+  });
+
   it("is a prefix of a route this gateway actually carries, in the control plane's copy", () => {
     for (const [provider, jobs] of Object.entries(GATEWAY_ROUTE)) {
       for (const [job, suffix] of Object.entries(jobs)) {

--- a/apps/gateway/test/support/egma-cloud.ts
+++ b/apps/gateway/test/support/egma-cloud.ts
@@ -1,0 +1,134 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+
+/**
+ * A strict local stand-in for the one door Egma Cloud opens to inference keys.
+ *
+ * The gateway keeps no key store: it asks the deployment that minted the key
+ * whether the key is still good and whose it is. That ask is the seam, so the
+ * tests drive the real verifier against a real HTTP server over a real socket
+ * rather than against a hand-written verifier — which would prove the interface
+ * and not the behavior.
+ *
+ * **Strict on purpose.** It refuses anything that is not the contract: the
+ * wrong method, a body, a credential in a slot the gateway does not use. If the
+ * gateway ever starts sending a simulation's details along with the ask, this
+ * server is what notices — because "content-free validation" is a promise the
+ * product makes and a promise nobody can keep by intending to.
+ */
+
+export type EgmaCloudDoor = {
+  readonly origin: string;
+  readonly validationUrl: string;
+  /** Every ask that arrived, in order. What a content-free claim is read from. */
+  readonly asks: ValidationAsk[];
+  /** Make one more key good, as creating one in Egma Cloud would. */
+  issue(secret: string, organizationId: string, inferenceKeyId: string): void;
+  /** Stop one working, as revoking it in Egma Cloud would. */
+  revoke(secret: string): void;
+  /** Answer nothing at all, as an Egma Cloud that is down would. */
+  goDown(): void;
+  comeBack(): void;
+  stop(): Promise<void>;
+};
+
+export type ValidationAsk = {
+  readonly method: string;
+  readonly path: string;
+  readonly credential: string | null;
+  readonly body: string;
+  readonly headers: Readonly<Record<string, string>>;
+};
+
+export const VALIDATION_PATH = "/v1/inference-keys/validation";
+
+export async function startEgmaCloudDoor(): Promise<EgmaCloudDoor> {
+  const asks: ValidationAsk[] = [];
+  const good = new Map<string, { organizationId: string; inferenceKeyId: string }>();
+  let down = false;
+
+  const server: Server = createServer(
+    (request: IncomingMessage, response: ServerResponse) => {
+      let body = "";
+      request.on("data", (chunk: Buffer) => {
+        body += chunk.toString("utf8");
+      });
+      request.on("end", () => {
+        const url = new URL(request.url ?? "/", "http://cloud");
+        const headers: Record<string, string> = {};
+        for (const [name, value] of Object.entries(request.headers)) {
+          if (typeof value === "string") headers[name] = value;
+        }
+        asks.push({
+          method: request.method ?? "",
+          path: url.pathname,
+          credential: headers["egma-inference-key"] ?? null,
+          body,
+          headers,
+        });
+
+        if (down) {
+          // Not a refusal: a door that says nothing is a door that could not be
+          // asked, and the gateway has to tell those two apart.
+          response.destroy();
+          return;
+        }
+
+        if (url.pathname !== VALIDATION_PATH || request.method !== "POST") {
+          response.writeHead(404).end();
+          return;
+        }
+
+        const offered = headers["egma-inference-key"] ?? "";
+        const known = good.get(offered);
+        if (known === undefined) {
+          response
+            .writeHead(401, { "content-type": "application/json" })
+            .end(JSON.stringify({ error: "inference_key_refused" }));
+          return;
+        }
+
+        response.writeHead(200, { "content-type": "application/json" }).end(
+          JSON.stringify({
+            organization_id: known.organizationId,
+            inference_key_id: known.inferenceKeyId,
+          }),
+        );
+      });
+    },
+  );
+
+  await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("the Egma Cloud stand-in did not take a port");
+  }
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  return {
+    origin,
+    validationUrl: `${origin}${VALIDATION_PATH}`,
+    asks,
+    issue(secret, organizationId, inferenceKeyId) {
+      good.set(secret, { organizationId, inferenceKeyId });
+    },
+    revoke(secret) {
+      good.delete(secret);
+    },
+    goDown() {
+      down = true;
+    },
+    comeBack() {
+      down = false;
+    },
+    stop: () =>
+      new Promise<void>((stopped) => {
+        server.closeAllConnections();
+        server.close(() => stopped());
+      }),
+  };
+}

--- a/apps/gateway/test/support/upstreams.ts
+++ b/apps/gateway/test/support/upstreams.ts
@@ -32,8 +32,18 @@ export const EGMA_PROVIDER_KEY = {
 /** What a caller might send that must never reach a provider. */
 export const CALLER_PROVIDER_KEY = "sentinel-caller-provider-key-Do-Not-Forward";
 
-/** The preview's organization-scoped gateway credential, as a test holds it. */
-export const GATEWAY_SECRET = "sentinel-egma-inference-credential-Hs8Nc4";
+/**
+ * One organization's inference key, as a test holds it — a real one, issued in
+ * the Egma Cloud stand-in the gateway asks about it.
+ */
+export const GATEWAY_SECRET = "egma_ik_sentinel-inference-credential-Hs8Nc4";
+
+/**
+ * The key hosted Egma signs its own gateway credentials with, as this
+ * deployment's secret store holds it. Never on a wire; only a signature made
+ * with it is.
+ */
+export const INTERNAL_KEY = "sentinel-internal-gateway-signing-Yb4Fk8";
 
 export type SeenHttp = {
   readonly method: string;

--- a/apps/gateway/test/support/world.ts
+++ b/apps/gateway/test/support/world.ts
@@ -3,10 +3,12 @@ import { WebSocket } from "ws";
 import { startLocalGateway, type LocalGateway } from "../../src/host/node.ts";
 import { makeLog } from "../../src/record.ts";
 import type { Verifier } from "../../src/verify.ts";
+import { startEgmaCloudDoor, type EgmaCloudDoor } from "./egma-cloud.ts";
 import {
   CALLER_PROVIDER_KEY,
   EGMA_PROVIDER_KEY,
   GATEWAY_SECRET,
+  INTERNAL_KEY,
   startHttpUpstream,
   startSocketUpstream,
   type HttpUpstream,
@@ -15,7 +17,7 @@ import {
   type SocketUpstreamPlan,
 } from "./upstreams.ts";
 
-export { CALLER_PROVIDER_KEY, EGMA_PROVIDER_KEY, GATEWAY_SECRET };
+export { CALLER_PROVIDER_KEY, EGMA_PROVIDER_KEY, GATEWAY_SECRET, INTERNAL_KEY };
 
 /**
  * One gateway, its providers, and everything that was written down.
@@ -28,7 +30,7 @@ export { CALLER_PROVIDER_KEY, EGMA_PROVIDER_KEY, GATEWAY_SECRET };
  */
 
 export const ORGANIZATION = "org_01K3XQ7M4E8YB2FVN0H9TZQWER";
-export const INFERENCE_KEY_ID = "inference-key-preview-1";
+export const INFERENCE_KEY_ID = "ifk_01K3XQ7M4E8YB2FVN0H9TZQWES";
 
 export type World = {
   readonly origin: string;
@@ -45,10 +47,10 @@ export type WorldPlan = {
   readonly cartesia?: SocketUpstreamPlan;
   readonly settings?: Readonly<Record<string, string>>;
   /**
-   * A verifier of the test's own, for the behavior the preview's static one
-   * cannot show: a credential that stops being good. The gateway takes one
-   * verifier and this is that seam being used exactly as a later store will use
-   * it.
+   * A verifier of the test's own, for the few cases that are about the seam
+   * rather than about either shipped answer. Everything else runs the real
+   * one — hosted Egma's signature, and an inference key asked about at the
+   * Egma Cloud stand-in over a real socket.
    */
   readonly verifier?: Verifier;
 };
@@ -73,6 +75,8 @@ export const OPENAI_PLAN: HttpUpstreamPlan = {
 
 export type Standing = {
   readonly world: World;
+  /** Where inference keys really live, as far as the gateway is concerned. */
+  readonly cloud: EgmaCloudDoor;
   readonly openai: HttpUpstream;
   readonly deepgram: SocketUpstream;
   readonly cartesia: SocketUpstream;
@@ -82,6 +86,8 @@ export async function standUp(plan: WorldPlan = {}): Promise<Standing> {
   const openai = await startHttpUpstream(plan.openai ?? OPENAI_PLAN);
   const deepgram = await startSocketUpstream(plan.deepgram ?? DEEPGRAM_PLAN);
   const cartesia = await startSocketUpstream(plan.cartesia ?? CARTESIA_PLAN);
+  const cloud = await startEgmaCloudDoor();
+  cloud.issue(GATEWAY_SECRET, ORGANIZATION, INFERENCE_KEY_ID);
 
   const raw: string[] = [];
   const lines: Record<string, unknown>[] = [];
@@ -94,9 +100,8 @@ export async function standUp(plan: WorldPlan = {}): Promise<Standing> {
   try {
     gateway = await startLocalGateway(
       {
-        EGMA_GATEWAY_ORGANIZATION_SECRET: GATEWAY_SECRET,
-        EGMA_GATEWAY_ORGANIZATION_ID: ORGANIZATION,
-        EGMA_GATEWAY_INFERENCE_KEY_ID: INFERENCE_KEY_ID,
+        EGMA_GATEWAY_INTERNAL_KEY: INTERNAL_KEY,
+        EGMA_GATEWAY_VALIDATION_URL: cloud.validationUrl,
         EGMA_GATEWAY_DEEPGRAM_KEY: EGMA_PROVIDER_KEY.deepgram,
         EGMA_GATEWAY_OPENAI_KEY: EGMA_PROVIDER_KEY.openai,
         EGMA_GATEWAY_CARTESIA_KEY: EGMA_PROVIDER_KEY.cartesia,
@@ -108,7 +113,7 @@ export async function standUp(plan: WorldPlan = {}): Promise<Standing> {
       { log, ...(plan.verifier === undefined ? {} : { verifier: plan.verifier }) },
     );
   } catch (fault) {
-    await Promise.all([openai.stop(), deepgram.stop(), cartesia.stop()]);
+    await Promise.all([openai.stop(), deepgram.stop(), cartesia.stop(), cloud.stop()]);
     throw fault;
   }
 
@@ -119,9 +124,15 @@ export async function standUp(plan: WorldPlan = {}): Promise<Standing> {
       raw,
       stop: async () => {
         await gateway.stop();
-        await Promise.all([openai.stop(), deepgram.stop(), cartesia.stop()]);
+        await Promise.all([
+          openai.stop(),
+          deepgram.stop(),
+          cartesia.stop(),
+          cloud.stop(),
+        ]);
       },
     },
+    cloud,
     openai,
     deepgram,
     cartesia,

--- a/apps/grader/src/index.ts
+++ b/apps/grader/src/index.ts
@@ -3,6 +3,7 @@ import {
   connectClickHouse,
   disconnect,
   disconnectClickHouse,
+  managedDeploymentFrom,
 } from "@egma/db";
 
 import { loadConfig } from "./config.ts";
@@ -40,6 +41,10 @@ connect({
   ...(config.encryptionKey === undefined
     ? {}
     : { encryptionKey: config.encryptionKey }),
+  // The same three names the control plane reads, read the same way. A grader
+  // that resolved a different gateway address from the simulator beside it
+  // would judge a conversation on an account nobody chose.
+  managedDeployment: managedDeploymentFrom(process.env),
 });
 connectClickHouse({ clickhouseUrl: config.clickhouseUrl });
 

--- a/apps/grader/src/judge/contract.ts
+++ b/apps/grader/src/judge/contract.ts
@@ -93,6 +93,22 @@ export type ResolvedJudge = {
   readonly provider: JudgeProvider;
   readonly model: string;
   readonly key: string;
+  /**
+   * Where this provider is reached, or `undefined` for the provider's own
+   * address.
+   *
+   * **The whole of what managed model access asks of a judge maker.** Under
+   * managed access this is the Egma model gateway's route for the provider, and
+   * `key` is the credential that authorizes the gateway rather than the
+   * provider — the same request, the same body, the same protocol, sent to a
+   * different base and authenticated with a different secret. Nothing else
+   * moves, which is what keeps a second provider-adapter layer from growing
+   * beside the one file per provider that exists now.
+   *
+   * `undefined` is customer-owned access: the provider's own endpoint, with the
+   * organization's own key, and Egma is not on the path at all.
+   */
+  readonly endpoint?: string | undefined;
 };
 
 /**

--- a/apps/grader/src/judge/index.ts
+++ b/apps/grader/src/judge/index.ts
@@ -1,7 +1,10 @@
 import {
+  gatewayAddressFor,
   getJudgeConfiguration,
   JUDGE_PROVIDERS,
+  readModelAccess,
   resolveJudgeKey,
+  resolveManagedAccess,
   resolveModelProviderKeys,
   type AuthContext,
   type GraderModel,
@@ -159,14 +162,24 @@ export type JudgeResolution = () => Promise<ProjectJudge | NoJudge>;
  */
 export function judgesOnce(auth: AuthContext): ConversationJudges {
   let theProjects: Promise<ProjectJudge | NoJudge> | undefined;
-  const byProvider = new Map<string, Promise<string | NoJudge>>();
+  const byProvider = new Map<string, Promise<Reached | NoJudge>>();
 
-  const keyForProvider = (
+  /**
+   * How this organization reaches one provider, resolved at most once however
+   * many graders ask.
+   *
+   * **The access mode is read once and the answer applies to every judged
+   * check on this conversation**, which is the same rule the claim path keeps
+   * one grain up: who supplies the credential is the organization's current
+   * state, read when the work is prepared, and two graders judging one
+   * conversation must not be able to land on two different answers.
+   */
+  const accessOnce = (
     provider: GraderModel["provider"],
-  ): Promise<string | NoJudge> => {
+  ): Promise<Reached | NoJudge> => {
     const held = byProvider.get(provider);
     if (held !== undefined) return held;
-    const resolving = organizationKeyFor(auth, provider);
+    const resolving = reachFor(auth, provider);
     byProvider.set(provider, resolving);
     return resolving;
   };
@@ -186,8 +199,8 @@ export function judgesOnce(auth: AuthContext): ConversationJudges {
       const asked = makerFor(selected.provider, makers);
       if (asked instanceof NoJudge) return asked;
 
-      const key = await keyForProvider(selected.provider);
-      if (key instanceof NoJudge) return key;
+      const reached = await accessOnce(selected.provider);
+      if (reached instanceof NoJudge) return reached;
 
       return {
         ask: asked.maker({
@@ -197,28 +210,70 @@ export function judgesOnce(auth: AuthContext): ConversationJudges {
           // two vocabularies that only happen to overlap.
           provider: asked.provider,
           model: selected.model,
-          key,
+          key: reached.key,
+          ...(reached.endpoint === undefined ? {} : { endpoint: reached.endpoint }),
         }),
       };
     },
   };
 }
 
+/** Where one provider is reached for this organization, and with what. */
+type Reached = {
+  readonly key: string;
+  /** The Egma model gateway's route, or `undefined` for the provider itself. */
+  readonly endpoint?: string | undefined;
+};
+
 /**
- * The organization's own key for one provider, or the sentence a person can
- * act on.
+ * How this organization reaches one provider, or the sentence a person can act
+ * on.
  *
- * **A missing credential is an infrastructure error and never a failed
+ * **Two answers, decided by the organization's own model access, and the judge
+ * maker below cannot tell which it got.** Under managed access the endpoint is
+ * the Egma model gateway's route for this provider and the key is what
+ * authorizes the gateway; under customer-owned access the endpoint is absent
+ * and the key is the organization's own. Same request, same body, same
+ * protocol — which is the whole reason the grader needs no second provider
+ * adapter for managed access.
+ *
+ * **Every way this fails is an infrastructure error and never a failed
  * verdict.** A check that could not be made did not fail: nothing about the
  * agent was learned, and recording it as a failure would put a red row on a
- * report for a key somebody has not pasted yet. The sentence names the provider
- * and where to add it, because that is what the person reading the rationale
- * has to do next.
+ * report for a key somebody has not pasted yet. Each sentence names what is
+ * missing and where to fix it, because that is what the person reading the
+ * rationale has to do next.
  */
-async function organizationKeyFor(
+async function reachFor(
   auth: AuthContext,
   provider: GraderModel["provider"],
-): Promise<string | NoJudge> {
+): Promise<Reached | NoJudge> {
+  const access = await readModelAccess(auth);
+
+  if (access.mode === "managed") {
+    let managed: Awaited<ReturnType<typeof resolveManagedAccess>>;
+    try {
+      managed = await resolveManagedAccess(auth);
+    } catch (error) {
+      return new NoJudge(
+        `this grader judges with ${provider} through the Egma model gateway, and this organization's managed access could not be prepared: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    const endpoint = gatewayAddressFor(managed.gatewayAddress, provider, "llm");
+    if (endpoint === undefined) {
+      // Refused rather than answered with the gateway's bare address, which
+      // would send this request to a path the gateway turns away — read by
+      // whoever sees the rationale as the provider being wrong.
+      return new NoJudge(
+        `this grader judges with ${provider}, and the Egma model gateway carries no language-model route for it in this release.`,
+      );
+    }
+    return { key: managed.credential, endpoint };
+  }
+
   let resolved: Awaited<ReturnType<typeof resolveModelProviderKeys>>;
   try {
     resolved = await resolveModelProviderKeys(auth, [provider]);
@@ -239,7 +294,9 @@ async function organizationKeyFor(
       `this grader judges with ${provider}, and this organization holds no ${provider} model-provider credential; add one under Model providers in Organization settings.`,
     );
   }
-  return key;
+  // No endpoint: Egma is not on the model traffic path under customer-owned
+  // access, and the judge maker reaches the provider's own address.
+  return { key };
 }
 
 /**

--- a/apps/grader/src/judge/openai.ts
+++ b/apps/grader/src/judge/openai.ts
@@ -25,6 +25,16 @@ import { asJudgeReads } from "./input.ts";
 const OPENAI_CHAT_COMPLETIONS = "https://api.openai.com/v1/chat/completions";
 
 /**
+ * The one path this provider answers, appended to whichever base is in play.
+ *
+ * Split from the address above rather than written twice, because under managed
+ * access the base moves and the path does not: the Egma model gateway carries
+ * this provider's own protocol at this provider's own path, which is what makes
+ * managed access a base URL rather than a rewrite.
+ */
+const CHAT_COMPLETIONS_PATH = "/chat/completions";
+
+/**
  * How many times a call is made before the assertion is `errored`.
  *
  * Three, for the reason the grading job's own attempt count is three: the
@@ -61,17 +71,25 @@ export function openaiJudge(judge: ResolvedJudge): Judge {
     });
 
     const said = await withRetries(async () => {
-      const response = await fetch(OPENAI_CHAT_COMPLETIONS, {
-        method: "POST",
-        headers: {
-          // The one place the key is ever written down, and it is written into
-          // a header on the way out. Nothing logs this object.
-          authorization: `Bearer ${judge.key}`,
-          "content-type": "application/json",
+      const response = await fetch(
+        judge.endpoint === undefined
+          ? OPENAI_CHAT_COMPLETIONS
+          : `${judge.endpoint.replace(/\/+$/, "")}${CHAT_COMPLETIONS_PATH}`,
+        {
+          method: "POST",
+          headers: {
+            // The one place the key is ever written down, and it is written into
+            // a header on the way out. Nothing logs this object. Under managed
+            // access this is the gateway's credential rather than a provider's,
+            // sent in the slot the provider's own adapter would use — which is
+            // exactly how the gateway is reachable with no second adapter.
+            authorization: `Bearer ${judge.key}`,
+            "content-type": "application/json",
+          },
+          body,
+          signal: AbortSignal.timeout(DEADLINE_MILLISECONDS),
         },
-        body,
-        signal: AbortSignal.timeout(DEADLINE_MILLISECONDS),
-      });
+      );
 
       if (!response.ok) {
         // The provider's own words, trimmed to a line — never the request, so
@@ -178,7 +196,8 @@ function answerOf(said: unknown): JudgeAnswer {
   return {
     decision: decision as Decision,
     rationale:
-      typeof fields["rationale"] === "string" && fields["rationale"].trim() !== ""
+      typeof fields["rationale"] === "string" &&
+      fields["rationale"].trim() !== ""
         ? fields["rationale"].trim()
         : "the judge gave no reason.",
     citedTurns: citedTurnsOf(fields["cited_turns"]),
@@ -213,6 +232,7 @@ function contentOf(said: unknown): string {
 function citedTurnsOf(value: unknown): readonly number[] {
   if (!Array.isArray(value)) return [];
   return value.filter(
-    (at): at is number => Number.isInteger(at) && typeof at === "number" && at > 0,
+    (at): at is number =>
+      Number.isInteger(at) && typeof at === "number" && at > 0,
   );
 }

--- a/apps/grader/test/grader-model.test.ts
+++ b/apps/grader/test/grader-model.test.ts
@@ -1,14 +1,19 @@
+import { newId } from "@egma/ids";
 import {
   claimGradingJobs,
+  connectManagedAccess,
+  disconnectManagedAccess,
   getGrader,
+  holdManagedDeployment,
   GRADING_CAPABILITIES,
   readVerdicts,
   removeModelProviderCredential,
+  setModelAccess,
   storeModelProviderCredential,
   type AuthContext,
   type RecordedVerdict,
 } from "@egma/db";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import {
   aConversation,
@@ -364,5 +369,142 @@ describe("a credential the organization does not hold", () => {
         key: THE_ORGANIZATIONS_KEY,
       });
     }
+  });
+});
+
+describe("a grader on managed model access", () => {
+  /**
+   * The grader's half of the two model-access modes, at the seam a judge is
+   * actually resolved at.
+   *
+   * **What changes is a base address and one credential, and nothing else.**
+   * The maker is handed the Egma model gateway's route for the provider and the
+   * credential that authorizes the gateway rather than the provider — the same
+   * request, the same body, the same protocol. That is the whole reason the
+   * grader needed no second provider adapter for managed access, and the
+   * assertion below is what says the claim is true rather than intended.
+   */
+  const THE_GATEWAY = "https://gateway.egma.test";
+  const THE_PASTED_KEY = "egma_ik_sentinel-grader-managed-P1Q2";
+
+  async function judgeUnderManagedAccess(name: string): Promise<{
+    readonly configured: readonly Record<string, unknown>[];
+    readonly resolved: unknown;
+  }> {
+    const graderId = await seedGrader(
+      world,
+      aJudgedCopy({ name, graderModel: { provider: "openai", model: "gpt-4o" } }),
+    );
+    const grader = await getGrader(world.auth, graderId);
+    const judge = scriptedJudge({ answers: {} });
+    const resolved = await judgesOnce(theEngine()).judgeFor(
+      {
+        graderModel: grader?.graderModel ?? null,
+        judgeModel: grader?.judgeModel ?? null,
+      },
+      judge.makers,
+    );
+    return { configured: judge.configured, resolved };
+  }
+
+  afterEach(async () => {
+    // Back to the deployment every other case in this file stands in.
+    holdManagedDeployment({
+      hosted: false,
+      gatewayAddress: undefined,
+      internalGatewayKey: undefined,
+    });
+    await setModelAccess(world.adminAuth, "customer-owned").catch(() => undefined);
+  });
+
+  it("judges through the gateway with the key its deployment connected", async () => {
+    holdManagedDeployment({
+      hosted: false,
+      gatewayAddress: THE_GATEWAY,
+      internalGatewayKey: undefined,
+    });
+    await connectManagedAccess(world.adminAuth, {
+      key: THE_PASTED_KEY,
+      cloudOrganizationId: newId("org"),
+    });
+    await setModelAccess(world.adminAuth, "managed");
+
+    const { configured, resolved } = await judgeUnderManagedAccess(
+      "Judged through the Egma model gateway",
+    );
+
+    expect(resolved).not.toBeInstanceOf(NoJudge);
+    expect(configured.at(-1)).toEqual({
+      provider: "openai",
+      // The pinned selection is untouched by who supplies the credential.
+      model: "gpt-4o",
+      key: THE_PASTED_KEY,
+      endpoint: `${THE_GATEWAY}/openai/v1`,
+    });
+    // And never the organization's own provider account, which is stored and
+    // deliberately not what a managed grader spends.
+    expect(configured.at(-1)).not.toHaveProperty("key", THE_ORGANIZATIONS_KEY);
+  });
+
+  it("judges through the gateway on hosted Egma with nothing connected at all", async () => {
+    holdManagedDeployment({
+      hosted: true,
+      gatewayAddress: THE_GATEWAY,
+      internalGatewayKey: "sentinel-grader-internal-signing-R3S4",
+    });
+    await setModelAccess(world.adminAuth, "managed");
+
+    const { configured, resolved } = await judgeUnderManagedAccess(
+      "Judged on hosted Egma's own credential",
+    );
+
+    expect(resolved).not.toBeInstanceOf(NoJudge);
+    const asked = configured.at(-1) as { key: string; endpoint: string };
+    expect(asked.endpoint).toBe(`${THE_GATEWAY}/openai/v1`);
+    expect(asked.key.startsWith("egma_ig_")).toBe(true);
+    // The signing key is never any part of what goes out.
+    expect(asked.key).not.toContain("sentinel-grader-internal-signing-R3S4");
+  });
+
+  it("errors rather than judging, when managed access has nothing behind it", async () => {
+    holdManagedDeployment({
+      hosted: false,
+      gatewayAddress: THE_GATEWAY,
+      internalGatewayKey: undefined,
+    });
+    // Reconnected under the binding this world already carries — rotation, not
+    // a move — then disconnected deliberately. The mode is left exactly as it
+    // was, which is what makes the next grading say so instead of quietly
+    // spending somebody's own account.
+    await setModelAccess(world.adminAuth, "managed");
+    await disconnectManagedAccess(world.adminAuth);
+
+    const { resolved } = await judgeUnderManagedAccess(
+      "Judged with nothing connected",
+    );
+
+    // An infrastructure error a person can act on, never a failed verdict: a
+    // check that could not be made did not fail.
+    expect(resolved).toBeInstanceOf(NoJudge);
+    expect(String((resolved as Error).message)).toContain("inference key");
+  });
+
+  it("spends the organization's own account again the moment the mode changes back", async () => {
+    holdManagedDeployment({
+      hosted: true,
+      gatewayAddress: THE_GATEWAY,
+      internalGatewayKey: "sentinel-grader-internal-signing-R3S4",
+    });
+    await setModelAccess(world.adminAuth, "customer-owned");
+
+    const { configured } = await judgeUnderManagedAccess(
+      "Judged back on the organization's account",
+    );
+
+    expect(configured.at(-1)).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+      key: THE_ORGANIZATIONS_KEY,
+    });
   });
 });

--- a/apps/simulator/src/egma_simulator/model.py
+++ b/apps/simulator/src/egma_simulator/model.py
@@ -199,6 +199,25 @@ def _selected_model_client(
     if provider != "openai":
         return ScriptedModel(spec.scenario_instructions)
 
+    # **Under managed access the thinking leg is the same client, told a
+    # different address and handed a different credential.** The gateway
+    # carries this provider's own protocol at this provider's own path, so
+    # nothing about the request changes — which is what keeps a second
+    # provider-adapter layer from growing beside this one.
+    if selected.gateway is not None:
+        base_url = selected.gateway.base_for(provider, "llm")
+        if base_url is None:
+            raise ModelFailure(
+                f"this persona thinks with {provider} through the Egma model "
+                "gateway, and this release carries no language-model route "
+                "for it there"
+            )
+        return OpenAICompatibleModel(
+            base_url=base_url,
+            api_key=selected.gateway.credential,
+            model_name=selected.llm.model,
+        )
+
     if selected.llm.key is None:
         raise ModelFailure(
             f"this persona thinks with {provider}, and the work order carried "

--- a/apps/simulator/src/egma_simulator/spec.py
+++ b/apps/simulator/src/egma_simulator/spec.py
@@ -241,6 +241,58 @@ class SpeechSelection(ModelSelection):
 
 
 @dataclass(frozen=True)
+class GatewayAccess:
+    """Where managed model traffic goes, and what authorizes it there.
+
+    **Present only under managed access, and it is the whole of what
+    managed access adds to a work order.** No provider key travels at
+    all — Egma's own credentials stay inside the Egma model gateway and
+    this process is never handed one — so what arrives instead is one
+    address and one credential for the gateway's own door.
+
+    Each leg composes its own provider path onto the address; see
+    :data:`GATEWAY_ROUTE`. The credential goes in the slot the shipped
+    provider adapter already puts a key in, which is why a managed leg
+    is the same Pipecat service told a different base address and handed
+    a different secret, and not a second adapter.
+    """
+
+    address: str
+    credential: str = field(default="", repr=False)
+    """Kept out of the dataclass repr, like every other credential in
+    this process: a log line carrying one is a log line that should not
+    have."""
+
+    def base_for(self, provider: str, job: str) -> str | None:
+        """Where one leg reaches its provider through the gateway, or
+        ``None`` where this release carries no route for that pair.
+
+        ``None`` is a refusal to guess. Answering the gateway's bare
+        address would send the leg to a path the gateway turns away, and
+        whoever read the failure would see the provider being wrong.
+        """
+        suffix = GATEWAY_ROUTE.get(provider, {}).get(job)
+        return None if suffix is None else f"{self.address.rstrip('/')}{suffix}"
+
+
+GATEWAY_ROUTE: dict[str, dict[str, str]] = {
+    "openai": {"llm": "/openai/v1"},
+    "deepgram": {"stt": "/deepgram"},
+    "cartesia": {"tts": "/cartesia/tts/websocket"},
+}
+"""Where each provider-job pair is reached through the Egma model gateway.
+
+**The Python half of one list that three things have to agree about**:
+this, the control plane's own copy beside the provider catalog, and the
+gateway's route table, which is the authority. The suffix stops where
+the shipped adapter starts appending — Pipecat's Deepgram service adds
+``/v1/listen`` to whatever base it is given, the OpenAI chat client adds
+``/chat/completions``, and Cartesia's service is handed a whole socket
+address — so each entry ends exactly where its adapter takes over.
+"""
+
+
+@dataclass(frozen=True)
 class SelectedModels:
     """What this simulation's persona thinks, listens and speaks with.
 
@@ -260,19 +312,24 @@ class SelectedModels:
     llm: ModelSelection
     stt: ModelSelection
     tts: SpeechSelection
+    gateway: GatewayAccess | None = None
+    """Present under managed access and absent under customer-owned, and
+    the two are exclusive by the contract's own shape rather than by
+    anything read here."""
 
     @property
     def secrets(self) -> tuple[str, ...]:
-        """Every key this block holds, for redaction.
+        """Every credential this block holds, for redaction.
 
         One place to ask, exactly as the platform settings' own has, so a
-        fourth key arriving cannot fall out of the scrubbing.
+        fourth secret arriving cannot fall out of the scrubbing — which
+        is why the gateway credential is here beside the provider keys.
+        Only one of the two kinds is ever present.
         """
-        return tuple(
-            secret
-            for secret in (self.llm.key, self.stt.key, self.tts.key)
-            if secret is not None
-        )
+        held = (self.llm.key, self.stt.key, self.tts.key)
+        if self.gateway is not None:
+            held = (*held, self.gateway.credential)
+        return tuple(secret for secret in held if secret)
 
     @classmethod
     def from_document(cls, written: Any) -> SelectedModels | None:
@@ -285,8 +342,16 @@ class SelectedModels:
         if not written:
             return None
         tts = written["tts"]
+        gateway = written.get("gateway")
         return cls(
             access=written["access"],
+            gateway=(
+                None
+                if gateway is None
+                else GatewayAccess(
+                    address=gateway["address"], credential=gateway["credential"]
+                )
+            ),
             llm=_selection(written["llm"]),
             stt=_selection(written["stt"]),
             tts=SpeechSelection(

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -508,6 +508,18 @@ class SpeechProviders:
     so a mouth and a pair of ears are told two different addresses.
     """
 
+    managed: bool = False
+    """Whether these legs reach their providers through the Egma model gateway.
+
+    **It exists so that a leg with no gateway route can be refused rather
+    than built.** Under managed access the value in ``stt_key`` and
+    ``tts_key`` authorizes the gateway and nothing else, and every builder
+    below reads a missing base address as "the provider's own" — so without
+    this flag a pair the gateway has no route for would open a connection
+    straight to the provider and present an Egma credential as that
+    company's API key. See :meth:`checked`.
+    """
+
     stt_model: str | None = None
     tts_model: str | None = None
     tts_voice: str | None = None
@@ -595,6 +607,10 @@ class SpeechProviders:
                     if gateway is None
                     else gateway.base_for(models.tts.provider, "tts")
                 ),
+                # **What says these keys are the gateway's rather than a
+                # provider's**, so a leg with no route can be refused instead
+                # of built. See `checked`.
+                managed=gateway is not None,
                 stt_model=models.stt.model,
                 tts_model=models.tts.model,
                 tts_voice=models.tts.voice_id,
@@ -645,6 +661,32 @@ class SpeechProviders:
                     "speech leg this simulator has; it speaks and listens "
                     f"with {', '.join(allowed)}"
                 )
+
+        # **A managed leg with no gateway route is refused, never sent
+        # straight to the provider.** The key these legs hold authorizes the
+        # Egma model gateway; a builder handed no address falls back to the
+        # provider's own, which would put an ``egma_ig_`` or ``egma_ik_``
+        # value on a third party's wire as their API key. The thinking leg
+        # already refuses exactly this case in ``model.py``, and the grader's
+        # resolver answers ``NoJudge`` for it; speech was the one that did
+        # not.
+        #
+        # Here rather than where the legs are resolved, for this method's own
+        # reason one paragraph up: a chat simulation has no mouth and no ears
+        # and must not fail over a route it was never going to use.
+        if self.managed:
+            for job, provider, base in (
+                ("stt", self.stt, self.stt_base_url),
+                ("tts", self.tts, self.tts_base_url),
+            ):
+                if base is None:
+                    raise SpeechFault(
+                        f"this persona uses {provider} for {job} through the "
+                        "Egma model gateway, and this release carries no "
+                        "route for that pair there; the leg is refused "
+                        "rather than opened straight at the provider holding "
+                        "an Egma credential"
+                    )
         return self
 
 

--- a/apps/simulator/src/egma_simulator/speech.py
+++ b/apps/simulator/src/egma_simulator/speech.py
@@ -568,12 +568,33 @@ class SpeechProviders:
         vad = said.vad_provider or config.vad_provider
 
         if models is not None:
+            # **Under managed access both legs are told the gateway's own
+            # address for their provider and handed the gateway's own
+            # credential**, in the same fields they always took a provider
+            # address and a provider key. Each is the same shipped Pipecat
+            # service; nothing about the model, the voice, the band or the
+            # protocol moves.
+            gateway = models.gateway
             return cls(
                 stt=models.stt.provider,
                 tts=models.tts.provider,
                 vad=vad,
-                stt_key=models.stt.key,
-                tts_key=models.tts.key,
+                stt_key=(
+                    models.stt.key if gateway is None else gateway.credential
+                ),
+                tts_key=(
+                    models.tts.key if gateway is None else gateway.credential
+                ),
+                stt_base_url=(
+                    None
+                    if gateway is None
+                    else gateway.base_for(models.stt.provider, "stt")
+                ),
+                tts_base_url=(
+                    None
+                    if gateway is None
+                    else gateway.base_for(models.tts.provider, "tts")
+                ),
                 stt_model=models.stt.model,
                 tts_model=models.tts.model,
                 tts_voice=models.tts.voice_id,

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -104,6 +104,24 @@ EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
     # A chat simulation has no mouth and no ears, so a speech key on its wire
     # is a secret travelling for nothing.
     "spec-v2/chat-carrying-a-speech-key.json": ("/models/stt", "not", None),
+    # Egma's provider credentials stay inside the Egma model gateway, so a
+    # managed work order carrying one is refused before this worker ever holds
+    # it — and managed access with no gateway is a work order with nowhere for
+    # the traffic to go, which must not arrive as a leg quietly calling a
+    # provider directly. Customer-owned with a gateway block is the mirror: Egma
+    # is off the model traffic path there, so the address and the credential are
+    # two things nothing would use and one of them is a credential.
+    "spec-v2/managed-carrying-a-provider-key.json": (
+        "/models/llm",
+        "additionalProperties",
+        "key",
+    ),
+    "spec-v2/managed-without-a-gateway.json": ("/models", "required", "gateway"),
+    "spec-v2/customer-owned-carrying-a-gateway.json": (
+        "/models",
+        "additionalProperties",
+        "gateway",
+    ),
     "spec-v2/unknown-field.json": ("", "additionalProperties", "agent_id"),
     "report/completed-claiming-never-ran.json": (
         "/events/0/facts/ending",

--- a/apps/simulator/tests/test_deployment.py
+++ b/apps/simulator/tests/test_deployment.py
@@ -448,6 +448,20 @@ MAY_BE_ABSENT = {
     "EGMA_JUDGE_PROVIDER": "a judge belongs to the project that chose it",
     "EGMA_JUDGE_MODEL": "a judge belongs to the project that chose it",
     "EGMA_JUDGE_API_KEY": "a judge belongs to the project that chose it",
+    # Managed model access, which every deployment starts without.
+    #
+    # An organization supplies its own provider keys until somebody connects
+    # an inference key, and that is not a lesser state — it is the mode most
+    # deployments stay in. Requiring these would make Egma refuse to start
+    # until a self-hoster had opened an account with Egma Cloud, which is the
+    # opposite of what managed access is for.
+    #
+    # Absent is never silent where it matters. A claim that needs the gateway
+    # address and does not have it lands as a visible infrastructure error
+    # naming what is missing, rather than a leg quietly calling a provider.
+    "EGMA_MODEL_GATEWAY_URL": "unset until managed access is connected",
+    "EGMA_CLOUD_URL": "the application's own default is hosted Egma's address",
+    "EGMA_GATEWAY_INTERNAL_KEY": "hosted Egma's alone; a self-hosted deployment presents the key it connected",
     # Mail, which is optional and load-bearing in being optional: with none,
     # an invitation hands its link back to whoever sent it.
     "EGMA_SMTP_URL": "optional by design",

--- a/apps/simulator/tests/test_persona_models.py
+++ b/apps/simulator/tests/test_persona_models.py
@@ -31,7 +31,7 @@ from egma_simulator.spec import (
     SimulationSpec,
     SpeechSelection,
 )
-from egma_simulator.speech import SpeechProviders, voice_for_simulation
+from egma_simulator.speech import SpeechFault, SpeechProviders, voice_for_simulation
 
 A_URL = "http://control-plane.test"
 
@@ -514,3 +514,67 @@ def test_a_claimed_managed_document_becomes_the_gateway_it_carries():
     assert spec.models.llm.key is None
     assert spec.models.stt.key is None
     assert spec.models.tts.key is None
+
+
+def test_a_managed_leg_with_no_gateway_route_is_refused_rather_than_opened(
+    a_container,
+):
+    """The leak this exists to close.
+
+    The key a managed leg holds authorizes the Egma model gateway. Every
+    builder reads a missing base address as "the provider's own", so a leg
+    for a pair the gateway has no route for would open a connection straight
+    to that provider and present an Egma credential as their API key — a
+    third party holding an Egma secret, and a failure that reads as a bad
+    key rather than as a missing route.
+    """
+    no_route = SelectedModels(
+        access="managed",
+        gateway=GatewayAccess(address=THE_GATEWAY, credential=GATEWAY_CREDENTIAL),
+        llm=ModelSelection(provider="openai", model="m"),
+        stt=ModelSelection(provider="deepgram", model="n"),
+        # A leg this simulator really has and the gateway has no route for,
+        # which is exactly the shape a growing provider catalog produces:
+        # ElevenLabs speaks here and is not a shipped gateway route.
+        tts=SpeechSelection(
+            provider="elevenlabs", model="s", voice_id="v", speed=1.0
+        ),
+    )
+    providers = SpeechProviders.for_simulation(a_container, None, no_route)
+
+    with pytest.raises(SpeechFault) as refusal:
+        providers.checked()
+
+    assert "elevenlabs" in str(refusal.value)
+    assert "tts" in str(refusal.value)
+    # And the sentence says what was avoided, so nobody reads it as the
+    # provider rejecting a key.
+    assert "route" in str(refusal.value)
+
+
+def test_a_chat_simulation_is_not_refused_over_a_leg_it_never_builds(a_container):
+    """The refusal above is at build time and not at resolution, for the
+    reason every other speech check is: a chat simulation has no mouth and no
+    ears, and must not fail over a route it was never going to use."""
+    no_route = SelectedModels(
+        access="managed",
+        gateway=GatewayAccess(address=THE_GATEWAY, credential=GATEWAY_CREDENTIAL),
+        llm=ModelSelection(provider="openai", model="m"),
+        stt=ModelSelection(provider="deepgram", model="n"),
+        tts=SpeechSelection(
+            provider="deepgram", model="s", voice_id="v", speed=1.0
+        ),
+    )
+
+    # Resolving is what a chat simulation does; building is what it does not.
+    providers = SpeechProviders.for_simulation(a_container, None, no_route)
+
+    assert providers.managed is True
+    assert providers.tts_base_url is None
+
+
+def test_a_managed_pair_the_gateway_carries_passes_the_same_check(a_container):
+    providers = SpeechProviders.for_simulation(a_container, None, MANAGED).checked()
+
+    assert providers.stt_base_url == f"{THE_GATEWAY}/deepgram"
+    assert providers.tts_base_url == f"{THE_GATEWAY}/cartesia/tts/websocket"

--- a/apps/simulator/tests/test_persona_models.py
+++ b/apps/simulator/tests/test_persona_models.py
@@ -21,6 +21,7 @@ from egma_simulator.config import SimulatorConfig
 from egma_simulator.contract import SUPPORTED_SPEC_VERSIONS, ContractViolation
 from egma_simulator.model import ModelFailure, OpenAICompatibleModel, build_model_client
 from egma_simulator.spec import (
+    GatewayAccess,
     Limits,
     ModelSelection,
     PlatformModel,
@@ -33,6 +34,9 @@ from egma_simulator.spec import (
 from egma_simulator.speech import SpeechProviders, voice_for_simulation
 
 A_URL = "http://control-plane.test"
+
+THE_GATEWAY = "https://gateway.egma.test"
+GATEWAY_CREDENTIAL = "SENTINEL-managed-gateway-credential-94gh"
 
 SELECTED = SelectedModels(
     access="customer-owned",
@@ -54,6 +58,24 @@ SELECTED = SelectedModels(
         speed=1.25,
     ),
 )
+
+
+MANAGED = SelectedModels(
+    access="managed",
+    gateway=GatewayAccess(address=THE_GATEWAY, credential=GATEWAY_CREDENTIAL),
+    llm=ModelSelection(provider="openai", model="the-model-the-persona-selected"),
+    stt=ModelSelection(
+        provider="deepgram", model="the-model-the-persona-listens-with"
+    ),
+    tts=SpeechSelection(
+        provider="cartesia",
+        model="the-model-the-persona-speaks-with",
+        voice_id="the-voice-the-persona-selected",
+        speed=1.2,
+    ),
+)
+"""The same persona, on managed access: the same three selections, no
+provider key anywhere, and one credential for the gateway's own door."""
 
 THE_PLATFORMS_OWN = PlatformSettings(
     model=PlatformModel(
@@ -281,15 +303,11 @@ def test_every_selected_key_is_offered_for_redaction_in_one_place():
     }
 
 
-def test_a_managed_work_order_offers_no_key_because_it_carries_none():
-    managed = SelectedModels(
-        access="managed",
-        llm=ModelSelection(provider="openai", model="m"),
-        stt=ModelSelection(provider="deepgram", model="n"),
-        tts=SpeechSelection(provider="cartesia", model="s", voice_id="v", speed=1.0),
-    )
-
-    assert managed.secrets == ()
+def test_a_managed_work_order_offers_no_provider_key_because_it_carries_none():
+    """The one credential a managed order holds authorizes the Egma model
+    gateway, and it is scrubbed exactly as a provider key is."""
+    assert MANAGED.secrets == ("SENTINEL-managed-gateway-credential-94gh",)
+    assert "SENTINEL-selected-thinking-key-91ab" not in MANAGED.secrets
 
 
 def test_no_selected_key_appears_in_a_repr_of_what_holds_it():
@@ -398,3 +416,101 @@ def test_this_simulator_declares_the_versions_it_implements():
     drain step: a row needing a document this process cannot read is never
     offered to it at all."""
     assert SUPPORTED_SPEC_VERSIONS == (1, 2)
+
+
+# -- Managed access: the same legs, a different address and one credential ---
+
+
+def test_managed_legs_are_told_the_gateways_address_and_its_credential(a_container):
+    """The same shipped services, told a different base and handed a
+    different secret. Nothing about the model, the voice or the protocol
+    moves — which is what keeps a second provider-adapter layer from
+    growing beside Pipecat."""
+    providers = SpeechProviders.for_simulation(
+        a_container, THE_PLATFORMS_OWN.speech, MANAGED
+    )
+
+    assert providers.stt == "deepgram"
+    assert providers.stt_base_url == f"{THE_GATEWAY}/deepgram"
+    assert providers.stt_key == GATEWAY_CREDENTIAL
+    assert providers.tts == "cartesia"
+    assert providers.tts_base_url == f"{THE_GATEWAY}/cartesia/tts/websocket"
+    assert providers.tts_key == GATEWAY_CREDENTIAL
+    # The pinned selections are untouched by who supplies the credentials.
+    assert providers.stt_model == "the-model-the-persona-listens-with"
+    assert providers.tts_model == "the-model-the-persona-speaks-with"
+    assert providers.tts_voice == "the-voice-the-persona-selected"
+
+
+def test_a_managed_brain_thinks_through_the_gateway_with_its_credential(a_container):
+    client = build_model_client(a_container, a_spec_with(models=MANAGED))
+
+    assert isinstance(client, OpenAICompatibleModel)
+    assert client._base_url == f"{THE_GATEWAY}/openai/v1"
+    assert client._api_key == GATEWAY_CREDENTIAL
+    assert client._model_name == "the-model-the-persona-selected"
+
+
+def test_a_customer_owned_order_names_no_gateway_at_all(a_container):
+    """Egma is not on the model traffic path under customer-owned access, so
+    the legs reach their own providers exactly as they always did."""
+    providers = SpeechProviders.for_simulation(
+        a_container, THE_PLATFORMS_OWN.speech, SELECTED
+    )
+
+    assert providers.stt_base_url is None
+    assert providers.tts_base_url is None
+
+
+def test_a_managed_leg_with_no_gateway_route_is_refused_rather_than_guessed():
+    """Answering the gateway's bare address would send the leg to a path the
+    gateway turns away, and whoever read the failure would see the provider
+    being wrong."""
+    gateway = GatewayAccess(address=THE_GATEWAY, credential=GATEWAY_CREDENTIAL)
+
+    assert gateway.base_for("deepgram", "tts") is None
+    assert gateway.base_for("a-provider-with-no-route", "llm") is None
+
+
+def test_a_managed_gateway_credential_never_appears_in_a_repr():
+    assert GATEWAY_CREDENTIAL not in repr(MANAGED)
+    assert GATEWAY_CREDENTIAL not in repr(MANAGED.gateway)
+
+
+def test_a_claimed_managed_document_becomes_the_gateway_it_carries():
+    document = {
+        "contract_version": 2,
+        "simulation_id": "sim-1",
+        "modality": "voice",
+        "connection": {"type": "scripted", "config": {}, "credentials": None},
+        "persona": {"traits": {}},
+        "scenario": {"instructions": "Say the thing."},
+        "limits": {"max_duration_seconds": 300, "max_turns": 40},
+        "models": {
+            "access": "managed",
+            "gateway": {
+                "address": THE_GATEWAY,
+                "credential": GATEWAY_CREDENTIAL,
+            },
+            "llm": {"provider": "openai", "model": "m"},
+            "stt": {"provider": "deepgram", "model": "n"},
+            "tts": {
+                "provider": "cartesia",
+                "model": "s",
+                "voice_id": "v",
+                "speed": 1.0,
+            },
+        },
+    }
+
+    spec = SimulationSpec.from_document(document)
+
+    assert spec.models is not None
+    assert spec.models.access == "managed"
+    assert spec.models.gateway is not None
+    assert spec.models.gateway.address == THE_GATEWAY
+    assert spec.models.gateway.credential == GATEWAY_CREDENTIAL
+    # No provider key anywhere, because none travelled.
+    assert spec.models.llm.key is None
+    assert spec.models.stt.key is None
+    assert spec.models.tts.key is None

--- a/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
@@ -670,14 +670,23 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
 
       {!confirmingDisconnect ? null : (
         <Dialog
-          title="Disconnect Egma?"
+          /*
+           * The key is named, on the same rule the sibling remove-credential
+           * dialog follows: a destructive dialog says which thing it is about.
+           * The safe hint is all there is to name one by — it is the only part
+           * of a connected key anybody can see — and it is exactly enough to
+           * tell an administrator holding two whether this is the one they
+           * meant.
+           */
+          title={`Disconnect Egma (…${managed.hint ?? ""})?`}
           onClose={() => setConfirmingDisconnect(false)}
         >
           {(dismiss) => (
             <>
               <p>
-                This deployment will hold no inference key for the Egma model
-                gateway. While this organization stays on Managed by Egma, every
+                Egma will hold no inference key for this organization. The key
+                ending …{managed.hint} is removed from this deployment, and
+                while this organization stays on Managed by Egma every
                 simulation and every grading job stops with an error naming the
                 missing key.
               </p>

--- a/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
@@ -8,21 +8,26 @@ import { roleOf } from "../../../../../lib/me.ts";
 import {
   credentialsIn,
   jobsOfProvider,
+  managedIn,
   labelOfProvider,
   modelProviderCredentialPath,
   providersIn,
   JOB_LABEL,
+  MANAGED_ACCESS_PATH,
   MODE_LABEL,
   MODEL_ACCESS_PATH,
   MODEL_CATALOG_PATH,
   MODEL_PROVIDER_CREDENTIALS_PATH,
   type ModelAccess,
+  type ModelAccessMode,
   type ModelCatalog,
   type ModelProviderCredential,
 } from "../../../../../lib/model-access.ts";
 import {
+  Actions,
   Badge,
   Button,
+  Choice,
   Field,
   Form,
   FormActions,
@@ -123,6 +128,10 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
   const [confirmingRemove, setConfirmingRemove] = useState<ProviderRow | null>(
     null,
   );
+  /** Whether the Connect Egma form is open, and what has been typed into it. */
+  const [connecting, setConnecting] = useState(false);
+  const [inferenceKey, setInferenceKey] = useState("");
+  const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
 
   useEffect(() => {
     if (access?.status === "signed-out" || catalog?.status === "signed-out") {
@@ -300,24 +309,123 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
     },
   ];
 
+  const hosted = access.value.hosted === true;
+  const managed = managedIn(access.value);
+  const managedAvailable = access.value.managed_available === true;
+
+  async function chooseMode(next: ModelAccessMode): Promise<void> {
+    if (!mayAdminister || busy || next === mode) return;
+    setRefused(null);
+    setSaved(null);
+    setBusy(true);
+
+    const written = await writeJson(MODEL_ACCESS_PATH, {
+      method: "PUT",
+      project: projectId,
+      body: { mode: next },
+    });
+
+    setBusy(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    reloadAccess();
+  }
+
+  async function connect(): Promise<void> {
+    if (!mayAdminister || inferenceKey.trim() === "" || busy) return;
+    setRefused(null);
+    setSaved(null);
+    setBusy(true);
+
+    const written = await writeJson(MANAGED_ACCESS_PATH, {
+      method: "PUT",
+      project: projectId,
+      body: { key: inferenceKey.trim() },
+    });
+
+    setBusy(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    // Cleared the moment it lands: what was typed is a secret, and a form that
+    // kept it on screen would be the one place in the product that shows one.
+    setInferenceKey("");
+    setConnecting(false);
+    setSaved("Egma");
+    reloadAccess();
+  }
+
+  async function disconnect(): Promise<void> {
+    if (!mayAdminister || busy) return;
+    setRefused(null);
+    setSaved(null);
+    setBusy(true);
+
+    const written = await deleteJson(MANAGED_ACCESS_PATH, { project: projectId });
+
+    setBusy(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    setConnecting(false);
+    reloadAccess();
+  }
+
   return (
     <Frame projectId={projectId}>
       <Section
         title="Model access"
         lead="Who supplies the provider keys every persona and grader in this organization spends."
       >
+        {mayAdminister ? (
+          <Choice<ModelAccessMode>
+            label="Model access"
+            value={mode}
+            options={access.value.modes.map((one) => ({
+              value: one,
+              label: MODE_LABEL[one],
+            }))}
+            onChange={(next) => void chooseMode(next)}
+          />
+        ) : (
+          <Help>
+            <Badge tone="neutral">{MODE_LABEL[mode]}</Badge>
+          </Help>
+        )}
+
         <Help>
-          <Badge tone="neutral">{MODE_LABEL[mode]}</Badge>{" "}
           {mode === "customer-owned"
             ? "This organization uses its own provider accounts. The simulator and the grader call those providers directly, and Egma is not on the path."
-            : "This organization uses Egma's provider accounts through the Egma model gateway."}
+            : "This organization uses Egma's provider accounts through the Egma model gateway. Egma's provider keys stay inside that gateway and never reach a simulator or a grader."}
         </Help>
 
-        {access.value.managed_available ? null : (
+        {/*
+         * The one thing that stops the choice landing, said before somebody
+         * makes it rather than as a refusal afterwards. Never shown on hosted
+         * Egma, where there is nothing to connect and managed access is
+         * always available.
+         */}
+        {managedAvailable || mode === "managed" ? null : (
           <Help>
-            Managed by Egma is not available on this deployment: it sends model
-            traffic through the Egma model gateway, and no connection to it has
-            been made here. Customer-owned is the only mode that can be chosen.
+            Managed by Egma sends model traffic through the Egma model gateway,
+            and this deployment has connected no inference key for it. Connect
+            one below to make it available.
           </Help>
         )}
 
@@ -327,7 +435,133 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
             organization admin.
           </Help>
         )}
+
+        {/* A refusal from the mode switch, which has no form of its own. */}
+        {refused === null || open !== undefined || connecting ? null : (
+          <Failure
+            title="Egma did not change model access."
+            message={refused.message}
+            onRetry={reloadAccess}
+          />
+        )}
       </Section>
+
+      {/*
+       * Managed by Egma, in the shape this deployment actually has.
+       *
+       * Hosted Egma operates the gateway and signs its own credentials, so
+       * there is nothing to paste and nothing to disconnect — the whole state
+       * is Available. A self-hosted deployment holds one inference key, and the
+       * states are Connect Egma, Connected, Replace and Disconnect.
+       */}
+      {hosted ? (
+        <Section
+          title="Managed by Egma"
+          lead="Egma supplies the provider accounts for this organization's model traffic."
+        >
+          <Help>
+            <Badge tone="good">Available</Badge> Nothing to connect and nothing
+            to paste. This deployment operates the Egma model gateway, so a
+            persona and a grader can run before this organization has an account
+            with any model provider.
+          </Help>
+        </Section>
+      ) : (
+        <Section
+          title="Managed by Egma"
+          lead="One inference key, created in Egma Cloud, that lets this deployment use Egma's provider accounts."
+        >
+          <Help>
+            {managed.connected ? (
+              <>
+                <Badge tone="good">Connected</Badge>{" "}
+                <span>…{managed.hint}</span> Simulations and grading on Managed
+                by Egma present this key at the Egma model gateway. It is sealed
+                here and cannot be read back.
+              </>
+            ) : (
+              <>
+                <Badge tone="warn">Not connected</Badge> Create an inference key
+                in Egma Cloud and paste it here. Egma checks it before anything
+                is stored, and stores it sealed.
+              </>
+            )}
+          </Help>
+
+          {!mayAdminister ? null : (
+            <Actions>
+              <Button
+                disabled={busy}
+                ariaExpanded={connecting}
+                onClick={() => {
+                  setInferenceKey("");
+                  setRefused(null);
+                  setSaved(null);
+                  setConnecting(!connecting);
+                }}
+              >
+                {managed.connected ? "Replace key" : "Connect Egma"}
+              </Button>
+              {!managed.connected ? null : (
+                <Button
+                  disabled={busy}
+                  onClick={() => setConfirmingDisconnect(true)}
+                >
+                  Disconnect
+                </Button>
+              )}
+            </Actions>
+          )}
+
+          {!connecting ? null : (
+            <Form onSubmit={() => void connect()}>
+              <Field
+                label={
+                  managed.connected
+                    ? "Replacement inference key"
+                    : "Inference key from Egma Cloud"
+                }
+                htmlFor="managed-access-key"
+                hint="Egma Cloud shows an inference key once, when it is created. Egma checks this one with Egma Cloud before storing it, and reports Connected only after Egma Cloud confirms which organization owns it."
+              >
+                <TextInput
+                  id="managed-access-key"
+                  value={inferenceKey}
+                  type="password"
+                  disabled={!mayAdminister}
+                  onChange={setInferenceKey}
+                />
+              </Field>
+
+              {refused === null ? null : (
+                <Failure
+                  title="Egma did not connect that key."
+                  message={refused.message}
+                  onRetry={() => void connect()}
+                />
+              )}
+
+              <FormActions>
+                <Button
+                  weight="strong"
+                  type="submit"
+                  busy={busy}
+                  disabled={!mayAdminister || inferenceKey.trim() === ""}
+                >
+                  {managed.connected ? "Replace key" : "Connect Egma"}
+                </Button>
+                <Button disabled={busy} onClick={() => setConnecting(false)}>
+                  Cancel
+                </Button>
+              </FormActions>
+            </Form>
+          )}
+
+          {saved !== "Egma" || refused !== null ? null : (
+            <Help>Egma is connected.</Help>
+          )}
+        </Section>
+      )}
 
       {mode !== "customer-owned" ? null : (
         <Section
@@ -432,6 +666,39 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
             </>
           )}
         </Section>
+      )}
+
+      {!confirmingDisconnect ? null : (
+        <Dialog
+          title="Disconnect Egma?"
+          onClose={() => setConfirmingDisconnect(false)}
+        >
+          {(dismiss) => (
+            <>
+              <p>
+                This deployment will hold no inference key for the Egma model
+                gateway. While this organization stays on Managed by Egma, every
+                simulation and every grading job stops with an error naming the
+                missing key.
+              </p>
+              <p>
+                The stored key cannot be read back, so reconnecting means having
+                the key itself — or creating a new one in Egma Cloud.
+              </p>
+              <Button onClick={dismiss}>Cancel</Button>{" "}
+              <Button
+                tone="destructive"
+                busy={busy}
+                onClick={() => {
+                  setConfirmingDisconnect(false);
+                  void disconnect();
+                }}
+              >
+                Disconnect
+              </Button>
+            </>
+          )}
+        </Dialog>
       )}
 
       {confirmingRemove === null ? null : (

--- a/apps/web/lib/model-access.ts
+++ b/apps/web/lib/model-access.ts
@@ -31,6 +31,23 @@ export type ModelProviderCredential = {
   readonly updated_at: string;
 };
 
+/**
+ * The organization's connection to the Egma model gateway, as a self-hosted
+ * deployment holds it.
+ *
+ * **Connected, a hint, and which Egma Cloud organization it is bound to. Never
+ * the key.** There is no field here a secret could travel in, because there is
+ * none in the answer either: a connected key is sealed and there is no route
+ * that reads one back.
+ */
+export type ManagedConnection = {
+  readonly connected: boolean;
+  /** The last characters of the connected key, or null where none is. */
+  readonly hint: string | null;
+  readonly cloud_organization_id: string | null;
+  readonly connected_at: string | null;
+};
+
 export type ModelAccess = {
   readonly mode: ModelAccessMode;
   /** When the choice was last made, or null where nobody has made one. */
@@ -39,11 +56,21 @@ export type ModelAccess = {
   /**
    * Whether managed access can be chosen on this deployment at all.
    *
-   * **A fact about the deployment, never about the organization's current
-   * choice.** A form that offered a mode the server refuses would let somebody
-   * decide before telling them the decision cannot land.
+   * **A fact about the deployment and this organization's connection, never
+   * about the organization's current choice.** A form that offered a mode the
+   * server refuses would let somebody decide before telling them the decision
+   * cannot land.
    */
   readonly managed_available: boolean;
+  /**
+   * Whether this is hosted Egma, which operates the gateway.
+   *
+   * It decides which of two managed shapes the screen draws: a state to read,
+   * or a key to connect. A page that guessed from `managed_available` would
+   * draw a Connect form on a deployment with nothing to connect.
+   */
+  readonly hosted: boolean;
+  readonly managed: ManagedConnection;
   readonly credentials: readonly ModelProviderCredential[];
 };
 
@@ -67,9 +94,25 @@ export type ModelCatalog = {
 export const MODEL_ACCESS_PATH = "/api/model-access";
 export const MODEL_CATALOG_PATH = "/api/model-catalog";
 export const MODEL_PROVIDER_CREDENTIALS_PATH = "/api/model-provider-credentials";
+export const MANAGED_ACCESS_PATH = "/api/managed-access";
 
 export function modelProviderCredentialPath(provider: string): string {
   return `${MODEL_PROVIDER_CREDENTIALS_PATH}/${encodeURIComponent(provider)}`;
+}
+
+/**
+ * The connection an answer actually carried, and not connected at all when it
+ * carried something this page cannot read.
+ *
+ * The same guard `credentialsIn` makes one field over, for the same reason: a
+ * read whose shape is not the expected one is a deployment mid-upgrade, and
+ * trusting it costs the whole settings page rather than one row.
+ */
+export function managedIn(access: ModelAccess | undefined): ManagedConnection {
+  const said = access?.managed;
+  return typeof said === "object" && said !== null
+    ? said
+    : { connected: false, hint: null, cloud_organization_id: null, connected_at: null };
 }
 
 /** What a person calls each mode, said the way the settings screen says it. */

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -130,6 +130,12 @@ const config: NextConfig = {
         // hosted deployment it did not, which is why every bare path in this
         // file is named outright rather than left to the wildcard.
         { source: "/api/model-access", destination: `${api}/api/model-access` },
+        // The self-hosted deployment's one inference key: connected, replaced
+        // and disconnected here, and never read back out.
+        {
+          source: "/api/managed-access",
+          destination: `${api}/api/managed-access`,
+        },
         { source: "/api/model-catalog", destination: `${api}/api/model-catalog` },
         {
           source: "/api/model-provider-credentials",

--- a/apps/web/test/model-providers.test.tsx
+++ b/apps/web/test/model-providers.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ModelProvidersPage from "../app/projects/[projectId]/settings/model-providers/page.tsx";
+import type { Me } from "../lib/me.ts";
+
+/**
+ * Model providers, in the three shapes a deployment can put it in.
+ *
+ * **Hosted managed access is a state to read; self-hosted managed access is a
+ * key to connect.** The two are different screens behind one word, and a page
+ * that guessed which one it was on would draw a Connect form on a deployment
+ * with nothing to connect. So the deployment says which it is, and this reads
+ * back what a person actually sees in each.
+ *
+ * Nothing here asserts that a component exists or that a source file contains a
+ * string: the API's real answers go in front of the real page, and the DOM is
+ * what is read.
+ */
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/projects/prj_1/settings/model-providers",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useParams: () => ({ projectId: "prj_1" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: unknown }) => (
+    <a href={href} {...rest}>
+      {children as never}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+const ME: Me = {
+  user: { id: "usr_1", email: "ada@acme.example" },
+  organizations: [{ id: "org_1", name: "Acme", slug: "acme", role: "admin" }],
+  projects: [{ id: "prj_1", name: "Default", slug: "default" }],
+};
+
+const CATALOG = {
+  jobs: ["llm", "stt", "tts"],
+  providers: [
+    {
+      provider: "openai",
+      job: "llm",
+      label: "OpenAI",
+      recommended_model: "gpt-4o-mini",
+      recommended: true,
+      model_is_free_text: true,
+    },
+  ],
+  reserved: [],
+};
+
+function accessAnswer(
+  over: Partial<{
+    mode: string;
+    hosted: boolean;
+    managed_available: boolean;
+    managed: Record<string, unknown>;
+  }>,
+): Record<string, unknown> {
+  return {
+    mode: "customer-owned",
+    updated_at: null,
+    modes: ["managed", "customer-owned"],
+    managed_available: false,
+    hosted: false,
+    managed: {
+      connected: false,
+      hint: null,
+      cloud_organization_id: null,
+      connected_at: null,
+    },
+    credentials: [],
+    ...over,
+  };
+}
+
+function apiAnswers(answers: Record<string, unknown>): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string) => {
+      const url = new URL(input, "http://egma.test");
+      const held = answers[url.pathname];
+      if (held === undefined) throw new Error(`nothing stubbed for ${url.pathname}`);
+      return new Response(JSON.stringify(held), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }),
+  );
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, replace: vi.fn(), assign: vi.fn() },
+  });
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+async function open(access: Record<string, unknown>): Promise<void> {
+  apiAnswers({
+    "/api/me": ME,
+    "/api/projects": { projects: ME.projects },
+    "/api/model-access": access,
+    "/api/model-catalog": CATALOG,
+  });
+  render(<ModelProvidersPage />);
+  await waitFor(() => expect(screen.getByText("Model access")).toBeDefined());
+}
+
+describe("hosted Egma", () => {
+  it("says managed access is Available, with nothing to paste and nothing to disconnect", async () => {
+    await open(
+      accessAnswer({ mode: "managed", hosted: true, managed_available: true }),
+    );
+
+    expect(screen.getByText("Available")).toBeDefined();
+    // There is no key to connect, so no form and no destructive action exist
+    // to be found — which is the shape rather than a rule anybody follows.
+    expect(screen.queryByRole("button", { name: "Connect Egma" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull();
+    expect(document.querySelectorAll('input[type="password"]')).toHaveLength(0);
+  });
+});
+
+describe("a self-hosted deployment with nothing connected", () => {
+  it("offers Connect Egma, and says why managed access cannot be chosen yet", async () => {
+    await open(accessAnswer({}));
+
+    expect(screen.getByText("Not connected")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Connect Egma" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull();
+    expect(
+      screen.getByText(/connected no inference key for it/),
+    ).toBeDefined();
+    // The choice is still drawn, because refusing to show a mode is not the
+    // same as explaining it — and the sentence above is the explanation.
+    expect(screen.getByRole("radio", { name: "Managed by Egma" })).toBeDefined();
+  });
+
+  it("opens exactly one masked field, and the key is never a value on screen", async () => {
+    await open(accessAnswer({}));
+
+    expect(document.querySelectorAll('input[type="password"]')).toHaveLength(0);
+    screen.getByRole("button", { name: "Connect Egma" }).click();
+
+    await waitFor(() =>
+      expect(document.querySelectorAll('input[type="password"]')).toHaveLength(1),
+    );
+    const field = document.querySelector<HTMLInputElement>("#managed-access-key");
+    expect(field?.type).toBe("password");
+    expect(field?.value).toBe("");
+  });
+});
+
+describe("a self-hosted deployment with a key connected", () => {
+  it("shows Connected and a safe hint, and offers Replace and Disconnect", async () => {
+    await open(
+      accessAnswer({
+        mode: "managed",
+        managed_available: true,
+        managed: {
+          connected: true,
+          hint: "A1B2",
+          cloud_organization_id: "org_cloud_1",
+          connected_at: "2026-08-17T10:00:00.000Z",
+        },
+      }),
+    );
+
+    expect(screen.getByText("Connected")).toBeDefined();
+    expect(screen.getByText("…A1B2")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Replace key" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Disconnect" })).toBeDefined();
+    // Managed access is chosen, so the provider rows are not the story here.
+    expect(screen.queryByLabelText("Model providers")).toBeNull();
+  });
+});

--- a/apps/web/test/model-providers.test.tsx
+++ b/apps/web/test/model-providers.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ModelProvidersPage from "../app/projects/[projectId]/settings/model-providers/page.tsx";
@@ -188,5 +188,30 @@ describe("a self-hosted deployment with a key connected", () => {
     expect(screen.getByRole("button", { name: "Disconnect" })).toBeDefined();
     // Managed access is chosen, so the provider rows are not the story here.
     expect(screen.queryByLabelText("Model providers")).toBeNull();
+  });
+
+  it("names the key in the disconnect dialog, because a destructive one must", async () => {
+    await open(
+      accessAnswer({
+        mode: "managed",
+        managed_available: true,
+        managed: {
+          connected: true,
+          hint: "A1B2",
+          cloud_organization_id: "org_cloud_1",
+          connected_at: "2026-08-17T10:00:00.000Z",
+        },
+      }),
+    );
+
+    screen.getByRole("button", { name: "Disconnect" }).click();
+
+    const dialog = await waitFor(() => screen.getByRole("dialog"));
+    // The safe hint is the only part of a connected key anybody can see, and
+    // it is exactly enough to tell an administrator holding two which one this
+    // is about.
+    expect(within(dialog).getAllByText(/A1B2/).length).toBeGreaterThan(0);
+    // And it says what stops, rather than only what is removed.
+    expect(within(dialog).getByText(/stops with an error/)).toBeDefined();
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,6 +339,32 @@ services:
       # these two directly and gives that credential the same shape.
       EGMA_BLOB_ACCESS_KEY_ID: ${EGMA_BLOB_ACCESS_KEY_ID:-${EGMA_S3_READ_ACCESS_KEY_ID:?no default — the read-only credential playback links are signed with. openssl rand -hex 8 makes one, set it in .env}}
       EGMA_BLOB_SECRET_ACCESS_KEY: ${EGMA_BLOB_SECRET_ACCESS_KEY:-${EGMA_S3_READ_SECRET_ACCESS_KEY:?no default — openssl rand -base64 24 makes one, set it in .env beside EGMA_S3_READ_ACCESS_KEY_ID}}
+      # ── Managed model access ───────────────────────────────────────────
+      # Whether this is hosted Egma, where the Egma model gateway and the
+      # provider accounts behind it belong. It decides three things and
+      # nothing else: a new organization starts on Managed by Egma rather
+      # than Customer-owned, managed work is authorized by a credential this
+      # deployment signs rather than by a pasted inference key, and inference
+      # keys can be created here at all. A self-hosted deployment leaves it
+      # off, which is the default and the ordinary case.
+      EGMA_HOSTED: ${EGMA_HOSTED:-false}
+      # Where the Egma model gateway answers. Unset on a deployment that has
+      # not connected managed model access, which is every deployment until
+      # somebody does; a claim that needs it and does not have it lands as a
+      # visible infrastructure error rather than as a leg quietly calling a
+      # provider directly.
+      EGMA_MODEL_GATEWAY_URL: ${EGMA_MODEL_GATEWAY_URL:-}
+      # The key hosted Egma signs its own gateway credentials with. Hosted
+      # Egma's alone: a self-hosted deployment presents the inference key its
+      # administrator connected and holds nothing here. It is the same value
+      # and the same name the gateway itself reads, because it is one secret
+      # shared by the two ends of one wire.
+      EGMA_GATEWAY_INTERNAL_KEY: ${EGMA_GATEWAY_INTERNAL_KEY:-}
+      # Where Egma Cloud answers when an administrator connects an inference
+      # key. One content-free request, made on their behalf when they paste
+      # one and never again. Hosted Egma is at one address, so this has a
+      # default; a deployment pointed at a staging Egma Cloud sets it.
+      EGMA_CLOUD_URL: ${EGMA_CLOUD_URL:-}
       EGMA_SINGLE_ORGANIZATION: ${EGMA_SINGLE_ORGANIZATION:-true}
       EGMA_TRUST_PROXY: ${EGMA_TRUST_PROXY:-false}
       # The budget belongs to the organization rather than to a key, so
@@ -651,6 +677,27 @@ services:
       # There is still deliberately no model key here. A judge belongs to the
       # project that configured it, never to a container.
       EGMA_ENCRYPTION_KEY: ${EGMA_ENCRYPTION_KEY:?no default — openssl rand -hex 32 makes one, set it in .env and back it up beside the database}
+      # ── Managed model access ───────────────────────────────────────────
+      # Whether this is hosted Egma, where the Egma model gateway and the
+      # provider accounts behind it belong. It decides three things and
+      # nothing else: a new organization starts on Managed by Egma rather
+      # than Customer-owned, managed work is authorized by a credential this
+      # deployment signs rather than by a pasted inference key, and inference
+      # keys can be created here at all. A self-hosted deployment leaves it
+      # off, which is the default and the ordinary case.
+      EGMA_HOSTED: ${EGMA_HOSTED:-false}
+      # Where the Egma model gateway answers. Unset on a deployment that has
+      # not connected managed model access, which is every deployment until
+      # somebody does; a claim that needs it and does not have it lands as a
+      # visible infrastructure error rather than as a leg quietly calling a
+      # provider directly.
+      EGMA_MODEL_GATEWAY_URL: ${EGMA_MODEL_GATEWAY_URL:-}
+      # The key hosted Egma signs its own gateway credentials with. Hosted
+      # Egma's alone: a self-hosted deployment presents the inference key its
+      # administrator connected and holds nothing here. It is the same value
+      # and the same name the gateway itself reads, because it is one secret
+      # shared by the two ends of one wire.
+      EGMA_GATEWAY_INTERNAL_KEY: ${EGMA_GATEWAY_INTERNAL_KEY:-}
       # This copy's own name for itself, in claims and in its log. Unset is
       # fine and usual — it names itself after its host and process, which is
       # what tells two copies apart.

--- a/packages/db/migrations/0036_managed_model_access.sql
+++ b/packages/db/migrations/0036_managed_model_access.sql
@@ -1,0 +1,50 @@
+-- Managed model access: the two halves of one inference key, in the two
+-- deployments that hold them.
+--
+--  * `inference_key` is hosted Egma's half — the hash of a key an organization
+--    administrator created, its name, its safe hint and its lifecycle times.
+--    There is no column a readable copy could live in, which is what makes
+--    "shown once" a property of the schema rather than of a route's manners.
+--    Several rows may be active for one organization at once, so a replacement
+--    can be brought up before the old key is revoked.
+--  * `managed_access_key` is a self-hosted deployment's half — the key itself,
+--    sealed with the same master key and the same envelope every other
+--    credential in this schema uses, plus the Egma Cloud organization that
+--    validation said owns it. One row per organization: connecting replaces,
+--    disconnecting removes, and the binding is what refuses a key belonging to
+--    somebody else's Egma Cloud organization.
+--
+-- Additive. Nothing is dropped, nothing is backfilled, and no organization's
+-- model access is decided here.
+
+CREATE TABLE "inference_key" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"name" text NOT NULL,
+	"hash" text NOT NULL,
+	"prefix" text NOT NULL,
+	"display_suffix" text NOT NULL,
+	"created_by" text COLLATE "C",
+	"last_used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "inference_key_hash_unique" UNIQUE("hash"),
+	CONSTRAINT "inference_key_id_prefix" CHECK ("inference_key"."id" ~ '^ifk_[0-9A-HJKMNP-TV-Z]{26}$')
+);
+--> statement-breakpoint
+CREATE TABLE "managed_access_key" (
+	"organization_id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"cloud_organization_id" text COLLATE "C" NOT NULL,
+	"credentials" text NOT NULL,
+	"credentials_hint" text NOT NULL,
+	"connected_by" text COLLATE "C",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "managed_access_key_organization_id_prefix" CHECK ("managed_access_key"."organization_id" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$')
+);
+--> statement-breakpoint
+ALTER TABLE "inference_key" ADD CONSTRAINT "inference_key_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "inference_key" ADD CONSTRAINT "inference_key_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "managed_access_key" ADD CONSTRAINT "managed_access_key_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "managed_access_key" ADD CONSTRAINT "managed_access_key_connected_by_user_id_fk" FOREIGN KEY ("connected_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/db/migrations/meta/0036_snapshot.json
+++ b/packages/db/migrations/meta/0036_snapshot.json
@@ -1,0 +1,6275 @@
+{
+  "id": "4a5d3363-2612-445c-ac48-95f3604ad245",
+  "prevId": "7fa9f1c0-23fe-4d53-ac9b-7746cb2c11a4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.platform_instance": {
+      "name": "platform_instance",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_instance_id_unique": {
+          "name": "platform_instance_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_instance_id_format": {
+          "name": "platform_instance_id_format",
+          "value": "\"platform_instance\".\"id\" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_setting": {
+      "name": "platform_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_setting_name_unique": {
+          "name": "platform_setting_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "platform_setting_id_prefix": {
+          "name": "platform_setting_id_prefix",
+          "value": "\"platform_setting\".\"id\" ~ '^pfs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_revision_prefix": {
+          "name": "project_revision_prefix",
+          "value": "\"project\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inference_key": {
+      "name": "inference_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "inference_key_organization_id_organization_id_fk": {
+          "name": "inference_key_organization_id_organization_id_fk",
+          "tableFrom": "inference_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_key_created_by_user_id_fk": {
+          "name": "inference_key_created_by_user_id_fk",
+          "tableFrom": "inference_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "inference_key_hash_unique": {
+          "name": "inference_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "inference_key_id_prefix": {
+          "name": "inference_key_id_prefix",
+          "value": "\"inference_key\".\"id\" ~ '^ifk_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.managed_access_key": {
+      "name": "managed_access_key",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cloud_organization_id": {
+          "name": "cloud_organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "managed_access_key_organization_id_organization_id_fk": {
+          "name": "managed_access_key_organization_id_organization_id_fk",
+          "tableFrom": "managed_access_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "managed_access_key_connected_by_user_id_fk": {
+          "name": "managed_access_key_connected_by_user_id_fk",
+          "tableFrom": "managed_access_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "managed_access_key_organization_id_prefix": {
+          "name": "managed_access_key_organization_id_prefix",
+          "value": "\"managed_access_key\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_access": {
+      "name": "model_access",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_access_organization_id_organization_id_fk": {
+          "name": "model_access_organization_id_organization_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_access_updated_by_user_id_fk": {
+          "name": "model_access_updated_by_user_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "model_access_organization_id_prefix": {
+          "name": "model_access_organization_id_prefix",
+          "value": "\"model_access\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_access_mode_allowed": {
+          "name": "model_access_mode_allowed",
+          "value": "\"model_access\".\"mode\" in ('managed', 'customer-owned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_provider_credential": {
+      "name": "model_provider_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_credential_organization_id_organization_id_fk": {
+          "name": "model_provider_credential_organization_id_organization_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_created_by_user_id_fk": {
+          "name": "model_provider_credential_created_by_user_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_credential_one_per_provider": {
+          "name": "model_provider_credential_one_per_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_credential_id_prefix": {
+          "name": "model_provider_credential_id_prefix",
+          "value": "\"model_provider_credential\".\"id\" ~ '^mpc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_revision_prefix": {
+          "name": "model_provider_credential_revision_prefix",
+          "value": "\"model_provider_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_provider_allowed": {
+          "name": "model_provider_credential_provider_allowed",
+          "value": "\"model_provider_credential\".\"provider\" in ('openai', 'deepgram', 'cartesia')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models": {
+          "name": "models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_state": {
+          "name": "capability_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "capabilities_measured": {
+          "name": "capabilities_measured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_supported": {
+          "name": "capabilities_supported",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_checked_at": {
+          "name": "capabilities_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_source": {
+          "name": "capability_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_production": {
+          "name": "watch_production",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "production_cursor": {
+          "name": "production_cursor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_registered_at": {
+          "name": "webhook_registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivered_at": {
+          "name": "webhook_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_capability_state_allowed": {
+          "name": "connection_capability_state_allowed",
+          "value": "\"connection\".\"capability_state\" in ('unknown', 'known')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        },
+        "connection_capability_evidence_agrees": {
+          "name": "connection_capability_evidence_agrees",
+          "value": "(\"connection\".\"capability_state\" = 'known') = (\"connection\".\"capabilities_measured\" is not null and \"connection\".\"capabilities_supported\" is not null and \"connection\".\"capabilities_checked_at\" is not null and \"connection\".\"capability_source\" is not null)"
+        },
+        "connection_capabilities_supported_were_measured": {
+          "name": "connection_capabilities_supported_were_measured",
+          "value": "\"connection\".\"capabilities_supported\" is null or \"connection\".\"capabilities_supported\" <@ \"connection\".\"capabilities_measured\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.production_trace_claim": {
+      "name": "production_trace_claim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_call_id": {
+          "name": "provider_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degraded": {
+          "name": "degraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "production_trace_claim_unwritten_idx": {
+          "name": "production_trace_claim_unwritten_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"production_trace_claim\".\"status\" = 'claimed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "production_trace_claim_organization_id_organization_id_fk": {
+          "name": "production_trace_claim_organization_id_organization_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_connection_id_connection_id_fk": {
+          "name": "production_trace_claim_connection_id_connection_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_project_organization_fk": {
+          "name": "production_trace_claim_project_organization_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "production_trace_claim_trace_id_unique": {
+          "name": "production_trace_claim_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "production_trace_claim_id_prefix": {
+          "name": "production_trace_claim_id_prefix",
+          "value": "\"production_trace_claim\".\"id\" ~ '^ptc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "production_trace_claim_status_allowed": {
+          "name": "production_trace_claim_status_allowed",
+          "value": "\"production_trace_claim\".\"status\" in ('claimed', 'written')"
+        },
+        "production_trace_claim_transport_allowed": {
+          "name": "production_trace_claim_transport_allowed",
+          "value": "\"production_trace_claim\".\"transport\" in ('webhook', 'pull')"
+        },
+        "production_trace_claim_written_agrees": {
+          "name": "production_trace_claim_written_agrees",
+          "value": "(\"production_trace_claim\".\"status\" = 'written') = (\"production_trace_claim\".\"written_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.retell_webhook_refusal": {
+      "name": "retell_webhook_refusal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "how_many": {
+          "name": "how_many",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retell_webhook_refusal_reason_unique": {
+          "name": "retell_webhook_refusal_reason_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reason"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "retell_webhook_refusal_id_prefix": {
+          "name": "retell_webhook_refusal_id_prefix",
+          "value": "\"retell_webhook_refusal\".\"id\" ~ '^rwr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "retell_webhook_refusal_reason_allowed": {
+          "name": "retell_webhook_refusal_reason_allowed",
+          "value": "\"retell_webhook_refusal\".\"reason\" in ('unknown_agent', 'switched_off', 'bad_signature', 'other_kind')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_id_idx": {
+          "name": "grader_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_id_grader_library_id_fk": {
+          "name": "grader_library_id_grader_library_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_library": {
+      "name": "grader_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_definition": {
+          "name": "output_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code": {
+          "name": "source_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_language": {
+          "name": "source_code_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_library_predefined_name_unique": {
+          "name": "grader_library_predefined_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"grader_library\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_organization_id_project_id_idx": {
+          "name": "grader_library_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_library_organization_id_organization_id_fk": {
+          "name": "grader_library_organization_id_organization_id_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_project_organization_fk": {
+          "name": "grader_library_project_organization_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_library_id_prefix": {
+          "name": "grader_library_id_prefix",
+          "value": "\"grader_library\".\"id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_library_type_allowed": {
+          "name": "grader_library_type_allowed",
+          "value": "\"grader_library\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_library_tenancy_is_whole_or_egmas": {
+          "name": "grader_library_tenancy_is_whole_or_egmas",
+          "value": "(\"grader_library\".\"organization_id\" is null) = (\"grader_library\".\"project_id\" is null)"
+        },
+        "grader_library_source_code_within_budget": {
+          "name": "grader_library_source_code_within_budget",
+          "value": "\"grader_library\".\"source_code\" is null or octet_length(\"grader_library\".\"source_code\") <= 262144"
+        },
+        "grader_library_source_code_columns_agree": {
+          "name": "grader_library_source_code_columns_agree",
+          "value": "(\"grader_library\".\"source_code\" is null) = (\"grader_library\".\"source_code_language\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grader_model": {
+          "name": "grader_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_credential_id_judge_credential_id_fk": {
+          "name": "judge_configuration_credential_id_judge_credential_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "judge_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        },
+        "judge_configuration_source_allowed": {
+          "name": "judge_configuration_source_allowed",
+          "value": "\"judge_configuration\".\"source\" in ('credential', 'platform')"
+        },
+        "judge_configuration_has_one_key_source": {
+          "name": "judge_configuration_has_one_key_source",
+          "value": "(\"judge_configuration\".\"source\" = 'credential' and \"judge_configuration\".\"credential_id\" is not null and \"judge_configuration\".\"credentials\" is null and \"judge_configuration\".\"credentials_hint\" is null) or (\"judge_configuration\".\"source\" = 'platform' and \"judge_configuration\".\"credential_id\" is null and \"judge_configuration\".\"credentials\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_credential": {
+      "name": "judge_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "judge_credential_organization_id_idx": {
+          "name": "judge_credential_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"judge_credential\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judge_credential_organization_id_organization_id_fk": {
+          "name": "judge_credential_organization_id_organization_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_credential_created_by_user_id_fk": {
+          "name": "judge_credential_created_by_user_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_credential_id_prefix": {
+          "name": "judge_credential_id_prefix",
+          "value": "\"judge_credential\".\"id\" ~ '^jcr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_revision_prefix": {
+          "name": "judge_credential_revision_prefix",
+          "value": "\"judge_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_provider_allowed": {
+          "name": "judge_credential_provider_allowed",
+          "value": "\"judge_credential\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool": {
+      "name": "mock_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_milliseconds": {
+          "name": "delay_milliseconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_tool_project_id_tool_name_unique": {
+          "name": "mock_tool_project_id_tool_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_tool_organization_id_project_id_idx": {
+          "name": "mock_tool_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_organization_id_organization_id_fk": {
+          "name": "mock_tool_organization_id_organization_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_created_by_user_id_fk": {
+          "name": "mock_tool_created_by_user_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_tool_project_organization_fk": {
+          "name": "mock_tool_project_organization_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mock_tool_id_project_id_unique": {
+          "name": "mock_tool_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_id_prefix": {
+          "name": "mock_tool_id_prefix",
+          "value": "\"mock_tool\".\"id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "mock_tool_delay_within_budget": {
+          "name": "mock_tool_delay_within_budget",
+          "value": "\"mock_tool\".\"delay_milliseconds\" between 0 and 30000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool_agent": {
+      "name": "mock_tool_agent",
+      "schema": "",
+      "columns": {
+        "mock_tool_id": {
+          "name": "mock_tool_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mock_tool_agent_agent_id_idx": {
+          "name": "mock_tool_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_agent_mock_tool_id_mock_tool_id_fk": {
+          "name": "mock_tool_agent_mock_tool_id_mock_tool_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_id_agent_id_fk": {
+          "name": "mock_tool_agent_agent_id_agent_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_mock_tool_project_fk": {
+          "name": "mock_tool_agent_mock_tool_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_project_fk": {
+          "name": "mock_tool_agent_agent_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mock_tool_agent_pk": {
+          "name": "mock_tool_agent_pk",
+          "columns": [
+            "mock_tool_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "mock_tool_agent_mock_tool_id_position_unique": {
+          "name": "mock_tool_agent_mock_tool_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mock_tool_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_agent_mock_tool_id_prefix": {
+          "name": "mock_tool_agent_mock_tool_id_prefix",
+          "value": "\"mock_tool_agent\".\"mock_tool_id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicability_revision": {
+          "name": "applicability_revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_revision_prefix": {
+          "name": "test_revision_prefix",
+          "value": "\"test\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_applicability_revision_prefix": {
+          "name": "test_applicability_revision_prefix",
+          "value": "\"test\".\"applicability_revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_archive_reason_allowed": {
+          "name": "test_archive_reason_allowed",
+          "value": "\"test\".\"archive_reason\" in ('needs_agent')"
+        },
+        "test_archive_reason_needs_an_archive": {
+          "name": "test_archive_reason_needs_an_archive",
+          "value": "\"test\".\"archive_reason\" is null or \"test\".\"archived_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_agent": {
+      "name": "test_agent",
+      "schema": "",
+      "columns": {
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_agent_agent_id_idx": {
+          "name": "test_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_agent_test_id_test_id_fk": {
+          "name": "test_agent_test_id_test_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_id_agent_id_fk": {
+          "name": "test_agent_agent_id_agent_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_created_by_user_id_fk": {
+          "name": "test_agent_created_by_user_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_agent_test_project_fk": {
+          "name": "test_agent_test_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_project_fk": {
+          "name": "test_agent_agent_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_agent_pk": {
+          "name": "test_agent_pk",
+          "columns": [
+            "test_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_agent_test_id_prefix": {
+          "name": "test_agent_test_id_prefix",
+          "value": "\"test_agent\".\"test_id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tool_snapshot": {
+          "name": "mock_tool_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"skipped_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0\n          and \"run\".\"canceled_count\" >= 0 and \"run\".\"skipped_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')\n        or (\"run_event\".\"status\" = 'skipped' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_detail": {
+          "name": "ending_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_repair": {
+          "name": "ending_repair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_coverage": {
+          "name": "mock_tool_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_capabilities": {
+          "name": "skipped_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_repair_allowed": {
+          "name": "simulation_ending_repair_allowed",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_repair\" in ('model_providers')"
+        },
+        "simulation_ending_repair_has_a_reason_to_exist": {
+          "name": "simulation_ending_repair_has_a_reason_to_exist",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_detail\" is not null"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_skipped_shape": {
+          "name": "simulation_skipped_shape",
+          "value": "\"simulation\".\"status\" <> 'skipped'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"claimed_at\" is null\n          and \"simulation\".\"started_at\" is null and \"simulation\".\"cancel_requested_at\" is null\n          and \"simulation\".\"skip_reason\" is not null\n          and \"simulation\".\"skipped_capabilities\" is not null)"
+        },
+        "simulation_skip_reason_belongs_to_a_skip": {
+          "name": "simulation_skip_reason_belongs_to_a_skip",
+          "value": "\"simulation\".\"status\" = 'skipped'\n        or (\"simulation\".\"skip_reason\" is null and \"simulation\".\"skipped_capabilities\" is null)"
+        },
+        "simulation_skip_reason_allowed": {
+          "name": "simulation_skip_reason_allowed",
+          "value": "\"simulation\".\"skip_reason\" is null or \"simulation\".\"skip_reason\" in ('required_capability_unsupported', 'required_capability_unknown')"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_mock_tool_coverage_only_when_ended": {
+          "name": "simulation_mock_tool_coverage_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null or \"simulation\".\"mock_tool_coverage\" is null"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_plan": {
+      "name": "grading_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groups": {
+          "name": "groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_credential_ids": {
+          "name": "judge_credential_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_plan_judge_credential_ids_idx": {
+          "name": "grading_plan_judge_credential_ids_idx",
+          "columns": [
+            {
+              "expression": "judge_credential_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "grading_plan_organization_id_project_id_idx": {
+          "name": "grading_plan_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_plan_organization_id_organization_id_fk": {
+          "name": "grading_plan_organization_id_organization_id_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_project_organization_fk": {
+          "name": "grading_plan_project_organization_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_run_project_fk": {
+          "name": "grading_plan_run_project_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_plan_run_id_unique": {
+          "name": "grading_plan_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_plan_id_prefix": {
+          "name": "grading_plan_id_prefix",
+          "value": "\"grading_plan\".\"id\" ~ '^gpl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_plan_state_allowed": {
+          "name": "grading_plan_state_allowed",
+          "value": "\"grading_plan\".\"state\" in ('run_start', 'migration_snapshot', 'not_recorded')"
+        },
+        "grading_plan_recorded_plans_carry_their_moment": {
+          "name": "grading_plan_recorded_plans_carry_their_moment",
+          "value": "(\"grading_plan\".\"state\" = 'not_recorded')\n        = (\"grading_plan\".\"captured_at\" is null)"
+        },
+        "grading_plan_groups_are_a_list": {
+          "name": "grading_plan_groups_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"groups\") = 'array'"
+        },
+        "grading_plan_credentials_are_a_list": {
+          "name": "grading_plan_credentials_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"judge_credential_ids\") = 'array'"
+        },
+        "grading_plan_unrecorded_holds_nothing": {
+          "name": "grading_plan_unrecorded_holds_nothing",
+          "value": "\"grading_plan\".\"state\" <> 'not_recorded'\n        or (\"grading_plan\".\"groups\" = '[]'::jsonb\n          and \"grading_plan\".\"judge_credential_ids\" = '[]'::jsonb)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotent_operation": {
+      "name": "idempotent_operation",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "idempotent_operation_organization_id_organization_id_fk": {
+          "name": "idempotent_operation_organization_id_organization_id_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_project_organization_fk": {
+          "name": "idempotent_operation_project_organization_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_actor_fk": {
+          "name": "idempotent_operation_actor_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotent_operation_pk": {
+          "name": "idempotent_operation_pk",
+          "columns": [
+            "organization_id",
+            "project_id",
+            "actor_id",
+            "operation",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "idempotent_operation_organization_id_prefix": {
+          "name": "idempotent_operation_organization_id_prefix",
+          "value": "\"idempotent_operation\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "idempotent_operation_allowed": {
+          "name": "idempotent_operation_allowed",
+          "value": "\"idempotent_operation\".\"operation\" in ('start_run')"
+        },
+        "idempotent_operation_key_is_not_empty": {
+          "name": "idempotent_operation_key_is_not_empty",
+          "value": "length(\"idempotent_operation\".\"idempotency_key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1786961303765,
       "tag": "0035_customer_owned_model_access",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1786971693012,
+      "tag": "0036_managed_model_access",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/errors.ts
+++ b/packages/db/src/access/errors.ts
@@ -1170,28 +1170,57 @@ export function refuseRetry(
 export class ManagedAccessNotConnectedError extends Error {
   constructor() {
     super(
-      "managed model access sends this organization's model traffic through the Egma model gateway, and this organization has connected no inference key for it. Choose Customer-owned and add a credential for each provider your personas and graders select.",
+      "managed model access sends this organization's model traffic through the Egma model gateway, and this organization has connected no inference key for it. Create one in Egma Cloud and connect it under Model providers, or choose Customer-owned and add a credential for each provider your personas and graders select.",
     );
     this.name = "ManagedAccessNotConnectedError";
   }
 }
 
 /**
- * A simulation or a grading job selected managed model access on a deployment
- * that has no Egma model gateway connection behind it.
+ * An inference key was pasted whose Egma Cloud organization is not the one this
+ * deployment is already bound to.
  *
- * **A tripwire rather than a fault, and it is typed so it lands as one.** No
- * door in this release can store `managed` — the setting refuses it by name —
- * so a claim that reaches this has found a row nothing should have written.
- * Saying so as an infrastructure error naming the mode, with somewhere to go,
- * is what keeps it from arriving as a bare dispatch failure with nothing on it
- * a person could act on. The release that connects a gateway is the one that
- * makes this reachable and answers it.
+ * **Refused rather than obeyed, and this is the binding doing its job.** A
+ * deployment that switched accounts on a paste would move every later
+ * simulation's spend onto a different customer's provider account, silently,
+ * from one text field. So the second organization's key is turned away while
+ * the first binding stands, and the way to change it is to disconnect
+ * deliberately first.
+ *
+ * The sentence names the bound organization, because "this key belongs to
+ * somebody else" is unhelpful to the administrator who holds keys for two.
+ */
+export class ManagedAccessBoundElsewhereError extends Error {
+  /** The Egma Cloud organization this deployment is bound to. */
+  readonly cloudOrganizationId: string;
+
+  constructor(cloudOrganizationId: string) {
+    super(
+      `this deployment's managed access is bound to Egma Cloud organization ${cloudOrganizationId}, and this key belongs to another one. Disconnect managed access first if you mean to move this deployment to a different Egma Cloud organization.`,
+    );
+    this.name = "ManagedAccessBoundElsewhereError";
+    this.cloudOrganizationId = cloudOrganizationId;
+  }
+}
+
+/**
+ * A simulation or a grading job selected managed model access on a deployment
+ * that does not know where the Egma model gateway is.
+ *
+ * **Egma misconfigured, not the customer unconfigured**, and the two are kept
+ * apart on purpose: `ManagedAccessNotConnectedError` is an administrator with
+ * one thing to paste, and this is a deployment started without the address its
+ * managed traffic goes to. Telling an administrator to connect a key they have
+ * already connected would send them looking in the wrong place.
+ *
+ * An infrastructure error either way, and never a fallback: a simulation
+ * quietly conducted straight against a provider on somebody else's account
+ * would be worse than one that stopped and said why.
  */
 export class ManagedAccessUnavailableError extends Error {
   constructor() {
     super(
-      "this organization is on managed model access, which sends its model traffic through the Egma model gateway, and this deployment has no connection to one. Choose Customer-owned under Model providers and add a credential for each provider your personas and graders select.",
+      "this organization is on managed model access, which sends its model traffic through the Egma model gateway, and this deployment has not been told where that gateway is. This is a deployment setting rather than something to fix under Model providers.",
     );
     this.name = "ManagedAccessUnavailableError";
   }

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -120,6 +120,7 @@ export {
   JudgeNotConfiguredError,
   JudgeProviderMismatchError,
   LastAdminError,
+  ManagedAccessBoundElsewhereError,
   ManagedAccessNotConnectedError,
   ManagedAccessUnavailableError,
   MockToolTakenError,
@@ -616,6 +617,37 @@ export {
   type ModelProviderCredential,
   type ModelProviderCredentialInput,
 } from "./model-provider-credentials.ts";
+/**
+ * Managed model access: the inference keys hosted Egma mints, the one a
+ * self-hosted deployment connects, and the credential Egma's own two services
+ * present at the gateway.
+ *
+ * The same rule the provider credentials keep, one table over: **nothing
+ * exported here can answer with a key.** `listInferenceKeys` answers a name, a
+ * safe hint and four times; `readManagedAccessConnection` answers Connected and
+ * a hint; and the one door to a usable credential —
+ * `resolveManagedAccess` — refuses every context that did not come from a
+ * simulation or a grading claim.
+ */
+export {
+  createInferenceKey,
+  listInferenceKeys,
+  resolveInferenceKey,
+  revokeInferenceKey,
+  type InferenceKey,
+  type NewInferenceKey,
+  type ResolvedInferenceKey,
+} from "./inference-keys.ts";
+export {
+  connectManagedAccess,
+  disconnectManagedAccess,
+  managedAccessAvailable,
+  readManagedAccessConnection,
+  resolveManagedAccess,
+  type ConnectManagedAccess,
+  type ManagedAccessConnection,
+  type ResolvedManagedAccess,
+} from "./managed-access.ts";
 export {
   MODEL_ACCESS_MODES,
   type ModelAccessMode,

--- a/packages/db/src/access/inference-keys.ts
+++ b/packages/db/src/access/inference-keys.ts
@@ -227,6 +227,7 @@ export async function resolveInferenceKey(
     .select({
       id: inferenceKey.id,
       organizationId: inferenceKey.organizationId,
+      lastUsedAt: inferenceKey.lastUsedAt,
     })
     .from(inferenceKey)
     .where(and(eq(inferenceKey.hash, hash), isNull(inferenceKey.revokedAt)))
@@ -234,10 +235,43 @@ export async function resolveInferenceKey(
 
   if (row === undefined) return undefined;
 
-  await db()
-    .update(inferenceKey)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(inferenceKey.id, row.id));
-
+  noteUsed(row.id, row.lastUsedAt);
   return { inferenceKeyId: row.id, organizationId: row.organizationId };
+}
+
+/**
+ * How stale the stamp may be before it is worth a write.
+ *
+ * The column answers one question — is anybody still using this key — and a
+ * minute's resolution answers it exactly as well as a millisecond's. What the
+ * coarseness buys is the hot path: a voice simulation opens several connections
+ * and every one of them lands on this row, so a write per connection is every
+ * connection on one key queueing behind the same row lock.
+ */
+const USE_STAMP_WINDOW_MS = 60_000;
+
+/**
+ * Write down that a key was used, without a connection waiting for it.
+ *
+ * **Two ways this stays off the hot path, and both are needed.** It is skipped
+ * entirely while the stamp is fresh, so a busy key writes once a minute rather
+ * than once a connection — which is what stops every connection on one key
+ * contending on one row. And what is left is not awaited: a caller is a voice
+ * connection opening, and the answer it is waiting for is already in hand.
+ *
+ * A failure is swallowed on purpose. This column exists so an operator can see
+ * a key nobody needs; a key that works must not stop working because a
+ * bookkeeping write did not land.
+ */
+function noteUsed(inferenceKeyId: string, lastUsedAt: Date | null): void {
+  const now = Date.now();
+  if (lastUsedAt !== null && now - lastUsedAt.getTime() < USE_STAMP_WINDOW_MS) {
+    return;
+  }
+
+  void db()
+    .update(inferenceKey)
+    .set({ lastUsedAt: new Date(now) })
+    .where(eq(inferenceKey.id, inferenceKeyId))
+    .catch(() => undefined);
 }

--- a/packages/db/src/access/inference-keys.ts
+++ b/packages/db/src/access/inference-keys.ts
@@ -1,0 +1,243 @@
+import { newId } from "@egma/ids";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { db } from "../client.ts";
+import { inferenceKey } from "../schema/models.ts";
+import type { AuthContext } from "./context.ts";
+import { UnprocessableInputError } from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+import { within } from "./within.ts";
+
+/**
+ * The keys an organization holds for the Egma model gateway, as hosted Egma
+ * keeps them: **a hash, a name, a safe hint and four times.**
+ *
+ * There is no read here that returns a key, and that is the shape rather than a
+ * rule: `COLUMNS` names every column an answer may carry and the hash is not
+ * among them, so the secret is absent from every shape this module produces
+ * rather than blanked in one it could be forgotten in. An administrator sees a
+ * key once, at the moment they create it, and afterwards sees only enough of it
+ * to tell it from the other three.
+ *
+ * **An inference key is not a product key and this is not `api_key`.** A
+ * product key resolves to a person, their current role and a project, and opens
+ * every ordinary Egma door. This one resolves to an organization and opens one
+ * thing: managed model traffic through the Egma model gateway. Two tables
+ * rather than a scope column, because that is what makes "an inference key
+ * cannot use a normal Egma product interface" true by where the secret is
+ * looked up — the product's resolver reads `api_key`, and no row here is in it.
+ */
+
+/** An inference key as anybody is ever allowed to see it again. */
+export type InferenceKey = {
+  readonly id: string;
+  readonly organizationId: string;
+  readonly name: string;
+  /** `<prefix>…<last four>`. Enough to tell two keys apart, never enough to be one. */
+  readonly looksLike: string;
+  readonly createdByUserId: string | null;
+  readonly createdAt: Date;
+  readonly lastUsedAt: Date | null;
+  readonly revokedAt: Date | null;
+};
+
+const COLUMNS = {
+  id: inferenceKey.id,
+  organizationId: inferenceKey.organizationId,
+  name: inferenceKey.name,
+  prefix: inferenceKey.prefix,
+  displaySuffix: inferenceKey.displaySuffix,
+  createdByUserId: inferenceKey.createdBy,
+  createdAt: inferenceKey.createdAt,
+  lastUsedAt: inferenceKey.lastUsedAt,
+  revokedAt: inferenceKey.revokedAt,
+} as const;
+
+type Row = {
+  readonly id: string;
+  readonly organizationId: string;
+  readonly name: string;
+  readonly prefix: string;
+  readonly displaySuffix: string;
+  readonly createdByUserId: string | null;
+  readonly createdAt: Date;
+  readonly lastUsedAt: Date | null;
+  readonly revokedAt: Date | null;
+};
+
+function described(row: Row): InferenceKey {
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    name: row.name,
+    looksLike: `${row.prefix}…${row.displaySuffix}`,
+    createdByUserId: row.createdByUserId,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+    revokedAt: row.revokedAt,
+  };
+}
+
+/**
+ * Every inference key this organization holds, live and revoked alike, oldest
+ * first.
+ *
+ * **Administration, so `manage_organization` rather than `read`.** A product key
+ * is listed at every role because every role mints one at login and has to be
+ * able to rotate their own. Nobody's login mints one of these: an inference key
+ * authorizes spending from Egma's provider accounts on the whole organization's
+ * behalf, which is the same kind of decision as choosing model access itself,
+ * and the permission table already says who makes those.
+ *
+ * Revoked keys stay in the answer. A key that stopped working is the record of
+ * an installation that used to exist, and a list that hid it would leave an
+ * administrator wondering whether they ever revoked the one they meant to.
+ */
+export async function listInferenceKeys(
+  auth: AuthContext,
+): Promise<readonly InferenceKey[]> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const rows = await db()
+    .select(COLUMNS)
+    .from(inferenceKey)
+    .where(within(auth, inferenceKey))
+    .orderBy(inferenceKey.id);
+
+  return rows.map(described);
+}
+
+export type NewInferenceKey = {
+  /** What an administrator calls this key. Required; an unnamed key is unrevokable in practice. */
+  readonly name: string;
+  /** A single SHA-256 over the high-entropy secret. Hashing is the caller's. */
+  readonly hash: string;
+  readonly prefix: string;
+  readonly displaySuffix: string;
+};
+
+/**
+ * Mint one, from a secret this module never sees.
+ *
+ * **The plaintext does not arrive here and cannot.** What is passed in is a
+ * hash, a prefix and four characters; the secret itself exists in the route
+ * that minted it for exactly as long as it takes to write it into one response,
+ * and nothing in this package has ever held it. So "Egma Cloud does not store a
+ * readable copy" is true of the argument list before it is true of the table.
+ */
+export async function createInferenceKey(
+  auth: AuthContext,
+  input: NewInferenceKey,
+): Promise<InferenceKey> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const name = input.name.trim();
+  if (name === "") {
+    throw new UnprocessableInputError(
+      "an inference key needs a name — which installation it is for — so that a list of several says which one to revoke",
+    );
+  }
+  if (name.length > 200) {
+    throw new UnprocessableInputError(
+      "an inference key's name fits in 200 characters; it is a label for telling two installations apart, not a place for anything longer",
+    );
+  }
+
+  const [row] = await db()
+    .insert(inferenceKey)
+    .values({
+      id: newId("ifk"),
+      organizationId: auth.organizationId,
+      name,
+      hash: input.hash,
+      prefix: input.prefix,
+      displaySuffix: input.displaySuffix,
+      createdBy: auth.userId,
+    })
+    .returning(COLUMNS);
+
+  if (row === undefined) throw new Error("the inference key was not written");
+  return described(row);
+}
+
+/**
+ * Stop one working, from the next connection onward.
+ *
+ * **Effective on the next connection and never on the current frame**, which is
+ * the promise the gateway's own authentication makes: a key is checked when an
+ * HTTP request or a WebSocket opens, so a simulation already speaking finishes
+ * on the credential it opened with and the one after it is refused. Nothing
+ * caches the answer, so there is no window to wait out.
+ *
+ * Naming a key in another customer's account changes nothing and answers
+ * nothing — the predicate is the caller's own organization, so the row is not
+ * there to update. Revoking one already revoked is the same outcome, said
+ * without pretending a second revocation happened.
+ */
+export async function revokeInferenceKey(
+  auth: AuthContext,
+  inferenceKeyId: string,
+): Promise<InferenceKey | undefined> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const now = new Date();
+  const [row] = await db()
+    .update(inferenceKey)
+    .set({ revokedAt: now, updatedAt: now })
+    .where(
+      within(
+        auth,
+        inferenceKey,
+        and(eq(inferenceKey.id, inferenceKeyId), isNull(inferenceKey.revokedAt)),
+      ),
+    )
+    .returning(COLUMNS);
+
+  return row === undefined ? undefined : described(row);
+}
+
+/** Which organization one good inference key acts for, and which key it was. */
+export type ResolvedInferenceKey = {
+  readonly inferenceKeyId: string;
+  readonly organizationId: string;
+};
+
+/**
+ * A key's hash turned into the organization it authorizes, or nothing.
+ *
+ * **The whole of what an inference key resolves to, and deliberately not an
+ * `AuthContext`.** A product key resolves to a person, a role and a project
+ * because it opens doors that read a customer's data; this one opens exactly
+ * one thing and the only question that thing asks is which organization the
+ * connection acts for. Answering with a context would be answering a question
+ * nobody asked with an authority nobody granted — and it is what would let a
+ * later door accept this credential by mistake.
+ *
+ * No context is taken either, for the reason `resolveApiKey` takes none: the
+ * caller is a connection that has not established who it is yet, and this read
+ * is how it does.
+ *
+ * A revoked key answers nothing, read from the row rather than from a cache —
+ * which is what makes revocation effective on the next connection.
+ */
+export async function resolveInferenceKey(
+  hash: string,
+): Promise<ResolvedInferenceKey | undefined> {
+  const [row] = await db()
+    .select({
+      id: inferenceKey.id,
+      organizationId: inferenceKey.organizationId,
+    })
+    .from(inferenceKey)
+    .where(and(eq(inferenceKey.hash, hash), isNull(inferenceKey.revokedAt)))
+    .limit(1);
+
+  if (row === undefined) return undefined;
+
+  await db()
+    .update(inferenceKey)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(inferenceKey.id, row.id));
+
+  return { inferenceKeyId: row.id, organizationId: row.organizationId };
+}

--- a/packages/db/src/access/managed-access.ts
+++ b/packages/db/src/access/managed-access.ts
@@ -1,3 +1,5 @@
+import { eq } from "drizzle-orm";
+
 import { db } from "../client.ts";
 import {
   managedDeployment,
@@ -136,26 +138,40 @@ export async function connectManagedAccess(
     );
   }
 
-  const [existing] = await db()
-    .select({ cloudOrganizationId: managedAccessKey.cloudOrganizationId })
-    .from(managedAccessKey)
-    .where(within(auth, managedAccessKey))
-    .limit(1);
-
-  if (
-    existing !== undefined &&
-    existing.cloudOrganizationId !== input.cloudOrganizationId
-  ) {
-    throw new ManagedAccessBoundElsewhereError(existing.cloudOrganizationId);
-  }
-
+  /**
+   * **The binding is enforced by the write and by nothing before it.**
+   *
+   * This used to read the stored binding, compare it, and then upsert
+   * unconditionally — and between the read and the write there was a window.
+   * Two administrators connecting at once both read the same answer, both
+   * passed, and the second write silently rebound the deployment to another
+   * Egma Cloud organization with no disconnect: every later simulation's spend
+   * attributed to an account nobody chose, and the administrator who lost the
+   * race told "Connected" with their own key's hint. Exactly what the rule
+   * exists to prevent, arrived at by timing.
+   *
+   * So the comparison moved inside the statement. The `UPDATE` arm fires only
+   * when the row already says what this key says, which makes the three cases
+   * one atomic decision Postgres takes while holding the row:
+   *
+   * - **no row** — the `INSERT` lands, and this deployment is bound. A second
+   *   connect racing it conflicts, finds the winner's organization in the row,
+   *   and is refused rather than overwriting it;
+   * - **the same organization** — the arm fires. Ordinary rotation, unchanged;
+   * - **another organization** — the arm is suppressed, nothing is written, and
+   *   no row comes back. That silence is the refusal.
+   *
+   * Nothing is read first, on purpose: a check in front of this would look
+   * load-bearing and would not be, which is how the window got there.
+   */
   const now = new Date();
+  const sealed = sealCredentials({ key });
   const [row] = await db()
     .insert(managedAccessKey)
     .values({
       organizationId: auth.organizationId,
       cloudOrganizationId: input.cloudOrganizationId,
-      credentials: sealCredentials({ key }),
+      credentials: sealed,
       credentialsHint: key.slice(-HINT_LENGTH),
       connectedBy: auth.userId,
       updatedAt: now,
@@ -163,12 +179,19 @@ export async function connectManagedAccess(
     .onConflictDoUpdate({
       target: managedAccessKey.organizationId,
       set: {
-        cloudOrganizationId: input.cloudOrganizationId,
-        credentials: sealCredentials({ key }),
+        credentials: sealed,
         credentialsHint: key.slice(-HINT_LENGTH),
         connectedBy: auth.userId,
         updatedAt: now,
       },
+      // The whole guard. `cloud_organization_id` is deliberately absent from
+      // `set` as well: an arm that could rewrite the binding is an arm that
+      // could rebind, and the only value it may ever hold is the one it
+      // already has.
+      setWhere: eq(
+        managedAccessKey.cloudOrganizationId,
+        input.cloudOrganizationId,
+      ),
     })
     .returning({
       hint: managedAccessKey.credentialsHint,
@@ -177,7 +200,21 @@ export async function connectManagedAccess(
     });
 
   if (row === undefined) {
-    throw new Error("the organization's managed-access key was not written");
+    // The arm was suppressed, so a binding stands and it is not this key's.
+    // Read it now — only to name it in the sentence, and after the refusal has
+    // already been decided by the write.
+    const [bound] = await db()
+      .select({ cloudOrganizationId: managedAccessKey.cloudOrganizationId })
+      .from(managedAccessKey)
+      .where(within(auth, managedAccessKey))
+      .limit(1);
+
+    if (bound === undefined) {
+      // No row at all and no insert: nothing in this schema produces that, so
+      // it is Egma being broken rather than an administrator being refused.
+      throw new Error("the organization's managed-access key was not written");
+    }
+    throw new ManagedAccessBoundElsewhereError(bound.cloudOrganizationId);
   }
   return {
     connected: true,

--- a/packages/db/src/access/managed-access.ts
+++ b/packages/db/src/access/managed-access.ts
@@ -1,0 +1,327 @@
+import { db } from "../client.ts";
+import {
+  managedDeployment,
+  signInternalGatewayCredential,
+} from "../managed-deployment.ts";
+import { managedAccessKey } from "../schema/models.ts";
+import { openCredentials, sealCredentials } from "../sealing.ts";
+import type { AuthContext } from "./context.ts";
+import {
+  ManagedAccessBoundElsewhereError,
+  ManagedAccessNotConnectedError,
+  ManagedAccessUnavailableError,
+  UnprocessableInputError,
+} from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+import { within } from "./within.ts";
+
+/**
+ * How this organization reaches the Egma model gateway, and the one door that
+ * opens the credential for the services that use it.
+ *
+ * Two deployments, two answers, one seam:
+ *
+ * - **hosted Egma** signs an organization-scoped credential with a key only it
+ *   and the gateway hold. Nothing is stored per organization, nothing is
+ *   pasted, and there is nothing an administrator has to do — which is exactly
+ *   what "a hosted user pastes nothing" has to mean in code.
+ * - **a self-hosted deployment** presents the one inference key its
+ *   administrator connected, sealed in its own Postgres and opened only here.
+ *
+ * **Neither answer is ever a provider credential.** Egma's own provider keys
+ * live inside the gateway and this module has no way to reach one, which is the
+ * property the whole arrangement exists to hold: the simulator and the grader
+ * authenticate to the gateway, and the gateway authenticates to the provider.
+ */
+
+/** What a person may see about a self-hosted organization's connection. */
+export type ManagedAccessConnection = {
+  /** Whether an inference key is connected at all. */
+  readonly connected: boolean;
+  /** The last characters of the connected key, or null where none is. */
+  readonly hint: string | null;
+  /** The Egma Cloud organization this deployment is bound to, or null. */
+  readonly cloudOrganizationId: string | null;
+  readonly updatedAt: Date | null;
+};
+
+const NOT_CONNECTED: ManagedAccessConnection = {
+  connected: false,
+  hint: null,
+  cloudOrganizationId: null,
+  updatedAt: null,
+};
+
+/**
+ * The organization's managed-access connection, as anybody in it reads it.
+ *
+ * **Connected, a hint, and the binding. Never the key.** The shape has no field
+ * a secret could travel in — the sealed envelope is not selected and not
+ * returned — so a page, a log or a serializer has nothing to leak. Readable at
+ * every role for the reason the access mode is: which of two words is on this
+ * row is not a secret, and somebody looking at a persona's models has to be
+ * able to see who supplies the credential behind them.
+ */
+export async function readManagedAccessConnection(
+  auth: AuthContext,
+): Promise<ManagedAccessConnection> {
+  authorize(auth, "read", here(auth));
+
+  const [row] = await db()
+    .select({
+      hint: managedAccessKey.credentialsHint,
+      cloudOrganizationId: managedAccessKey.cloudOrganizationId,
+      updatedAt: managedAccessKey.updatedAt,
+    })
+    .from(managedAccessKey)
+    .where(within(auth, managedAccessKey))
+    .limit(1);
+
+  return row === undefined
+    ? NOT_CONNECTED
+    : {
+        connected: true,
+        hint: row.hint,
+        cloudOrganizationId: row.cloudOrganizationId,
+        updatedAt: row.updatedAt,
+      };
+}
+
+/** Enough of the tail to tell two keys apart in a list, and no more. */
+const HINT_LENGTH = 4;
+
+export type ConnectManagedAccess = {
+  /** The inference key, in the clear, on its way into the envelope. */
+  readonly key: string;
+  /**
+   * Which Egma Cloud organization validation said owns this key.
+   *
+   * **Answered by Egma Cloud and never by whoever pasted the key.** The caller
+   * has already made the one content-free validation request and is passing on
+   * what came back; this module writes it down so that the *next* key has
+   * something to be checked against.
+   */
+  readonly cloudOrganizationId: string;
+};
+
+/**
+ * Connect an inference key, or replace the one already connected.
+ *
+ * **Only an `admin`**, on the same row of the permission table that names model
+ * access and provider credentials: this decides whose provider account every
+ * simulation in the organization spends from.
+ *
+ * **The binding is enforced here and is the reason the cloud organization is
+ * stored.** A deployment that has connected one Egma Cloud organization's key
+ * refuses another organization's outright rather than switching to it. Managed
+ * traffic silently moving onto a different customer's provider account is not a
+ * thing an accidental paste should be able to do, so the way to change it is to
+ * disconnect first — a deliberate act, on its own, with its own confirmation.
+ *
+ * Replacing a key from the *same* Egma Cloud organization is ordinary rotation
+ * and lands without ceremony: that is the second half of "rotation can overlap
+ * safely", the first half being that Egma Cloud keeps the old key working until
+ * somebody revokes it.
+ */
+export async function connectManagedAccess(
+  auth: AuthContext,
+  input: ConnectManagedAccess,
+): Promise<ManagedAccessConnection> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const key = input.key.trim();
+  if (key === "") {
+    throw new UnprocessableInputError(
+      "connecting managed access needs the inference key Egma Cloud showed you when you created it",
+    );
+  }
+
+  const [existing] = await db()
+    .select({ cloudOrganizationId: managedAccessKey.cloudOrganizationId })
+    .from(managedAccessKey)
+    .where(within(auth, managedAccessKey))
+    .limit(1);
+
+  if (
+    existing !== undefined &&
+    existing.cloudOrganizationId !== input.cloudOrganizationId
+  ) {
+    throw new ManagedAccessBoundElsewhereError(existing.cloudOrganizationId);
+  }
+
+  const now = new Date();
+  const [row] = await db()
+    .insert(managedAccessKey)
+    .values({
+      organizationId: auth.organizationId,
+      cloudOrganizationId: input.cloudOrganizationId,
+      credentials: sealCredentials({ key }),
+      credentialsHint: key.slice(-HINT_LENGTH),
+      connectedBy: auth.userId,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: managedAccessKey.organizationId,
+      set: {
+        cloudOrganizationId: input.cloudOrganizationId,
+        credentials: sealCredentials({ key }),
+        credentialsHint: key.slice(-HINT_LENGTH),
+        connectedBy: auth.userId,
+        updatedAt: now,
+      },
+    })
+    .returning({
+      hint: managedAccessKey.credentialsHint,
+      cloudOrganizationId: managedAccessKey.cloudOrganizationId,
+      updatedAt: managedAccessKey.updatedAt,
+    });
+
+  if (row === undefined) {
+    throw new Error("the organization's managed-access key was not written");
+  }
+  return {
+    connected: true,
+    hint: row.hint,
+    cloudOrganizationId: row.cloudOrganizationId,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Take the connection away.
+ *
+ * Nothing is scanned first and nothing else is changed — in particular the
+ * organization's model access is left exactly as it was. Disconnecting while on
+ * managed access leaves an organization whose next claim has no credential to
+ * present, and that lands as a visible infrastructure error naming what to
+ * reconnect. That is a better answer than this function quietly deciding
+ * somebody's access mode for them.
+ */
+export async function disconnectManagedAccess(
+  auth: AuthContext,
+): Promise<boolean> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const removed = await db()
+    .delete(managedAccessKey)
+    .where(within(auth, managedAccessKey))
+    .returning({ organizationId: managedAccessKey.organizationId });
+
+  return removed.length > 0;
+}
+
+/** Where the traffic goes, and what authorizes it. Nothing else. */
+export type ResolvedManagedAccess = {
+  /** The Egma model gateway's address, with no trailing slash. */
+  readonly gatewayAddress: string;
+  /**
+   * The credential this connection presents: hosted Egma's signed internal
+   * credential, or the organization's own inference key.
+   *
+   * **Never an upstream provider secret.** There is no code path from here to
+   * one: Egma's provider credentials are the gateway's deployment secrets and
+   * this process cannot read them.
+   */
+  readonly credential: string;
+};
+
+/**
+ * The one door to a managed-access credential, and **Egma's own two services
+ * are the only things that may knock.**
+ *
+ * The gate is the model-provider key's, verbatim, and for the same reason: the
+ * only things Egma does with a gateway credential are conduct a simulation and
+ * judge one, and the only things that do either are the simulator and the
+ * grading engine. So the check is on how the caller came to exist rather than
+ * on what their role permits — a context built from a simulation claim says
+ * `simulator` on its face and one built from a grading claim says `engine`, and
+ * every other context in the product, a person's session and an `admin` alike,
+ * is refused. There is no product surface that hands anybody this value back,
+ * and this is what keeps it that way while roles move around.
+ *
+ * Two typed refusals rather than one, because they are two different repairs.
+ * A deployment with no gateway address is Egma misconfigured; an organization
+ * on managed access with nothing connected is an administrator with one thing
+ * to paste.
+ */
+export async function resolveManagedAccess(
+  auth: AuthContext,
+): Promise<ResolvedManagedAccess> {
+  authorize(auth, "read", here(auth));
+
+  if (auth.via !== "simulator" && auth.via !== "engine") {
+    throw new Error(
+      "a managed-access credential is opened for Egma's simulator or its grading engine and for nothing else, because conducting and judging are the only things Egma does with one",
+    );
+  }
+
+  const deployment = managedDeployment();
+  if (deployment.gatewayAddress === undefined) {
+    throw new ManagedAccessUnavailableError();
+  }
+
+  if (deployment.hosted) {
+    if (deployment.internalGatewayKey === undefined) {
+      throw new ManagedAccessUnavailableError();
+    }
+    return {
+      gatewayAddress: deployment.gatewayAddress,
+      credential: signInternalGatewayCredential(
+        auth.organizationId,
+        deployment.internalGatewayKey,
+      ),
+    };
+  }
+
+  const [row] = await db()
+    .select({ credentials: managedAccessKey.credentials })
+    .from(managedAccessKey)
+    .where(within(auth, managedAccessKey))
+    .limit(1);
+
+  if (row === undefined) throw new ManagedAccessNotConnectedError();
+
+  return {
+    gatewayAddress: deployment.gatewayAddress,
+    credential: openedKey(row.credentials),
+  };
+}
+
+/**
+ * One envelope opened, or a fault saying the row is broken.
+ *
+ * A row that will not open is Egma being broken rather than the customer being
+ * unconnected, so it throws rather than reading as "connect a key" — which
+ * would tell an administrator to paste something they already pasted.
+ */
+function openedKey(sealed: string): string {
+  const opened = openCredentials(sealed);
+  const key =
+    typeof opened === "object" && opened !== null && !Array.isArray(opened)
+      ? (opened as Record<string, unknown>)["key"]
+      : undefined;
+
+  if (typeof key !== "string" || key === "") {
+    throw new Error(
+      "the organization's managed-access key holds a value in a shape Egma never writes; reconnect managed access under Model providers",
+    );
+  }
+  return key;
+}
+
+/**
+ * Whether this organization can choose managed access at all right now.
+ *
+ * **A fact about the deployment and this organization's connection, never about
+ * whether anything would work.** Hosted Egma is always available: it operates
+ * the gateway and signs its own credentials, so there is nothing to connect. A
+ * self-hosted deployment is available once an inference key is connected, and
+ * not before — which is what the setting refuses on, so that a form never
+ * offers a choice the server will turn down.
+ */
+export async function managedAccessAvailable(
+  auth: AuthContext,
+): Promise<boolean> {
+  if (managedDeployment().hosted) return true;
+  return (await readManagedAccessConnection(auth)).connected;
+}

--- a/packages/db/src/access/model-access.ts
+++ b/packages/db/src/access/model-access.ts
@@ -8,6 +8,7 @@ import {
 import { isModelProvider, type ModelProvider } from "../models/catalog.ts";
 import { openCredentials } from "../sealing.ts";
 import type { AuthContext } from "./context.ts";
+import { managedAccessAvailable } from "./managed-access.ts";
 import { ManagedAccessNotConnectedError, UnprocessableInputError } from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
 import { within } from "./within.ts";
@@ -94,9 +95,11 @@ function validMode(mode: string): ModelAccessMode {
  * **`managed` is refused while nothing is connected**, and that refusal is the
  * self-hosted rule the specification names: an organization may not select
  * Egma's provider accounts until it holds an inference key for the Egma model
- * gateway. Nothing in this release connects one, so nothing in this release may
- * select managed access — said in a sentence that names what is missing rather
- * than by leaving the value quietly unwritable.
+ * gateway. On hosted Egma there is nothing to connect — the deployment operates
+ * the gateway and signs its own credentials — so managed access is always
+ * selectable there, and this refusal never fires. On a self-hosted deployment
+ * it fires until an administrator connects a key, said in a sentence that names
+ * what is missing rather than by leaving the value quietly unwritable.
  */
 export async function setModelAccess(
   auth: AuthContext,
@@ -105,7 +108,7 @@ export async function setModelAccess(
   authorize(auth, "manage_organization", here(auth));
 
   const valid = validMode(mode);
-  if (valid === "managed") {
+  if (valid === "managed" && !(await managedAccessAvailable(auth))) {
     throw new ManagedAccessNotConnectedError();
   }
 

--- a/packages/db/src/access/provisioning.ts
+++ b/packages/db/src/access/provisioning.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 
 import { db, type Queryable } from "../client.ts";
 import { managedDeployment } from "../managed-deployment.ts";
+import { RECOMMENDED_PERSONA_MODELS } from "../models/selections.ts";
 import { judgeConfiguration } from "../schema/graders.ts";
 import { modelAccess } from "../schema/models.ts";
 import { persona, personaVersion } from "../schema/personas.ts";
@@ -60,6 +61,30 @@ const STARTER_TRAITS: PersonaTraits = {
  * `provisioning-starter-persona.test.ts` compares these rows against ones
  * `createPersona` wrote, and fails on a column only one of them fills.
  */
+/**
+ * Whether a project's seeded objects are born with explicit model selections.
+ *
+ * **Hosted Egma yes, a self-hosted deployment no, and the split is the whole
+ * of what makes a hosted first run need no setup.** A hosted organization is on
+ * Managed by Egma from the moment it exists, so a seeded persona that selects
+ * Deepgram, OpenAI and Cartesia can be executed at once, on Egma's provider
+ * accounts, with nothing pasted and nothing edited. That is the promise this
+ * whole area exists to keep, and a seeded persona with no selections would
+ * break it at the last step: it would resolve through deployment-wide model
+ * settings, and hosted Egma has none.
+ *
+ * A self-hosted deployment gets the opposite answer for the opposite reason.
+ * Those deployments hold deployment-wide model settings and a platform judge,
+ * and usually no organization credential — so a seeded persona with explicit
+ * selections would fail its first claim naming a provider nobody had been
+ * asked for, and a seeded grader with an explicit model would write `errored`
+ * verdicts. Seeding nothing keeps them exactly as they are, and giving their
+ * *existing* personas and graders explicit successors is the migration's job.
+ */
+function seedsExplicitSelections(): boolean {
+  return managedDeployment().hosted;
+}
+
 async function insertStarterPersona(
   on: Queryable,
   values: {
@@ -86,6 +111,12 @@ async function insertStarterPersona(
     personaId: id,
     version: 1,
     traits: STARTER_TRAITS,
+    // **The release's proved defaults, on a deployment that can execute them.**
+    // `null` is the compatibility path and stays the answer everywhere else;
+    // see `seedsExplicitSelections`. The traits' own `voice` is not read when a
+    // version carries selections — the TTS selection is the one source — so the
+    // legacy field above serves the deployments that have no selections.
+    models: seedsExplicitSelections() ? RECOMMENDED_PERSONA_MODELS : null,
     createdBy: values.createdBy,
   });
 

--- a/packages/db/src/access/provisioning.ts
+++ b/packages/db/src/access/provisioning.ts
@@ -64,6 +64,12 @@ const STARTER_TRAITS: PersonaTraits = {
 /**
  * Whether a project's seeded objects are born with explicit model selections.
  *
+ * **One function, and both seeders read it.** The starter persona is written
+ * here and the mandatory grader copy is written in `seeded-graders.ts`; a
+ * deployment that seeded one and not the other would produce a project whose
+ * persona runs and whose grader cannot judge it, or the reverse. The rule is
+ * one sentence and it is written once.
+ *
  * **Hosted Egma yes, a self-hosted deployment no, and the split is the whole
  * of what makes a hosted first run need no setup.** A hosted organization is on
  * Managed by Egma from the moment it exists, so a seeded persona that selects
@@ -81,7 +87,7 @@ const STARTER_TRAITS: PersonaTraits = {
  * verdicts. Seeding nothing keeps them exactly as they are, and giving their
  * *existing* personas and graders explicit successors is the migration's job.
  */
-function seedsExplicitSelections(): boolean {
+export function seedsExplicitSelections(): boolean {
   return managedDeployment().hosted;
 }
 

--- a/packages/db/src/access/provisioning.ts
+++ b/packages/db/src/access/provisioning.ts
@@ -2,7 +2,9 @@ import { newId } from "@egma/ids";
 import { eq } from "drizzle-orm";
 
 import { db, type Queryable } from "../client.ts";
+import { managedDeployment } from "../managed-deployment.ts";
 import { judgeConfiguration } from "../schema/graders.ts";
+import { modelAccess } from "../schema/models.ts";
 import { persona, personaVersion } from "../schema/personas.ts";
 import { organization, project } from "../schema/tenancy.ts";
 import { platformJudgeRow } from "./judges.ts";
@@ -267,6 +269,31 @@ export async function provisionOrganization(
         ? {}
         : { defaultJudge: input.defaultJudge }),
     });
+
+    /**
+     * **A hosted organization starts on managed model access, and a
+     * self-hosted one does not.**
+     *
+     * The whole difference is who can supply a credential without being asked
+     * for one. Hosted Egma operates the Egma model gateway and keeps the
+     * provider accounts behind it, so a new project's seeded default persona
+     * and predefined grader can complete a run before anybody has opened an
+     * account with a model provider — which is the problem this entire area
+     * exists to solve. A self-hosted deployment can supply nothing until an
+     * administrator connects an inference key, so it starts customer-owned and
+     * a missing row reads as exactly that.
+     *
+     * Written here rather than defaulted at read time, because it is a
+     * decision: an organization that later chooses customer-owned must not
+     * quietly go back to managed the next time somebody reads the row.
+     */
+    if (managedDeployment().hosted) {
+      await tx.insert(modelAccess).values({
+        organizationId,
+        mode: "managed",
+        updatedBy: input.ownerUserId,
+      });
+    }
 
     // Everyone is an admin in v1 and roles are invisible, but the permission
     // map is real from the first commit. The creator of an organization is its

--- a/packages/db/src/access/seeded-graders.ts
+++ b/packages/db/src/access/seeded-graders.ts
@@ -7,6 +7,8 @@ import {
   PREDEFINED_GRADERS,
   type PredefinedGrader,
 } from "../grader-library/catalog.ts";
+import { managedDeployment } from "../managed-deployment.ts";
+import { RECOMMENDED_GRADER_MODEL } from "../models/selections.ts";
 import { grader, graderVersion } from "../schema/graders.ts";
 import { project } from "../schema/tenancy.ts";
 import type { GraderConfig } from "./graders.ts";
@@ -117,6 +119,27 @@ export async function insertSeededGrader(
     version: 1,
     config: NOTHING_TO_FILL_IN,
     judgeModel: null,
+    /**
+     * **The release's proved judge model, on a deployment that can execute it.**
+     *
+     * Hosted Egma is on Managed by Egma from the moment an organization exists,
+     * so this grader can ask a model on Egma's own account with nothing
+     * configured — which is what makes a hosted first run produce a verdict
+     * rather than a row saying no judge was set. The starter persona one file
+     * over is given its selections by the same rule and for the same reason.
+     *
+     * `null` everywhere else, and that is the compatibility path rather than an
+     * omission: a self-hosted deployment's project judge decides exactly as it
+     * always did, and an explicit selection there would spend an organization
+     * credential nobody has stored and write `errored` verdicts for it.
+     *
+     * It lands on the *version*, beside the config, because it is judged
+     * content: a verdict written under it stays readable as "decided by this
+     * model" long afterwards. The copy still reads its judge prompt through
+     * `library_id` and never holds one, so nothing about the pointer rules
+     * moves.
+     */
+    graderModel: managedDeployment().hosted ? RECOMMENDED_GRADER_MODEL : null,
     createdBy: values.createdBy,
   });
 

--- a/packages/db/src/access/seeded-graders.ts
+++ b/packages/db/src/access/seeded-graders.ts
@@ -7,8 +7,8 @@ import {
   PREDEFINED_GRADERS,
   type PredefinedGrader,
 } from "../grader-library/catalog.ts";
-import { managedDeployment } from "../managed-deployment.ts";
 import { RECOMMENDED_GRADER_MODEL } from "../models/selections.ts";
+import { seedsExplicitSelections } from "./provisioning.ts";
 import { grader, graderVersion } from "../schema/graders.ts";
 import { project } from "../schema/tenancy.ts";
 import type { GraderConfig } from "./graders.ts";
@@ -133,13 +133,18 @@ export async function insertSeededGrader(
      * always did, and an explicit selection there would spend an organization
      * credential nobody has stored and write `errored` verdicts for it.
      *
+     * The rule itself is `seedsExplicitSelections`, shared with the starter
+     * persona rather than spelled again here: a deployment that seeded one and
+     * not the other would make a project whose persona runs and whose grader
+     * cannot judge it.
+     *
      * It lands on the *version*, beside the config, because it is judged
      * content: a verdict written under it stays readable as "decided by this
      * model" long afterwards. The copy still reads its judge prompt through
      * `library_id` and never holds one, so nothing about the pointer rules
      * moves.
      */
-    graderModel: managedDeployment().hosted ? RECOMMENDED_GRADER_MODEL : null,
+    graderModel: seedsExplicitSelections() ? RECOMMENDED_GRADER_MODEL : null,
     createdBy: values.createdBy,
   });
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -3,6 +3,11 @@ import { sql } from "drizzle-orm";
 import pg from "pg";
 
 import * as schema from "./schema/index.ts";
+import {
+  holdManagedDeployment,
+  releaseManagedDeployment,
+  type ManagedDeployment,
+} from "./managed-deployment.ts";
 import { holdMasterKey, releaseMasterKey } from "./sealing.ts";
 
 /**
@@ -29,12 +34,27 @@ export type ConnectOptions = {
    * one, everything runs except sealing and unsealing a credential.
    */
   readonly encryptionKey?: string;
+  /**
+   * What this deployment is, where the Egma model gateway answers, and — on
+   * hosted Egma — the key its own gateway credentials are signed with.
+   *
+   * Here beside the master key rather than read from the environment where it
+   * is used, for the master key's reason: two processes prepare managed work —
+   * the control plane's claim door and the grading engine — and a value each of
+   * them read separately is a value the two can disagree about. Absent means a
+   * deployment that has not been told, which is a visible infrastructure error
+   * at the claim that needed it and never a quiet fallback.
+   */
+  readonly managedDeployment?: ManagedDeployment;
 };
 
 export function connect(options: ConnectOptions): void {
   if (pool !== undefined) throw new Error("already connected to Postgres");
   if (options.encryptionKey !== undefined) {
     holdMasterKey(options.encryptionKey);
+  }
+  if (options.managedDeployment !== undefined) {
+    holdManagedDeployment(options.managedDeployment);
   }
   pool = new pg.Pool({
     connectionString: options.databaseUrl,
@@ -58,6 +78,7 @@ export async function disconnect(): Promise<void> {
   database = undefined;
   databaseUrl = undefined;
   releaseMasterKey();
+  releaseManagedDeployment();
   await open?.end();
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,6 +16,7 @@ export {
   INTERNAL_GATEWAY_CREDENTIAL_PREFIX,
   INTERNAL_GATEWAY_CREDENTIAL_SECONDS,
   managedDeployment,
+  managedDeploymentFrom,
   signInternalGatewayCredential,
   type ManagedDeployment,
 } from "./managed-deployment.ts";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,24 @@
 export { connect, disconnect, ping, type ConnectOptions } from "./client.ts";
+/**
+ * What kind of deployment this is, and how its own connections to the Egma
+ * model gateway are signed.
+ *
+ * Here beside `connect` rather than on the data-access surface because it
+ * reaches no store and takes no context: it is deployment configuration handed
+ * in at boot, and the format of the internal gateway credential, which the
+ * gateway's verifier reads at the other end of the wire. Exported because it is
+ * the **one** place that format is written down on this side; a second spelling
+ * of it anywhere would be a credential one half of Egma could mint and the
+ * other half could not read.
+ */
+export {
+  holdManagedDeployment,
+  INTERNAL_GATEWAY_CREDENTIAL_PREFIX,
+  INTERNAL_GATEWAY_CREDENTIAL_SECONDS,
+  managedDeployment,
+  signInternalGatewayCredential,
+  type ManagedDeployment,
+} from "./managed-deployment.ts";
 export {
   MIGRATIONS_DIRECTORY,
   readMigrations,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -147,6 +147,23 @@ export {
  * the grading service would be a second answer about one conversation with
  * nothing stored to settle it against.
  */
+/**
+ * Where each provider-job pair is reached **through the Egma model gateway**.
+ *
+ * Here beside the fold and on the fold's exact terms: it reaches no store, takes
+ * no context, and is arithmetic over release catalog data. Exported for the
+ * fold's other reason, sharply — three things have to agree about these paths,
+ * and two of them are in this repository. The grader's judge makers read this;
+ * the simulator's speech legs mirror it in Python; the gateway's own route table
+ * is the authority, and a deterministic test holds the lists against each other.
+ * A second copy written into the grading engine or the claim path would be a
+ * leg quietly pointed at a path the gateway answers `404` for, read by whoever
+ * sees it as the provider being wrong.
+ */
+export {
+  GATEWAY_ROUTE,
+  gatewayAddressFor,
+} from "./models/catalog.ts";
 export {
   everySpanIn,
   measuresFromSpans,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,7 @@ export {
   INTERNAL_GATEWAY_CREDENTIAL_SECONDS,
   managedDeployment,
   managedDeploymentFrom,
+  securely,
   signInternalGatewayCredential,
   type ManagedDeployment,
 } from "./managed-deployment.ts";

--- a/packages/db/src/managed-deployment.ts
+++ b/packages/db/src/managed-deployment.ts
@@ -153,13 +153,82 @@ export function signInternalGatewayCredential(
 export function managedDeploymentFrom(
   environment: Readonly<Record<string, string | undefined>>,
 ): ManagedDeployment {
-  const hosted = (environment["EGMA_HOSTED"] ?? "").trim().toLowerCase();
+  const said = (environment["EGMA_HOSTED"] ?? "").trim().toLowerCase();
+  const hosted = said === "true" || said === "1" || said === "yes";
   const address = environment["EGMA_MODEL_GATEWAY_URL"]?.trim();
   const internal = environment["EGMA_GATEWAY_INTERNAL_KEY"]?.trim();
+
+  /**
+   * **A hosted deployment with no signing key refuses to start.**
+   *
+   * The two are one setting wearing two names: hosted Egma authorizes its own
+   * managed work by signing a credential, and a hosted deployment that lost
+   * the key it signs with would come up looking healthy, provision every new
+   * organization onto Managed by Egma, and fail every one of their claims. The
+   * shape of that failure is the reason it is loud here: a missing signing key
+   * reads downstream as "this deployment was never told where its gateway is",
+   * which sends an operator to the wrong setting.
+   *
+   * Loud at boot rather than at the first claim, on the master key's exact
+   * terms one file over.
+   */
+  if (hosted && (internal === undefined || internal === "")) {
+    throw new Error(
+      "EGMA_HOSTED is on and EGMA_GATEWAY_INTERNAL_KEY is not set. A hosted deployment authorizes its own managed model traffic by signing a credential with that key, so without it every organization it creates starts on Managed by Egma and every one of their simulations fails at the gateway. Set it, or turn EGMA_HOSTED off.",
+    );
+  }
+
   return {
-    hosted: hosted === "true" || hosted === "1" || hosted === "yes",
-    gatewayAddress: address === undefined || address === "" ? undefined : address,
+    hosted,
+    gatewayAddress:
+      address === undefined || address === ""
+        ? undefined
+        : securely("EGMA_MODEL_GATEWAY_URL", address),
     internalGatewayKey:
       internal === undefined || internal === "" ? undefined : internal,
   };
+}
+
+/**
+ * An address managed traffic may be sent to, or a refusal.
+ *
+ * **`https:` unless it is loopback**, and both halves are deliberate. Managed
+ * traffic carries a credential that authorizes Egma's provider accounts, and a
+ * plain-text address puts that credential on the wire for anybody on the path;
+ * a deployment that fell back to `http:` by a typo would leak it silently
+ * rather than fail. Loopback is carved out because the deterministic suite runs
+ * a real gateway on `127.0.0.1` over real sockets — and a test that had to be
+ * given a certificate to prove a relay would be proving TLS setup instead.
+ */
+export function securely(name: string, address: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(address);
+  } catch {
+    throw new Error(`${name} must be an absolute address, and "${address}" is not`);
+  }
+  if (parsed.protocol === "https:") return address;
+  if (parsed.protocol === "http:" && isLoopback(parsed.hostname)) return address;
+  throw new Error(
+    `${name} must be an https address — it carries a credential that authorizes Egma's provider accounts, and a plain-text one puts that credential on the wire. Only a loopback address may be http:, which is what the deterministic suite uses.`,
+  );
+}
+
+/**
+ * The one place `http:` is allowed.
+ *
+ * **Anchored at both ends, and that is not pedantry.** A prefix test on
+ * `127.` calls `127.0.0.1.attacker.example` loopback, and a host somebody else
+ * controls would then be a legal plain-text destination for a credential that
+ * authorizes Egma's provider accounts. So the whole hostname has to be the
+ * loopback name or a complete loopback address, and nothing that merely starts
+ * like one.
+ */
+export function isLoopback(hostname: string): boolean {
+  const bare = hostname.replace(/^\[|\]$/g, "");
+  return (
+    bare === "localhost" ||
+    bare === "::1" ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(bare)
+  );
 }

--- a/packages/db/src/managed-deployment.ts
+++ b/packages/db/src/managed-deployment.ts
@@ -139,3 +139,27 @@ export function signInternalGatewayCredential(
   );
   return `${INTERNAL_GATEWAY_CREDENTIAL_PREFIX}${encoded}.${signature}`;
 }
+
+/**
+ * The three names a deployment answers, read once and in one place.
+ *
+ * **One reader rather than one per service**, because the control plane and the
+ * grading engine both prepare managed work and a name spelled differently in
+ * two `config.ts` files is a deployment where the grader and the simulator
+ * disagree about who Egma is. `EGMA_GATEWAY_INTERNAL_KEY` is deliberately the
+ * same name the gateway itself reads: it is one secret, shared by the two ends
+ * of one wire, and two names for it would be two things to rotate.
+ */
+export function managedDeploymentFrom(
+  environment: Readonly<Record<string, string | undefined>>,
+): ManagedDeployment {
+  const hosted = (environment["EGMA_HOSTED"] ?? "").trim().toLowerCase();
+  const address = environment["EGMA_MODEL_GATEWAY_URL"]?.trim();
+  const internal = environment["EGMA_GATEWAY_INTERNAL_KEY"]?.trim();
+  return {
+    hosted: hosted === "true" || hosted === "1" || hosted === "yes",
+    gatewayAddress: address === undefined || address === "" ? undefined : address,
+    internalGatewayKey:
+      internal === undefined || internal === "" ? undefined : internal,
+  };
+}

--- a/packages/db/src/managed-deployment.ts
+++ b/packages/db/src/managed-deployment.ts
@@ -1,0 +1,141 @@
+import { createHmac } from "node:crypto";
+
+/**
+ * The three facts about *this deployment* that managed model access needs, and
+ * the one place they are held.
+ *
+ * They arrive through `connect()`, the same door the database URL and the
+ * master key do, and for the same reason: work-order preparation and grading
+ * preparation both read them, they live in two different processes, and a value
+ * each process read out of its own environment separately is a value the two
+ * can disagree about. One door, one holder, one answer.
+ *
+ * **What is here is deployment configuration and never a customer's.** Which
+ * kind of deployment this is, where the Egma model gateway answers, and — on
+ * hosted Egma — the key its own connections are signed with. No organization's
+ * anything is in this file.
+ */
+
+export type ManagedDeployment = {
+  /**
+   * Whether this is hosted Egma, which is the deployment that operates the
+   * gateway and owns the inference keys.
+   *
+   * **One flag, and it decides three things.** A new organization starts on
+   * managed access rather than customer-owned; managed work is authorized by
+   * the internal gateway credential rather than by a pasted inference key; and
+   * inference keys can be created here at all. A self-hosted deployment does
+   * none of the three, which is exactly what "hosted users paste nothing and
+   * self-hosted users paste one key" means when it is written down as code.
+   */
+  readonly hosted: boolean;
+  /**
+   * Where the Egma model gateway answers, with no trailing slash — the address
+   * a managed work order carries and a grader's judge is pointed at.
+   *
+   * `undefined` on a deployment that has not been told one, which is every
+   * self-hosted deployment that has not connected managed access and is a
+   * misconfiguration on a hosted one. Absent is a visible infrastructure error
+   * at the claim that needed it, never a fallback to calling a provider
+   * directly: a simulation quietly conducted on somebody else's account is
+   * worse than one that failed with a reason.
+   */
+  readonly gatewayAddress: string | undefined;
+  /**
+   * The key this deployment signs its own gateway credentials with. Hosted
+   * Egma's only; a self-hosted deployment presents its pasted inference key
+   * instead and holds nothing here.
+   */
+  readonly internalGatewayKey: string | undefined;
+};
+
+const UNCONFIGURED: ManagedDeployment = {
+  hosted: false,
+  gatewayAddress: undefined,
+  internalGatewayKey: undefined,
+};
+
+let held: ManagedDeployment = UNCONFIGURED;
+
+/** Called by `connect()`. Nothing else sets this. */
+export function holdManagedDeployment(deployment: ManagedDeployment): void {
+  held = {
+    hosted: deployment.hosted,
+    gatewayAddress: deployment.gatewayAddress?.replace(/\/+$/, ""),
+    internalGatewayKey: deployment.internalGatewayKey,
+  };
+}
+
+/** Called by `disconnect()`, so a closed process holds nothing. */
+export function releaseManagedDeployment(): void {
+  held = UNCONFIGURED;
+}
+
+export function managedDeployment(): ManagedDeployment {
+  return held;
+}
+
+/**
+ * The static prefix every internal gateway credential starts with.
+ *
+ * It exists for the reason `egma_sk_` does: a value with a fixed shape can be
+ * recognised in a log, a paste or a scan. It also tells the gateway's verifier
+ * which of its two authentication stories a credential belongs to before it
+ * spends a network round trip finding out.
+ */
+export const INTERNAL_GATEWAY_CREDENTIAL_PREFIX = "egma_ig_";
+
+/**
+ * How long one internal gateway credential is good for.
+ *
+ * **Bounded, and the bound is the whole reason it carries a time at all.** An
+ * organization-scoped credential with no expiry is one that authorizes that
+ * organization's model traffic forever if a work order is ever read by somebody
+ * who should not have — and a work order is the one place it appears. Twelve
+ * hours is far longer than any simulation this carries, so nothing in flight
+ * can be cut off by it, and far shorter than forever.
+ */
+export const INTERNAL_GATEWAY_CREDENTIAL_SECONDS = 12 * 60 * 60;
+
+function base64url(value: Buffer | string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+/**
+ * The credential hosted Egma's own work orders carry: **the organization, and a
+ * signature over it made with a key only this deployment and the gateway
+ * hold.**
+ *
+ * `egma_ig_<payload>.<signature>`, where the payload names the organization and
+ * the moment the credential stops being good.
+ *
+ * **The organization travels inside the signature and that is what makes it not
+ * a caller's to choose.** The rule managed access rests on is that a header, a
+ * query value, a path or a body can never say which organization a connection
+ * acts for. This does not break it: what the caller presents is one opaque
+ * credential, and the gateway reads an organization out of it only after the
+ * signature has proved that this deployment wrote it. A caller who edits the
+ * organization invalidates the signature, and a caller who cannot make a
+ * signature cannot name an organization at all.
+ *
+ * **It is minted, never exchanged.** Nothing calls anything to get one — this
+ * is a hash, computed where the work order is assembled — so there is no
+ * per-simulation grant round trip, and no provider credential comes back
+ * because none is asked for. It authenticates the gateway connection and does
+ * nothing else.
+ */
+export function signInternalGatewayCredential(
+  organizationId: string,
+  key: string,
+  now: Date = new Date(),
+): string {
+  const payload = JSON.stringify({
+    o: organizationId,
+    x: Math.floor(now.getTime() / 1000) + INTERNAL_GATEWAY_CREDENTIAL_SECONDS,
+  });
+  const encoded = base64url(payload);
+  const signature = base64url(
+    createHmac("sha256", key).update(encoded, "utf8").digest(),
+  );
+  return `${INTERNAL_GATEWAY_CREDENTIAL_PREFIX}${encoded}.${signature}`;
+}

--- a/packages/db/src/models/catalog.ts
+++ b/packages/db/src/models/catalog.ts
@@ -171,3 +171,51 @@ function firstEntryFor(job: ModelJob): ProviderCatalogEntry {
   }
   return first;
 }
+
+/**
+ * Where each provider-job pair is reached **through the Egma model gateway**,
+ * as a suffix on the gateway's own address.
+ *
+ * **Release catalog data, exactly like the provider catalog above, and it lives
+ * here for the same reason.** Three things have to agree about it: the
+ * simulator's speech legs, the grader's judge makers, and the gateway's own
+ * route table. The first two read this; the third is the authority, and a
+ * deterministic test holds the two lists against each other so a route renamed
+ * in the gateway cannot leave a leg quietly pointed at a path nothing answers.
+ *
+ * **A suffix rather than a whole address, because the address is the
+ * deployment's.** A work order carries one gateway address; each leg composes
+ * its own path onto it. What each suffix is depends on what the shipped
+ * provider adapter does with a base: Pipecat's Deepgram service appends
+ * `/v1/listen`, so the suffix stops at the provider's name; the OpenAI chat
+ * client appends `/chat/completions`, so the suffix carries `/v1`; Cartesia's
+ * service takes a whole socket address, so the suffix is the whole path.
+ */
+export const GATEWAY_ROUTE: Readonly<
+  Record<ModelProvider, Partial<Record<ModelJob, string>>>
+> = {
+  openai: { llm: "/openai/v1" },
+  deepgram: { stt: "/deepgram" },
+  cartesia: { tts: "/cartesia/tts/websocket" },
+};
+
+/**
+ * The address one leg is told, or `undefined` where this release carries no
+ * gateway route for that provider and job.
+ *
+ * Absent is a refusal to guess. A provider-job pair with no route is a pair
+ * managed access cannot execute, and answering the gateway's bare address would
+ * send the leg to a path the gateway refuses — a `404` from Egma, read by
+ * whoever sees it as the provider being wrong.
+ */
+export function gatewayAddressFor(
+  gatewayAddress: string,
+  provider: string,
+  job: ModelJob,
+): string | undefined {
+  if (!isModelProvider(provider)) return undefined;
+  const suffix = GATEWAY_ROUTE[provider][job];
+  return suffix === undefined
+    ? undefined
+    : `${gatewayAddress.replace(/\/+$/, "")}${suffix}`;
+}

--- a/packages/db/src/schema/models.ts
+++ b/packages/db/src/schema/models.ts
@@ -2,7 +2,14 @@ import { pgTable, text, unique } from "drizzle-orm/pg-core";
 
 import { organization } from "./tenancy.ts";
 import { user } from "./identity.ts";
-import { createdAt, idText, oneOf, prefixCheck, updatedAt } from "./columns.ts";
+import {
+  createdAt,
+  idText,
+  moment,
+  oneOf,
+  prefixCheck,
+  updatedAt,
+} from "./columns.ts";
 import { MODEL_PROVIDERS } from "../models/catalog.ts";
 
 /**
@@ -129,5 +136,116 @@ export const modelProviderCredential = pgTable(
       table.organizationId,
       table.provider,
     ),
+  ],
+);
+
+/**
+ * One inference key an organization holds for the Egma model gateway, as
+ * hosted Egma stores it: **a hash and its lifecycle, never a readable copy.**
+ *
+ * The sibling of `api_key` and deliberately not the same table. A product key
+ * resolves to a person, a role and a project, and opens every ordinary Egma
+ * door; this one resolves to an organization and opens exactly one thing —
+ * managed model traffic through the Egma model gateway. Keeping them apart is
+ * what makes "an inference key cannot use a normal Egma product interface" a
+ * property of where the secret is looked up rather than a rule a door has to
+ * remember: the product's resolver reads `api_key` and this row is not in it.
+ *
+ * **Several active keys per organization, on purpose.** Separate installations
+ * hold separate keys, and rotation is create-then-revoke rather than
+ * replace-in-place — so an administrator can bring a replacement up before the
+ * old key stops working and nothing stops mid-run.
+ */
+export const inferenceKey = pgTable(
+  "inference_key",
+  {
+    id: idText("id").primaryKey(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /**
+     * What an administrator calls this key, so a list of several says which
+     * installation each belongs to. Required: an unnamed key in a list of four
+     * is a key nobody dares revoke.
+     */
+    name: text("name").notNull(),
+    /**
+     * A single SHA-256 over the secret, and the whole of what is kept.
+     *
+     * Unique across the deployment, which is what lets a validation request
+     * find a key by its hash alone without naming an organization first — the
+     * organization is the row's answer, never the caller's question.
+     */
+    hash: text("hash").notNull(),
+    /** The static prefix every inference key starts with. */
+    prefix: text("prefix").notNull(),
+    /** The last characters of the secret. Enough to tell two keys apart. */
+    displaySuffix: text("display_suffix").notNull(),
+    createdBy: idText("created_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    /** When a connection last authenticated with it, so a dead key is visible. */
+    lastUsedAt: moment("last_used_at"),
+    /** When it stopped working. Read on every connection, so there is no cache to wait out. */
+    revokedAt: moment("revoked_at"),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("inference_key_id_prefix", table.id, "ifk"),
+    unique("inference_key_hash_unique").on(table.hash),
+  ],
+);
+
+/**
+ * The one inference key a self-hosted organization has connected, sealed.
+ *
+ * **The other end of the row above, in the other deployment.** Hosted Egma
+ * keeps the hash so it can answer "is this key good and whose is it"; the
+ * self-hosted deployment keeps the secret itself, because it has to present it
+ * every time a simulation opens a connection to the gateway. Neither holds what
+ * the other does, which is the whole arrangement: a stolen hosted database
+ * yields no usable key, and a stolen self-hosted one yields exactly the one
+ * organization's own key and nothing else's.
+ *
+ * **One per organization, held by the primary key.** A self-hosted deployment
+ * connects one key at a time; rotating is replacing this row, and the safe
+ * overlap lives in Egma Cloud where several keys may be active at once.
+ *
+ * **`cloud_organization_id` is the binding, and it is why this column exists.**
+ * Validation answers which Egma Cloud organization owns the key, and that
+ * answer is written down — so a key belonging to somebody else's Egma Cloud
+ * organization is refused while a binding stands, rather than quietly moving
+ * this deployment's managed traffic onto another customer's account.
+ */
+export const managedAccessKey = pgTable(
+  "managed_access_key",
+  {
+    organizationId: idText("organization_id")
+      .primaryKey()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** The Egma Cloud organization this local organization is bound to. */
+    cloudOrganizationId: idText("cloud_organization_id").notNull(),
+    /** The key, sealed with the deployment's own master key. Never read back out. */
+    credentials: text("credentials").notNull(),
+    /** The last characters of the key. Never enough of it to use. */
+    credentialsHint: text("credentials_hint").notNull(),
+    connectedBy: idText("connected_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck(
+      "managed_access_key_organization_id_prefix",
+      table.organizationId,
+      "org",
+    ),
+    // `cloud_organization_id` carries no format check, and that is the
+    // convention rather than an omission: a prefix check pins the identifiers
+    // *this* deployment mints, and this one is another deployment's answer,
+    // written down exactly as validation returned it. A check here would be
+    // Egma Cloud's identifier format frozen into a self-hoster's database.
   ],
 );

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -64,6 +64,7 @@ const MANAGED_DEPLOYMENT = [
   "INTERNAL_GATEWAY_CREDENTIAL_PREFIX",
   "INTERNAL_GATEWAY_CREDENTIAL_SECONDS",
   "managedDeployment",
+  "managedDeploymentFrom",
   "signInternalGatewayCredential",
 ];
 

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -823,6 +823,8 @@ const THE_FOLD = [
  * for a conversation's tool calls, and two implementations of "every span, once"
  * is one of them quietly missing a list.
  */
+const THE_GATEWAY_ROUTES = ["GATEWAY_ROUTE", "gatewayAddressFor"];
+
 const THE_MEASURES = [
   "everySpanIn",
   "measuresFromSpans",
@@ -845,6 +847,7 @@ describe("the data-access module's surface", () => {
         ...VALUES,
         ...READ_LIMITS,
         ...THE_FOLD,
+        ...THE_GATEWAY_ROUTES,
         ...THE_MEASURES,
         ...THE_MOCKED_WORLD,
         ...THE_PLATFORMS_SETTINGS,

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -43,6 +43,31 @@ const MIGRATIONS = [
 const IDENTITY = ["IDENTITY_MODELS", "identityId", "identityStore"];
 
 /**
+ * What kind of deployment this is, and how it signs its own connections to the
+ * Egma model gateway.
+ *
+ * Deployment configuration handed in at boot, beside the connection above and
+ * for the connection's reason: it reaches no store and takes no context.
+ * `managedDeployment` answers what `connect` was told; the other three are the
+ * *format* of the internal gateway credential — the one place this side of the
+ * wire writes it down, so that a gateway verifier at the other end reads the
+ * same thing Egma mints. A second spelling anywhere would be a credential one
+ * half of Egma could make and the other half could not check.
+ */
+const MANAGED_DEPLOYMENT = [
+  // Settable as well as readable, unlike the master key beside it, and for one
+  // reason: a deployment is hosted or self-hosted for its whole life, so the
+  // only way to exercise both answers is to tell one process it is the other.
+  // It reaches no store and holds no customer's anything, so what it widens is
+  // a boot-time setting rather than a door into data.
+  "holdManagedDeployment",
+  "INTERNAL_GATEWAY_CREDENTIAL_PREFIX",
+  "INTERNAL_GATEWAY_CREDENTIAL_SECONDS",
+  "managedDeployment",
+  "signInternalGatewayCredential",
+];
+
+/**
  * What produces an `AuthContext`: which organization a person is in, which
  * projects are in it, and what a credential resolves to. An eighth name here is
  * a decision somebody makes on purpose, and the build rule makes them make it.
@@ -59,6 +84,11 @@ const CONTEXT_ESTABLISHING = [
   "resolveDeviceAuthorization",
   "readInvitation",
   "acceptInvitation",
+  // One inference key's hash turned into the organization it authorizes.
+  // `resolveApiKey`'s shape with less authority: no context comes back, because
+  // the one thing an inference key opens is a connection to the Egma model
+  // gateway.
+  "resolveInferenceKey",
 ];
 
 /**
@@ -330,6 +360,28 @@ const CONTEXT_REQUIRING = [
   // things egma does with one — and answers only the providers it was asked
   // for, so a work order never carries a secret its selections do not name.
   "resolveModelProviderKeys",
+  // The inference keys hosted Egma mints for the Egma model gateway. Created
+  // by an admin, shown once by the route that minted the secret, and answered
+  // here as a name, a safe hint and four times — there is no shape in this
+  // module a key could travel back in.
+  "createInferenceKey",
+  "listInferenceKeys",
+  "revokeInferenceKey",
+  // The self-hosted half: the one key an administrator connected, sealed, read
+  // back as Connected and a hint, and replaced or removed deliberately.
+  "connectManagedAccess",
+  "disconnectManagedAccess",
+  "readManagedAccessConnection",
+  // Whether managed access can be chosen here at all — always on hosted Egma,
+  // and on a self-hosted deployment once a key is connected. A form reads it so
+  // that it never offers a choice the setting would refuse.
+  "managedAccessAvailable",
+  // The one door to a usable gateway credential, on `resolveModelProviderKeys`'
+  // exact terms: it takes the context and then refuses every one that did not
+  // come from a simulation or a grading claim. What it answers is where the
+  // traffic goes and what authorizes it — never an upstream provider secret,
+  // which this process cannot reach at all.
+  "resolveManagedAccess",
   // The same translation for a mock tool's scope: names off a reviewed file
   // turned into the agents it applies to. It reads agents and nothing else, and
   // only ones the context already reaches.
@@ -523,10 +575,15 @@ const VALUES = [
   // `managed` with no inference key behind it fails one claim at a time for a
   // setting that read as saved.
   "ManagedAccessNotConnectedError",
-  // The same state found on the claim path instead — a tripwire, because no
-  // door in this release can write it. Typed so it lands as an infrastructure
-  // error naming the mode rather than as a bare dispatch failure.
+  // The same state found on the claim path instead: a deployment that has not
+  // been told where its gateway is. Egma misconfigured rather than a customer
+  // unconnected, which is why it is not the error above.
   "ManagedAccessUnavailableError",
+  // An inference key pasted whose Egma Cloud organization is not the one this
+  // deployment is bound to. Refused while the binding stands, because managed
+  // spend moving onto another customer's account is not a thing one paste
+  // should be able to do.
+  "ManagedAccessBoundElsewhereError",
   // A second answer for a tool this project already answers for. Its own class
   // because nothing about the body is wrong and something is already there,
   // which is a different answer in kind.
@@ -778,6 +835,7 @@ describe("the data-access module's surface", () => {
         ...CONNECTION,
         ...MIGRATIONS,
         ...IDENTITY,
+        ...MANAGED_DEPLOYMENT,
         ...CONTEXT_ESTABLISHING,
         ...INSTANCE_SCOPED,
         ...WORK_DISPATCHING,

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -65,6 +65,9 @@ const MANAGED_DEPLOYMENT = [
   "INTERNAL_GATEWAY_CREDENTIAL_SECONDS",
   "managedDeployment",
   "managedDeploymentFrom",
+  // The TLS floor, shared with the one other place an address managed traffic
+  // reaches is read: an https address, or a loopback one for the suite.
+  "securely",
   "signInternalGatewayCredential",
 ];
 

--- a/packages/db/test/managed-deployment-config.test.ts
+++ b/packages/db/test/managed-deployment-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { managedDeploymentFrom, securely } from "@egma/db";
+
+/**
+ * What a deployment is refused for saying, at boot rather than at the first
+ * simulation.
+ *
+ * Two rules, and each exists because the failure it prevents is silent. A
+ * hosted deployment with no signing key comes up healthy, puts every new
+ * organization on Managed by Egma, and fails every claim — reading downstream
+ * as a missing gateway address, which sends an operator to the wrong setting.
+ * And a plain-text address for managed traffic puts a credential that
+ * authorizes Egma's provider accounts on the wire for anybody on the path.
+ */
+
+describe("a hosted deployment", () => {
+  it("refuses to start without the key it signs its own credentials with", () => {
+    expect(() =>
+      managedDeploymentFrom({
+        EGMA_HOSTED: "true",
+        EGMA_MODEL_GATEWAY_URL: "https://gateway.egma.example",
+      }),
+    ).toThrow(/EGMA_GATEWAY_INTERNAL_KEY is not set/);
+  });
+
+  it("starts when it holds one", () => {
+    const deployment = managedDeploymentFrom({
+      EGMA_HOSTED: "true",
+      EGMA_MODEL_GATEWAY_URL: "https://gateway.egma.example",
+      EGMA_GATEWAY_INTERNAL_KEY: "sentinel-signing-A1B2",
+    });
+
+    expect(deployment.hosted).toBe(true);
+    expect(deployment.gatewayAddress).toBe("https://gateway.egma.example");
+  });
+
+  it("is off unless somebody said so plainly, and an empty value is off", () => {
+    for (const said of [undefined, "", "false", "no", "0", "maybe"]) {
+      const deployment = managedDeploymentFrom(
+        said === undefined ? {} : { EGMA_HOSTED: said },
+      );
+      expect(deployment.hosted, String(said)).toBe(false);
+    }
+  });
+
+  it("needs no signing key when it is not hosted, which is every self-hoster", () => {
+    const deployment = managedDeploymentFrom({
+      EGMA_MODEL_GATEWAY_URL: "https://gateway.egma.example",
+    });
+    expect(deployment.hosted).toBe(false);
+    expect(deployment.internalGatewayKey).toBeUndefined();
+  });
+});
+
+describe("an address managed traffic is sent to", () => {
+  it("is https, because it carries a credential for Egma's provider accounts", () => {
+    expect(securely("X", "https://gateway.egma.ai")).toBe("https://gateway.egma.ai");
+    expect(() => securely("X", "http://gateway.egma.ai")).toThrow(/https address/);
+    expect(() => securely("X", "ws://gateway.egma.ai")).toThrow(/https address/);
+    expect(() => securely("X", "not-an-address")).toThrow(/absolute address/);
+  });
+
+  it("may be http only on loopback, which is what the deterministic suite drives", () => {
+    for (const local of [
+      "http://127.0.0.1:8787",
+      "http://localhost:3000/v1/inference-keys/validation",
+      "http://[::1]:8787",
+    ]) {
+      expect(securely("X", local), local).toBe(local);
+    }
+    // And a hostname that merely looks local is not.
+    expect(() => securely("X", "http://localhost.attacker.example")).toThrow(
+      /https address/,
+    );
+    expect(() => securely("X", "http://127.0.0.1.attacker.example")).toThrow(
+      /https address/,
+    );
+  });
+
+  it("is refused where a deployment names one, rather than at the first claim", () => {
+    expect(() =>
+      managedDeploymentFrom({ EGMA_MODEL_GATEWAY_URL: "http://gateway.egma.ai" }),
+    ).toThrow(/https address/);
+  });
+});

--- a/packages/db/test/managed-model-access.test.ts
+++ b/packages/db/test/managed-model-access.test.ts
@@ -29,6 +29,7 @@ import {
 
 import {
   createConnectedDatabase,
+  openSingleConnection,
   type MigratedDatabase,
 } from "./support/database.ts";
 import { seedOrganization, seedUser } from "./support/tenancy.ts";
@@ -408,6 +409,145 @@ describe("a self-hosted organization connecting one", () => {
 
     const read = await readManagedAccessConnection(actingAsAcme());
     expect(read.hint).toBe(CLOUD_KEY.slice(-4));
+  });
+
+  /**
+   * **The refusal is the write's, not a check in front of it.**
+   *
+   * This is the distinction the rule lives or dies on, and it is why these
+   * three cases assert on the row rather than on the exception. A comparison
+   * made before the write has a window: two administrators connecting at once
+   * both read the same answer, both pass, and the second write rebinds the
+   * deployment to another Egma Cloud organization with no disconnect — every
+   * later simulation's spend on an account nobody chose, and the administrator
+   * who lost the race told "Connected" with their own key's hint.
+   *
+   * So the comparison is inside the statement, and what these prove is that
+   * *the write itself* declines: the `UPDATE` arm fires only when the row
+   * already says what the key says, and a suppressed arm writes nothing at
+   * all. Racing threads would prove nothing here — a race that happens not to
+   * interleave passes against the broken version too, which is exactly how
+   * this survived the first round. What settles it is the semantics.
+   */
+  it("declines in the write even when a check made before it would have passed", async () => {
+    /**
+     * The race, made deterministic — no threads, one explicit transaction.
+     *
+     * A second connection opens a transaction and inserts the binding for one
+     * Egma Cloud organization *without committing*, so it holds that row. The
+     * ordinary connect path then runs for a **different** organization: any
+     * check it made before writing would see no binding at all and pass, and
+     * its write blocks on the held row. Committing releases it, and what
+     * happens next is the whole question — Postgres re-evaluates the conflict
+     * against the row that is now really there.
+     *
+     * With the comparison inside the statement the arm is suppressed and the
+     * connect is refused. With a comparison in front of the statement it
+     * fires, and the deployment is silently rebound to an organization nobody
+     * disconnected from — which is the failure this reproduces rather than
+     * describes.
+     */
+    await disconnectManagedAccess(actingAsAcme());
+
+    const holder = await openSingleConnection(database.url);
+    let refused: unknown;
+    try {
+      await holder.sql("begin");
+      await holder.sql(
+        `insert into managed_access_key
+           (organization_id, cloud_organization_id, credentials, credentials_hint, connected_by, updated_at)
+         values ($1, $2, 'v1.held-by-the-other-administrator', 'HELD', $3, now())`,
+        [acme.organization, globex.organization, ada],
+      );
+
+      // Its write blocks on the held row; the commit is what lets it proceed.
+      const connecting = connectManagedAccess(actingAsAcme(), {
+        key: "egma_ik_sentinel-lost-the-race-Zz5Aa6",
+        cloudOrganizationId: acme.organization,
+      }).catch((fault: unknown) => fault);
+
+      await new Promise((settle) => setTimeout(settle, 100));
+      await holder.sql("commit");
+      refused = await connecting;
+    } finally {
+      await holder.close();
+    }
+
+    expect(refused).toBeInstanceOf(ManagedAccessBoundElsewhereError);
+
+    // And the binding the other administrator established still stands, with
+    // their key still sealed under it.
+    const read = await readManagedAccessConnection(actingAsAcme());
+    expect(read.cloudOrganizationId).toBe(globex.organization);
+    expect(read.hint).toBe("HELD");
+
+    // Put it back where the rest of this file expects it.
+    await disconnectManagedAccess(actingAsAcme());
+    await connectManagedAccess(actingAsAcme(), {
+      key: OTHER_CLOUD_KEY,
+      cloudOrganizationId: globex.organization,
+    });
+  });
+
+  it("declines in the write itself, leaving the stored key and binding untouched", async () => {
+    const before = await readManagedAccessConnection(actingAsAcme());
+    expect(before.cloudOrganizationId).toBe(globex.organization);
+
+    await expect(
+      connectManagedAccess(actingAsAcme(), {
+        key: "egma_ik_sentinel-another-cloud-organization-Rr7Ss8",
+        cloudOrganizationId: acme.organization,
+      }),
+    ).rejects.toBeInstanceOf(ManagedAccessBoundElsewhereError);
+
+    // Nothing moved: not the binding, not the sealed key, not the hint, and
+    // not the moment it was last connected.
+    const after = await readManagedAccessConnection(actingAsAcme());
+    expect(after).toEqual(before);
+    expect(await storedEnvelope(acme.organization)).not.toContain(
+      "Rr7Ss8",
+    );
+  });
+
+  it("names the organization the deployment is really bound to, not the one that asked", async () => {
+    const refused = await connectManagedAccess(actingAsAcme(), {
+      key: "egma_ik_sentinel-wrong-cloud-Tt9Uu0",
+      cloudOrganizationId: acme.organization,
+    }).catch((fault: unknown) => fault);
+
+    expect(refused).toBeInstanceOf(ManagedAccessBoundElsewhereError);
+    expect((refused as ManagedAccessBoundElsewhereError).cloudOrganizationId).toBe(
+      globex.organization,
+    );
+  });
+
+  it("still lets the same organization's key land, which is what rotation is", async () => {
+    const rotated = "egma_ik_sentinel-rotated-same-organization-Vv1Ww2";
+    const landed = await connectManagedAccess(actingAsAcme(), {
+      key: rotated,
+      cloudOrganizationId: globex.organization,
+    });
+
+    expect(landed.hint).toBe(rotated.slice(-4));
+    expect(landed.cloudOrganizationId).toBe(globex.organization);
+  });
+
+  it("lets another organization's key land once the binding has been given up", async () => {
+    expect(await disconnectManagedAccess(actingAsAcme())).toBe(true);
+
+    const moved = await connectManagedAccess(actingAsAcme(), {
+      key: "egma_ik_sentinel-after-disconnect-Xx3Yy4",
+      cloudOrganizationId: acme.organization,
+    });
+
+    expect(moved.cloudOrganizationId).toBe(acme.organization);
+
+    // Put it back where the rest of this file expects it.
+    await disconnectManagedAccess(actingAsAcme());
+    await connectManagedAccess(actingAsAcme(), {
+      key: CLOUD_KEY,
+      cloudOrganizationId: globex.organization,
+    });
   });
 
   it("replaces a key from the same Egma Cloud organization, which is ordinary rotation", async () => {

--- a/packages/db/test/managed-model-access.test.ts
+++ b/packages/db/test/managed-model-access.test.ts
@@ -141,6 +141,20 @@ async function storedEnvelope(
   return rows[0]?.credentials;
 }
 
+/** The stamp, once the write that is deliberately not awaited has landed. */
+async function eventuallyStamped(inferenceKeyId: string): Promise<Date> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const { rows } = await database.sql<{ last_used_at: Date | null }>(
+      "select last_used_at from inference_key where id = $1",
+      [inferenceKeyId],
+    );
+    const stamped = rows[0]?.last_used_at;
+    if (stamped instanceof Date) return stamped;
+    await new Promise((settle) => setTimeout(settle, 10));
+  }
+  throw new Error("the use stamp never landed");
+}
+
 /** The hash a route computes before it ever calls the store. */
 function hashed(secret: string): string {
   return createHash("sha256").update(secret, "utf8").digest("hex");
@@ -253,6 +267,42 @@ describe("one inference key resolved by its hash", () => {
     });
   });
 
+  it("does not make a connection wait on writing down that it was used", async () => {
+    const secret = "egma_ik_sentinel-hot-path-Zz1Xx2";
+    const created = await createInferenceKey(actingAsAcme(), {
+      name: "Hot path",
+      hash: hashed(secret),
+      prefix: "egma_ik_",
+      displaySuffix: "Xx2",
+    });
+
+    // The answer a connection is waiting for is in hand before the stamp is
+    // written: the read is what the caller awaits, and the write is not
+    // awaited at all.
+    const resolved = await resolveInferenceKey(hashed(secret));
+    expect(resolved?.inferenceKeyId).toBe(created.id);
+
+    // A second open a moment later writes nothing, because the stamp is
+    // fresh — which is what stops every connection on one key queueing behind
+    // one row lock. Observed as the stamp not moving.
+    const first = await database.sql<{ last_used_at: Date | null }>(
+      "select last_used_at from inference_key where id = $1",
+      [created.id],
+    );
+    // The first write may still be in flight; wait for it to land at all.
+    const landed = await eventuallyStamped(created.id);
+    expect(landed).toBeInstanceOf(Date);
+
+    await resolveInferenceKey(hashed(secret));
+    await new Promise((settle) => setTimeout(settle, 50));
+    const again = await database.sql<{ last_used_at: Date | null }>(
+      "select last_used_at from inference_key where id = $1",
+      [created.id],
+    );
+    expect(again.rows[0]?.last_used_at?.getTime()).toBe(landed.getTime());
+    expect(first.rows.length).toBe(1);
+  });
+
   it("marks it used, so a key nobody needs is visible as one", async () => {
     const secret = "egma_ik_sentinel-used-N3P4";
     const created = await createInferenceKey(actingAsAcme(), {
@@ -262,6 +312,9 @@ describe("one inference key resolved by its hash", () => {
       displaySuffix: "N3P4",
     });
     await resolveInferenceKey(hashed(secret));
+    // The write is deliberately not awaited by the caller, so the read that
+    // observes it waits for it here instead.
+    await eventuallyStamped(created.id);
 
     const listed = (await listInferenceKeys(actingAsAcme())).find(
       (key) => key.id === created.id,

--- a/packages/db/test/managed-model-access.test.ts
+++ b/packages/db/test/managed-model-access.test.ts
@@ -1,0 +1,523 @@
+import { createHash } from "node:crypto";
+
+import { newId } from "@egma/ids";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  connectManagedAccess,
+  createInferenceKey,
+  holdManagedDeployment,
+  disconnectManagedAccess,
+  INTERNAL_GATEWAY_CREDENTIAL_PREFIX,
+  listInferenceKeys,
+  ManagedAccessBoundElsewhereError,
+  ManagedAccessNotConnectedError,
+  ManagedAccessUnavailableError,
+  managedAccessAvailable,
+  NotPermittedError,
+  readManagedAccessConnection,
+  readModelAccess,
+  resolveInferenceKey,
+  resolveManagedAccess,
+  revokeInferenceKey,
+  setModelAccess,
+  UnprocessableInputError,
+  type AuthContext,
+  type ManagedDeployment,
+  type Role,
+} from "@egma/db";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * Managed model access at the store: the inference keys hosted Egma mints, the
+ * one a self-hosted deployment connects, and the credential Egma's own two
+ * services present at the Egma model gateway.
+ *
+ * Everything is asserted through the access functions except the two reads that
+ * go around them on purpose — the `hash` column and the sealed `credentials`
+ * column. Those are the promises the product actually makes about this data:
+ * that Egma Cloud keeps no readable copy of a key, and that a self-hosted
+ * deployment keeps only a sealed one. A read the module could dress up would
+ * not be able to say either.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const globex = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+const grace = newId("usr");
+
+/** Sentinels, so a leak anywhere is a string a scan can find. */
+const CLOUD_KEY = "egma_ik_sentinel-managed-access-A1B2";
+const OTHER_CLOUD_KEY = "egma_ik_sentinel-second-install-C3D4";
+const INTERNAL_KEY = "sentinel-internal-gateway-signing-E5F6";
+const GATEWAY = "https://gateway.egma.example";
+
+function actingAsAcme(role: Role = "admin"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+function actingAsGlobex(role: Role = "admin"): AuthContext {
+  return {
+    userId: grace,
+    organizationId: globex.organization,
+    projectId: globex.project,
+    role,
+    via: "session",
+  };
+}
+
+/** What a simulation claim resolves to: no person, and `simulator` on its face. */
+function theSimulatorInAcme(): AuthContext {
+  return {
+    userId: "simulator",
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role: "viewer",
+    via: "simulator",
+  };
+}
+
+/** The grading engine's own, which opens the same door for the same reason. */
+function theEngineInAcme(): AuthContext {
+  return {
+    userId: "engine",
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role: "viewer",
+    via: "engine",
+  };
+}
+
+const SELF_HOSTED: ManagedDeployment = {
+  hosted: false,
+  gatewayAddress: GATEWAY,
+  internalGatewayKey: undefined,
+};
+
+const HOSTED: ManagedDeployment = {
+  hosted: true,
+  gatewayAddress: GATEWAY,
+  internalGatewayKey: INTERNAL_KEY,
+};
+
+/**
+ * What kind of deployment this test is standing in, changed between cases.
+ *
+ * The two answers are two deployments in production and one module here, so the
+ * seam is where they are told apart — which is exactly the seam worth testing.
+ */
+function standingIn(deployment: ManagedDeployment): void {
+  holdManagedDeployment(deployment);
+}
+
+async function storedHash(inferenceKeyId: string): Promise<string | undefined> {
+  const { rows } = await database.sql<{ hash: string }>(
+    "select hash from inference_key where id = $1",
+    [inferenceKeyId],
+  );
+  return rows[0]?.hash;
+}
+
+async function storedEnvelope(
+  organizationId: string,
+): Promise<string | undefined> {
+  const { rows } = await database.sql<{ credentials: string }>(
+    "select credentials from managed_access_key where organization_id = $1",
+    [organizationId],
+  );
+  return rows[0]?.credentials;
+}
+
+/** The hash a route computes before it ever calls the store. */
+function hashed(secret: string): string {
+  return createHash("sha256").update(secret, "utf8").digest("hex");
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("managed-model-access");
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedUser(database, grace, "grace@globex.example");
+  standingIn(SELF_HOSTED);
+});
+
+afterEach(() => {
+  standingIn(SELF_HOSTED);
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("an inference key, as Egma Cloud files it", () => {
+  it("answers a name, a safe hint and its lifecycle — and holds no key to answer with", async () => {
+    const created = await createInferenceKey(actingAsAcme(), {
+      name: "Lakeside self-hosted",
+      hash: hashed(CLOUD_KEY),
+      prefix: "egma_ik_",
+      displaySuffix: CLOUD_KEY.slice(-4),
+    });
+
+    expect(created.name).toBe("Lakeside self-hosted");
+    expect(created.looksLike).toBe(`egma_ik_…${CLOUD_KEY.slice(-4)}`);
+    expect(created.revokedAt).toBeNull();
+    expect(created.lastUsedAt).toBeNull();
+    expect(JSON.stringify(created)).not.toContain(CLOUD_KEY);
+  });
+
+  it("stores a hash of it and nowhere a readable copy", async () => {
+    const created = await createInferenceKey(actingAsAcme(), {
+      name: "Second install",
+      hash: hashed(OTHER_CLOUD_KEY),
+      prefix: "egma_ik_",
+      displaySuffix: OTHER_CLOUD_KEY.slice(-4),
+    });
+
+    expect(await storedHash(created.id)).toBe(hashed(OTHER_CLOUD_KEY));
+
+    const { rows } = await database.sql<Record<string, unknown>>(
+      "select * from inference_key where id = $1",
+      [created.id],
+    );
+    expect(JSON.stringify(rows)).not.toContain(OTHER_CLOUD_KEY);
+  });
+
+  it("needs a name, because a list of four unnamed keys is four nobody dares revoke", async () => {
+    await expect(
+      createInferenceKey(actingAsAcme(), {
+        name: "   ",
+        hash: hashed("egma_ik_sentinel-unnamed-G7H8"),
+        prefix: "egma_ik_",
+        displaySuffix: "G7H8",
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableInputError);
+  });
+
+  it("is an administrator's to create, list and revoke, and nobody else's", async () => {
+    for (const role of ["member", "viewer"] as const) {
+      await expect(listInferenceKeys(actingAsAcme(role))).rejects.toBeInstanceOf(
+        NotPermittedError,
+      );
+      await expect(
+        createInferenceKey(actingAsAcme(role), {
+          name: "no",
+          hash: hashed("egma_ik_sentinel-no-J9K0"),
+          prefix: "egma_ik_",
+          displaySuffix: "J9K0",
+        }),
+      ).rejects.toBeInstanceOf(NotPermittedError);
+    }
+  });
+
+  it("belongs to its own organization, and another customer's list is empty of it", async () => {
+    const mine = await listInferenceKeys(actingAsAcme());
+    expect(mine.length).toBeGreaterThan(0);
+    expect(await listInferenceKeys(actingAsGlobex())).toEqual([]);
+  });
+});
+
+describe("one inference key resolved by its hash", () => {
+  it("answers the organization it authorizes, and no context at all", async () => {
+    const created = await createInferenceKey(actingAsAcme(), {
+      name: "Resolvable",
+      hash: hashed("egma_ik_sentinel-resolvable-L1M2"),
+      prefix: "egma_ik_",
+      displaySuffix: "L1M2",
+    });
+
+    const resolved = await resolveInferenceKey(
+      hashed("egma_ik_sentinel-resolvable-L1M2"),
+    );
+
+    expect(resolved).toEqual({
+      inferenceKeyId: created.id,
+      organizationId: acme.organization,
+    });
+  });
+
+  it("marks it used, so a key nobody needs is visible as one", async () => {
+    const secret = "egma_ik_sentinel-used-N3P4";
+    const created = await createInferenceKey(actingAsAcme(), {
+      name: "Used",
+      hash: hashed(secret),
+      prefix: "egma_ik_",
+      displaySuffix: "N3P4",
+    });
+    await resolveInferenceKey(hashed(secret));
+
+    const listed = (await listInferenceKeys(actingAsAcme())).find(
+      (key) => key.id === created.id,
+    );
+    expect(listed?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it("answers nothing once it is revoked, read from the row rather than a cache", async () => {
+    const secret = "egma_ik_sentinel-revoked-Q5R6";
+    const created = await createInferenceKey(actingAsAcme(), {
+      name: "Retired",
+      hash: hashed(secret),
+      prefix: "egma_ik_",
+      displaySuffix: "Q5R6",
+    });
+
+    expect(await resolveInferenceKey(hashed(secret))).toBeDefined();
+
+    const revoked = await revokeInferenceKey(actingAsAcme(), created.id);
+    expect(revoked?.revokedAt).toBeInstanceOf(Date);
+
+    expect(await resolveInferenceKey(hashed(secret))).toBeUndefined();
+  });
+
+  it("leaves the other keys of the same organization working, which is what makes rotation overlap", async () => {
+    const older = "egma_ik_sentinel-rotate-old-S7T8";
+    const newer = "egma_ik_sentinel-rotate-new-V9W0";
+    const first = await createInferenceKey(actingAsAcme(), {
+      name: "Before rotation",
+      hash: hashed(older),
+      prefix: "egma_ik_",
+      displaySuffix: "S7T8",
+    });
+    await createInferenceKey(actingAsAcme(), {
+      name: "After rotation",
+      hash: hashed(newer),
+      prefix: "egma_ik_",
+      displaySuffix: "V9W0",
+    });
+
+    expect(await resolveInferenceKey(hashed(newer))).toBeDefined();
+    await revokeInferenceKey(actingAsAcme(), first.id);
+
+    expect(await resolveInferenceKey(hashed(older))).toBeUndefined();
+    expect(await resolveInferenceKey(hashed(newer))).toBeDefined();
+  });
+
+  it("cannot be revoked from another customer's account", async () => {
+    const secret = "egma_ik_sentinel-not-yours-X1Y2";
+    const created = await createInferenceKey(actingAsAcme(), {
+      name: "Acme's",
+      hash: hashed(secret),
+      prefix: "egma_ik_",
+      displaySuffix: "X1Y2",
+    });
+
+    expect(await revokeInferenceKey(actingAsGlobex(), created.id)).toBeUndefined();
+    expect(await resolveInferenceKey(hashed(secret))).toBeDefined();
+  });
+});
+
+describe("a self-hosted organization connecting one", () => {
+  it("reads back Connected and a safe hint, and never the key", async () => {
+    await connectManagedAccess(actingAsAcme(), {
+      key: CLOUD_KEY,
+      cloudOrganizationId: globex.organization,
+    });
+
+    const read = await readManagedAccessConnection(actingAsAcme());
+    expect(read.connected).toBe(true);
+    expect(read.hint).toBe(CLOUD_KEY.slice(-4));
+    expect(read.cloudOrganizationId).toBe(globex.organization);
+    expect(JSON.stringify(read)).not.toContain(CLOUD_KEY);
+  });
+
+  it("seals it, so the column holds ciphertext and not the key", async () => {
+    const envelope = await storedEnvelope(acme.organization);
+
+    expect(envelope).toBeDefined();
+    expect(envelope).not.toContain(CLOUD_KEY);
+    expect(envelope).toMatch(/^v1\./);
+  });
+
+  it("refuses a key owned by another Egma Cloud organization while the binding stands", async () => {
+    await expect(
+      connectManagedAccess(actingAsAcme(), {
+        key: OTHER_CLOUD_KEY,
+        cloudOrganizationId: acme.organization,
+      }),
+    ).rejects.toBeInstanceOf(ManagedAccessBoundElsewhereError);
+
+    const read = await readManagedAccessConnection(actingAsAcme());
+    expect(read.hint).toBe(CLOUD_KEY.slice(-4));
+  });
+
+  it("replaces a key from the same Egma Cloud organization, which is ordinary rotation", async () => {
+    await connectManagedAccess(actingAsAcme(), {
+      key: OTHER_CLOUD_KEY,
+      cloudOrganizationId: globex.organization,
+    });
+
+    expect((await readManagedAccessConnection(actingAsAcme())).hint).toBe(
+      OTHER_CLOUD_KEY.slice(-4),
+    );
+  });
+
+  it("is an administrator's to connect and disconnect, and nobody else's", async () => {
+    for (const role of ["member", "viewer"] as const) {
+      await expect(
+        connectManagedAccess(actingAsAcme(role), {
+          key: CLOUD_KEY,
+          cloudOrganizationId: globex.organization,
+        }),
+      ).rejects.toBeInstanceOf(NotPermittedError);
+      await expect(
+        disconnectManagedAccess(actingAsAcme(role)),
+      ).rejects.toBeInstanceOf(NotPermittedError);
+    }
+  });
+
+  it("is another customer's business and not readable across the boundary", async () => {
+    expect(await readManagedAccessConnection(actingAsGlobex())).toEqual({
+      connected: false,
+      hint: null,
+      cloudOrganizationId: null,
+      updatedAt: null,
+    });
+  });
+});
+
+describe("the credential one claim is prepared with", () => {
+  it("is opened for the simulator and for the grading engine", async () => {
+    for (const asking of [theSimulatorInAcme(), theEngineInAcme()]) {
+      const resolved = await resolveManagedAccess(asking);
+      expect(resolved.gatewayAddress).toBe(GATEWAY);
+      expect(resolved.credential).toBe(OTHER_CLOUD_KEY);
+    }
+  });
+
+  it("is refused to a person, at every role including admin", async () => {
+    for (const role of ["admin", "member", "viewer"] as const) {
+      await expect(resolveManagedAccess(actingAsAcme(role))).rejects.toThrow(
+        /simulator or its grading engine/,
+      );
+    }
+  });
+
+  it("is hosted Egma's own signed credential where nothing was pasted", async () => {
+    standingIn(HOSTED);
+
+    const resolved = await resolveManagedAccess(theSimulatorInAcme());
+
+    expect(resolved.gatewayAddress).toBe(GATEWAY);
+    expect(resolved.credential.startsWith(INTERNAL_GATEWAY_CREDENTIAL_PREFIX)).toBe(
+      true,
+    );
+    // The organization travels inside the signature rather than beside it, and
+    // the signing key is never any part of what goes out.
+    expect(resolved.credential).not.toContain(INTERNAL_KEY);
+    expect(resolved.credential).not.toContain(OTHER_CLOUD_KEY);
+  });
+
+  it("says which organization it is for, so hosted work is not one deployment-wide credential", async () => {
+    standingIn(HOSTED);
+
+    const forAcme = await resolveManagedAccess(theSimulatorInAcme());
+    const forGlobex = await resolveManagedAccess({
+      userId: "simulator",
+      organizationId: globex.organization,
+      projectId: globex.project,
+      role: "viewer",
+      via: "simulator",
+    });
+
+    expect(forAcme.credential).not.toBe(forGlobex.credential);
+  });
+
+  it("says an administrator has one thing to connect, when nothing is connected", async () => {
+    await expect(resolveManagedAccess(theSimulatorInGlobex())).rejects.toBeInstanceOf(
+      ManagedAccessNotConnectedError,
+    );
+  });
+
+  it("says the deployment is misconfigured, when nobody told it where the gateway is", async () => {
+    standingIn({ hosted: false, gatewayAddress: undefined, internalGatewayKey: undefined });
+
+    await expect(resolveManagedAccess(theSimulatorInAcme())).rejects.toBeInstanceOf(
+      ManagedAccessUnavailableError,
+    );
+  });
+});
+
+function theSimulatorInGlobex(): AuthContext {
+  return {
+    userId: "simulator",
+    organizationId: globex.organization,
+    projectId: globex.project,
+    role: "viewer",
+    via: "simulator",
+  };
+}
+
+describe("choosing managed access", () => {
+  it("is refused on a self-hosted deployment with nothing connected", async () => {
+    expect(await managedAccessAvailable(actingAsGlobex())).toBe(false);
+    await expect(
+      setModelAccess(actingAsGlobex(), "managed"),
+    ).rejects.toBeInstanceOf(ManagedAccessNotConnectedError);
+  });
+
+  it("lands on a self-hosted deployment once a key is connected", async () => {
+    expect(await managedAccessAvailable(actingAsAcme())).toBe(true);
+
+    const chosen = await setModelAccess(actingAsAcme(), "managed");
+    expect(chosen.mode).toBe("managed");
+    expect((await readModelAccess(actingAsAcme())).mode).toBe("managed");
+  });
+
+  it("is always available on hosted Egma, where there is nothing to connect", async () => {
+    standingIn(HOSTED);
+
+    expect(await managedAccessAvailable(actingAsGlobex())).toBe(true);
+    expect((await setModelAccess(actingAsGlobex(), "managed")).mode).toBe(
+      "managed",
+    );
+  });
+});
+
+describe("disconnecting", () => {
+  it("takes the key away and leaves the access mode exactly as it was", async () => {
+    expect((await readModelAccess(actingAsAcme())).mode).toBe("managed");
+
+    expect(await disconnectManagedAccess(actingAsAcme())).toBe(true);
+
+    expect((await readManagedAccessConnection(actingAsAcme())).connected).toBe(
+      false,
+    );
+    // Deliberately unchanged: the next claim lands as a visible infrastructure
+    // error naming what to reconnect, rather than this quietly deciding
+    // somebody's access mode for them.
+    expect((await readModelAccess(actingAsAcme())).mode).toBe("managed");
+  });
+
+  it("frees the binding, so another Egma Cloud organization's key can be connected", async () => {
+    await connectManagedAccess(actingAsAcme(), {
+      key: OTHER_CLOUD_KEY,
+      cloudOrganizationId: acme.organization,
+    });
+
+    expect((await readManagedAccessConnection(actingAsAcme())).cloudOrganizationId).toBe(
+      acme.organization,
+    );
+  });
+
+  it("answers false where there was nothing to disconnect", async () => {
+    await disconnectManagedAccess(actingAsAcme());
+    expect(await disconnectManagedAccess(actingAsAcme())).toBe(false);
+  });
+});

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -48,6 +48,16 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   // identity because a rotation replaces the whole envelope and the row has to
   // keep the identity it had.
   model_provider_credential: "mpc",
+  // One inference key for the Egma model gateway, as hosted Egma files it: a
+  // hash and its lifecycle, never a readable copy. Its own identity because an
+  // organization holds several at once — that is what makes rotation overlap —
+  // and because revoking one has to name something that is not the secret.
+  inference_key: "ifk",
+  // The one inference key a self-hosted organization has connected, sealed.
+  // Keyed by the organization, whose identity it carries, for `model_access`'s
+  // exact reason: one answer per customer, so there is no second identifier to
+  // mint and none to name wrongly.
+  managed_access_key: "org",
   membership: "mbr",
   invitation: "inv",
   api_key: "key",

--- a/packages/db/test/seeded-defaults-per-deployment.test.ts
+++ b/packages/db/test/seeded-defaults-per-deployment.test.ts
@@ -1,0 +1,185 @@
+import { newId } from "@egma/ids";
+import {
+  getGrader,
+  getPersona,
+  holdManagedDeployment,
+  listGraders,
+  listPersonas,
+  provisionOrganization,
+  readModelAccess,
+  RECOMMENDED_GRADER_MODEL,
+  RECOMMENDED_PERSONA_MODELS,
+  type AuthContext,
+} from "@egma/db";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedUser } from "./support/tenancy.ts";
+
+/**
+ * What a new project is born holding, and why the answer is different on the
+ * two kinds of deployment.
+ *
+ * **This is the last step of the zero-setup first run.** A hosted organization
+ * is on Managed by Egma from the moment it exists, so its seeded persona and
+ * its seeded grader can be given the release's proved model selections and
+ * executed at once, on Egma's provider accounts, with nothing pasted and
+ * nothing edited. A seeded persona *without* selections would break that at the
+ * last step: it would resolve through deployment-wide model settings, and
+ * hosted Egma has none.
+ *
+ * A self-hosted deployment gets the opposite answer for the opposite reason,
+ * and it is asserted here just as hard: those deployments hold deployment-wide
+ * settings and a platform judge and usually no organization credential, so
+ * seeded selections would fail the first claim naming a provider nobody was
+ * asked for. Giving *their* existing personas and graders explicit successors
+ * belongs to the migration.
+ *
+ * Everything goes through the front door signup itself uses — one call to
+ * `provisionOrganization` — and is read back through the ordinary factory
+ * reads.
+ */
+
+let database: MigratedDatabase;
+
+const HOSTED = {
+  hosted: true,
+  gatewayAddress: "https://gateway.egma.example",
+  internalGatewayKey: "sentinel-seeded-defaults-signing-A1B2",
+} as const;
+
+const SELF_HOSTED = {
+  hosted: false,
+  gatewayAddress: undefined,
+  internalGatewayKey: undefined,
+} as const;
+
+type Provisioned = {
+  readonly auth: AuthContext;
+  readonly organizationId: string;
+  readonly projectId: string;
+};
+
+async function aNewCustomer(label: string): Promise<Provisioned> {
+  const userId = newId("usr");
+  await seedUser(database, userId, `${label}-${userId.slice(-6)}@acme.example`);
+
+  const provisioned = await provisionOrganization({
+    ownerUserId: userId,
+    organizationName: label,
+    organizationSlug: `${label}-${userId.slice(-6)}`,
+    projectName: "Default",
+    projectSlug: "default",
+  });
+
+  return {
+    organizationId: provisioned.organizationId,
+    projectId: provisioned.projectId,
+    auth: {
+      userId,
+      organizationId: provisioned.organizationId,
+      projectId: provisioned.projectId,
+      role: "admin",
+      via: "session",
+    },
+  };
+}
+
+/** The project's default persona, as anybody in it reads one. */
+async function theSeededPersona(where: Provisioned) {
+  const [starter] = (await listPersonas(where.auth)).items;
+  expect(starter, "a new project has no persona at all").toBeDefined();
+  return getPersona(where.auth, starter?.id ?? "");
+}
+
+/** The project's mandatory grading copy, as anybody in it reads one. */
+async function theSeededGrader(where: Provisioned) {
+  const [seeded] = (await listGraders(where.auth)).items;
+  expect(seeded, "a new project has no grader at all").toBeDefined();
+  return getGrader(where.auth, seeded?.id ?? "");
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("seeded-defaults-per-deployment");
+});
+
+afterAll(async () => {
+  holdManagedDeployment(SELF_HOSTED);
+  await database.drop();
+});
+
+describe("a new project on hosted Egma", () => {
+  it("is born on Managed by Egma, with a persona that has already chosen its models", async () => {
+    holdManagedDeployment(HOSTED);
+    const acme = await aNewCustomer("hosted");
+
+    expect((await readModelAccess(acme.auth)).mode).toBe("managed");
+
+    const starter = await theSeededPersona(acme);
+    // The release's proved defaults, whole — the same values the Models form
+    // fills in, so the seeded persona and an authored one start from one
+    // choice rather than two that can drift.
+    expect(starter?.models).toEqual(RECOMMENDED_PERSONA_MODELS);
+  });
+
+  it("is born with a grader that has already chosen the model it judges with", async () => {
+    holdManagedDeployment(HOSTED);
+    const acme = await aNewCustomer("hosted-grader");
+
+    const seeded = await theSeededGrader(acme);
+    expect(seeded?.graderModel).toEqual(RECOMMENDED_GRADER_MODEL);
+    // The selection lands beside the config on the version, and the copy still
+    // reads its judge prompt through the library pointer rather than holding
+    // one — so nothing about the pointer rules moved to make room for it.
+    expect(seeded?.libraryId).toBeDefined();
+    expect(seeded).not.toHaveProperty("prompt");
+    // And it is still the mandatory copy it always was.
+    expect(seeded?.required).toBe(true);
+    expect(seeded?.scope).toBe("simulations");
+  });
+
+  it("needs nothing configured to get there, which is the whole point", async () => {
+    holdManagedDeployment(HOSTED);
+    const acme = await aNewCustomer("hosted-nothing-configured");
+
+    const starter = await theSeededPersona(acme);
+    const seeded = await theSeededGrader(acme);
+
+    // No credential was stored, no key was pasted, no form was opened. What
+    // the two objects hold is a provider and a model each, and nothing that
+    // could authorize one.
+    expect(JSON.stringify(starter?.models)).not.toMatch(/key|secret|credential/i);
+    expect(JSON.stringify(seeded?.graderModel)).not.toMatch(
+      /key|secret|credential/i,
+    );
+  });
+});
+
+describe("a new project on a self-hosted deployment", () => {
+  it("keeps its seeded persona on the compatibility path, with no selections at all", async () => {
+    holdManagedDeployment(SELF_HOSTED);
+    const lakeside = await aNewCustomer("self-hosted");
+
+    // Customer-owned, because nothing has been connected to Egma's provider
+    // accounts and nothing may spend from them.
+    expect((await readModelAccess(lakeside.auth)).mode).toBe("customer-owned");
+
+    const starter = await theSeededPersona(lakeside);
+    // `null` rather than defaults: this deployment resolves models through its
+    // own settings, and a seeded selection would fail the first claim naming a
+    // provider nobody was asked for.
+    expect(starter?.models).toBeNull();
+  });
+
+  it("keeps its seeded grader judging through the project's own judge", async () => {
+    holdManagedDeployment(SELF_HOSTED);
+    const lakeside = await aNewCustomer("self-hosted-grader");
+
+    const seeded = await theSeededGrader(lakeside);
+    expect(seeded?.graderModel).toBeNull();
+    expect(seeded?.judgeModel).toBeNull();
+  });
+});

--- a/packages/ids/src/index.ts
+++ b/packages/ids/src/index.ts
@@ -63,6 +63,13 @@ export const ID_PREFIXES = [
    * something that is not the secret.
    */
   "mpc",
+  /**
+   * An organization's inference key for the Egma model gateway, as hosted Egma
+   * files it. Its own identity because an organization may hold several at once
+   * — that is what makes rotation overlap safely — and because an administrator
+   * revoking one has to be able to name something that is not the secret.
+   */
+  "ifk",
   "mck",
   "ste",
   "run",

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -79,6 +79,17 @@ const CONTEXT_ESTABLISHING = [
   "resolveDeviceAuthorization",
   "readInvitation",
   "acceptInvitation",
+  /**
+   * `resolveInferenceKey` was added on 2026-08-17 with managed model access, on
+   * `resolveApiKey`'s exact terms and after the rule stopped the build. It takes
+   * the hash of a high-entropy secret Egma issued to one organization and
+   * answers which organization that is. There is no argument other than the
+   * secret, so it cannot be asked about somebody else's — and it deliberately
+   * answers *less* than `resolveApiKey` does: an organization and a key id,
+   * never a whole context, because the one thing an inference key authorizes is
+   * a connection to the Egma model gateway.
+   */
+  "resolveInferenceKey",
 ];
 
 /**

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/customer-owned-carrying-a-gateway.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/customer-owned-carrying-a-gateway.json
@@ -1,0 +1,36 @@
+{
+  "_why": "Customer-owned access with a gateway block. Egma is not on the model traffic path here at all — the simulator calls the providers itself with the organization's own keys — so an address and a credential for the Egma model gateway are two things nothing would use and one of them is a credential.",
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": { "url": "wss://lakeside-dental.livekit.cloud", "agentName": "front-desk" },
+    "credentials": { "apiKey": "APIexample0key0", "apiSecret": "example0secret0value0not0a0real0one" }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen.",
+      "language": "en-GB",
+      "voice": { "provider": "cartesia", "voiceId": "measured-alto-3", "speed": 0.95 }
+    }
+  },
+  "scenario": { "instructions": "Move Tuesday's check-up to a Thursday." },
+  "limits": { "max_duration_seconds": 300, "max_turns": 40 },
+  "models": {
+    "access": "customer-owned",
+    "gateway": {
+      "address": "https://gateway.egma.ai",
+      "credential": "egma_ik_sentinel-should-not-be-here-Rt7Yu2"
+    },
+    "llm": { "provider": "openai", "model": "gpt-4o-mini", "key": "sk-sentinel-customer-owned-A1B2" },
+    "stt": { "provider": "deepgram", "model": "nova-3-general", "key": "dg-sentinel-customer-owned-C3D4" },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-sentinel-customer-owned-E5F6",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1.15
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/customer-owned-carrying-a-gateway.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/customer-owned-carrying-a-gateway.json
@@ -1,30 +1,52 @@
 {
-  "_why": "Customer-owned access with a gateway block. Egma is not on the model traffic path here at all — the simulator calls the providers itself with the organization's own keys — so an address and a credential for the Egma model gateway are two things nothing would use and one of them is a credential.",
   "contract_version": 2,
   "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
   "modality": "voice",
   "connection": {
     "type": "livekit",
-    "config": { "url": "wss://lakeside-dental.livekit.cloud", "agentName": "front-desk" },
-    "credentials": { "apiKey": "APIexample0key0", "apiSecret": "example0secret0value0not0a0real0one" }
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
   },
   "persona": {
     "traits": {
       "personality": "Retired teacher, 68, calling from a quiet kitchen.",
       "language": "en-GB",
-      "voice": { "provider": "cartesia", "voiceId": "measured-alto-3", "speed": 0.95 }
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
     }
   },
-  "scenario": { "instructions": "Move Tuesday's check-up to a Thursday." },
-  "limits": { "max_duration_seconds": 300, "max_turns": 40 },
+  "scenario": {
+    "instructions": "Move Tuesday's check-up to a Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
   "models": {
     "access": "customer-owned",
     "gateway": {
       "address": "https://gateway.egma.ai",
       "credential": "egma_ik_sentinel-should-not-be-here-Rt7Yu2"
     },
-    "llm": { "provider": "openai", "model": "gpt-4o-mini", "key": "sk-sentinel-customer-owned-A1B2" },
-    "stt": { "provider": "deepgram", "model": "nova-3-general", "key": "dg-sentinel-customer-owned-C3D4" },
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-sentinel-customer-owned-A1B2"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-sentinel-customer-owned-C3D4"
+    },
     "tts": {
       "provider": "cartesia",
       "model": "sonic-3.5",

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/managed-carrying-a-provider-key.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/managed-carrying-a-provider-key.json
@@ -1,22 +1,36 @@
 {
-  "_why": "Managed access with a provider key on one selection. The whole point of the two closed shapes: Egma's provider credentials stay inside the Egma model gateway, so a managed work order carrying one is refused here rather than arriving at a simulator that had no business holding it.",
   "contract_version": 2,
   "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
   "modality": "voice",
   "connection": {
     "type": "livekit",
-    "config": { "url": "wss://lakeside-dental.livekit.cloud", "agentName": "front-desk" },
-    "credentials": { "apiKey": "APIexample0key0", "apiSecret": "example0secret0value0not0a0real0one" }
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
   },
   "persona": {
     "traits": {
       "personality": "Retired teacher, 68, calling from a quiet kitchen.",
       "language": "en-GB",
-      "voice": { "provider": "cartesia", "voiceId": "measured-alto-3", "speed": 0.95 }
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
     }
   },
-  "scenario": { "instructions": "Move Tuesday's check-up to a Thursday." },
-  "limits": { "max_duration_seconds": 300, "max_turns": 40 },
+  "scenario": {
+    "instructions": "Move Tuesday's check-up to a Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
   "models": {
     "access": "managed",
     "gateway": {
@@ -28,7 +42,10 @@
       "model": "gpt-4o-mini",
       "key": "sk-sentinel-a-key-that-must-never-travel-managed"
     },
-    "stt": { "provider": "deepgram", "model": "nova-3-general" },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general"
+    },
     "tts": {
       "provider": "cartesia",
       "model": "sonic-3.5",

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/managed-carrying-a-provider-key.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/managed-carrying-a-provider-key.json
@@ -1,0 +1,39 @@
+{
+  "_why": "Managed access with a provider key on one selection. The whole point of the two closed shapes: Egma's provider credentials stay inside the Egma model gateway, so a managed work order carrying one is refused here rather than arriving at a simulator that had no business holding it.",
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": { "url": "wss://lakeside-dental.livekit.cloud", "agentName": "front-desk" },
+    "credentials": { "apiKey": "APIexample0key0", "apiSecret": "example0secret0value0not0a0real0one" }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen.",
+      "language": "en-GB",
+      "voice": { "provider": "cartesia", "voiceId": "measured-alto-3", "speed": 0.95 }
+    }
+  },
+  "scenario": { "instructions": "Move Tuesday's check-up to a Thursday." },
+  "limits": { "max_duration_seconds": 300, "max_turns": 40 },
+  "models": {
+    "access": "managed",
+    "gateway": {
+      "address": "https://gateway.egma.ai",
+      "credential": "egma_ik_sentinel-managed-work-order-key-Rt7Yu2"
+    },
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-sentinel-a-key-that-must-never-travel-managed"
+    },
+    "stt": { "provider": "deepgram", "model": "nova-3-general" },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1.15
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/managed-without-a-gateway.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/managed-without-a-gateway.json
@@ -1,26 +1,46 @@
 {
-  "_why": "Managed access with no gateway block. There is nowhere for the traffic to go and nothing to authorize it, so this is refused on the sending side rather than arriving at a simulator that would fall back to calling a provider directly.",
   "contract_version": 2,
   "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
   "modality": "voice",
   "connection": {
     "type": "livekit",
-    "config": { "url": "wss://lakeside-dental.livekit.cloud", "agentName": "front-desk" },
-    "credentials": { "apiKey": "APIexample0key0", "apiSecret": "example0secret0value0not0a0real0one" }
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
   },
   "persona": {
     "traits": {
       "personality": "Retired teacher, 68, calling from a quiet kitchen.",
       "language": "en-GB",
-      "voice": { "provider": "cartesia", "voiceId": "measured-alto-3", "speed": 0.95 }
+      "voice": {
+        "provider": "cartesia",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
     }
   },
-  "scenario": { "instructions": "Move Tuesday's check-up to a Thursday." },
-  "limits": { "max_duration_seconds": 300, "max_turns": 40 },
+  "scenario": {
+    "instructions": "Move Tuesday's check-up to a Thursday."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
   "models": {
     "access": "managed",
-    "llm": { "provider": "openai", "model": "gpt-4o-mini" },
-    "stt": { "provider": "deepgram", "model": "nova-3-general" },
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general"
+    },
     "tts": {
       "provider": "cartesia",
       "model": "sonic-3.5",

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/managed-without-a-gateway.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/managed-without-a-gateway.json
@@ -1,0 +1,31 @@
+{
+  "_why": "Managed access with no gateway block. There is nowhere for the traffic to go and nothing to authorize it, so this is refused on the sending side rather than arriving at a simulator that would fall back to calling a provider directly.",
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": { "url": "wss://lakeside-dental.livekit.cloud", "agentName": "front-desk" },
+    "credentials": { "apiKey": "APIexample0key0", "apiSecret": "example0secret0value0not0a0real0one" }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen.",
+      "language": "en-GB",
+      "voice": { "provider": "cartesia", "voiceId": "measured-alto-3", "speed": 0.95 }
+    }
+  },
+  "scenario": { "instructions": "Move Tuesday's check-up to a Thursday." },
+  "limits": { "max_duration_seconds": 300, "max_turns": 40 },
+  "models": {
+    "access": "managed",
+    "llm": { "provider": "openai", "model": "gpt-4o-mini" },
+    "stt": { "provider": "deepgram", "model": "nova-3-general" },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1.15
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/valid/voice-managed.json
+++ b/packages/simulation-contract/fixtures/spec-v2/valid/voice-managed.json
@@ -34,6 +34,10 @@
   },
   "models": {
     "access": "managed",
+    "gateway": {
+      "address": "https://gateway.egma.ai",
+      "credential": "egma_ik_sentinel-managed-work-order-key-Rt7Yu2"
+    },
     "llm": {
       "provider": "openai",
       "model": "gpt-4o-mini"

--- a/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
@@ -338,11 +338,12 @@
           }
         },
         {
-          "description": "Managed access: the traffic goes through the Egma model gateway and no provider key travels at all.",
+          "description": "Managed access: the traffic goes through the Egma model gateway, no provider key travels at all, and the one credential that does authorizes the gateway rather than any provider.",
           "type": "object",
           "additionalProperties": false,
           "required": [
             "access",
+            "gateway",
             "llm",
             "stt",
             "tts"
@@ -352,6 +353,9 @@
               "description": "Egma supplies the provider credentials through the Egma model gateway, and this document carries none of them.",
               "type": "string",
               "const": "managed"
+            },
+            "gateway": {
+              "$ref": "#/$defs/gateway"
             },
             "llm": {
               "$ref": "#/$defs/managed_selection"
@@ -505,6 +509,28 @@
           ]
         }
       ]
+    },
+    "gateway": {
+      "description": "Where managed model traffic goes, and what authorizes it. **The address is the Egma model gateway's and never a provider's**: each leg appends its own provider's path to it, so a shipped provider adapter reaches the gateway by being told a different base address and nothing else. Nothing here is chosen by the simulator and nothing here is a provider secret \u2014 Egma's provider credentials stay inside the gateway, and the worker conducting this simulation is never handed one. Resolved when the claim is prepared rather than when the run was created, so a reconnected key reaches the next simulation to be claimed and leaves the ones already conducting alone.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "address",
+        "credential"
+      ],
+      "properties": {
+        "address": {
+          "description": "The Egma model gateway's own address, with no trailing slash. Deployment configuration, never a persona's and never a caller's.",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^https?://[^/].*[^/]$"
+        },
+        "credential": {
+          "description": "What this connection presents at the gateway: hosted Egma's own signed credential, or the organization's inference key. In the clear for exactly this hand-off, held in memory for the simulation, registered for redaction, and never logged, persisted or reported \u2014 no report document has anywhere to put it. **Never an upstream provider secret**, which is the whole difference between managed access and customer-owned access.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
     }
   },
   "allOf": [

--- a/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
@@ -523,7 +523,7 @@
           "description": "The Egma model gateway's own address, with no trailing slash. Deployment configuration, never a persona's and never a caller's. **`https:` unless it is loopback**: a work order's gateway credential authorizes Egma's provider accounts, and a plain-text address would put it on the wire for anybody on the path. Loopback is carved out for the deterministic suite, which drives a real gateway over real sockets on `127.0.0.1` and would otherwise be proving TLS setup rather than a relay.",
           "type": "string",
           "minLength": 1,
-          "pattern": "^(https://[^/\\\\s]+|http://(localhost|127\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}|\\\\[::1\\\\])(:\\\\d+)?)(/[^\\\\s]*[^/\\\\s])?$"
+          "pattern": "^(https://[^/\\s]+|http://(localhost|127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|\\[::1\\])(:\\d+)?)(/[^\\s]*[^/\\s])?$"
         },
         "credential": {
           "description": "What this connection presents at the gateway: hosted Egma's own signed credential, or the organization's inference key. In the clear for exactly this hand-off, held in memory for the simulation, registered for redaction, and never logged, persisted or reported \u2014 no report document has anywhere to put it. **Never an upstream provider secret**, which is the whole difference between managed access and customer-owned access.",

--- a/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
@@ -520,10 +520,10 @@
       ],
       "properties": {
         "address": {
-          "description": "The Egma model gateway's own address, with no trailing slash. Deployment configuration, never a persona's and never a caller's.",
+          "description": "The Egma model gateway's own address, with no trailing slash. Deployment configuration, never a persona's and never a caller's. **`https:` unless it is loopback**: a work order's gateway credential authorizes Egma's provider accounts, and a plain-text address would put it on the wire for anybody on the path. Loopback is carved out for the deterministic suite, which drives a real gateway over real sockets on `127.0.0.1` and would otherwise be proving TLS setup rather than a relay.",
           "type": "string",
           "minLength": 1,
-          "pattern": "^https?://[^/].*[^/]$"
+          "pattern": "^(https://[^/\\\\s]+|http://(localhost|127\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}|\\\\[::1\\\\])(:\\\\d+)?)(/[^\\\\s]*[^/\\\\s])?$"
         },
         "credential": {
           "description": "What this connection presents at the gateway: hosted Egma's own signed credential, or the organization's inference key. In the clear for exactly this hand-off, held in memory for the simulation, registered for redaction, and never logged, persisted or reported \u2014 no report document has anywhere to put it. **Never an upstream provider secret**, which is the whole difference between managed access and customer-owned access.",

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -203,6 +203,27 @@ const EXPECTED_REJECTION: Record<string, Rejection> = {
     at: "/models/stt",
     keyword: "not",
   },
+  // Egma's provider credentials stay inside the Egma model gateway. A managed
+  // work order carrying one is refused on the sending side rather than arriving
+  // at a simulator that had no business holding it.
+  "spec-v2/managed-carrying-a-provider-key.json": {
+    at: "/models",
+    keyword: "oneOf",
+  },
+  // Managed access with nowhere for the traffic to go and nothing to authorize
+  // it. Refused rather than delivered, because the only thing a simulator could
+  // do with it is fall back to calling a provider directly.
+  "spec-v2/managed-without-a-gateway.json": {
+    at: "/models",
+    keyword: "oneOf",
+  },
+  // Customer-owned access is Egma off the model traffic path entirely, so a
+  // gateway address and a gateway credential are two things nothing would use
+  // and one of them is a credential.
+  "spec-v2/customer-owned-carrying-a-gateway.json": {
+    at: "/models",
+    keyword: "oneOf",
+  },
   "spec-v2/unknown-field.json": {
     at: "",
     keyword: "additionalProperties",
@@ -320,6 +341,7 @@ describe("the two schemas, as one contract", () => {
         "managed_selection",
         "speech_selection",
         "managed_speech_selection",
+        "gateway",
       ]) {
         delete defs[added];
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,12 @@ importers:
       '@types/nodemailer':
         specifier: ^8.0.1
         version: 8.0.1
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      ws:
+        specifier: ^8.21.2
+        version: 8.21.2
 
   apps/cli:
     dependencies:


### PR DESCRIPTION
## What this is

The managed half of model access. A hosted organization is born on **Managed by Egma** and completes its first voice simulation and verdict with zero configuration — the seeded default persona and predefined grader already carry proved model selections, and every leg travels through the Egma model gateway on Egma's provider accounts. A self-hosted organization connects one **inference-only Egma key** and gets the same flow. Nobody pastes a provider key for managed access, and no provider secret ever enters a simulator or grader.

## What's in it

- **Two halves of one inference key** (migration `0036`, additive): hosted Egma stores a hash, name, safe hint, and lifecycle times — no column a readable copy could live in; a self-hosted deployment seals the key itself beside the Egma Cloud organization that validation said owns it. Created named, shown once, several active per organization so rotation overlaps; revocation bites the next HTTP or WebSocket connection; an inference key is structurally nobody at every product door, and a product key is refused by the gateway without a validation ask.
- **The gateway stopped holding a secret and started checking two.** Behind the same replaceable `Verifier` seam: an internal hosted credential (`egma_ig_…` — HMAC-SHA256 over the whole payload, fixed algorithm, constant-time comparison, 12-hour bound, the organization inside the signature so no caller-supplied value can name one) checked locally; and inference keys validated against the platform on every connection open — the gateway stores nothing, so revocation needs no cache to expire. A third answer, `unavailable`, maps to `503` with its own record class: an unreachable validator never blames a customer's key with a `401`.
- **Self-hosted connection**: paste → exactly one content-free validation (empty body, asserted) → Connected with a safe hint; a key owned by another organization is refused while the binding stands; replace and disconnect are first-class, and the disconnect dialog names the key it severs.
- **Managed work orders**: the claim path resolves gateway address + execution credential — never an upstream provider key — and the customer-owned path stays exactly inverse. The contract's managed shape is closed and requires the gateway block; both languages refuse the invalid hybrids.
- **A managed leg with no gateway route refuses instead of leaking.** Every leg — speech, model, judge — now fails a routeless managed pair loudly at build time, and a table test pins that every provider-job pair the product catalog offers has a gateway route, so growing the catalog cannot silently arm a fallback to a provider's own endpoint carrying an Egma credential.
- **UI**: the mode switch, hosted Available, self-hosted Connect / Connected / Replace / Disconnect — walked in the browser on desktop and phone.
- **Deployment ships inert.** The three settings that would enable hosted managed access in production are deliberately unset in the deployment configuration, with the flip written out beside them: enabling real traffic is a human release decision taken after the latency review, not a side effect of merging this.

## How it's proved

The deterministic suite now runs the spec's full 2×2 matrix — hosted-managed, hosted-customer-owned, self-hosted-managed, self-hosted-customer-owned — through real product interfaces and the **real gateway application** against strict local provider servers that assert they were shown Egma's credentials while the work order carried none. The hosted-managed cell includes a genuine fresh-project first run: sign up, register an agent, write one test naming no persona, and the seeded objects conduct all three legs through the gateway — the case passes with every Models form deleted. Failure cells (invalid key, revoked key, unreachable validator, routeless leg) land as typed infrastructure errors, never verdicts. ~2,100 fast-lane, 65 browser, ~690 simulator tests green; the preview deployment serves the exact branch head and was probed live (signed credential relays a real completion; forged credential and product key `401`; organization-naming header `400`).

## The accepted trade, named

An `egma_ig_` internal gateway credential is a **bearer token for twelve hours** — no nonce, bound to neither simulation nor worker, so anyone who can read a work order can replay it for the rest of the window and spend from Egma's provider accounts as that organization. The alternative (a per-simulation grant exchange) is rejected by design; a work order already carries provider keys in the clear under customer-owned access, so a work-order reader is already a serious compromise. Narrowing this later — a nonce, or binding to the simulation — is a credential-format change behind the verifier seam with no product surface to move.

## Recorded notes (deliberately left)

- The loopback predicate for the TLS floor exists twice (platform config and gateway config, which cannot share an import); no test currently holds the two spellings together.
- The inference-key path's connection-open cost (one validation ask) is unmeasured; the pre-production latency re-measure must cover it.
- Screenshot-level visual review of the three new screens is still owed; component and browser-walk coverage stand in meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1bq5Zyqjz2uK56wvr2w3

---
_Generated by [Claude Code](https://claude.ai/code/session_016f1bq5Zyqjz2uK56wvr2w3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789573231&installation_model_id=431960&pr_number=137&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F137&signature=35b0b026ed80ec57d3d36ac1e9ce8943217a9a3526831e69ca4d33ace1f54329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds managed model access using organization-bound inference keys and a gateway verifier, while preserving customer-owned provider access.
- Adds inference-key creation, validation, rotation, revocation, and encrypted self-hosted connection storage.
- Routes managed simulation and grading work through the model gateway without exposing provider credentials.
- Adds managed-access configuration, schemas, migrations, UI controls, and end-to-end coverage.
- Fixes the previously reported organization-binding race by enforcing the existing binding in the atomic upsert.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/access/managed-access.ts | Atomically stores and rotates managed-access credentials while preventing concurrent writes from changing an established cloud-organization binding. |
| apps/api/src/routes/model-access.ts | Exposes managed-access connection lifecycle operations and maps organization-binding conflicts to the API contract. |
| apps/api/src/routes/claims.ts | Resolves managed gateway credentials into simulation work orders while retaining customer-owned provider-key behavior. |
| apps/gateway/src/verify.ts | Verifies hosted internal credentials and remotely validated inference keys through the gateway verifier seam. |
| packages/db/migrations/0036_managed_model_access.sql | Adds inference-key metadata and one managed-access credential binding per local organization. |
| apps/web/app/projects/[projectId]/settings/model-providers/page.tsx | Adds managed-access mode selection and connect, replace, and disconnect workflows. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Administrator connects inference key] --> B[Validate key with Egma Cloud]
  B --> C{Managed-access row exists?}
  C -->|No| D[Insert organization binding and sealed key]
  C -->|Yes, same cloud organization| E[Atomically rotate sealed key]
  C -->|Yes, different cloud organization| F[Conditional update affects no row]
  F --> G[Return binding conflict]
  D --> H[Managed traffic uses gateway]
  E --> H
```
</details>

<sub>Reviews (2): Last reviewed commit: ["The binding is enforced by the write, so..."](https://github.com/egma-ai/egma/commit/a65c62ce957e638df8133d314f123c7099872ef8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54004543)</sub>

<!-- /greptile_comment -->