### PR TITLE
Protect browser telemetry before session replay

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -13,13 +13,59 @@
  * project token, which is write-only by design: it can submit events and
  * read none back, which is what makes it publishable inside a page at all.
  *
- * What a key turns on: pageviews and clicks, session replay (as far as the
- * PostHog project's own settings allow), web vitals, and the errors pages
- * throw. All of it is about how egma's own product is used — nothing here
- * reads a transcript, a recording, or anything else a customer's agent said.
+ * What a key turns on: pageviews, session replay (as far as the PostHog
+ * project's own settings allow), web vitals, and the errors pages throw.
+ * Replay sees the page, so the fixed policy below masks its text, inputs,
+ * private attributes, URLs, network content, console, frames, and canvases.
  */
 
-import posthog from "posthog-js";
+import posthog, {
+  type BeforeSendFn,
+  type CapturedNetworkRequest,
+} from "posthog-js";
+
+const RECORDED_URL_PROPERTY = /(?:url|href|referrer)$/i;
+const PRIVATE_REPLAY_ATTRIBUTE =
+  /^(?:aria-|data-)|^(?:action|alt|for|formaction|href|id|name|placeholder|src|srcset|title|value)$/i;
+
+function stripUrlSecrets(value: string): string {
+  const separator = value.search(/[?#]/);
+  const stripped = separator === -1 ? value : value.slice(0, separator);
+
+  try {
+    const url = new URL(stripped);
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  } catch {
+    return stripped;
+  }
+}
+
+const sanitizeEventUrls: BeforeSendFn = (event) => {
+  if (event === null) return null;
+
+  for (const properties of [event.properties, event.$set, event.$set_once]) {
+    if (properties === undefined) continue;
+    for (const [name, value] of Object.entries(properties)) {
+      if (typeof value === "string" && RECORDED_URL_PROPERTY.test(name)) {
+        properties[name] = stripUrlSecrets(value);
+      }
+    }
+  }
+  return event;
+};
+
+function sanitizeRecordedRequest(
+  request: CapturedNetworkRequest,
+): CapturedNetworkRequest {
+  request.name = stripUrlSecrets(request.name);
+  request.requestHeaders = undefined;
+  request.requestBody = undefined;
+  request.responseHeaders = undefined;
+  request.responseBody = undefined;
+  return request;
+}
 
 // One condition, the flag. next.config already refused any build that said
 // `on` without a key, so the key read below is TypeScript's concern, not a
@@ -33,6 +79,22 @@ if (process.env.NEXT_PUBLIC_EGMA_TELEMETRY === "on" && key !== undefined && key 
     // of what a single-page app needs, pinned so an SDK upgrade cannot change
     // behavior silently.
     defaults: "2025-05-24",
+    autocapture: false,
     capture_exceptions: true,
+    disable_capture_url_hashes: true,
+    enable_recording_console_log: false,
+    logs: { captureConsoleLogs: false },
+    before_send: sanitizeEventUrls,
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: "*",
+      maskAttributeFn: (name, value) =>
+        PRIVATE_REPLAY_ATTRIBUTE.test(name) ? "" : value,
+      recordHeaders: false,
+      recordBody: false,
+      recordCrossOriginIframes: false,
+      captureCanvas: { recordCanvas: false },
+      maskCapturedNetworkRequestFn: sanitizeRecordedRequest,
+    },
   });
 }

--- a/apps/web/test/instrumentation-client.test.ts
+++ b/apps/web/test/instrumentation-client.test.ts
@@ -1,0 +1,73 @@
+import type {
+  BeforeSendFn,
+  CapturedNetworkRequest,
+  PostHogConfig,
+} from "posthog-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const init = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-js", () => ({ default: { init } }));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  init.mockReset();
+});
+
+describe("browser platform telemetry", () => {
+  it("removes page content and URL secrets before PostHog can record them", async () => {
+    vi.stubEnv("NEXT_PUBLIC_EGMA_TELEMETRY", "on");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://us.i.posthog.com");
+
+    await import("../instrumentation-client.ts");
+
+    const config = init.mock.calls[0]?.[1] as PostHogConfig;
+    expect(config).toMatchObject({
+      autocapture: false,
+      disable_capture_url_hashes: true,
+      enable_recording_console_log: false,
+      logs: { captureConsoleLogs: false },
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: "*",
+        recordHeaders: false,
+        recordBody: false,
+        recordCrossOriginIframes: false,
+        captureCanvas: { recordCanvas: false },
+      },
+    });
+
+    const beforeSend = config.before_send as BeforeSendFn;
+    const event = beforeSend({
+      uuid: "00000000-0000-4000-8000-000000000000",
+      event: "$pageview",
+      properties: {
+        $current_url: "https://user:pass@app.egma.ai/invite?token=secret#private",
+        $referrer: "https://example.com/source?email=private@example.com",
+      },
+    });
+    expect(event?.properties).toMatchObject({
+      $current_url: "https://app.egma.ai/invite",
+      $referrer: "https://example.com/source",
+    });
+
+    const maskRequest = config.session_recording.maskCapturedNetworkRequestFn;
+    const request = maskRequest?.({
+      name: "https://app.egma.ai/audio.wav?signature=secret#private",
+      entryType: "resource",
+      startTime: 0,
+      duration: 1,
+      requestHeaders: { Authorization: "Bearer secret" },
+      responseBody: "private transcript",
+    } as CapturedNetworkRequest);
+    expect(request).toMatchObject({ name: "https://app.egma.ai/audio.wav" });
+    expect(JSON.stringify(request)).not.toContain("secret");
+    expect(JSON.stringify(request)).not.toContain("private transcript");
+
+    const maskAttribute = config.session_recording.maskAttributeFn;
+    expect(maskAttribute?.("aria-label", "private transcript")).toBe("");
+    expect(maskAttribute?.("class", "recording-player")).toBe("recording-player");
+  });
+});


### PR DESCRIPTION
## What changed

- mask all replay text and inputs
- remove URL credentials, query strings, and fragments
- prevent replay from recording DOM secrets, network bodies or headers, console output, cross-origin frames, and canvases
- disable broad click autocapture
- add one focused privacy check

Session replay stays controlled by the existing EGMA_TELEMETRY switch and the PostHog project setting.

## Verified

- pnpm exec vitest run --project fast apps/web/test/instrumentation-client.test.ts
- pnpm --filter @egma/web typecheck
- pnpm lint
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789768536&installation_model_id=431960&pr_number=147&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F147&signature=d3554eab060bbb7ad9c08ec7064e8dda384502337647107c88744510b738ecc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR strengthens browser telemetry privacy while preserving the existing telemetry feature gate.
- Disables broad click autocapture and console recording.
- Masks replay text, inputs, sensitive DOM attributes, frames, and canvas capture.
- Removes credentials, query strings, fragments, network headers, and network bodies before telemetry is sent.
- Adds a focused test for the privacy configuration and sanitizers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed initialization consistently applies privacy controls when telemetry is enabled, and the added test verifies the principal URL, network, and DOM-redaction behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/instrumentation-client.ts | Adds URL and network sanitizers and configures PostHog to suppress sensitive replay sources; no concrete defect was established. |
| apps/web/test/instrumentation-client.test.ts | Verifies the configured privacy controls and directly exercises URL, request, and DOM-attribute sanitization. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Browser activity] --> B{EGMA telemetry enabled?}
  B -- No --> C[No PostHog initialization]
  B -- Yes --> D[PostHog capture]
  D --> E[Event URL sanitizer]
  D --> F[Session replay privacy controls]
  F --> G[DOM masking]
  F --> H[Network request sanitizer]
  E --> I[PostHog ingestion]
  G --> I
  H --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Protect browser telemetry before session..."](https://github.com/egma-ai/egma/commit/179ad3a50effb7fbb2446a09939ec8359625926d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54949597)</sub>

<!-- /greptile_comment -->