### PR TITLE
The upgrade: sealed candidates, explicit successors, and a completion marker that re-checks itself

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,11 +5,13 @@ import {
   disconnectClickHouse,
   managedDeploymentFrom,
   runClickHouseMigrations,
+  recordModelUpgradeCompletion,
   runMigrations,
   seedDefaultJudge,
   seedGraderLibrary,
   seedPlatformSettings,
   seedRunningGraders,
+  upgradeModelSetup,
 } from "@egma/db";
 
 import { loadConfig } from "./config.ts";
@@ -73,6 +75,27 @@ const shelved = await seedGraderLibrary();
 // keeps it off across every restart.
 const judging = await seedRunningGraders();
 
+// And the upgrade that gives every persona and grader on this installation an
+// explicit model, from whatever the deployment was configured with before the
+// model catalog existed. After the seeding above, because a project that just
+// gained its mandatory grading copy is a grader this has to consider.
+//
+// Idempotent for the same reason as everything above it, and stronger: it only
+// ever looks at versions that carry no selections, so the run after the first
+// finds nothing to do. It copies nothing into a deployment serving several
+// organizations, and it guesses nothing anywhere — where the answer is
+// ambiguous it writes an action an administrator reads under Model providers.
+const upgraded = await upgradeModelSetup({
+  singleOrganization: config.singleOrganization,
+});
+
+// Then the marker, which is the only thing the later removal of the legacy
+// paths is allowed to act on. It is written the first time every current
+// persona and grader has selections and nothing nonterminal still needs the old
+// contract or an old credential reference — re-checked here on every boot,
+// because only this installation can know.
+const finished = await recordModelUpgradeCompletion();
+
 const { app } = buildApi({ config });
 if (seeded.length > 0) {
   // The names, never the values and never their hints: what is worth saying is
@@ -97,6 +120,41 @@ if (judging.length > 0) {
   app.log.info(
     { projects: judging.map((copy) => copy.projectId) },
     "Egma's expected-behaviors grader was switched on in projects that had never had it",
+  );
+}
+if (
+  upgraded.personas.length > 0 ||
+  upgraded.graders.length > 0 ||
+  upgraded.candidates.length > 0 ||
+  upgraded.actions.length > 0 ||
+  upgraded.managedAccess.length > 0
+) {
+  // Identifiers and provider names, never a key and never its hint: what is
+  // worth saying is which personas and graders now carry explicit models, which
+  // stored keys were found, and what was left for somebody to choose.
+  app.log.info(
+    {
+      personas: upgraded.personas,
+      graders: upgraded.graders,
+      candidates: upgraded.candidates.length,
+      activated: upgraded.activated,
+      actions: upgraded.actions,
+      managedAccess: upgraded.managedAccess,
+    },
+    "existing personas and graders were moved onto explicit model selections",
+  );
+}
+if (finished.completed) {
+  app.log.info(
+    { completedAt: finished.completedAt },
+    "this installation has finished moving onto model selections",
+  );
+} else {
+  // The conditions rather than a bare "not yet": somebody reading this while
+  // deciding whether an old worker can be drained needs to know which.
+  app.log.info(
+    { outstanding: finished.outstanding },
+    "this installation is still serving work that needs the legacy model paths",
   );
 }
 if (judged.length > 0) {

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -164,6 +164,20 @@ type Body = Record<string, unknown>;
  */
 function platformBlock(
   held: PlatformSettingValues,
+  /**
+   * Whether this persona chose its own models.
+   *
+   * **A persona with selections is sent no deployment-wide model or speech
+   * settings at all**, and that is the specification's line about where those
+   * rows go — the model, speech and voice-activity settings leave the
+   * deployment's own store, and the carrier and media settings stay. It matters
+   * beyond tidiness: those three settings carry three provider keys, and a work
+   * order whose every leg is already authorized by the selections' own
+   * credentials would be putting three more secrets on the wire with nothing to
+   * spend them on. A simulation on the compatibility path still receives all of
+   * it, unchanged, because that is what the compatibility path is.
+   */
+  chosen: boolean,
 ): Record<string, unknown> | undefined {
   // Written out setting by setting rather than folded over the catalog, for
   // the reason `config.ts` reads each variable by name: this is where a
@@ -193,7 +207,9 @@ function platformBlock(
     trunk_password: held.carrier_trunk_password,
   });
 
-  const platform = onlyWhatIsHeld({ model, speech, carrier });
+  const platform = chosen
+    ? onlyWhatIsHeld({ carrier })
+    : onlyWhatIsHeld({ model, speech, carrier });
   // A platform that has configured nothing sends no block at all, so a spec
   // it assembles is byte for byte the spec it was before these settings
   // existed — which is what makes every fixture written before today still
@@ -520,14 +536,6 @@ async function assembledSpec(
     };
   }
 
-  // Read for **each** simulation and never cached, which is the whole point
-  // of the settings living in the store: an operator who replaces a spent key
-  // has it in effect on the next simulation, with no container restarted and
-  // nothing to remember to do. One more small select is nothing beside
-  // conducting a conversation over a telephone connection, and a measurement
-  // may ask for caching later — nothing has yet.
-  const platform = platformBlock(await resolvePlatformSettings(claim.auth));
-
   if (!runs.has(claim.runId)) {
     runs.set(claim.runId, await getRun(claim.auth, claim.runId));
   }
@@ -566,6 +574,21 @@ async function assembledSpec(
     personaVersion.models === null
       ? undefined
       : await modelsBlock(claim, personaVersion.models);
+
+  // Read for **each** simulation and never cached, which is the whole point
+  // of the settings living in the store: an operator who replaces a spent key
+  // has it in effect on the next simulation, with no container restarted and
+  // nothing to remember to do. One more small select is nothing beside
+  // conducting a conversation over a telephone connection, and a measurement
+  // may ask for caching later — nothing has yet.
+  //
+  // After the selections, because what this may carry depends on whether the
+  // persona made any: one that did is sent the carrier settings and none of the
+  // model or speech ones.
+  const platform = platformBlock(
+    await resolvePlatformSettings(claim.auth),
+    models !== undefined,
+  );
 
   const spec = {
     contract_version:

--- a/apps/api/src/routes/model-access.ts
+++ b/apps/api/src/routes/model-access.ts
@@ -1,8 +1,11 @@
 import {
+  activateCredentialCandidate,
   connectManagedAccess,
   disconnectManagedAccess,
   IdentityConflictError,
+  listCredentialCandidates,
   listModelProviderCredentials,
+  listModelUpgradeActions,
   managedAccessAvailable,
   managedDeployment,
   ManagedAccessBoundElsewhereError,
@@ -13,13 +16,16 @@ import {
   RECOMMENDED_ENTRY,
   readManagedAccessConnection,
   readModelAccess,
+  readModelUpgradeCompletion,
   removeModelProviderCredential,
   RESERVED_PROVIDER_JOBS,
   setModelAccess,
   storeModelProviderCredential,
   UnprocessableInputError,
   type AuthContext,
+  type CredentialCandidate,
   type ModelProviderCredential,
+  type ModelUpgradeAction,
 } from "@egma/db";
 import type { FastifyInstance, FastifyReply } from "fastify";
 
@@ -117,6 +123,18 @@ export const MODEL_PROVIDER_CREDENTIALS_PATH = "/api/model-provider-credentials"
 export const MODEL_PROVIDER_CREDENTIAL_PATH =
   "/api/model-provider-credentials/:provider";
 export const MANAGED_ACCESS_PATH = "/api/managed-access";
+/**
+ * What the upgrade onto model selections left for this organization, and where
+ * this installation stands on finishing it.
+ *
+ * One read rather than three, because a person meets all of it in one place: a
+ * banner saying what has still to be chosen, the stored keys to choose between,
+ * and — for whoever is deciding whether an old worker can be drained — whether
+ * anything still needs the legacy paths at all.
+ */
+export const MODEL_UPGRADE_PATH = "/api/model-upgrade";
+/** One stored key the upgrade found, named to be made the active one. */
+export const MODEL_CREDENTIAL_CANDIDATE_PATH = "/api/model-credential-candidates/:id";
 
 type Body = Record<string, unknown>;
 
@@ -162,6 +180,36 @@ function described(credential: ModelProviderCredential): Record<string, unknown>
     hint: credential.hint,
     revision: credential.revision,
     updated_at: credential.updatedAt.toISOString(),
+  };
+}
+
+/** One outstanding decision on the wire. Egma's own words, and no secret. */
+function describedAction(action: ModelUpgradeAction): Record<string, unknown> {
+  return {
+    id: action.id,
+    kind: action.kind,
+    subject: action.subject,
+    detail: action.detail,
+    created_at: action.createdAt.toISOString(),
+  };
+}
+
+/**
+ * One stored key on the wire: whose provider it is for, where it was found,
+ * four characters of it, and whether it is the one being spent.
+ *
+ * The envelope is absent from this shape rather than blanked, exactly as it is
+ * from a credential's.
+ */
+function describedCandidate(candidate: CredentialCandidate): Record<string, unknown> {
+  return {
+    id: candidate.id,
+    provider: candidate.provider,
+    source: candidate.source,
+    source_name: candidate.sourceName,
+    hint: candidate.hint,
+    active: candidate.active,
+    selectable: candidate.selectable,
   };
 }
 
@@ -322,6 +370,71 @@ export async function modelAccessRoutes(
    * connect, so a route that accepted a pasted key there would be a second
    * authentication story nobody asked for.
    */
+  /**
+   * What the upgrade left to decide, and whether this installation is finished.
+   *
+   * **Readable at every role, and the candidates are not.** Which persona is
+   * still on the old path is the reason somebody's run reported what it
+   * reported, so anybody who can read the organization can see it. Which stored
+   * keys exist to choose between is the same kind of fact as a credential's
+   * hint, so it is an admin's — and a member gets an empty list rather than a
+   * refusal, because the rest of the answer is theirs to read.
+   *
+   * **The completion facts are the deployment's**, not this organization's.
+   * They are here because this is the read the screen already makes, and
+   * because an operator draining old workers has to be able to ask somewhere.
+   */
+  app.get(MODEL_UPGRADE_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const [actions, completion] = await Promise.all([
+      listModelUpgradeActions(auth),
+      readModelUpgradeCompletion(),
+    ]);
+    const candidates =
+      auth.role === "admin" ? await listCredentialCandidates(auth) : [];
+
+    return reply.send({
+      actions: actions.map(describedAction),
+      candidates: candidates.map(describedCandidate),
+      /**
+       * Whether every persona and grader on this installation carries explicit
+       * selections and nothing nonterminal still needs the legacy paths. It is
+       * what the release that removes them is gated on, and it is the honest
+       * answer to "can these old workers go".
+       */
+      completed: completion.completed,
+      completed_at: completion.completedAt?.toISOString() ?? null,
+      outstanding: completion.outstanding,
+    });
+  });
+
+  /**
+   * Make one of the stored keys this organization's credential for its
+   * provider.
+   *
+   * The envelope moves sealed; nothing is opened, nothing is shown back, and no
+   * persona or grader version is minted — a credential is operational state and
+   * never authored behavior.
+   */
+  app.put(MODEL_CREDENTIAL_CANDIDATE_PATH, async (request, reply) => {
+    const { auth } = requesterOf(request);
+    const { id } = request.params as { id: string };
+
+    if (auth.role !== "admin") {
+      return refuseRole(reply, auth, "choose a stored provider key");
+    }
+
+    try {
+      const chosen = await activateCredentialCandidate(auth, id);
+      return reply.send({ provider: chosen.provider, hint: chosen.hint });
+    } catch (refusal) {
+      if (refusal instanceof UnprocessableInputError) {
+        return unprocessable(reply, refusal.message);
+      }
+      throw refusal;
+    }
+  });
+
   app.put(MANAGED_ACCESS_PATH, async (request, reply) => {
     const { auth } = requesterOf(request);
     const body = (request.body ?? {}) as Body;

--- a/apps/api/src/routes/model-access.ts
+++ b/apps/api/src/routes/model-access.ts
@@ -10,6 +10,7 @@ import {
   managedDeployment,
   ManagedAccessBoundElsewhereError,
   ManagedAccessNotConnectedError,
+  NotPermittedError,
   MODEL_ACCESS_MODES,
   MODEL_JOBS,
   PROVIDER_CATALOG,
@@ -189,6 +190,7 @@ function describedAction(action: ModelUpgradeAction): Record<string, unknown> {
     id: action.id,
     kind: action.kind,
     subject: action.subject,
+    subject_name: action.subjectName,
     detail: action.detail,
     created_at: action.createdAt.toISOString(),
   };
@@ -420,14 +422,17 @@ export async function modelAccessRoutes(
     const { auth } = requesterOf(request);
     const { id } = request.params as { id: string };
 
-    if (auth.role !== "admin") {
-      return refuseRole(reply, auth, "choose a stored provider key");
-    }
-
     try {
       const chosen = await activateCredentialCandidate(auth, id);
       return reply.send({ provider: chosen.provider, hint: chosen.hint });
     } catch (refusal) {
+      // Who may do this is `manage_organization`, and the data-access layer
+      // already owns that decision — the same row of the permission table that
+      // names provider credentials. A role literal here would be a second copy
+      // of it, free to drift from the one that is actually enforced.
+      if (refusal instanceof NotPermittedError) {
+        return refuseRole(reply, auth, "choose a stored provider key");
+      }
       if (refusal instanceof UnprocessableInputError) {
         return unprocessable(reply, refusal.message);
       }

--- a/apps/api/test/managed-model-access.test.ts
+++ b/apps/api/test/managed-model-access.test.ts
@@ -523,10 +523,16 @@ describe("hosted Egma, managed by Egma", () => {
     const pushed = await ask(api.app, "POST", "/api/tests", key, RESCHEDULING);
     expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
 
+    const seededAgent = registered.body.agent as {
+      id: string;
+      version_id: string;
+    };
     const spec = await oneWorkOrder({
       ada,
       key,
       connectionId: (registered.body.connection as { id: string }).id,
+      agentId: seededAgent.id,
+      agentVersionId: seededAgent.version_id,
       versionId: String(pushed.body.version_id),
       serviceToken: api.config.simulatorServiceToken,
     });

--- a/apps/api/test/managed-model-access.test.ts
+++ b/apps/api/test/managed-model-access.test.ts
@@ -1,8 +1,12 @@
 import { newId } from "@egma/ids";
 import {
+  appendVerdicts,
   connectManagedAccess,
+  completeSimulation,
   createPersona,
   getSimulation,
+  listGraders,
+  startSimulation,
   RECOMMENDED_GRADER_MODEL,
   RECOMMENDED_PERSONA_MODELS,
   storeModelProviderCredential,
@@ -181,6 +185,8 @@ type World = {
   readonly ada: Customer;
   readonly key: string;
   readonly connectionId: string;
+  readonly agentId: string;
+  readonly agentVersionId: string;
   readonly versionId: string;
   readonly serviceToken: string;
 };
@@ -189,7 +195,15 @@ type World = {
 async function aCustomer(
   label: string,
   deployment: ManagedDeployment,
-  options: { readonly validateInferenceKey?: (key: string) => Promise<never> } = {},
+  options: {
+    readonly validateInferenceKey?: (key: string) => Promise<never>;
+    /**
+     * A real trace store, for the one case that reads a *verdict* back. It is
+     * opt-in because it costs a migrated store per case, and three of the four
+     * cells are settling which account paid rather than what was decided.
+     */
+    readonly traceStore?: boolean;
+  } = {},
 ): Promise<World> {
   api = await createApi(label, {
     managedDeployment: deployment,
@@ -216,14 +230,20 @@ async function aCustomer(
   });
   expect(pushed.statusCode, JSON.stringify(pushed.body)).toBe(201);
 
+  const agent = registered.body.agent as { id: string; version_id: string };
   return {
     ada,
     key,
     connectionId: (registered.body.connection as { id: string }).id,
+    agentId: agent.id,
+    agentVersionId: agent.version_id,
     versionId: String(pushed.body.version_id),
     serviceToken: api.config.simulatorServiceToken,
   };
 }
+
+/** The run every work order in this file came from, for the read-back below. */
+let lastRunId: string | undefined;
 
 /** One work order, off the door the shipped simulator knocks on. */
 async function oneWorkOrder(world: World): Promise<Record<string, unknown>> {
@@ -233,6 +253,7 @@ async function oneWorkOrder(world: World): Promise<Record<string, unknown>> {
     idempotency_key: newId("run"),
   });
   expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+  lastRunId = String(started.body.id);
 
   const claimed = await api.app.inject({
     method: "POST",
@@ -335,6 +356,66 @@ function opened(socket: WebSocket): Promise<void> {
   });
 }
 
+/**
+ * The same conversation read back through the doors a person reads it through.
+ *
+ * **This is the half the matrix used to skip**, and skipping it left the whole
+ * proof one seam short of what the specification asks for: it settled what the
+ * *simulator* was handed and said nothing about what the product then shows.
+ * Two things are asserted, and the second is the one that matters most.
+ *
+ * The conversation is visible, filed under its run, pinned to the persona
+ * version the work order carried — so the selections that executed and the
+ * version a page names are the same version.
+ *
+ * And **no credential of any kind appears in either answer**. A work order
+ * legitimately carries provider keys, and an inference or gateway credential
+ * under managed access; a public read may carry none of them. That is a
+ * different door with a different rule, and only reading it can say so.
+ */
+async function readBackThroughThePublicPaths(
+  world: World,
+  spec: Record<string, unknown>,
+  secrets: readonly string[],
+): Promise<void> {
+  const simulationId = String(spec.simulation_id);
+
+  const conversation = await ask(
+    api.app,
+    "GET",
+    `/api/simulations/${simulationId}`,
+    world.key,
+  );
+  expect(conversation.statusCode, JSON.stringify(conversation.body)).toBe(200);
+  expect(conversation.body.id).toBe(simulationId);
+  expect(conversation.body.run_id).toBe(lastRunId);
+  const shownPersona = conversation.body.persona as {
+    version_id: string;
+    traits: unknown;
+  };
+  // The version the work order executed is the version the page names, and the
+  // traits it carried are the traits the page shows — two doors, one pin.
+  expect(shownPersona.version_id).toMatch(/^prsv_/u);
+  expect(shownPersona.traits).toEqual(
+    (spec.persona as { traits: unknown }).traits,
+  );
+  // Unjudged, because nothing has graded it. Said as a state rather than as a
+  // verdict, which is the distinction the whole verdict vocabulary rests on: a
+  // conversation nothing has looked at has not failed.
+  expect(conversation.body.verdict).not.toBe("failed");
+
+  const run = await ask(api.app, "GET", `/api/runs/${String(lastRunId)}`, world.key);
+  expect(run.statusCode, JSON.stringify(run.body)).toBe(200);
+  expect(run.body.id).toBe(lastRunId);
+
+  const shown = `${JSON.stringify(conversation.body)}${JSON.stringify(run.body)}`;
+  for (const secret of secrets) {
+    expect(shown, `a public read showed ${secret.slice(0, 12)}…`).not.toContain(
+      secret,
+    );
+  }
+}
+
 const HOSTED = (gatewayAddress: string): ManagedDeployment => ({
   hosted: true,
   gatewayAddress,
@@ -397,6 +478,14 @@ describe("hosted Egma, managed by Egma", () => {
     expect(JSON.stringify(openai?.seen)).not.toContain(
       models.gateway?.credential,
     );
+
+    await readBackThroughThePublicPaths(world, spec, [
+      String(models.gateway?.credential),
+      EGMA_PROVIDER_KEY.openai,
+      EGMA_PROVIDER_KEY.deepgram,
+      EGMA_PROVIDER_KEY.cartesia,
+      INTERNAL_KEY,
+    ]);
   });
 
   /**
@@ -502,6 +591,93 @@ describe("hosted Egma, managed by Egma", () => {
   });
 });
 
+/**
+ * The other half of the public read: a verdict, decided and then read back the
+ * way a person reads one.
+ *
+ * **One case rather than four**, because what differs between the four cells is
+ * which account paid for the model call — and a verdict row does not record
+ * that and must not. What this settles is the seam the other three do not
+ * reach: a judgment written by the grading engine comes back through the public
+ * simulation interface as a verdict on that conversation, with the grader
+ * version that decided it, and with no credential anywhere near it.
+ */
+describe("hosted Egma, managed, read back as a verdict", () => {
+  it("shows the judgment through the public simulation interface", async () => {
+    const address = await standUpProviders(undefined);
+    const world = await aCustomer("matrix_hosted_verdict", HOSTED(address), {
+      traceStore: true,
+    });
+
+    const spec = await oneWorkOrder(world);
+    const simulationId = String(spec.simulation_id);
+    const engine = {
+      userId: "engine",
+      organizationId: world.ada.organizationId,
+      projectId: world.ada.projectId,
+      role: "viewer" as const,
+      via: "engine" as const,
+    };
+
+    // The conversation conducted and reported, through the same two doors the
+    // simulator lands one with. A verdict on a conversation still in flight is
+    // not something the product shows, and asserting one would be asserting a
+    // state that cannot happen.
+    const admin = contextFor(world.ada, "admin");
+    await startSimulation(admin, simulationId, "sim-1");
+    await completeSimulation(admin, simulationId, "sim-1", {
+      endingReason: "persona_concluded",
+      turnCount: 4,
+    });
+
+    // The project's own seeded grader, at the version this run pinned — read
+    // through the ordinary door rather than invented, so the verdict names a
+    // grader that really judges here.
+    const [judging] = (await listGraders(engine)).items;
+    expect(judging, "the seeded grader is missing").toBeDefined();
+
+    await appendVerdicts(engine, [
+      {
+        // Verdicts are filed under the simulation's own id — the public read
+        // asks for them by it — while the *trace* beside them is filed under
+        // the derived one. Two grains, two keys, and only one of them is this.
+        traceId: simulationId,
+        graderId: String(judging?.id),
+        graderVersionId: String(judging?.versionId),
+        assertion: "0",
+        source: "simulation",
+        verdict: "passed",
+        score: 1,
+        rationale: "the new time was read back before the call ended",
+        citedSpanIds: [],
+        runId: String(lastRunId),
+        agentId: world.agentId,
+        agentVersionId: world.agentVersionId,
+        judgedAtMicroseconds: BigInt(Date.now()) * 1000n,
+      },
+    ]);
+
+    const conversation = await ask(
+      api.app,
+      "GET",
+      `/api/simulations/${simulationId}`,
+      world.key,
+    );
+
+    expect(conversation.statusCode, JSON.stringify(conversation.body)).toBe(200);
+    // The judgment, as the page shows it: a verdict rather than a raw row, and
+    // the counts it was folded from.
+    expect(conversation.body.verdict).toBe("passed");
+    expect((conversation.body.counts as { passed: number }).passed).toBe(1);
+    // And still no credential of any kind, on the door that now carries a
+    // judgment as well as a conversation.
+    const shown = JSON.stringify(conversation.body);
+    for (const secret of [INTERNAL_KEY, ...Object.values(EGMA_PROVIDER_KEY)]) {
+      expect(shown).not.toContain(secret);
+    }
+  });
+});
+
 describe("hosted Egma, customer-owned", () => {
   it("calls the providers directly with the organization's own keys", async () => {
     await standUpDirectProviders();
@@ -532,6 +708,8 @@ describe("hosted Egma, customer-owned", () => {
     expect(openai?.seen[0]?.headers["authorization"]).toBe(
       `Bearer ${CUSTOMER_KEY.openai}`,
     );
+
+    await readBackThroughThePublicPaths(world, spec, Object.values(CUSTOMER_KEY));
   });
 });
 
@@ -604,6 +782,13 @@ describe("a self-hosted deployment, managed by Egma", () => {
         expect(asked.body).toBe("");
         expect(asked.credential).toBe(secret);
       }
+
+      await readBackThroughThePublicPaths(world, spec, [
+        secret,
+        EGMA_PROVIDER_KEY.openai,
+        EGMA_PROVIDER_KEY.deepgram,
+        EGMA_PROVIDER_KEY.cartesia,
+      ]);
     } finally {
       await cloud.stop();
     }
@@ -637,6 +822,8 @@ describe("a self-hosted deployment, customer-owned", () => {
     expect(deepgram?.seen[0]?.headers["authorization"]).toBe(
       `Token ${CUSTOMER_KEY.deepgram}`,
     );
+
+    await readBackThroughThePublicPaths(world, spec, Object.values(CUSTOMER_KEY));
   });
 });
 

--- a/apps/api/test/model-upgrade-routes.test.ts
+++ b/apps/api/test/model-upgrade-routes.test.ts
@@ -1,0 +1,282 @@
+import {
+  createPersona,
+  listModelProviderCredentials,
+  seedPlatformSettings,
+  upgradeModelSetup,
+  type PersonaTraits,
+} from "@egma/db";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { JUDGE_CREDENTIALS_PATH } from "../src/routes/judge.ts";
+import {
+  MODEL_CREDENTIAL_CANDIDATE_PATH,
+  MODEL_UPGRADE_PATH,
+} from "../src/routes/model-access.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  colleagueOf,
+  contextFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * What an administrator sees of the upgrade, over real HTTP.
+ *
+ * **A compatibility path that nobody can see is a trap**, because a persona
+ * still on it keeps running until the release that removes it arrives. These
+ * doors are what make the outstanding choices visible while there is still time
+ * to make them — and the one thing they let somebody do is pick which of two
+ * stored keys an organization spends from.
+ *
+ * The keys are sentinels, and every answer is scanned for all of them: nothing
+ * here may hand back a stored key, including the door whose whole job is to
+ * make one active.
+ */
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+const LEGACY = {
+  thinking: "sk-sentinel-upgrade-route-model-key-A1B2",
+  listening: "dg-sentinel-upgrade-route-listening-C3D4",
+  speaking: "ct-sentinel-upgrade-route-speaking-E5F6",
+  judging: "sk-sentinel-upgrade-route-judge-key-G7H8",
+} as const;
+
+const CONFIGURED_BEFORE_THE_CATALOG = {
+  persona_model_provider: "openai",
+  persona_model: "gpt-4o-mini",
+  persona_model_key: LEGACY.thinking,
+  speech_to_text_provider: "deepgram",
+  speech_to_text_model: "nova-3-general",
+  speech_to_text_key: LEGACY.listening,
+  text_to_speech_provider: "cartesia",
+  text_to_speech_model: "sonic-3.5",
+  text_to_speech_key: LEGACY.speaking,
+} as const;
+
+const NORA: PersonaTraits = {
+  personality: "Rings about a boiler service and has no idea what plan she is on.",
+  language: "en",
+  // A speaking provider this release's catalog does not carry, so this persona
+  // cannot receive a guessed successor.
+  voice: { provider: "elevenlabs", voiceId: "EXAVITQu4vr4xnSDxMaL", speed: 0.9 },
+};
+
+type World = {
+  readonly ada: Customer;
+  readonly adminKey: string;
+};
+
+/**
+ * A deployment configured the way the previous release configured one, with a
+ * judge key of its own beside the deployment's — so OpenAI has two candidates
+ * and nothing activates for it.
+ */
+async function aDeploymentBeforeTheCatalog(label: string): Promise<World> {
+  api = await createApi(label);
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+  await seedPlatformSettings(CONFIGURED_BEFORE_THE_CATALOG);
+  // The organization's own judge key, beside the deployment's own platform
+  // judge that `createApi` already seeded — so OpenAI ends up with three stored
+  // keys from three different places and Egma may activate none of them.
+  await ask(api.app, "POST", JUDGE_CREDENTIALS_PATH, ada.secret, {
+    label: "Acme's own judge key",
+    provider: "openai",
+    key: LEGACY.judging,
+  });
+  await createPersona(contextFor(ada, "member"), {
+    name: "Nora",
+    traits: NORA,
+  });
+
+  await upgradeModelSetup({ singleOrganization: true });
+  return { ada, adminKey: ada.secret };
+}
+
+describe("what the upgrade left to decide", () => {
+  it("is answered as sentences a person can act on, and never a key", async () => {
+    const { adminKey } = await aDeploymentBeforeTheCatalog("upgrade_actions");
+
+    const answer = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+
+    expect(answer.statusCode).toBe(200);
+    const kinds = (answer.body.actions as { kind: string }[]).map(
+      (one) => one.kind,
+    );
+    expect(kinds).toContain("select_model_provider_credential");
+    expect(kinds).toContain("select_persona_models");
+    for (const key of Object.values(LEGACY)) {
+      expect(JSON.stringify(answer.body)).not.toContain(key);
+    }
+  });
+
+  it("shows an admin the stored keys, with where each one was found", async () => {
+    const { adminKey } = await aDeploymentBeforeTheCatalog("upgrade_candidates");
+
+    const answer = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+    const candidates = answer.body.candidates as {
+      provider: string;
+      source: string;
+      source_name: string;
+      hint: string;
+      active: boolean;
+      selectable: boolean;
+    }[];
+
+    // Every place the previous release kept a key: the three deployment
+    // settings, the organization's own judge credential, and the deployment's
+    // own key on the project's platform judge — which is a key that project
+    // never held and could not see.
+    expect(candidates.map((one) => `${one.provider}/${one.source}`)).toEqual([
+      "cartesia/platform_setting",
+      "deepgram/platform_setting",
+      "openai/platform_setting",
+      "openai/judge_credential",
+      "openai/judge_configuration",
+    ]);
+    expect(
+      candidates
+        .filter((one) => one.source === "platform_setting")
+        .map((one) => one.source_name),
+    ).toEqual([
+      "text_to_speech_key",
+      "speech_to_text_key",
+      "persona_model_key",
+    ]);
+    expect(
+      candidates.find((one) => one.source === "judge_credential")?.source_name,
+    ).toBe("Acme's own judge key");
+    for (const one of candidates) {
+      expect(one.hint).toHaveLength(4);
+      expect(one.selectable).toBe(true);
+    }
+    // Neither OpenAI key is active: two candidates, and Egma will not guess
+    // which account they belong to.
+    expect(
+      candidates.filter((one) => one.active).map((one) => one.provider),
+    ).toEqual(["cartesia", "deepgram"]);
+  });
+
+  /**
+   * A member reads the sentences and not the keys. The rest of the answer is
+   * theirs — it is the reason their run reported what it reported — so this is
+   * an empty list rather than a refusal.
+   */
+  it("shows a member what is outstanding and none of the stored keys", async () => {
+    const { ada } = await aDeploymentBeforeTheCatalog("upgrade_member");
+    const bob = (await colleagueOf(api.app, ada, "bob@acme.example", "member")).secret;
+
+    const answer = await ask(api.app, "GET", MODEL_UPGRADE_PATH, bob);
+
+    expect(answer.statusCode).toBe(200);
+    expect((answer.body.actions as unknown[]).length).toBeGreaterThan(0);
+    expect(answer.body.candidates).toEqual([]);
+  });
+
+  it("says this installation has not finished, and which condition is standing", async () => {
+    const { adminKey } = await aDeploymentBeforeTheCatalog("upgrade_completion");
+
+    const answer = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+
+    expect(answer.body.completed).toBe(false);
+    expect(answer.body.completed_at).toBeNull();
+    // The persona that could not be given a successor is the whole of it.
+    expect(answer.body.outstanding).toEqual(["personas"]);
+  });
+});
+
+describe("choosing which stored key an organization spends", () => {
+  it("makes it the credential, and hands back four characters of it", async () => {
+    const { ada, adminKey } = await aDeploymentBeforeTheCatalog("upgrade_choose");
+    const before = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+    const [judges] = (
+      before.body.candidates as { id: string; provider: string; source: string }[]
+    ).filter((one) => one.source === "judge_credential");
+
+    const chosen = await ask(
+      api.app,
+      "PUT",
+      MODEL_CREDENTIAL_CANDIDATE_PATH.replace(":id", String(judges?.id)),
+      adminKey,
+    );
+
+    expect(chosen.statusCode).toBe(200);
+    expect(chosen.body.provider).toBe("openai");
+    expect(String(chosen.body.hint)).toHaveLength(4);
+    expect(JSON.stringify(chosen.body)).not.toContain(LEGACY.judging);
+
+    const stored = await listModelProviderCredentials(contextFor(ada, "admin"));
+    expect(stored.map((one) => one.provider).sort()).toEqual([
+      "cartesia",
+      "deepgram",
+      "openai",
+    ]);
+  });
+
+  it("clears the choice it was asked to make, and marks exactly one active", async () => {
+    const { adminKey } = await aDeploymentBeforeTheCatalog("upgrade_cleared");
+    const before = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+    const [judges] = (
+      before.body.candidates as { id: string; source: string }[]
+    ).filter((one) => one.source === "judge_credential");
+
+    await ask(
+      api.app,
+      "PUT",
+      MODEL_CREDENTIAL_CANDIDATE_PATH.replace(":id", String(judges?.id)),
+      adminKey,
+    );
+    const after = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+
+    expect(
+      (after.body.actions as { kind: string }[]).map((one) => one.kind),
+    ).not.toContain("select_model_provider_credential");
+    const openai = (
+      after.body.candidates as { provider: string; active: boolean; id: string }[]
+    ).filter((one) => one.provider === "openai");
+    expect(openai.filter((one) => one.active).map((one) => one.id)).toEqual([
+      judges?.id,
+    ]);
+  });
+
+  it("is an admin's, and a member is told so by their role", async () => {
+    const { ada, adminKey } = await aDeploymentBeforeTheCatalog("upgrade_role");
+    const before = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+    const [any] = before.body.candidates as { id: string }[];
+    const bob = (await colleagueOf(api.app, ada, "bob@acme.example", "member")).secret;
+
+    const refused = await ask(
+      api.app,
+      "PUT",
+      MODEL_CREDENTIAL_CANDIDATE_PATH.replace(":id", String(any?.id)),
+      bob,
+    );
+
+    expect(refused.statusCode).toBe(403);
+    expect(JSON.stringify(refused.body)).toContain("member");
+  });
+
+  it("refuses a stored key belonging to another organization, by not finding it", async () => {
+    const { adminKey } = await aDeploymentBeforeTheCatalog("upgrade_tenancy");
+    const before = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
+    const [any] = before.body.candidates as { id: string }[];
+    const gene = await signUp(api.app, "gene@globex.example", "Globex");
+
+    const refused = await ask(
+      api.app,
+      "PUT",
+      MODEL_CREDENTIAL_CANDIDATE_PATH.replace(":id", String(any?.id)),
+      gene.secret,
+    );
+
+    expect(refused.statusCode).toBe(422);
+    expect(JSON.stringify(refused.body)).toContain("not a stored key");
+  });
+});

--- a/apps/api/test/model-upgrade-routes.test.ts
+++ b/apps/api/test/model-upgrade-routes.test.ts
@@ -107,11 +107,22 @@ describe("what the upgrade left to decide", () => {
     const answer = await ask(api.app, "GET", MODEL_UPGRADE_PATH, adminKey);
 
     expect(answer.statusCode).toBe(200);
-    const kinds = (answer.body.actions as { kind: string }[]).map(
-      (one) => one.kind,
-    );
+    const actions = answer.body.actions as {
+      kind: string;
+      subject_name: string | null;
+    }[];
+    const kinds = actions.map((one) => one.kind);
     expect(kinds).toContain("select_model_provider_credential");
     expect(kinds).toContain("select_persona_models");
+    // Named, so two blocked personas are two rows a person can tell apart —
+    // and this installation really has two: the seeded starter persona and the
+    // one authored here, both speaking through a provider this release's
+    // catalog does not carry.
+    const blocked = actions
+      .filter((one) => one.kind === "select_persona_models")
+      .map((one) => one.subject_name);
+    expect(blocked.length).toBeGreaterThan(1);
+    expect(blocked).toContain("Nora");
     for (const key of Object.values(LEGACY)) {
       expect(JSON.stringify(answer.body)).not.toContain(key);
     }

--- a/apps/api/test/provider-seam.test.ts
+++ b/apps/api/test/provider-seam.test.ts
@@ -121,7 +121,12 @@ describe("the provider's footprint on the schema", () => {
     // Who supplies the organization's model credentials, and the credentials
     // themselves. Both are Egma's own, and the auth provider reaches neither.
     "model_access",
+    // What the upgrade onto model selections found and what it would not
+    // decide: a legacy provider key copied sealed, and one sentence naming a
+    // choice somebody has to make. Egma's own, like everything else here.
+    "model_credential_candidate",
     "model_provider_credential",
+    "model_upgrade_action",
     "organization",
     "organization_settings",
     "persona",

--- a/apps/api/test/upgrade-and-run.test.ts
+++ b/apps/api/test/upgrade-and-run.test.ts
@@ -1,0 +1,574 @@
+import { newId } from "@egma/ids";
+import {
+  createPersona,
+  getGrader,
+  getPersona,
+  listGraders,
+  listModelUpgradeActions,
+  readModelUpgradeCompletion,
+  recordModelUpgradeCompletion,
+  seedPlatformSettings,
+  upgradeModelSetup,
+  type PersonaTraits,
+} from "@egma/db";
+import { specComplaints } from "@egma/simulation-contract";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+
+import { judgesOnce, NoJudge } from "../../grader/src/judge/index.ts";
+import { scriptedJudge } from "../../grader/test/support/scripted-judge.ts";
+import {
+  startHttpUpstream,
+  startSocketUpstream,
+  type HttpUpstream,
+  type SocketUpstream,
+} from "../../gateway/test/support/upstreams.ts";
+import { CLAIMS_PATH } from "../src/routes/claims.ts";
+import {
+  MODEL_CREDENTIAL_CANDIDATE_PATH,
+  MODEL_UPGRADE_PATH,
+} from "../src/routes/model-access.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  contextFor,
+  projectKeyFor,
+  request as ask,
+  signUp,
+  type Customer,
+} from "./support/traces.ts";
+
+/**
+ * An installation that existed before model selections did, upgraded and then
+ * put to work — the release candidate's own migration path, end to end.
+ *
+ * **The two halves have to be true at the same time, and that is the whole
+ * case.** A persona the upgrade could answer for runs its *next* simulation
+ * from its own explicit selections, on the key the upgrade found and an
+ * administrator confirmed. A persona it could not answer for runs its next
+ * simulation exactly as it always did, from the deployment's own settings, on
+ * the old work-order contract — because the compatibility period is what makes
+ * an upgrade something other than an outage.
+ *
+ * **Then the mixed-version rule, which is the same fact seen from the worker.**
+ * A simulator built before selections existed declares version 1 and is offered
+ * only the work it can conduct. It is never handed a document it cannot read.
+ *
+ * **And then the marker.** It stays unwritten while one persona is still on the
+ * old path, and it stays unwritten after that persona is given selections while
+ * a simulation pinned to its *old* version is still queued — because that work
+ * order is on the old contract and removing the legacy path would strand it.
+ *
+ * Every key is a sentinel, so every answer can be scanned for all of them.
+ */
+
+let api: TestApi;
+let openai: HttpUpstream | undefined;
+let deepgram: SocketUpstream | undefined;
+let cartesia: SocketUpstream | undefined;
+
+afterEach(async () => {
+  await api?.close();
+  await Promise.all([openai?.stop(), deepgram?.stop(), cartesia?.stop()]);
+  openai = undefined;
+  deepgram = undefined;
+  cartesia = undefined;
+});
+
+/** The keys the previous release kept, one in each of its three places. */
+const LEGACY = {
+  thinking: "sk-sentinel-upgraded-run-model-key-A1B2",
+  listening: "dg-sentinel-upgraded-run-listening-C3D4",
+  speaking: "ct-sentinel-upgraded-run-speaking-E5F6",
+} as const;
+
+/** What the deployment was configured with before the catalog existed. */
+const CONFIGURED_BEFORE_THE_CATALOG = {
+  persona_model_provider: "openai",
+  persona_model: "gpt-4o-mini",
+  persona_model_key: LEGACY.thinking,
+  persona_model_reasoning_effort: "high",
+  speech_to_text_provider: "deepgram",
+  speech_to_text_model: "nova-2-phonecall",
+  speech_to_text_key: LEGACY.listening,
+  text_to_speech_provider: "cartesia",
+  text_to_speech_model: "sonic-2",
+  text_to_speech_voice: "a-deployment-wide-voice",
+  text_to_speech_key: LEGACY.speaking,
+  voice_activity_provider: "silero",
+  media_backend: "livekit",
+} as const;
+
+/** Speaks with the provider the deployment speaks with, so she has a successor. */
+const RITA: PersonaTraits = {
+  personality: "Books three cleans a month and knows the schedule better than the agent.",
+  language: "en-US",
+  voice: { provider: "cartesia", voiceId: "ritas-own-voice", speed: 1.15 },
+};
+
+const RETELL_VOICE = {
+  type: "retell",
+  modality: "voice",
+  config: { retellAgentId: "agent_in_retell_1" },
+  credentials: { apiKey: "retell-sentinel-upgraded-run-J9K0" },
+} as const;
+
+type Models = {
+  readonly access: string;
+  readonly llm: { readonly provider: string; readonly model: string; readonly key?: string };
+  readonly stt: { readonly provider: string; readonly model: string; readonly key?: string };
+  readonly tts: {
+    readonly provider: string;
+    readonly model: string;
+    readonly key?: string;
+    readonly voice_id: string;
+    readonly speed: number;
+  };
+};
+
+type World = {
+  readonly ada: Customer;
+  readonly key: string;
+  readonly connectionId: string;
+  readonly ritaTestVersion: string;
+  readonly starterTestVersion: string;
+  readonly ritaId: string;
+  readonly starterId: string;
+  readonly serviceToken: string;
+};
+
+/** Provider servers with nothing in front of them: customer-owned access. */
+async function standUpProviders(): Promise<void> {
+  openai = await startHttpUpstream({
+    path: "/v1/chat/completions",
+    expectAuthorization: `Bearer ${LEGACY.thinking}`,
+    chunks: ['{"choices":[{"message":{"content":"hello"}}]}'],
+  });
+  deepgram = await startSocketUpstream({
+    path: "/v1/listen",
+    expect: {
+      at: "header",
+      name: "authorization",
+      value: `Token ${LEGACY.listening}`,
+    },
+    echo: true,
+  });
+  cartesia = await startSocketUpstream({
+    path: "/tts/websocket",
+    expect: { at: "query", name: "api_key", value: LEGACY.speaking },
+    echo: true,
+  });
+}
+
+/**
+ * An installation as the previous release left it, taken through the upgrade
+ * and through the one choice the upgrade would not make.
+ *
+ * The two OpenAI keys are real: the deployment's own model key and the
+ * deployment's own judge key on the project's platform judge. Egma cannot tell
+ * whether they are one account without reading them, so it activates neither
+ * and asks — and this walks the asking and the answering through the product's
+ * own doors, because that is the loop a real administrator walks.
+ */
+async function anUpgradedInstallation(label: string): Promise<World> {
+  api = await createApi(label, { singleOrganization: true });
+  await seedPlatformSettings(CONFIGURED_BEFORE_THE_CATALOG);
+
+  const ada = await signUp(api.app, "ada@acme.example", "Acme");
+  const key = await projectKeyFor(api.app, ada);
+
+  const registered = await ask(api.app, "POST", "/api/agents", key, {
+    name: "Front desk",
+    connection: RETELL_VOICE,
+  });
+  expect(registered.statusCode, JSON.stringify(registered.body)).toBe(201);
+
+  // A persona written the way the previous release wrote one: traits, and
+  // nothing else, because there was nothing else to say.
+  const rita = await createPersona(contextFor(ada, "member"), {
+    name: "Rita",
+    traits: RITA,
+  });
+  const listed = (await ask(api.app, "GET", "/api/personas", key)).body
+    .items as { id: string; name: string }[];
+  const seeded = listed.find((one) => one.name !== "Rita");
+
+  const ritaTest = await ask(api.app, "POST", "/api/tests", key, {
+    name: "Reschedules a booked appointment",
+    scenario: "Their cleaning is booked for Thursday and has to move.",
+    expected_behaviors: ["confirms the new time back before finishing"],
+    personas: ["Rita"],
+  });
+  expect(ritaTest.statusCode, JSON.stringify(ritaTest.body)).toBe(201);
+  const starterTest = await ask(api.app, "POST", "/api/tests", key, {
+    name: "Asks about the plan",
+    scenario: "Wants to know what the current plan covers.",
+    expected_behaviors: ["says what the plan covers"],
+    personas: [String(seeded?.name)],
+  });
+  expect(starterTest.statusCode, JSON.stringify(starterTest.body)).toBe(201);
+
+  await upgradeModelSetup({ singleOrganization: true });
+
+  // The one choice the upgrade would not make, made through the product.
+  const outstanding = await ask(api.app, "GET", MODEL_UPGRADE_PATH, ada.secret);
+  const deploymentsOwn = (
+    outstanding.body.candidates as {
+      id: string;
+      provider: string;
+      source_name: string;
+    }[]
+  ).find((one) => one.source_name === "persona_model_key");
+  const chosen = await ask(
+    api.app,
+    "PUT",
+    MODEL_CREDENTIAL_CANDIDATE_PATH.replace(":id", String(deploymentsOwn?.id)),
+    ada.secret,
+  );
+  expect(chosen.statusCode, JSON.stringify(chosen.body)).toBe(200);
+
+  return {
+    ada,
+    key,
+    connectionId: (registered.body.connection as { id: string }).id,
+    ritaTestVersion: String(ritaTest.body.version_id),
+    starterTestVersion: String(starterTest.body.version_id),
+    ritaId: rita.id,
+    starterId: String(seeded?.id),
+    serviceToken: api.config.simulatorServiceToken,
+  };
+}
+
+/** One run's work orders, off the door the shipped simulator knocks on. */
+async function claim(
+  world: World,
+  testVersion: string,
+  versions: readonly number[] = [1, 2],
+): Promise<{ runId: string; specs: Record<string, unknown>[] }> {
+  const started = await ask(api.app, "POST", "/api/runs", world.key, {
+    connection: world.connectionId,
+    test_versions: [testVersion],
+    idempotency_key: newId("run"),
+  });
+  expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+
+  const claimed = await api.app.inject({
+    method: "POST",
+    url: CLAIMS_PATH,
+    headers: { authorization: `Bearer ${world.serviceToken}` },
+    payload: {
+      claimant: "sim-1",
+      capacity: 5,
+      wait_seconds: 0,
+      contract_versions: versions,
+    },
+  });
+  return {
+    runId: String(started.body.id),
+    specs: (claimed.json() as { specs?: Record<string, unknown>[] }).specs ?? [],
+  };
+}
+
+/** The three legs, conducted from the work order and from nothing else. */
+async function conductEveryLeg(models: Models): Promise<number> {
+  const thought = await fetch(`${openai?.origin ?? ""}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${String(models.llm.key)}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ model: models.llm.model, messages: [] }),
+  });
+
+  await opened(
+    new WebSocket(
+      `${(deepgram?.origin ?? "").replace(/^http/u, "ws")}/v1/listen?model=${models.stt.model}`,
+      { headers: { authorization: `Token ${String(models.stt.key)}` } },
+    ),
+  );
+  await opened(
+    new WebSocket(
+      `${(cartesia?.origin ?? "").replace(/^http/u, "ws")}/tts/websocket?api_key=${String(models.tts.key)}`,
+    ),
+  );
+  return thought.status;
+}
+
+function opened(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.on("open", () => {
+      socket.close(1000, "done");
+      resolve();
+    });
+    socket.on("error", reject);
+    socket.on(
+      "unexpected-response",
+      (_request: unknown, response: { statusCode?: number | undefined }) =>
+        reject(new Error(`the socket was refused with ${String(response.statusCode)}`)),
+    );
+  });
+}
+
+describe("a persona the upgrade could answer for", () => {
+  it("conducts its next simulation from its own selections, on the key the upgrade found", async () => {
+    await standUpProviders();
+    const world = await anUpgradedInstallation("upgraded_run_migrated");
+
+    const migrated = await getPersona(contextFor(world.ada, "member"), world.ritaId);
+    expect(migrated?.version).toBe(2);
+
+    const { specs } = await claim(world, world.ritaTestVersion);
+    const [spec] = specs;
+    expect(spec, "no work order was claimed").toBeDefined();
+    expect(specComplaints(spec ?? {})).toEqual([]);
+
+    // Version 2, because this persona has explicit selections now.
+    expect(spec?.contract_version).toBe(2);
+    const models = spec?.models as Models;
+    expect(models.access).toBe("customer-owned");
+    expect(models.llm).toMatchObject({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      key: LEGACY.thinking,
+    });
+    expect(models.stt).toMatchObject({
+      provider: "deepgram",
+      model: "nova-2-phonecall",
+      key: LEGACY.listening,
+    });
+    // Her own voice and her own pace, not the deployment-wide ones.
+    expect(models.tts).toMatchObject({
+      provider: "cartesia",
+      model: "sonic-2",
+      voice_id: "ritas-own-voice",
+      speed: 1.15,
+      key: LEGACY.speaking,
+    });
+    // The retired setting reaches nothing, and neither does any other legacy
+    // model or speech setting: a persona that chose for itself is sent the
+    // carrier settings and none of the deployment's provider keys.
+    expect(JSON.stringify(spec)).not.toContain("reasoning");
+    const platform = spec?.platform as Record<string, unknown> | undefined;
+    expect(platform?.model).toBeUndefined();
+    expect(platform?.speech).toBeUndefined();
+    expect(platform?.carrier).toBeDefined();
+
+    // And it really conducts, on the keys the upgrade found and an
+    // administrator confirmed.
+    expect(await conductEveryLeg(models)).toBe(200);
+    expect(openai?.seen[0]?.headers["authorization"]).toBe(
+      `Bearer ${LEGACY.thinking}`,
+    );
+    expect(deepgram?.seen[0]?.query.get("model")).toBe("nova-2-phonecall");
+  });
+
+  it("judges its next verdict from its grader's own selection", async () => {
+    await standUpProviders();
+    const world = await anUpgradedInstallation("upgraded_run_grader");
+    const admin = contextFor(world.ada, "admin");
+
+    const seeded = (await listGraders(admin)).items.find(
+      (one) => one.name === "expected_behaviors",
+    );
+    const upgraded = await getGrader(admin, String(seeded?.id));
+
+    // The project's judge configuration, said out loud on the grader's own
+    // version — so nothing consults the project any more.
+    expect(upgraded?.version).toBe(2);
+    expect(upgraded?.graderModel).toEqual({
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+
+    const recorder = scriptedJudge({ answers: {} });
+    const judged = await judgesOnce({
+      userId: "engine",
+      organizationId: world.ada.organizationId,
+      projectId: world.ada.projectId,
+      role: "viewer",
+      via: "engine",
+    }).judgeFor(
+      { graderModel: upgraded?.graderModel ?? null, judgeModel: null },
+      recorder.makers,
+    );
+
+    if (judged instanceof NoJudge) throw new Error(String(judged.message ?? judged));
+    expect(judged).not.toBeInstanceOf(NoJudge);
+    const asked = recorder.configured.at(-1) as {
+      provider: string;
+      model: string;
+      key: string;
+      endpoint?: string;
+    };
+    expect(asked.model).toBe("gpt-4o-mini");
+    // The organization's own credential — the one the administrator chose from
+    // the keys the upgrade found — and no gateway, because this organization
+    // pays for its own model traffic.
+    expect(asked.key).toBe(LEGACY.thinking);
+    expect(asked.endpoint).toBeUndefined();
+  });
+});
+
+describe("a persona the upgrade would not guess for", () => {
+  it("conducts its next simulation exactly as it always did", async () => {
+    await standUpProviders();
+    const world = await anUpgradedInstallation("upgraded_run_compatible");
+
+    const untouched = await getPersona(
+      contextFor(world.ada, "member"),
+      world.starterId,
+    );
+    expect(untouched?.version).toBe(1);
+    expect(untouched?.models).toBeNull();
+
+    const { specs } = await claim(world, world.starterTestVersion);
+    const [spec] = specs;
+    expect(spec, "no work order was claimed").toBeDefined();
+    expect(specComplaints(spec ?? {})).toEqual([]);
+
+    // The document it was always handed: version 1, no models block at all, and
+    // the deployment's own settings deciding — which is what the compatibility
+    // period is.
+    expect(spec?.contract_version).toBe(1);
+    expect(spec?.models).toBeUndefined();
+    const platform = spec?.platform as {
+      model: Record<string, string>;
+      speech: Record<string, string>;
+    };
+    expect(platform.model.provider).toBe("openai");
+    expect(platform.model.key).toBe(LEGACY.thinking);
+    expect(platform.speech.tts_provider).toBe("cartesia");
+    // And the deployment's own voice, because this persona's voice provider is
+    // one the legacy speech path still carries and the selections never do.
+    expect(platform.speech.tts_voice).toBe("a-deployment-wide-voice");
+  });
+
+  it("is named in an action that says what to choose, and where", async () => {
+    api = await createApi("upgraded_run_action", { singleOrganization: true });
+    await seedPlatformSettings(CONFIGURED_BEFORE_THE_CATALOG);
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    await upgradeModelSetup({ singleOrganization: true });
+
+    const actions = await listModelUpgradeActions(contextFor(ada, "admin"));
+    const hers = actions.find((one) => one.kind === "select_persona_models");
+
+    expect(hers?.detail).toContain("elevenlabs");
+    expect(hers?.detail).toContain("Persona models");
+    // Never a substitute: the speaking providers this release does carry are
+    // not offered in place of the one it does not.
+    expect(hers?.detail).not.toContain("cartesia this release");
+  });
+});
+
+describe("a simulator built before selections existed", () => {
+  it("is offered the work it can conduct, and never a document it cannot read", async () => {
+    await standUpProviders();
+    const world = await anUpgradedInstallation("upgraded_run_mixed");
+
+    // A worker declaring version 1 alone, which is what every simulator built
+    // before the second version means by saying nothing.
+    const migrated = await claim(world, world.ritaTestVersion, [1]);
+    const legacy = await claim(world, world.starterTestVersion, [1]);
+
+    // The migrated persona's work order is version 2 and this worker cannot
+    // read one, so it is left where it is rather than handed over and failed.
+    expect(migrated.specs).toEqual([]);
+    // And the compatibility persona's is the document it always was.
+    expect(legacy.specs).toHaveLength(1);
+    expect(legacy.specs[0]?.contract_version).toBe(1);
+
+    // The worker beside it that can read both takes the one that was left.
+    const both = await api.app.inject({
+      method: "POST",
+      url: CLAIMS_PATH,
+      headers: { authorization: `Bearer ${world.serviceToken}` },
+      payload: {
+        claimant: "sim-2",
+        capacity: 5,
+        wait_seconds: 0,
+        contract_versions: [1, 2],
+      },
+    });
+    const waiting = (both.json() as { specs: Record<string, unknown>[] }).specs;
+    expect(waiting).toHaveLength(1);
+    expect(waiting[0]?.contract_version).toBe(2);
+  });
+});
+
+describe("the completion marker", () => {
+  it("stays unwritten while one persona is still on the old path", async () => {
+    await standUpProviders();
+    const world = await anUpgradedInstallation("upgraded_run_marker_personas");
+
+    const standing = await readModelUpgradeCompletion();
+
+    expect(standing.completed).toBe(false);
+    expect(standing.outstanding).toContain("personas");
+    expect(String(world.starterId)).toMatch(/^prs_/u);
+  });
+
+  /**
+   * The drain the marker really guards, and the reason it is not enough to ask
+   * whether every *persona* has selections: a simulation pinned to an old
+   * version is a work order on the old contract, and removing that contract
+   * while it is queued would strand it.
+   */
+  it("stays unwritten while a simulation on the old contract is still queued", async () => {
+    await standUpProviders();
+    const world = await anUpgradedInstallation("upgraded_run_marker_drain");
+
+    const started = await ask(api.app, "POST", "/api/runs", world.key, {
+      connection: world.connectionId,
+      test_versions: [world.starterTestVersion],
+      idempotency_key: newId("run"),
+    });
+    expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+
+    // The persona is given selections, which settles the `personas` condition
+    // and settles nothing about the work already queued behind it.
+    const standing = await ask(
+      api.app,
+      "GET",
+      `/api/personas/${world.starterId}`,
+      world.key,
+    );
+    const chose = await ask(api.app, "PATCH", `/api/personas/${world.starterId}`, world.key, {
+      expected_revision: standing.body.revision,
+      expected_version_id: standing.body.version_id,
+      models: {
+        llm: { provider: "openai", model: "gpt-4o-mini" },
+        stt: { provider: "deepgram", model: "nova-3-general" },
+        tts: {
+          provider: "cartesia",
+          model: "sonic-3.5",
+          voice_id: "a-voice-somebody-chose",
+          speed: 1,
+        },
+      },
+    });
+    expect(chose.statusCode, JSON.stringify(chose.body)).toBe(200);
+
+    const midDrain = await readModelUpgradeCompletion();
+    expect(midDrain.outstanding).toEqual(["simulations"]);
+    expect((await recordModelUpgradeCompletion()).completed).toBe(false);
+
+    // Drained: the queued work lands terminal, and nothing on this installation
+    // needs the legacy paths any more.
+    const canceled = await ask(
+      api.app,
+      "POST",
+      `/api/runs/${started.body.id as string}/cancel`,
+      world.key,
+    );
+    expect(canceled.statusCode, JSON.stringify(canceled.body)).toBe(200);
+
+    const finished = await recordModelUpgradeCompletion();
+    expect(finished.outstanding).toEqual([]);
+    expect(finished.completed).toBe(true);
+    expect(finished.completedAt).toBeInstanceOf(Date);
+
+    // And the answer a person or an operator reads is the same one.
+    const answer = await ask(api.app, "GET", MODEL_UPGRADE_PATH, world.ada.secret);
+    expect(answer.body.completed).toBe(true);
+    expect(answer.body.outstanding).toEqual([]);
+  });
+});

--- a/apps/api/test/upgrade-and-run.test.ts
+++ b/apps/api/test/upgrade-and-run.test.ts
@@ -1,6 +1,8 @@
 import { newId } from "@egma/ids";
 import {
+  completeSimulation,
   createPersona,
+  getGradingPlan,
   getGrader,
   getPersona,
   listGraders,
@@ -8,6 +10,7 @@ import {
   readModelUpgradeCompletion,
   recordModelUpgradeCompletion,
   seedPlatformSettings,
+  startSimulation,
   upgradeModelSetup,
   type PersonaTraits,
 } from "@egma/db";
@@ -491,6 +494,88 @@ describe("a simulator built before selections existed", () => {
     const waiting = (both.json() as { specs: Record<string, unknown>[] }).specs;
     expect(waiting).toHaveLength(1);
     expect(waiting[0]?.contract_version).toBe(2);
+  });
+});
+
+/**
+ * The condition that is easiest to get wrong, and was.
+ *
+ * A run frozen before the upgrade pins grader versions with no selection of
+ * their own, and its plan records the judge those graders will ask. On a
+ * deployment judged by its **own** judge that plan names no credential at all —
+ * the sentinel word goes in place of an id — so a marker that only read the
+ * credential index would declare this installation finished with grading jobs
+ * still queued behind exactly the configuration the next release removes.
+ */
+describe("grading work frozen before the upgrade", () => {
+  it("holds the marker back even though its plan names no credential", async () => {
+    await standUpProviders();
+    api = await createApi("upgraded_run_platform_judge", {
+      singleOrganization: true,
+    });
+    await seedPlatformSettings(CONFIGURED_BEFORE_THE_CATALOG);
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+    const key = await projectKeyFor(api.app, ada);
+
+    const registered = await ask(api.app, "POST", "/api/agents", key, {
+      name: "Front desk",
+      connection: RETELL_VOICE,
+    });
+    await createPersona(contextFor(ada, "member"), { name: "Rita", traits: RITA });
+    const pushed = await ask(api.app, "POST", "/api/tests", key, {
+      name: "Reschedules a booked appointment",
+      scenario: "Their cleaning is booked for Thursday and has to move.",
+      expected_behaviors: ["confirms the new time back before finishing"],
+      personas: ["Rita"],
+    });
+
+    // Started and conducted *before* the upgrade, so the plan it froze pins
+    // grader versions that carry no selection.
+    const started = await ask(api.app, "POST", "/api/runs", key, {
+      connection: (registered.body.connection as { id: string }).id,
+      test_versions: [String(pushed.body.version_id)],
+      idempotency_key: newId("run"),
+    });
+    expect(started.statusCode, JSON.stringify(started.body)).toBe(201);
+    const claimed = await api.app.inject({
+      method: "POST",
+      url: CLAIMS_PATH,
+      headers: { authorization: `Bearer ${api.config.simulatorServiceToken}` },
+      payload: { claimant: "sim-1", capacity: 1, wait_seconds: 0 },
+    });
+    const [spec] = (claimed.json() as { specs: Record<string, unknown>[] }).specs;
+    const simulationId = String(spec?.simulation_id);
+    const admin = contextFor(ada, "admin");
+    await startSimulation(admin, simulationId, "sim-1");
+    await completeSimulation(admin, simulationId, "sim-1", {
+      endingReason: "persona_concluded",
+      turnCount: 4,
+    });
+
+    // The plan really does name no credential, which is the trap.
+    const plan = await getGradingPlan(admin, String(started.body.id));
+    expect(plan?.state).toBe("run_start");
+    const { rows } = await api.database.sql<{ ids: unknown; status: string }>(
+      `select p.judge_credential_ids as ids, j.status
+         from grading_plan p
+         join simulation s on s.run_id = p.run_id
+         join grading_job j on j.simulation_id = s.id
+        where p.run_id = $1`,
+      [String(started.body.id)],
+    );
+    expect(rows[0]?.ids).toEqual([]);
+    expect(rows[0]?.status).toBe("pending");
+
+    await upgradeModelSetup({ singleOrganization: true });
+
+    const standing = await readModelUpgradeCompletion();
+    expect(standing.completed).toBe(false);
+    // Two conditions standing, and `grading` is the one this case is about:
+    // the job frozen against the old judge configuration, on a plan that names
+    // no credential at all. (`personas` is the seeded starter persona, whose
+    // own voice this release's catalog does not carry — see the case above.)
+    expect(standing.outstanding).toEqual(["personas", "grading"]);
+    expect((await recordModelUpgradeCompletion()).completed).toBe(false);
   });
 });
 

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -122,6 +122,20 @@ EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
         "additionalProperties",
         "gateway",
     ),
+    # A version-2 document is one whose persona selected its own models, and
+    # those selections carry the credentials that authorize every leg — so the
+    # deployment's own model and speech settings beside them would be three
+    # more provider keys on the wire with nothing to spend them on.
+    "spec-v2/platform-carrying-model-settings.json": (
+        "/platform",
+        "additionalProperties",
+        "model",
+    ),
+    "spec-v2/platform-carrying-speech-settings.json": (
+        "/platform",
+        "additionalProperties",
+        "speech",
+    ),
     "spec-v2/unknown-field.json": ("", "additionalProperties", "agent_id"),
     "report/completed-claiming-never-ran.json": (
         "/events/0/facts/ending",

--- a/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
@@ -473,6 +473,14 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
                 ),
               },
               {
+                key: "which",
+                header: "Which one",
+                // Without this an organization with two blocked personas reads
+                // the same two words twice and cannot tell which persona either
+                // row is about.
+                cell: (action) => <span>{action.subject_name ?? "—"}</span>,
+              },
+              {
                 key: "why",
                 header: "Why",
                 cell: (action) => <span>{action.detail}</span>,

--- a/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/model-providers/page.tsx
@@ -6,22 +6,31 @@ import { useEffect, useState } from "react";
 import { deleteJson, writeJson, type Refusal } from "../../../../../lib/api.ts";
 import { roleOf } from "../../../../../lib/me.ts";
 import {
+  actionsIn,
+  candidatesIn,
+  credentialCandidatePath,
   credentialsIn,
   jobsOfProvider,
   managedIn,
   labelOfProvider,
   modelProviderCredentialPath,
   providersIn,
+  ACTION_LABEL,
+  CANDIDATE_SOURCE_LABEL,
   JOB_LABEL,
   MANAGED_ACCESS_PATH,
   MODE_LABEL,
   MODEL_ACCESS_PATH,
   MODEL_CATALOG_PATH,
   MODEL_PROVIDER_CREDENTIALS_PATH,
+  MODEL_UPGRADE_PATH,
+  type CredentialCandidate,
   type ModelAccess,
   type ModelAccessMode,
   type ModelCatalog,
   type ModelProviderCredential,
+  type ModelUpgrade,
+  type ModelUpgradeAction,
 } from "../../../../../lib/model-access.ts";
 import {
   Actions,
@@ -118,6 +127,17 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
   );
   const { answer: catalog, reload: reloadCatalog } =
     useProjectRead<ModelCatalog>(MODEL_CATALOG_PATH, projectId);
+  /**
+   * What the upgrade onto model selections would not decide for this
+   * organization.
+   *
+   * A separate read rather than a field on the access one, because it is a
+   * different question with a different answer for a member — and because a
+   * deployment that has finished has nothing here at all, which is the ordinary
+   * state and must cost the settings page nothing.
+   */
+  const { answer: upgrade, reload: reloadUpgrade } =
+    useProjectRead<ModelUpgrade>(MODEL_UPGRADE_PATH, projectId);
 
   /** The provider whose replacement form is open, by name. */
   const [editing, setEditing] = useState<string | null>(null);
@@ -387,8 +407,138 @@ function ModelProviders({ projectId }: { readonly projectId: string }) {
     reloadAccess();
   }
 
+  const outstanding: readonly ModelUpgradeAction[] =
+    upgrade?.status === "ready" ? actionsIn(upgrade.value) : [];
+  const stored: readonly CredentialCandidate[] =
+    upgrade?.status === "ready" ? candidatesIn(upgrade.value) : [];
+  /**
+   * The stored keys worth showing: the ones for a provider somebody still has
+   * to choose between.
+   *
+   * A provider that already has a key needs no choosing, and a provider with
+   * one candidate chose itself — so listing every stored key would be a table
+   * of decisions nobody has to make, on a page whose whole point is the ones
+   * they do.
+   */
+  const toChoose = stored.filter((one) =>
+    outstanding.some(
+      (action) =>
+        action.kind === "select_model_provider_credential" &&
+        action.subject === one.provider,
+    ),
+  );
+
+  async function chooseCandidate(candidate: CredentialCandidate): Promise<void> {
+    if (!mayAdminister || busy) return;
+    setRefused(null);
+    setSaved(null);
+    setBusy(true);
+
+    const written = await writeJson(credentialCandidatePath(candidate.id), {
+      method: "PUT",
+      project: projectId,
+    });
+
+    setBusy(false);
+    if (written.status === "signed-out") {
+      window.location.replace("/sign-in");
+      return;
+    }
+    if (written.status !== "ready") {
+      setRefused(written.refusal);
+      return;
+    }
+    setSaved(labelOfProvider(shipped, candidate.provider));
+    reloadAccess();
+    reloadUpgrade();
+  }
+
   return (
     <Frame projectId={projectId}>
+      {outstanding.length === 0 ? null : (
+        <Section
+          title="Still to choose"
+          lead="Egma moved this organization onto model selections and would not guess these. Until each one is chosen, the persona, grader or key it names keeps working the way it did before."
+        >
+          <DataTable<ModelUpgradeAction>
+            label="Choices the upgrade left"
+            rows={outstanding}
+            keyOf={(action) => action.id}
+            columns={[
+              {
+                key: "what",
+                header: "What to do",
+                cell: (action) => (
+                  <Badge tone="warn">{ACTION_LABEL[action.kind]}</Badge>
+                ),
+              },
+              {
+                key: "why",
+                header: "Why",
+                cell: (action) => <span>{action.detail}</span>,
+              },
+            ]}
+          />
+
+          {toChoose.length === 0 ? null : (
+            <DataTable<CredentialCandidate>
+              label="Stored keys to choose between"
+              rows={toChoose}
+              keyOf={(candidate) => candidate.id}
+              columns={[
+                {
+                  key: "provider",
+                  header: "Provider",
+                  cell: (candidate) => (
+                    <span>{labelOfProvider(shipped, candidate.provider)}</span>
+                  ),
+                },
+                {
+                  key: "found",
+                  header: "Found in",
+                  cell: (candidate) => (
+                    <span>
+                      {CANDIDATE_SOURCE_LABEL[candidate.source]} ·{" "}
+                      {candidate.source_name}
+                    </span>
+                  ),
+                },
+                {
+                  key: "hint",
+                  header: "Key",
+                  cell: (candidate) => <span>…{candidate.hint}</span>,
+                },
+                {
+                  key: "choose",
+                  header: "",
+                  cell: (candidate) =>
+                    candidate.active ? (
+                      <Badge tone="good">In use</Badge>
+                    ) : (
+                      <Button
+                        disabled={
+                          !mayAdminister || busy || !candidate.selectable
+                        }
+                        onClick={() => void chooseCandidate(candidate)}
+                      >
+                        Use this key
+                      </Button>
+                    ),
+                },
+              ]}
+            />
+          )}
+
+          {toChoose.every((one) => one.selectable) ? null : (
+            <Help>
+              A stored key for a provider this release does not carry is kept and
+              shown, and cannot be used. Store a key for a provider in the table
+              below instead.
+            </Help>
+          )}
+        </Section>
+      )}
+
       <Section
         title="Model access"
         lead="Who supplies the provider keys every persona and grader in this organization spends."

--- a/apps/web/lib/model-access.ts
+++ b/apps/web/lib/model-access.ts
@@ -203,3 +203,88 @@ export function entriesForJob(
   if (!Array.isArray(catalog?.providers)) return [];
   return catalog.providers.filter((entry) => entry.job === job);
 }
+
+/**
+ * What the upgrade onto model selections left for this organization to decide,
+ * as `GET /api/model-upgrade` answers it.
+ *
+ * **Nothing here holds a key either.** A stored key the upgrade found is a
+ * provider, where it was found, and four characters — the same shape a
+ * credential has, for the same reason.
+ */
+export type ModelUpgradeAction = {
+  readonly id: string;
+  readonly kind:
+    | "select_model_provider_credential"
+    | "select_persona_models"
+    | "select_grader_model"
+    | "set_up_model_access";
+  /** The persona, grader, provider or organization it is about. */
+  readonly subject: string;
+  /** Egma's own sentence, written to be acted on. */
+  readonly detail: string;
+  readonly created_at: string;
+};
+
+/** One key the upgrade found, offered as the one this organization spends. */
+export type CredentialCandidate = {
+  readonly id: string;
+  readonly provider: string;
+  readonly source: "platform_setting" | "judge_credential" | "judge_configuration";
+  /** Which row exactly — a setting's name, a credential's label, a project. */
+  readonly source_name: string;
+  /** The last characters of the key. Never enough of it to use. */
+  readonly hint: string;
+  readonly active: boolean;
+  /** Whether this release's catalog carries its provider at all. */
+  readonly selectable: boolean;
+};
+
+export type ModelUpgrade = {
+  readonly actions: readonly ModelUpgradeAction[];
+  /** Empty for anybody but an admin, who is the only role that may choose. */
+  readonly candidates: readonly CredentialCandidate[];
+  /** Whether this installation has finished moving onto model selections. */
+  readonly completed: boolean;
+  readonly completed_at: string | null;
+  readonly outstanding: readonly string[];
+};
+
+export const MODEL_UPGRADE_PATH = "/api/model-upgrade";
+
+export function credentialCandidatePath(id: string): string {
+  return `/api/model-credential-candidates/${encodeURIComponent(id)}`;
+}
+
+/** What a person calls each outstanding decision, said once. */
+export const ACTION_LABEL: Readonly<Record<ModelUpgradeAction["kind"], string>> = {
+  select_model_provider_credential: "Choose a provider key",
+  select_persona_models: "Select a persona's models",
+  select_grader_model: "Select a grader's model",
+  set_up_model_access: "Set up model access",
+};
+
+/** Where each stored key was found, in words rather than a column name. */
+export const CANDIDATE_SOURCE_LABEL: Readonly<
+  Record<CredentialCandidate["source"], string>
+> = {
+  platform_setting: "Deployment setting",
+  judge_credential: "Judge credential",
+  judge_configuration: "Project judge",
+};
+
+/**
+ * The actions an answer actually carried, and none at all when it carried
+ * something this page cannot read — `credentialsIn`'s guard, for its reason.
+ */
+export function actionsIn(
+  upgrade: ModelUpgrade | undefined,
+): readonly ModelUpgradeAction[] {
+  return Array.isArray(upgrade?.actions) ? upgrade.actions : [];
+}
+
+export function candidatesIn(
+  upgrade: ModelUpgrade | undefined,
+): readonly CredentialCandidate[] {
+  return Array.isArray(upgrade?.candidates) ? upgrade.candidates : [];
+}

--- a/apps/web/lib/model-access.ts
+++ b/apps/web/lib/model-access.ts
@@ -221,6 +221,13 @@ export type ModelUpgradeAction = {
     | "set_up_model_access";
   /** The persona, grader, provider or organization it is about. */
   readonly subject: string;
+  /**
+   * What that subject is called: the persona's or grader's own name, the
+   * provider's word, or null for the organization itself. Two blocked personas
+   * is the ordinary case, and an identifier is not something anybody can tell
+   * them apart by.
+   */
+  readonly subject_name: string | null;
   /** Egma's own sentence, written to be acted on. */
   readonly detail: string;
   readonly created_at: string;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -145,6 +145,16 @@ const config: NextConfig = {
           source: "/api/model-provider-credentials/:path*",
           destination: `${api}/api/model-provider-credentials/:path*`,
         },
+        // What the upgrade onto model selections left for this organization to
+        // decide, and the one door that settles a provider with two stored
+        // keys. Both named outright for the reason above: the section they draw
+        // is invisible when its read 404s, which is the one failure it exists
+        // to prevent.
+        { source: "/api/model-upgrade", destination: `${api}/api/model-upgrade` },
+        {
+          source: "/api/model-credential-candidates/:path*",
+          destination: `${api}/api/model-credential-candidates/:path*`,
+        },
         // The shelf of grader definitions the Library screen draws itself
         // from. One rule and no `:path*` beside it, because the library is
         // read and never authored: a second address under it would be a

--- a/apps/web/test/model-providers.test.tsx
+++ b/apps/web/test/model-providers.test.tsx
@@ -111,12 +111,25 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-async function open(access: Record<string, unknown>): Promise<void> {
+/** An installation with nothing left over from the upgrade, which is most of them. */
+const NOTHING_OUTSTANDING = {
+  actions: [],
+  candidates: [],
+  completed: true,
+  completed_at: "2026-08-17T00:00:00.000Z",
+  outstanding: [],
+};
+
+async function open(
+  access: Record<string, unknown>,
+  upgrade: Record<string, unknown> = NOTHING_OUTSTANDING,
+): Promise<void> {
   apiAnswers({
     "/api/me": ME,
     "/api/projects": { projects: ME.projects },
     "/api/model-access": access,
     "/api/model-catalog": CATALOG,
+    "/api/model-upgrade": upgrade,
   });
   render(<ModelProvidersPage />);
   await waitFor(() => expect(screen.getByText("Model access")).toBeDefined());
@@ -213,5 +226,107 @@ describe("a self-hosted deployment with a key connected", () => {
     expect(within(dialog).getAllByText(/A1B2/).length).toBeGreaterThan(0);
     // And it says what stops, rather than only what is removed.
     expect(within(dialog).getByText(/stops with an error/)).toBeDefined();
+  });
+});
+
+/**
+ * What the upgrade left for somebody to choose, on the screen it is chosen on.
+ *
+ * **A compatibility path nobody can see is a trap.** A persona still resolving
+ * through the deployment's old settings keeps running, so nothing about it
+ * looks wrong until the release that removes those settings arrives. This
+ * section is what makes the choice visible while there is still time.
+ */
+describe("an installation with choices left over from the upgrade", () => {
+  const OUTSTANDING = {
+    actions: [
+      {
+        id: "mua_1",
+        kind: "select_model_provider_credential",
+        subject: "openai",
+        detail:
+          "Egma found 2 stored openai keys on this installation and cannot tell whether they are the same account, so none was activated.",
+        created_at: "2026-08-17T00:00:00.000Z",
+      },
+      {
+        id: "mua_2",
+        kind: "select_persona_models",
+        subject: "prs_1",
+        detail:
+          "this persona's own voice is elevenlabs and this deployment speaks with cartesia. Egma will not choose between them.",
+        created_at: "2026-08-17T00:00:00.000Z",
+      },
+    ],
+    candidates: [
+      {
+        id: "mcc_1",
+        provider: "openai",
+        source: "platform_setting",
+        source_name: "persona_model_key",
+        hint: "A1B2",
+        active: false,
+        selectable: true,
+      },
+      {
+        id: "mcc_2",
+        provider: "openai",
+        source: "judge_credential",
+        source_name: "Acme's judge key",
+        hint: "G7H8",
+        active: false,
+        selectable: true,
+      },
+      {
+        id: "mcc_3",
+        provider: "deepgram",
+        source: "platform_setting",
+        source_name: "speech_to_text_key",
+        hint: "C3D4",
+        active: true,
+        selectable: true,
+      },
+    ],
+    completed: false,
+    completed_at: null,
+    outstanding: ["personas"],
+  };
+
+  it("says what to do and why, in Egma's own words and never a key", async () => {
+    await open(accessAnswer({}), OUTSTANDING);
+
+    expect(screen.getByText("Still to choose")).toBeDefined();
+    expect(screen.getByText("Choose a provider key")).toBeDefined();
+    expect(screen.getByText("Select a persona's models")).toBeDefined();
+    expect(
+      screen.getByText(/Egma will not choose between them/u),
+    ).toBeDefined();
+  });
+
+  /**
+   * Only the keys somebody actually has to choose between. The Deepgram key
+   * chose itself — one candidate — so offering it here would be a decision
+   * nobody has to make on a page whose whole point is the ones they do.
+   */
+  it("offers the two keys for the provider that has two, and no others", async () => {
+    await open(accessAnswer({}), OUTSTANDING);
+
+    const table = screen.getByRole("table", {
+      name: "Stored keys to choose between",
+    });
+    expect(within(table).getAllByRole("button", { name: "Use this key" })).toHaveLength(2);
+    expect(within(table).getByText("Deployment setting · persona_model_key")).toBeDefined();
+    expect(within(table).getByText("Judge credential · Acme's judge key")).toBeDefined();
+    expect(within(table).queryByText(/speech_to_text_key/u)).toBeNull();
+    // Four characters, and no route anywhere that could answer with more.
+    expect(within(table).getByText("…A1B2")).toBeDefined();
+  });
+
+  it("is absent entirely on an installation that has finished", async () => {
+    await open(accessAnswer({}));
+
+    expect(screen.queryByText("Still to choose")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Use this key" }),
+    ).toBeNull();
   });
 });

--- a/apps/web/test/model-providers.test.tsx
+++ b/apps/web/test/model-providers.test.tsx
@@ -244,6 +244,7 @@ describe("an installation with choices left over from the upgrade", () => {
         id: "mua_1",
         kind: "select_model_provider_credential",
         subject: "openai",
+        subject_name: "openai",
         detail:
           "Egma found 2 stored openai keys on this installation and cannot tell whether they are the same account, so none was activated.",
         created_at: "2026-08-17T00:00:00.000Z",
@@ -252,6 +253,7 @@ describe("an installation with choices left over from the upgrade", () => {
         id: "mua_2",
         kind: "select_persona_models",
         subject: "prs_1",
+        subject_name: "Nora",
         detail:
           "this persona's own voice is elevenlabs and this deployment speaks with cartesia. Egma will not choose between them.",
         created_at: "2026-08-17T00:00:00.000Z",
@@ -291,12 +293,16 @@ describe("an installation with choices left over from the upgrade", () => {
     outstanding: ["personas"],
   };
 
-  it("says what to do and why, in Egma's own words and never a key", async () => {
+  it("says what to do, which one, and why — in Egma's own words and never a key", async () => {
     await open(accessAnswer({}), OUTSTANDING);
 
     expect(screen.getByText("Still to choose")).toBeDefined();
     expect(screen.getByText("Choose a provider key")).toBeDefined();
     expect(screen.getByText("Select a persona's models")).toBeDefined();
+    // Which persona, because two blocked personas read the same two words twice
+    // and an identifier is not something anybody can tell them apart by.
+    const table = screen.getByRole("table", { name: "Choices the upgrade left" });
+    expect(within(table).getByText("Nora")).toBeDefined();
     expect(
       screen.getByText(/Egma will not choose between them/u),
     ).toBeDefined();

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -386,6 +386,58 @@ describe("the pages", () => {
   });
 
   /**
+   * Every API path the Model providers screen reaches, held against the rules
+   * that forward them — matched the way Next matches, rather than looked for as
+   * a substring.
+   *
+   * **A `toContain` on this file cannot fail in the way that matters.** The
+   * failure is a path the page fetches and the config does not forward: Next
+   * serves its own 404 HTML, the read comes back unusable, and a section whose
+   * whole job is to make an outstanding choice visible renders nothing at all
+   * and says nothing about why. That is exactly what happened to
+   * `/api/model-upgrade` and `/api/model-credential-candidates/:id`, and a
+   * string check for a path nobody had added would have passed by not being
+   * written. So the paths come off the module the page imports them from, and
+   * each is matched against the config's real sources.
+   */
+  it("forward every path the model screens fetch, matched as Next matches", async () => {
+    const config = await readFile(path.join(WEB, "next.config.ts"), "utf8");
+    const sources = [...config.matchAll(/source:\s*"([^"]+)"/gu)].map(
+      (found) => found[1] ?? "",
+    );
+
+    /** Next's own rule: a bare source is exact, and `:path*` covers a prefix. */
+    const forwarded = (asked: string): boolean =>
+      sources.some((source) => {
+        if (!source.startsWith("/api/")) return false;
+        const wildcard = source.indexOf("/:");
+        return wildcard === -1
+          ? source === asked
+          : asked.startsWith(source.slice(0, wildcard) + "/");
+      });
+
+    const model = await import("../lib/model-access.ts");
+    const asked = [
+      model.MODEL_ACCESS_PATH,
+      model.MODEL_CATALOG_PATH,
+      model.MODEL_PROVIDER_CREDENTIALS_PATH,
+      model.modelProviderCredentialPath("openai"),
+      model.MANAGED_ACCESS_PATH,
+      model.MODEL_UPGRADE_PATH,
+      model.credentialCandidatePath("mcc_01M08M1BTYEBDV6F0WAF91MVBZ"),
+    ];
+
+    for (const one of asked) {
+      expect(forwarded(one), `${one} is fetched and forwarded nowhere`).toBe(
+        true,
+      );
+    }
+    // And the check itself can fail, which is the whole reason it is written
+    // this way rather than as a list of substrings.
+    expect(forwarded("/api/a-door-egma-does-not-have")).toBe(false);
+  });
+
+  /**
    * The Settings pages reach four more of the API's paths, and none of them is
    * served by this process. Without the rules the pages would post at Next and
    * read its 404 page as egma's refusal.

--- a/packages/db/migrations/0037_model_upgrade.sql
+++ b/packages/db/migrations/0037_model_upgrade.sql
@@ -1,0 +1,67 @@
+-- The upgrade onto model selections: what it found, what it would not decide,
+-- and the stamp that says it has finished.
+--
+--  * `model_credential_candidate` is one legacy provider key, copied here
+--    sealed exactly as it was stored. Copied and not moved, because the row it
+--    came from keeps working through the compatibility period. One row per
+--    source and never per secret: two sources holding one key are two
+--    candidates, because calling them the same key would mean comparing
+--    plaintext, ciphertext or hints, and none of the three may be used to infer
+--    that two keys are equal. A sole candidate for a provider may become that
+--    organization's active credential; two mean an administrator chooses.
+--  * `model_upgrade_action` is a decision the upgrade refused to make on
+--    somebody's behalf — a provider with two candidates, a persona whose voice
+--    provider disagrees with the deployment's, a grader with no effective
+--    legacy model, an organization on a deployment that copies nothing into it.
+--    One row per subject, so the list does not grow every time a container
+--    restarts. Its sentence is Egma's own writing and carries no secret.
+--  * `model_upgrade_completion` is one row belonging to the whole deployment,
+--    on `platform_instance`'s terms. It is written the first time every current
+--    persona and grader carries explicit selections and no queued, claimed or
+--    grading work still depends on the old contract or an old credential
+--    reference — and it is what the later removal reads before it takes the
+--    legacy paths out.
+--
+-- Additive. Nothing is dropped, nothing is backfilled here, and every read that
+-- worked before this file still works after it. The collection itself is a boot
+-- act rather than a statement in this file, because it has to copy sealed
+-- envelopes, mint persona and grader versions, and write sentences a person
+-- reads — none of which belongs in SQL that cannot be tested a case at a time.
+
+CREATE TABLE "model_credential_candidate" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"provider" text NOT NULL,
+	"source" text NOT NULL,
+	"source_name" text NOT NULL,
+	"credentials" text NOT NULL,
+	"credentials_hint" text NOT NULL,
+	"activated_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "model_credential_candidate_one_per_source" UNIQUE("organization_id","provider","source","source_name"),
+	CONSTRAINT "model_credential_candidate_id_prefix" CHECK ("model_credential_candidate"."id" ~ '^mcc_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "model_credential_candidate_source_allowed" CHECK ("model_credential_candidate"."source" in ('platform_setting', 'judge_credential', 'judge_configuration'))
+);
+--> statement-breakpoint
+CREATE TABLE "model_upgrade_action" (
+	"id" text COLLATE "C" PRIMARY KEY NOT NULL,
+	"organization_id" text COLLATE "C" NOT NULL,
+	"kind" text NOT NULL,
+	"subject" text NOT NULL,
+	"detail" text NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "model_upgrade_action_one_per_subject" UNIQUE("organization_id","kind","subject"),
+	CONSTRAINT "model_upgrade_action_id_prefix" CHECK ("model_upgrade_action"."id" ~ '^mua_[0-9A-HJKMNP-TV-Z]{26}$'),
+	CONSTRAINT "model_upgrade_action_kind_allowed" CHECK ("model_upgrade_action"."kind" in ('select_model_provider_credential', 'select_persona_models', 'select_grader_model', 'set_up_model_access'))
+);
+--> statement-breakpoint
+CREATE TABLE "model_upgrade_completion" (
+	"singleton" boolean PRIMARY KEY DEFAULT true NOT NULL,
+	"completed_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "model_upgrade_completion_is_one_row" CHECK ("model_upgrade_completion"."singleton")
+);
+--> statement-breakpoint
+ALTER TABLE "model_credential_candidate" ADD CONSTRAINT "model_credential_candidate_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "model_upgrade_action" ADD CONSTRAINT "model_upgrade_action_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/migrations/0037_model_upgrade.sql
+++ b/packages/db/migrations/0037_model_upgrade.sql
@@ -15,11 +15,13 @@
 --    legacy model, an organization on a deployment that copies nothing into it.
 --    One row per subject, so the list does not grow every time a container
 --    restarts. Its sentence is Egma's own writing and carries no secret.
---  * `model_upgrade_completion` is one row belonging to the whole deployment,
---    on `platform_instance`'s terms. It is written the first time every current
+--  * `platform_instance.model_upgrade_completed_at` is the marker, and it is a
+--    column on that row rather than a table of its own because that row already
+--    means "this installation" — one per deployment, surviving a restart and
+--    moving with a restored backup. It is stamped the first time every current
 --    persona and grader carries explicit selections and no queued, claimed or
 --    grading work still depends on the old contract or an old credential
---    reference — and it is what the later removal reads before it takes the
+--    reference, and it is what the later removal reads before it takes the
 --    legacy paths out.
 --
 -- Additive. Nothing is dropped, nothing is backfilled here, and every read that
@@ -57,11 +59,6 @@ CREATE TABLE "model_upgrade_action" (
 	CONSTRAINT "model_upgrade_action_kind_allowed" CHECK ("model_upgrade_action"."kind" in ('select_model_provider_credential', 'select_persona_models', 'select_grader_model', 'set_up_model_access'))
 );
 --> statement-breakpoint
-CREATE TABLE "model_upgrade_completion" (
-	"singleton" boolean PRIMARY KEY DEFAULT true NOT NULL,
-	"completed_at" timestamp with time zone NOT NULL,
-	CONSTRAINT "model_upgrade_completion_is_one_row" CHECK ("model_upgrade_completion"."singleton")
-);
---> statement-breakpoint
+ALTER TABLE "platform_instance" ADD COLUMN "model_upgrade_completed_at" timestamp with time zone;--> statement-breakpoint
 ALTER TABLE "model_credential_candidate" ADD CONSTRAINT "model_credential_candidate_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "model_upgrade_action" ADD CONSTRAINT "model_upgrade_action_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/migrations/0037_model_upgrade.sql
+++ b/packages/db/migrations/0037_model_upgrade.sql
@@ -9,6 +9,13 @@
 --    plaintext, ciphertext or hints, and none of the three may be used to infer
 --    that two keys are equal. A sole candidate for a provider may become that
 --    organization's active credential; two mean an administrator chooses.
+--    Its `shape` column records what is *inside* the copy, because the two
+--    legacy stores do not agree: every credential table seals a `{ key }`
+--    document so the envelope can grow a field, and the deployment's own
+--    settings seal the value itself because a setting is one value. Recording
+--    it is what lets collection open nothing at all — the translation happens
+--    once, when a candidate becomes an active credential and has to be written
+--    in the shape that store reads.
 --  * `model_upgrade_action` is a decision the upgrade refused to make on
 --    somebody's behalf — a provider with two candidates, a persona whose voice
 --    provider disagrees with the deployment's, a grader with no effective
@@ -38,11 +45,13 @@ CREATE TABLE "model_credential_candidate" (
 	"source_name" text NOT NULL,
 	"credentials" text NOT NULL,
 	"credentials_hint" text NOT NULL,
+	"shape" text NOT NULL,
 	"activated_at" timestamp with time zone,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "model_credential_candidate_one_per_source" UNIQUE("organization_id","provider","source","source_name"),
 	CONSTRAINT "model_credential_candidate_id_prefix" CHECK ("model_credential_candidate"."id" ~ '^mcc_[0-9A-HJKMNP-TV-Z]{26}$'),
-	CONSTRAINT "model_credential_candidate_source_allowed" CHECK ("model_credential_candidate"."source" in ('platform_setting', 'judge_credential', 'judge_configuration'))
+	CONSTRAINT "model_credential_candidate_source_allowed" CHECK ("model_credential_candidate"."source" in ('platform_setting', 'judge_credential', 'judge_configuration')),
+	CONSTRAINT "model_credential_candidate_shape_allowed" CHECK ("model_credential_candidate"."shape" in ('key_document', 'bare_value'))
 );
 --> statement-breakpoint
 CREATE TABLE "model_upgrade_action" (

--- a/packages/db/migrations/0038_upgrade_tracks_its_sources.sql
+++ b/packages/db/migrations/0038_upgrade_tracks_its_sources.sql
@@ -1,0 +1,37 @@
+-- The upgrade tracks the rows it copied from, and remembers what it wrote.
+--
+-- Two columns, and both exist because a legacy key can still be rotated while
+-- the compatibility period lasts: `writePlatformSettings` and
+-- `editJudgeCredential` are open doors, and an operator who rotates a spent key
+-- through either of them expects the next simulation to spend the new one.
+--
+--  * `model_credential_candidate.source_changed_at` is the source row's own
+--    `updated_at` at the moment of the copy. It is what tells a later boot that
+--    the source has moved — asked of the source rather than worked out by
+--    comparing what is inside two envelopes, which this upgrade may not read
+--    and which would answer "changed" every time anyway, because the sealing
+--    nonce is fresh on every write.
+--  * `model_provider_credential.upgraded_from` names the candidate a credential
+--    is *tracking*, or null for a key an administrator typed. It is what lets a
+--    rotation reach the credential the upgrade wrote, and what stops the
+--    upgrade ever reaching one an administrator wrote: storing a key through
+--    Model providers clears it, and from that moment their choice is the only
+--    answer. Not a foreign key, because it is a record of where a secret came
+--    from rather than a pointer anything follows.
+--
+-- Additive, and the backfill is deliberately none: an existing candidate takes
+-- the epoch, so the first boot after this migration refreshes it from its
+-- source once and settles. An existing credential takes null, which reads as
+-- "an administrator's" — the safe direction, because the cost of being wrong
+-- that way is a rotation somebody has to repeat rather than a choice Egma
+-- overwrote.
+
+ALTER TABLE "model_provider_credential" ADD COLUMN "upgraded_from" text COLLATE "C";--> statement-breakpoint
+-- Added with the epoch as a default so a deployment that already applied 0037
+-- keeps its candidates, then the default is dropped so the live column matches
+-- the one the application declares. The epoch is the honest value: it says the
+-- copy is older than anything the source can report, so the first boot after
+-- this refreshes it once from its source and every boot after that writes
+-- nothing.
+ALTER TABLE "model_credential_candidate" ADD COLUMN "source_changed_at" timestamp with time zone NOT NULL DEFAULT to_timestamp(0);--> statement-breakpoint
+ALTER TABLE "model_credential_candidate" ALTER COLUMN "source_changed_at" DROP DEFAULT;

--- a/packages/db/migrations/meta/0037_snapshot.json
+++ b/packages/db/migrations/meta/0037_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "0c93b505-c23e-41c9-8c4c-5e30be35236b",
+  "id": "dcb0ae34-9e70-4e47-9d1a-6216830e5729",
   "prevId": "4a5d3363-2612-445c-ac48-95f3604ad245",
   "version": "7",
   "dialect": "postgresql",
@@ -1730,6 +1730,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "shape": {
+          "name": "shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
         "activated_at": {
           "name": "activated_at",
           "type": "timestamp with time zone",
@@ -1782,6 +1788,10 @@
         "model_credential_candidate_source_allowed": {
           "name": "model_credential_candidate_source_allowed",
           "value": "\"model_credential_candidate\".\"source\" in ('platform_setting', 'judge_credential', 'judge_configuration')"
+        },
+        "model_credential_candidate_shape_allowed": {
+          "name": "model_credential_candidate_shape_allowed",
+          "value": "\"model_credential_candidate\".\"shape\" in ('key_document', 'bare_value')"
         }
       },
       "isRLSEnabled": false

--- a/packages/db/migrations/meta/0037_snapshot.json
+++ b/packages/db/migrations/meta/0037_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "e2436c9e-1307-4be5-b5bc-68144f30ea65",
+  "id": "0c93b505-c23e-41c9-8c4c-5e30be35236b",
   "prevId": "4a5d3363-2612-445c-ac48-95f3604ad245",
   "version": "7",
   "dialect": "postgresql",
@@ -20,6 +20,12 @@
           "type": "text COLLATE \"C\"",
           "primaryKey": false,
           "notNull": true
+        },
+        "model_upgrade_completed_at": {
+          "name": "model_upgrade_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -1872,37 +1878,6 @@
         "model_upgrade_action_kind_allowed": {
           "name": "model_upgrade_action_kind_allowed",
           "value": "\"model_upgrade_action\".\"kind\" in ('select_model_provider_credential', 'select_persona_models', 'select_grader_model', 'set_up_model_access')"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.model_upgrade_completion": {
-      "name": "model_upgrade_completion",
-      "schema": "",
-      "columns": {
-        "singleton": {
-          "name": "singleton",
-          "type": "boolean",
-          "primaryKey": true,
-          "notNull": true,
-          "default": true
-        },
-        "completed_at": {
-          "name": "completed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "model_upgrade_completion_is_one_row": {
-          "name": "model_upgrade_completion_is_one_row",
-          "value": "\"model_upgrade_completion\".\"singleton\""
         }
       },
       "isRLSEnabled": false

--- a/packages/db/migrations/meta/0037_snapshot.json
+++ b/packages/db/migrations/meta/0037_snapshot.json
@@ -1,0 +1,6504 @@
+{
+  "id": "e2436c9e-1307-4be5-b5bc-68144f30ea65",
+  "prevId": "4a5d3363-2612-445c-ac48-95f3604ad245",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.platform_instance": {
+      "name": "platform_instance",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_instance_id_unique": {
+          "name": "platform_instance_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_instance_id_format": {
+          "name": "platform_instance_id_format",
+          "value": "\"platform_instance\".\"id\" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_setting": {
+      "name": "platform_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_setting_name_unique": {
+          "name": "platform_setting_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "platform_setting_id_prefix": {
+          "name": "platform_setting_id_prefix",
+          "value": "\"platform_setting\".\"id\" ~ '^pfs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_revision_prefix": {
+          "name": "project_revision_prefix",
+          "value": "\"project\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inference_key": {
+      "name": "inference_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "inference_key_organization_id_organization_id_fk": {
+          "name": "inference_key_organization_id_organization_id_fk",
+          "tableFrom": "inference_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_key_created_by_user_id_fk": {
+          "name": "inference_key_created_by_user_id_fk",
+          "tableFrom": "inference_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "inference_key_hash_unique": {
+          "name": "inference_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "inference_key_id_prefix": {
+          "name": "inference_key_id_prefix",
+          "value": "\"inference_key\".\"id\" ~ '^ifk_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.managed_access_key": {
+      "name": "managed_access_key",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cloud_organization_id": {
+          "name": "cloud_organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "managed_access_key_organization_id_organization_id_fk": {
+          "name": "managed_access_key_organization_id_organization_id_fk",
+          "tableFrom": "managed_access_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "managed_access_key_connected_by_user_id_fk": {
+          "name": "managed_access_key_connected_by_user_id_fk",
+          "tableFrom": "managed_access_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "managed_access_key_organization_id_prefix": {
+          "name": "managed_access_key_organization_id_prefix",
+          "value": "\"managed_access_key\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_access": {
+      "name": "model_access",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_access_organization_id_organization_id_fk": {
+          "name": "model_access_organization_id_organization_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_access_updated_by_user_id_fk": {
+          "name": "model_access_updated_by_user_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "model_access_organization_id_prefix": {
+          "name": "model_access_organization_id_prefix",
+          "value": "\"model_access\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_access_mode_allowed": {
+          "name": "model_access_mode_allowed",
+          "value": "\"model_access\".\"mode\" in ('managed', 'customer-owned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_provider_credential": {
+      "name": "model_provider_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_credential_organization_id_organization_id_fk": {
+          "name": "model_provider_credential_organization_id_organization_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_created_by_user_id_fk": {
+          "name": "model_provider_credential_created_by_user_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_credential_one_per_provider": {
+          "name": "model_provider_credential_one_per_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_credential_id_prefix": {
+          "name": "model_provider_credential_id_prefix",
+          "value": "\"model_provider_credential\".\"id\" ~ '^mpc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_revision_prefix": {
+          "name": "model_provider_credential_revision_prefix",
+          "value": "\"model_provider_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_provider_allowed": {
+          "name": "model_provider_credential_provider_allowed",
+          "value": "\"model_provider_credential\".\"provider\" in ('openai', 'deepgram', 'cartesia')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_credential_candidate": {
+      "name": "model_credential_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_credential_candidate_organization_id_organization_id_fk": {
+          "name": "model_credential_candidate_organization_id_organization_id_fk",
+          "tableFrom": "model_credential_candidate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_credential_candidate_one_per_source": {
+          "name": "model_credential_candidate_one_per_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider",
+            "source",
+            "source_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_credential_candidate_id_prefix": {
+          "name": "model_credential_candidate_id_prefix",
+          "value": "\"model_credential_candidate\".\"id\" ~ '^mcc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_credential_candidate_source_allowed": {
+          "name": "model_credential_candidate_source_allowed",
+          "value": "\"model_credential_candidate\".\"source\" in ('platform_setting', 'judge_credential', 'judge_configuration')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_upgrade_action": {
+      "name": "model_upgrade_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_upgrade_action_organization_id_organization_id_fk": {
+          "name": "model_upgrade_action_organization_id_organization_id_fk",
+          "tableFrom": "model_upgrade_action",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_upgrade_action_one_per_subject": {
+          "name": "model_upgrade_action_one_per_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kind",
+            "subject"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_upgrade_action_id_prefix": {
+          "name": "model_upgrade_action_id_prefix",
+          "value": "\"model_upgrade_action\".\"id\" ~ '^mua_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_upgrade_action_kind_allowed": {
+          "name": "model_upgrade_action_kind_allowed",
+          "value": "\"model_upgrade_action\".\"kind\" in ('select_model_provider_credential', 'select_persona_models', 'select_grader_model', 'set_up_model_access')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_upgrade_completion": {
+      "name": "model_upgrade_completion",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "model_upgrade_completion_is_one_row": {
+          "name": "model_upgrade_completion_is_one_row",
+          "value": "\"model_upgrade_completion\".\"singleton\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models": {
+          "name": "models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_state": {
+          "name": "capability_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "capabilities_measured": {
+          "name": "capabilities_measured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_supported": {
+          "name": "capabilities_supported",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_checked_at": {
+          "name": "capabilities_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_source": {
+          "name": "capability_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_production": {
+          "name": "watch_production",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "production_cursor": {
+          "name": "production_cursor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_registered_at": {
+          "name": "webhook_registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivered_at": {
+          "name": "webhook_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_capability_state_allowed": {
+          "name": "connection_capability_state_allowed",
+          "value": "\"connection\".\"capability_state\" in ('unknown', 'known')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        },
+        "connection_capability_evidence_agrees": {
+          "name": "connection_capability_evidence_agrees",
+          "value": "(\"connection\".\"capability_state\" = 'known') = (\"connection\".\"capabilities_measured\" is not null and \"connection\".\"capabilities_supported\" is not null and \"connection\".\"capabilities_checked_at\" is not null and \"connection\".\"capability_source\" is not null)"
+        },
+        "connection_capabilities_supported_were_measured": {
+          "name": "connection_capabilities_supported_were_measured",
+          "value": "\"connection\".\"capabilities_supported\" is null or \"connection\".\"capabilities_supported\" <@ \"connection\".\"capabilities_measured\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.production_trace_claim": {
+      "name": "production_trace_claim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_call_id": {
+          "name": "provider_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degraded": {
+          "name": "degraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "production_trace_claim_unwritten_idx": {
+          "name": "production_trace_claim_unwritten_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"production_trace_claim\".\"status\" = 'claimed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "production_trace_claim_organization_id_organization_id_fk": {
+          "name": "production_trace_claim_organization_id_organization_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_connection_id_connection_id_fk": {
+          "name": "production_trace_claim_connection_id_connection_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_project_organization_fk": {
+          "name": "production_trace_claim_project_organization_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "production_trace_claim_trace_id_unique": {
+          "name": "production_trace_claim_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "production_trace_claim_id_prefix": {
+          "name": "production_trace_claim_id_prefix",
+          "value": "\"production_trace_claim\".\"id\" ~ '^ptc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "production_trace_claim_status_allowed": {
+          "name": "production_trace_claim_status_allowed",
+          "value": "\"production_trace_claim\".\"status\" in ('claimed', 'written')"
+        },
+        "production_trace_claim_transport_allowed": {
+          "name": "production_trace_claim_transport_allowed",
+          "value": "\"production_trace_claim\".\"transport\" in ('webhook', 'pull')"
+        },
+        "production_trace_claim_written_agrees": {
+          "name": "production_trace_claim_written_agrees",
+          "value": "(\"production_trace_claim\".\"status\" = 'written') = (\"production_trace_claim\".\"written_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.retell_webhook_refusal": {
+      "name": "retell_webhook_refusal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "how_many": {
+          "name": "how_many",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retell_webhook_refusal_reason_unique": {
+          "name": "retell_webhook_refusal_reason_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reason"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "retell_webhook_refusal_id_prefix": {
+          "name": "retell_webhook_refusal_id_prefix",
+          "value": "\"retell_webhook_refusal\".\"id\" ~ '^rwr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "retell_webhook_refusal_reason_allowed": {
+          "name": "retell_webhook_refusal_reason_allowed",
+          "value": "\"retell_webhook_refusal\".\"reason\" in ('unknown_agent', 'switched_off', 'bad_signature', 'other_kind')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_id_idx": {
+          "name": "grader_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_id_grader_library_id_fk": {
+          "name": "grader_library_id_grader_library_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_library": {
+      "name": "grader_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_definition": {
+          "name": "output_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code": {
+          "name": "source_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_language": {
+          "name": "source_code_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_library_predefined_name_unique": {
+          "name": "grader_library_predefined_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"grader_library\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_organization_id_project_id_idx": {
+          "name": "grader_library_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_library_organization_id_organization_id_fk": {
+          "name": "grader_library_organization_id_organization_id_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_project_organization_fk": {
+          "name": "grader_library_project_organization_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_library_id_prefix": {
+          "name": "grader_library_id_prefix",
+          "value": "\"grader_library\".\"id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_library_type_allowed": {
+          "name": "grader_library_type_allowed",
+          "value": "\"grader_library\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_library_tenancy_is_whole_or_egmas": {
+          "name": "grader_library_tenancy_is_whole_or_egmas",
+          "value": "(\"grader_library\".\"organization_id\" is null) = (\"grader_library\".\"project_id\" is null)"
+        },
+        "grader_library_source_code_within_budget": {
+          "name": "grader_library_source_code_within_budget",
+          "value": "\"grader_library\".\"source_code\" is null or octet_length(\"grader_library\".\"source_code\") <= 262144"
+        },
+        "grader_library_source_code_columns_agree": {
+          "name": "grader_library_source_code_columns_agree",
+          "value": "(\"grader_library\".\"source_code\" is null) = (\"grader_library\".\"source_code_language\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grader_model": {
+          "name": "grader_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_credential_id_judge_credential_id_fk": {
+          "name": "judge_configuration_credential_id_judge_credential_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "judge_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        },
+        "judge_configuration_source_allowed": {
+          "name": "judge_configuration_source_allowed",
+          "value": "\"judge_configuration\".\"source\" in ('credential', 'platform')"
+        },
+        "judge_configuration_has_one_key_source": {
+          "name": "judge_configuration_has_one_key_source",
+          "value": "(\"judge_configuration\".\"source\" = 'credential' and \"judge_configuration\".\"credential_id\" is not null and \"judge_configuration\".\"credentials\" is null and \"judge_configuration\".\"credentials_hint\" is null) or (\"judge_configuration\".\"source\" = 'platform' and \"judge_configuration\".\"credential_id\" is null and \"judge_configuration\".\"credentials\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_credential": {
+      "name": "judge_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "judge_credential_organization_id_idx": {
+          "name": "judge_credential_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"judge_credential\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judge_credential_organization_id_organization_id_fk": {
+          "name": "judge_credential_organization_id_organization_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_credential_created_by_user_id_fk": {
+          "name": "judge_credential_created_by_user_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_credential_id_prefix": {
+          "name": "judge_credential_id_prefix",
+          "value": "\"judge_credential\".\"id\" ~ '^jcr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_revision_prefix": {
+          "name": "judge_credential_revision_prefix",
+          "value": "\"judge_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_provider_allowed": {
+          "name": "judge_credential_provider_allowed",
+          "value": "\"judge_credential\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool": {
+      "name": "mock_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_milliseconds": {
+          "name": "delay_milliseconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_tool_project_id_tool_name_unique": {
+          "name": "mock_tool_project_id_tool_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_tool_organization_id_project_id_idx": {
+          "name": "mock_tool_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_organization_id_organization_id_fk": {
+          "name": "mock_tool_organization_id_organization_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_created_by_user_id_fk": {
+          "name": "mock_tool_created_by_user_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_tool_project_organization_fk": {
+          "name": "mock_tool_project_organization_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mock_tool_id_project_id_unique": {
+          "name": "mock_tool_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_id_prefix": {
+          "name": "mock_tool_id_prefix",
+          "value": "\"mock_tool\".\"id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "mock_tool_delay_within_budget": {
+          "name": "mock_tool_delay_within_budget",
+          "value": "\"mock_tool\".\"delay_milliseconds\" between 0 and 30000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool_agent": {
+      "name": "mock_tool_agent",
+      "schema": "",
+      "columns": {
+        "mock_tool_id": {
+          "name": "mock_tool_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mock_tool_agent_agent_id_idx": {
+          "name": "mock_tool_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_agent_mock_tool_id_mock_tool_id_fk": {
+          "name": "mock_tool_agent_mock_tool_id_mock_tool_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_id_agent_id_fk": {
+          "name": "mock_tool_agent_agent_id_agent_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_mock_tool_project_fk": {
+          "name": "mock_tool_agent_mock_tool_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_project_fk": {
+          "name": "mock_tool_agent_agent_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mock_tool_agent_pk": {
+          "name": "mock_tool_agent_pk",
+          "columns": [
+            "mock_tool_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "mock_tool_agent_mock_tool_id_position_unique": {
+          "name": "mock_tool_agent_mock_tool_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mock_tool_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_agent_mock_tool_id_prefix": {
+          "name": "mock_tool_agent_mock_tool_id_prefix",
+          "value": "\"mock_tool_agent\".\"mock_tool_id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicability_revision": {
+          "name": "applicability_revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_revision_prefix": {
+          "name": "test_revision_prefix",
+          "value": "\"test\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_applicability_revision_prefix": {
+          "name": "test_applicability_revision_prefix",
+          "value": "\"test\".\"applicability_revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_archive_reason_allowed": {
+          "name": "test_archive_reason_allowed",
+          "value": "\"test\".\"archive_reason\" in ('needs_agent')"
+        },
+        "test_archive_reason_needs_an_archive": {
+          "name": "test_archive_reason_needs_an_archive",
+          "value": "\"test\".\"archive_reason\" is null or \"test\".\"archived_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_agent": {
+      "name": "test_agent",
+      "schema": "",
+      "columns": {
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_agent_agent_id_idx": {
+          "name": "test_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_agent_test_id_test_id_fk": {
+          "name": "test_agent_test_id_test_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_id_agent_id_fk": {
+          "name": "test_agent_agent_id_agent_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_created_by_user_id_fk": {
+          "name": "test_agent_created_by_user_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_agent_test_project_fk": {
+          "name": "test_agent_test_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_project_fk": {
+          "name": "test_agent_agent_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_agent_pk": {
+          "name": "test_agent_pk",
+          "columns": [
+            "test_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_agent_test_id_prefix": {
+          "name": "test_agent_test_id_prefix",
+          "value": "\"test_agent\".\"test_id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tool_snapshot": {
+          "name": "mock_tool_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"skipped_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0\n          and \"run\".\"canceled_count\" >= 0 and \"run\".\"skipped_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')\n        or (\"run_event\".\"status\" = 'skipped' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_detail": {
+          "name": "ending_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_repair": {
+          "name": "ending_repair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_coverage": {
+          "name": "mock_tool_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_capabilities": {
+          "name": "skipped_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_repair_allowed": {
+          "name": "simulation_ending_repair_allowed",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_repair\" in ('model_providers')"
+        },
+        "simulation_ending_repair_has_a_reason_to_exist": {
+          "name": "simulation_ending_repair_has_a_reason_to_exist",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_detail\" is not null"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_skipped_shape": {
+          "name": "simulation_skipped_shape",
+          "value": "\"simulation\".\"status\" <> 'skipped'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"claimed_at\" is null\n          and \"simulation\".\"started_at\" is null and \"simulation\".\"cancel_requested_at\" is null\n          and \"simulation\".\"skip_reason\" is not null\n          and \"simulation\".\"skipped_capabilities\" is not null)"
+        },
+        "simulation_skip_reason_belongs_to_a_skip": {
+          "name": "simulation_skip_reason_belongs_to_a_skip",
+          "value": "\"simulation\".\"status\" = 'skipped'\n        or (\"simulation\".\"skip_reason\" is null and \"simulation\".\"skipped_capabilities\" is null)"
+        },
+        "simulation_skip_reason_allowed": {
+          "name": "simulation_skip_reason_allowed",
+          "value": "\"simulation\".\"skip_reason\" is null or \"simulation\".\"skip_reason\" in ('required_capability_unsupported', 'required_capability_unknown')"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_mock_tool_coverage_only_when_ended": {
+          "name": "simulation_mock_tool_coverage_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null or \"simulation\".\"mock_tool_coverage\" is null"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_plan": {
+      "name": "grading_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groups": {
+          "name": "groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_credential_ids": {
+          "name": "judge_credential_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_plan_judge_credential_ids_idx": {
+          "name": "grading_plan_judge_credential_ids_idx",
+          "columns": [
+            {
+              "expression": "judge_credential_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "grading_plan_organization_id_project_id_idx": {
+          "name": "grading_plan_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_plan_organization_id_organization_id_fk": {
+          "name": "grading_plan_organization_id_organization_id_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_project_organization_fk": {
+          "name": "grading_plan_project_organization_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_run_project_fk": {
+          "name": "grading_plan_run_project_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_plan_run_id_unique": {
+          "name": "grading_plan_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_plan_id_prefix": {
+          "name": "grading_plan_id_prefix",
+          "value": "\"grading_plan\".\"id\" ~ '^gpl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_plan_state_allowed": {
+          "name": "grading_plan_state_allowed",
+          "value": "\"grading_plan\".\"state\" in ('run_start', 'migration_snapshot', 'not_recorded')"
+        },
+        "grading_plan_recorded_plans_carry_their_moment": {
+          "name": "grading_plan_recorded_plans_carry_their_moment",
+          "value": "(\"grading_plan\".\"state\" = 'not_recorded')\n        = (\"grading_plan\".\"captured_at\" is null)"
+        },
+        "grading_plan_groups_are_a_list": {
+          "name": "grading_plan_groups_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"groups\") = 'array'"
+        },
+        "grading_plan_credentials_are_a_list": {
+          "name": "grading_plan_credentials_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"judge_credential_ids\") = 'array'"
+        },
+        "grading_plan_unrecorded_holds_nothing": {
+          "name": "grading_plan_unrecorded_holds_nothing",
+          "value": "\"grading_plan\".\"state\" <> 'not_recorded'\n        or (\"grading_plan\".\"groups\" = '[]'::jsonb\n          and \"grading_plan\".\"judge_credential_ids\" = '[]'::jsonb)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotent_operation": {
+      "name": "idempotent_operation",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "idempotent_operation_organization_id_organization_id_fk": {
+          "name": "idempotent_operation_organization_id_organization_id_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_project_organization_fk": {
+          "name": "idempotent_operation_project_organization_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_actor_fk": {
+          "name": "idempotent_operation_actor_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotent_operation_pk": {
+          "name": "idempotent_operation_pk",
+          "columns": [
+            "organization_id",
+            "project_id",
+            "actor_id",
+            "operation",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "idempotent_operation_organization_id_prefix": {
+          "name": "idempotent_operation_organization_id_prefix",
+          "value": "\"idempotent_operation\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "idempotent_operation_allowed": {
+          "name": "idempotent_operation_allowed",
+          "value": "\"idempotent_operation\".\"operation\" in ('start_run')"
+        },
+        "idempotent_operation_key_is_not_empty": {
+          "name": "idempotent_operation_key_is_not_empty",
+          "value": "length(\"idempotent_operation\".\"idempotency_key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0038_snapshot.json
+++ b/packages/db/migrations/meta/0038_snapshot.json
@@ -1,0 +1,6501 @@
+{
+  "id": "4cd20843-4f13-4c11-a5e0-4615c7641ac4",
+  "prevId": "dcb0ae34-9e70-4e47-9d1a-6216830e5729",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.platform_instance": {
+      "name": "platform_instance",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_upgrade_completed_at": {
+          "name": "model_upgrade_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "platform_instance_id_unique": {
+          "name": "platform_instance_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_instance_id_format": {
+          "name": "platform_instance_id_format",
+          "value": "\"platform_instance\".\"id\" ~ '^pf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_setting": {
+      "name": "platform_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_setting_name_unique": {
+          "name": "platform_setting_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "platform_setting_id_prefix": {
+          "name": "platform_setting_id_prefix",
+          "value": "\"platform_setting\".\"id\" ~ '^pfs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_id_prefix": {
+          "name": "account_id_prefix",
+          "value": "\"account\".\"id\" ~ '^acc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_id_prefix": {
+          "name": "session_id_prefix",
+          "value": "\"session\".\"id\" ~ '^ses_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_external_identity_unique": {
+          "name": "user_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_id_prefix": {
+          "name": "user_id_prefix",
+          "value": "\"user\".\"id\" ~ '^usr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verification_id_prefix": {
+          "name": "verification_id_prefix",
+          "value": "\"verification\".\"id\" ~ '^vrf_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_organization_id_idx": {
+          "name": "api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_key_project_organization_fk": {
+          "name": "api_key_project_organization_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hash_unique": {
+          "name": "api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "api_key_id_prefix": {
+          "name": "api_key_id_prefix",
+          "value": "\"api_key\".\"id\" ~ '^key_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "api_key_scope_allowed": {
+          "name": "api_key_scope_allowed",
+          "value": "\"api_key\".\"scope\" in ('organization', 'project')"
+        },
+        "api_key_project_scope_agrees": {
+          "name": "api_key_project_scope_agrees",
+          "value": "(\"api_key\".\"scope\" = 'project') = (\"api_key\".\"project_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_created_by_user_id_fk": {
+          "name": "invitation_created_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_token_hash_unique": {
+          "name": "invitation_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_id_prefix": {
+          "name": "invitation_id_prefix",
+          "value": "\"invitation\".\"id\" ~ '^inv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "invitation_role_allowed": {
+          "name": "invitation_role_allowed",
+          "value": "\"invitation\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_organization_id_idx": {
+          "name": "membership_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_organization_id_organization_id_fk": {
+          "name": "membership_organization_id_organization_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_user_id_user_id_fk": {
+          "name": "membership_user_id_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_created_by_user_id_fk": {
+          "name": "membership_created_by_user_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_user_id_unique": {
+          "name": "membership_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "membership_organization_id_user_id_unique": {
+          "name": "membership_organization_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "membership_id_prefix": {
+          "name": "membership_id_prefix",
+          "value": "\"membership\".\"id\" ~ '^mbr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "membership_role_allowed": {
+          "name": "membership_role_allowed",
+          "value": "\"membership\".\"role\" in ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identity_provider": {
+          "name": "external_identity_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_external_identity_unique": {
+          "name": "organization_external_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_identity_provider",
+            "external_identity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_id_prefix": {
+          "name": "organization_id_prefix",
+          "value": "\"organization\".\"id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_residency": {
+          "name": "data_residency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_settings_organization_id_organization_id_fk": {
+          "name": "organization_settings_organization_id_organization_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organization_settings_organization_id_prefix": {
+          "name": "organization_settings_organization_id_prefix",
+          "value": "\"organization_settings\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_persona_id": {
+          "name": "default_persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"project\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_default_persona_id_persona_id_fk": {
+          "name": "project_default_persona_id_persona_id_fk",
+          "tableFrom": "project",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "default_persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_created_by_user_id_fk": {
+          "name": "project_created_by_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_id_slug_unique": {
+          "name": "project_organization_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        },
+        "project_id_organization_id_unique": {
+          "name": "project_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "project_id_prefix": {
+          "name": "project_id_prefix",
+          "value": "\"project\".\"id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "project_revision_prefix": {
+          "name": "project_revision_prefix",
+          "value": "\"project\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inference_key": {
+      "name": "inference_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_suffix": {
+          "name": "display_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "inference_key_organization_id_organization_id_fk": {
+          "name": "inference_key_organization_id_organization_id_fk",
+          "tableFrom": "inference_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_key_created_by_user_id_fk": {
+          "name": "inference_key_created_by_user_id_fk",
+          "tableFrom": "inference_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "inference_key_hash_unique": {
+          "name": "inference_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "inference_key_id_prefix": {
+          "name": "inference_key_id_prefix",
+          "value": "\"inference_key\".\"id\" ~ '^ifk_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.managed_access_key": {
+      "name": "managed_access_key",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cloud_organization_id": {
+          "name": "cloud_organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "managed_access_key_organization_id_organization_id_fk": {
+          "name": "managed_access_key_organization_id_organization_id_fk",
+          "tableFrom": "managed_access_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "managed_access_key_connected_by_user_id_fk": {
+          "name": "managed_access_key_connected_by_user_id_fk",
+          "tableFrom": "managed_access_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "managed_access_key_organization_id_prefix": {
+          "name": "managed_access_key_organization_id_prefix",
+          "value": "\"managed_access_key\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_access": {
+      "name": "model_access",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_access_organization_id_organization_id_fk": {
+          "name": "model_access_organization_id_organization_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_access_updated_by_user_id_fk": {
+          "name": "model_access_updated_by_user_id_fk",
+          "tableFrom": "model_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "model_access_organization_id_prefix": {
+          "name": "model_access_organization_id_prefix",
+          "value": "\"model_access\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_access_mode_allowed": {
+          "name": "model_access_mode_allowed",
+          "value": "\"model_access\".\"mode\" in ('managed', 'customer-owned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_provider_credential": {
+      "name": "model_provider_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upgraded_from": {
+          "name": "upgraded_from",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_credential_organization_id_organization_id_fk": {
+          "name": "model_provider_credential_organization_id_organization_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_created_by_user_id_fk": {
+          "name": "model_provider_credential_created_by_user_id_fk",
+          "tableFrom": "model_provider_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_credential_one_per_provider": {
+          "name": "model_provider_credential_one_per_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_credential_id_prefix": {
+          "name": "model_provider_credential_id_prefix",
+          "value": "\"model_provider_credential\".\"id\" ~ '^mpc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_revision_prefix": {
+          "name": "model_provider_credential_revision_prefix",
+          "value": "\"model_provider_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_provider_credential_provider_allowed": {
+          "name": "model_provider_credential_provider_allowed",
+          "value": "\"model_provider_credential\".\"provider\" in ('openai', 'deepgram', 'cartesia')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_credential_candidate": {
+      "name": "model_credential_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shape": {
+          "name": "shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_changed_at": {
+          "name": "source_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_credential_candidate_organization_id_organization_id_fk": {
+          "name": "model_credential_candidate_organization_id_organization_id_fk",
+          "tableFrom": "model_credential_candidate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_credential_candidate_one_per_source": {
+          "name": "model_credential_candidate_one_per_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider",
+            "source",
+            "source_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_credential_candidate_id_prefix": {
+          "name": "model_credential_candidate_id_prefix",
+          "value": "\"model_credential_candidate\".\"id\" ~ '^mcc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_credential_candidate_source_allowed": {
+          "name": "model_credential_candidate_source_allowed",
+          "value": "\"model_credential_candidate\".\"source\" in ('platform_setting', 'judge_credential', 'judge_configuration')"
+        },
+        "model_credential_candidate_shape_allowed": {
+          "name": "model_credential_candidate_shape_allowed",
+          "value": "\"model_credential_candidate\".\"shape\" in ('key_document', 'bare_value')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_upgrade_action": {
+      "name": "model_upgrade_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_upgrade_action_organization_id_organization_id_fk": {
+          "name": "model_upgrade_action_organization_id_organization_id_fk",
+          "tableFrom": "model_upgrade_action",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_upgrade_action_one_per_subject": {
+          "name": "model_upgrade_action_one_per_subject",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kind",
+            "subject"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_upgrade_action_id_prefix": {
+          "name": "model_upgrade_action_id_prefix",
+          "value": "\"model_upgrade_action\".\"id\" ~ '^mua_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "model_upgrade_action_kind_allowed": {
+          "name": "model_upgrade_action_kind_allowed",
+          "value": "\"model_upgrade_action\".\"kind\" in ('select_model_provider_credential', 'select_persona_models', 'select_grader_model', 'set_up_model_access')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_organization_id_organization_id_fk": {
+          "name": "device_code_organization_id_organization_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_code_project_organization_fk": {
+          "name": "device_code_project_organization_fk",
+          "tableFrom": "device_code",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_code_device_code_unique": {
+          "name": "device_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_code_user_code_unique": {
+          "name": "device_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_code_id_prefix": {
+          "name": "device_code_id_prefix",
+          "value": "\"device_code\".\"id\" ~ '^dvc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "device_code_status_allowed": {
+          "name": "device_code_status_allowed",
+          "value": "\"device_code\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "device_code_authorized_for_agrees": {
+          "name": "device_code_authorized_for_agrees",
+          "value": "(\"device_code\".\"organization_id\" is null) = (\"device_code\".\"project_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona": {
+      "name": "persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persona_organization_id_project_id_idx": {
+          "name": "persona_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"persona\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persona_organization_id_organization_id_fk": {
+          "name": "persona_organization_id_organization_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_current_version_id_persona_version_id_fk": {
+          "name": "persona_current_version_id_persona_version_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persona_created_by_user_id_fk": {
+          "name": "persona_created_by_user_id_fk",
+          "tableFrom": "persona",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "persona_project_organization_fk": {
+          "name": "persona_project_organization_fk",
+          "tableFrom": "persona",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_id_project_id_unique": {
+          "name": "persona_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_id_prefix": {
+          "name": "persona_id_prefix",
+          "value": "\"persona\".\"id\" ~ '^prs_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.persona_version": {
+      "name": "persona_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models": {
+          "name": "models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "persona_version_persona_id_persona_id_fk": {
+          "name": "persona_version_persona_id_persona_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "persona_version_created_by_user_id_fk": {
+          "name": "persona_version_created_by_user_id_fk",
+          "tableFrom": "persona_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persona_version_persona_id_version_unique": {
+          "name": "persona_version_persona_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "persona_id",
+            "version"
+          ]
+        },
+        "persona_version_id_persona_id_unique": {
+          "name": "persona_version_id_persona_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "persona_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "persona_version_id_prefix": {
+          "name": "persona_version_id_prefix",
+          "value": "\"persona_version\".\"id\" ~ '^prsv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_project_id_name_unique": {
+          "name": "agent_project_id_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_organization_id_project_id_idx": {
+          "name": "agent_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_created_by_user_id_fk": {
+          "name": "agent_created_by_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_project_organization_fk": {
+          "name": "agent_project_organization_fk",
+          "tableFrom": "agent",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_id_project_id_unique": {
+          "name": "agent_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_id_prefix": {
+          "name": "agent_id_prefix",
+          "value": "\"agent\".\"id\" ~ '^agt_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topology": {
+          "name": "topology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_state": {
+          "name": "capability_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "capabilities_measured": {
+          "name": "capabilities_measured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_supported": {
+          "name": "capabilities_supported",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_checked_at": {
+          "name": "capabilities_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_source": {
+          "name": "capability_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_production": {
+          "name": "watch_production",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "production_cursor": {
+          "name": "production_cursor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_registered_at": {
+          "name": "webhook_registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_delivered_at": {
+          "name": "webhook_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_agent_id_name_unique": {
+          "name": "connection_agent_id_name_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_agent_id_idx": {
+          "name": "connection_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_organization_id_organization_id_fk": {
+          "name": "connection_organization_id_organization_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_id_agent_id_fk": {
+          "name": "connection_agent_id_agent_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_created_by_user_id_fk": {
+          "name": "connection_created_by_user_id_fk",
+          "tableFrom": "connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "connection_project_organization_fk": {
+          "name": "connection_project_organization_fk",
+          "tableFrom": "connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_agent_project_fk": {
+          "name": "connection_agent_project_fk",
+          "tableFrom": "connection",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connection_id_agent_id_unique": {
+          "name": "connection_id_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connection_id_prefix": {
+          "name": "connection_id_prefix",
+          "value": "\"connection\".\"id\" ~ '^con_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "connection_type_allowed": {
+          "name": "connection_type_allowed",
+          "value": "\"connection\".\"type\" in ('retell', 'phone', 'livekit')"
+        },
+        "connection_modality_allowed": {
+          "name": "connection_modality_allowed",
+          "value": "\"connection\".\"modality\" in ('voice', 'chat')"
+        },
+        "connection_topology_allowed": {
+          "name": "connection_topology_allowed",
+          "value": "\"connection\".\"topology\" in ('agent-dials-out', 'hosted-broker', 'egma-dials-in')"
+        },
+        "connection_capability_state_allowed": {
+          "name": "connection_capability_state_allowed",
+          "value": "\"connection\".\"capability_state\" in ('unknown', 'known')"
+        },
+        "connection_credentials_hint_agrees": {
+          "name": "connection_credentials_hint_agrees",
+          "value": "(\"connection\".\"credentials\" is null) = (\"connection\".\"credentials_hint\" is null)"
+        },
+        "connection_capability_evidence_agrees": {
+          "name": "connection_capability_evidence_agrees",
+          "value": "(\"connection\".\"capability_state\" = 'known') = (\"connection\".\"capabilities_measured\" is not null and \"connection\".\"capabilities_supported\" is not null and \"connection\".\"capabilities_checked_at\" is not null and \"connection\".\"capability_source\" is not null)"
+        },
+        "connection_capabilities_supported_were_measured": {
+          "name": "connection_capabilities_supported_were_measured",
+          "value": "\"connection\".\"capabilities_supported\" is null or \"connection\".\"capabilities_supported\" <@ \"connection\".\"capabilities_measured\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.production_trace_claim": {
+      "name": "production_trace_claim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_call_id": {
+          "name": "provider_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degraded": {
+          "name": "degraded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "production_trace_claim_unwritten_idx": {
+          "name": "production_trace_claim_unwritten_idx",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"production_trace_claim\".\"status\" = 'claimed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "production_trace_claim_organization_id_organization_id_fk": {
+          "name": "production_trace_claim_organization_id_organization_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_connection_id_connection_id_fk": {
+          "name": "production_trace_claim_connection_id_connection_id_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "production_trace_claim_project_organization_fk": {
+          "name": "production_trace_claim_project_organization_fk",
+          "tableFrom": "production_trace_claim",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "production_trace_claim_trace_id_unique": {
+          "name": "production_trace_claim_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "production_trace_claim_id_prefix": {
+          "name": "production_trace_claim_id_prefix",
+          "value": "\"production_trace_claim\".\"id\" ~ '^ptc_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "production_trace_claim_status_allowed": {
+          "name": "production_trace_claim_status_allowed",
+          "value": "\"production_trace_claim\".\"status\" in ('claimed', 'written')"
+        },
+        "production_trace_claim_transport_allowed": {
+          "name": "production_trace_claim_transport_allowed",
+          "value": "\"production_trace_claim\".\"transport\" in ('webhook', 'pull')"
+        },
+        "production_trace_claim_written_agrees": {
+          "name": "production_trace_claim_written_agrees",
+          "value": "(\"production_trace_claim\".\"status\" = 'written') = (\"production_trace_claim\".\"written_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.retell_webhook_refusal": {
+      "name": "retell_webhook_refusal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "how_many": {
+          "name": "how_many",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retell_webhook_refusal_reason_unique": {
+          "name": "retell_webhook_refusal_reason_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reason"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "retell_webhook_refusal_id_prefix": {
+          "name": "retell_webhook_refusal_id_prefix",
+          "value": "\"retell_webhook_refusal\".\"id\" ~ '^rwr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "retell_webhook_refusal_reason_allowed": {
+          "name": "retell_webhook_refusal_reason_allowed",
+          "value": "\"retell_webhook_refusal\".\"reason\" in ('unknown_agent', 'switched_off', 'bad_signature', 'other_kind')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader": {
+      "name": "grader",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simulations'"
+        },
+        "production_sample_rate": {
+          "name": "production_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "production_sample_accumulator": {
+          "name": "production_sample_accumulator",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_organization_id_project_id_idx": {
+          "name": "grader_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grader\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_id_idx": {
+          "name": "grader_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_organization_id_organization_id_fk": {
+          "name": "grader_organization_id_organization_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_id_grader_library_id_fk": {
+          "name": "grader_library_id_grader_library_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "grader_current_version_id_grader_version_id_fk": {
+          "name": "grader_current_version_id_grader_version_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "grader_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grader_created_by_user_id_fk": {
+          "name": "grader_created_by_user_id_fk",
+          "tableFrom": "grader",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "grader_project_organization_fk": {
+          "name": "grader_project_organization_fk",
+          "tableFrom": "grader",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_id_prefix": {
+          "name": "grader_id_prefix",
+          "value": "\"grader\".\"id\" ~ '^grd_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_type_allowed": {
+          "name": "grader_type_allowed",
+          "value": "\"grader\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_scope_allowed": {
+          "name": "grader_scope_allowed",
+          "value": "\"grader\".\"scope\" in ('simulations', 'production', 'both')"
+        },
+        "grader_production_sample_rate_is_a_percentage": {
+          "name": "grader_production_sample_rate_is_a_percentage",
+          "value": "\"grader\".\"production_sample_rate\" between 0 and 100"
+        },
+        "grader_production_sample_accumulator_is_a_remainder": {
+          "name": "grader_production_sample_accumulator_is_a_remainder",
+          "value": "\"grader\".\"production_sample_accumulator\" between 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_library": {
+      "name": "grader_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_definition": {
+          "name": "output_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code": {
+          "name": "source_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_code_language": {
+          "name": "source_code_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grader_library_predefined_name_unique": {
+          "name": "grader_library_predefined_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"grader_library\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grader_library_organization_id_project_id_idx": {
+          "name": "grader_library_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grader_library_organization_id_organization_id_fk": {
+          "name": "grader_library_organization_id_organization_id_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_library_project_organization_fk": {
+          "name": "grader_library_project_organization_fk",
+          "tableFrom": "grader_library",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grader_library_id_prefix": {
+          "name": "grader_library_id_prefix",
+          "value": "\"grader_library\".\"id\" ~ '^grl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grader_library_type_allowed": {
+          "name": "grader_library_type_allowed",
+          "value": "\"grader_library\".\"type\" in ('llm_as_judge', 'code')"
+        },
+        "grader_library_tenancy_is_whole_or_egmas": {
+          "name": "grader_library_tenancy_is_whole_or_egmas",
+          "value": "(\"grader_library\".\"organization_id\" is null) = (\"grader_library\".\"project_id\" is null)"
+        },
+        "grader_library_source_code_within_budget": {
+          "name": "grader_library_source_code_within_budget",
+          "value": "\"grader_library\".\"source_code\" is null or octet_length(\"grader_library\".\"source_code\") <= 262144"
+        },
+        "grader_library_source_code_columns_agree": {
+          "name": "grader_library_source_code_columns_agree",
+          "value": "(\"grader_library\".\"source_code\" is null) = (\"grader_library\".\"source_code_language\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grader_version": {
+      "name": "grader_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grader_id": {
+          "name": "grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grader_model": {
+          "name": "grader_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grader_version_grader_id_grader_id_fk": {
+          "name": "grader_version_grader_id_grader_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grader_version_created_by_user_id_fk": {
+          "name": "grader_version_created_by_user_id_fk",
+          "tableFrom": "grader_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grader_version_grader_id_version_unique": {
+          "name": "grader_version_grader_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grader_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grader_version_id_prefix": {
+          "name": "grader_version_id_prefix",
+          "value": "\"grader_version\".\"id\" ~ '^grv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_configuration": {
+      "name": "judge_configuration",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_configuration_organization_id_organization_id_fk": {
+          "name": "judge_configuration_organization_id_organization_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_credential_id_judge_credential_id_fk": {
+          "name": "judge_configuration_credential_id_judge_credential_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "judge_credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_created_by_user_id_fk": {
+          "name": "judge_configuration_created_by_user_id_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "judge_configuration_project_organization_fk": {
+          "name": "judge_configuration_project_organization_fk",
+          "tableFrom": "judge_configuration",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_configuration_project_id_prefix": {
+          "name": "judge_configuration_project_id_prefix",
+          "value": "\"judge_configuration\".\"project_id\" ~ '^prj_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_configuration_provider_allowed": {
+          "name": "judge_configuration_provider_allowed",
+          "value": "\"judge_configuration\".\"provider\" in ('openai')"
+        },
+        "judge_configuration_source_allowed": {
+          "name": "judge_configuration_source_allowed",
+          "value": "\"judge_configuration\".\"source\" in ('credential', 'platform')"
+        },
+        "judge_configuration_has_one_key_source": {
+          "name": "judge_configuration_has_one_key_source",
+          "value": "(\"judge_configuration\".\"source\" = 'credential' and \"judge_configuration\".\"credential_id\" is not null and \"judge_configuration\".\"credentials\" is null and \"judge_configuration\".\"credentials_hint\" is null) or (\"judge_configuration\".\"source\" = 'platform' and \"judge_configuration\".\"credential_id\" is null and \"judge_configuration\".\"credentials\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.judge_credential": {
+      "name": "judge_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_hint": {
+          "name": "credentials_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "judge_credential_organization_id_idx": {
+          "name": "judge_credential_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"judge_credential\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judge_credential_organization_id_organization_id_fk": {
+          "name": "judge_credential_organization_id_organization_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judge_credential_created_by_user_id_fk": {
+          "name": "judge_credential_created_by_user_id_fk",
+          "tableFrom": "judge_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_credential_id_prefix": {
+          "name": "judge_credential_id_prefix",
+          "value": "\"judge_credential\".\"id\" ~ '^jcr_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_revision_prefix": {
+          "name": "judge_credential_revision_prefix",
+          "value": "\"judge_credential\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "judge_credential_provider_allowed": {
+          "name": "judge_credential_provider_allowed",
+          "value": "\"judge_credential\".\"provider\" in ('openai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool": {
+      "name": "mock_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_milliseconds": {
+          "name": "delay_milliseconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mock_tool_project_id_tool_name_unique": {
+          "name": "mock_tool_project_id_tool_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mock_tool_organization_id_project_id_idx": {
+          "name": "mock_tool_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mock_tool\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_organization_id_organization_id_fk": {
+          "name": "mock_tool_organization_id_organization_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_created_by_user_id_fk": {
+          "name": "mock_tool_created_by_user_id_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mock_tool_project_organization_fk": {
+          "name": "mock_tool_project_organization_fk",
+          "tableFrom": "mock_tool",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mock_tool_id_project_id_unique": {
+          "name": "mock_tool_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_id_prefix": {
+          "name": "mock_tool_id_prefix",
+          "value": "\"mock_tool\".\"id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "mock_tool_delay_within_budget": {
+          "name": "mock_tool_delay_within_budget",
+          "value": "\"mock_tool\".\"delay_milliseconds\" between 0 and 30000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mock_tool_agent": {
+      "name": "mock_tool_agent",
+      "schema": "",
+      "columns": {
+        "mock_tool_id": {
+          "name": "mock_tool_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mock_tool_agent_agent_id_idx": {
+          "name": "mock_tool_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mock_tool_agent_mock_tool_id_mock_tool_id_fk": {
+          "name": "mock_tool_agent_mock_tool_id_mock_tool_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_id_agent_id_fk": {
+          "name": "mock_tool_agent_agent_id_agent_id_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_mock_tool_project_fk": {
+          "name": "mock_tool_agent_mock_tool_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "mock_tool",
+          "columnsFrom": [
+            "mock_tool_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mock_tool_agent_agent_project_fk": {
+          "name": "mock_tool_agent_agent_project_fk",
+          "tableFrom": "mock_tool_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mock_tool_agent_pk": {
+          "name": "mock_tool_agent_pk",
+          "columns": [
+            "mock_tool_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "mock_tool_agent_mock_tool_id_position_unique": {
+          "name": "mock_tool_agent_mock_tool_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mock_tool_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "mock_tool_agent_mock_tool_id_prefix": {
+          "name": "mock_tool_agent_mock_tool_id_prefix",
+          "value": "\"mock_tool_agent\".\"mock_tool_id\" ~ '^mck_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicability_revision": {
+          "name": "applicability_revision",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_organization_id_project_id_idx": {
+          "name": "test_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"test\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_organization_id_organization_id_fk": {
+          "name": "test_organization_id_organization_id_fk",
+          "tableFrom": "test",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_current_version_id_test_version_id_fk": {
+          "name": "test_current_version_id_test_version_id_fk",
+          "tableFrom": "test",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_created_by_user_id_fk": {
+          "name": "test_created_by_user_id_fk",
+          "tableFrom": "test",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_project_organization_fk": {
+          "name": "test_project_organization_fk",
+          "tableFrom": "test",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_id_project_id_unique": {
+          "name": "test_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_id_prefix": {
+          "name": "test_id_prefix",
+          "value": "\"test\".\"id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_revision_prefix": {
+          "name": "test_revision_prefix",
+          "value": "\"test\".\"revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_applicability_revision_prefix": {
+          "name": "test_applicability_revision_prefix",
+          "value": "\"test\".\"applicability_revision\" ~ '^rev_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "test_archive_reason_allowed": {
+          "name": "test_archive_reason_allowed",
+          "value": "\"test\".\"archive_reason\" in ('needs_agent')"
+        },
+        "test_archive_reason_needs_an_archive": {
+          "name": "test_archive_reason_needs_an_archive",
+          "value": "\"test\".\"archive_reason\" is null or \"test\".\"archived_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_agent": {
+      "name": "test_agent",
+      "schema": "",
+      "columns": {
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_agent_agent_id_idx": {
+          "name": "test_agent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_agent_test_id_test_id_fk": {
+          "name": "test_agent_test_id_test_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_id_agent_id_fk": {
+          "name": "test_agent_agent_id_agent_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_created_by_user_id_fk": {
+          "name": "test_agent_created_by_user_id_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_agent_test_project_fk": {
+          "name": "test_agent_test_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_agent_agent_project_fk": {
+          "name": "test_agent_agent_project_fk",
+          "tableFrom": "test_agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_agent_pk": {
+          "name": "test_agent_pk",
+          "columns": [
+            "test_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_agent_test_id_prefix": {
+          "name": "test_agent_test_id_prefix",
+          "value": "\"test_agent\".\"test_id\" ~ '^tst_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_persona": {
+      "name": "test_persona",
+      "schema": "",
+      "columns": {
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "test_persona_persona_id_idx": {
+          "name": "test_persona_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_persona_test_version_id_test_version_id_fk": {
+          "name": "test_persona_test_version_id_test_version_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_persona_persona_id_persona_id_fk": {
+          "name": "test_persona_persona_id_persona_id_fk",
+          "tableFrom": "test_persona",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_persona_pk": {
+          "name": "test_persona_pk",
+          "columns": [
+            "test_version_id",
+            "persona_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "test_persona_version_id_position_unique": {
+          "name": "test_persona_version_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_version_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_persona_test_version_id_prefix": {
+          "name": "test_persona_test_version_id_prefix",
+          "value": "\"test_persona\".\"test_version_id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_version": {
+      "name": "test_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_version_test_id_test_id_fk": {
+          "name": "test_version_test_id_test_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_version_created_by_user_id_fk": {
+          "name": "test_version_created_by_user_id_fk",
+          "tableFrom": "test_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_version_test_id_version_unique": {
+          "name": "test_version_test_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_id",
+            "version"
+          ]
+        },
+        "test_version_id_test_id_unique": {
+          "name": "test_version_id_test_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "test_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_version_id_prefix": {
+          "name": "test_version_id_prefix",
+          "value": "\"test_version\".\"id\" ~ '^tstv_[0-9A-HJKMNP-TV-Z]{26}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run": {
+      "name": "run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_via": {
+          "name": "triggered_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_test_versions": {
+          "name": "pinned_test_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_personas": {
+          "name": "requested_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_snapshot": {
+          "name": "connection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mock_tool_snapshot": {
+          "name": "mock_tool_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_simulation_count": {
+          "name": "expected_simulation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_count": {
+          "name": "canceled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_organization_id_id_idx": {
+          "name": "run_organization_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_organization_id_project_id_id_idx": {
+          "name": "run_organization_id_project_id_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_agent_id_idx": {
+          "name": "run_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_organization_id_organization_id_fk": {
+          "name": "run_organization_id_organization_id_fk",
+          "tableFrom": "run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_triggered_by_user_id_fk": {
+          "name": "run_triggered_by_user_id_fk",
+          "tableFrom": "run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_retry_of_run_id_run_id_fk": {
+          "name": "run_retry_of_run_id_run_id_fk",
+          "tableFrom": "run",
+          "tableTo": "run",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "run_project_organization_fk": {
+          "name": "run_project_organization_fk",
+          "tableFrom": "run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_agent_project_fk": {
+          "name": "run_agent_project_fk",
+          "tableFrom": "run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_connection_agent_fk": {
+          "name": "run_connection_agent_fk",
+          "tableFrom": "run",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_id_project_id_unique": {
+          "name": "run_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "run_id_prefix": {
+          "name": "run_id_prefix",
+          "value": "\"run\".\"id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_status_allowed": {
+          "name": "run_status_allowed",
+          "value": "\"run\".\"status\" in ('pending', 'running', 'completed', 'canceled')"
+        },
+        "run_triggered_via_allowed": {
+          "name": "run_triggered_via_allowed",
+          "value": "\"run\".\"triggered_via\" in ('manual')"
+        },
+        "run_expects_at_least_one_simulation": {
+          "name": "run_expects_at_least_one_simulation",
+          "value": "\"run\".\"expected_simulation_count\" > 0"
+        },
+        "run_counts_written_together": {
+          "name": "run_counts_written_together",
+          "value": "((\"run\".\"completed_count\" is null) = (\"run\".\"failed_count\" is null))\n        and ((\"run\".\"failed_count\" is null) = (\"run\".\"canceled_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"skipped_count\" is null))\n        and ((\"run\".\"canceled_count\" is null) = (\"run\".\"finished_at\" is null))"
+        },
+        "run_counts_are_counts": {
+          "name": "run_counts_are_counts",
+          "value": "(\"run\".\"completed_count\" is null)\n        or (\"run\".\"completed_count\" >= 0 and \"run\".\"failed_count\" >= 0\n          and \"run\".\"canceled_count\" >= 0 and \"run\".\"skipped_count\" >= 0)"
+        },
+        "run_finished_is_terminal": {
+          "name": "run_finished_is_terminal",
+          "value": "\"run\".\"finished_at\" is null or \"run\".\"status\" in ('completed', 'canceled')"
+        },
+        "run_completed_is_finished": {
+          "name": "run_completed_is_finished",
+          "value": "\"run\".\"status\" <> 'completed' or \"run\".\"finished_at\" is not null"
+        },
+        "run_started_when_left_pending": {
+          "name": "run_started_when_left_pending",
+          "value": "case\n        when \"run\".\"status\" = 'pending' then \"run\".\"started_at\" is null\n        when \"run\".\"status\" in ('running', 'completed') then \"run\".\"started_at\" is not null\n        else true\n      end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_event": {
+      "name": "run_event",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_event_organization_id_organization_id_fk": {
+          "name": "run_event_organization_id_organization_id_fk",
+          "tableFrom": "run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_project_organization_fk": {
+          "name": "run_event_project_organization_fk",
+          "tableFrom": "run_event",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_run_project_fk": {
+          "name": "run_event_run_project_fk",
+          "tableFrom": "run_event",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_event_simulation_run_fk": {
+          "name": "run_event_simulation_run_fk",
+          "tableFrom": "run_event",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_event_pk": {
+          "name": "run_event_pk",
+          "columns": [
+            "run_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_event_run_id_prefix": {
+          "name": "run_event_run_id_prefix",
+          "value": "\"run_event\".\"run_id\" ~ '^run_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "run_event_kind_allowed": {
+          "name": "run_event_kind_allowed",
+          "value": "\"run_event\".\"kind\" in ('run', 'simulation')"
+        },
+        "run_event_seq_counts_from_one": {
+          "name": "run_event_seq_counts_from_one",
+          "value": "\"run_event\".\"seq\" >= 1"
+        },
+        "run_event_run_shape": {
+          "name": "run_event_run_shape",
+          "value": "\"run_event\".\"kind\" <> 'run'\n        or (\"run_event\".\"simulation_id\" is null\n          and \"run_event\".\"verdict\" is null and \"run_event\".\"reason\" is null\n          and \"run_event\".\"status\" in ('pending', 'running', 'completed', 'canceled'))"
+        },
+        "run_event_simulation_shape": {
+          "name": "run_event_simulation_shape",
+          "value": "\"run_event\".\"kind\" <> 'simulation'\n        or (\"run_event\".\"simulation_id\" is not null\n          and \"run_event\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped'))"
+        },
+        "run_event_verdict_allowed": {
+          "name": "run_event_verdict_allowed",
+          "value": "\"run_event\".\"verdict\" is null or \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped', 'errored')"
+        },
+        "run_event_verdict_agrees": {
+          "name": "run_event_verdict_agrees",
+          "value": "\"run_event\".\"verdict\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"verdict\" in ('passed', 'failed', 'skipped'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"verdict\" = 'errored')\n        or (\"run_event\".\"status\" = 'canceled' and \"run_event\".\"verdict\" = 'skipped')\n        or (\"run_event\".\"status\" = 'skipped' and \"run_event\".\"verdict\" = 'skipped')"
+        },
+        "run_event_reason_agrees": {
+          "name": "run_event_reason_agrees",
+          "value": "\"run_event\".\"reason\" is null\n        or (\"run_event\".\"status\" = 'completed' and \"run_event\".\"reason\" in ('persona_concluded', 'agent_ended', 'limit_reached'))\n        or (\"run_event\".\"status\" = 'failed' and \"run_event\".\"reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.simulation": {
+      "name": "simulation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona_version_id": {
+          "name": "persona_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_version_id": {
+          "name": "test_version_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ending_reason": {
+          "name": "ending_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_detail": {
+          "name": "ending_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_repair": {
+          "name": "ending_repair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "measured_audio_band_hertz": {
+          "name": "measured_audio_band_hertz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_reference": {
+          "name": "recording_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mock_tool_coverage": {
+          "name": "mock_tool_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_capabilities": {
+          "name": "skipped_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulation_run_id_idx": {
+          "name": "simulation_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_queued_idx": {
+          "name": "simulation_queued_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_heartbeat_idx": {
+          "name": "simulation_heartbeat_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"simulation\".\"status\" in ('claimed', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_version_id_idx": {
+          "name": "simulation_persona_version_id_idx",
+          "columns": [
+            {
+              "expression": "persona_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_persona_id_idx": {
+          "name": "simulation_persona_id_idx",
+          "columns": [
+            {
+              "expression": "persona_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_version_id_idx": {
+          "name": "simulation_test_version_id_idx",
+          "columns": [
+            {
+              "expression": "test_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulation_test_id_idx": {
+          "name": "simulation_test_id_idx",
+          "columns": [
+            {
+              "expression": "test_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulation_organization_id_organization_id_fk": {
+          "name": "simulation_organization_id_organization_id_fk",
+          "tableFrom": "simulation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_project_organization_fk": {
+          "name": "simulation_project_organization_fk",
+          "tableFrom": "simulation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_agent_project_fk": {
+          "name": "simulation_agent_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_connection_agent_fk": {
+          "name": "simulation_connection_agent_fk",
+          "tableFrom": "simulation",
+          "tableTo": "connection",
+          "columnsFrom": [
+            "connection_id",
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id",
+            "agent_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_run_project_fk": {
+          "name": "simulation_run_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_version_persona_fk": {
+          "name": "simulation_persona_version_persona_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona_version",
+          "columnsFrom": [
+            "persona_version_id",
+            "persona_id"
+          ],
+          "columnsTo": [
+            "id",
+            "persona_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_persona_project_fk": {
+          "name": "simulation_persona_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "persona",
+          "columnsFrom": [
+            "persona_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_version_test_fk": {
+          "name": "simulation_test_version_test_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test_version",
+          "columnsFrom": [
+            "test_version_id",
+            "test_id"
+          ],
+          "columnsTo": [
+            "id",
+            "test_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulation_test_project_fk": {
+          "name": "simulation_test_project_fk",
+          "tableFrom": "simulation",
+          "tableTo": "test",
+          "columnsFrom": [
+            "test_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulation_run_id_position_unique": {
+          "name": "simulation_run_id_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "position"
+          ]
+        },
+        "simulation_id_project_id_unique": {
+          "name": "simulation_id_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        },
+        "simulation_id_run_id_unique": {
+          "name": "simulation_id_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "simulation_id_prefix": {
+          "name": "simulation_id_prefix",
+          "value": "\"simulation\".\"id\" ~ '^sim_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "simulation_status_allowed": {
+          "name": "simulation_status_allowed",
+          "value": "\"simulation\".\"status\" in ('queued', 'claimed', 'running', 'completed', 'failed', 'canceled', 'skipped')"
+        },
+        "simulation_modality_allowed": {
+          "name": "simulation_modality_allowed",
+          "value": "\"simulation\".\"modality\" in ('voice', 'chat')"
+        },
+        "simulation_position_counts_from_one": {
+          "name": "simulation_position_counts_from_one",
+          "value": "\"simulation\".\"position\" >= 1"
+        },
+        "simulation_ending_reason_allowed": {
+          "name": "simulation_ending_reason_allowed",
+          "value": "\"simulation\".\"ending_reason\" is null or \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached', 'agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')"
+        },
+        "simulation_ending_repair_allowed": {
+          "name": "simulation_ending_repair_allowed",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_repair\" in ('model_providers')"
+        },
+        "simulation_ending_repair_has_a_reason_to_exist": {
+          "name": "simulation_ending_repair_has_a_reason_to_exist",
+          "value": "\"simulation\".\"ending_repair\" is null or \"simulation\".\"ending_detail\" is not null"
+        },
+        "simulation_ending_reason_agrees": {
+          "name": "simulation_ending_reason_agrees",
+          "value": "case \"simulation\".\"status\"\n        when 'completed' then \"simulation\".\"ending_reason\" in ('persona_concluded', 'agent_ended', 'limit_reached')\n        when 'failed' then \"simulation\".\"ending_reason\" in ('agent_never_joined', 'not_answered', 'capacity', 'simulator_error', 'orphaned', 'dispatch_failed')\n        else \"simulation\".\"ending_reason\" is null\n      end"
+        },
+        "simulation_test_pin_columns_agree": {
+          "name": "simulation_test_pin_columns_agree",
+          "value": "(\"simulation\".\"test_id\" is null) = (\"simulation\".\"test_version_id\" is null)"
+        },
+        "simulation_claim_columns_agree": {
+          "name": "simulation_claim_columns_agree",
+          "value": "((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"claimed_by\" is null))\n        and ((\"simulation\".\"claimed_at\" is null) = (\"simulation\".\"heartbeat_at\" is null))"
+        },
+        "simulation_queued_shape": {
+          "name": "simulation_queued_shape",
+          "value": "\"simulation\".\"status\" <> 'queued'\n        or (\"simulation\".\"claimed_at\" is null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null and \"simulation\".\"cancel_requested_at\" is null)"
+        },
+        "simulation_claimed_shape": {
+          "name": "simulation_claimed_shape",
+          "value": "\"simulation\".\"status\" <> 'claimed'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_running_shape": {
+          "name": "simulation_running_shape",
+          "value": "\"simulation\".\"status\" <> 'running'\n        or (\"simulation\".\"claimed_at\" is not null and \"simulation\".\"started_at\" is not null\n          and \"simulation\".\"ended_at\" is null)"
+        },
+        "simulation_completed_shape": {
+          "name": "simulation_completed_shape",
+          "value": "\"simulation\".\"status\" <> 'completed'\n        or (\"simulation\".\"started_at\" is not null and \"simulation\".\"ended_at\" is not null)"
+        },
+        "simulation_failed_shape": {
+          "name": "simulation_failed_shape",
+          "value": "\"simulation\".\"status\" <> 'failed' or \"simulation\".\"ended_at\" is not null"
+        },
+        "simulation_canceled_shape": {
+          "name": "simulation_canceled_shape",
+          "value": "\"simulation\".\"status\" <> 'canceled'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"cancel_requested_at\" is not null)"
+        },
+        "simulation_skipped_shape": {
+          "name": "simulation_skipped_shape",
+          "value": "\"simulation\".\"status\" <> 'skipped'\n        or (\"simulation\".\"ended_at\" is not null and \"simulation\".\"claimed_at\" is null\n          and \"simulation\".\"started_at\" is null and \"simulation\".\"cancel_requested_at\" is null\n          and \"simulation\".\"skip_reason\" is not null\n          and \"simulation\".\"skipped_capabilities\" is not null)"
+        },
+        "simulation_skip_reason_belongs_to_a_skip": {
+          "name": "simulation_skip_reason_belongs_to_a_skip",
+          "value": "\"simulation\".\"status\" = 'skipped'\n        or (\"simulation\".\"skip_reason\" is null and \"simulation\".\"skipped_capabilities\" is null)"
+        },
+        "simulation_skip_reason_allowed": {
+          "name": "simulation_skip_reason_allowed",
+          "value": "\"simulation\".\"skip_reason\" is null or \"simulation\".\"skip_reason\" in ('required_capability_unsupported', 'required_capability_unknown')"
+        },
+        "simulation_report_only_when_ended": {
+          "name": "simulation_report_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"recording_reference\" is null\n          and \"simulation\".\"measured_audio_band_hertz\" is null)"
+        },
+        "simulation_summary_facts_only_when_ended": {
+          "name": "simulation_summary_facts_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null\n        or (\"simulation\".\"turn_count\" is null and \"simulation\".\"provider_reference\" is null)"
+        },
+        "simulation_turn_count_is_a_count": {
+          "name": "simulation_turn_count_is_a_count",
+          "value": "\"simulation\".\"turn_count\" is null or \"simulation\".\"turn_count\" >= 0"
+        },
+        "simulation_mock_tool_coverage_only_when_ended": {
+          "name": "simulation_mock_tool_coverage_only_when_ended",
+          "value": "\"simulation\".\"ended_at\" is not null or \"simulation\".\"mock_tool_coverage\" is null"
+        },
+        "simulation_audio_facts_are_voice_facts": {
+          "name": "simulation_audio_facts_are_voice_facts",
+          "value": "\"simulation\".\"modality\" = 'voice'\n        or (\"simulation\".\"measured_audio_band_hertz\" is null\n          and \"simulation\".\"recording_reference\" is null)"
+        },
+        "simulation_audio_band_is_a_rate": {
+          "name": "simulation_audio_band_is_a_rate",
+          "value": "\"simulation\".\"measured_audio_band_hertz\" is null or \"simulation\".\"measured_audio_band_hertz\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_plan": {
+      "name": "grading_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groups": {
+          "name": "groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_credential_ids": {
+          "name": "judge_credential_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_plan_judge_credential_ids_idx": {
+          "name": "grading_plan_judge_credential_ids_idx",
+          "columns": [
+            {
+              "expression": "judge_credential_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "grading_plan_organization_id_project_id_idx": {
+          "name": "grading_plan_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_plan_organization_id_organization_id_fk": {
+          "name": "grading_plan_organization_id_organization_id_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_project_organization_fk": {
+          "name": "grading_plan_project_organization_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_plan_run_project_fk": {
+          "name": "grading_plan_run_project_fk",
+          "tableFrom": "grading_plan",
+          "tableTo": "run",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_plan_run_id_unique": {
+          "name": "grading_plan_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_plan_id_prefix": {
+          "name": "grading_plan_id_prefix",
+          "value": "\"grading_plan\".\"id\" ~ '^gpl_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_plan_state_allowed": {
+          "name": "grading_plan_state_allowed",
+          "value": "\"grading_plan\".\"state\" in ('run_start', 'migration_snapshot', 'not_recorded')"
+        },
+        "grading_plan_recorded_plans_carry_their_moment": {
+          "name": "grading_plan_recorded_plans_carry_their_moment",
+          "value": "(\"grading_plan\".\"state\" = 'not_recorded')\n        = (\"grading_plan\".\"captured_at\" is null)"
+        },
+        "grading_plan_groups_are_a_list": {
+          "name": "grading_plan_groups_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"groups\") = 'array'"
+        },
+        "grading_plan_credentials_are_a_list": {
+          "name": "grading_plan_credentials_are_a_list",
+          "value": "jsonb_typeof(\"grading_plan\".\"judge_credential_ids\") = 'array'"
+        },
+        "grading_plan_unrecorded_holds_nothing": {
+          "name": "grading_plan_unrecorded_holds_nothing",
+          "value": "\"grading_plan\".\"state\" <> 'not_recorded'\n        or (\"grading_plan\".\"groups\" = '[]'::jsonb\n          and \"grading_plan\".\"judge_credential_ids\" = '[]'::jsonb)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotent_operation": {
+      "name": "idempotent_operation",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "idempotent_operation_organization_id_organization_id_fk": {
+          "name": "idempotent_operation_organization_id_organization_id_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_project_organization_fk": {
+          "name": "idempotent_operation_project_organization_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idempotent_operation_actor_fk": {
+          "name": "idempotent_operation_actor_fk",
+          "tableFrom": "idempotent_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotent_operation_pk": {
+          "name": "idempotent_operation_pk",
+          "columns": [
+            "organization_id",
+            "project_id",
+            "actor_id",
+            "operation",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "idempotent_operation_organization_id_prefix": {
+          "name": "idempotent_operation_organization_id_prefix",
+          "value": "\"idempotent_operation\".\"organization_id\" ~ '^org_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "idempotent_operation_allowed": {
+          "name": "idempotent_operation_allowed",
+          "value": "\"idempotent_operation\".\"operation\" in ('start_run')"
+        },
+        "idempotent_operation_key_is_not_empty": {
+          "name": "idempotent_operation_key_is_not_empty",
+          "value": "length(\"idempotent_operation\".\"idempotency_key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grading_job": {
+      "name": "grading_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulation_id": {
+          "name": "simulation_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_span_at": {
+          "name": "first_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_span_at": {
+          "name": "last_span_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_closed_at": {
+          "name": "root_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regrade_grader_id": {
+          "name": "regrade_grader_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grading_job_outstanding_idx": {
+          "name": "grading_job_outstanding_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"grading_job\".\"status\" in ('pending', 'claimed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "grading_job_organization_id_project_id_idx": {
+          "name": "grading_job_organization_id_project_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "grading_job_organization_id_organization_id_fk": {
+          "name": "grading_job_organization_id_organization_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_regrade_grader_id_grader_id_fk": {
+          "name": "grading_job_regrade_grader_id_grader_id_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "grader",
+          "columnsFrom": [
+            "regrade_grader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "grading_job_project_organization_fk": {
+          "name": "grading_job_project_organization_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grading_job_simulation_project_fk": {
+          "name": "grading_job_simulation_project_fk",
+          "tableFrom": "grading_job",
+          "tableTo": "simulation",
+          "columnsFrom": [
+            "simulation_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grading_job_simulation_id_unique": {
+          "name": "grading_job_simulation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "simulation_id"
+          ]
+        },
+        "grading_job_trace_id_unique": {
+          "name": "grading_job_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "grading_job_id_prefix": {
+          "name": "grading_job_id_prefix",
+          "value": "\"grading_job\".\"id\" ~ '^gjb_[0-9A-HJKMNP-TV-Z]{26}$'"
+        },
+        "grading_job_status_allowed": {
+          "name": "grading_job_status_allowed",
+          "value": "\"grading_job\".\"status\" in ('pending', 'claimed', 'graded', 'abandoned')"
+        },
+        "grading_job_source_allowed": {
+          "name": "grading_job_source_allowed",
+          "value": "\"grading_job\".\"source\" in ('simulation', 'production')"
+        },
+        "grading_job_source_names_its_conversation": {
+          "name": "grading_job_source_names_its_conversation",
+          "value": "case \"grading_job\".\"source\"\n        when 'simulation' then \"grading_job\".\"simulation_id\" is not null and \"grading_job\".\"trace_id\" is null\n        when 'production' then \"grading_job\".\"trace_id\" is not null and \"grading_job\".\"simulation_id\" is null\n        else false\n      end"
+        },
+        "grading_job_production_carries_its_trace_times": {
+          "name": "grading_job_production_carries_its_trace_times",
+          "value": "(\"grading_job\".\"source\" = 'production') = (\"grading_job\".\"first_span_at\" is not null\n        and \"grading_job\".\"last_span_at\" is not null\n        and \"grading_job\".\"last_seen_at\" is not null)"
+        },
+        "grading_job_only_a_trace_closes_a_root": {
+          "name": "grading_job_only_a_trace_closes_a_root",
+          "value": "\"grading_job\".\"root_closed_at\" is null or \"grading_job\".\"source\" = 'production'"
+        },
+        "grading_job_trace_times_run_forwards": {
+          "name": "grading_job_trace_times_run_forwards",
+          "value": "\"grading_job\".\"first_span_at\" is null or \"grading_job\".\"first_span_at\" <= \"grading_job\".\"last_span_at\""
+        },
+        "grading_job_claim_columns_agree": {
+          "name": "grading_job_claim_columns_agree",
+          "value": "((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"claimed_by\" is null))\n        and ((\"grading_job\".\"claimed_at\" is null) = (\"grading_job\".\"heartbeat_at\" is null))"
+        },
+        "grading_job_pending_shape": {
+          "name": "grading_job_pending_shape",
+          "value": "\"grading_job\".\"status\" <> 'pending'\n        or (\"grading_job\".\"claimed_at\" is null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_claimed_shape": {
+          "name": "grading_job_claimed_shape",
+          "value": "\"grading_job\".\"status\" <> 'claimed'\n        or (\"grading_job\".\"claimed_at\" is not null and \"grading_job\".\"finished_at\" is null)"
+        },
+        "grading_job_finished_is_terminal": {
+          "name": "grading_job_finished_is_terminal",
+          "value": "(\"grading_job\".\"finished_at\" is null)\n        = (\"grading_job\".\"status\" not in ('graded', 'abandoned'))"
+        },
+        "grading_job_attempts_are_counted": {
+          "name": "grading_job_attempts_are_counted",
+          "value": "\"grading_job\".\"attempts\" >= 0"
+        },
+        "grading_job_only_outstanding_work_is_narrowed": {
+          "name": "grading_job_only_outstanding_work_is_narrowed",
+          "value": "\"grading_job\".\"regrade_grader_id\" is null\n        or \"grading_job\".\"status\" in ('pending', 'claimed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -264,7 +264,7 @@
     {
       "idx": 37,
       "version": "7",
-      "when": 1786995097828,
+      "when": 1786996356722,
       "tag": "0037_model_upgrade",
       "breakpoints": true
     }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -264,7 +264,7 @@
     {
       "idx": 37,
       "version": "7",
-      "when": 1786996356722,
+      "when": 1786997076792,
       "tag": "0037_model_upgrade",
       "breakpoints": true
     }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1786997076792,
       "tag": "0037_model_upgrade",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1787001011427,
+      "tag": "0038_upgrade_tracks_its_sources",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1786971693012,
       "tag": "0036_managed_model_access",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1786995097828,
+      "tag": "0037_model_upgrade",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -802,3 +802,51 @@ export {
 } from "./grading.ts";
 export type { GradingJobStatus, GradingSource } from "../schema/grading.ts";
 export type { Listening } from "../client.ts";
+
+/**
+ * The upgrade onto model selections, and what it left behind.
+ *
+ * `upgradeModelSetup` is the fifth deployment-configuring export, on
+ * `seedRunningGraders`' exact terms: it names no customer, takes no
+ * `AuthContext`, and runs in the same breath as the migrations because it
+ * finishes a change the release shipped. What it will not do is as important as
+ * what it does — it never invents a provider, never compares two secrets, and
+ * never copies deployment-wide configuration into more than one organization.
+ * Where the answer is ambiguous it writes an action instead, and those *are*
+ * customer-facing: `listModelUpgradeActions` and `listCredentialCandidates`
+ * take the context like every other read, and `activateCredentialCandidate` is
+ * the admin-only door that settles a provider with two stored keys.
+ *
+ * `readModelUpgradeCompletion` is the marker the later removal of the legacy
+ * paths is gated on. It writes nothing and takes nothing, because whether this
+ * *installation* has finished is a fact about the deployment rather than about
+ * anybody on it.
+ */
+export {
+  upgradeModelSetup,
+  type ModelUpgradeReport,
+} from "./model-upgrade.ts";
+export {
+  readModelUpgradeCompletion,
+  recordModelUpgradeCompletion,
+  UPGRADE_CONDITIONS,
+  type ModelUpgradeCompletion,
+  type UpgradeCondition,
+} from "./model-upgrade-completion.ts";
+export {
+  activateCredentialCandidate,
+  anythingOnTheLegacyPath,
+  listCredentialCandidates,
+  listModelUpgradeActions,
+  modelUpgradeOutstanding,
+  type CredentialCandidate,
+  type ModelUpgradeAction,
+} from "./model-upgrade-actions.ts";
+export type {
+  CredentialCandidateSource,
+  ModelUpgradeActionKind,
+} from "../schema/upgrade.ts";
+export {
+  CREDENTIAL_CANDIDATE_SOURCES,
+  MODEL_UPGRADE_ACTIONS,
+} from "../schema/upgrade.ts";

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -835,10 +835,8 @@ export {
 } from "./model-upgrade-completion.ts";
 export {
   activateCredentialCandidate,
-  anythingOnTheLegacyPath,
   listCredentialCandidates,
   listModelUpgradeActions,
-  modelUpgradeOutstanding,
   type CredentialCandidate,
   type ModelUpgradeAction,
 } from "./model-upgrade-actions.ts";

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -842,9 +842,11 @@ export {
 } from "./model-upgrade-actions.ts";
 export type {
   CredentialCandidateSource,
+  CredentialEnvelopeShape,
   ModelUpgradeActionKind,
 } from "../schema/upgrade.ts";
 export {
   CREDENTIAL_CANDIDATE_SOURCES,
+  CREDENTIAL_ENVELOPE_SHAPES,
   MODEL_UPGRADE_ACTIONS,
 } from "../schema/upgrade.ts";

--- a/packages/db/src/access/model-provider-credentials.ts
+++ b/packages/db/src/access/model-provider-credentials.ts
@@ -237,7 +237,18 @@ export async function storeModelProviderCredential(
       // check already did.
       const [rotated] = await tx
         .update(modelProviderCredential)
-        .set({ ...envelope, revision: newId("rev"), updatedAt: now })
+        .set({
+          ...envelope,
+          revision: newId("rev"),
+          // **Theirs from now on.** This row may have been written by the
+          // upgrade from a legacy key it found, and while that is true a
+          // rotation of that legacy row still reaches it. An administrator
+          // typing a key here is a later and better answer than any legacy row
+          // can offer, so the provenance is given up and nothing the upgrade
+          // does can touch this credential again.
+          upgradedFrom: null,
+          updatedAt: now,
+        })
         .where(eq(modelProviderCredential.id, existing.id))
         .returning(COLUMNS);
 

--- a/packages/db/src/access/model-upgrade-actions.ts
+++ b/packages/db/src/access/model-upgrade-actions.ts
@@ -1,0 +1,311 @@
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
+
+import { db } from "../client.ts";
+
+import { grader, graderVersion } from "../schema/graders.ts";
+import { modelProviderCredential } from "../schema/models.ts";
+import { persona, personaVersion } from "../schema/personas.ts";
+import {
+  modelCredentialCandidate,
+  modelUpgradeAction,
+  type CredentialCandidateSource,
+  type ModelUpgradeActionKind,
+} from "../schema/upgrade.ts";
+import { newId } from "@egma/ids";
+import { isModelProvider, type ModelProvider } from "../models/catalog.ts";
+import type { AuthContext } from "./context.ts";
+import { UnprocessableInputError } from "./errors.ts";
+import { authorize, here } from "./permissions.ts";
+import { within } from "./within.ts";
+
+/**
+ * What the upgrade left for an administrator, and the one thing they can do
+ * about a key it would not choose between.
+ *
+ * **These are visible because a silent compatibility path is a trap.** A
+ * persona that kept the legacy path still runs — that is the point of the
+ * compatibility period — so nothing about it looks broken until the release
+ * that removes the legacy path arrives and it stops. The action is what makes
+ * the choice visible while there is still time to make it, and it names the
+ * screen it is made on.
+ *
+ * **Nothing here can show a key.** A candidate answers its provider, where it
+ * was found, and four characters. Activating one moves a sealed envelope from
+ * one row to another without opening it, exactly as the upgrade itself does.
+ */
+
+/** One decision still outstanding, as a person reads it. */
+export type ModelUpgradeAction = {
+  readonly id: string;
+  readonly kind: ModelUpgradeActionKind;
+  /** The persona, grader, provider or organization it is about. */
+  readonly subject: string;
+  /** Egma's own sentence. Never a key, a hint, or anything a customer wrote. */
+  readonly detail: string;
+  readonly createdAt: Date;
+};
+
+/**
+ * The decisions this organization still has to make.
+ *
+ * **Filtered against what is true now rather than against the stamp.** An
+ * administrator who gives a persona its models has finished that action, and
+ * the list has to say so on the next read rather than at the next restart. The
+ * stamp is bookkeeping written by the boot act; this is the answer.
+ *
+ * Readable at every role, on the model access read's terms: what is missing is
+ * not a secret, and somebody who cannot fix it still has to be able to see why
+ * their run reported what it reported.
+ */
+export async function listModelUpgradeActions(
+  auth: AuthContext,
+): Promise<readonly ModelUpgradeAction[]> {
+  authorize(auth, "read", here(auth));
+
+  const rows = await db()
+    .select({
+      id: modelUpgradeAction.id,
+      kind: modelUpgradeAction.kind,
+      subject: modelUpgradeAction.subject,
+      detail: modelUpgradeAction.detail,
+      createdAt: modelUpgradeAction.createdAt,
+    })
+    .from(modelUpgradeAction)
+    .where(
+      and(
+        within(auth, modelUpgradeAction),
+        sql`case ${modelUpgradeAction.kind}
+              when 'select_persona_models' then exists (
+                select 1 from persona p
+                  join persona_version v on v.id = p.current_version_id
+                 where p.id = ${modelUpgradeAction.subject}
+                   and v.models is null)
+              when 'select_grader_model' then exists (
+                select 1 from grader g
+                  join grader_version gv on gv.id = g.current_version_id
+                 where g.id = ${modelUpgradeAction.subject}
+                   and g.type = 'llm_as_judge'
+                   and g.deleted_at is null and gv.grader_model is null)
+              when 'select_model_provider_credential' then not exists (
+                select 1 from model_provider_credential c
+                 where c.organization_id = ${modelUpgradeAction.organizationId}
+                   and c.provider = ${modelUpgradeAction.subject})
+              else exists (
+                select 1 from persona p
+                  join persona_version v on v.id = p.current_version_id
+                 where p.organization_id = ${modelUpgradeAction.organizationId}
+                   and v.models is null)
+                or exists (
+                select 1 from grader g
+                  join grader_version gv on gv.id = g.current_version_id
+                 where g.organization_id = ${modelUpgradeAction.organizationId}
+                   and g.type = 'llm_as_judge'
+                   and g.deleted_at is null and gv.grader_model is null)
+            end`,
+      ),
+    )
+    .orderBy(asc(modelUpgradeAction.createdAt), asc(modelUpgradeAction.id));
+
+  return rows.map((row) => ({
+    ...row,
+    kind: row.kind as ModelUpgradeActionKind,
+  }));
+}
+
+/** One legacy key the upgrade found, as a person choosing between two sees it. */
+export type CredentialCandidate = {
+  readonly id: string;
+  /** The provider account it authorizes, as the legacy row spelled it. */
+  readonly provider: string;
+  /** Which kind of legacy row it came from. */
+  readonly source: CredentialCandidateSource;
+  /** Which row exactly — the setting's name, the credential's label, a project. */
+  readonly sourceName: string;
+  /** The last characters of the key. Never enough of it to use. */
+  readonly hint: string;
+  /** Whether this is the key the organization is now using for that provider. */
+  readonly active: boolean;
+  /**
+   * Whether it *could* be. False for a provider this release's catalog does not
+   * carry — the key is kept and shown, because throwing it away would lose the
+   * only record that it was ever configured, but nothing can spend it.
+   */
+  readonly selectable: boolean;
+  readonly createdAt: Date;
+};
+
+/**
+ * Every legacy key the upgrade found for this organization.
+ *
+ * **Only an administrator**, on the row of the permission table that already
+ * names provider credentials: which of two accounts this organization's
+ * simulations spend from is that kind of decision.
+ */
+export async function listCredentialCandidates(
+  auth: AuthContext,
+): Promise<readonly CredentialCandidate[]> {
+  authorize(auth, "manage_organization", here(auth));
+
+  const rows = await db()
+    .select({
+      id: modelCredentialCandidate.id,
+      provider: modelCredentialCandidate.provider,
+      source: modelCredentialCandidate.source,
+      sourceName: modelCredentialCandidate.sourceName,
+      hint: modelCredentialCandidate.credentialsHint,
+      activatedAt: modelCredentialCandidate.activatedAt,
+      createdAt: modelCredentialCandidate.createdAt,
+    })
+    .from(modelCredentialCandidate)
+    .where(within(auth, modelCredentialCandidate))
+    .orderBy(
+      asc(modelCredentialCandidate.provider),
+      asc(modelCredentialCandidate.id),
+    );
+
+  return rows.map((row) => ({
+    id: row.id,
+    provider: row.provider,
+    source: row.source as CredentialCandidateSource,
+    sourceName: row.sourceName,
+    hint: row.hint,
+    active: row.activatedAt !== null,
+    selectable: isModelProvider(row.provider),
+    createdAt: row.createdAt,
+  }));
+}
+
+/**
+ * Make one candidate this organization's active credential for its provider.
+ *
+ * **The envelope moves sealed and nothing is opened.** The stored key becomes
+ * the organization's key for that provider from the next claim onwards — which
+ * is ordinary rotation, and it mints no persona or grader version, because a
+ * credential is operational state and never authored behavior.
+ *
+ * **A provider this release does not carry is refused by name.** There is no
+ * credential row it could become, and storing one would be Egma holding a
+ * secret for an account nothing can spend from.
+ */
+export async function activateCredentialCandidate(
+  auth: AuthContext,
+  id: string,
+): Promise<{ readonly provider: ModelProvider; readonly hint: string }> {
+  authorize(auth, "manage_organization", here(auth));
+
+  return db().transaction(async (tx) => {
+    const [candidate] = await tx
+      .select({
+        id: modelCredentialCandidate.id,
+        provider: modelCredentialCandidate.provider,
+        credentials: modelCredentialCandidate.credentials,
+        hint: modelCredentialCandidate.credentialsHint,
+      })
+      .from(modelCredentialCandidate)
+      .where(
+        and(
+          within(auth, modelCredentialCandidate),
+          eq(modelCredentialCandidate.id, id),
+        ),
+      )
+      .limit(1);
+
+    if (candidate === undefined) {
+      throw new UnprocessableInputError(
+        "that is not a stored key this organization was offered a choice between",
+      );
+    }
+    if (!isModelProvider(candidate.provider)) {
+      throw new UnprocessableInputError(
+        `${candidate.provider} is not a provider in this release's model catalog, so its stored key cannot be used. Store a key for a provider this release carries instead.`,
+      );
+    }
+
+    const now = new Date();
+    await tx
+      .insert(modelProviderCredential)
+      .values({
+        id: newId("mpc"),
+        organizationId: auth.organizationId,
+        provider: candidate.provider,
+        credentials: candidate.credentials,
+        credentialsHint: candidate.hint,
+        revision: newId("rev"),
+        createdBy: auth.userId,
+      })
+      .onConflictDoUpdate({
+        target: [
+          modelProviderCredential.organizationId,
+          modelProviderCredential.provider,
+        ],
+        set: {
+          credentials: candidate.credentials,
+          credentialsHint: candidate.hint,
+          revision: newId("rev"),
+          updatedAt: now,
+        },
+      });
+
+    // Exactly one candidate per provider is the active one, so choosing this
+    // one un-chooses the other. Two rows both stamped active would be two
+    // answers to "which key is this organization spending".
+    await tx
+      .update(modelCredentialCandidate)
+      .set({ activatedAt: null })
+      .where(
+        and(
+          within(auth, modelCredentialCandidate),
+          eq(modelCredentialCandidate.provider, candidate.provider),
+        ),
+      );
+    await tx
+      .update(modelCredentialCandidate)
+      .set({ activatedAt: now })
+      .where(eq(modelCredentialCandidate.id, candidate.id));
+
+    return { provider: candidate.provider, hint: candidate.hint };
+  });
+}
+
+/**
+ * Whether this organization still has anything on the legacy path at all — the
+ * one-line answer a settings screen draws a banner from.
+ *
+ * Deliberately a count of live facts rather than of action rows: an
+ * organization that never needed an action has none, and an organization whose
+ * personas were all given selections this morning has stale ones.
+ */
+export async function modelUpgradeOutstanding(auth: AuthContext): Promise<number> {
+  authorize(auth, "read", here(auth));
+  return (await listModelUpgradeActions(auth)).length;
+}
+
+/** Whether a persona or grader of this organization is still on the old path. */
+export async function anythingOnTheLegacyPath(auth: AuthContext): Promise<boolean> {
+  authorize(auth, "read", here(auth));
+
+  const [waiting] = await db()
+    .select({ found: sql<number>`1` })
+    .from(persona)
+    .innerJoin(personaVersion, eq(persona.currentVersionId, personaVersion.id))
+    .where(
+      and(within(auth, persona), isNull(personaVersion.models)),
+    )
+    .limit(1);
+  if (waiting !== undefined) return true;
+
+  const [judged] = await db()
+    .select({ found: sql<number>`1` })
+    .from(grader)
+    .innerJoin(graderVersion, eq(grader.currentVersionId, graderVersion.id))
+    .where(
+      and(
+        within(auth, grader),
+        eq(grader.type, "llm_as_judge"),
+        isNull(grader.deletedAt),
+        isNull(graderVersion.graderModel),
+      ),
+    )
+    .limit(1);
+  return judged !== undefined;
+}

--- a/packages/db/src/access/model-upgrade-actions.ts
+++ b/packages/db/src/access/model-upgrade-actions.ts
@@ -11,6 +11,7 @@ import {
 } from "../schema/upgrade.ts";
 import { newId } from "@egma/ids";
 import { isModelProvider, type ModelProvider } from "../models/catalog.ts";
+import { asACredential } from "./model-upgrade.ts";
 import type { AuthContext } from "./context.ts";
 import { UnprocessableInputError } from "./errors.ts";
 import { authorize, here } from "./permissions.ts";
@@ -198,6 +199,7 @@ export async function activateCredentialCandidate(
         provider: modelCredentialCandidate.provider,
         credentials: modelCredentialCandidate.credentials,
         hint: modelCredentialCandidate.credentialsHint,
+        shape: modelCredentialCandidate.shape,
       })
       .from(modelCredentialCandidate)
       .where(
@@ -226,7 +228,7 @@ export async function activateCredentialCandidate(
         id: newId("mpc"),
         organizationId: auth.organizationId,
         provider: candidate.provider,
-        credentials: candidate.credentials,
+        credentials: asACredential(candidate),
         credentialsHint: candidate.hint,
         revision: newId("rev"),
         createdBy: auth.userId,
@@ -237,7 +239,7 @@ export async function activateCredentialCandidate(
           modelProviderCredential.provider,
         ],
         set: {
-          credentials: candidate.credentials,
+          credentials: asACredential(candidate),
           credentialsHint: candidate.hint,
           revision: newId("rev"),
           updatedAt: now,

--- a/packages/db/src/access/model-upgrade-actions.ts
+++ b/packages/db/src/access/model-upgrade-actions.ts
@@ -39,6 +39,17 @@ export type ModelUpgradeAction = {
   readonly kind: ModelUpgradeActionKind;
   /** The persona, grader, provider or organization it is about. */
   readonly subject: string;
+  /**
+   * What that subject is called, as a person knows it: the persona's or
+   * grader's own name, the provider's word, or null for an action about the
+   * organization itself.
+   *
+   * **Read live rather than stored.** Two personas both blocked is the ordinary
+   * case, and an identifier is not something anybody can tell them apart by; a
+   * *stored* name would go stale the first time somebody renamed one, so a list
+   * meant to be acted on would name a persona that no longer exists.
+   */
+  readonly subjectName: string | null;
   /** Egma's own sentence. Never a key, a hint, or anything a customer wrote. */
   readonly detail: string;
   readonly createdAt: Date;
@@ -66,6 +77,14 @@ export async function listModelUpgradeActions(
       id: modelUpgradeAction.id,
       kind: modelUpgradeAction.kind,
       subject: modelUpgradeAction.subject,
+      subjectName: sql<string | null>`case ${modelUpgradeAction.kind}
+          when 'select_persona_models'
+            then (select p.name from persona p where p.id = ${modelUpgradeAction.subject})
+          when 'select_grader_model'
+            then (select g.name from grader g where g.id = ${modelUpgradeAction.subject})
+          when 'select_model_provider_credential' then ${modelUpgradeAction.subject}
+          else null
+        end`,
       detail: modelUpgradeAction.detail,
       createdAt: modelUpgradeAction.createdAt,
     })

--- a/packages/db/src/access/model-upgrade-actions.ts
+++ b/packages/db/src/access/model-upgrade-actions.ts
@@ -1,10 +1,8 @@
-import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 
 import { db } from "../client.ts";
 
-import { grader, graderVersion } from "../schema/graders.ts";
 import { modelProviderCredential } from "../schema/models.ts";
-import { persona, personaVersion } from "../schema/personas.ts";
 import {
   modelCredentialCandidate,
   modelUpgradeAction,
@@ -265,47 +263,4 @@ export async function activateCredentialCandidate(
 
     return { provider: candidate.provider, hint: candidate.hint };
   });
-}
-
-/**
- * Whether this organization still has anything on the legacy path at all — the
- * one-line answer a settings screen draws a banner from.
- *
- * Deliberately a count of live facts rather than of action rows: an
- * organization that never needed an action has none, and an organization whose
- * personas were all given selections this morning has stale ones.
- */
-export async function modelUpgradeOutstanding(auth: AuthContext): Promise<number> {
-  authorize(auth, "read", here(auth));
-  return (await listModelUpgradeActions(auth)).length;
-}
-
-/** Whether a persona or grader of this organization is still on the old path. */
-export async function anythingOnTheLegacyPath(auth: AuthContext): Promise<boolean> {
-  authorize(auth, "read", here(auth));
-
-  const [waiting] = await db()
-    .select({ found: sql<number>`1` })
-    .from(persona)
-    .innerJoin(personaVersion, eq(persona.currentVersionId, personaVersion.id))
-    .where(
-      and(within(auth, persona), isNull(personaVersion.models)),
-    )
-    .limit(1);
-  if (waiting !== undefined) return true;
-
-  const [judged] = await db()
-    .select({ found: sql<number>`1` })
-    .from(grader)
-    .innerJoin(graderVersion, eq(grader.currentVersionId, graderVersion.id))
-    .where(
-      and(
-        within(auth, grader),
-        eq(grader.type, "llm_as_judge"),
-        isNull(grader.deletedAt),
-        isNull(graderVersion.graderModel),
-      ),
-    )
-    .limit(1);
-  return judged !== undefined;
 }

--- a/packages/db/src/access/model-upgrade-actions.ts
+++ b/packages/db/src/access/model-upgrade-actions.ts
@@ -240,6 +240,11 @@ export async function activateCredentialCandidate(
       );
     }
 
+    // Opened once, here, and checked on the way through — so a stored key that
+    // will not open is refused at the moment somebody chooses it rather than at
+    // the first simulation that selects its provider.
+    const envelope = asACredential(candidate);
+
     const now = new Date();
     await tx
       .insert(modelProviderCredential)
@@ -247,9 +252,15 @@ export async function activateCredentialCandidate(
         id: newId("mpc"),
         organizationId: auth.organizationId,
         provider: candidate.provider,
-        credentials: asACredential(candidate),
+        credentials: envelope,
         credentialsHint: candidate.hint,
         revision: newId("rev"),
+        // What they chose is *this stored key*, so the credential goes on
+        // tracking it: rotating that legacy row at its source is a rotation of
+        // the thing they picked, and reaches the next claim. Typing a key into
+        // the form beside this is the other decision, and that one gives the
+        // provenance up.
+        upgradedFrom: candidate.id,
         createdBy: auth.userId,
       })
       .onConflictDoUpdate({
@@ -258,9 +269,10 @@ export async function activateCredentialCandidate(
           modelProviderCredential.provider,
         ],
         set: {
-          credentials: asACredential(candidate),
+          credentials: envelope,
           credentialsHint: candidate.hint,
           revision: newId("rev"),
+          upgradedFrom: candidate.id,
           updatedAt: now,
         },
       });

--- a/packages/db/src/access/model-upgrade-completion.ts
+++ b/packages/db/src/access/model-upgrade-completion.ts
@@ -237,6 +237,15 @@ export async function recordModelUpgradeCompletion(): Promise<ModelUpgradeComple
    * is seen and the stamp is refused, and work committed after it began was not
    * yet true at the moment the stamp names. Either way the timestamp is honest.
    *
+   * **`statement_timestamp()` rather than `now()`, and the difference is the
+   * whole point of the sentence above.** In Postgres `now()` is the
+   * *transaction's* start, and this transaction waits on an advisory lock
+   * before its update runs — so `now()` would stamp a moment before the
+   * predicate that justifies it was ever evaluated, by however long the wait
+   * lasted. Seconds, in practice. But this is a permanent record that a later
+   * release and an operator both read as "everything was clear at this time",
+   * and a record must not name a moment before its own evidence.
+   *
    * The advisory lock is the upgrade act's own, so a boot's upgrade and the
    * marker that follows it cannot interleave with another replica's.
    */
@@ -247,7 +256,7 @@ export async function recordModelUpgradeCompletion(): Promise<ModelUpgradeComple
 
     const { rows } = (await tx.execute(sql`
       update platform_instance
-         set model_upgrade_completed_at = now()
+         set model_upgrade_completed_at = statement_timestamp()
        where singleton
          and model_upgrade_completed_at is null
          and not ${CONDITIONS.personas}

--- a/packages/db/src/access/model-upgrade-completion.ts
+++ b/packages/db/src/access/model-upgrade-completion.ts
@@ -1,7 +1,8 @@
-import { sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 import { db } from "../client.ts";
-import { modelUpgradeCompletion } from "../schema/upgrade.ts";
+import { platformInstance } from "../schema/platform.ts";
+import { platformInstanceId } from "./instance.ts";
 
 /**
  * Whether this installation has finished moving onto model selections — the one
@@ -100,10 +101,18 @@ async function outstandingConditions(): Promise<readonly UpgradeCondition[]> {
   return UPGRADE_CONDITIONS.filter((condition) => answer[condition] === true);
 }
 
+/**
+ * The stamp as it stands, read off the row that means "this installation".
+ *
+ * A missing row is a missing marker rather than a fault: an installation that
+ * has never answered its own identity has never been asked anything, so it has
+ * certainly not finished.
+ */
 async function storedMarker(): Promise<Date | null> {
   const [row] = await db()
-    .select({ completedAt: modelUpgradeCompletion.completedAt })
-    .from(modelUpgradeCompletion)
+    .select({ completedAt: platformInstance.modelUpgradeCompletedAt })
+    .from(platformInstance)
+    .where(eq(platformInstance.singleton, true))
     .limit(1);
   return row?.completedAt ?? null;
 }
@@ -151,14 +160,28 @@ export async function recordModelUpgradeCompletion(): Promise<ModelUpgradeComple
     return { completed: false, completedAt: null, outstanding };
   }
 
+  // The identity row is minted here if this installation has never answered its
+  // own identity, which is the ordinary state of a deployment whose public
+  // route nobody has called yet.
+  await platformInstanceId();
+
+  const now = new Date();
   const [written] = await db()
-    .insert(modelUpgradeCompletion)
-    .values({ singleton: true, completedAt: new Date() })
-    .onConflictDoNothing({ target: modelUpgradeCompletion.singleton })
-    .returning({ completedAt: modelUpgradeCompletion.completedAt });
+    .update(platformInstance)
+    .set({ modelUpgradeCompletedAt: now })
+    .where(
+      and(
+        eq(platformInstance.singleton, true),
+        isNull(platformInstance.modelUpgradeCompletedAt),
+      ),
+    )
+    .returning({ completedAt: platformInstance.modelUpgradeCompletedAt });
 
   return {
     completed: true,
+    // The row a concurrent boot stamped first, where this update matched
+    // nothing: two replicas finishing together settle on one moment rather than
+    // on whichever wrote last.
     completedAt: written?.completedAt ?? (await storedMarker()),
     outstanding: [],
   };

--- a/packages/db/src/access/model-upgrade-completion.ts
+++ b/packages/db/src/access/model-upgrade-completion.ts
@@ -1,8 +1,9 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { db } from "../client.ts";
 import { platformInstance } from "../schema/platform.ts";
 import { platformInstanceId } from "./instance.ts";
+import { UPGRADING_MODEL_SETUP } from "./model-upgrade.ts";
 
 /**
  * Whether this installation has finished moving onto model selections — the one
@@ -93,43 +94,59 @@ export type ModelUpgradeCompletion = {
   readonly outstanding: readonly UpgradeCondition[];
 };
 
+/**
+ * The four conditions, as one SQL expression each.
+ *
+ * **Written once and used twice**: to *report* what is standing, and — inside
+ * the very statement that writes the stamp — to decide whether it may be
+ * written at all. A second copy of these predicates is a second thing that can
+ * disagree with the one that actually gates the marker, and the one that gates
+ * it is the one that matters.
+ */
+const CONDITIONS = {
+  personas: sql`exists (
+    select 1 from persona p
+      join persona_version v on v.id = p.current_version_id
+     where v.models is null
+  )`,
+  graders: sql`exists (
+    select 1 from grader g
+      join grader_version gv on gv.id = g.current_version_id
+     where g.type = 'llm_as_judge'
+       and g.deleted_at is null and gv.grader_model is null
+  )`,
+  simulations: sql`exists (
+    select 1 from simulation s
+      join persona_version v on v.id = s.persona_version_id
+     where s.status in ('queued', 'claimed', 'running') and v.models is null
+  )`,
+  grading: sql`exists (
+    select 1 from grading_job j
+      join simulation s on s.id = j.simulation_id
+      join grading_plan p on p.run_id = s.run_id
+     where j.status in ('pending', 'claimed')
+       and (
+         jsonb_array_length(p.judge_credential_ids) > 0
+         or exists (
+           select 1
+             from jsonb_array_elements(p.groups) as grp
+             cross join lateral jsonb_array_elements(grp->'items') as item
+             join grader_version gv on gv.id = item->>'graderVersionId'
+            where item->'judge'->>'tag' = 'configured'
+              and gv.grader_model is null
+         )
+       )
+  )`,
+} as const satisfies Record<UpgradeCondition, unknown>;
+
 /** Whether each condition still has work behind it. */
 async function outstandingConditions(): Promise<readonly UpgradeCondition[]> {
   const { rows } = (await db().execute(sql`
     select
-      exists (
-        select 1 from persona p
-          join persona_version v on v.id = p.current_version_id
-         where v.models is null
-      ) as personas,
-      exists (
-        select 1 from grader g
-          join grader_version gv on gv.id = g.current_version_id
-         where g.type = 'llm_as_judge'
-           and g.deleted_at is null and gv.grader_model is null
-      ) as graders,
-      exists (
-        select 1 from simulation s
-          join persona_version v on v.id = s.persona_version_id
-         where s.status in ('queued', 'claimed', 'running') and v.models is null
-      ) as simulations,
-      exists (
-        select 1 from grading_job j
-          join simulation s on s.id = j.simulation_id
-          join grading_plan p on p.run_id = s.run_id
-         where j.status in ('pending', 'claimed')
-           and (
-             jsonb_array_length(p.judge_credential_ids) > 0
-             or exists (
-               select 1
-                 from jsonb_array_elements(p.groups) as grp
-                 cross join lateral jsonb_array_elements(grp->'items') as item
-                 join grader_version gv on gv.id = item->>'graderVersionId'
-                where item->'judge'->>'tag' = 'configured'
-                  and gv.grader_model is null
-             )
-           )
-      ) as grading
+      ${CONDITIONS.personas} as personas,
+      ${CONDITIONS.graders} as graders,
+      ${CONDITIONS.simulations} as simulations,
+      ${CONDITIONS.grading} as grading
   `)) as unknown as { rows: readonly Record<string, boolean>[] };
 
   const [answer] = rows;
@@ -203,24 +220,72 @@ export async function recordModelUpgradeCompletion(): Promise<ModelUpgradeComple
   // route nobody has called yet.
   await platformInstanceId();
 
-  const now = new Date();
-  const [written] = await db()
-    .update(platformInstance)
-    .set({ modelUpgradeCompletedAt: now })
-    .where(
-      and(
-        eq(platformInstance.singleton, true),
-        isNull(platformInstance.modelUpgradeCompletedAt),
-      ),
-    )
-    .returning({ completedAt: platformInstance.modelUpgradeCompletedAt });
+  /**
+   * The conditions and the stamp, decided by **one statement**.
+   *
+   * **A read followed by a write is two moments, and the stamp is a permanent
+   * record of one.** Another replica serving this database can commit a
+   * selection-free persona between them — ordinary authoring, still legal for
+   * the whole compatibility period — and the timestamp would then memorialise a
+   * state that never simultaneously held. Nothing is *stranded* by that,
+   * because every read re-evaluates and the cleanup release is required to as
+   * well; but a permanent record of a moment that never happened is still
+   * wrong, and it is a record operators and a later release read.
+   *
+   * So the conditions are re-asserted in the `where` of the update that writes
+   * the stamp. One statement takes one snapshot: work committed before it began
+   * is seen and the stamp is refused, and work committed after it began was not
+   * yet true at the moment the stamp names. Either way the timestamp is honest.
+   *
+   * The advisory lock is the upgrade act's own, so a boot's upgrade and the
+   * marker that follows it cannot interleave with another replica's.
+   */
+  return db().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${UPGRADING_MODEL_SETUP}::text, 0))`,
+    );
 
-  return {
-    completed: true,
-    // The row a concurrent boot stamped first, where this update matched
-    // nothing: two replicas finishing together settle on one moment rather than
-    // on whichever wrote last.
-    completedAt: written?.completedAt ?? (await storedMarker()),
-    outstanding: [],
-  };
+    const { rows } = (await tx.execute(sql`
+      update platform_instance
+         set model_upgrade_completed_at = now()
+       where singleton
+         and model_upgrade_completed_at is null
+         and not ${CONDITIONS.personas}
+         and not ${CONDITIONS.graders}
+         and not ${CONDITIONS.simulations}
+         and not ${CONDITIONS.grading}
+      returning model_upgrade_completed_at
+    `)) as unknown as {
+      // A raw statement, so the driver hands back what Postgres wrote rather
+      // than what a typed column read would have parsed. Read as a string and
+      // turned into the moment it names, once, here.
+      rows: readonly { model_upgrade_completed_at: string }[];
+    };
+
+    const [stamped] = rows;
+    if (stamped !== undefined) {
+      return {
+        completed: true,
+        completedAt: new Date(stamped.model_upgrade_completed_at),
+        outstanding: [],
+      };
+    }
+
+    // Nothing was written, and there are two ways that happens: a concurrent
+    // boot stamped it first, or a condition stopped holding between the report
+    // above and this statement. Reading both back says which, and neither is a
+    // fault.
+    const [row] = await tx
+      .select({ completedAt: platformInstance.modelUpgradeCompletedAt })
+      .from(platformInstance)
+      .where(eq(platformInstance.singleton, true))
+      .limit(1);
+    const settled = row?.completedAt ?? null;
+    const standing = await outstandingConditions();
+    return {
+      completed: settled !== null && standing.length === 0,
+      completedAt: settled,
+      outstanding: standing,
+    };
+  });
 }

--- a/packages/db/src/access/model-upgrade-completion.ts
+++ b/packages/db/src/access/model-upgrade-completion.ts
@@ -1,0 +1,165 @@
+import { sql } from "drizzle-orm";
+
+import { db } from "../client.ts";
+import { modelUpgradeCompletion } from "../schema/upgrade.ts";
+
+/**
+ * Whether this installation has finished moving onto model selections — the one
+ * fact the later removal of the legacy paths is allowed to act on.
+ *
+ * **It is a marker rather than a release number, and that is the whole point.**
+ * A release cannot know whether a particular deployment's personas have all
+ * been given selections, whether somebody's queued simulation is still waiting
+ * on the old work-order contract, or whether an old grading plan still has a
+ * judge credential to resolve. Only the installation knows, and it can only
+ * know by asking. So the conditions are re-asked on every boot and the stamp is
+ * written the first time they all hold.
+ *
+ * **Written once, never withdrawn.** Nothing writes a legacy-shaped row any
+ * more, so a deployment that finished cannot un-finish; a marker that could
+ * flip back would be one no cleanup could safely read.
+ *
+ * **This file builds the marker and the checks that read it. It removes
+ * nothing.** Taking the legacy paths out is the next release's work, and doing
+ * any of it here would be removing them before the marker they are gated on
+ * could ever have been written.
+ */
+
+/**
+ * What is still standing between this installation and the removal.
+ *
+ * Each word names one condition, and the four together are the ticket's own
+ * sentence: every current persona and grader has explicit models, and no
+ * nonterminal work depends on a legacy contract or a legacy credential
+ * reference.
+ */
+export const UPGRADE_CONDITIONS = [
+  /** Some current persona version still carries no selections. */
+  "personas",
+  /** Some current grader version still carries no selection. */
+  "graders",
+  /**
+   * Some simulation that has not finished is pinned to a persona version with
+   * no selections — which is a work order on the old simulation contract, still
+   * to be claimed or still being conducted.
+   */
+  "simulations",
+  /**
+   * Some grading job that has not finished belongs to a run whose frozen plan
+   * names a judge credential — the legacy credential reference, still to be
+   * resolved.
+   */
+  "grading",
+] as const;
+export type UpgradeCondition = (typeof UPGRADE_CONDITIONS)[number];
+
+export type ModelUpgradeCompletion = {
+  /** Whether the marker is written. */
+  readonly completed: boolean;
+  /** When it was written, or null while it is not. */
+  readonly completedAt: Date | null;
+  /**
+   * What is still outstanding, in the order above. Empty exactly when the
+   * marker is written — and it is what a person reading a drain check needs,
+   * because "not finished" with nothing after it sends somebody looking.
+   */
+  readonly outstanding: readonly UpgradeCondition[];
+};
+
+/** Whether each condition still has work behind it. */
+async function outstandingConditions(): Promise<readonly UpgradeCondition[]> {
+  const { rows } = (await db().execute(sql`
+    select
+      exists (
+        select 1 from persona p
+          join persona_version v on v.id = p.current_version_id
+         where v.models is null
+      ) as personas,
+      exists (
+        select 1 from grader g
+          join grader_version gv on gv.id = g.current_version_id
+         where g.type = 'llm_as_judge'
+           and g.deleted_at is null and gv.grader_model is null
+      ) as graders,
+      exists (
+        select 1 from simulation s
+          join persona_version v on v.id = s.persona_version_id
+         where s.status in ('queued', 'claimed', 'running') and v.models is null
+      ) as simulations,
+      exists (
+        select 1 from grading_job j
+          join simulation s on s.id = j.simulation_id
+          join grading_plan p on p.run_id = s.run_id
+         where j.status in ('pending', 'claimed')
+           and jsonb_array_length(p.judge_credential_ids) > 0
+      ) as grading
+  `)) as unknown as { rows: readonly Record<string, boolean>[] };
+
+  const [answer] = rows;
+  if (answer === undefined) throw new Error("the upgrade conditions answered nothing");
+  return UPGRADE_CONDITIONS.filter((condition) => answer[condition] === true);
+}
+
+async function storedMarker(): Promise<Date | null> {
+  const [row] = await db()
+    .select({ completedAt: modelUpgradeCompletion.completedAt })
+    .from(modelUpgradeCompletion)
+    .limit(1);
+  return row?.completedAt ?? null;
+}
+
+/**
+ * The marker as it stands, and what is outstanding while it is not written.
+ *
+ * **The read a drain check makes.** It asks nothing of the caller and writes
+ * nothing, so it is safe from any process and at any moment — including from a
+ * worker deciding whether it is still obliged to speak the old contract.
+ *
+ * Not authorized against an `AuthContext`, on `seedRunningGraders`' terms:
+ * there is no customer here. Whether this deployment has finished an upgrade is
+ * a fact about the deployment, it spans every organization on it, and there is
+ * no organization a caller could name.
+ */
+export async function readModelUpgradeCompletion(): Promise<ModelUpgradeCompletion> {
+  const completedAt = await storedMarker();
+  if (completedAt !== null) {
+    return { completed: true, completedAt, outstanding: [] };
+  }
+  return {
+    completed: false,
+    completedAt: null,
+    outstanding: await outstandingConditions(),
+  };
+}
+
+/**
+ * Write the marker if — and only if — every condition holds.
+ *
+ * Called on boot, after the upgrade itself, so a deployment whose last legacy
+ * persona was given selections this morning is marked complete at its next
+ * restart rather than never. Idempotent: the row is one row and a second write
+ * conflicts with itself and does nothing.
+ */
+export async function recordModelUpgradeCompletion(): Promise<ModelUpgradeCompletion> {
+  const completedAt = await storedMarker();
+  if (completedAt !== null) {
+    return { completed: true, completedAt, outstanding: [] };
+  }
+
+  const outstanding = await outstandingConditions();
+  if (outstanding.length > 0) {
+    return { completed: false, completedAt: null, outstanding };
+  }
+
+  const [written] = await db()
+    .insert(modelUpgradeCompletion)
+    .values({ singleton: true, completedAt: new Date() })
+    .onConflictDoNothing({ target: modelUpgradeCompletion.singleton })
+    .returning({ completedAt: modelUpgradeCompletion.completedAt });
+
+  return {
+    completed: true,
+    completedAt: written?.completedAt ?? (await storedMarker()),
+    outstanding: [],
+  };
+}

--- a/packages/db/src/access/model-upgrade-completion.ts
+++ b/packages/db/src/access/model-upgrade-completion.ts
@@ -16,9 +16,14 @@ import { platformInstanceId } from "./instance.ts";
  * know by asking. So the conditions are re-asked on every boot and the stamp is
  * written the first time they all hold.
  *
- * **Written once, never withdrawn.** Nothing writes a legacy-shaped row any
- * more, so a deployment that finished cannot un-finish; a marker that could
- * flip back would be one no cleanup could safely read.
+ * **The stamp is written once and never withdrawn, and it is not a
+ * permission.** It records the first moment every condition held. During the
+ * compatibility period the ordinary authoring doors still write personas and
+ * graders with no selections, so a stamped installation can legitimately go
+ * back to having outstanding work — which is why the read below re-evaluates
+ * every condition on every call and answers `completed` from that, never from
+ * the stamp. Anything deciding whether a legacy path may be removed must ask
+ * this door and act on its answer, not on the presence of a timestamp.
  *
  * **This file builds the marker and the checks that read it. It removes
  * nothing.** Taking the legacy paths out is the next release's work, and doing
@@ -46,18 +51,39 @@ export const UPGRADE_CONDITIONS = [
    */
   "simulations",
   /**
-   * Some grading job that has not finished belongs to a run whose frozen plan
-   * names a judge credential — the legacy credential reference, still to be
-   * resolved.
+   * Some grading job that has not finished still resolves through the legacy
+   * judge path — either its run's frozen plan names a judge credential, or the
+   * plan pins a grader version that carries no selection of its own and will
+   * therefore ask the project's judge configuration when it runs.
+   *
+   * **Both halves, and the second is the one that is easy to miss.** A plan
+   * judged by the *deployment's* own judge names no credential at all — the
+   * plan stores the `platform` sentinel rather than an id, so the credential
+   * index is empty — and a marker that only read that index would declare a
+   * deployment finished while grading jobs were still queued behind exactly
+   * the configuration the next release removes.
    */
   "grading",
 ] as const;
 export type UpgradeCondition = (typeof UPGRADE_CONDITIONS)[number];
 
 export type ModelUpgradeCompletion = {
-  /** Whether the marker is written. */
+  /**
+   * Whether the conditions hold **now**, evaluated freshly on every read.
+   *
+   * **Never read off the stamp, and that is the whole rule.** The stamp says
+   * when the conditions first held; it does not say they still do. During the
+   * compatibility period the ordinary authoring doors can still write a persona
+   * or a grader with no selections — that is what makes the period a period —
+   * so a stamped installation can legitimately acquire new legacy-shaped work
+   * the day after it was stamped. Anything that acts on this must ask, not
+   * remember.
+   */
   readonly completed: boolean;
-  /** When it was written, or null while it is not. */
+  /**
+   * When the conditions were first all true, or null while they never have
+   * been. It is a record of a moment and never a permission.
+   */
   readonly completedAt: Date | null;
   /**
    * What is still outstanding, in the order above. Empty exactly when the
@@ -92,7 +118,17 @@ async function outstandingConditions(): Promise<readonly UpgradeCondition[]> {
           join simulation s on s.id = j.simulation_id
           join grading_plan p on p.run_id = s.run_id
          where j.status in ('pending', 'claimed')
-           and jsonb_array_length(p.judge_credential_ids) > 0
+           and (
+             jsonb_array_length(p.judge_credential_ids) > 0
+             or exists (
+               select 1
+                 from jsonb_array_elements(p.groups) as grp
+                 cross join lateral jsonb_array_elements(grp->'items') as item
+                 join grader_version gv on gv.id = item->>'graderVersionId'
+                where item->'judge'->>'tag' = 'configured'
+                  and gv.grader_model is null
+             )
+           )
       ) as grading
   `)) as unknown as { rows: readonly Record<string, boolean>[] };
 
@@ -130,15 +166,15 @@ async function storedMarker(): Promise<Date | null> {
  * no organization a caller could name.
  */
 export async function readModelUpgradeCompletion(): Promise<ModelUpgradeCompletion> {
-  const completedAt = await storedMarker();
-  if (completedAt !== null) {
-    return { completed: true, completedAt, outstanding: [] };
-  }
-  return {
-    completed: false,
-    completedAt: null,
-    outstanding: await outstandingConditions(),
-  };
+  // Both, always, and in that order: the conditions as they are now, and the
+  // moment they first held. A read that short-circuited on the stamp would be
+  // the one thing this type's own documentation forbids.
+  const [outstanding, completedAt] = await Promise.all([
+    outstandingConditions(),
+    storedMarker(),
+  ]);
+
+  return { completed: outstanding.length === 0, completedAt, outstanding };
 }
 
 /**
@@ -150,14 +186,16 @@ export async function readModelUpgradeCompletion(): Promise<ModelUpgradeCompleti
  * conflicts with itself and does nothing.
  */
 export async function recordModelUpgradeCompletion(): Promise<ModelUpgradeCompletion> {
+  const outstanding = await outstandingConditions();
   const completedAt = await storedMarker();
+
+  if (outstanding.length > 0) {
+    // Stamped already and no longer clear: the stamp stays, because it records
+    // a moment that really happened, and the answer says what is standing now.
+    return { completed: false, completedAt, outstanding };
+  }
   if (completedAt !== null) {
     return { completed: true, completedAt, outstanding: [] };
-  }
-
-  const outstanding = await outstandingConditions();
-  if (outstanding.length > 0) {
-    return { completed: false, completedAt: null, outstanding };
   }
 
   // The identity row is minted here if this installation has never answered its

--- a/packages/db/src/access/model-upgrade.ts
+++ b/packages/db/src/access/model-upgrade.ts
@@ -1,0 +1,946 @@
+import { newId } from "@egma/ids";
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import { db, type Transaction } from "../client.ts";
+import { managedDeployment } from "../managed-deployment.ts";
+import {
+  isModelProvider,
+  PROVIDERS_BY_JOB,
+  type ModelJob,
+  type ModelProvider,
+} from "../models/catalog.ts";
+import type {
+  GraderModel,
+  PersonaModels,
+  SpeechSelection,
+} from "../models/selections.ts";
+import { newRevision } from "../revisions.ts";
+import { grader, graderVersion, judgeConfiguration, judgeCredential } from "../schema/graders.ts";
+import { modelAccess, modelProviderCredential } from "../schema/models.ts";
+import { persona, personaVersion } from "../schema/personas.ts";
+import { platformSetting, type PlatformSettingName } from "../schema/platform.ts";
+import { organization, project } from "../schema/tenancy.ts";
+import {
+  modelCredentialCandidate,
+  modelUpgradeAction,
+  type CredentialCandidateSource,
+  type ModelUpgradeActionKind,
+} from "../schema/upgrade.ts";
+import type { DeploymentTenancy } from "./platform-settings.ts";
+import { traitsFromRow } from "./personas.ts";
+
+/**
+ * The upgrade that moves an installation configured before the model catalog
+ * existed onto explicit persona and grader selections — additively, without
+ * rewriting one line of history.
+ *
+ * **It is a boot act rather than a statement in a migration file, and the
+ * reason is what it has to do.** It copies sealed envelopes between tables,
+ * mints persona and grader versions through the same rules an edit does, reads
+ * a persona's own voice against a deployment-wide speaking provider, and writes
+ * sentences a person has to be able to act on. None of that is SQL anybody
+ * could test a case at a time, and all of it has to be idempotent because a
+ * deployment runs it on every start.
+ *
+ * **The whole of what it will not do is as important as what it does.** It
+ * never invents a provider, a model, a voice or a speed. It never compares two
+ * secrets to decide they are the same key. It never copies a deployment-wide
+ * key or selection into more than one organization. Where the answer is not
+ * unambiguous it writes an *action* — one sentence naming what an administrator
+ * has to choose — and leaves the legacy path working exactly as it was.
+ *
+ * **Nothing here is a cleanup.** Every legacy row stays: the deployment's own
+ * settings, the judge credentials, the project judge configurations, the old
+ * versions and the old work orders. That is what makes the compatibility period
+ * real, and removing them is the next release's job, gated on the completion
+ * marker this file also writes.
+ */
+
+/**
+ * What the upgrade did, for the boot log. Identifiers and provider names only —
+ * no key, no hint, and nothing a customer authored.
+ */
+export type ModelUpgradeReport = {
+  /** Organizations a hosted deployment wrote managed access for. */
+  readonly managedAccess: readonly string[];
+  /** Legacy keys copied in as candidates, by their new `mcc_` ids. */
+  readonly candidates: readonly string[];
+  /** Providers whose sole candidate became the active credential. */
+  readonly activated: readonly string[];
+  /** Personas given an explicit successor version. */
+  readonly personas: readonly string[];
+  /** Graders given an explicit successor version. */
+  readonly graders: readonly string[];
+  /** Decisions left for an administrator, as kind and subject. */
+  readonly actions: readonly {
+    readonly kind: ModelUpgradeActionKind;
+    readonly subject: string;
+  }[];
+};
+
+/**
+ * What this act is locked on: this deployment, and nothing narrower.
+ *
+ * `seedRunningGraders`' lock, for its reason. The reads that decide what to
+ * write span every organization, persona and grader, so two replicas holding
+ * two finer locks would still both read "nothing has been upgraded" and both
+ * write.
+ */
+const UPGRADING_MODEL_SETUP = "egma:upgrade-model-setup";
+
+/**
+ * The one grader type that asks a model at all.
+ *
+ * A `code` grader computes its answer and speaks to nobody, so it has no legacy
+ * judge to move across and nothing an explicit selection would decide. Leaving
+ * it out is what keeps the completion marker reachable on a deployment whose
+ * latency graders would otherwise wait forever for a model they never use.
+ */
+const JUDGED = "llm_as_judge";
+
+/**
+ * Which catalog provider a legacy word means, where this release carries one.
+ *
+ * **A map rather than a guess, and the absences are the interesting half.**
+ *
+ * - `openai_realtime` is the transport this release's OpenAI listening entry
+ *   *is*, so a deployment on it moves across unchanged.
+ * - Legacy `openai` **listening** is the segmented `audio/transcriptions`
+ *   endpoint, which this release deliberately does not ship — the catalog
+ *   carries the realtime socket instead, and the two take different model ids.
+ *   Moving one to the other would be a substitution nobody asked for, arriving
+ *   as a provider refusal on somebody's first simulation. So it is absent, and
+ *   a persona on it keeps the legacy path and gets an action.
+ * - `elevenlabs` speaking is not in this release's catalog at all. Deferred
+ *   rather than cancelled — and until it returns, a persona on it keeps the
+ *   legacy path and gets an action saying so. No substitute is chosen: another
+ *   company's voice is not this persona's voice.
+ * - `scripted` is the deterministic test provider. It is not an account
+ *   anybody holds and it is not selectable from the catalog, so it cannot be
+ *   migrated into one.
+ */
+const CATALOG_PROVIDER: Readonly<Record<ModelJob, Readonly<Record<string, ModelProvider>>>> = {
+  llm: { openai: "openai" },
+  stt: { deepgram: "deepgram", openai_realtime: "openai" },
+  tts: { cartesia: "cartesia", openai: "openai" },
+};
+
+/** The provider a legacy word names for this job, or `undefined`. */
+function catalogProviderFor(job: ModelJob, legacy: string): ModelProvider | undefined {
+  const mapped = CATALOG_PROVIDER[job][legacy];
+  if (mapped === undefined) return undefined;
+  // Belt and braces: the map is release data and the catalog is release data,
+  // and a pair that fell out of one but not the other must not become visible.
+  return PROVIDERS_BY_JOB[job].some((entry) => entry.provider === mapped)
+    ? mapped
+    : undefined;
+}
+
+/**
+ * Where each legacy key lives, and which model job's provider setting names the
+ * account it belongs to.
+ *
+ * The judge's keys are not here because they are not deployment settings — they
+ * are collected from their own tables below.
+ */
+const SETTING_KEYS: readonly {
+  readonly key: PlatformSettingName;
+  readonly provider: PlatformSettingName;
+  readonly job: ModelJob;
+}[] = [
+  { key: "persona_model_key", provider: "persona_model_provider", job: "llm" },
+  { key: "speech_to_text_key", provider: "speech_to_text_provider", job: "stt" },
+  { key: "text_to_speech_key", provider: "text_to_speech_provider", job: "tts" },
+];
+
+/** The settings this upgrade reads, by name, with their stored hints. */
+type Settings = ReadonlyMap<string, { readonly value: string; readonly hint: string }>;
+
+/**
+ * A non-secret setting's whole value, read off its hint.
+ *
+ * **The hint *is* the value for anything that is not a secret**, which the
+ * platform settings table says in as many words, so a provider name, a model id
+ * and a voice id are all readable without opening one envelope. That is worth
+ * saying out loud: this upgrade never unseals anything, including the values it
+ * copies, and it could not compare two keys even if it wanted to.
+ */
+function plain(settings: Settings, name: PlatformSettingName): string | undefined {
+  const held = settings.get(name)?.hint.trim();
+  return held === undefined || held === "" ? undefined : held;
+}
+
+export async function upgradeModelSetup(
+  deployment: DeploymentTenancy,
+): Promise<ModelUpgradeReport> {
+  return db().transaction(async (tx) => {
+    // Taken before anything is read, so the replica that arrives second waits
+    // here and then finds every decision already made.
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${UPGRADING_MODEL_SETUP}::text, 0))`,
+    );
+
+    const organizations = await tx
+      .select({ id: organization.id })
+      .from(organization)
+      .orderBy(organization.id);
+
+    const managed = await grantHostedManagedAccess(tx, organizations);
+
+    /**
+     * Whether deployment-wide configuration may be copied into an organization
+     * at all.
+     *
+     * **Both halves, and the second is not redundant.** The flag is what the
+     * deployment declares itself to be; the count is what is actually in the
+     * database. A deployment left on the single-organization flag that has
+     * somehow grown a second organization must not copy one team's provider key
+     * into another team's — so the count decides, and the flag alone never
+     * does.
+     */
+    const single =
+      deployment.singleOrganization && organizations.length === 1
+        ? organizations[0]?.id
+        : undefined;
+
+    if (single === undefined) {
+      const actions = await noticeEveryOrganization(tx, organizations);
+      await settleFinishedActions(tx);
+      return {
+        managedAccess: managed,
+        candidates: [],
+        activated: [],
+        personas: [],
+        graders: [],
+        actions,
+      };
+    }
+
+    const settings = await readSettings(tx);
+    const collected = await collectCandidates(tx, single, settings);
+    const chosen = await activateSoleCandidates(tx, single);
+    const personas = await upgradePersonas(tx, single, settings);
+    const graders = await upgradeGraders(tx, single);
+
+    await settleFinishedActions(tx);
+
+    return {
+      managedAccess: managed,
+      candidates: collected,
+      activated: chosen.activated,
+      personas: personas.upgraded,
+      graders: graders.upgraded,
+      actions: [...chosen.actions, ...personas.actions, ...graders.actions],
+    };
+  });
+}
+
+/**
+ * On hosted Egma, give every organization that has never chosen the access its
+ * deployment operates.
+ *
+ * **Who pays is the deployment's own policy, and this is the one thing about it
+ * that was left half-applied.** Hosted Egma already writes `managed` on every
+ * organization it provisions, so an organization created the day before this
+ * release reads `customer-owned` while the one created the day after reads
+ * `managed` — two answers to a question the deployment, not the customer,
+ * decides. It matters beyond tidiness: the mandatory grading backfill seeds a
+ * hosted project's expected-behaviors copy with the release's proved model, and
+ * a project whose organization reads `customer-owned` would resolve that
+ * selection against a credential nobody stored and write `errored` verdicts for
+ * it.
+ *
+ * **It copies no secret and no model selection**, so it is not the backfill the
+ * specification forbids across several organizations: nothing deployment-wide
+ * moves into anybody's rows, and every persona and grader keeps exactly the
+ * selections it had.
+ *
+ * **Nothing happens on a self-hosted deployment**, which has no provider
+ * accounts of Egma's to spend and must connect an inference key first. And
+ * nothing happens on a hosted deployment that has not been switched on: the
+ * hosted flag is unset in production, so this is inert there until a human
+ * turns managed access on.
+ */
+async function grantHostedManagedAccess(
+  tx: Transaction,
+  organizations: readonly { readonly id: string }[],
+): Promise<readonly string[]> {
+  if (!managedDeployment().hosted) return [];
+  if (organizations.length === 0) return [];
+
+  const written = await tx
+    .insert(modelAccess)
+    .values(
+      organizations.map((one) => ({
+        organizationId: one.id,
+        mode: "managed" as const,
+        // Nobody: the deployment decided this, and no administrator asked.
+        updatedBy: null,
+      })),
+    )
+    // An organization that has chosen keeps its choice — including one that
+    // deliberately chose customer-owned on hosted Egma.
+    .onConflictDoNothing({ target: modelAccess.organizationId })
+    .returning({ id: modelAccess.organizationId });
+
+  return written.map((row) => row.id);
+}
+
+/**
+ * The visible action for every organization on a deployment that copies nothing
+ * into it.
+ *
+ * A deployment serving several customers holds one set of model settings and
+ * one platform judge key, and there is no organization they belong to. So
+ * nothing is backfilled, existing work stays on the compatibility path, and
+ * each organization whose personas or graders still lack selections is told —
+ * once — that it has to choose.
+ */
+async function noticeEveryOrganization(
+  tx: Transaction,
+  organizations: readonly { readonly id: string }[],
+): Promise<readonly { readonly kind: ModelUpgradeActionKind; readonly subject: string }[]> {
+  const written: { kind: ModelUpgradeActionKind; subject: string }[] = [];
+  for (const one of organizations) {
+    if (!(await stillOnTheLegacyPath(tx, one.id))) continue;
+    await recordAction(tx, one.id, "set_up_model_access", one.id, [
+      "This deployment serves several organizations, so Egma copied no",
+      "deployment-wide provider key or model choice into this one. Choose",
+      "Managed by Egma, or add this organization's own provider credentials,",
+      "and select the models for its personas and graders.",
+    ].join(" "));
+    written.push({ kind: "set_up_model_access", subject: one.id });
+  }
+  return written;
+}
+
+async function stillOnTheLegacyPath(
+  tx: Transaction,
+  organizationId: string,
+): Promise<boolean> {
+  const [row] = await tx
+    .select({ found: sql<number>`1` })
+    .from(persona)
+    .innerJoin(personaVersion, eq(persona.currentVersionId, personaVersion.id))
+    .where(
+      and(
+        eq(persona.organizationId, organizationId),
+        isNull(personaVersion.models),
+      ),
+    )
+    .limit(1);
+  if (row !== undefined) return true;
+
+  const [judged] = await tx
+    .select({ found: sql<number>`1` })
+    .from(grader)
+    .innerJoin(graderVersion, eq(grader.currentVersionId, graderVersion.id))
+    .where(
+      and(
+        eq(grader.organizationId, organizationId),
+        eq(grader.type, JUDGED),
+        isNull(grader.deletedAt),
+        isNull(graderVersion.graderModel),
+      ),
+    )
+    .limit(1);
+  return judged !== undefined;
+}
+
+async function readSettings(tx: Transaction): Promise<Settings> {
+  const rows = await tx
+    .select({
+      name: platformSetting.name,
+      value: platformSetting.value,
+      hint: platformSetting.hint,
+    })
+    .from(platformSetting);
+  return new Map(rows.map((row) => [row.name, { value: row.value, hint: row.hint }]));
+}
+
+/**
+ * Every place a legacy provider key could be, copied here sealed.
+ *
+ * **Three sources, and the specification names all three**: the deployment's
+ * own model, listening and speaking keys; the organization's judge credentials;
+ * and a project judge configuration that still *owns* a key rather than
+ * pointing at one. A configuration that points at a judge credential is not a
+ * fourth source — the credential it points at is already the second — and
+ * treating it as one would manufacture a second candidate for a provider that
+ * really has one, which is exactly the arithmetic that decides whether anything
+ * activates.
+ *
+ * **The envelope is copied byte for byte and nothing is opened.** That is what
+ * keeps the old references working through the compatibility period, and it is
+ * why this can run with no ability to tell two keys apart.
+ */
+async function collectCandidates(
+  tx: Transaction,
+  organizationId: string,
+  settings: Settings,
+): Promise<readonly string[]> {
+  const found: {
+    provider: string;
+    source: CredentialCandidateSource;
+    sourceName: string;
+    credentials: string;
+    credentialsHint: string;
+  }[] = [];
+
+  for (const { key, provider, job } of SETTING_KEYS) {
+    const sealed = settings.get(key);
+    const named = plain(settings, provider);
+    if (sealed === undefined || named === undefined) continue;
+    found.push({
+      // The catalog's word where this release carries the pair, and the legacy
+      // word where it does not. Recording the legacy word rather than dropping
+      // the row keeps the key findable — by an administrator today, and by the
+      // release that adds that provider back.
+      provider: catalogProviderFor(job, named) ?? named,
+      source: "platform_setting",
+      sourceName: key,
+      credentials: sealed.value,
+      credentialsHint: sealed.hint,
+    });
+  }
+
+  const credentials = await tx
+    .select({
+      label: judgeCredential.label,
+      provider: judgeCredential.provider,
+      credentials: judgeCredential.credentials,
+      hint: judgeCredential.credentialsHint,
+    })
+    .from(judgeCredential)
+    .where(
+      and(
+        eq(judgeCredential.organizationId, organizationId),
+        isNull(judgeCredential.archivedAt),
+      ),
+    )
+    .orderBy(judgeCredential.label);
+  for (const row of credentials) {
+    found.push({
+      provider: catalogProviderFor("llm", row.provider) ?? row.provider,
+      source: "judge_credential",
+      sourceName: row.label,
+      credentials: row.credentials,
+      credentialsHint: row.hint,
+    });
+  }
+
+  const platformJudges = await tx
+    .select({
+      projectId: judgeConfiguration.projectId,
+      provider: judgeConfiguration.provider,
+      credentials: judgeConfiguration.credentials,
+      hint: judgeConfiguration.credentialsHint,
+    })
+    .from(judgeConfiguration)
+    .where(
+      and(
+        eq(judgeConfiguration.organizationId, organizationId),
+        eq(judgeConfiguration.source, "platform"),
+      ),
+    )
+    .orderBy(judgeConfiguration.projectId);
+  for (const row of platformJudges) {
+    if (row.credentials === null) continue;
+    found.push({
+      provider: catalogProviderFor("llm", row.provider) ?? row.provider,
+      source: "judge_configuration",
+      sourceName: row.projectId,
+      credentials: row.credentials,
+      credentialsHint: row.hint ?? "",
+    });
+  }
+
+  if (found.length === 0) return [];
+
+  const written = await tx
+    .insert(modelCredentialCandidate)
+    .values(
+      found.map((one) => ({
+        id: newId("mcc"),
+        organizationId,
+        provider: one.provider,
+        source: one.source,
+        sourceName: one.sourceName,
+        credentials: one.credentials,
+        credentialsHint: one.credentialsHint,
+      })),
+    )
+    // The source is the identity, so a second run over the same deployment
+    // writes nothing — and a key rotated in its original row is not a new
+    // candidate, because it is the same source.
+    .onConflictDoNothing({
+      target: [
+        modelCredentialCandidate.organizationId,
+        modelCredentialCandidate.provider,
+        modelCredentialCandidate.source,
+        modelCredentialCandidate.sourceName,
+      ],
+    })
+    .returning({ id: modelCredentialCandidate.id });
+
+  return written.map((row) => row.id);
+}
+
+/**
+ * A provider with exactly one candidate gets that key as the organization's
+ * active credential. A provider with two gets an action instead.
+ *
+ * **The rule is a count and never a comparison.** Two sources holding the same
+ * key are two candidates here, because deciding they were one would mean
+ * reading a plaintext, a ciphertext or a hint as evidence of equality, and none
+ * of the three is evidence of anything: two envelopes of one key differ, two
+ * hints of two different keys can match, and the plaintext is not a thing this
+ * upgrade may open. So Egma counts, and where it cannot be sure it asks.
+ *
+ * **A credential an administrator already stored is never overwritten.** They
+ * chose it after this release shipped, which is a later and better answer than
+ * anything a legacy row can offer.
+ */
+async function activateSoleCandidates(
+  tx: Transaction,
+  organizationId: string,
+): Promise<{
+  readonly activated: readonly string[];
+  readonly actions: readonly { readonly kind: ModelUpgradeActionKind; readonly subject: string }[];
+}> {
+  const candidates = await tx
+    .select({
+      id: modelCredentialCandidate.id,
+      provider: modelCredentialCandidate.provider,
+      credentials: modelCredentialCandidate.credentials,
+      hint: modelCredentialCandidate.credentialsHint,
+    })
+    .from(modelCredentialCandidate)
+    .where(eq(modelCredentialCandidate.organizationId, organizationId))
+    .orderBy(modelCredentialCandidate.id);
+
+  const byProvider = new Map<string, typeof candidates>();
+  for (const one of candidates) {
+    byProvider.set(one.provider, [...(byProvider.get(one.provider) ?? []), one]);
+  }
+
+  const activated: string[] = [];
+  const actions: { kind: ModelUpgradeActionKind; subject: string }[] = [];
+
+  for (const [provider, forProvider] of [...byProvider].sort()) {
+    // A provider this release does not carry cannot be activated and cannot be
+    // chosen between: there is no credential row it could become. The personas
+    // and graders that named it get their own actions, which say what to do;
+    // a second one here would be a sentence with no button.
+    if (!isModelProvider(provider)) continue;
+
+    if (forProvider.length > 1) {
+      await recordAction(
+        tx,
+        organizationId,
+        "select_model_provider_credential",
+        provider,
+        `Egma found ${forProvider.length} stored ${provider} keys on this installation and cannot tell whether they are the same account, so none was activated. Choose which one this organization uses, or store a replacement, under Model providers.`,
+      );
+      actions.push({ kind: "select_model_provider_credential", subject: provider });
+      continue;
+    }
+
+    const [sole] = forProvider;
+    if (sole === undefined) continue;
+
+    const [written] = await tx
+      .insert(modelProviderCredential)
+      .values({
+        id: newId("mpc"),
+        organizationId,
+        provider,
+        credentials: sole.credentials,
+        credentialsHint: sole.hint,
+        revision: newId("rev"),
+        createdBy: null,
+      })
+      .onConflictDoNothing({
+        target: [
+          modelProviderCredential.organizationId,
+          modelProviderCredential.provider,
+        ],
+      })
+      .returning({ id: modelProviderCredential.id });
+
+    if (written === undefined) continue;
+
+    await tx
+      .update(modelCredentialCandidate)
+      .set({ activatedAt: new Date() })
+      .where(eq(modelCredentialCandidate.id, sole.id));
+    activated.push(provider);
+  }
+
+  return { activated, actions };
+}
+
+/** Why one persona could not be given an explicit successor. */
+type Blocked = { readonly blocked: string };
+
+function isBlocked(value: unknown): value is Blocked {
+  return typeof value === "object" && value !== null && "blocked" in value;
+}
+
+/**
+ * The three selections a persona's successor version carries, worked out from
+ * the deployment's settings and the persona's own voice — or the sentence
+ * saying why there is no unambiguous answer.
+ *
+ * **The voice precedence is the specification's, and the conflict case is the
+ * whole reason it is written down.** A persona's versioned voice is what that
+ * persona *sounds like*, so its provider, id and speed win outright. The
+ * deployment supplies a voice only where the persona has none. And where the
+ * persona's voice provider disagrees with the deployment's speaking provider,
+ * there is no answer that is not a guess — one of the two is about to change,
+ * and Egma is not the one who should decide which — so the persona keeps the
+ * legacy path and somebody chooses.
+ *
+ * **The legacy reasoning-effort setting is deliberately not read here.** It is
+ * not part of what a persona selects, and a successor carrying it would be a
+ * new version writing down a field this release retired.
+ */
+function selectionsFor(
+  settings: Settings,
+  voice: { readonly provider: string; readonly voiceId: string; readonly speed: number } | undefined,
+): PersonaModels | Blocked {
+  const llmProvider = plain(settings, "persona_model_provider");
+  const llmModel = plain(settings, "persona_model");
+  const sttProvider = plain(settings, "speech_to_text_provider");
+  const sttModel = plain(settings, "speech_to_text_model");
+  const ttsProvider = plain(settings, "text_to_speech_provider");
+  const ttsModel = plain(settings, "text_to_speech_model");
+
+  const missing = [
+    llmProvider === undefined ? "a model provider" : undefined,
+    llmModel === undefined ? "a model" : undefined,
+    sttProvider === undefined ? "a speech-to-text provider" : undefined,
+    sttModel === undefined ? "a speech-to-text model" : undefined,
+    ttsProvider === undefined ? "a text-to-speech provider" : undefined,
+    ttsModel === undefined ? "a text-to-speech model" : undefined,
+  ].filter((one): one is string => one !== undefined);
+  if (
+    llmProvider === undefined ||
+    llmModel === undefined ||
+    sttProvider === undefined ||
+    sttModel === undefined ||
+    ttsProvider === undefined ||
+    ttsModel === undefined
+  ) {
+    return {
+      blocked: `this deployment's settings name ${missing.join(", ")} nowhere, so Egma could not work out what this persona thinks, listens and speaks with. Select its models under Persona models.`,
+    };
+  }
+
+  const llm = catalogProviderFor("llm", llmProvider);
+  if (llm === undefined) return { blocked: notCarried("thinks with", llmProvider) };
+  const stt = catalogProviderFor("stt", sttProvider);
+  if (stt === undefined) return { blocked: notCarried("listens with", sttProvider) };
+
+  const speaking = voice?.provider ?? ttsProvider;
+  if (voice !== undefined && voice.provider !== ttsProvider) {
+    return {
+      blocked: `this persona's own voice is ${voice.provider} and this deployment speaks with ${ttsProvider}. Egma will not choose between them. Select this persona's text-to-speech provider, model and voice under Persona models.`,
+    };
+  }
+  const tts = catalogProviderFor("tts", speaking);
+  if (tts === undefined) return { blocked: notCarried("speaks with", speaking) };
+
+  const voiceId = voice?.voiceId ?? plain(settings, "text_to_speech_voice");
+  if (voiceId === undefined) {
+    return {
+      blocked:
+        "neither this persona nor this deployment names a voice for it to speak with, so Egma could not work one out. Select its text-to-speech voice under Persona models.",
+    };
+  }
+
+  const speech: SpeechSelection = {
+    provider: tts,
+    model: ttsModel,
+    voiceId,
+    // A persona that has said nothing about how fast it talks talks the way the
+    // voice does, which is what the selection's own default already means.
+    speed: voice?.speed ?? 1,
+  };
+
+  return {
+    llm: { provider: llm, model: llmModel },
+    stt: { provider: stt, model: sttModel },
+    tts: speech,
+  };
+}
+
+function notCarried(doing: string, provider: string): string {
+  return `this deployment ${doing} ${provider}, which is not a provider in this release's model catalog, so Egma will not choose a substitute for it. Select a provider this release carries under Persona models.`;
+}
+
+/**
+ * Every current persona still on the compatibility path, given one explicit
+ * successor version — or one sentence saying why it could not have one.
+ *
+ * **One new version, and the old ones are not touched.** A run that pinned last
+ * week's version keeps meaning what it meant, and the successor is the whole
+ * persona as the next simulation will meet it: the same traits, plus what it
+ * thinks, listens and speaks with, written down.
+ *
+ * **Only personas whose *current* version lacks selections**, which is what
+ * makes running this twice write nothing the second time: after the first run
+ * the current version has them, so the second finds nothing to do.
+ */
+async function upgradePersonas(
+  tx: Transaction,
+  organizationId: string,
+  settings: Settings,
+): Promise<{
+  readonly upgraded: readonly string[];
+  readonly actions: readonly { readonly kind: ModelUpgradeActionKind; readonly subject: string }[];
+}> {
+  const waiting = await tx
+    .select({
+      id: persona.id,
+      versionId: personaVersion.id,
+      version: personaVersion.version,
+      traits: personaVersion.traits,
+    })
+    .from(persona)
+    .innerJoin(personaVersion, eq(persona.currentVersionId, personaVersion.id))
+    .where(
+      and(
+        eq(persona.organizationId, organizationId),
+        isNull(personaVersion.models),
+      ),
+    )
+    .orderBy(persona.id);
+
+  const upgraded: string[] = [];
+  const actions: { kind: ModelUpgradeActionKind; subject: string }[] = [];
+
+  for (const one of waiting) {
+    const traits = traitsFromRow(one.traits, one.versionId);
+    const selections = selectionsFor(settings, traits.voice);
+    if (isBlocked(selections)) {
+      await recordAction(
+        tx,
+        organizationId,
+        "select_persona_models",
+        one.id,
+        selections.blocked,
+      );
+      actions.push({ kind: "select_persona_models", subject: one.id });
+      continue;
+    }
+
+    const versionId = newId("prsv");
+    await tx.insert(personaVersion).values({
+      id: versionId,
+      personaId: one.id,
+      version: one.version + 1,
+      // The traits verbatim, including the legacy voice fields. Nothing reads
+      // those once a version carries selections — the speaking selection is the
+      // one source — and rewriting them would be an upgrade editing content
+      // somebody wrote.
+      traits: one.traits,
+      models: selections,
+      // Nobody: Egma wrote this, and the persona's author did not ask for it.
+      createdBy: null,
+    });
+    await tx
+      .update(persona)
+      .set({ currentVersionId: versionId, revision: newRevision(), updatedAt: new Date() })
+      .where(eq(persona.id, one.id));
+    upgraded.push(one.id);
+  }
+
+  return { upgraded, actions };
+}
+
+/**
+ * Every current grader still on the compatibility path, given one explicit
+ * successor version — or one sentence saying why it could not have one.
+ *
+ * **The per-grader override wins.** A grader that named its own judge model
+ * said, in as many words, that the project's default was not the model it
+ * wanted; carrying the project's over it would silently change what that check
+ * is judged by. Where the grader named none, the project's judge configuration
+ * is what it was effectively running on, and that is what moves across.
+ *
+ * **The successor names no `judge_model`.** It carries a complete selection
+ * that is never overridden by anything, so keeping the old override beside it
+ * would be a field nothing reads on a version somebody has to interpret.
+ */
+async function upgradeGraders(
+  tx: Transaction,
+  organizationId: string,
+): Promise<{
+  readonly upgraded: readonly string[];
+  readonly actions: readonly { readonly kind: ModelUpgradeActionKind; readonly subject: string }[];
+}> {
+  const waiting = await tx
+    .select({
+      id: grader.id,
+      projectId: grader.projectId,
+      versionId: graderVersion.id,
+      version: graderVersion.version,
+      config: graderVersion.config,
+      judgeModel: graderVersion.judgeModel,
+      judgeProvider: judgeConfiguration.provider,
+      judgeConfigured: judgeConfiguration.model,
+    })
+    .from(grader)
+    .innerJoin(graderVersion, eq(grader.currentVersionId, graderVersion.id))
+    .leftJoin(judgeConfiguration, eq(grader.projectId, judgeConfiguration.projectId))
+    .where(
+      and(
+        eq(grader.organizationId, organizationId),
+        // A code grader asks no model, so a selection on it would decide
+        // nothing. It is not on a legacy path — it was never on a model path
+        // at all — so it neither gains a successor nor holds up the marker.
+        eq(grader.type, JUDGED),
+        isNull(grader.deletedAt),
+        isNull(graderVersion.graderModel),
+      ),
+    )
+    .orderBy(grader.id);
+
+  const upgraded: string[] = [];
+  const actions: { kind: ModelUpgradeActionKind; subject: string }[] = [];
+
+  for (const one of waiting) {
+    const override = overrideFrom(one.judgeModel);
+    const effective =
+      override ??
+      (one.judgeProvider === null || one.judgeConfigured === null
+        ? undefined
+        : { provider: one.judgeProvider, model: one.judgeConfigured });
+
+    if (effective === undefined) {
+      await recordAction(
+        tx,
+        organizationId,
+        "select_grader_model",
+        one.id,
+        "this grader names no model of its own and its project has no judge configured, so Egma could not work out what judges it. Select its model under Grader model.",
+      );
+      actions.push({ kind: "select_grader_model", subject: one.id });
+      continue;
+    }
+
+    const provider = catalogProviderFor("llm", effective.provider);
+    if (provider === undefined) {
+      await recordAction(
+        tx,
+        organizationId,
+        "select_grader_model",
+        one.id,
+        `this grader judges with ${effective.provider}, which is not a provider in this release's model catalog, so Egma will not choose a substitute for it. Select a provider this release carries under Grader model.`,
+      );
+      actions.push({ kind: "select_grader_model", subject: one.id });
+      continue;
+    }
+
+    const model: GraderModel = { provider, model: effective.model };
+    const versionId = newId("grv");
+    await tx.insert(graderVersion).values({
+      id: versionId,
+      graderId: one.id,
+      version: one.version + 1,
+      config: one.config,
+      judgeModel: null,
+      graderModel: model,
+      createdBy: null,
+    });
+    await tx
+      .update(grader)
+      .set({ currentVersionId: versionId, updatedAt: new Date() })
+      .where(eq(grader.id, one.id));
+    upgraded.push(one.id);
+  }
+
+  return { upgraded, actions };
+}
+
+/** The stored `judge_model` override, or nothing where the row holds none. */
+function overrideFrom(
+  value: unknown,
+): { readonly provider: string; readonly model: string } | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const held = value as Record<string, unknown>;
+  const { provider, model } = held;
+  return typeof provider === "string" && typeof model === "string"
+    ? { provider, model }
+    : undefined;
+}
+
+/**
+ * One decision left for an administrator, written once.
+ *
+ * Re-writing the same one refreshes its sentence and re-opens it if it had been
+ * settled, because a subject that has fallen back onto the legacy path really
+ * is outstanding again. The identity is the subject rather than the row, so the
+ * list does not grow every time a container starts.
+ */
+async function recordAction(
+  tx: Transaction,
+  organizationId: string,
+  kind: ModelUpgradeActionKind,
+  subject: string,
+  detail: string,
+): Promise<void> {
+  await tx
+    .insert(modelUpgradeAction)
+    .values({ id: newId("mua"), organizationId, kind, subject, detail })
+    .onConflictDoUpdate({
+      target: [
+        modelUpgradeAction.organizationId,
+        modelUpgradeAction.kind,
+        modelUpgradeAction.subject,
+      ],
+      set: { detail, resolvedAt: null, updatedAt: new Date() },
+    });
+}
+
+/**
+ * Stamp every action whose subject has since been settled.
+ *
+ * **The read that draws these filters live anyway**, so this is bookkeeping
+ * rather than correctness: it keeps the table from carrying rows about personas
+ * that were given their models months ago, and it is what a later reader uses
+ * to see that a decision was made rather than never needed.
+ */
+async function settleFinishedActions(tx: Transaction): Promise<void> {
+  await tx.execute(sql`
+    update model_upgrade_action as a
+       set resolved_at = now(), updated_at = now()
+     where a.resolved_at is null
+       and (
+         (a.kind = 'select_persona_models' and not exists (
+            select 1 from persona p
+              join persona_version v on v.id = p.current_version_id
+             where p.id = a.subject and v.models is null))
+      or (a.kind = 'select_grader_model' and not exists (
+            select 1 from grader g
+              join grader_version gv on gv.id = g.current_version_id
+             where g.id = a.subject and g.type = 'llm_as_judge'
+               and g.deleted_at is null and gv.grader_model is null))
+      or (a.kind = 'select_model_provider_credential' and exists (
+            select 1 from model_provider_credential c
+             where c.organization_id = a.organization_id and c.provider = a.subject))
+      or (a.kind = 'set_up_model_access' and not exists (
+            select 1 from persona p
+              join persona_version v on v.id = p.current_version_id
+             where p.organization_id = a.organization_id and v.models is null)
+          and not exists (
+            select 1 from grader g
+              join grader_version gv on gv.id = g.current_version_id
+             where g.organization_id = a.organization_id and g.type = 'llm_as_judge'
+               and g.deleted_at is null and gv.grader_model is null))
+       )
+  `);
+}

--- a/packages/db/src/access/model-upgrade.ts
+++ b/packages/db/src/access/model-upgrade.ts
@@ -24,8 +24,10 @@ import {
   modelCredentialCandidate,
   modelUpgradeAction,
   type CredentialCandidateSource,
+  type CredentialEnvelopeShape,
   type ModelUpgradeActionKind,
 } from "../schema/upgrade.ts";
+import { openCredentials, sealCredentials } from "../sealing.ts";
 import type { DeploymentTenancy } from "./platform-settings.ts";
 import { traitsFromRow } from "./personas.ts";
 
@@ -385,6 +387,7 @@ async function collectCandidates(
     sourceName: string;
     credentials: string;
     credentialsHint: string;
+    shape: CredentialEnvelopeShape;
   }[] = [];
 
   for (const { key, provider, job } of SETTING_KEYS) {
@@ -401,6 +404,9 @@ async function collectCandidates(
       sourceName: key,
       credentials: sealed.value,
       credentialsHint: sealed.hint,
+      // A platform setting seals the value itself. Recorded rather than
+      // converted, so nothing is opened while the keys are being collected.
+      shape: "bare_value",
     });
   }
 
@@ -426,6 +432,7 @@ async function collectCandidates(
       sourceName: row.label,
       credentials: row.credentials,
       credentialsHint: row.hint,
+      shape: "key_document",
     });
   }
 
@@ -452,6 +459,7 @@ async function collectCandidates(
       sourceName: row.projectId,
       credentials: row.credentials,
       credentialsHint: row.hint ?? "",
+      shape: "key_document",
     });
   }
 
@@ -468,6 +476,7 @@ async function collectCandidates(
         sourceName: one.sourceName,
         credentials: one.credentials,
         credentialsHint: one.credentialsHint,
+        shape: one.shape,
       })),
     )
     // The source is the identity, so a second run over the same deployment
@@ -514,6 +523,7 @@ async function activateSoleCandidates(
       provider: modelCredentialCandidate.provider,
       credentials: modelCredentialCandidate.credentials,
       hint: modelCredentialCandidate.credentialsHint,
+      shape: modelCredentialCandidate.shape,
     })
     .from(modelCredentialCandidate)
     .where(eq(modelCredentialCandidate.organizationId, organizationId))
@@ -555,7 +565,7 @@ async function activateSoleCandidates(
         id: newId("mpc"),
         organizationId,
         provider,
-        credentials: sole.credentials,
+        credentials: asACredential(sole),
         credentialsHint: sole.hint,
         revision: newId("rev"),
         createdBy: null,
@@ -578,6 +588,35 @@ async function activateSoleCandidates(
   }
 
   return { activated, actions };
+}
+
+/**
+ * One candidate's envelope, in the shape the credential store reads.
+ *
+ * **This is the one place the upgrade opens a secret, and it opens it to *use*
+ * it rather than to learn anything about it.** A credential sealed by the judge
+ * or credential stores already holds `{ key }` and is copied across untouched.
+ * A deployment setting seals the value itself, so becoming a credential means
+ * being written in the credential store's shape — which cannot be done without
+ * the plaintext, however briefly.
+ *
+ * Nothing is compared, nothing is logged, and nothing is returned: the
+ * plaintext exists for the length of one re-seal and the fresh envelope is what
+ * lands. Leaving the bare value in the credential column instead would put two
+ * shapes in one column and make every later reader guess which it had.
+ */
+export function asACredential(candidate: {
+  readonly credentials: string;
+  readonly shape: string;
+}): string {
+  if (candidate.shape === "key_document") return candidate.credentials;
+  const opened = openCredentials(candidate.credentials);
+  if (typeof opened !== "string" || opened === "") {
+    throw new Error(
+      "a stored deployment setting did not hold a value this upgrade could make a credential of; the row needs repairing before it can be used",
+    );
+  }
+  return sealCredentials({ key: opened });
 }
 
 /** Why one persona could not be given an explicit successor. */

--- a/packages/db/src/access/model-upgrade.ts
+++ b/packages/db/src/access/model-upgrade.ts
@@ -538,11 +538,29 @@ async function activateSoleCandidates(
   const actions: { kind: ModelUpgradeActionKind; subject: string }[] = [];
 
   for (const [provider, forProvider] of [...byProvider].sort()) {
-    // A provider this release does not carry cannot be activated and cannot be
-    // chosen between: there is no credential row it could become. The personas
-    // and graders that named it get their own actions, which say what to do;
-    // a second one here would be a sentence with no button.
-    if (!isModelProvider(provider)) continue;
+    /**
+     * A provider this release's catalog does not carry, and the reason this
+     * check is *after* the count rather than before it.
+     *
+     * There is no credential row such a key could become, so it cannot be
+     * activated and cannot be chosen between. But it was configured, it is
+     * still stored, and saying nothing about it is exactly the silence this
+     * whole section exists to break: the deployment would keep speaking through
+     * a provider the product no longer offers, and the only sign would be the
+     * persona actions naming it. So it gets an action of its own, naming the
+     * catalog, and the screen shows its key as kept and unusable.
+     */
+    if (!isModelProvider(provider)) {
+      await recordAction(
+        tx,
+        organizationId,
+        "select_model_provider_credential",
+        provider,
+        `This installation holds a stored ${provider} key, and ${provider} is not a provider in this release's model catalog — so Egma cannot use it and will not choose a substitute for it. Store a key for a provider this release carries under Model providers.`,
+      );
+      actions.push({ kind: "select_model_provider_credential", subject: provider });
+      continue;
+    }
 
     if (forProvider.length > 1) {
       await recordAction(
@@ -559,13 +577,37 @@ async function activateSoleCandidates(
     const [sole] = forProvider;
     if (sole === undefined) continue;
 
+    /**
+     * A stored key that will not open stops this provider and nothing else.
+     *
+     * The alternative is a boot that throws, and a deployment that will not
+     * start because one legacy row is corrupt is a worse answer than a
+     * deployment that starts and says which provider needs a key typed again.
+     * An administrator choosing a candidate by hand is told loudly instead —
+     * they asked about this exact key, so the refusal belongs in their answer.
+     */
+    let envelope: string;
+    try {
+      envelope = asACredential(sole);
+    } catch {
+      await recordAction(
+        tx,
+        organizationId,
+        "select_model_provider_credential",
+        provider,
+        `Egma could not read the stored ${provider} key it found on this installation, so nothing was activated for it. Store a ${provider} key again under Model providers.`,
+      );
+      actions.push({ kind: "select_model_provider_credential", subject: provider });
+      continue;
+    }
+
     const [written] = await tx
       .insert(modelProviderCredential)
       .values({
         id: newId("mpc"),
         organizationId,
         provider,
-        credentials: asACredential(sole),
+        credentials: envelope,
         credentialsHint: sole.hint,
         revision: newId("rev"),
         createdBy: null,
@@ -591,26 +633,49 @@ async function activateSoleCandidates(
 }
 
 /**
- * One candidate's envelope, in the shape the credential store reads.
+ * One candidate's envelope, in the shape the credential store reads — and
+ * checked, once, on the way through.
  *
  * **This is the one place the upgrade opens a secret, and it opens it to *use*
  * it rather than to learn anything about it.** A credential sealed by the judge
- * or credential stores already holds `{ key }` and is copied across untouched.
- * A deployment setting seals the value itself, so becoming a credential means
- * being written in the credential store's shape — which cannot be done without
- * the plaintext, however briefly.
+ * or credential stores already holds `{ key }` and is copied across untouched;
+ * a deployment setting seals the value itself, so becoming a credential means
+ * being written in the credential store's shape, which cannot be done without
+ * the plaintext however briefly.
  *
- * Nothing is compared, nothing is logged, and nothing is returned: the
- * plaintext exists for the length of one re-seal and the fresh envelope is what
- * lands. Leaving the bare value in the credential column instead would put two
- * shapes in one column and make every later reader guess which it had.
+ * **It opens both shapes, and that is deliberate rather than wasteful.** A
+ * `key_document` needs no conversion, but an envelope that will not open is a
+ * credential that fails at the first simulation that selects its provider —
+ * hours or days after somebody chose it, with a message about grading rather
+ * than about the choice they made. Opening it here moves that failure to the
+ * moment of the choice, where it can be answered.
+ *
+ * Opened exactly once. Nothing is compared, nothing is logged, and nothing is
+ * returned but the envelope: the plaintext exists for the length of one check
+ * and one re-seal.
  */
 export function asACredential(candidate: {
   readonly credentials: string;
   readonly shape: string;
 }): string {
-  if (candidate.shape === "key_document") return candidate.credentials;
   const opened = openCredentials(candidate.credentials);
+
+  if (candidate.shape === "key_document") {
+    const held =
+      typeof opened === "object" && opened !== null && !Array.isArray(opened)
+        ? (opened as Record<string, unknown>)["key"]
+        : undefined;
+    if (typeof held !== "string" || held === "") {
+      throw new Error(
+        "a stored credential did not hold a key this upgrade could make an organization credential of; the row needs repairing before it can be used",
+      );
+    }
+    // Unchanged, because it is already what the credential store reads. The
+    // open above was the check, and the envelope that lands is the one that was
+    // already there — so nothing is re-sealed and nothing moves.
+    return candidate.credentials;
+  }
+
   if (typeof opened !== "string" || opened === "") {
     throw new Error(
       "a stored deployment setting did not hold a value this upgrade could make a credential of; the row needs repairing before it can be used",
@@ -646,7 +711,18 @@ function isBlocked(value: unknown): value is Blocked {
  */
 function selectionsFor(
   settings: Settings,
-  voice: { readonly provider: string; readonly voiceId: string; readonly speed: number } | undefined,
+  /**
+   * The persona's own voice, which every persona has.
+   *
+   * **Required rather than optional, because the traits say so.** A version's
+   * `voice` is a written trait with a provider, an id and a speed, and the
+   * shape guard refuses a row without one — so a fallback to the deployment's
+   * voice here would be a branch nothing could reach, and an unreachable branch
+   * reads as a rule that exists. The specification's "the deployment supplies a
+   * voice only when the persona has none" is satisfied by there being no such
+   * persona.
+   */
+  voice: { readonly provider: string; readonly voiceId: string; readonly speed: number },
 ): PersonaModels | Blocked {
   const llmProvider = plain(settings, "persona_model_provider");
   const llmModel = plain(settings, "persona_model");
@@ -681,30 +757,21 @@ function selectionsFor(
   const stt = catalogProviderFor("stt", sttProvider);
   if (stt === undefined) return { blocked: notCarried("listens with", sttProvider) };
 
-  const speaking = voice?.provider ?? ttsProvider;
-  if (voice !== undefined && voice.provider !== ttsProvider) {
+  if (voice.provider !== ttsProvider) {
     return {
       blocked: `this persona's own voice is ${voice.provider} and this deployment speaks with ${ttsProvider}. Egma will not choose between them. Select this persona's text-to-speech provider, model and voice under Persona models.`,
     };
   }
-  const tts = catalogProviderFor("tts", speaking);
-  if (tts === undefined) return { blocked: notCarried("speaks with", speaking) };
+  const tts = catalogProviderFor("tts", voice.provider);
+  if (tts === undefined) return { blocked: notCarried("speaks with", voice.provider) };
 
-  const voiceId = voice?.voiceId ?? plain(settings, "text_to_speech_voice");
-  if (voiceId === undefined) {
-    return {
-      blocked:
-        "neither this persona nor this deployment names a voice for it to speak with, so Egma could not work one out. Select its text-to-speech voice under Persona models.",
-    };
-  }
-
+  // The persona's own voice and its own pace, which is the precedence written
+  // down: what a persona sounds like is the persona's, not the deployment's.
   const speech: SpeechSelection = {
     provider: tts,
     model: ttsModel,
-    voiceId,
-    // A persona that has said nothing about how fast it talks talks the way the
-    // voice does, which is what the selection's own default already means.
-    speed: voice?.speed ?? 1,
+    voiceId: voice.voiceId,
+    speed: voice.speed,
   };
 
   return {
@@ -942,6 +1009,18 @@ async function recordAction(
         modelUpgradeAction.subject,
       ],
       set: { detail, resolvedAt: null, updatedAt: new Date() },
+      /**
+       * Only where something really moved.
+       *
+       * **Without this the row is rewritten on every boot**, and a container
+       * that restarts twice an hour would carry an `updated_at` that says the
+       * decision arrived minutes ago and a `resolved_at` that was cleared for
+       * no reason. The timestamps are the only record of when Egma first asked
+       * and when somebody answered, and a write on every start makes both of
+       * them mean nothing.
+       */
+      setWhere: sql`${modelUpgradeAction.detail} <> ${detail}
+        or ${modelUpgradeAction.resolvedAt} is not null`,
     });
 }
 

--- a/packages/db/src/access/model-upgrade.ts
+++ b/packages/db/src/access/model-upgrade.ts
@@ -1,5 +1,5 @@
 import { newId } from "@egma/ids";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, sql } from "drizzle-orm";
 
 import { db, type Transaction } from "../client.ts";
 import { managedDeployment } from "../managed-deployment.ts";
@@ -88,7 +88,7 @@ export type ModelUpgradeReport = {
  * two finer locks would still both read "nothing has been upgraded" and both
  * write.
  */
-const UPGRADING_MODEL_SETUP = "egma:upgrade-model-setup";
+export const UPGRADING_MODEL_SETUP = "egma:upgrade-model-setup";
 
 /**
  * The one grader type that asks a model at all.
@@ -156,7 +156,10 @@ const SETTING_KEYS: readonly {
 ];
 
 /** The settings this upgrade reads, by name, with their stored hints. */
-type Settings = ReadonlyMap<string, { readonly value: string; readonly hint: string }>;
+type Settings = ReadonlyMap<
+  string,
+  { readonly value: string; readonly hint: string; readonly changedAt: Date }
+>;
 
 /**
  * A non-secret setting's whole value, read off its hint.
@@ -355,9 +358,15 @@ async function readSettings(tx: Transaction): Promise<Settings> {
       name: platformSetting.name,
       value: platformSetting.value,
       hint: platformSetting.hint,
+      changedAt: platformSetting.updatedAt,
     })
     .from(platformSetting);
-  return new Map(rows.map((row) => [row.name, { value: row.value, hint: row.hint }]));
+  return new Map(
+    rows.map((row) => [
+      row.name,
+      { value: row.value, hint: row.hint, changedAt: row.changedAt },
+    ]),
+  );
 }
 
 /**
@@ -388,6 +397,8 @@ async function collectCandidates(
     credentials: string;
     credentialsHint: string;
     shape: CredentialEnvelopeShape;
+    /** The source row's own `updated_at`, which is how a rotation is noticed. */
+    sourceChangedAt: Date;
   }[] = [];
 
   for (const { key, provider, job } of SETTING_KEYS) {
@@ -407,6 +418,7 @@ async function collectCandidates(
       // A platform setting seals the value itself. Recorded rather than
       // converted, so nothing is opened while the keys are being collected.
       shape: "bare_value",
+      sourceChangedAt: sealed.changedAt,
     });
   }
 
@@ -416,6 +428,7 @@ async function collectCandidates(
       provider: judgeCredential.provider,
       credentials: judgeCredential.credentials,
       hint: judgeCredential.credentialsHint,
+      changedAt: judgeCredential.updatedAt,
     })
     .from(judgeCredential)
     .where(
@@ -433,6 +446,7 @@ async function collectCandidates(
       credentials: row.credentials,
       credentialsHint: row.hint,
       shape: "key_document",
+      sourceChangedAt: row.changedAt,
     });
   }
 
@@ -442,6 +456,7 @@ async function collectCandidates(
       provider: judgeConfiguration.provider,
       credentials: judgeConfiguration.credentials,
       hint: judgeConfiguration.credentialsHint,
+      changedAt: judgeConfiguration.updatedAt,
     })
     .from(judgeConfiguration)
     .where(
@@ -460,6 +475,7 @@ async function collectCandidates(
       credentials: row.credentials,
       credentialsHint: row.hint ?? "",
       shape: "key_document",
+      sourceChangedAt: row.changedAt,
     });
   }
 
@@ -477,18 +493,39 @@ async function collectCandidates(
         credentials: one.credentials,
         credentialsHint: one.credentialsHint,
         shape: one.shape,
+        sourceChangedAt: one.sourceChangedAt,
       })),
     )
-    // The source is the identity, so a second run over the same deployment
-    // writes nothing — and a key rotated in its original row is not a new
-    // candidate, because it is the same source.
-    .onConflictDoNothing({
+    /**
+     * The source row is the identity, and the copy **tracks** it.
+     *
+     * A key rotated in its original row is not a new candidate — it is the same
+     * source saying something different — so the copy is refreshed rather than
+     * discarded. Discarding it was the fault: `writePlatformSettings` and
+     * `editJudgeCredential` are both open during the compatibility period, so
+     * an operator really can rotate one, and a copy frozen at the old value
+     * left this organization spending a key that had been revoked.
+     *
+     * **Guarded by the source's own clock and by nothing else.** No plaintext,
+     * no ciphertext, no hint: the source says when it last changed and the copy
+     * remembers when it was taken. Two seals of one key differ anyway, so a
+     * ciphertext comparison would answer "changed" every time and rewrite every
+     * row on every boot.
+     */
+    .onConflictDoUpdate({
       target: [
         modelCredentialCandidate.organizationId,
         modelCredentialCandidate.provider,
         modelCredentialCandidate.source,
         modelCredentialCandidate.sourceName,
       ],
+      set: {
+        credentials: sql`excluded.credentials`,
+        credentialsHint: sql`excluded.credentials_hint`,
+        shape: sql`excluded.shape`,
+        sourceChangedAt: sql`excluded.source_changed_at`,
+      },
+      setWhere: sql`${modelCredentialCandidate.sourceChangedAt} < excluded.source_changed_at`,
     })
     .returning({ id: modelCredentialCandidate.id });
 
@@ -524,6 +561,8 @@ async function activateSoleCandidates(
       credentials: modelCredentialCandidate.credentials,
       hint: modelCredentialCandidate.credentialsHint,
       shape: modelCredentialCandidate.shape,
+      sourceChangedAt: modelCredentialCandidate.sourceChangedAt,
+      activatedAt: modelCredentialCandidate.activatedAt,
     })
     .from(modelCredentialCandidate)
     .where(eq(modelCredentialCandidate.organizationId, organizationId))
@@ -536,6 +575,51 @@ async function activateSoleCandidates(
 
   const activated: string[] = [];
   const actions: { kind: ModelUpgradeActionKind; subject: string }[] = [];
+
+  /**
+   * A rotated source reaches the credential that is tracking it, whatever else
+   * is true of its provider.
+   *
+   * **Keyed on provenance and on nothing else**, which is what makes it safe to
+   * do before any of the rules below: the credential names the one candidate it
+   * follows, so a provider with two stored keys is not ambiguous here even
+   * though it is ambiguous for *activation*. A credential an administrator
+   * typed holds null and is unreachable from this statement.
+   *
+   * Guarded by when the source last moved, so a boot that rotated nothing
+   * leaves `updated_at` alone — a person reads it as "when the stored key last
+   * changed".
+   */
+  for (const candidate of candidates) {
+    if (candidate.activatedAt === null) continue;
+    if (!isModelProvider(candidate.provider)) continue;
+
+    let envelope: string;
+    try {
+      envelope = asACredential(candidate);
+    } catch {
+      continue;
+    }
+
+    const [rotated] = await tx
+      .update(modelProviderCredential)
+      .set({
+        credentials: envelope,
+        credentialsHint: candidate.hint,
+        revision: newId("rev"),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(modelProviderCredential.organizationId, organizationId),
+          eq(modelProviderCredential.upgradedFrom, candidate.id),
+          lt(modelProviderCredential.updatedAt, candidate.sourceChangedAt),
+        ),
+      )
+      .returning({ id: modelProviderCredential.id });
+
+    if (rotated !== undefined) activated.push(candidate.provider);
+  }
 
   for (const [provider, forProvider] of [...byProvider].sort()) {
     /**
@@ -601,6 +685,18 @@ async function activateSoleCandidates(
       continue;
     }
 
+    /**
+     * **Activation happens once per candidate, and only once.**
+     *
+     * A candidate already stamped is never inserted again. That is what stops
+     * an administrator who *removed* the credential being overruled by the next
+     * restart putting it back — the row is gone, the stamp says the upgrade has
+     * already had its turn, and their removal stands. Keeping such a credential
+     * *current* is the refresh above, which needs the row to still be there and
+     * to still be tracking this candidate.
+     */
+    if (sole.activatedAt !== null) continue;
+
     const [written] = await tx
       .insert(modelProviderCredential)
       .values({
@@ -610,6 +706,10 @@ async function activateSoleCandidates(
         credentials: envelope,
         credentialsHint: sole.hint,
         revision: newId("rev"),
+        // Which stored key this credential is following, so a rotation of that
+        // source can find it again and an administrator's own key never can be
+        // found this way at all.
+        upgradedFrom: sole.id,
         createdBy: null,
       })
       .onConflictDoNothing({

--- a/packages/db/src/access/model-upgrade.ts
+++ b/packages/db/src/access/model-upgrade.ts
@@ -1,5 +1,5 @@
 import { newId } from "@egma/ids";
-import { and, eq, isNull, lt, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, ne, or, sql } from "drizzle-orm";
 
 import { db, type Transaction } from "../client.ts";
 import { managedDeployment } from "../managed-deployment.ts";
@@ -506,11 +506,35 @@ async function collectCandidates(
      * an operator really can rotate one, and a copy frozen at the old value
      * left this organization spending a key that had been revoked.
      *
-     * **Guarded by the source's own clock and by nothing else.** No plaintext,
-     * no ciphertext, no hint: the source says when it last changed and the copy
-     * remembers when it was taken. Two seals of one key differ anyway, so a
-     * ciphertext comparison would answer "changed" every time and rewrite every
-     * row on every boot.
+     * **Guarded by the source's own clock, and by the safe hint beside it.**
+     *
+     * The clock is the main answer: the source says when it last changed and
+     * the copy remembers when it was taken. What it cannot answer alone is a
+     * rotation landing on the *same stamp* as the write the copy recorded — and
+     * that is far likelier than the column suggests, because every writer of
+     * these rows passes a JavaScript `Date`. `timestamptz` holds microseconds;
+     * a `Date` carries milliseconds, so the last three digits of every one of
+     * these stamps are zero and the real granularity is a millisecond. Two
+     * writes inside one millisecond compare equal, a strict `<` matches
+     * nothing, and the copy silently keeps a key that has been revoked.
+     *
+     * So the hint is asked as well. **This is not the comparison the
+     * specification forbids.** That rule is about deciding whether two
+     * *different sources* hold one account's key — inferring equality between
+     * two secrets nobody may read. This compares one copy against its own
+     * origin, on the four characters already published to every browser that
+     * draws the Model providers screen, to answer "has this row been
+     * rewritten". No secret is read and no two keys are equated.
+     *
+     * A ciphertext comparison would answer the same question and is still
+     * refused: the seal is nonced, so two writes of one key differ, and it
+     * would report "changed" on every boot and rewrite every row forever.
+     *
+     * **Where a rotation collides on both the millisecond and the last four
+     * characters, this copy stays behind until the next write moves either.**
+     * A stated residue rather than a claim of completeness — and far better
+     * than a `>=`, which would rewrite every row on every restart and make
+     * "when the stored key last changed" mean nothing.
      */
     .onConflictDoUpdate({
       target: [
@@ -525,7 +549,8 @@ async function collectCandidates(
         shape: sql`excluded.shape`,
         sourceChangedAt: sql`excluded.source_changed_at`,
       },
-      setWhere: sql`${modelCredentialCandidate.sourceChangedAt} < excluded.source_changed_at`,
+      setWhere: sql`${modelCredentialCandidate.sourceChangedAt} < excluded.source_changed_at
+        or ${modelCredentialCandidate.credentialsHint} <> excluded.credentials_hint`,
     })
     .returning({ id: modelCredentialCandidate.id });
 
@@ -586,9 +611,12 @@ async function activateSoleCandidates(
    * though it is ambiguous for *activation*. A credential an administrator
    * typed holds null and is unreachable from this statement.
    *
-   * Guarded by when the source last moved, so a boot that rotated nothing
-   * leaves `updated_at` alone — a person reads it as "when the stored key last
-   * changed".
+   * Guarded by when the source last moved **or** by its safe hint differing, so
+   * a boot that rotated nothing leaves `updated_at` alone — a person reads it
+   * as "when the stored key last changed" — while a rotation that landed on the
+   * same millisecond as this row's last write is still noticed. See the
+   * collection above for why a millisecond is the real granularity here, and
+   * why asking the hint is not the comparison the specification forbids.
    */
   for (const candidate of candidates) {
     if (candidate.activatedAt === null) continue;
@@ -613,7 +641,10 @@ async function activateSoleCandidates(
         and(
           eq(modelProviderCredential.organizationId, organizationId),
           eq(modelProviderCredential.upgradedFrom, candidate.id),
-          lt(modelProviderCredential.updatedAt, candidate.sourceChangedAt),
+          or(
+            lt(modelProviderCredential.updatedAt, candidate.sourceChangedAt),
+            ne(modelProviderCredential.credentialsHint, candidate.hint),
+          ),
         ),
       )
       .returning({ id: modelProviderCredential.id });

--- a/packages/db/src/access/personas.ts
+++ b/packages/db/src/access/personas.ts
@@ -326,7 +326,7 @@ function describedTraitsFromRow(
  * later, and an old version must stay readable exactly as it was written —
  * so the provider is taken on trust once it is a string.
  */
-function traitsFromRow(value: unknown, versionId: string): PersonaTraits {
+export function traitsFromRow(value: unknown, versionId: string): PersonaTraits {
   const malformed = () =>
     new Error(
       `version ${versionId} holds traits in a shape Egma never writes; the row needs repairing before anybody can read it`,

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -3,6 +3,7 @@ export * from "./platform.ts";
 export * from "./identity.ts";
 export * from "./tenancy.ts";
 export * from "./models.ts";
+export * from "./upgrade.ts";
 export * from "./device.ts";
 export * from "./personas.ts";
 export * from "./agents.ts";

--- a/packages/db/src/schema/models.ts
+++ b/packages/db/src/schema/models.ts
@@ -109,6 +109,24 @@ export const modelProviderCredential = pgTable(
     credentialsHint: text("credentials_hint").notNull(),
     /** The opaque token an edit has to name to be allowed to land. */
     revision: idText("revision").notNull(),
+    /**
+     * Which stored legacy key this credential is *tracking*, or null for a key
+     * an administrator typed.
+     *
+     * **Provenance, so a rotation can reach it and an administrator can never
+     * be overruled by one.** The upgrade activates a sole candidate and writes
+     * its identifier here; when that candidate's source row is rotated, the
+     * refresh finds this credential by that identifier and moves it too, which
+     * is ordinary rotation reaching the next claim. The moment an administrator
+     * writes a key through Model providers this becomes null, and nothing the
+     * upgrade does can touch the row again — their choice is the later and
+     * better answer, and it wins forever.
+     *
+     * Not a foreign key, deliberately: it is a record of where a secret came
+     * from, and a candidate deleted long afterwards must neither take a working
+     * credential with it nor be refused deletion because of one.
+     */
+    upgradedFrom: idText("upgraded_from"),
     createdBy: idText("created_by").references(() => user.id, {
       onDelete: "set null",
     }),

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -1,6 +1,6 @@
 import { boolean, pgTable, text, unique, uniqueIndex } from "drizzle-orm/pg-core";
 
-import { createdAt, idText, prefixCheck, updatedAt } from "./columns.ts";
+import { createdAt, idText, moment, prefixCheck, updatedAt } from "./columns.ts";
 
 /**
  * The identity of this Egma platform, not of any customer on it.
@@ -14,6 +14,23 @@ export const platformInstance = pgTable(
   {
     singleton: boolean("singleton").primaryKey().default(true),
     id: idText("id").notNull(),
+    /**
+     * When this installation finished moving onto model selections, and null
+     * while it has not.
+     *
+     * **The marker the later removal of the legacy model paths is gated on, and
+     * it is a column here because this is the row that means "this
+     * installation".** Whether every current persona and grader carries
+     * explicit selections, and whether anything queued or claimed still needs
+     * the old work-order contract or an old judge credential, is something only
+     * the deployment can know and only by asking. The conditions are re-asked
+     * on every boot and this is stamped the first time they all hold.
+     *
+     * Never withdrawn: nothing writes a legacy-shaped row any more, so a
+     * deployment that finished cannot un-finish, and a marker that could flip
+     * back would be one no cleanup could safely read.
+     */
+    modelUpgradeCompletedAt: moment("model_upgrade_completed_at"),
     createdAt: createdAt(),
   },
   (table) => [

--- a/packages/db/src/schema/upgrade.ts
+++ b/packages/db/src/schema/upgrade.ts
@@ -49,6 +49,26 @@ export type CredentialCandidateSource =
   (typeof CREDENTIAL_CANDIDATE_SOURCES)[number];
 
 /**
+ * What is *inside* one copied envelope, which is not the same question in every
+ * legacy store.
+ *
+ * **Two stores, two shapes, and finding this out late would have been a broken
+ * credential rather than a broken build.** Every credential table in this schema
+ * seals a small document, `{ key }`, so that the envelope can grow a field
+ * without a format guess. The deployment's own settings seal the value itself,
+ * because a platform setting is one value and there was never a second field to
+ * name. Both are sealed under the same master key with the same envelope
+ * format; what differs is the plaintext they hold.
+ *
+ * So the shape is recorded with the copy, and it is read exactly once — when a
+ * candidate becomes an organization's active credential and has to be written
+ * in the shape that store reads. Collection itself opens nothing.
+ */
+export const CREDENTIAL_ENVELOPE_SHAPES = ["key_document", "bare_value"] as const;
+export type CredentialEnvelopeShape =
+  (typeof CREDENTIAL_ENVELOPE_SHAPES)[number];
+
+/**
  * One legacy provider key, copied here sealed exactly as it was stored.
  *
  * **Copied rather than moved, and the difference is the compatibility period.**
@@ -99,6 +119,13 @@ export const modelCredentialCandidate = pgTable(
     /** The last characters of the key, as the row it came from already held. */
     credentialsHint: text("credentials_hint").notNull(),
     /**
+     * What the envelope holds inside. See `CREDENTIAL_ENVELOPE_SHAPES`: the
+     * credential stores seal `{ key }` and the deployment's own settings seal
+     * the value itself, and a copy that did not record which would be a
+     * credential nothing could open.
+     */
+    shape: text("shape").notNull(),
+    /**
      * When this candidate became the organization's active model-provider
      * credential, or null while it has not. Null on every candidate of a
      * provider that had more than one.
@@ -110,6 +137,9 @@ export const modelCredentialCandidate = pgTable(
     prefixCheck("model_credential_candidate_id_prefix", table.id, "mcc"),
     oneOf("model_credential_candidate_source_allowed", table.source, [
       ...CREDENTIAL_CANDIDATE_SOURCES,
+    ]),
+    oneOf("model_credential_candidate_shape_allowed", table.shape, [
+      ...CREDENTIAL_ENVELOPE_SHAPES,
     ]),
     /**
      * One candidate per legacy row, which is what makes re-running the upgrade

--- a/packages/db/src/schema/upgrade.ts
+++ b/packages/db/src/schema/upgrade.ts
@@ -1,6 +1,4 @@
-import { check, pgTable, text, unique } from "drizzle-orm/pg-core";
-import { sql } from "drizzle-orm";
-import { boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, unique } from "drizzle-orm/pg-core";
 
 import { organization } from "./tenancy.ts";
 import {
@@ -14,10 +12,13 @@ import {
 
 /**
  * What the upgrade onto model selections leaves behind: the legacy keys it
- * found, the decisions it refused to make on somebody's behalf, and the one
- * stamp that says this installation has finished.
+ * found, and the decisions it refused to make on somebody's behalf.
  *
- * **All three exist because an upgrade cannot guess.** A deployment configured
+ * The stamp that says an installation has *finished* is not here — it is one
+ * nullable column on `platform_instance`, which is already the row that belongs
+ * to the whole deployment and to no customer on it.
+ *
+ * **Both exist because an upgrade cannot guess.** A deployment configured
  * before persona and grader models existed holds provider keys in three
  * different places and model choices in a fourth; the upgrade collects what is
  * there and gives every current persona and grader an explicit successor where
@@ -198,37 +199,5 @@ export const modelUpgradeAction = pgTable(
       table.kind,
       table.subject,
     ),
-  ],
-);
-
-/**
- * The stamp that says this installation has finished moving onto model
- * selections.
- *
- * **Per installation, and `platform_instance` is the precedent**: one row that
- * belongs to the whole deployment and to no customer, so it survives a restart
- * and moves with a restored backup. A marker held in a process would be a
- * marker every replica held a different answer for.
- *
- * **It gates the later removal and nothing else.** Reading it is how the
- * release after this one knows that every current persona and grader carries
- * explicit selections and that no queued, claimed or grading work still depends
- * on the old contract or an old credential reference. Writing it is not a
- * decision anybody makes: the conditions are re-checked on every boot and the
- * stamp is written the first time they all hold.
- *
- * **Written once and never withdrawn.** A deployment that finished and then
- * authored a legacy-shaped row could not have — nothing writes one any more —
- * so a marker that could flip back would be a marker nothing could rely on.
- */
-export const modelUpgradeCompletion = pgTable(
-  "model_upgrade_completion",
-  {
-    singleton: boolean("singleton").primaryKey().default(true),
-    /** When the conditions were first all true. */
-    completedAt: moment("completed_at").notNull(),
-  },
-  (table) => [
-    check("model_upgrade_completion_is_one_row", sql`${table.singleton}`),
   ],
 );

--- a/packages/db/src/schema/upgrade.ts
+++ b/packages/db/src/schema/upgrade.ts
@@ -126,9 +126,31 @@ export const modelCredentialCandidate = pgTable(
      */
     shape: text("shape").notNull(),
     /**
+     * When the row this was copied from last changed, as that row's own
+     * `updated_at` said at the moment of the copy.
+     *
+     * **This is what makes a rotated legacy key reach the copy**, and it is a
+     * timestamp rather than a comparison of what is inside the envelopes for a
+     * reason the specification is explicit about: nothing in this upgrade may
+     * read a secret to decide anything, and two seals of one key differ anyway
+     * because the nonce is fresh on every write. So the question asked is "has
+     * the source row been written since this copy was taken", which the source
+     * answers about itself.
+     *
+     * An operator really can rotate one during the compatibility period —
+     * `writePlatformSettings` and `editJudgeCredential` are both still open —
+     * and a copy that ignored it would leave the organization spending a key
+     * that has been revoked.
+     */
+    sourceChangedAt: moment("source_changed_at").notNull(),
+    /**
      * When this candidate became the organization's active model-provider
      * credential, or null while it has not. Null on every candidate of a
      * provider that had more than one.
+     *
+     * **It is also what makes activation happen once.** A candidate already
+     * stamped is never inserted again, so an administrator who *removed* the
+     * credential is not overruled by the next restart putting it back.
      */
     activatedAt: moment("activated_at"),
     createdAt: createdAt(),

--- a/packages/db/src/schema/upgrade.ts
+++ b/packages/db/src/schema/upgrade.ts
@@ -1,0 +1,234 @@
+import { check, pgTable, text, unique } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { boolean } from "drizzle-orm/pg-core";
+
+import { organization } from "./tenancy.ts";
+import {
+  createdAt,
+  idText,
+  moment,
+  oneOf,
+  prefixCheck,
+  updatedAt,
+} from "./columns.ts";
+
+/**
+ * What the upgrade onto model selections leaves behind: the legacy keys it
+ * found, the decisions it refused to make on somebody's behalf, and the one
+ * stamp that says this installation has finished.
+ *
+ * **All three exist because an upgrade cannot guess.** A deployment configured
+ * before persona and grader models existed holds provider keys in three
+ * different places and model choices in a fourth; the upgrade collects what is
+ * there and gives every current persona and grader an explicit successor where
+ * the answer is unambiguous. Where it is not — two keys for one provider, a
+ * persona voice that disagrees with the deployment's speaking provider, a
+ * setting naming a provider this release does not carry — it writes an *action*
+ * instead and leaves the old path working. A guessed answer would be a
+ * simulation quietly conducted with a model nobody chose, and that is worse
+ * than a sentence asking somebody to choose.
+ */
+
+/**
+ * Where one legacy key was found. Every source Egma knows how to look in, and
+ * the word is what an administrator reads when several candidates make them
+ * choose.
+ *
+ * - `platform_setting` — a deployment-wide model, speech or speaking key.
+ * - `judge_credential` — an organization's own judge key.
+ * - `judge_configuration` — the deployment's own key on a project's `platform`
+ *   judge, which is a key the project never held and could not see.
+ */
+export const CREDENTIAL_CANDIDATE_SOURCES = [
+  "platform_setting",
+  "judge_credential",
+  "judge_configuration",
+] as const;
+export type CredentialCandidateSource =
+  (typeof CREDENTIAL_CANDIDATE_SOURCES)[number];
+
+/**
+ * One legacy provider key, copied here sealed exactly as it was stored.
+ *
+ * **Copied rather than moved, and the difference is the compatibility period.**
+ * The row it came from keeps working — an old grading plan still resolves its
+ * recorded judge credential, and a persona still on the legacy path still reads
+ * the deployment's own settings — so the envelope is duplicated byte for byte
+ * and nothing is opened to do it. The later cleanup removes the originals.
+ *
+ * **One row per source, never per secret.** Two sources holding the same key
+ * are two candidates here, because deciding they were the same key would mean
+ * comparing plaintext, ciphertext or hints — and the specification forbids
+ * inferring equality from any of the three. So the arithmetic is deliberately
+ * blunt: one candidate for a provider may become that organization's active
+ * credential, and two mean an administrator chooses.
+ *
+ * **`provider` carries no allowed-value check**, unlike every other provider
+ * column in this schema. A deployment configured before this release may name
+ * a provider this release's catalog does not carry, and refusing the row would
+ * throw the record away — leaving nothing to show an administrator and nothing
+ * for a later release that adds that provider back to find. What may become
+ * *active* is checked where activation happens, against the catalog, so an
+ * unusable candidate is recorded and never spendable.
+ */
+export const modelCredentialCandidate = pgTable(
+  "model_credential_candidate",
+  {
+    id: idText("id").primaryKey(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** The provider account this key belongs to, as the legacy row spelled it. */
+    provider: text("provider").notNull(),
+    /** Which kind of legacy row it came from. See `CREDENTIAL_CANDIDATE_SOURCES`. */
+    source: text("source").notNull(),
+    /**
+     * Which row exactly: the platform setting's name, the judge credential's
+     * label, or the project a `platform` judge configuration belongs to. It is
+     * what an administrator choosing between two candidates reads, so it has to
+     * say more than four characters of a key can.
+     */
+    sourceName: text("source_name").notNull(),
+    /**
+     * The sealed envelope, copied verbatim. The same `v1.<iv>.<ciphertext>.
+     * <tag>` under the same master key every credential in this schema uses,
+     * so nothing was opened to write this and nothing has to be to spend it.
+     */
+    credentials: text("credentials").notNull(),
+    /** The last characters of the key, as the row it came from already held. */
+    credentialsHint: text("credentials_hint").notNull(),
+    /**
+     * When this candidate became the organization's active model-provider
+     * credential, or null while it has not. Null on every candidate of a
+     * provider that had more than one.
+     */
+    activatedAt: moment("activated_at"),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    prefixCheck("model_credential_candidate_id_prefix", table.id, "mcc"),
+    oneOf("model_credential_candidate_source_allowed", table.source, [
+      ...CREDENTIAL_CANDIDATE_SOURCES,
+    ]),
+    /**
+     * One candidate per legacy row, which is what makes re-running the upgrade
+     * write nothing the second time. The source and its name together name the
+     * row it was copied from; the provider is in the key because one platform
+     * setting is a key for exactly one provider and one judge credential too.
+     */
+    unique("model_credential_candidate_one_per_source").on(
+      table.organizationId,
+      table.provider,
+      table.source,
+      table.sourceName,
+    ),
+  ],
+);
+
+/**
+ * What an administrator has to decide, because the upgrade would not.
+ *
+ * Each names the act rather than the fault — `select_persona_models` rather
+ * than "persona incomplete" — because the sentence beside it already says what
+ * went wrong and the word is what the screen draws a link from.
+ *
+ * - `select_model_provider_credential` — several legacy keys claim one
+ *   provider, so none became active. The subject is the provider.
+ * - `select_persona_models` — this persona could not receive an explicit
+ *   successor: the deployment's settings were incomplete, named a provider this
+ *   release does not carry, or its own voice provider disagreed with the
+ *   deployment's speaking provider. The subject is the persona.
+ * - `select_grader_model` — this grader had no effective legacy model, or one
+ *   naming a provider this release does not carry. The subject is the grader.
+ * - `set_up_model_access` — this organization is one of several on a
+ *   deployment, so nothing deployment-wide was copied into it at all. The
+ *   subject is the organization.
+ */
+export const MODEL_UPGRADE_ACTIONS = [
+  "select_model_provider_credential",
+  "select_persona_models",
+  "select_grader_model",
+  "set_up_model_access",
+] as const;
+export type ModelUpgradeActionKind = (typeof MODEL_UPGRADE_ACTIONS)[number];
+
+/**
+ * One thing an administrator has to choose before this organization has left
+ * the legacy path, written once by the upgrade and cleared when it is done.
+ *
+ * **One-time, held by the unique below.** The upgrade runs on every boot, so an
+ * action that could be written twice would become a list that grows every time
+ * a container restarts. The subject is in the key because one persona's missing
+ * selection and another's are two different decisions.
+ *
+ * **`detail` is Egma's own writing and never a customer's.** It names the model
+ * job, the provider and what is missing; it carries no key, no hint and no
+ * authored content, so it is safe in a log and safe in a browser.
+ */
+export const modelUpgradeAction = pgTable(
+  "model_upgrade_action",
+  {
+    id: idText("id").primaryKey(),
+    organizationId: idText("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** Which decision this is. See `MODEL_UPGRADE_ACTIONS`. */
+    kind: text("kind").notNull(),
+    /**
+     * What it is about: a persona id, a grader id, a provider's name, or the
+     * organization's own id. Not a foreign key, because a provider is not a row
+     * and because an action outliving a deleted persona is a stale sentence
+     * rather than a broken pointer — the read below drops it.
+     */
+    subject: text("subject").notNull(),
+    /** The sentence a person reads. Egma's words, never a secret. */
+    detail: text("detail").notNull(),
+    /** When somebody finished it, or null while it is still outstanding. */
+    resolvedAt: moment("resolved_at"),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    prefixCheck("model_upgrade_action_id_prefix", table.id, "mua"),
+    oneOf("model_upgrade_action_kind_allowed", table.kind, [
+      ...MODEL_UPGRADE_ACTIONS,
+    ]),
+    unique("model_upgrade_action_one_per_subject").on(
+      table.organizationId,
+      table.kind,
+      table.subject,
+    ),
+  ],
+);
+
+/**
+ * The stamp that says this installation has finished moving onto model
+ * selections.
+ *
+ * **Per installation, and `platform_instance` is the precedent**: one row that
+ * belongs to the whole deployment and to no customer, so it survives a restart
+ * and moves with a restored backup. A marker held in a process would be a
+ * marker every replica held a different answer for.
+ *
+ * **It gates the later removal and nothing else.** Reading it is how the
+ * release after this one knows that every current persona and grader carries
+ * explicit selections and that no queued, claimed or grading work still depends
+ * on the old contract or an old credential reference. Writing it is not a
+ * decision anybody makes: the conditions are re-checked on every boot and the
+ * stamp is written the first time they all hold.
+ *
+ * **Written once and never withdrawn.** A deployment that finished and then
+ * authored a legacy-shaped row could not have — nothing writes one any more —
+ * so a marker that could flip back would be a marker nothing could rely on.
+ */
+export const modelUpgradeCompletion = pgTable(
+  "model_upgrade_completion",
+  {
+    singleton: boolean("singleton").primaryKey().default(true),
+    /** When the conditions were first all true. */
+    completedAt: moment("completed_at").notNull(),
+  },
+  (table) => [
+    check("model_upgrade_completion_is_one_row", sql`${table.singleton}`),
+  ],
+);

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -295,6 +295,22 @@ const CONTEXT_REQUIRING = [
   "listTests",
   "listTraces",
   "markSimulationCanceled",
+  // What the upgrade onto model selections left for this organization: the
+  // decisions it refused to make, the stored keys it found, and the one door
+  // that makes one of them active. Reading an action is every role's, because
+  // it is the reason somebody's run reported what it reported; the keys and the
+  // choice between them are an admin's, on the row of the permission table that
+  // already names provider credentials.
+  "activateCredentialCandidate",
+  "listCredentialCandidates",
+  "listModelUpgradeActions",
+  // The upgrade itself and its marker: the deployment finishing a change the
+  // release shipped, and the one fact the later removal is allowed to act on.
+  // None of the three takes a context, because none of them is about anybody on
+  // this deployment — see the lint rule's own note.
+  "readModelUpgradeCompletion",
+  "recordModelUpgradeCompletion",
+  "upgradeModelSetup",
   "readOrganization",
   "readOrganizationSettings",
   // The deployment's own settings, on the judge configuration's exact terms:
@@ -540,6 +556,15 @@ const THE_MODEL_CATALOG = [
   "RECOMMENDED_PERSONA_MODELS",
   "SPEED_RANGE",
   "DEFAULT_MODEL_ACCESS",
+  // Where the upgrade found a legacy key, and what it left for somebody to
+  // choose. Closed lists for the same reason `ENDING_REPAIRS` is one: a screen
+  // draws a link from the word, and an unknown one would be a button nowhere.
+  "CREDENTIAL_CANDIDATE_SOURCES",
+  "MODEL_UPGRADE_ACTIONS",
+  // What still stands between this installation and the removal of the legacy
+  // paths, as four words rather than one boolean — somebody deciding whether an
+  // old worker can be drained needs to know which.
+  "UPGRADE_CONDITIONS",
 ];
 
 /** Vocabulary: the table definitions, how a caller proved who they are, and the refusals. */

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -560,6 +560,10 @@ const THE_MODEL_CATALOG = [
   // choose. Closed lists for the same reason `ENDING_REPAIRS` is one: a screen
   // draws a link from the word, and an unknown one would be a button nowhere.
   "CREDENTIAL_CANDIDATE_SOURCES",
+  // What is inside one copied envelope. Two legacy stores seal two different
+  // plaintexts under one format, and a copy that did not record which would be
+  // a credential nothing could open.
+  "CREDENTIAL_ENVELOPE_SHAPES",
   "MODEL_UPGRADE_ACTIONS",
   // What still stands between this installation and the removal of the legacy
   // paths, as four words rather than one boolean — somebody deciding whether an

--- a/packages/db/test/model-upgrade-refusals.test.ts
+++ b/packages/db/test/model-upgrade-refusals.test.ts
@@ -1,6 +1,7 @@
 import { newId } from "@egma/ids";
 import {
   activateCredentialCandidate,
+  createJudgeCredential,
   createPersona,
   getGrader,
   getPersona,
@@ -11,11 +12,14 @@ import {
   PREDEFINED_GRADERS,
   readModelAccess,
   readModelUpgradeCompletion,
+  resolveModelProviderKeys,
+  storeModelProviderCredential,
   seedPlatformSettings,
   seedRunningGraders,
   setJudgeConfiguration,
   upgradeModelSetup,
   useLibraryEntry,
+  writePlatformSettings,
   type AuthContext,
   type PersonaTraits,
 } from "@egma/db";
@@ -64,6 +68,20 @@ function acting(
 }
 
 const ONE_TEAM = { singleOrganization: true };
+
+/** The one context a stored provider key may be opened for. */
+function theSimulatorIn(tenant: {
+  organization: string;
+  project: string;
+}): AuthContext {
+  return {
+    userId: "simulator",
+    organizationId: tenant.organization,
+    projectId: tenant.project,
+    role: "viewer",
+    via: "simulator",
+  };
+}
 const SEVERAL_TEAMS = { singleOrganization: false };
 
 const SELF_HOSTED = {
@@ -435,3 +453,180 @@ async function firstPersona(tenant: {
   if (row === undefined) throw new Error("no persona was seeded");
   return row;
 }
+
+/**
+ * A legacy key rotated after the upgrade has already run.
+ *
+ * **Both doors are still open during the compatibility period** — an owner
+ * rotates a deployment key through `writePlatformSettings`, and an admin
+ * rotates a judge key through `editJudgeCredential` — so an installation whose
+ * key was revoked and replaced must not go on spending the revoked one. The
+ * copy tracks its source, and the credential the upgrade wrote tracks the copy.
+ */
+describe("a legacy key rotated after the upgrade has run", () => {
+  const solo = { organization: newId("org"), project: newId("prj") };
+
+  beforeAll(async () => {
+    holdManagedDeployment(SELF_HOSTED);
+    await database.drop();
+    database = await createConnectedDatabase("model_upgrade_rotation");
+    await seedUser(database, ada, "ada@acme.example");
+    await seedOrganization(database, solo.organization, [
+      { id: solo.project, slug: "main" },
+    ]);
+    await seedPlatformSettings({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o-mini",
+      persona_model_key: "sk-sentinel-rotation-model-key-OLD1",
+      speech_to_text_provider: "deepgram",
+      speech_to_text_model: "nova-3-general",
+      speech_to_text_key: "dg-sentinel-rotation-listening-OLD2",
+      text_to_speech_provider: "cartesia",
+      text_to_speech_model: "sonic-3.5",
+      text_to_speech_key: "ct-sentinel-rotation-speaking-OLD3",
+    });
+    await upgradeModelSetup(ONE_TEAM);
+  });
+
+  it("reaches the copy and the credential the upgrade wrote", async () => {
+    expect(
+      (await listCredentialCandidates(acting(solo))).find(
+        (one) => one.provider === "deepgram",
+      )?.hint,
+    ).toBe("OLD2");
+
+    // The door an operator really rotates a deployment key through.
+    await writePlatformSettings(acting(solo), ONE_TEAM, {
+      speech_to_text_key: "dg-sentinel-rotation-listening-NEW9",
+    });
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    const candidate = (await listCredentialCandidates(acting(solo))).find(
+      (one) => one.provider === "deepgram",
+    );
+    expect(candidate?.hint).toBe("NEW9");
+    expect(candidate?.active).toBe(true);
+    expect(report.activated).toEqual(["deepgram"]);
+
+    // And what a claim would spend is the new key, opened through the one door
+    // that opens one.
+    const resolved = await resolveModelProviderKeys(theSimulatorIn(solo), [
+      "deepgram",
+    ]);
+    expect(resolved.keys.get("deepgram")).toBe(
+      "dg-sentinel-rotation-listening-NEW9",
+    );
+  });
+
+  it("writes nothing at all when nothing rotated", async () => {
+    const before = await database.sql(
+      `select
+         (select count(*) from model_credential_candidate) as candidates,
+         (select max(updated_at) from model_provider_credential) as touched`,
+    );
+
+    const again = await upgradeModelSetup(ONE_TEAM);
+    const after = await database.sql(
+      `select
+         (select count(*) from model_credential_candidate) as candidates,
+         (select max(updated_at) from model_provider_credential) as touched`,
+    );
+
+    expect(again.activated).toEqual([]);
+    expect(again.candidates).toEqual([]);
+    // `updated_at` is what a person reads as "when the stored key last
+    // changed", so a boot that rotated nothing must not move it.
+    expect(after.rows[0]).toEqual(before.rows[0]);
+  });
+
+  /**
+   * The rule that must never bend: an administrator's own key is theirs.
+   *
+   * They typed it through Model providers, which is a later and better answer
+   * than any legacy row can offer — so a legacy rotation afterwards moves the
+   * copy and leaves the credential exactly where they put it.
+   */
+  it("never overwrites a key an administrator typed", async () => {
+    await storeModelProviderCredential(acting(solo), {
+      provider: "deepgram",
+      key: "dg-sentinel-rotation-typed-by-a-person-Z9",
+    });
+
+    await writePlatformSettings(acting(solo), ONE_TEAM, {
+      speech_to_text_key: "dg-sentinel-rotation-listening-LATER",
+    });
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    // The copy moved, because it tracks its source and always will.
+    expect(
+      (await listCredentialCandidates(acting(solo))).find(
+        (one) => one.provider === "deepgram",
+      )?.hint,
+    ).toBe("ATER");
+    // The credential did not, because it is no longer the upgrade's to move.
+    expect(report.activated).toEqual([]);
+    const resolved = await resolveModelProviderKeys(theSimulatorIn(solo), [
+      "deepgram",
+    ]);
+    expect(resolved.keys.get("deepgram")).toBe(
+      "dg-sentinel-rotation-typed-by-a-person-Z9",
+    );
+  });
+
+  /**
+   * A provider that has grown a second stored key **activates** nothing new,
+   * and the credential it already has goes on following the key it named.
+   *
+   * The two questions are different and only one of them is ambiguous. *Which
+   * account does this organization use* has two answers once there are two
+   * candidates, so nothing may be activated from them. *Which stored key is
+   * this credential following* has exactly one answer, written on the
+   * credential itself — so a rotation of that source still reaches it, and the
+   * revoked-key failure this whole fix is about does not come back the moment
+   * somebody adds a judge credential.
+   */
+  it("activates nothing more, and still follows the key its credential names", async () => {
+    // The first upgrade activated OpenAI from the one key there was; a judge
+    // credential added afterwards makes two, and the choice reopens.
+    await createJudgeCredential(acting(solo), {
+      label: "Acme's own judge key",
+      provider: "openai",
+      key: "sk-sentinel-rotation-judge-OLD4",
+    });
+    await upgradeModelSetup(ONE_TEAM);
+    // No action, and that is right rather than a gap: this organization already
+    // has an OpenAI credential, so "which of these do you use" is answered by
+    // the row that exists. The action is for a provider with two stored keys
+    // and *nothing* chosen.
+    expect(
+      (await listModelUpgradeActions(acting(solo))).map((one) => one.subject),
+    ).not.toContain("openai");
+
+    await writePlatformSettings(acting(solo), ONE_TEAM, {
+      persona_model_key: "sk-sentinel-rotation-model-key-NEW5",
+    });
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    const openai = (await listCredentialCandidates(acting(solo))).filter(
+      (one) => one.provider === "openai",
+    );
+    // The rotated copy is current, because a copy always tracks its source.
+    expect(openai.map((one) => one.hint).sort()).toEqual(["NEW5", "OLD4"]);
+    // Exactly one is active — the one the credential names — and no second
+    // credential was created from the newcomer.
+    expect(openai.filter((one) => one.active)).toHaveLength(1);
+    const { rows } = await database.sql(
+      "select count(*) as count from model_provider_credential where provider = 'openai'",
+    );
+    expect(Number((rows[0] as { count: string }).count)).toBe(1);
+    // And the key a claim would spend is the rotated one, because the
+    // credential says which stored key it follows and that one moved.
+    const resolved = await resolveModelProviderKeys(theSimulatorIn(solo), [
+      "openai",
+    ]);
+    expect(resolved.keys.get("openai")).toBe(
+      "sk-sentinel-rotation-model-key-NEW5",
+    );
+    expect(report.activated).toEqual(["openai"]);
+  });
+});

--- a/packages/db/test/model-upgrade-refusals.test.ts
+++ b/packages/db/test/model-upgrade-refusals.test.ts
@@ -576,6 +576,75 @@ describe("a legacy key rotated after the upgrade has run", () => {
   });
 
   /**
+   * A rotation that lands on the same stamp as the write the copy recorded.
+   *
+   * **Likelier than the column suggests.** `timestamptz` holds microseconds,
+   * but every writer of these rows passes a JavaScript `Date`, which carries
+   * milliseconds — so the last three digits are always zero and the real
+   * granularity is a millisecond. A strict clock comparison then matches
+   * nothing, and the organization goes on presenting a key that has been
+   * revoked. The stamps are forced equal here rather than raced for, so the
+   * case is about the guard rather than about how fast two writes can be.
+   */
+  it("is noticed even when it lands on the same stamp as the last one", async () => {
+    await writePlatformSettings(acting(solo), ONE_TEAM, {
+      text_to_speech_key: "ct-sentinel-rotation-speaking-SAME",
+    });
+    // The collision, made deterministic: the source now says exactly what the
+    // copy recorded, so nothing about the clock can tell them apart.
+    await database.sql(
+      `update platform_setting set updated_at = (
+         select source_changed_at from model_credential_candidate
+          where provider = 'cartesia')
+        where name = 'text_to_speech_key'`,
+    );
+
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    expect(
+      (await listCredentialCandidates(acting(solo))).find(
+        (one) => one.provider === "cartesia",
+      )?.hint,
+    ).toBe("SAME");
+    expect(report.activated).toContain("cartesia");
+    const resolved = await resolveModelProviderKeys(theSimulatorIn(solo), [
+      "cartesia",
+    ]);
+    expect(resolved.keys.get("cartesia")).toBe(
+      "ct-sentinel-rotation-speaking-SAME",
+    );
+  });
+
+  /**
+   * The other half of the same guard, and the residue it leaves stated plainly.
+   *
+   * Nothing at all changed, so nothing may be written — that is the property
+   * the whole guard exists to keep, and a `>=` would break it by refreshing
+   * every row on every boot. The cost is the one case neither half catches: a
+   * rotation colliding on the millisecond *and* on the last four characters
+   * stays behind until the next write moves either. Real, narrow, and better
+   * than rewriting every credential's "last changed" on every restart.
+   */
+  it("writes nothing when the clock and the last four characters both match", async () => {
+    const before = await database.sql(
+      `select
+         (select credentials from model_credential_candidate where provider = 'cartesia') as copied,
+         (select updated_at from model_provider_credential where provider = 'cartesia') as touched`,
+    );
+
+    const report = await upgradeModelSetup(ONE_TEAM);
+    const after = await database.sql(
+      `select
+         (select credentials from model_credential_candidate where provider = 'cartesia') as copied,
+         (select updated_at from model_provider_credential where provider = 'cartesia') as touched`,
+    );
+
+    expect(report.activated).toEqual([]);
+    expect(report.candidates).toEqual([]);
+    expect(after.rows[0]).toEqual(before.rows[0]);
+  });
+
+  /**
    * A provider that has grown a second stored key **activates** nothing new,
    * and the credential it already has goes on following the key it named.
    *

--- a/packages/db/test/model-upgrade-refusals.test.ts
+++ b/packages/db/test/model-upgrade-refusals.test.ts
@@ -14,9 +14,11 @@ import {
   readModelUpgradeCompletion,
   resolveModelProviderKeys,
   storeModelProviderCredential,
+  seedDefaultJudge,
   seedPlatformSettings,
   seedRunningGraders,
   setJudgeConfiguration,
+  setProjectJudge,
   upgradeModelSetup,
   useLibraryEntry,
   writePlatformSettings,
@@ -628,5 +630,104 @@ describe("a legacy key rotated after the upgrade has run", () => {
       "sk-sentinel-rotation-model-key-NEW5",
     );
     expect(report.activated).toEqual(["openai"]);
+  });
+});
+
+/**
+ * The boundary of the rotation fix, pinned so nobody has to rediscover it.
+ *
+ * **A rotated `EGMA_JUDGE_API_KEY` and a restart do not reach an existing
+ * platform judge row at all**, and that is deliberate behaviour this effort did
+ * not introduce: `seedDefaultJudge` reads only projects that have *no* judge
+ * configuration and writes with `onConflictDoNothing`, which the schema states
+ * as the whole promise that a project's chosen judge is never replaced. So the
+ * copy this upgrade takes cannot go stale against its source — the source did
+ * not move — and no refresh trigger of any kind could see a change that never
+ * happened.
+ *
+ * The door that *does* re-seal such a row from the deployment's current key is
+ * an administrator choosing the platform judge for a project, and it stamps the
+ * row. That one the refresh follows, which is the half worth proving here: the
+ * fix is not weaker than its source's own clock.
+ */
+describe("the deployment's own judge key", () => {
+  const solo = { organization: newId("org"), project: newId("prj") };
+
+  beforeAll(async () => {
+    holdManagedDeployment(SELF_HOSTED);
+    await database.drop();
+    database = await createConnectedDatabase("model_upgrade_judge_env");
+    await seedUser(database, ada, "ada@acme.example");
+    await seedOrganization(database, solo.organization, [
+      { id: solo.project, slug: "main" },
+    ]);
+  });
+
+  it("does not reach an existing project when the environment rotates it", async () => {
+    expect(
+      await seedDefaultJudge({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        key: "sk-sentinel-judge-env-OLD1",
+      }),
+    ).toEqual([solo.project]);
+    const before = await database.sql<{ hint: string; updated_at: Date }>(
+      "select credentials_hint as hint, updated_at from judge_configuration where project_id = $1",
+      [solo.project],
+    );
+
+    // The operator rotates the environment variable and restarts.
+    const seeded = await seedDefaultJudge({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      key: "sk-sentinel-judge-env-NEW9",
+    });
+
+    const after = await database.sql<{ hint: string; updated_at: Date }>(
+      "select credentials_hint as hint, updated_at from judge_configuration where project_id = $1",
+      [solo.project],
+    );
+
+    // Nothing was written, so there is nothing for the upgrade to notice. The
+    // grading engine goes on spending the key this project was seeded with —
+    // which is the deployment's standing behaviour and not this upgrade's.
+    expect(seeded).toEqual([]);
+    expect(after.rows[0]?.hint).toBe("OLD1");
+    expect(after.rows[0]?.updated_at).toEqual(before.rows[0]?.updated_at);
+  });
+
+  it("is followed by the refresh where a real door does re-seal the row", async () => {
+    await upgradeModelSetup(ONE_TEAM);
+    expect(
+      (await listCredentialCandidates(acting(solo))).find(
+        (one) => one.source === "judge_configuration",
+      )?.hint,
+    ).toBe("OLD1");
+
+    // An administrator choosing the platform judge for this project re-seals
+    // the row from the deployment's *current* key — the one this process was
+    // started with, which is where the rotated value really lives — and stamps
+    // the row on the way. That is the door the copy can follow.
+    await setProjectJudge(acting(solo), {
+      source: "platform",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      platformJudge: {
+        provider: "openai",
+        model: "gpt-4o-mini",
+        key: "sk-sentinel-judge-env-NEW9",
+      },
+    });
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    const copied = (await listCredentialCandidates(acting(solo))).find(
+      (one) => one.source === "judge_configuration",
+    );
+    expect(copied?.hint).toBe("NEW9");
+    expect(report.activated).toContain("openai");
+    const resolved = await resolveModelProviderKeys(theSimulatorIn(solo), [
+      "openai",
+    ]);
+    expect(resolved.keys.get("openai")).toBe("sk-sentinel-judge-env-NEW9");
   });
 });

--- a/packages/db/test/model-upgrade-refusals.test.ts
+++ b/packages/db/test/model-upgrade-refusals.test.ts
@@ -1,0 +1,420 @@
+import { newId } from "@egma/ids";
+import {
+  activateCredentialCandidate,
+  createPersona,
+  getGrader,
+  getPersona,
+  holdManagedDeployment,
+  listCredentialCandidates,
+  listGraders,
+  listModelUpgradeActions,
+  PREDEFINED_GRADERS,
+  readModelAccess,
+  readModelUpgradeCompletion,
+  seedPlatformSettings,
+  seedRunningGraders,
+  setJudgeConfiguration,
+  upgradeModelSetup,
+  useLibraryEntry,
+  type AuthContext,
+  type PersonaTraits,
+} from "@egma/db";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "./support/database.ts";
+import { seedOrganization, seedUser } from "./support/tenancy.ts";
+
+/**
+ * Everything the upgrade refuses to decide, and what it writes instead.
+ *
+ * **These are the cases that matter most.** The happy path is one release's
+ * settings becoming one persona's selections; these are the deployments where
+ * that arithmetic has no single right answer — a provider this release does not
+ * carry, a setting nobody ever filled in, a grader with no judge behind it at
+ * all, and a deployment serving several teams whose one set of settings belongs
+ * to none of them. In every one of them the same two things must be true:
+ * nothing was guessed, and somebody was told.
+ *
+ * The rows are written through the doors the previous release shipped —
+ * personas with no selections, graders judged by their project — against the
+ * current schema. That the previous release's *schema* upgrades cleanly is
+ * `model-upgrade.test.ts`'s subject and is not restated here.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const globex = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+
+function acting(
+  tenant: { organization: string; project: string },
+  role: "admin" | "member" = "admin",
+): AuthContext {
+  return {
+    userId: ada,
+    organizationId: tenant.organization,
+    projectId: tenant.project,
+    role,
+    via: "session",
+  };
+}
+
+const ONE_TEAM = { singleOrganization: true };
+const SEVERAL_TEAMS = { singleOrganization: false };
+
+const SELF_HOSTED = {
+  hosted: false,
+  gatewayAddress: undefined,
+  internalGatewayKey: undefined,
+} as const;
+
+const HOSTED = {
+  hosted: true,
+  gatewayAddress: "https://gateway.egma.example",
+  internalGatewayKey: "sentinel-internal-gateway-signing-key",
+} as const;
+
+const A_PERSONA = (provider: string): PersonaTraits => ({
+  personality: "Rings about a delivery that has not arrived and wants a date.",
+  language: "en",
+  voice: { provider, voiceId: "a-voice", speed: 1 } as PersonaTraits["voice"],
+});
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("model_upgrade_refusals");
+  holdManagedDeployment(SELF_HOSTED);
+  await seedUser(database, ada, "ada@acme.example");
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "main" },
+  ]);
+  await seedOrganization(database, globex.organization, [
+    { id: globex.project, slug: "main" },
+  ]);
+  await seedRunningGraders();
+});
+
+afterAll(async () => {
+  holdManagedDeployment(SELF_HOSTED);
+  await database?.drop();
+});
+
+describe("a deployment serving several teams", () => {
+  it("copies no deployment-wide key or selection into any of them", async () => {
+    await seedPlatformSettings({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o-mini",
+      persona_model_key: "sk-sentinel-several-teams-model-key-A1B2",
+      speech_to_text_provider: "deepgram",
+      speech_to_text_model: "nova-3-general",
+      speech_to_text_key: "dg-sentinel-several-teams-listening-C3D4",
+      text_to_speech_provider: "cartesia",
+      text_to_speech_model: "sonic-3.5",
+      text_to_speech_key: "ct-sentinel-several-teams-speaking-E5F6",
+    });
+    await createPersona(acting(acme), { name: "Rita", traits: A_PERSONA("cartesia") });
+    await createPersona(acting(globex), { name: "Gene", traits: A_PERSONA("cartesia") });
+
+    const report = await upgradeModelSetup(SEVERAL_TEAMS);
+
+    expect(report.personas).toEqual([]);
+    expect(report.graders).toEqual([]);
+    expect(report.candidates).toEqual([]);
+    expect(report.activated).toEqual([]);
+    const { rows } = await database.sql(
+      "select count(*) as count from model_provider_credential",
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+
+  it("tells every organization that has work still on the old path", async () => {
+    const acmes = await listModelUpgradeActions(acting(acme));
+    const globexes = await listModelUpgradeActions(acting(globex));
+
+    for (const actions of [acmes, globexes]) {
+      const [only] = actions;
+      expect(actions).toHaveLength(1);
+      expect(only?.kind).toBe("set_up_model_access");
+      expect(only?.detail).toContain("several organizations");
+      expect(only?.detail).toContain("Managed by Egma");
+    }
+    // And each sees only its own, which is the tenancy rule this read is held
+    // to like every other.
+    expect(acmes[0]?.subject).toBe(acme.organization);
+    expect(globexes[0]?.subject).toBe(globex.organization);
+  });
+
+  /**
+   * The flag alone is not the gate, and this is why it is not: a deployment
+   * left on the single-organization flag that has grown a second organization
+   * must not copy one team's provider key into the other team's rows.
+   */
+  it("still copies nothing when the flag says one team and the database says two", async () => {
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    expect(report.candidates).toEqual([]);
+    expect(report.personas).toEqual([]);
+    const { rows } = await database.sql(
+      "select count(*) as count from model_provider_credential",
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+
+  it("leaves the marker standing, because nothing has selections yet", async () => {
+    const standing = await readModelUpgradeCompletion();
+
+    expect(standing.completed).toBe(false);
+    expect(standing.outstanding).toEqual(["personas", "graders"]);
+  });
+});
+
+describe("hosted Egma, whose organizations existed before it operated a gateway", () => {
+  it("gives every one of them the access this deployment operates", async () => {
+    holdManagedDeployment(HOSTED);
+    expect((await readModelAccess(acting(acme))).mode).toBe("customer-owned");
+
+    const report = await upgradeModelSetup(SEVERAL_TEAMS);
+
+    expect([...report.managedAccess].sort()).toEqual(
+      [acme.organization, globex.organization].sort(),
+    );
+    expect((await readModelAccess(acting(acme))).mode).toBe("managed");
+    expect((await readModelAccess(acting(globex))).mode).toBe("managed");
+  });
+
+  it("copies no key and no selection while it does it", async () => {
+    const { rows } = await database.sql(
+      "select count(*) as count from model_provider_credential",
+    );
+
+    expect(Number(rows[0]?.count)).toBe(0);
+    expect((await getPersona(acting(acme), (await firstPersona(acme)).id))?.models).toBeNull();
+  });
+
+  it("leaves an organization that has already chosen exactly as it chose", async () => {
+    await database.sql(
+      "update model_access set mode = 'customer-owned' where organization_id = $1",
+      [globex.organization],
+    );
+
+    const report = await upgradeModelSetup(SEVERAL_TEAMS);
+
+    expect(report.managedAccess).toEqual([]);
+    expect((await readModelAccess(acting(globex))).mode).toBe("customer-owned");
+  });
+});
+
+describe("a deployment whose settings do not answer the whole question", () => {
+  let sole: MigratedDatabase;
+  const solo = { organization: newId("org"), project: newId("prj") };
+
+  beforeAll(async () => {
+    // A database of its own, because "one organization" is a fact about the
+    // whole deployment and the two above are in the same one.
+    holdManagedDeployment(SELF_HOSTED);
+    await database.drop();
+    sole = await createConnectedDatabase("model_upgrade_incomplete");
+    database = sole;
+    await seedUser(sole, ada, "ada@acme.example");
+    await seedOrganization(sole, solo.organization, [
+      { id: solo.project, slug: "main" },
+    ]);
+    await seedRunningGraders();
+  });
+
+  it("refuses to invent the model nobody ever named", async () => {
+    await seedPlatformSettings({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o-mini",
+      persona_model_key: "sk-sentinel-incomplete-model-key-J9K0",
+      speech_to_text_provider: "deepgram",
+      // Optional in the previous release, and absent on plenty of real
+      // deployments: the simulator had a default. A selection may not.
+      speech_to_text_key: "dg-sentinel-incomplete-listening-L1M2",
+      text_to_speech_provider: "cartesia",
+      text_to_speech_model: "sonic-3.5",
+      text_to_speech_key: "ct-sentinel-incomplete-speaking-N3P4",
+    });
+    const rita = await createPersona(acting(solo), {
+      name: "Rita",
+      traits: A_PERSONA("cartesia"),
+    });
+
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    expect(report.personas).toEqual([]);
+    expect((await getPersona(acting(solo), rita.id))?.models).toBeNull();
+    const [action] = (await listModelUpgradeActions(acting(solo))).filter(
+      (one) => one.subject === rita.id,
+    );
+    expect(action?.kind).toBe("select_persona_models");
+    expect(action?.detail).toContain("a speech-to-text model");
+    expect(action?.detail).toContain("Persona models");
+  });
+
+  it("still activates the keys it found, because a key is not a selection", async () => {
+    const candidates = await listCredentialCandidates(acting(solo));
+
+    expect(candidates.filter((one) => one.active).map((one) => one.provider)).toEqual(
+      ["cartesia", "deepgram", "openai"],
+    );
+  });
+});
+
+describe("a deployment speaking through a provider this release does not carry", () => {
+  const solo = { organization: newId("org"), project: newId("prj") };
+
+  beforeAll(async () => {
+    holdManagedDeployment(SELF_HOSTED);
+    await database.drop();
+    database = await createConnectedDatabase("model_upgrade_descoped");
+    await seedUser(database, ada, "ada@acme.example");
+    await seedOrganization(database, solo.organization, [
+      { id: solo.project, slug: "main" },
+    ]);
+    await seedRunningGraders();
+    await seedPlatformSettings({
+      persona_model_provider: "openai",
+      persona_model: "gpt-4o-mini",
+      persona_model_key: "sk-sentinel-descoped-model-key-Q5R6",
+      speech_to_text_provider: "deepgram",
+      speech_to_text_model: "nova-3-general",
+      speech_to_text_key: "dg-sentinel-descoped-listening-S7T8",
+      // Left this effort's catalog by founder decision. Deferred, not
+      // cancelled — and until it returns, nothing may be selected in its place.
+      text_to_speech_provider: "elevenlabs",
+      text_to_speech_model: "eleven_turbo_v2_5",
+      text_to_speech_key: "el-sentinel-descoped-speaking-U9V0",
+    });
+  });
+
+  it("chooses no substitute for it, and says why in the action", async () => {
+    const nora = await createPersona(acting(solo), {
+      name: "Nora",
+      traits: A_PERSONA("elevenlabs"),
+    });
+
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    expect(report.personas).toEqual([]);
+    expect((await getPersona(acting(solo), nora.id))?.models).toBeNull();
+    const [action] = (await listModelUpgradeActions(acting(solo))).filter(
+      (one) => one.subject === nora.id,
+    );
+    expect(action?.detail).toContain("elevenlabs");
+    expect(action?.detail).toContain("not a provider in this release's model catalog");
+    // Never a substitute. The other speaking providers this release does carry
+    // are not mentioned, because suggesting one would be the guess.
+    expect(action?.detail).not.toContain("cartesia");
+  });
+
+  it("keeps its key, shows where it came from, and refuses to spend it", async () => {
+    const candidates = await listCredentialCandidates(acting(solo));
+    const theirs = candidates.find((one) => one.provider === "elevenlabs");
+
+    expect(theirs?.source).toBe("platform_setting");
+    expect(theirs?.sourceName).toBe("text_to_speech_key");
+    expect(theirs?.selectable).toBe(false);
+    expect(theirs?.active).toBe(false);
+    await expect(
+      activateCredentialCandidate(acting(solo), String(theirs?.id)),
+    ).rejects.toThrow(/not a provider in this release's model catalog/);
+    const { rows } = await database.sql<{ provider: string }>(
+      "select provider from model_provider_credential order by provider",
+    );
+    expect(rows.map((row) => row.provider)).toEqual(["deepgram", "openai"]);
+  });
+});
+
+describe("a grader with no judge behind it at all", () => {
+  const solo = { organization: newId("org"), project: newId("prj") };
+
+  beforeAll(async () => {
+    holdManagedDeployment(SELF_HOSTED);
+    await database.drop();
+    database = await createConnectedDatabase("model_upgrade_no_judge");
+    await seedUser(database, ada, "ada@acme.example");
+    await seedOrganization(database, solo.organization, [
+      { id: solo.project, slug: "main" },
+    ]);
+    await seedRunningGraders();
+  });
+
+  it("is left judged by nothing rather than judged by something invented", async () => {
+    const [seeded] = (await listGraders(acting(solo))).items;
+    if (seeded === undefined) throw new Error("the seeded grader is missing");
+
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    expect(report.graders).toEqual([]);
+    expect((await getGrader(acting(solo), seeded.id))?.graderModel).toBeNull();
+    const [action] = (await listModelUpgradeActions(acting(solo))).filter(
+      (one) => one.subject === seeded.id,
+    );
+    expect(action?.kind).toBe("select_grader_model");
+    expect(action?.detail).toContain("no judge configured");
+    expect(action?.detail).toContain("Grader model");
+  });
+
+  /**
+   * A code grader asks no model. It is not on a legacy path — it was never on a
+   * model path — so it gains no selection and holds nothing up.
+   */
+  it("leaves a code grader alone, because it judges with nothing", async () => {
+    const latency = await useLibraryEntry(acting(solo), {
+      libraryId: PREDEFINED_GRADERS.latency,
+      params: { metric: "turn_response_latency", bound: 2000 },
+    });
+
+    const report = await upgradeModelSetup(ONE_TEAM);
+    const actions = await listModelUpgradeActions(acting(solo));
+
+    expect(report.graders).not.toContain(latency.id);
+    expect(actions.map((one) => one.subject)).not.toContain(latency.id);
+    const { rows } = await database.sql<{ grader_model: unknown }>(
+      `select gv.grader_model from grader g
+         join grader_version gv on gv.id = g.current_version_id
+        where g.id = $1`,
+      [latency.id],
+    );
+    expect(rows[0]?.grader_model).toBeNull();
+  });
+
+  it("gains its explicit successor the moment the project has a judge", async () => {
+    await setJudgeConfiguration(acting(solo), {
+      provider: "openai",
+      model: "gpt-4o",
+      key: "sk-sentinel-late-judge-key-W1X2",
+    });
+    const seeded = (await listGraders(acting(solo))).items.find(
+      (one) => one.libraryId === PREDEFINED_GRADERS.expectedBehaviors,
+    );
+
+    const report = await upgradeModelSetup(ONE_TEAM);
+
+    expect(report.graders).toContain(String(seeded?.id));
+    expect((await getGrader(acting(solo), String(seeded?.id)))?.graderModel).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+    });
+    expect(
+      (await listModelUpgradeActions(acting(solo))).map((one) => one.subject),
+    ).not.toContain(seeded?.id);
+  });
+});
+
+async function firstPersona(tenant: {
+  organization: string;
+  project: string;
+}): Promise<{ id: string }> {
+  const { rows } = await database.sql<{ id: string }>(
+    "select id from persona where organization_id = $1 order by id limit 1",
+    [tenant.organization],
+  );
+  const [row] = rows;
+  if (row === undefined) throw new Error("no persona was seeded");
+  return row;
+}

--- a/packages/db/test/model-upgrade-refusals.test.ts
+++ b/packages/db/test/model-upgrade-refusals.test.ts
@@ -304,6 +304,8 @@ describe("a deployment speaking through a provider this release does not carry",
     const [action] = (await listModelUpgradeActions(acting(solo))).filter(
       (one) => one.subject === nora.id,
     );
+    // Named, so an organization with two blocked personas can tell them apart.
+    expect(action?.subjectName).toBe("Nora");
     expect(action?.detail).toContain("elevenlabs");
     expect(action?.detail).toContain("not a provider in this release's model catalog");
     // Never a substitute. The other speaking providers this release does carry
@@ -311,7 +313,15 @@ describe("a deployment speaking through a provider this release does not carry",
     expect(action?.detail).not.toContain("cartesia");
   });
 
-  it("keeps its key, shows where it came from, and refuses to spend it", async () => {
+  /**
+   * The key is kept, and — the half that was missing — it is *said out loud*.
+   *
+   * A stored key nothing can spend and nothing mentions is a deployment
+   * speaking through a provider the product no longer offers, with the only
+   * sign being the persona actions naming it. So the provider gets an action of
+   * its own, and the screen shows the key as kept and unusable.
+   */
+  it("keeps its key, says so in an action, and refuses to spend it", async () => {
     const candidates = await listCredentialCandidates(acting(solo));
     const theirs = candidates.find((one) => one.provider === "elevenlabs");
 
@@ -319,6 +329,13 @@ describe("a deployment speaking through a provider this release does not carry",
     expect(theirs?.sourceName).toBe("text_to_speech_key");
     expect(theirs?.selectable).toBe(false);
     expect(theirs?.active).toBe(false);
+
+    const [named] = (await listModelUpgradeActions(acting(solo))).filter(
+      (one) => one.subject === "elevenlabs",
+    );
+    expect(named?.kind).toBe("select_model_provider_credential");
+    expect(named?.subjectName).toBe("elevenlabs");
+    expect(named?.detail).toContain("not a provider in this release's model catalog");
     await expect(
       activateCredentialCandidate(acting(solo), String(theirs?.id)),
     ).rejects.toThrow(/not a provider in this release's model catalog/);

--- a/packages/db/test/model-upgrade.test.ts
+++ b/packages/db/test/model-upgrade.test.ts
@@ -669,6 +669,22 @@ describe("running the upgrade again", () => {
   });
 });
 
+/**
+ * Until a backend is waiting on the upgrade's advisory lock, which is how this
+ * test knows the recording has really begun and really stopped.
+ */
+async function waitingOnTheUpgradeLock(): Promise<void> {
+  for (let tries = 0; tries < 200; tries += 1) {
+    const { rows } = await client.sql<{ count: string }>(
+      `select count(*) as count from pg_locks
+        where locktype = 'advisory' and not granted`,
+    );
+    if (Number(rows[0]?.count) > 0) return;
+    await new Promise((settle) => setTimeout(settle, 10));
+  }
+  throw new Error("nothing ever waited on the upgrade lock");
+}
+
 describe("the completion marker", () => {
   /**
    * The marker is about *work*, not about every outstanding decision. This
@@ -742,6 +758,92 @@ describe("the completion marker", () => {
     expect(recorded.completed).toBe(true);
     expect(recorded.completedAt).toBeInstanceOf(Date);
     expect(recorded.outstanding).toEqual([]);
+  });
+
+  /**
+   * The stamp and its conditions are one moment, proved by making them two.
+   *
+   * **The interleaving, with no threads.** Another replica commits a
+   * selection-free persona while the stamp is being written — legal authoring
+   * for the whole compatibility period. The old shape read the conditions,
+   * found them clear, and then wrote: anything committing in between was
+   * memorialised as a moment that never held. This holds that window open on
+   * purpose: a second connection takes the upgrade's own advisory lock, writes
+   * the persona, and only then commits — so `recordModelUpgradeCompletion`
+   * blocks at the lock, and by the time its one statement runs the persona is
+   * committed and visible to it.
+   *
+   * A check made *before* that statement would have passed. The statement
+   * refuses anyway, because the conditions are in its own `where`.
+   */
+  it("refuses the stamp in the write, even when a check before it would have passed", async () => {
+    // Clear right now, which is the "check that would have passed".
+    expect((await readModelUpgradeCompletion()).outstanding).toEqual([]);
+    await client.sql(
+      "update platform_instance set model_upgrade_completed_at = null",
+    );
+
+    const other = await openSingleConnection(database.url);
+    try {
+      await other.sql("begin");
+      await other.sql(
+        "select pg_advisory_xact_lock(hashtextextended($1::text, 0))",
+        ["egma:upgrade-model-setup"],
+      );
+
+      // Blocked at the lock, and deliberately not awaited yet.
+      const recording = recordModelUpgradeCompletion();
+
+      // Waited for rather than assumed. Without this the insert could land
+      // before the recording's transaction had even opened, and the case would
+      // pass on a shape that reads its conditions before it writes — which is
+      // exactly the shape it exists to refuse.
+      await waitingOnTheUpgradeLock();
+
+      // The other replica's ordinary authoring write, committed while the
+      // recording waits.
+      const personaId = newId("prs");
+      const versionId = newId("prsv");
+      await other.sql(
+        `insert into persona (id, organization_id, project_id, name, current_version_id, revision)
+         values ($1, $2, $3, $4, $5, $6)`,
+        [personaId, acme.organization, acme.project, "Raced in", versionId, newId("rev")],
+      );
+      await other.sql(
+        `insert into persona_version (id, persona_id, version, traits, models)
+         values ($1, $2, 1, $3, null)`,
+        [versionId, personaId, JSON.stringify(RITA)],
+      );
+      await other.sql("commit");
+
+      const settled = await recording;
+
+      expect(settled.completed).toBe(false);
+      expect(settled.outstanding).toEqual(["personas"]);
+      expect(settled.completedAt).toBeNull();
+      const { rows } = await client.sql<{ count: string }>(
+        "select count(*) as count from platform_instance where model_upgrade_completed_at is not null",
+      );
+      expect(Number(rows[0]?.count)).toBe(0);
+
+      // Put right again, so what follows is about the marker rather than about
+      // this case's leftovers.
+      await editPersona(actingAsAcme(), personaId, {
+        models: {
+          llm: { provider: "openai", model: "gpt-4o-mini" },
+          stt: { provider: "deepgram", model: "nova-3-general" },
+          tts: {
+            provider: "cartesia",
+            model: "sonic-3.5",
+            voiceId: "a-voice-somebody-chose",
+            speed: 1,
+          },
+        },
+      });
+      await recordModelUpgradeCompletion();
+    } finally {
+      await other.close();
+    }
   });
 
   it("stays written, and a second recording does not move it", async () => {

--- a/packages/db/test/model-upgrade.test.ts
+++ b/packages/db/test/model-upgrade.test.ts
@@ -568,7 +568,7 @@ describe("the completion marker", () => {
 
     expect(again.completedAt?.getTime()).toBe(first.completedAt?.getTime());
     const { rows } = await client.sql<{ count: string }>(
-      "select count(*) as count from model_upgrade_completion",
+      "select count(*) as count from platform_instance where model_upgrade_completed_at is not null",
     );
     expect(Number(rows[0]?.count)).toBe(1);
   });

--- a/packages/db/test/model-upgrade.test.ts
+++ b/packages/db/test/model-upgrade.test.ts
@@ -846,6 +846,52 @@ describe("the completion marker", () => {
     }
   });
 
+  /**
+   * The stamp names the moment its own predicate was verified, not the moment
+   * the transaction that verified it happened to open.
+   *
+   * `now()` in Postgres is the *transaction's* start, and this transaction
+   * waits on an advisory lock before its update runs — so `now()` would stamp a
+   * moment before the evidence for it existed, by however long the wait lasted.
+   * Held here on purpose, and the moment is read off Postgres' own clock rather
+   * than this process's so no skew between the two can decide it.
+   */
+  it("names the moment its predicate was verified, not the moment it opened", async () => {
+    await client.sql(
+      "update platform_instance set model_upgrade_completed_at = null",
+    );
+
+    const other = await openSingleConnection(database.url);
+    try {
+      await other.sql("begin");
+      await other.sql(
+        "select pg_advisory_xact_lock(hashtextextended($1::text, 0))",
+        ["egma:upgrade-model-setup"],
+      );
+
+      const recording = recordModelUpgradeCompletion();
+      await waitingOnTheUpgradeLock();
+
+      // Strictly after the blocked transaction opened, on the database's clock.
+      const { rows } = await other.sql<{ held: Date }>(
+        "select clock_timestamp() as held",
+      );
+      const held = rows[0]?.held;
+      await new Promise((settle) => setTimeout(settle, 50));
+      await other.sql("commit");
+
+      const settled = await recording;
+
+      expect(settled.completed).toBe(true);
+      expect(held).toBeInstanceOf(Date);
+      expect(settled.completedAt?.getTime()).toBeGreaterThanOrEqual(
+        (held as Date).getTime(),
+      );
+    } finally {
+      await other.close();
+    }
+  });
+
   it("stays written, and a second recording does not move it", async () => {
     const first = await readModelUpgradeCompletion();
     const again = await recordModelUpgradeCompletion();

--- a/packages/db/test/model-upgrade.test.ts
+++ b/packages/db/test/model-upgrade.test.ts
@@ -200,7 +200,6 @@ beforeAll(async () => {
   const own = await useLibraryEntry(actingAsAcme(), {
     libraryId: PREDEFINED_GRADERS.expectedBehaviors,
     name: "Strictly judged behaviors",
-    config: { assertions: [] },
   });
   ownJudge = own.id;
   await editGrader(actingAsAcme(), own.id, {

--- a/packages/db/test/model-upgrade.test.ts
+++ b/packages/db/test/model-upgrade.test.ts
@@ -1,0 +1,575 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  connect,
+  createPersona,
+  disconnect,
+  editPersona,
+  getPersona,
+  getPersonaVersion,
+  listCredentialCandidates,
+  listModelUpgradeActions,
+  readModelUpgradeCompletion,
+  recordModelUpgradeCompletion,
+  seedGraderLibrary,
+  seedPlatformSettings,
+  seedRunningGraders,
+  setJudgeConfiguration,
+  upgradeModelSetup,
+  useLibraryEntry,
+  editGrader,
+  getGrader,
+  listGraders,
+  PREDEFINED_GRADERS,
+  type AuthContext,
+  type ModelUpgradeReport,
+  type PersonaTraits,
+} from "@egma/db";
+
+import { readMigrations, runMigrations } from "../src/migrate.ts";
+import {
+  createEmptyDatabase,
+  openSingleConnection,
+  TEST_ENCRYPTION_KEY,
+  type EmptyDatabase,
+  type SingleConnection,
+} from "./support/database.ts";
+
+/**
+ * A deployment standing at the release before model selections existed, taken
+ * through the upgrade that gives its personas and graders explicit ones.
+ *
+ * **The database is really built at that release.** Every migration up to the
+ * upgrade's own is written into a directory and applied; the rows are then
+ * written through the doors that release shipped — a persona with no
+ * selections, a grader judged by its project's judge, keys in the three places
+ * that release kept them — and only then is the upgrade applied. Nothing here
+ * starts from today's schema and pretends.
+ *
+ * **What it is proving is that the upgrade is additive.** Every old version is
+ * still there, unedited, still readable, still saying what it said. What is new
+ * is one successor version per persona and grader, and one sealed copy of each
+ * key that was already stored. Where the answer was not unambiguous, nothing
+ * was written at all except a sentence naming what somebody has to choose.
+ *
+ * The sentinels are recognisable strings rather than real envelopes because
+ * **nothing in this upgrade opens one** — which is the property being asserted.
+ * They are compared byte for byte for exactly that reason.
+ */
+
+let database: EmptyDatabase;
+let asItWas: string;
+let client: SingleConnection;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+
+function actingAsAcme(role: "admin" | "member" = "admin"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+/** The deployment declares itself one team, which every real self-hoster is. */
+const ONE_TEAM = { singleOrganization: true };
+
+/**
+ * The three keys the previous release kept, each in its own place and each
+ * recognisable in a scan.
+ */
+const LEGACY_KEY = {
+  thinking: "sk-sentinel-legacy-persona-model-key-A1B2",
+  listening: "dg-sentinel-legacy-speech-to-text-key-C3D4",
+  speaking: "ct-sentinel-legacy-text-to-speech-key-E5F6",
+  judging: "sk-sentinel-legacy-judge-credential-key-G7H8",
+} as const;
+
+/** What the deployment was configured with, exactly as that release wrote it. */
+const DEPLOYMENT_SETTINGS = {
+  persona_model_provider: "openai",
+  persona_model: "gpt-4o-mini",
+  persona_model_key: LEGACY_KEY.thinking,
+  // Retired by this release: no successor version may carry it.
+  persona_model_reasoning_effort: "high",
+  speech_to_text_provider: "deepgram",
+  speech_to_text_model: "nova-2-phonecall",
+  speech_to_text_key: LEGACY_KEY.listening,
+  text_to_speech_provider: "cartesia",
+  text_to_speech_model: "sonic-2",
+  text_to_speech_voice: "a-deployment-wide-voice",
+  text_to_speech_key: LEGACY_KEY.speaking,
+  voice_activity_provider: "silero",
+  media_backend: "livekit",
+  // The carrier settings, which this upgrade must not touch at all.
+  carrier_trunk_address: "sip:trunk.carrier.example",
+  carrier_trunk_number: "+15550100",
+  carrier_trunk_username: "acme-trunk",
+} as const;
+
+const RITA: PersonaTraits = {
+  personality: "Books three cleans a month and knows the schedule better than the agent.",
+  language: "en",
+  // Speaks with the provider the deployment speaks with, so this one has an
+  // unambiguous successor.
+  voice: { provider: "cartesia", voiceId: "ritas-own-voice", speed: 1.15 },
+  manner: "brisk",
+};
+
+const NORA: PersonaTraits = {
+  personality: "Calls once a year about a boiler service and has no idea what plan she is on.",
+  language: "en",
+  // Speaks with a provider the deployment does not, and which this release's
+  // catalog does not carry either. Two reasons to refuse, and either is enough.
+  voice: { provider: "elevenlabs", voiceId: "EXAVITQu4vr4xnSDxMaL", speed: 0.9 },
+};
+
+let rita: { id: string; versionId: string };
+let nora: { id: string; versionId: string };
+let ownJudge: string;
+let projectsJudge: string;
+let upgrade: ModelUpgradeReport;
+
+beforeAll(async () => {
+  database = await createEmptyDatabase("model_upgrade");
+  asItWas = await mkdtemp(path.join(os.tmpdir(), "egma-model-upgrade-"));
+
+  // The schema exactly as the release before the upgrade shipped it.
+  const migrations = await readMigrations();
+  const subject = migrations.findIndex((one) => one.name.startsWith("0037_"));
+  if (subject === -1) throw new Error("0037 is missing");
+  for (const migration of migrations.slice(0, subject)) {
+    await writeFile(path.join(asItWas, migration.name), migration.sql);
+  }
+  const applied = await runMigrations(database.url, asItWas);
+  expect(applied.applied).toEqual(
+    migrations.slice(0, subject).map((one) => one.name),
+  );
+
+  connect({ databaseUrl: database.url, encryptionKey: TEST_ENCRYPTION_KEY });
+  client = await openSingleConnection(database.url);
+  await seedGraderLibrary();
+
+  await client.sql("insert into organization (id, name, slug) values ($1, $2, $2)", [
+    acme.organization,
+    "acme",
+  ]);
+  await client.sql(
+    "insert into project (id, organization_id, name, slug, revision) values ($1, $2, $3, $3, $4)",
+    [acme.project, acme.organization, "main", newId("rev")],
+  );
+  await client.sql(
+    `insert into "user" (id, email, name, email_verified) values ($1, $2, $3, true)`,
+    [ada, "ada@acme.example", "Ada"],
+  );
+
+  await seedPlatformSettings(DEPLOYMENT_SETTINGS);
+
+  // Two personas, both authored the way that release authored them: traits and
+  // nothing else, because there was nothing else to say.
+  const madeRita = await createPersona(actingAsAcme(), { name: "Rita", traits: RITA });
+  const madeNora = await createPersona(actingAsAcme(), { name: "Nora", traits: NORA });
+  rita = { id: madeRita.id, versionId: madeRita.versionId };
+  nora = { id: madeNora.id, versionId: madeNora.versionId };
+
+  // The project's judge, with the organization's own key behind it — the
+  // arrangement the release before this one shipped.
+  await setJudgeConfiguration(actingAsAcme(), {
+    provider: "openai",
+    model: "gpt-4o",
+    key: LEGACY_KEY.judging,
+  });
+
+  // The mandatory grading copy every project has, written the way that release
+  // wrote it: no model of its own, judged by the project's configuration.
+  await seedRunningGraders();
+  const [seeded] = (await listGraders(actingAsAcme())).items;
+  if (seeded === undefined) throw new Error("the seeded grader is missing");
+  projectsJudge = seeded.id;
+
+  // And one grader that named its own judge model, which is the override that
+  // has to win over the project's.
+  const own = await useLibraryEntry(actingAsAcme(), {
+    libraryId: PREDEFINED_GRADERS.expectedBehaviors,
+    name: "Strictly judged behaviors",
+    config: { assertions: [] },
+  });
+  ownJudge = own.id;
+  await editGrader(actingAsAcme(), own.id, {
+    judgeModel: { provider: "openai", model: "gpt-4o-mini" },
+  });
+
+  // Then the upgrade a self-hoster runs: the whole of what is pending, and the
+  // boot act that finishes it.
+  const upgraded = await runMigrations(database.url);
+  expect(upgraded.applied).toEqual(
+    migrations.slice(subject).map((one) => one.name),
+  );
+  upgrade = await upgradeModelSetup(ONE_TEAM);
+});
+
+afterAll(async () => {
+  await client?.close();
+  await disconnect();
+  await database?.drop();
+  await rm(asItWas, { recursive: true, force: true });
+});
+
+describe("a persona the deployment's settings answer for", () => {
+  it("gains one new version carrying what it thinks, listens and speaks with", async () => {
+    const upgraded = await getPersona(actingAsAcme(), rita.id);
+
+    expect(upgrade.personas).toEqual([rita.id]);
+    expect(upgraded?.version).toBe(2);
+    expect(upgraded?.versionId).not.toBe(rita.versionId);
+    expect(upgraded?.models).toEqual({
+      llm: { provider: "openai", model: "gpt-4o-mini" },
+      stt: { provider: "deepgram", model: "nova-2-phonecall" },
+      tts: {
+        provider: "cartesia",
+        model: "sonic-2",
+        // The persona's own voice and its own pace, not the deployment's.
+        voiceId: "ritas-own-voice",
+        speed: 1.15,
+      },
+    });
+  });
+
+  it("keeps its first version exactly as it was, still readable and still empty", async () => {
+    const original = await getPersonaVersion(actingAsAcme(), rita.versionId);
+
+    expect(original?.version).toBe(1);
+    expect(original?.models).toBeNull();
+    expect(original?.traits).toEqual(RITA);
+  });
+
+  /**
+   * The voice precedence, stated as the thing that would be wrong without it: a
+   * migrated persona sounding like the deployment rather than like itself.
+   */
+  it("speaks with its own voice, never the deployment-wide one", async () => {
+    const upgraded = await getPersona(actingAsAcme(), rita.id);
+
+    expect(upgraded?.models?.tts.voiceId).toBe("ritas-own-voice");
+    expect(upgraded?.models?.tts.voiceId).not.toBe(
+      DEPLOYMENT_SETTINGS.text_to_speech_voice,
+    );
+    expect(upgraded?.models?.tts.speed).toBe(RITA.voice.speed);
+  });
+
+  /**
+   * The retired setting, asserted over the whole stored document rather than
+   * over a field name — a successor that carried it under any spelling would be
+   * a new version writing down something this release does not have.
+   */
+  it("carries no reasoning effort, because that setting is not part of a selection", async () => {
+    const { rows } = await client.sql<{ models: unknown }>(
+      "select models from persona_version where persona_id = $1 and version = 2",
+      [rita.id],
+    );
+
+    expect(JSON.stringify(rows[0]?.models)).not.toContain("reasoning");
+    expect(JSON.stringify(rows[0]?.models)).not.toContain("high");
+  });
+});
+
+describe("a persona whose own voice disagrees with the deployment's", () => {
+  it("stays on the legacy path and receives no guessed version", async () => {
+    const untouched = await getPersona(actingAsAcme(), nora.id);
+
+    expect(upgrade.personas).not.toContain(nora.id);
+    expect(untouched?.version).toBe(1);
+    expect(untouched?.versionId).toBe(nora.versionId);
+    expect(untouched?.models).toBeNull();
+  });
+
+  it("is named in an action that says what to choose and why", async () => {
+    const actions = await listModelUpgradeActions(actingAsAcme());
+    const hers = actions.find((one) => one.subject === nora.id);
+
+    expect(hers?.kind).toBe("select_persona_models");
+    expect(hers?.detail).toContain("elevenlabs");
+    expect(hers?.detail).toContain("cartesia");
+    // A sentence naming a screen, because the person reading it has to go
+    // somewhere and do something.
+    expect(hers?.detail).toContain("Persona models");
+  });
+
+  /**
+   * The marker's whole purpose, seen from the one condition that is standing:
+   * a single persona left on the legacy path is enough to hold the later
+   * removal back, and the answer says which condition rather than only "no".
+   */
+  it("holds the completion marker back, and names the condition that is standing", async () => {
+    const standing = await readModelUpgradeCompletion();
+
+    expect(standing.completed).toBe(false);
+    expect(standing.outstanding).toEqual(["personas"]);
+  });
+
+  it("clears its action the moment somebody makes the choice", async () => {
+    await editPersona(actingAsAcme(), nora.id, {
+      models: {
+        llm: { provider: "openai", model: "gpt-4o-mini" },
+        stt: { provider: "deepgram", model: "nova-3-general" },
+        tts: {
+          provider: "cartesia",
+          model: "sonic-3.5",
+          voiceId: "a-voice-somebody-chose",
+          speed: 0.9,
+        },
+      },
+    });
+
+    const actions = await listModelUpgradeActions(actingAsAcme());
+    expect(actions.map((one) => one.subject)).not.toContain(nora.id);
+  });
+});
+
+describe("the graders", () => {
+  it("gives the one judged by its project the project's own model, explicitly", async () => {
+    const upgraded = await getGrader(actingAsAcme(), projectsJudge);
+
+    expect(upgrade.graders).toContain(projectsJudge);
+    expect(upgraded?.version).toBe(2);
+    expect(upgraded?.graderModel).toEqual({ provider: "openai", model: "gpt-4o" });
+  });
+
+  /**
+   * The precedence that has to hold, said as the failure it prevents: a grader
+   * that deliberately named a cheaper judge silently moved onto the project's
+   * stronger one, with verdicts to show for it.
+   */
+  it("lets a grader's own judge model beat the project's configuration", async () => {
+    const upgraded = await getGrader(actingAsAcme(), ownJudge);
+
+    expect(upgraded?.graderModel).toEqual({
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+    expect(upgraded?.graderModel?.model).not.toBe("gpt-4o");
+  });
+
+  it("leaves every earlier grader version exactly as it was", async () => {
+    const { rows } = await client.sql<{
+      version: number;
+      judge_model: unknown;
+      grader_model: unknown;
+    }>(
+      "select version, judge_model, grader_model from grader_version where grader_id = $1 order by version",
+      [ownJudge],
+    );
+
+    expect(rows.map((row) => row.version)).toEqual([1, 2, 3]);
+    // The override as it was authored, on the version that was authored with it.
+    expect(rows[1]?.judge_model).toEqual({ provider: "openai", model: "gpt-4o-mini" });
+    expect(rows[1]?.grader_model).toBeNull();
+    // And the successor says one thing: a complete selection, and no override
+    // for anything to consult beside it.
+    expect(rows[2]?.judge_model).toBeNull();
+  });
+});
+
+describe("the keys the deployment already held", () => {
+  it("copies every one of them in, sealed, with where it was found", async () => {
+    const candidates = await listCredentialCandidates(actingAsAcme());
+
+    expect(
+      candidates.map((one) => [one.provider, one.source, one.sourceName]),
+    ).toEqual([
+      ["cartesia", "platform_setting", "text_to_speech_key"],
+      ["deepgram", "platform_setting", "speech_to_text_key"],
+      ["openai", "platform_setting", "persona_model_key"],
+      ["openai", "judge_credential", "main judge key"],
+    ]);
+    expect(upgrade.candidates).toHaveLength(4);
+  });
+
+  it("hands out four characters and never a key", async () => {
+    const candidates = await listCredentialCandidates(actingAsAcme());
+
+    for (const one of candidates) {
+      expect(one.hint).toHaveLength(4);
+      for (const key of Object.values(LEGACY_KEY)) {
+        expect(JSON.stringify(one)).not.toContain(key);
+      }
+    }
+  });
+
+  /**
+   * The envelope moved byte for byte, which is what says nothing was opened.
+   * A re-sealed copy would differ — the initialisation vector is fresh on every
+   * write — so this equality is the assertion that the master key was never
+   * used.
+   */
+  it("copies the sealed envelope verbatim, so nothing was ever unsealed", async () => {
+    const { rows } = await client.sql<{ stored: string; copied: string }>(
+      `select s.value as stored, c.credentials as copied
+         from platform_setting s
+         join model_credential_candidate c on c.source_name = s.name
+        where s.name = 'speech_to_text_key'`,
+    );
+
+    expect(rows[0]?.copied).toBe(rows[0]?.stored);
+    expect(rows[0]?.copied).toMatch(/^v1\./);
+  });
+
+  it("activates the sole candidate for each provider that has exactly one", async () => {
+    const candidates = await listCredentialCandidates(actingAsAcme());
+    const active = candidates.filter((one) => one.active);
+
+    expect(upgrade.activated).toEqual(["cartesia", "deepgram"]);
+    expect(active.map((one) => one.provider)).toEqual(["cartesia", "deepgram"]);
+  });
+
+  /**
+   * Two OpenAI keys: the deployment's own model key and the organization's
+   * judge key. Egma cannot tell whether they are one account, because telling
+   * would mean reading a secret — so it activates neither and asks.
+   */
+  it("activates neither of two keys for one provider, and asks instead", async () => {
+    const candidates = await listCredentialCandidates(actingAsAcme());
+    const openai = candidates.filter((one) => one.provider === "openai");
+    const { rows } = await client.sql<{ provider: string }>(
+      "select provider from model_provider_credential where organization_id = $1 order by provider",
+      [acme.organization],
+    );
+
+    expect(openai).toHaveLength(2);
+    expect(openai.every((one) => !one.active)).toBe(true);
+    expect(rows.map((row) => row.provider)).toEqual(["cartesia", "deepgram"]);
+
+    const actions = await listModelUpgradeActions(actingAsAcme());
+    const asking = actions.find((one) => one.subject === "openai");
+    expect(asking?.kind).toBe("select_model_provider_credential");
+    expect(asking?.detail).toContain("2 stored openai keys");
+    expect(asking?.detail).toContain("Model providers");
+  });
+
+  it("leaves the rows it copied from exactly where they were", async () => {
+    const { rows: settings } = await client.sql<{ count: string }>(
+      "select count(*) as count from platform_setting",
+    );
+    const { rows: judges } = await client.sql<{ source: string; credential_id: string | null }>(
+      "select source, credential_id from judge_configuration where project_id = $1",
+      [acme.project],
+    );
+
+    expect(Number(settings[0]?.count)).toBe(
+      Object.keys(DEPLOYMENT_SETTINGS).length,
+    );
+    // The project's judge still points at the credential it always pointed at,
+    // so an old grading plan can still resolve it.
+    expect(judges[0]?.source).toBe("credential");
+    expect(judges[0]?.credential_id).not.toBeNull();
+  });
+});
+
+describe("what the upgrade must not touch", () => {
+  it("leaves the carrier settings byte for byte as they were", async () => {
+    const { rows } = await client.sql<{ name: string; hint: string }>(
+      `select name, hint from platform_setting
+        where name like 'carrier_%' or name = 'media_backend'
+        order by name`,
+    );
+
+    expect(rows).toEqual([
+      { name: "carrier_trunk_address", hint: "sip:trunk.carrier.example" },
+      { name: "carrier_trunk_number", hint: "+15550100" },
+      { name: "carrier_trunk_username", hint: "acme-trunk" },
+      { name: "media_backend", hint: "livekit" },
+    ]);
+  });
+
+  it("writes no model access on a self-hosted deployment", async () => {
+    const { rows } = await client.sql<{ count: string }>(
+      "select count(*) as count from model_access",
+    );
+
+    expect(upgrade.managedAccess).toEqual([]);
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+});
+
+describe("running the upgrade again", () => {
+  it("writes nothing at all the second time", async () => {
+    const before = await client.sql<{ personas: string; graders: string; candidates: string; credentials: string }>(
+      `select
+         (select count(*) from persona_version) as personas,
+         (select count(*) from grader_version) as graders,
+         (select count(*) from model_credential_candidate) as candidates,
+         (select count(*) from model_provider_credential) as credentials`,
+    );
+
+    const again = await upgradeModelSetup(ONE_TEAM);
+    const after = await client.sql<{ personas: string; graders: string; candidates: string; credentials: string }>(
+      `select
+         (select count(*) from persona_version) as personas,
+         (select count(*) from grader_version) as graders,
+         (select count(*) from model_credential_candidate) as candidates,
+         (select count(*) from model_provider_credential) as credentials`,
+    );
+
+    expect(again.personas).toEqual([]);
+    expect(again.graders).toEqual([]);
+    expect(again.candidates).toEqual([]);
+    expect(again.activated).toEqual([]);
+    expect(after.rows[0]).toEqual(before.rows[0]);
+  });
+
+  it("does not duplicate the action it already wrote", async () => {
+    const { rows } = await client.sql<{ count: string }>(
+      "select count(*) as count from model_upgrade_action where kind = 'select_model_provider_credential'",
+    );
+
+    expect(Number(rows[0]?.count)).toBe(1);
+  });
+});
+
+describe("the completion marker", () => {
+  /**
+   * The marker is about *work*, not about every outstanding decision. This
+   * organization still has two OpenAI keys and has chosen neither, and that
+   * genuinely does not stop the legacy paths being removed: nothing queued
+   * needs the old contract, and no grading plan is waiting on a credential
+   * reference. So the conditions are clear while the action is still open, and
+   * the marker waits only to be recorded.
+   */
+  it("has nothing outstanding once the work is done, even with a key still to choose", async () => {
+    const standing = await readModelUpgradeCompletion();
+    const asking = await listModelUpgradeActions(actingAsAcme());
+
+    expect(standing.outstanding).toEqual([]);
+    expect(standing.completed).toBe(false);
+    expect(asking.map((one) => one.kind)).toEqual([
+      "select_model_provider_credential",
+    ]);
+  });
+
+  it("is written once every persona and grader carries selections", async () => {
+    const recorded = await recordModelUpgradeCompletion();
+
+    expect(recorded.completed).toBe(true);
+    expect(recorded.completedAt).toBeInstanceOf(Date);
+    expect(recorded.outstanding).toEqual([]);
+  });
+
+  it("stays written, and a second recording does not move it", async () => {
+    const first = await readModelUpgradeCompletion();
+    const again = await recordModelUpgradeCompletion();
+
+    expect(again.completedAt?.getTime()).toBe(first.completedAt?.getTime());
+    const { rows } = await client.sql<{ count: string }>(
+      "select count(*) as count from model_upgrade_completion",
+    );
+    expect(Number(rows[0]?.count)).toBe(1);
+  });
+});

--- a/packages/db/test/model-upgrade.test.ts
+++ b/packages/db/test/model-upgrade.test.ts
@@ -6,8 +6,16 @@ import { newId } from "@egma/ids";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
+  claimGradingJobs,
+  claimSimulations,
+  completeSimulation,
+  finishGradingJob,
   connect,
+  createAgent,
   createPersona,
+  createTest,
+  startRun,
+  startSimulation,
   disconnect,
   editPersona,
   getPersona,
@@ -137,6 +145,9 @@ let nora: { id: string; versionId: string };
 let ownJudge: string;
 let projectsJudge: string;
 let upgrade: ModelUpgradeReport;
+let history: { runId: string; simulationId: string };
+/** Every column of the record the previous release wrote, before the upgrade. */
+let before: Record<string, Record<string, unknown> | undefined>;
 
 beforeAll(async () => {
   database = await createEmptyDatabase("model_upgrade");
@@ -205,6 +216,81 @@ beforeAll(async () => {
   await editGrader(actingAsAcme(), own.id, {
     judgeModel: { provider: "openai", model: "gpt-4o-mini" },
   });
+
+  /**
+   * And one run, conducted and finished the way that release finished one.
+   *
+   * **History is the thing an upgrade is most easily wrong about**, and a
+   * database holding only personas and graders cannot say whether this one is:
+   * every assertion about "nothing was rewritten" would be about definitions
+   * rather than about the record of what happened. So this seeds a real run
+   * with a real simulation, lands it terminal, and the case below reads every
+   * column of both back afterwards.
+   *
+   * Verdicts are deliberately not here: they are ClickHouse rows, and this
+   * migration adds no ClickHouse file at all — `clickhouse-migrations` is
+   * untouched by this release, which is a stronger statement than any assertion
+   * this suite could make about one.
+   */
+  const agent = await createAgent(actingAsAcme(), {
+    name: "Front desk",
+    connection: {
+      type: "retell",
+      modality: "chat",
+      environment: "staging",
+      config: { retellAgentId: "agent_in_retell_1" },
+      credentials: { apiKey: "retell-secret-A1B2C3D4WXYZ" },
+    },
+  });
+  const authored = await createTest(actingAsAcme(), {
+    name: "Reschedules a booked appointment",
+    scenario: "Their cleaning is booked for Thursday morning and has to move.",
+    expectedBehaviors: ["confirms the new time back before finishing"],
+    personaIds: [madeRita.id],
+  });
+  const run = await startRun(actingAsAcme(), {
+    agentId: agent.id,
+    connectionId: agent.connection?.id ?? "",
+    testVersionIds: [authored.versionId],
+  });
+  const [claimed] = await claimSimulations({
+    claimant: "sim-of-the-old-release",
+    capacity: 1,
+  });
+  if (claimed === undefined) throw new Error("the seeded run claimed nothing");
+  await startSimulation(actingAsAcme(), claimed.id, "sim-of-the-old-release");
+  await completeSimulation(
+    actingAsAcme(),
+    claimed.id,
+    "sim-of-the-old-release",
+    { endingReason: "persona_concluded", turnCount: 6 },
+  );
+  // And the grading job it enqueued, judged and finished — because the record
+  // this suite is about is a *finished* one, and a job left pending would be
+  // outstanding work rather than history.
+  const [judging] = await claimGradingJobs({
+    claimant: "grader-of-the-old-release",
+    capacity: 1,
+  });
+  if (judging === undefined) throw new Error("the seeded run enqueued no grading");
+  await finishGradingJob(judging.auth, judging.id, "grader-of-the-old-release");
+  history = { runId: run.id, simulationId: claimed.id };
+
+  // Every column of both, exactly as the previous release left them.
+  before = {
+    run: (await client.sql("select * from run where id = $1", [run.id])).rows[0],
+    simulation: (
+      await client.sql("select * from simulation where id = $1", [claimed.id])
+    ).rows[0],
+    plan: (
+      await client.sql("select * from grading_plan where run_id = $1", [run.id])
+    ).rows[0],
+    job: (
+      await client.sql("select * from grading_job where simulation_id = $1", [
+        claimed.id,
+      ])
+    ).rows[0],
+  };
 
   // Then the upgrade a self-hoster runs: the whole of what is pending, and the
   // boot act that finishes it.
@@ -472,6 +558,56 @@ describe("the keys the deployment already held", () => {
   });
 });
 
+describe("the record of what already happened", () => {
+  /**
+   * Every column of the run, the conversation, the frozen plan and the grading
+   * job, compared whole rather than field by field — a comparison that names
+   * the fields it checks is a comparison that cannot notice the one somebody
+   * added.
+   */
+  it("comes back byte for byte, run, simulation, plan and grading job alike", async () => {
+    const now = {
+      run: (
+        await client.sql("select * from run where id = $1", [history.runId])
+      ).rows[0],
+      simulation: (
+        await client.sql("select * from simulation where id = $1", [
+          history.simulationId,
+        ])
+      ).rows[0],
+      plan: (
+        await client.sql("select * from grading_plan where run_id = $1", [
+          history.runId,
+        ])
+      ).rows[0],
+      job: (
+        await client.sql("select * from grading_job where simulation_id = $1", [
+          history.simulationId,
+        ])
+      ).rows[0],
+    };
+
+    expect(now).toEqual(before);
+  });
+
+  /**
+   * And the conversation still says who conducted it — pinned to the version
+   * that ran, which is now *not* the persona's current one. That is the whole
+   * worth of pinning, and an upgrade that moved the pin would have rewritten
+   * history while leaving every row's own columns intact.
+   */
+  it("stays pinned to the persona version that really ran, not the successor", async () => {
+    const { rows } = await client.sql<{ persona_version_id: string }>(
+      "select persona_version_id from simulation where id = $1",
+      [history.simulationId],
+    );
+    const current = await getPersona(actingAsAcme(), rita.id);
+
+    expect(rows[0]?.persona_version_id).toBe(rita.versionId);
+    expect(rows[0]?.persona_version_id).not.toBe(current?.versionId);
+  });
+});
+
 describe("what the upgrade must not touch", () => {
   it("leaves the carrier settings byte for byte as they were", async () => {
     const { rows } = await client.sql<{ name: string; hint: string }>(
@@ -547,13 +683,60 @@ describe("the completion marker", () => {
     const asking = await listModelUpgradeActions(actingAsAcme());
 
     expect(standing.outstanding).toEqual([]);
-    expect(standing.completed).toBe(false);
+    // Answered from the conditions rather than from the stamp — which has not
+    // been written yet, and is a record of a moment rather than a permission.
+    expect(standing.completed).toBe(true);
+    expect(standing.completedAt).toBeNull();
     expect(asking.map((one) => one.kind)).toEqual([
       "select_model_provider_credential",
     ]);
   });
 
-  it("is written once every persona and grader carries selections", async () => {
+  /**
+   * The latch that is not one, and the reason the read may never short-circuit
+   * on the stamp.
+   *
+   * **Authoring keeps working during the compatibility period** — that is what
+   * makes it a period — so an ordinary `createPersona` with no selections is a
+   * legitimate write on a stamped installation, and it puts this deployment
+   * back to having outstanding work. A read that answered "finished" because a
+   * timestamp existed would tell the next release it may remove a path this
+   * persona still needs.
+   */
+  it("goes back to unfinished when new work arrives on the old path", async () => {
+    await recordModelUpgradeCompletion();
+    const stamped = await readModelUpgradeCompletion();
+    expect(stamped.completed).toBe(true);
+    expect(stamped.completedAt).toBeInstanceOf(Date);
+
+    const late = await createPersona(actingAsAcme(), {
+      name: "Authored during the transition",
+      traits: RITA,
+    });
+
+    const standing = await readModelUpgradeCompletion();
+    expect(standing.outstanding).toEqual(["personas"]);
+    expect(standing.completed).toBe(false);
+    // The stamp stays, because the moment it records really happened.
+    expect(standing.completedAt).toEqual(stamped.completedAt);
+
+    // And putting it right again puts the answer right again, with no restart.
+    await editPersona(actingAsAcme(), late.id, {
+      models: {
+        llm: { provider: "openai", model: "gpt-4o-mini" },
+        stt: { provider: "deepgram", model: "nova-3-general" },
+        tts: {
+          provider: "cartesia",
+          model: "sonic-3.5",
+          voiceId: "a-voice-somebody-chose",
+          speed: 1,
+        },
+      },
+    });
+    expect((await readModelUpgradeCompletion()).completed).toBe(true);
+  });
+
+  it("is stamped once every persona and grader carries selections", async () => {
     const recorded = await recordModelUpgradeCompletion();
 
     expect(recorded.completed).toBe(true);

--- a/packages/db/test/schema-shape.test.ts
+++ b/packages/db/test/schema-shape.test.ts
@@ -77,6 +77,15 @@ const TABLE_PREFIX: Readonly<Record<string, IdPrefix>> = {
   // The organization's judge credentials: the keys egma judges with, and the
   // one place any of them is stored.
   judge_credential: "jcr",
+  // One legacy provider key the upgrade found and copied, sealed, as a
+  // candidate for its provider. Its own identity because an administrator
+  // choosing between two of them has to name one, and the only other thing on
+  // the row that could name it is four characters of a secret.
+  model_credential_candidate: "mcc",
+  // One decision the upgrade refused to make on somebody's behalf. Its own
+  // identity because a screen lists them and somebody clears them one at a
+  // time.
+  model_upgrade_action: "mua",
   mock_tool: "mck",
   // The scope's junction, pinning the mock tool it narrows — the shape the
   // persona junction has, for the same reason.

--- a/packages/ids/src/index.ts
+++ b/packages/ids/src/index.ts
@@ -70,6 +70,21 @@ export const ID_PREFIXES = [
    * revoking one has to be able to name something that is not the secret.
    */
   "ifk",
+  /**
+   * One legacy provider key the upgrade found and copied, sealed, as a
+   * candidate for its provider. Its own identity because an administrator
+   * choosing between two of them has to name one, and the only other thing on
+   * the row that could name it is four characters of a secret.
+   */
+  "mcc",
+  /**
+   * One decision the upgrade onto model selections refused to make: a provider
+   * with two candidate keys, a persona or grader with no unambiguous successor,
+   * an organization on a deployment that copies nothing into it. Its own
+   * identity because a screen lists them and somebody clears them one at a
+   * time.
+   */
+  "mua",
   "mck",
   "ste",
   "run",

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -248,18 +248,36 @@ const WORK_DISPATCHING = [
  * *ever* held a copy rather than whether it holds one now, so a team that
  * switched theirs off is not overruled at the next start.
  *
+ * `upgradeModelSetup` was added on 2026-08-17 with managed model access, and it
+ * is the same act again on the personas and graders a deployment already had:
+ * a release before the model catalog existed left every one of them resolving
+ * through deployment-wide settings, and this gives each an explicit successor
+ * from what that deployment was already configured with. It names no customer
+ * because the configuration it reads belongs to none — which is exactly why it
+ * copies nothing at all on a deployment serving several organizations. Its one
+ * parameter is what kind of deployment this is, so a test can hand in either.
+ *
+ * `readModelUpgradeCompletion` and `recordModelUpgradeCompletion` are the
+ * marker beside it, and they are the strongest case in this list: whether *this
+ * installation* has finished spans every organization on it, so there is no
+ * organization a caller could name and no context under which the question
+ * would even be well posed. Neither takes an argument at all.
+ *
  * The rule enforces the second half of that the same way it does for work
  * dispatch: nothing here may be handed an `organizationId` or a `projectId`. A
  * function here that grew one would be an ordinary cross-tenant *write* wearing
  * an exemption, which is worse than the read work dispatch guards against.
  *
- * A fifth name here is a decision somebody has to make on purpose.
+ * An eighth name here is a decision somebody has to make on purpose.
  */
 const DEPLOYMENT_CONFIGURING = [
+  "readModelUpgradeCompletion",
+  "recordModelUpgradeCompletion",
   "seedDefaultJudge",
   "seedGraderLibrary",
   "seedPlatformSettings",
   "seedRunningGraders",
+  "upgradeModelSetup",
 ];
 
 /**

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/platform-carrying-model-settings.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/platform-carrying-model-settings.json
@@ -1,0 +1,65 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3Q2A",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  },
+  "platform": {
+    "model": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-platform-0005"
+    },
+    "carrier": {
+      "media_backend": "livekit"
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/invalid/platform-carrying-speech-settings.json
+++ b/packages/simulation-contract/fixtures/spec-v2/invalid/platform-carrying-speech-settings.json
@@ -1,0 +1,64 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3Q2B",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  },
+  "platform": {
+    "speech": {
+      "stt_provider": "deepgram",
+      "stt_key": "dg-spec-fixture-platform-0006"
+    },
+    "carrier": {
+      "media_backend": "livekit"
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec-v2/valid/voice-customer-owned-with-a-carrier.json
+++ b/packages/simulation-contract/fixtures/spec-v2/valid/voice-customer-owned-with-a-carrier.json
@@ -1,0 +1,64 @@
+{
+  "contract_version": 2,
+  "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PZX",
+  "modality": "voice",
+  "connection": {
+    "type": "livekit",
+    "config": {
+      "url": "wss://lakeside-dental.livekit.cloud",
+      "agentName": "front-desk",
+      "metadata": "{\"clinic\":\"lakeside\",\"locale\":\"en-GB\"}"
+    },
+    "credentials": {
+      "apiKey": "APIexample0key0",
+      "apiSecret": "example0secret0value0not0a0real0one"
+    }
+  },
+  "persona": {
+    "traits": {
+      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+      "language": "en-GB",
+      "voice": {
+        "provider": "elevenlabs",
+        "voiceId": "measured-alto-3",
+        "speed": 0.95
+      }
+    }
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "access": "customer-owned",
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "key": "sk-spec-fixture-llm-0001"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "key": "dg-spec-fixture-stt-0002"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "key": "ct-spec-fixture-tts-0003",
+      "voice_id": "5ee9feff-1265-424a-9d7f-8e4d431a12c7",
+      "speed": 1
+    }
+  },
+  "platform": {
+    "carrier": {
+      "media_backend": "livekit",
+      "trunk_address": "sip:trunk.carrier.example",
+      "trunk_number": "+15550100",
+      "trunk_username": "lakeside-trunk",
+      "trunk_password": "spec-fixture-trunk-password-0004"
+    }
+  }
+}

--- a/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v2.schema.json
@@ -124,16 +124,10 @@
       }
     },
     "platform": {
-      "description": "What this deployment has been configured with, unsealed for exactly this hand-off: who the persona thinks with, what it speaks and hears with, and how a call reaches the telephone network. These belong to the whole deployment rather than to any customer on it, and they used to live in each simulator's own environment \u2014 which meant a second simulator on another machine needed a file copied to it, and a container started without one dialled nothing while reporting itself healthy. They ride this document instead, through the same door and with the same authority as the connection's credentials beside them, and are read afresh for each simulation so a changed key applies to the next one with no restart. Every block is optional and so is every field inside it: a setting the platform does not hold leaves the simulator's own value standing, and a setting it does hold replaces it. A platform that has configured nothing sends nothing, and a simulator conducts exactly as it did before this block existed.",
+      "description": "What this deployment has been configured with, unsealed for exactly this hand-off. On version 2 this is the carrier settings and nothing else: how a call reaches the telephone network belongs to the deployment, and a persona cannot select it. The model and speech settings that version 1 carries here are absent by construction \u2014 a version-2 document is one whose persona selected its own models, and those selections already carry the credentials that authorize every leg, so sending the deployment's provider keys beside them would be three more secrets on the wire with nothing to spend them on. A simulation still on the compatibility path is written in version 1 and receives all of it, unchanged. Every field inside the carrier block stays optional: a deployment that has never been given a carrier sends nothing and still conducts chat and voice simulations.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "model": {
-          "$ref": "#/$defs/platform_model"
-        },
-        "speech": {
-          "$ref": "#/$defs/platform_speech"
-        },
         "carrier": {
           "$ref": "#/$defs/platform_carrier"
         }
@@ -144,80 +138,6 @@
     }
   },
   "$defs": {
-    "platform_model": {
-      "description": "What the persona thinks with. Every field is optional, because a platform mid-setup holds some of them and not others, and one that holds none of them is every platform before anybody set it up.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "provider": {
-          "description": "Which client speaks to the model \u2014 the simulator's own open vocabulary, not an enum here: a simulator holding no client for a provider refuses at runtime with the ones it has, rather than this schema refusing the document.",
-          "type": "string",
-          "minLength": 1
-        },
-        "model": {
-          "description": "Which model to ask for, verbatim as the provider names it. Configuration rather than a constant of the product: providers retire and add models on their own schedule.",
-          "type": "string",
-          "minLength": 1
-        },
-        "key": {
-          "description": "The provider key, in the clear for exactly this hand-off. Held in memory for the simulation, registered for redaction, and never logged, persisted or reported. No report document has anywhere to put it.",
-          "type": "string",
-          "minLength": 1
-        },
-        "reasoning_effort": {
-          "description": "How hard the model should think before the persona speaks, in the provider's own vocabulary \u2014 an open string, not an enum here, because the accepted values differ between providers speaking one chat-completions shape and have grown more than once. Absent means send nothing at all, which is what keeps a model that has never heard of the field working exactly as it did. A persona is in a hurry rather than solving a puzzle: the reasoning under test is the agent's, and every moment the persona spends thinking is silence on a live line that nobody real would leave. It belongs to the deployment's own settings and never to a persona's selections, so a persona that selects its own models uses its provider's default reasoning behavior.",
-          "type": "string",
-          "minLength": 1
-        }
-      }
-    },
-    "platform_speech": {
-      "description": "What the persona speaks and hears with on a voice simulation, and what tells it the agent has started and stopped speaking. A key per leg rather than one per provider: the two legs are two accounts as often as they are one, and a shape that could not say so would make the second one unreachable.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "stt_provider": {
-          "description": "The persona's ears. An open vocabulary, refused at runtime by the simulator holding no such leg.",
-          "type": "string",
-          "minLength": 1
-        },
-        "stt_key": {
-          "description": "The listening leg's provider key, on the same terms as the model key above.",
-          "type": "string",
-          "minLength": 1
-        },
-        "stt_model": {
-          "description": "Which model the listening leg asks for, where its provider has more than one. Here beside tts_model rather than left in each simulator's environment, which is where it used to live alone: that asymmetry was the one speech setting a deployment could not change centrally, so moving the persona's mouth was a settings page and moving its ears was editing a container and restarting it.",
-          "type": "string",
-          "minLength": 1
-        },
-        "tts_provider": {
-          "description": "The persona's mouth. Chosen apart from the ears on purpose \u2014 a real mouth with scripted ears is a configuration somebody will want.",
-          "type": "string",
-          "minLength": 1
-        },
-        "tts_key": {
-          "description": "The speaking leg's provider key, on the same terms as the model key above.",
-          "type": "string",
-          "minLength": 1
-        },
-        "tts_model": {
-          "description": "Which model the speaking leg asks for, where its provider has more than one.",
-          "type": "string",
-          "minLength": 1
-        },
-        "tts_voice": {
-          "description": "Which voice the speaking leg asks for when the persona's own traits name none.",
-          "type": "string",
-          "minLength": 1
-        },
-        "vad_provider": {
-          "description": "What tells the persona the agent has started or stopped speaking. Needs no key either way.",
-          "type": "string",
-          "minLength": 1
-        }
-      }
-    },
     "platform_carrier": {
       "description": "How a call reaches the telephone network: which bridge places it, and the trunk the carrier authenticates. Absent on every deployment that has never been given a carrier \u2014 which still runs chat and voice simulations perfectly well \u2014 and that absence is an ordinary state rather than a fault. The media server's own key and secret are deliberately not here: they are read by a third-party container when it is created and cannot come from the platform's store, so they stay in each simulator's environment.",
       "type": "object",

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -394,22 +394,21 @@ describe("the two schemas, as one contract", () => {
    * Version 2 carries the carrier settings and refuses the rest.
    */
   it("narrow the platform block on version 2 to the carrier settings alone", () => {
-    const blockOf = (schema: Record<string, unknown>): readonly string[] =>
-      Object.keys(
-        (
-          (schema.properties as Record<string, Record<string, unknown>>)
-            .platform.properties as Record<string, unknown>
-        ) ?? {},
+    const blockOf = (schema: Record<string, unknown>): readonly string[] => {
+      const platform = (
+        schema.properties as Record<string, Record<string, unknown> | undefined>
+      ).platform;
+      return Object.keys(
+        (platform?.properties as Record<string, unknown> | undefined) ?? {},
       ).sort();
+    };
 
     expect(blockOf(specSchema)).toEqual(["carrier", "model", "speech"]);
     expect(blockOf(specSchemaV2)).toEqual(["carrier"]);
     // Closed, so the two it drops are refused rather than ignored.
     expect(
-      (
-        (specSchemaV2.properties as Record<string, Record<string, unknown>>)
-          .platform as Record<string, unknown>
-      ).additionalProperties,
+      (specSchemaV2.properties as Record<string, Record<string, unknown>>)
+        .platform?.additionalProperties,
     ).toBe(false);
   });
 

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -224,6 +224,22 @@ const EXPECTED_REJECTION: Record<string, Rejection> = {
     at: "/models",
     keyword: "oneOf",
   },
+  // A version-2 document is one whose persona selected its own models, and
+  // those selections carry the credentials that authorize every leg — so the
+  // deployment's own model and speech settings beside them would be three more
+  // provider keys on the wire with nothing to spend them on. Refused rather
+  // than carried and ignored, because a document that may hold two answers is
+  // one every reader has to decide between.
+  "spec-v2/platform-carrying-model-settings.json": {
+    at: "/platform",
+    keyword: "additionalProperties",
+    property: "model",
+  },
+  "spec-v2/platform-carrying-speech-settings.json": {
+    at: "/platform",
+    keyword: "additionalProperties",
+    property: "speech",
+  },
   "spec-v2/unknown-field.json": {
     at: "",
     keyword: "additionalProperties",
@@ -293,7 +309,8 @@ describe("the two schemas, as one contract", () => {
   });
 
   /**
-   * Version 2 is version 1 with one block added, and this is what says so.
+   * Version 2 is version 1 with one block added and one block narrowed, and
+   * this is what says so.
    *
    * Written out rather than derived, because the two schemas are two frozen
    * documents on purpose: a reader has to be able to see the whole of what a
@@ -308,7 +325,7 @@ describe("the two schemas, as one contract", () => {
    * who has that version in front of them, so a sentence reworded in one and
    * not the other is the documents doing their job rather than drifting.
    */
-  it("differ by the models block and by nothing else", () => {
+  it("differ by the models block, the narrowed platform block, and nothing else", () => {
     /** Every `description`, anywhere, gone — see the note above. */
     const withoutProse = (node: unknown): unknown => {
       if (Array.isArray(node)) return node.map(withoutProse);
@@ -330,10 +347,21 @@ describe("the two schemas, as one contract", () => {
       const properties = clone.properties as Record<string, unknown>;
       delete properties.contract_version;
       delete properties.models;
+      // The second difference, and it is pinned on its own below rather than
+      // compared here: a version-2 document's persona selected its own models,
+      // so the deployment's model and speech settings have nothing to decide
+      // and are refused rather than carried. The carrier settings stay, because
+      // how a call reaches the telephone network is the deployment's and a
+      // persona cannot select it.
+      delete properties.platform;
       clone.required = (clone.required as string[]).filter(
         (name) => name !== "models",
       );
       const defs = clone.$defs as Record<string, unknown>;
+      // The two version 1 defines for the blocks version 2 refuses, gone with
+      // the property that referenced them.
+      delete defs.platform_model;
+      delete defs.platform_speech;
       for (const added of [
         "models",
         "model_selection",
@@ -353,6 +381,36 @@ describe("the two schemas, as one contract", () => {
     };
 
     expect(stripped(specSchemaV2)).toEqual(stripped(specSchema));
+  });
+
+  /**
+   * The narrowing itself, pinned where deleting it fails something.
+   *
+   * Version 1 hands a simulator the deployment's model, speech and carrier
+   * settings. Version 2 is a document whose persona selected its own models and
+   * whose selections carry the credentials that authorize every leg — so the
+   * first two would be three provider keys travelling with nothing to spend
+   * them on, and a reader holding both would have to decide which answer wins.
+   * Version 2 carries the carrier settings and refuses the rest.
+   */
+  it("narrow the platform block on version 2 to the carrier settings alone", () => {
+    const blockOf = (schema: Record<string, unknown>): readonly string[] =>
+      Object.keys(
+        (
+          (schema.properties as Record<string, Record<string, unknown>>)
+            .platform.properties as Record<string, unknown>
+        ) ?? {},
+      ).sort();
+
+    expect(blockOf(specSchema)).toEqual(["carrier", "model", "speech"]);
+    expect(blockOf(specSchemaV2)).toEqual(["carrier"]);
+    // Closed, so the two it drops are refused rather than ignored.
+    expect(
+      (
+        (specSchemaV2.properties as Record<string, Record<string, unknown>>)
+          .platform as Record<string, unknown>
+      ).additionalProperties,
+    ).toBe(false);
   });
 
   /**


### PR DESCRIPTION
## What this is

The transition. An existing installation upgrades onto the new model-access system with nothing rewritten and nothing guessed: legacy credentials become sealed candidates, compatible personas and graders receive one explicit successor version each, every ambiguity becomes a visible administrator action instead of a silent choice, and a per-installation completion marker records — and re-verifies — when the legacy paths are finally drained. The four-path matrix now proves the release shape end to end, reading results back through the public read paths.

## What's in it

- **Migration `0037` (additive)**: `model_credential_candidate` (every legacy secret copied sealed, with its source and its envelope shape — the legacy stores disagree about what is *inside* an envelope, and translation happens exactly once, at the moment of choice, checked loudly), `model_upgrade_action` (one decision per subject, unique so a restart cannot duplicate it), and the completion marker on the installation row.
- **The boot act**: collects candidates from all three legacy sources without ever opening one (proved by byte-equality with the source rows); activates a sole candidate per provider; several candidates activate nothing and ask; mints one successor version per compatible persona (voice precedence: the persona's own versioned voice, ID, and speed always beat the deployment's; no successor carries the legacy reasoning-effort setting) and per judged grader (a per-grader override beats the project judge); multi-organization deployments get no backfill and every organization with legacy work gets told; descoped providers get an action naming the catalog, never a substitute; archived personas are included so un-archiving cannot strand. One transaction under an advisory lock — a crash rolls back to a clean first run.
- **Mixed-version safety proved live**: a compatibility persona still claims its version-1 document with deployment settings deciding, while its migrated neighbor claims version 2 from its own selections — and a version-2 document now carries the carrier block only, no deployment model or speech settings, pinned by golden fixtures in both languages and a schema closed to exactly that.
- **The completion marker re-checks itself.** Its four conditions (personas, graders, simulations, grading — including plans pinned to selection-free grader versions, the case a platform-judge deployment would otherwise hide) are re-evaluated on every read; the stamp records the first moment they held and can go back to unfinished when new legacy-shaped work arrives. The later cleanup is instructed to re-check, never to trust the stamp.
- **"Still to choose"** on the Model providers screen: outstanding candidates and actions, each naming its subject, with the descoped-provider case visible and disabled rather than vanished. The API rewrites that make the section reachable are pinned by a test that matches paths the way the hosted router actually matches them, proven able to fail.
- **Hosted backfill**: a pre-existing hosted organization that never chose gains the `managed` access row (no keys, no selections moved) so its seeded graders judge instead of erroring — inert wherever hosted mode is off.
- **The four-path matrix, upgraded**: all four deployment × access cells conduct through the real gateway application and now read the simulation, the run, and a judged `passed` verdict back through `GET /api/simulations/:id` and `GET /api/runs/:id`, scanned for every credential in play. The previous-release fixture carries a real run → simulation → grading to terminal through the old release's own doors, compared column-for-column after the upgrade and still pinned to the version that really executed.

## Recorded notes (deliberately left)

- The rewrites test hand-lists the seven model-screen paths; enumerating the module's path exports would close the class if an eighth arrives.
- A descoped provider's action stands on the screen until a release re-adds that provider — it cannot be settled by design, since no credential for it can exist.
- The completion read is now a per-request evaluation rather than a boot-time one; its queries are bounded by nonterminal work, not history.
- The shipped starter persona speaks a voice this catalog does not carry, so every self-hosted upgrade blocks its default persona on a visible action until an administrator picks its models — correct per the no-guessing rule, and documented for operators.
- Verdict rows live in the trace store, which this release does not migrate; their untouched-ness is stated, not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1bq5Zyqjz2uK56wvr2w3

---
_Generated by [Claude Code](https://claude.ai/code/session_016f1bq5Zyqjz2uK56wvr2w3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789592412&installation_model_id=431960&pr_number=143&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F143&signature=200ba32090ce814098d395b10fcdcb8cb2c4049afaf7cb801c75641705d783eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the migration and compatibility path from legacy model configuration to explicit credentials and selections, together with a completion marker that is re-evaluated on reads.
- Collects sealed legacy credentials as administrator-selectable candidates and creates explicit successor persona and grader versions where migration is unambiguous.
- Adds upgrade status and candidate-activation APIs plus the corresponding Model providers UI.
- Keeps legacy and explicit-selection simulations interoperable while restricting version-2 work orders to their selected model settings.
- Tracks whether current personas, graders, simulations, and grading jobs still require legacy paths.
- Extends migration, route, contract, and end-to-end matrix coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/access/model-upgrade.ts | Implements transactional legacy-candidate collection, credential activation and refresh, explicit successor creation, and administrator-action generation. |
| packages/db/src/access/model-upgrade-completion.ts | Defines the four completion predicates and conditionally records the first clear statement snapshot while re-evaluating current status on every read. |
| packages/db/migrations/0037_model_upgrade.sql | Adds credential-candidate and upgrade-action storage plus the installation completion marker. |
| packages/db/migrations/0038_upgrade_tracks_its_sources.sql | Adds source provenance needed to refresh migrated credentials when tracked legacy rows change. |
| apps/api/src/routes/model-access.ts | Exposes upgrade status, actions, redacted candidates, and authorized candidate activation. |
| apps/api/src/routes/claims.ts | Separates compatibility and explicit-selection work-order shapes so version-2 documents omit deployment model and speech settings. |
| apps/web/app/projects/[projectId]/settings/model-providers/page.tsx | Presents outstanding migration choices and stored credential candidates on the Model providers screen. |
| packages/simulation-contract/schemas/simulation-spec.v2.schema.json | Narrows the version-2 contract to the carrier-only platform block expected for explicitly selected models. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[API boot] --> B[Run schema migrations]
  B --> C[Seed platform and grader defaults]
  C --> D[Acquire model-upgrade advisory lock]
  D --> E[Collect sealed legacy credential candidates]
  E --> F{Migration unambiguous?}
  F -->|Yes| G[Activate credential and create explicit successor versions]
  F -->|No| H[Create administrator upgrade actions]
  G --> I[Re-evaluate completion conditions]
  H --> I
  I --> J{Legacy-shaped work remains?}
  J -->|No| K[Record first completion timestamp]
  J -->|Yes| L[Report outstanding conditions]
  K --> M[Serve upgrade status through public API]
  L --> M
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Notice a rotation that lands on the same..."](https://github.com/egma-ai/egma/commit/314304274dc73f8d1b083f10678a3b7caff7ace3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54112685)</sub>

<!-- /greptile_comment -->