### PR TITLE
Retry transient ClickHouse migration lag

### DIFF
--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -1,0 +1,4 @@
+# Database work
+
+Before changing migrations, their runners, or their tests, read
+`migrations/README.md` and apply every rule there.

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/db/migrations/README.md
+++ b/packages/db/migrations/README.md
@@ -24,12 +24,16 @@ In practice:
 - **Remove in two releases, not one.** Stop reading the thing first and ship
   that; drop it in a later release than the one that stopped using it. A
   rename is an add and a remove, in that order, never one statement.
-- **Never rewrite an applied file.** The runner refuses a changed file
-  rather than skipping it (`packages/db/src/migrate.ts`), so the history
-  here is what production actually ran.
+- **Freeze shipped history, not local state.** Before merge, a migration may be
+  rewritten or squashed even if a local development database applied it;
+  repair that local ledger. After merge or use outside local development, add
+  a new file instead; the runner refuses a changed recorded file.
 - **ClickHouse migrations must resume safely.** There is no transaction around
   a file, so every statement uses `IF EXISTS` or `IF NOT EXISTS` and survives a
   second run after a partial failure.
+- **Pack compatible ClickHouse changes to one table into one `ALTER`.** If they
+  must be separate, keep them ordered and let the runner retry only
+  `517 CANNOT_ASSIGN_ALTER` while table metadata catches up.
 
 A change that cannot follow the rule in one step — a type change, a backfill
 that must rewrite — ships as expand, migrate, contract across releases, and

--- a/packages/db/src/clickhouse/migrate.ts
+++ b/packages/db/src/clickhouse/migrate.ts
@@ -1,6 +1,11 @@
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 
-import { createClient, type ClickHouseClient } from "@clickhouse/client";
+import {
+  ClickHouseError,
+  createClient,
+  type ClickHouseClient,
+} from "@clickhouse/client";
 
 import {
   pendingMigrations,
@@ -50,6 +55,17 @@ const BOOKKEEPING_TABLE = "egma_meta_migration";
  */
 const STATEMENT_SEPARATOR = "--> statement-breakpoint";
 
+/**
+ * Replicated ClickHouse tables publish an ALTER to shared metadata before each
+ * replica necessarily observes it. A following ALTER can therefore receive
+ * CANNOT_ASSIGN_ALTER with an explicit instruction to retry. Ten seconds of
+ * bounded backoff fits inside the deployment health window without turning an
+ * unrelated migration error into a loop.
+ */
+const REPLICA_CATCHUP_ATTEMPTS = 8;
+const REPLICA_CATCHUP_FIRST_WAIT_MS = 250;
+const REPLICA_CATCHUP_MAX_WAIT_MS = 2_000;
+
 export async function runClickHouseMigrations(
   clickhouseUrl: string,
   directory: string = CLICKHOUSE_MIGRATIONS_DIRECTORY,
@@ -69,6 +85,40 @@ function statementsOf(migration: Migration): string[] {
     .split(STATEMENT_SEPARATOR)
     .map((statement) => statement.trim().replace(/;$/, ""))
     .filter((statement) => statement.replace(/--[^\n]*/g, "").trim() !== "");
+}
+
+function replicaIsCatchingUp(cause: unknown): cause is ClickHouseError {
+  return (
+    cause instanceof ClickHouseError &&
+    cause.code === "517" &&
+    cause.type === "CANNOT_ASSIGN_ALTER"
+  );
+}
+
+async function applyStatement(
+  client: ClickHouseClient,
+  statement: string,
+): Promise<void> {
+  for (let attempt = 1; attempt <= REPLICA_CATCHUP_ATTEMPTS; attempt += 1) {
+    try {
+      await client.command({ query: statement });
+      return;
+    } catch (cause) {
+      if (
+        !replicaIsCatchingUp(cause) ||
+        attempt === REPLICA_CATCHUP_ATTEMPTS
+      ) {
+        throw cause;
+      }
+
+      await sleep(
+        Math.min(
+          REPLICA_CATCHUP_FIRST_WAIT_MS * 2 ** (attempt - 1),
+          REPLICA_CATCHUP_MAX_WAIT_MS,
+        ),
+      );
+    }
+  }
 }
 
 async function apply(
@@ -105,7 +155,7 @@ async function apply(
   for (const migration of pendingMigrations(migrations, alreadyApplied)) {
     for (const statement of statementsOf(migration)) {
       try {
-        await client.command({ query: statement });
+        await applyStatement(client, statement);
       } catch (cause) {
         throw new Error(`migration ${migration.name} failed`, { cause });
       }

--- a/packages/db/test/clickhouse-migrations.test.ts
+++ b/packages/db/test/clickhouse-migrations.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { fileURLToPath } from "node:url";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -52,6 +54,72 @@ type Table = {
 
 function fixture(name: string): string {
   return fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url));
+}
+
+type ClickHouseFailure = {
+  readonly code: number;
+  readonly type: string;
+};
+
+async function fakeClickHouse(
+  failAlter: (attempt: number) => ClickHouseFailure | undefined,
+): Promise<{
+  readonly url: string;
+  readonly state: {
+    stableStatements: number;
+    alterAttempts: number;
+    ledgerWrites: number;
+  };
+  readonly close: () => Promise<void>;
+}> {
+  const state = { stableStatements: 0, alterAttempts: 0, ledgerWrites: 0 };
+  const server = createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const url = new URL(request.url ?? "/", "http://clickhouse.test");
+      const query = url.searchParams.get("query") ?? body;
+
+      if (query.includes("CREATE TABLE IF NOT EXISTS retry_probe")) {
+        state.stableStatements += 1;
+      }
+      if (query.includes("INSERT INTO egma_meta_migration")) {
+        state.ledgerWrites += 1;
+      }
+      if (query.includes("ALTER TABLE retry_probe")) {
+        state.alterAttempts += 1;
+        const failure = failAlter(state.alterAttempts);
+        if (failure !== undefined) {
+          response.statusCode = 500;
+          response.end(
+            `Code: ${failure.code}. DB::Exception: test failure ` +
+              `(${failure.type})`,
+          );
+          return;
+        }
+      }
+
+      response.statusCode = 200;
+      response.end();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    state,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
 }
 
 /**
@@ -300,6 +368,72 @@ describe("a migration that cannot apply", () => {
     expect(String(failure?.cause)).toMatch(/NoSuchEngine/);
     expect(String(failure?.cause)).not.toMatch(/lands_first/);
   });
+});
+
+describe("a replicated ALTER whose metadata is still catching up", () => {
+  it("retries the statement ClickHouse explicitly asks it to retry", async () => {
+    const clickhouse = await fakeClickHouse((attempt) =>
+      attempt === 1 ? { code: 517, type: "CANNOT_ASSIGN_ALTER" } : undefined,
+    );
+
+    try {
+      const result = await runClickHouseMigrations(
+        clickhouse.url,
+        fixture("clickhouse-transient"),
+      );
+
+      expect(clickhouse.state.stableStatements).toBe(1);
+      expect(clickhouse.state.alterAttempts).toBe(2);
+      expect(clickhouse.state.ledgerWrites).toBe(1);
+      expect(result.applied).toEqual(["0000_retry_replicated_alter.sql"]);
+    } finally {
+      await clickhouse.close();
+    }
+  });
+
+  it("does not retry a different ClickHouse error", async () => {
+    const clickhouse = await fakeClickHouse(() => ({
+      code: 56,
+      type: "UNKNOWN_STORAGE",
+    }));
+
+    try {
+      await expect(
+        runClickHouseMigrations(
+          clickhouse.url,
+          fixture("clickhouse-transient"),
+        ),
+      ).rejects.toThrow(/migration 0000_retry_replicated_alter\.sql failed/);
+      expect(clickhouse.state.alterAttempts).toBe(1);
+      expect(clickhouse.state.ledgerWrites).toBe(0);
+    } finally {
+      await clickhouse.close();
+    }
+  });
+
+  it(
+    "stops after the replica catch-up limit without recording the migration",
+    async () => {
+      const clickhouse = await fakeClickHouse(() => ({
+        code: 517,
+        type: "CANNOT_ASSIGN_ALTER",
+      }));
+
+      try {
+        await expect(
+          runClickHouseMigrations(
+            clickhouse.url,
+            fixture("clickhouse-transient"),
+          ),
+        ).rejects.toThrow(/migration 0000_retry_replicated_alter\.sql failed/);
+        expect(clickhouse.state.alterAttempts).toBe(8);
+        expect(clickhouse.state.ledgerWrites).toBe(0);
+      } finally {
+        await clickhouse.close();
+      }
+    },
+    15_000,
+  );
 });
 
 describe("the schema a boot leaves behind", () => {

--- a/packages/db/test/fixtures/clickhouse-transient/0000_retry_replicated_alter.sql
+++ b/packages/db/test/fixtures/clickhouse-transient/0000_retry_replicated_alter.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS retry_probe
+(
+    id UInt8
+)
+ENGINE = MergeTree
+ORDER BY id
+;
+--> statement-breakpoint
+ALTER TABLE retry_probe
+    ADD COLUMN IF NOT EXISTS caught_up UInt8
+;


### PR DESCRIPTION
## What failed

Production API startup stopped while applying two ALTER statements to replicated ClickHouse tables. ClickHouse returned code 517, CANNOT_ASSIGN_ALTER, and explicitly asked the client to retry because replica metadata was one version behind. The migration runner treated that temporary state as permanent, so the API exited and the tunnel could not start.

## Fix

- keep the migration rules in one scoped guide shared by Codex and Claude Code
- retry only ClickHouse code 517 with type CANNOT_ASSIGN_ALTER
- retry only the failed statement
- use a bounded exponential wait: eight attempts, about 9.75 seconds total
- keep all other migration errors immediate
- write the migration ledger only after every statement succeeds

## Scoped proof

- ClickHouse migration tests: 26 passed
- database build: passed
- test TypeScript check: passed
- repository lint: passed
- independent review: no blockers

No full test suite was run locally. CI owns the full-tree checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789589918&installation_model_id=431960&pr_number=142&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F142&signature=29184be041aa708ef55b3f6fd4747d401f0588f0451821a7aa96f137b5e8521b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds narrowly scoped retry handling for transient ClickHouse replica metadata lag while preserving immediate failure for other errors and delaying ledger writes until the migration succeeds.
- Retries only code 517 with type `CANNOT_ASSIGN_ALTER`.
- Uses bounded exponential backoff and retries only the failed statement.
- Adds focused success, non-retryable-error, and retry-exhaustion tests.
- Documents retry-safe ClickHouse migration practices.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/clickhouse/migrate.ts | Adds statement-level, bounded retry handling for the specific transient replica metadata error while preserving migration failure and ledger ordering. |
| packages/db/test/clickhouse-migrations.test.ts | Adds focused HTTP-level tests covering transient recovery, immediate propagation of unrelated errors, retry exhaustion, and ledger behavior. |
| packages/db/migrations/README.md | Clarifies shipped migration immutability and documents retry-safe ordering for replicated ClickHouse ALTER operations. |
| packages/db/test/fixtures/clickhouse-transient/0000_retry_replicated_alter.sql | Provides an idempotent two-statement migration fixture used to verify that only the failed ALTER is retried. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Apply migration statement] --> B{Command succeeds?}
    B -->|Yes| C[Continue to next statement]
    B -->|No| D{517 CANNOT_ASSIGN_ALTER?}
    D -->|No| E[Fail migration immediately]
    D -->|Yes| F{Attempts remaining?}
    F -->|No| E
    F -->|Yes| G[Wait with bounded exponential backoff]
    G --> A
    C --> H{All statements succeeded?}
    H -->|Yes| I[Write migration ledger]
    H -->|No| A
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: scope database migration guidance"](https://github.com/egma-ai/egma/commit/e4e49177666dbed4c759ef077a1651f164f4b8cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54097353)</sub>

<!-- /greptile_comment -->