### PR TITLE
Provenance removal from the UI 

### DIFF
--- a/apps/grader/src/graders/latency.ts
+++ b/apps/grader/src/graders/latency.ts
@@ -34,13 +34,14 @@ import type { Execution, Judgment } from "./contract.ts";
  * made — and the rationale says which measurement decided, so nobody has to
  * guess.
  *
- * **And it says who measured, when that was not egma.** The measure module
+ * **Who measured is on the row, and not in the sentence.** The measure module
  * reads three sources — egma's own timing spans, a derivation off a recognised
  * framework's spans, and the block an agent platform reported about its own
- * conversation — and a verdict decided by the third names the platform in its
- * rationale. The bound is applied identically whoever took the number; what
- * changes is that the record does not let a platform's account of its own agent
- * pass silently as egma's observation of it.
+ * conversation — and every measurement carries which one it came from. The
+ * bound is applied identically whoever took the number, and so is the rationale:
+ * one sentence shape for all three, because a verdict says what was measured and
+ * against what. The provenance stays machine-readable on the measure for any
+ * surface that later asks for it.
  *
  * ## What it says when it cannot say anything
  *
@@ -255,9 +256,12 @@ function boundIn(entry: Readonly<Record<string, string | number>>): Bounded | un
  * seconds" are different things to go and look at, and a rationale that hid the
  * difference would leave a developer opening the wrong transcript.
  *
- * And it says **who measured, when it was not egma** — see `whoMeasured` below.
- * The two sentence shapes are otherwise the ones they have always been, word
- * for word, so a verdict on a conversation egma timed reads exactly as it did.
+ * It says nothing about **who measured**. A number egma timed, a number egma
+ * worked out and a number a platform reported are held to the bound the same
+ * way, and they are read the same way: the two sentence shapes here are the ones
+ * they have always been, word for word, whatever the source. Provenance lives on
+ * the measure itself, where a surface can ask for it without a rationale having
+ * to carry it.
  */
 function rationaleFor(
   asked: Bounded,
@@ -272,28 +276,7 @@ function rationaleFor(
   const against = held
     ? `within the bound of ${asked.bound}`
     : `over the bound of ${asked.bound}`;
-  return `${asked.metric} ${taken}, ${against}${whoMeasured(measured)}.`;
-}
-
-/**
- * The clause that names the platform, on a verdict decided by a number egma did
- * not take.
- *
- * **A verdict computed from what a platform reported has to say so.** The
- * number is real and the bound is real, but the evidence is the platform's
- * account of its own agent rather than something egma watched happen — and the
- * two are not the same kind of fact. A developer deciding whether to believe a
- * failing check needs to know which one they are holding, and a rationale is the
- * only place on a verdict row where that can be said in words a person reads.
- *
- * Nothing at all for a measure egma timed or derived, so those rationales are
- * byte-for-byte what they were. The empty reporter is guarded too: the contract
- * refuses a block without one, and a clause reading "as reported by" with
- * nothing after it would be worse than the silence.
- */
-function whoMeasured(measured: MeasuredFromSpans): string {
-  if (measured.origin !== "reported" || measured.reportedBy === "") return "";
-  return `, as reported by ${measured.reportedBy} — the platform's own measurement, not Egma's observation`;
+  return `${asked.metric} ${taken}, ${against}.`;
 }
 
 /** egma could not make this check. Never `failed`: nothing is said about the agent. */

--- a/apps/grader/test/latency.test.ts
+++ b/apps/grader/test/latency.test.ts
@@ -196,16 +196,16 @@ describe("one config entry, one assertion", () => {
  *
  * The bound is applied identically — the platform's measurements are raw
  * samples, so "every measurement holds the bound, the worst decides" means what
- * it always meant. What changes is the record: the rationale names the
- * platform, so nobody reading a failing check has to go and work out whose
- * measurement it rests on.
+ * it always meant. And the sentence is identical too: a rationale says what was
+ * measured, what it came to and what it was held to, whoever took the number.
+ * Which source it came from is on the measure, where a surface can ask for it.
  *
  * The numbers are the live proof's own: a Retell production conversation whose
  * worst turn took 2145 ms, over the two-second bound the project already had
  * wired, with nothing to say so until the block was read.
  */
 describe("a verdict computed from what the platform reported", () => {
-  it("fails the bound the platform's own worst measurement missed, and names it", () => {
+  it("fails the bound the platform's own worst measurement missed", () => {
     const [only] = executeLatency(
       execution([{ metric: "turn_response_latency", bound: 2_000 }], {
         source: "production",
@@ -221,14 +221,17 @@ describe("a verdict computed from what the platform reported", () => {
       score: 0,
     });
     expect(only?.rationale).toBe(
-      "turn_response_latency was 2145 milliseconds at its worst, across 2 measurements, over the bound of 2000, as reported by retell — the platform's own measurement, not Egma's observation.",
+      "turn_response_latency was 2145 milliseconds at its worst, across 2 measurements, over the bound of 2000.",
     );
+    // Nobody is named. The provenance rides the measure, not the sentence.
+    expect(only?.rationale).not.toContain("reported by");
+    expect(only?.rationale).not.toContain("retell");
     // The root span the block rode in on, which is the only span an aggregate
     // over the whole conversation can honestly cite.
     expect(only?.citedSpanIds).toEqual([ROOT_SPAN]);
   });
 
-  it("passes a fast conversation, and still says whose measurement it was", () => {
+  it("passes a fast conversation, in the same words a timed one passes in", () => {
     const [only] = executeLatency(
       execution([{ metric: "turn_response_latency", bound: 2_000 }], {
         source: "production",
@@ -238,14 +241,16 @@ describe("a verdict computed from what the platform reported", () => {
 
     expect(only).toMatchObject({ verdict: "passed", score: 1 });
     expect(only?.rationale).toBe(
-      "turn_response_latency was 517 milliseconds at its worst, across 2 measurements, within the bound of 2000, as reported by retell — the platform's own measurement, not Egma's observation.",
+      "turn_response_latency was 517 milliseconds at its worst, across 2 measurements, within the bound of 2000.",
     );
+    expect(only?.rationale).not.toContain("reported by");
   });
 
   /**
-   * The clause is the reported measure's alone. A verdict on a number egma
-   * timed reads exactly as it did before there was a third source — which is
-   * what keeps this addition from rewriting every rationale already on a page.
+   * One sentence shape for every source, checked from the other side: a verdict
+   * on a number egma timed reads exactly as a verdict on a number a platform
+   * reported. That is what makes the source a fact about the measure rather than
+   * a difference a reader has to account for.
    */
   it("says nothing about a platform on a measure egma measured itself", () => {
     const [only] = executeLatency(

--- a/apps/grader/test/production.test.ts
+++ b/apps/grader/test/production.test.ts
@@ -413,7 +413,7 @@ describe("a production trace whose platform reported its own latency", () => {
     ],
   });
 
-  it("fails the bound the platform's own worst measurement missed, and says whose it was", async () => {
+  it("fails the bound the platform's own worst measurement missed", async () => {
     const graderId = await seedGrader(
       world,
       aLatencyCopy({ name: "Two seconds in the wild", scope: "production" }),
@@ -437,10 +437,10 @@ describe("a production trace whose platform reported its own latency", () => {
     });
     expect(mine?.rationale).toContain("2145 milliseconds at its worst");
     expect(mine?.rationale).toContain("over the bound of 2000");
-    // And the record says whose measurement decided it, because a platform's
-    // account of its own agent is not egma's observation of it.
-    expect(mine?.rationale).toContain("as reported by retell");
-    expect(mine?.rationale).toContain("not Egma's observation");
+    // And it names nobody: the sentence a person reads is the same sentence
+    // whoever took the number, while which source it was stays on the measure.
+    expect(mine?.rationale).not.toContain("reported by");
+    expect(mine?.rationale).not.toContain("retell");
     // Cited on the root span the block rode in on, which is the only span an
     // aggregate over the whole conversation can honestly point at.
     expect(mine?.citedSpanIds).toHaveLength(1);
@@ -462,7 +462,7 @@ describe("a production trace whose platform reported its own latency", () => {
 
     expect(mine).toMatchObject({ verdict: "passed", score: 1 });
     expect(mine?.rationale).toContain("517 milliseconds at its worst");
-    expect(mine?.rationale).toContain("as reported by retell");
+    expect(mine?.rationale).not.toContain("reported by");
   });
 });
 

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -354,45 +354,34 @@ function Measures({ measured }: { measured: readonly Measured[] }) {
           </div>
         ))
       )}
-      {measured.some(
-        (one) => one.derived === true && one.reported_by === undefined,
-      ) ? (
+      {measured.some(workedOut) ? (
         <div className={styles.contextFact}>
           <span />
           <strong className={styles.muted}>{MEASURES.derived}</strong>
         </div>
       ) : null}
-      {reportingPlatform(measured) === undefined ? null : (
-        <div className={styles.contextFact}>
-          <span />
-          <strong className={styles.muted}>
-            {MEASURES.reported(reportingPlatform(measured) ?? "")}
-          </strong>
-        </div>
-      )}
     </section>
   );
 }
 
 /**
- * The agent platform that reported figures on this page, or nothing where none
- * did.
+ * Whether Egma worked this figure out from the framework's own timings — the
+ * one origin the page still says anything about.
  *
- * One name rather than a list, because there is only ever one to have: the
- * figures a platform reports ride the one span that opens the exchange, written
- * by the one platform the exchange happened on. Reading the first is therefore
- * reading the only one, and a page that listed them would be dressing a
- * certainty up as a set.
+ * **`derived` alone does not answer it.** A figure an agent platform reported
+ * arrives derived as well, because Egma did not time it either; `reported_by`
+ * beside it is what tells the two apart. Without that second half the page would
+ * tell a developer their platform's number was "worked out from your framework's
+ * own timings", which is a claim about an observation Egma never made. So the
+ * platform's field is read here as a gate and nothing else: a figure carrying it
+ * is neither marked nor caveated, and reads exactly as a figure Egma timed.
+ *
+ * The rest of the provenance is on the record rather than on the page, by a
+ * product decision this predicate is the whole of on this screen. Any figure's
+ * origin is still there to be asked for the day a surface asks.
  */
-function reportingPlatform(
-  measured: readonly Measured[],
-): string | undefined {
-  for (const one of measured) {
-    if (one.reported_by !== undefined && one.reported_by !== "") {
-      return one.reported_by;
-    }
-  }
-  return undefined;
+function workedOut(one: Measured): boolean {
+  return one.derived === true && one.reported_by === undefined;
 }
 
 /**
@@ -420,15 +409,11 @@ function measurement(one: Measured): string {
   // mixing timed and worked-out numbers must let a reader tell which is which
   // without counting rows.
   //
-  // **The platform's mark is asked for first, and it is not the other one
-  // reworded.** A figure a platform reported was not worked out from anything;
-  // saying it was would be this page inventing an observation Egma never made.
-  const from =
-    one.reported_by !== undefined && one.reported_by !== ""
-      ? ` · ${MEASURES.reportedOne(one.reported_by)}`
-      : one.derived === true
-        ? ` · ${MEASURES.derivedOne}`
-        : "";
+  // **One predicate decides it, the same one the panel's caveat uses**, so the
+  // mark and the sentence can never come to disagree about a figure — and a
+  // figure a platform reported takes neither, rather than taking the worked-out
+  // wording about an observation Egma never made.
+  const from = workedOut(one) ? ` · ${MEASURES.derivedOne}` : "";
   if (one.partial === true) return `${shown} · ${MEASURES.partialWorst}${from}`;
   return one.samples.length === 1
     ? `${shown}${from}`

--- a/apps/web/lib/transcript-copy.ts
+++ b/apps/web/lib/transcript-copy.ts
@@ -322,28 +322,17 @@ export const MEASURES = {
   derived:
     "Some figures here were worked out from your framework's own timings " +
     "rather than timed by Egma. Each says which.",
-  /** The mark beside one worked-out figure, so a reader need not guess which. */
-  derivedOne: "from your framework's timings",
   /**
-   * Where a number the **platform** measured came from — a different sentence
-   * from the one above, deliberately.
+   * The mark beside one worked-out figure, so a reader need not guess which.
    *
-   * **These figures were not worked out by Egma at all.** Retell publishes no
-   * per-turn timing, so there is nothing for Egma to work anything out from;
-   * what there is, is Retell's own measurement of its own agent, handed over
-   * and judged as it stands. Saying "worked out from your framework's timings"
-   * about it would claim Egma observed something it never saw — a caveat that
-   * is itself untrue is worse than none, because it is the sentence a developer
-   * decides how much to believe the verdict on.
-   *
-   * The platform's name is filled in from the answer rather than written here:
-   * this page never hardcodes which platforms exist.
+   * **It belongs to that one origin and no other.** A figure an agent platform
+   * measured and handed over was not worked out from any framework's timings,
+   * so this wording is false about it — and a caveat that is itself untrue is
+   * worse than none, because it is the sentence a developer decides how much to
+   * believe a verdict on. A platform-reported figure therefore takes no mark and
+   * no caveat at all; where it came from stays on the record, not on the page.
    */
-  reported: (platform: string): string =>
-    `Some figures here were measured by ${platform} and reported to Egma, ` +
-    `not observed by Egma. Each says which.`,
-  /** The mark beside one such figure, so a reader need not guess which. */
-  reportedOne: (platform: string): string => `as reported by ${platform}`,
+  derivedOne: "from your framework's timings",
   /** One measurement is the number; several are the worst of them. */
   worst: "worst",
   counted: (howMany: number): string =>

--- a/apps/web/lib/transcripts.ts
+++ b/apps/web/lib/transcripts.ts
@@ -146,11 +146,15 @@ export type Measured = {
    * The agent platform that measured this figure — `retell` — on the figures a
    * platform reported rather than Egma measured.
    *
-   * **Absent on everything else, and that absence is the whole signal.** Egma
+   * **Absent on everything else, and the page reads it as a gate only.** Egma
    * working a number out from your framework's spans and a platform reporting
-   * its own number are different claims, and the page must not word one as the
-   * other: `derived` alone cannot tell them apart, so a figure carrying this
-   * field is said differently from one that does not.
+   * its own number are different claims, and `derived` alone cannot tell them
+   * apart — so this field is what stops the worked-out caveat being said about a
+   * figure Egma never worked out. A figure carrying it renders bare: no mark, no
+   * caveat, the same as a figure Egma timed.
+   *
+   * It stays on the answer whether or not a screen shows it. Who measured is a
+   * fact about the record, and the day a surface asks for it, it is here.
    */
   readonly reported_by?: string;
   /** One sample, or the series a per-turn measure produced. Never empty. */

--- a/apps/web/test/transcripts.test.ts
+++ b/apps/web/test/transcripts.test.ts
@@ -1015,42 +1015,49 @@ describe("saying which numbers Egma worked out", () => {
   });
 
   /**
-   * **A figure the agent platform measured is said differently, and the
-   * difference is not decoration.** Retell publishes no per-turn timing, so
-   * there is nothing for Egma to have worked anything out from: the number is
-   * Retell's own measurement of its own agent, handed over and judged as it
-   * stands. The sentence above would claim Egma observed it, and a caveat that
-   * is itself untrue is worse than none — it is the sentence a developer
-   * decides how far to believe a failing check on.
+   * **A figure an agent platform measured reads bare — no mark, no caveat.**
+   *
+   * Who took a number is a fact about the record, and the record keeps it: the
+   * measure still arrives carrying `reported_by`. What it no longer does is
+   * appear in a sentence a customer reads, so a platform-reported figure sits on
+   * this page exactly as a figure Egma timed does. The day a surface wants
+   * provenance back, the answer already carries it.
    */
-  it("says a platform-reported figure in its own words, never the worked-out ones", async () => {
+  it("renders a platform-reported figure bare, with nothing said about it", async () => {
     const page = await readFile(path.join(WEB, DETAIL_PAGE), "utf8");
 
-    expect(page).toContain("one.reported_by");
-    expect(page).toContain("MEASURES.reported");
-    expect(page).toContain("MEASURES.reportedOne");
-
-    const said = copy.MEASURES.reported("retell");
-    expect(said).toContain("retell");
-    expect(said).toContain("not observed by Egma");
-    // And none of the worked-out wording, which is the whole point of there
-    // being two sentences rather than one.
-    expect(said).not.toContain("worked out");
-    expect(said).not.toContain("framework");
-
-    // Marked on the figure too, in the words the verdict's own rationale uses.
-    expect(copy.MEASURES.reportedOne("retell")).toBe("as reported by retell");
+    // No sentence and no mark on the page, and no words left in the copy for
+    // either: a phrase nothing renders is a phrase somebody re-wires by mistake.
+    expect(page).not.toContain("MEASURES.reported");
+    expect(Object.keys(copy.MEASURES)).not.toContain("reported");
+    expect(Object.keys(copy.MEASURES)).not.toContain("reportedOne");
+    // And nothing anywhere in the page's words names a platform.
+    expect(page).not.toContain("as reported by");
   });
 
   /**
-   * The two caveats never speak for each other. A page whose only untimed
-   * figures were reported by a platform must not also say Egma worked
-   * something out from a framework's timings, because it did not.
+   * **The wording that must never come back.** A figure a platform reported
+   * arrives `derived: true` as well, because Egma did not time it either — so a
+   * page reading `derived` alone would tell a developer their platform's number
+   * was "worked out from your framework's own timings", about an observation
+   * Egma never made. A caveat that is itself untrue is worse than none: it is
+   * the sentence somebody decides how far to believe a failing check on.
+   *
+   * One predicate answers it for both the mark and the panel's sentence, so the
+   * two can never come to disagree about a figure.
    */
-  it("does not show the worked-out caveat for a figure a platform reported", async () => {
+  it("never words a platform-reported figure as one Egma worked out", async () => {
     const page = await readFile(path.join(WEB, DETAIL_PAGE), "utf8");
 
-    expect(page).toContain("one.reported_by === undefined");
+    // The gate itself: reported figures are outside it, by the field that is
+    // the only thing telling them from worked-out ones.
+    expect(page).toContain(
+      "return one.derived === true && one.reported_by === undefined;",
+    );
+    // And it is the only way to either the caveat or the mark.
+    expect(page).toContain("{measured.some(workedOut) ? (");
+    expect(page).toContain("const from = workedOut(one)");
+    expect(page.split("MEASURES.derivedOne")).toHaveLength(2);
   });
 
   it("keeps the nothing-was-measured sentence exactly as it was", () => {
@@ -1071,8 +1078,6 @@ describe("saying which numbers Egma worked out", () => {
     for (const said of [
       copy.MEASURES.derived,
       copy.MEASURES.derivedOne,
-      copy.MEASURES.reported("retell"),
-      copy.MEASURES.reportedOne("retell"),
       copy.MEASURES.none,
     ]) {
       expect(said.toLowerCase()).not.toContain("span");


### PR DESCRIPTION
Egma reads a measurement from three places: its own timing spans, a derivation off a recognised framework's spans, and the block an agent platform reports about its own conversation. Every measurement carries which of the three it came from, and it keeps carrying it — the origin, the reporter's name, the field on the wire, the block on the root span, all unchanged.

What changes is the prose. Naming the source in a customer-readable sentence turned out to raise a question ("do I trust this number?") on the one screen that cannot answer it, so the words come out and the data stays.

**The verdict.** A latency rationale drops the clause naming the platform. One sentence shape answers for all three sources now:

    turn_response_latency was 2347 milliseconds at its worst, across 4 measurements, over the bound of 2000.

The bound, the worst measurement, the count and the cited span are exactly what they were.

**The transcript page.** A figure a platform reported renders bare — no mark on the figure, no caveat under the panel — the same as a figure Egma timed. A figure Egma worked out from your framework's own timings keeps its mark and its caveat, word for word.

**The one thing guarded rather than assumed.** A platform-reported figure arrives flagged as not-timed-by-Egma as well, because Egma did not time it either. A page reading that flag alone would tell a developer their platform's number was "worked out from your framework's own timings" — a claim about an observation Egma never made, and a caveat that is itself untrue is worse than none. One predicate now decides both the mark and the panel's sentence, and it requires the platform's field to be absent, so the wrong wording has no path to a reported figure and the two places cannot come to disagree.

Storage, the wire and the normalizers are untouched, so any surface that wants provenance back can have it without a migration.

Tests: the grader's reported-verdict tests assert the clause is gone while keeping every verdict assertion; the web tests pin the bare rendering, the unchanged worked-out wording, and the gate itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789588879&installation_model_id=431960&pr_number=141&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F141&signature=904cdf154c814bc45eb2b8bde8a5e32e30c8061e81568721bd27b171dfc2fee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes platform provenance from customer-readable latency rationales and transcript measurements while retaining provenance in the underlying measurement data.
- Uses one source-independent rationale shape for latency verdicts.
- Renders platform-reported transcript measurements without a provenance mark or caveat.
- Centralizes framework-derived rendering behind a predicate that excludes platform-reported measurements.
- Updates grader and web tests to pin the revised wording and classification behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or compatibility issues identified.

The changed wording and rendering preserve measurement provenance in the data model, and the new predicate correctly distinguishes every reachable timed, framework-derived, and platform-reported measurement shape.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/grader/src/graders/latency.ts | Removes the reporter clause from latency rationales without changing grading, bounds, samples, or cited spans. |
| apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx | Removes platform-reported labels and centralizes framework-derived marks and caveats through the correctly scoped `workedOut` predicate. |
| apps/web/lib/transcript-copy.ts | Deletes platform-reporting copy while preserving the existing framework-derived explanation. |
| apps/web/lib/transcripts.ts | Clarifies that `reported_by` remains record-level provenance and acts as a rendering gate. |
| apps/grader/test/latency.test.ts | Updates unit expectations to enforce source-independent rationale text while retaining verdict and citation assertions. |
| apps/grader/test/production.test.ts | Updates end-to-end reported-measurement assertions to verify that platform names are absent from verdict rationales. |
| apps/web/test/transcripts.test.ts | Pins bare rendering for reported measurements and verifies that the shared predicate exclusively controls derived copy. |

<sub>Reviews (1): Last reviewed commit: ["Provenance is a fact about the record, n..."](https://github.com/egma-ai/egma/commit/b3e09b0eda0d38d51cd12e5d392c23346fc4175a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54090738)</sub>

<!-- /greptile_comment -->