### PR TITLE
Add structured production platform logs

### DIFF
--- a/apps/api/src/auth/email.ts
+++ b/apps/api/src/auth/email.ts
@@ -6,7 +6,8 @@ import { createTransport } from "nodemailer";
  * A bare self-host has no SMTP credentials and asking for them before anything
  * works is where the pleasant part of a local install ends. So there is one
  * interface and two transports, and **the one that delivers nothing is the
- * default**: it writes the message to the log and says so. Signup completes,
+ * default**: it records that delivery was skipped, but never logs the recipient
+ * or the signed link in the message. Signup completes,
  * verification is simply not required, and an invitation link is shown to the
  * person who created it rather than posted to somebody who will never see it.
  *
@@ -38,9 +39,10 @@ export type EmailSender = {
 };
 
 /**
- * The default, and today the only one. A self-hoster who has configured no
- * SMTP still sees every message egma would have sent, in the place they are
- * already reading when something goes wrong.
+ * The default. Its callback records that delivery was skipped; the server's
+ * callback deliberately ignores the email because it contains personal data
+ * and a signed link. Tests can use a capturing callback to inspect the email
+ * transport without putting that content in a production log.
  */
 export function loggingEmailSender(
   write: (email: Email) => void,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@egma/db";
 
 import { loadConfig } from "./config.ts";
+import { platformEvent } from "./platform-log.ts";
 import { buildApi } from "./server.ts";
 
 const config = loadConfig();
@@ -131,8 +132,14 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
       await app.close();
       await disconnect();
       await disconnectClickHouse();
+      app.log.info(platformEvent("egma.service.stopped", "API service stopped"));
     })();
   });
 }
 
 await app.listen({ host: config.host, port: config.port });
+app.log.info(
+  platformEvent("egma.service.started", "API service started", {
+    "server.port": config.port,
+  }),
+);

--- a/apps/api/src/platform-log.ts
+++ b/apps/api/src/platform-log.ts
@@ -1,0 +1,60 @@
+/** The first version of Egma's vendor-neutral platform log contract. */
+const LOG_SCHEMA_VERSION = 1;
+
+type Attribute = string | number | boolean;
+
+/**
+ * The fields every deliberate platform event carries before the deployment
+ * collector turns the JSON line into an OpenTelemetry log record.
+ *
+ * The event name is stable and low-cardinality. Variable facts stay in flat
+ * scalar attributes so a collector can promote them without keeping customer
+ * payloads or arbitrary objects.
+ */
+export function platformEvent(
+  name: `egma.${string}`,
+  body: string,
+  attributes: Readonly<Record<string, Attribute>> = {},
+): Record<string, Attribute> {
+  return {
+    "otel.event.name": name,
+    "egma.log_schema_version": LOG_SCHEMA_VERSION,
+    body,
+    ...attributes,
+  };
+}
+
+/**
+ * A useful exception class without copying an exception message or stack.
+ * Both can contain a request body, provider credential, or customer content.
+ */
+export function safeExceptionType(error: unknown): string {
+  const type = error instanceof Error ? error.name : typeof error;
+  return /^[A-Za-z][A-Za-z0-9_.-]{0,127}$/.test(type) ? type : "Error";
+}
+
+/** The useful part of an exception, without its message, stack, or cause. */
+export function safeException(error: unknown): {
+  readonly type: string;
+  readonly message: string;
+  readonly stack: string;
+} {
+  return {
+    type: safeExceptionType(error),
+    message: "[redacted]",
+    stack: "",
+  };
+}
+
+/**
+ * Pino applies these before a line reaches standard output. Request, response,
+ * and provider-detail objects have no safe general representation, so they are
+ * omitted. Exceptions retain only their class; Pino's required stack field is
+ * present but empty.
+ */
+export const PRIVATE_LOG_SERIALIZERS = {
+  err: safeException,
+  req: (_request: unknown): Record<string, never> => ({}),
+  res: (_response: unknown): Record<string, never> => ({}),
+  details: (_details: unknown): undefined => undefined,
+} as const;

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -43,6 +43,7 @@ import {
 } from "../http/acting.ts";
 import { credentialed, requesterOf } from "../http/credentialed.ts";
 import type { RateLimit } from "../http/rate-limit.ts";
+import { platformEvent, safeExceptionType } from "../platform-log.ts";
 import type { RetellReach } from "../retell/api.ts";
 import { reconcileRetellWebhook } from "../retell/registration.ts";
 import { given, projectNamed, text } from "../http/reading.ts";
@@ -1266,16 +1267,25 @@ export async function agentRoutes(
           options.retellReach ?? {},
         ).catch((cause: unknown) => {
           request.log.error(
-            { err: cause },
-            "could not reach Retell to bring the webhook into line; Egma polls this connection",
+            platformEvent(
+              "egma.retell.webhook.reconcile_failed",
+              "Retell webhook reconciliation failed; Egma will poll this connection",
+              {
+                "error.type": "retell_webhook_reconcile_failed",
+                "exception.type": safeExceptionType(cause),
+              },
+            ),
           );
           return undefined;
         });
 
         if (outcome?.kind === "not-taken") {
           request.log.info(
-            { connectionId, reason: outcome.reason },
-            "Retell did not take the webhook change; Egma polls this connection",
+            platformEvent(
+              "egma.retell.webhook.reconcile_deferred",
+              "Retell did not take the webhook change; Egma will poll this connection",
+              { "error.type": "retell_webhook_not_taken" },
+            ),
           );
         }
 

--- a/apps/api/src/routes/claims.ts
+++ b/apps/api/src/routes/claims.ts
@@ -20,6 +20,7 @@ import type { FastifyInstance } from "fastify";
 
 import { acceptsServiceToken } from "../auth/service-token.ts";
 import { invalid, notTheService } from "../http/refusals.ts";
+import { platformEvent, safeExceptionType } from "../platform-log.ts";
 import {
   verifyRetellDirectChatAgent,
   type RetellDirectTargetCheck,
@@ -511,13 +512,19 @@ export async function claimRoutes(
         const spec = assembled[index];
         if (spec === undefined) continue;
         if ("retryable" in spec) {
-          const retryable = String(spec.retryable);
           // A provider outage says nothing about the customer or their agent.
           // Give this lease back instead of minting a terminal error; a later
           // claim repeats the bounded check.
           request.log.warn(
-            { simulationId: claim.id, runId: claim.runId },
-            retryable,
+            platformEvent(
+              "egma.simulation.dispatch.deferred",
+              "simulation dispatch was deferred after provider preflight",
+              {
+                "egma.simulation_id": claim.id,
+                "egma.run_id": claim.runId,
+                "error.type": "provider_preflight_failed",
+              },
+            ),
           );
           const released = await releaseSimulationClaim(
             claim.auth,
@@ -539,8 +546,15 @@ export async function claimRoutes(
             );
             if (canceled === undefined) {
               request.log.error(
-                { simulationId: claim.id, runId: claim.runId },
-                `simulation ${claim.id} could neither release nor land its canceled transient provider preflight`,
+                platformEvent(
+                  "egma.simulation.claim.release_failed",
+                  "simulation claim could not be released or canceled",
+                  {
+                    "egma.simulation_id": claim.id,
+                    "egma.run_id": claim.runId,
+                    "error.type": "simulation_claim_release_failed",
+                  },
+                ),
               );
             }
           }
@@ -558,8 +572,15 @@ export async function claimRoutes(
           // the judgement is minted beside it, and a run waiting only on
           // this row settles with truthful counts.
           request.log.error(
-            { simulationId: claim.id, runId: claim.runId },
-            `simulation ${claim.id} was claimed and could not be dispatched: ${spec.unbuildable}`,
+            platformEvent(
+              "egma.simulation.dispatch.failed",
+              "claimed simulation could not be dispatched",
+              {
+                "egma.simulation_id": claim.id,
+                "egma.run_id": claim.runId,
+                "error.type": "simulation_spec_unbuildable",
+              },
+            ),
           );
           await failSimulationDispatch(
             claim.auth,
@@ -571,15 +592,31 @@ export async function claimRoutes(
             // saying so costs one log line rather than aborting a batch a
             // simulator is standing ready to conduct.
             request.log.error(
-              { simulationId: claim.id, runId: claim.runId },
-              `simulation ${claim.id} could not even land dispatch_failed: ${
-                fault instanceof Error ? fault.message : String(fault)
-              }`,
+              platformEvent(
+                "egma.simulation.dispatch.failure_record_failed",
+                "simulation dispatch failure could not be recorded",
+                {
+                  "egma.simulation_id": claim.id,
+                  "egma.run_id": claim.runId,
+                  "error.type": "dispatch_failure_record_failed",
+                  "exception.type": safeExceptionType(fault),
+                },
+              ),
             );
           });
           continue;
         }
         specs.push(spec);
+        request.log.info(
+          platformEvent(
+            "egma.simulation.dispatched",
+            "simulation was placed in a claim response",
+            {
+              "egma.simulation_id": claim.id,
+              "egma.run_id": claim.runId,
+            },
+          ),
+        );
       }
 
       return await reply.send({ specs });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,6 +1,6 @@
 import { ping, pingClickHouse } from "@egma/db";
 import type { Fetch as RetellFetch } from "@egma/retell";
-import Fastify, { type FastifyInstance } from "fastify";
+import Fastify, { LogController, type FastifyInstance } from "fastify";
 
 import {
   createIdentity,
@@ -50,6 +50,10 @@ import {
 import type { RetellReach } from "./retell/api.ts";
 import { startOrphanSweep, type OrphanSweep } from "./simulation-sweep.ts";
 import type { Config } from "./config.ts";
+import {
+  platformEvent,
+  PRIVATE_LOG_SERIALIZERS,
+} from "./platform-log.ts";
 
 /** Where the auth provider's own endpoints live, under the shared origin. */
 export const AUTH_BASE_PATH = "/api/auth";
@@ -114,12 +118,17 @@ export type Api = {
 
 export function buildApi(options: ServerOptions): Api {
   const { config } = options;
+  const logger = {
+    level: options.logTo === undefined ? (process.env.LOG_LEVEL ?? "info") : "info",
+    serializers: PRIVATE_LOG_SERIALIZERS,
+    ...(options.logTo === undefined ? {} : { stream: options.logTo }),
+  };
 
   const app = Fastify({
-    logger:
-      options.logTo === undefined
-        ? { level: process.env.LOG_LEVEL ?? "info" }
-        : { level: "info", stream: options.logTo },
+    logger,
+    // Fastify's built-in request lines include the raw URL and client address.
+    // One safe completion record is written below from the route template.
+    logController: new LogController({ disableRequestLogging: true }),
     // Forwarded headers are believed only when somebody said there is a proxy
     // in front. Everything that reads the request's origin — the provider's
     // cookie attributes among them — reads what this resolves.
@@ -132,10 +141,15 @@ export function buildApi(options: ServerOptions): Api {
   const emailSender =
     options.emailSender ??
     (config.smtp === undefined
-      ? loggingEmailSender((email) => {
+      ? loggingEmailSender(() => {
+          // The body contains a signed link and the recipient is personal
+          // data. Neither belongs in platform telemetry. The application flow
+          // already returns the link directly when this transport is active.
           app.log.info(
-            { to: email.to, subject: email.subject, body: email.body },
-            "no mail transport is configured, so this message was not sent",
+            platformEvent(
+              "egma.email.delivery.skipped",
+              "email was not sent because no mail transport is configured",
+            ),
           );
         })
       : smtpEmailSender(config.smtp));
@@ -148,17 +162,12 @@ export function buildApi(options: ServerOptions): Api {
     ...(options.deviceAuthorizationInterval === undefined
       ? {}
       : { deviceAuthorizationInterval: options.deviceAuthorizationInterval }),
-    // The provider says what happened in a sentence and hands the cause along
-    // beside it. Pino writes an `Error` as `{}` under any key but `err`, so
-    // putting a cause anywhere else leaves an operator reading "Failed to run
-    // background task:" with nothing under it. The cause goes where the
-    // serializer looks for it, and whatever else came with it stays beside it.
-    log: (level, message, details) => {
+    // Provider diagnostics are not a second path around the platform log's
+    // privacy boundary. The provider's message and arbitrary detail objects can
+    // contain customer values, so only a safe exception shape reaches Pino.
+    log: (level, _message, details) => {
       const cause = details.find((detail) => detail instanceof Error);
-      app.log[level](
-        { err: cause, details: details.filter((detail) => detail !== cause) },
-        message,
-      );
+      app.log[level]({ err: cause }, "identity provider reported a diagnostic");
     },
     hooks: {
       admitIdentity: admitIdentity(config.singleOrganization),
@@ -221,6 +230,28 @@ export function buildApi(options: ServerOptions): Api {
     return reply
       .code(healthy ? 200 : 503)
       .send({ status: healthy ? "ok" : "unavailable", postgres, clickhouse });
+  });
+
+  app.addHook("onResponse", (request, reply, done) => {
+    const route = request.routeOptions.url;
+    if (route === "/health" && reply.statusCode < 400) {
+      done();
+      return;
+    }
+
+    const event = platformEvent(
+      "egma.http.server.request.finished",
+      "HTTP request finished",
+      {
+        "http.request.method": request.method,
+        "http.route": route ?? "<unmatched>",
+        "http.response.status_code": reply.statusCode,
+        duration_ms: reply.elapsedTime,
+      },
+    );
+    if (reply.statusCode >= 500) request.log.error(event);
+    else request.log.info(event);
+    done();
   });
 
   // Read before login and before any repository identifier is sent. It is

--- a/apps/api/test/claims-routes.test.ts
+++ b/apps/api/test/claims-routes.test.ts
@@ -241,8 +241,11 @@ describe("the token gate", () => {
 
 describe("claiming work", () => {
   it("answers a queued simulation as a schema-valid spec, credentials included", async () => {
+    const lines: string[] = [];
     const { ada, key, connectionId, versionId } =
-      await aCustomerReadyToRun("claims_spec");
+      await aCustomerReadyToRun("claims_spec", {
+        logTo: { write: (line) => lines.push(line) },
+      });
     const { runId, simulationId } = await aQueuedRun(key, connectionId, versionId);
 
     const answered = await claim(api.config.simulatorServiceToken, {
@@ -263,6 +266,17 @@ describe("claiming work", () => {
 
     expect(spec.contract_version).toBe(1);
     expect(spec.simulation_id).toBe(simulationId);
+    expect(
+      lines
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .find(
+          (line) =>
+            line["otel.event.name"] === "egma.simulation.dispatched",
+        ),
+    ).toMatchObject({
+      "egma.run_id": runId,
+      "egma.simulation_id": simulationId,
+    });
     expect(spec.modality).toBe("chat");
     expect(spec.connection).toEqual({
       type: "retell",

--- a/apps/api/test/password-reset.test.ts
+++ b/apps/api/test/password-reset.test.ts
@@ -466,16 +466,11 @@ describe("asking for a link", () => {
   });
 
   /**
-   * And when a message that nothing waits for does not go, **an operator can
-   * read why**.
-   *
-   * The log is the only place such a failure can appear, and the provider hands
-   * the cause along beside its own sentence. Pino writes an `Error` as `{}`
-   * under any key but `err`, so a bridge that put the cause anywhere else left
-   * "Failed to run background task:" with an empty object under it: an operator
-   * learns that something broke and nothing about what.
+   * A mail failure keeps its exception class and source frames. Its message is
+   * removed before the log is written because an SMTP response can quote the
+   * recipient or message content.
    */
-  it("writes the cause of a message that did not go, where an operator reads it", async () => {
+  it("writes a safe exception shape when a message does not go", async () => {
     const lines: string[] = [];
     api = await createApi("reset_send_failed", {
       emailDelivers: true,
@@ -493,8 +488,12 @@ describe("asking for a link", () => {
         .find((line) => line.level >= 50 && line.err !== undefined),
     );
     const cause = failure.err as { type?: string; message?: string; stack?: string };
-    expect(cause.message).toBe("the smtp server refused the message");
-    expect(cause.stack).toContain("the smtp server refused the message");
+    expect(cause.type).toBe("Error");
+    expect(cause.message).toBe("[redacted]");
+    expect(cause.stack).toBe("");
+    expect(JSON.stringify(failure)).not.toContain(
+      "the smtp server refused the message",
+    );
   });
 
   /**

--- a/apps/api/test/platform-logging.test.ts
+++ b/apps/api/test/platform-logging.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createApi, type TestApi } from "./support/api.ts";
+
+let api: TestApi;
+
+afterEach(async () => {
+  await api?.close();
+});
+
+describe("platform logging", () => {
+  it("writes one safe structured request record and keeps fallback email content out", async () => {
+    const lines: string[] = [];
+    api = await createApi("platform_logging", {
+      defaultEmailSender: true,
+      logTo: { write: (line) => lines.push(line) },
+      traceStore: true,
+    });
+
+    const email = "private-recipient@example.com";
+    await api.app.inject({
+      method: "POST",
+      url: "/api/signup",
+      payload: {
+        email,
+        password: "a-long-enough-password",
+        organizationName: "Acme",
+      },
+    });
+    await api.app.inject({
+      method: "POST",
+      url: "/api/password-reset",
+      payload: { email },
+    });
+    await api.app.inject({
+      method: "GET",
+      url: "/api/platform?private_token=must-not-reach-the-log",
+    });
+
+    const beforeHealth = lines.filter((line) =>
+      line.includes('"otel.event.name":"egma.http.server.request.finished"'),
+    ).length;
+    expect((await api.app.inject("/health")).statusCode).toBe(200);
+
+    const records = lines.map(
+      (line) => JSON.parse(line) as Record<string, unknown>,
+    );
+    const requests = records.filter(
+      (record) =>
+        record["otel.event.name"] === "egma.http.server.request.finished",
+    );
+    const platformRequest = requests.find(
+      (record) => record["http.route"] === "/api/platform",
+    );
+
+    expect(platformRequest).toMatchObject({
+      level: 30,
+      "otel.event.name": "egma.http.server.request.finished",
+      "egma.log_schema_version": 1,
+      body: "HTTP request finished",
+      "http.request.method": "GET",
+      "http.route": "/api/platform",
+      "http.response.status_code": 200,
+      duration_ms: expect.any(Number),
+    });
+    expect(
+      requests.filter((record) => record["http.route"] === "/api/platform"),
+    ).toHaveLength(1);
+    expect(
+      lines.filter((line) =>
+        line.includes('"otel.event.name":"egma.http.server.request.finished"'),
+      ),
+    ).toHaveLength(beforeHealth);
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        "otel.event.name": "egma.email.delivery.skipped",
+        "egma.log_schema_version": 1,
+      }),
+    );
+
+    const privateValue = "customer-value-must-not-reach-docker";
+    api.app.log.error(
+      {
+        err: new Error(privateValue),
+        req: { body: privateValue },
+        res: { payload: privateValue },
+        details: [{ email: privateValue }],
+      },
+      "safe serializer proof",
+    );
+    const privacyRecord = JSON.parse(lines.at(-1) ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(privacyRecord).toMatchObject({
+      level: 50,
+      err: {
+        type: "Error",
+        message: "[redacted]",
+        stack: "",
+      },
+      msg: "safe serializer proof",
+      req: {},
+      res: {},
+    });
+    expect(privacyRecord).not.toHaveProperty("details");
+    expect(JSON.stringify(privacyRecord)).not.toContain(privateValue);
+    expect(lines.join("\n")).not.toContain(email);
+    expect(lines.join("\n")).not.toContain("must-not-reach-the-log");
+    expect(lines.join("\n")).not.toContain("token=");
+  });
+});

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -128,6 +128,8 @@ export type TestApiOptions = {
    * once per message, so a test can arm it after the messages it is not about.
    */
   readonly emailSendCompletesOn?: () => Promise<void> | undefined;
+  /** Use the server's no-SMTP sender instead of this helper's captured sender. */
+  readonly defaultEmailSender?: boolean;
   /** A budget small enough to reach, for the tests about reaching it. */
   readonly rateLimit?: RateLimit;
   /** A sweep cadence short enough to observe, for the tests about the sweep. */
@@ -223,7 +225,7 @@ export async function createApi(
 
   const { app, identity } = buildApi({
     config,
-    emailSender,
+    ...(options.defaultEmailSender === true ? {} : { emailSender }),
     ...(options.rateLimit === undefined ? {} : { rateLimit: options.rateLimit }),
     ...(options.logTo === undefined ? {} : { logTo: options.logTo }),
     ...(options.orphanSweepIntervalMilliseconds === undefined

--- a/apps/grader/package.json
+++ b/apps/grader/package.json
@@ -12,11 +12,14 @@
     "@egma/db": "workspace:*",
     "@egma/ids": "workspace:*",
     "@egma/simulation-contract": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation": "^0.221.0",
     "@opentelemetry/instrumentation-http": "^0.221.0",
+    "@opentelemetry/instrumentation-pino": "^0.67.0",
     "@opentelemetry/instrumentation-pg": "^0.73.0",
     "@opentelemetry/instrumentation-undici": "^0.31.0",
     "@opentelemetry/sdk-node": "^0.221.0",
+    "pino": "^10.3.1",
     "posthog-node": "^5.49.1"
   }
 }

--- a/apps/grader/src/index.ts
+++ b/apps/grader/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from "@egma/db";
 
 import { loadConfig } from "./config.ts";
-import { makeLog } from "./log.ts";
+import { makeLog, platformEvent } from "./log.ts";
 import { startService } from "./service.ts";
 
 /**
@@ -47,7 +47,10 @@ const service = startService({ config, log });
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.once(signal, () => {
-    log.info("stopping", { signal });
+    log.info(
+      platformEvent("egma.service.stop_requested", { signal }),
+      "grader service stop requested",
+    );
     // Asked to stop rather than killed: the job in hand is finished and its
     // verdicts are written before anything closes. A copy that was killed
     // mid-judgment would cost one lease and no data — but there is no reason to
@@ -59,4 +62,4 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
 await service.finished;
 await disconnect();
 await disconnectClickHouse();
-log.info("stopped");
+log.info(platformEvent("egma.service.stopped"), "grader service stopped");

--- a/apps/grader/src/log.ts
+++ b/apps/grader/src/log.ts
@@ -1,56 +1,46 @@
+import pino, { type Logger } from "pino";
+
 import type { LogLevel } from "./config.ts";
 
+/** The small part of Pino the grader service writes through. */
+export type Log = Pick<Logger, "debug" | "info" | "warn" | "error">;
+
+type Attribute = string | number | boolean;
+
 /**
- * One line per thing that happened, as JSON on standard output.
- *
- * No dependency, because there is nothing here worth one: a container's log is
- * whatever the process writes to its output, and a service with no inbound
- * surface has no request to correlate. What it must never carry is a
- * credential — nothing here reads one, and nothing here is ever handed a
- * conversation's contents.
+ * Pino writes one JSON line to standard output. The deployment collector reads
+ * that line and exports it as OTLP. Pino's OpenTelemetry instrumentation adds
+ * active trace context without creating a second log export path.
  */
+export function makeLog(level: LogLevel, claimant: string): Logger {
+  return pino({
+    level: level.toLowerCase(),
+    base: { "service.instance.id": claimant },
+  });
+}
 
-const RANK: Readonly<Record<LogLevel, number>> = {
-  DEBUG: 10,
-  INFO: 20,
-  WARN: 30,
-  ERROR: 40,
-};
-
-export type Log = {
-  debug(message: string, about?: Record<string, unknown>): void;
-  info(message: string, about?: Record<string, unknown>): void;
-  warn(message: string, about?: Record<string, unknown>): void;
-  error(message: string, about?: Record<string, unknown>): void;
-};
-
-export function makeLog(level: LogLevel, claimant: string): Log {
-  const write = (
-    at: LogLevel,
-    message: string,
-    about?: Record<string, unknown>,
-  ): void => {
-    if (RANK[at] < RANK[level]) return;
-    process.stdout.write(
-      `${JSON.stringify({
-        at: new Date().toISOString(),
-        level: at,
-        claimant,
-        message,
-        ...about,
-      })}\n`,
-    );
-  };
-
+/** Stable fields common to every deliberate grader event. */
+export function platformEvent(
+  name: `egma.${string}`,
+  attributes: Readonly<Record<string, Attribute>> = {},
+): Record<string, Attribute> {
   return {
-    debug: (message, about) => write("DEBUG", message, about),
-    info: (message, about) => write("INFO", message, about),
-    warn: (message, about) => write("WARN", message, about),
-    error: (message, about) => write("ERROR", message, about),
+    "otel.event.name": name,
+    "egma.log_schema_version": 1,
+    ...attributes,
   };
 }
 
-/** What an error says, without a stack and without whatever it wrapped. */
+/** What an error says for the queue's own stored retry reason. */
 export function saying(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * A useful exception class without copying a message or stack into telemetry.
+ * Either may contain provider output, a prompt, or another customer value.
+ */
+export function safeExceptionType(error: unknown): string {
+  const type = error instanceof Error ? error.name : typeof error;
+  return /^[A-Za-z][A-Za-z0-9_.-]{0,127}$/.test(type) ? type : "Error";
 }

--- a/apps/grader/src/service.ts
+++ b/apps/grader/src/service.ts
@@ -7,11 +7,38 @@ import {
   type GradingClaim,
   type Listening,
 } from "@egma/db";
+import { SpanStatusCode, trace } from "@opentelemetry/api";
 
 import type { Config } from "./config.ts";
 import { gradeClaim } from "./grade.ts";
 import type { JudgeMakers } from "./judge/index.ts";
-import { saying, type Log } from "./log.ts";
+import {
+  platformEvent,
+  safeExceptionType,
+  saying,
+  type Log,
+} from "./log.ts";
+
+const tracer = trace.getTracer("@egma/grader");
+
+/** Opaque joins shared by every event about one grading job. */
+function claimAttributes(
+  claim: GradingClaim,
+): Readonly<Record<string, string | number>> {
+  return {
+    "egma.grading_job_id": claim.id,
+    "egma.organization_id": claim.organizationId,
+    "egma.project_id": claim.projectId,
+    "egma.source": claim.source,
+    "egma.attempt": claim.attempts,
+    ...(claim.simulationId === null
+      ? {}
+      : { "egma.simulation_id": claim.simulationId }),
+    ...(claim.traceId === null
+      ? {}
+      : { "egma.production_trace_id": claim.traceId }),
+  };
+}
 
 /**
  * The service: claim, judge, finish, and wait to be woken.
@@ -101,9 +128,10 @@ export function startService(options: ServiceOptions): Service {
 
   const finished = (async (): Promise<void> => {
     watching = await watchGradingWork(nudge);
-    log.info("listening for finished conversations", {
-      capacity: config.capacity,
-    });
+    log.info(
+      platformEvent("egma.service.started", { capacity: config.capacity }),
+      "grader service started",
+    );
 
     while (running) {
       let claimed: readonly GradingClaim[] = [];
@@ -117,11 +145,16 @@ export function startService(options: ServiceOptions): Service {
       } catch (error) {
         // The control plane is unreachable or refused. Say so once and wait;
         // there is nothing held, so there is nothing to lose by waiting.
-        log.error("could not claim grading work", { error: saying(error) });
+        log.error(
+          platformEvent("egma.grading_job.claim_failed", {
+            "error.type": "grading_job_claim_failed",
+            "exception.type": safeExceptionType(error),
+          }),
+          "grader could not claim work",
+        );
       }
 
       if (claimed.length > 0) {
-        log.debug("claimed", { jobs: claimed.length });
         await Promise.all(claimed.map((claim) => holdAndGrade(claim, options)));
         // A full claim means the queue may hold more, so ask again before
         // sleeping — otherwise a burst of two hundred conversations would be
@@ -161,15 +194,43 @@ async function holdAndGrade(
   claim: GradingClaim,
   options: ServiceOptions,
 ): Promise<void> {
+  await tracer.startActiveSpan(
+    "egma.grading_job.process",
+    { attributes: claimAttributes(claim) },
+    async (span) => {
+      try {
+        await gradeHeldClaim(claim, options);
+      } finally {
+        span.end();
+      }
+    },
+  );
+}
+
+/** One claimed job while its platform trace is active. */
+async function gradeHeldClaim(
+  claim: GradingClaim,
+  options: ServiceOptions,
+): Promise<void> {
   const { config, log } = options;
+  const about = claimAttributes(claim);
+
+  log.info(
+    platformEvent("egma.grading_job.claimed", about),
+    "grading job claimed",
+  );
 
   const beating = setInterval(() => {
     void recordGradingHeartbeat(claim.auth, claim.id, config.claimant).catch(
       (error: unknown) => {
-        log.warn("a heartbeat did not land", {
-          job: claim.id,
-          error: saying(error),
-        });
+        log.warn(
+          platformEvent("egma.grading_job.heartbeat_failed", {
+            ...about,
+            "error.type": "grading_job_heartbeat_failed",
+            "exception.type": safeExceptionType(error),
+          }),
+          "grading job heartbeat failed",
+        );
       },
     );
   }, config.heartbeatSeconds * 1000);
@@ -184,19 +245,28 @@ async function holdAndGrade(
     // version replaces rather than doubles. Finishing first would risk the
     // opposite: a job marked judged with nothing written under it.
     await finishGradingJob(claim.auth, claim.id, config.claimant);
-    log.info("judged a conversation", {
-      job: claim.id,
-      source: graded.source,
-      conversation: graded.traceId,
-      graders: graded.graders,
-      verdicts: graded.verdicts,
-    });
+    log.info(
+      platformEvent("egma.grading_job.finished", {
+        ...about,
+        "egma.outcome": "succeeded",
+        grader_count: graded.graders,
+        verdict_count: graded.verdicts,
+      }),
+      "grading job finished",
+    );
   } catch (error) {
-    log.error("could not judge a conversation", {
-      job: claim.id,
-      attempt: claim.attempts,
-      error: saying(error),
-    });
+    const span = trace.getActiveSpan();
+    span?.setAttribute("error.type", "grading_job_failed");
+    span?.setStatus({ code: SpanStatusCode.ERROR });
+    log.error(
+      platformEvent("egma.grading_job.finished", {
+        ...about,
+        "egma.outcome": "failed",
+        "error.type": "grading_job_failed",
+        "exception.type": safeExceptionType(error),
+      }),
+      "grading job failed",
+    );
     await releaseGradingJob(
       claim.auth,
       claim.id,
@@ -205,10 +275,14 @@ async function holdAndGrade(
     ).catch((releasing: unknown) => {
       // The lease is the backstop under this: a job nobody could release is
       // claimable again the moment the copy holding it stops answering.
-      log.warn("could not release the job either", {
-        job: claim.id,
-        error: saying(releasing),
-      });
+      log.warn(
+        platformEvent("egma.grading_job.release_failed", {
+          ...about,
+          "error.type": "grading_job_release_failed",
+          "exception.type": safeExceptionType(releasing),
+        }),
+        "failed grading job could not be released",
+      );
       return undefined;
     });
   } finally {

--- a/apps/grader/src/telemetry.ts
+++ b/apps/grader/src/telemetry.ts
@@ -4,9 +4,9 @@
  * loads before the entry module, why `on` without both required values is
  * refused at boot by name, and why a backend that fails past that check says
  * so on standard error instead of stopping the service. This is that file one
- * app over, minus what a grader does not have: no fastify, and no pino —
- * `log.ts` writes its own JSON lines, which the deployment's filelog
- * collector reads from standard output like everything else's. Its trace
+ * app over, minus what a grader does not have: no fastify. Pino writes JSON
+ * lines, which the deployment's filelog collector reads from standard output
+ * like everything else's. Its trace
  * spans go to the same configured OTLP destination as the API. The collector
  * exporter chooses the span backend; PostHog is the current one. Crash
  * reports use a separate, direct PostHog adapter.
@@ -39,11 +39,12 @@ if (environment.EGMA_TELEMETRY?.trim().toLowerCase() === "on") {
     environment.OTEL_EXPORTER_OTLP_ENDPOINT ??= endpoint;
     environment.OTEL_SERVICE_NAME ??= "egma-grader";
 
-    const [{ NodeSDK }, http, undici, pg, { PostHog }] = await Promise.all([
+    const [{ NodeSDK }, http, undici, pg, pino, { PostHog }] = await Promise.all([
       import("@opentelemetry/sdk-node"),
       import("@opentelemetry/instrumentation-http"),
       import("@opentelemetry/instrumentation-undici"),
       import("@opentelemetry/instrumentation-pg"),
+      import("@opentelemetry/instrumentation-pino"),
       import("posthog-node"),
     ]);
 
@@ -55,6 +56,9 @@ if (environment.EGMA_TELEMETRY?.trim().toLowerCase() === "on") {
         new http.HttpInstrumentation(),
         new undici.UndiciInstrumentation(),
         new pg.PgInstrumentation(),
+        // Pino still writes the one JSON line the deployment collector reads.
+        // This bridge only adds the active trace and span identifiers.
+        new pino.PinoInstrumentation({ disableLogSending: true }),
       ],
     });
     sdk.start();

--- a/apps/grader/test/entry-point.test.ts
+++ b/apps/grader/test/entry-point.test.ts
@@ -75,7 +75,7 @@ beforeAll(async () => {
   // saying which variable.
   await eventually(
     "the service to say it is listening",
-    async () => (output.includes("listening for finished conversations") ? true : undefined),
+    async () => (output.includes("grader service started") ? true : undefined),
     30_000,
   );
 });
@@ -148,7 +148,7 @@ describe("the process the image runs", () => {
     // the store had the row.
     await eventually(
       "the service to say it judged a conversation",
-      async () => (output.includes("judged a conversation") ? true : undefined),
+      async () => (output.includes("grading job finished") ? true : undefined),
       10_000,
     );
 
@@ -159,13 +159,21 @@ describe("the process the image runs", () => {
 
     expect(lines.length).toBeGreaterThan(0);
     for (const line of lines) {
-      expect(line["claimant"]).toBe("grader-from-the-image");
+      expect(line["service.instance.id"]).toBe("grader-from-the-image");
+      expect(line["egma.log_schema_version"]).toBe(1);
       // Nothing a customer wrote reaches the log — a job id and a count, never
       // a transcript and never a credential.
       expect(JSON.stringify(line)).not.toContain("Booked for Tuesday");
     }
-    expect(lines.some((line) => line["message"] === "judged a conversation")).toBe(
-      true,
+    expect(lines).toContainEqual(
+      expect.objectContaining({
+        level: 30,
+        "otel.event.name": "egma.grading_job.finished",
+        msg: "grading job finished",
+        "egma.simulation_id": expect.any(String),
+        "egma.grading_job_id": expect.any(String),
+        "egma.outcome": "succeeded",
+      }),
     );
   });
 

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -1139,10 +1139,10 @@ export async function jobFor(
 export function capturedLog(): { readonly log: Log; readonly lines: string[] } {
   const lines: string[] = [];
   const at =
-    (level: string) =>
-    (message: string, fields: Record<string, unknown> = {}): void => {
-      lines.push(JSON.stringify({ level, message, ...fields }));
-    };
+    (level: string): Log["info"] =>
+      ((fields: Record<string, unknown>, body?: string): void => {
+        lines.push(JSON.stringify({ level, msg: body, ...fields }));
+      }) as Log["info"];
 
   return {
     lines,

--- a/apps/simulator/pyproject.toml
+++ b/apps/simulator/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "opentelemetry-sdk==1.44.0",
     "pipecat-ai[deepgram,elevenlabs,livekit,tracing]==1.7.0",
     "rfc3339-validator>=0.1.4",
+    "structlog>=26.1.0",
 ]
 
 [project.scripts]

--- a/apps/simulator/src/egma_simulator/__main__.py
+++ b/apps/simulator/src/egma_simulator/__main__.py
@@ -18,18 +18,15 @@ import asyncio
 import logging
 import signal
 import sys
-import traceback
 
 from .config import SimulatorConfig
+from .platform_logging import json_log_formatter
 from .redaction import RedactingFilter, SecretRegistry
-from .service import SimulatorService
 
 
 def _configure_logging(level: str, registry: SecretRegistry) -> None:
     handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(
-        logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
-    )
+    handler.setFormatter(json_log_formatter(registry))
     handler.addFilter(RedactingFilter(registry))
     root = logging.getLogger()
     root.setLevel(level.upper())
@@ -45,24 +42,25 @@ def _gather_loguru(level: str) -> None:
     filter with a way around it is not one. Every loguru record is handed
     to the standard library instead; the level numbers already agree.
 
-    A traceback is rendered into the message rather than handed along as
-    ``exc_info``, because the filter scrubs a record's message and nothing
-    else: passed the other way, a credential inside an exception would go
-    out unscrubbed. This way the diagnostic survives and is scrubbed.
+    Exceptions stay as exception information so the JSON formatter can emit
+    the class and safe frame locations. Runtime messages and source lines do
+    not leave the process. The shared filter also scrubs the retained fields.
     """
     from loguru import logger as loguru_logger
 
     def hand_over(message) -> None:
         record = message.record
-        text = record["message"]
         failure = record["exception"]
-        if failure is not None:
-            text += "\n" + "".join(
-                traceback.format_exception(
-                    failure.type, failure.value, failure.traceback
-                )
-            )
-        logging.getLogger(record["name"]).log(record["level"].no, text)
+        exc_info = (
+            (failure.type, failure.value, failure.traceback)
+            if failure is not None
+            else None
+        )
+        logging.getLogger(record["name"]).log(
+            record["level"].no,
+            record["message"],
+            exc_info=exc_info,
+        )
 
     loguru_logger.remove()
     loguru_logger.add(hand_over, level=level.upper())
@@ -99,6 +97,11 @@ def secrets_of(config: SimulatorConfig) -> SecretRegistry:
 async def _run(config: SimulatorConfig) -> None:
     registry = secrets_of(config)
     _configure_logging(config.log_level, registry)
+
+    # Pipecat writes a Loguru banner while the service module is imported.
+    # Import only after Loguru is gathered so that record uses the same JSON
+    # and redaction path as every later third-party record.
+    from .service import SimulatorService
 
     service = SimulatorService(config, secrets=registry)
     task = asyncio.ensure_future(service.run())

--- a/apps/simulator/src/egma_simulator/conductor.py
+++ b/apps/simulator/src/egma_simulator/conductor.py
@@ -52,6 +52,7 @@ from .blob import BlobStore
 from .media import RemoteParticipantLeftFrame, VoiceMedia
 from .model import PersonaReply
 from .persona import Persona, Turn
+from .platform_logging import log_event
 from .plugs import PlugError, VoiceConnection
 from .recording import AudioFacts, dual_channel_wav
 from .speech import (
@@ -952,8 +953,15 @@ class VoiceConductor:
                     self._recording_rate,
                 ),
             )
-        except Exception:
-            logger.exception("the recording could not be written; reporting none")
+        except Exception as failure:
+            log_event(
+                logger,
+                logging.ERROR,
+                "egma.simulation.recording_failed",
+                "simulation recording upload failed",
+                attributes={"error.type": type(failure).__name__},
+                exc_info=True,
+            )
             return
         self.audio = AudioFacts(recording=reference)
 

--- a/apps/simulator/src/egma_simulator/platform_logging.py
+++ b/apps/simulator/src/egma_simulator/platform_logging.py
@@ -1,0 +1,236 @@
+"""Structured platform logs for the simulator.
+
+``structlog`` does the standard-library integration, context binding,
+exception handling, and JSON rendering. This module supplies only Egma's
+OpenTelemetry field names, scalar allowlist, limits, and redaction policy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import traceback
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+import structlog
+
+LOG_SCHEMA_VERSION = 1
+LOG_ATTRIBUTES = "_egma_log_attributes"
+EVENT_NAME = "otel.event.name"
+
+_DEFAULT_EVENT_NAME = "egma.log"
+_RESERVED_FIELDS = {
+    "timestamp",
+    "severity_text",
+    "severity_number",
+    EVENT_NAME,
+    "body",
+    "egma.log_schema_version",
+}
+_BODY_LIMIT = 4 * 1024
+_ATTRIBUTE_LIMIT = 1024
+_STACKTRACE_LIMIT = 16 * 1024
+
+
+class Redactor(Protocol):
+    def redact(self, text: str) -> str: ...
+
+
+def _severity(level: int) -> tuple[str, int]:
+    if level >= logging.CRITICAL:
+        return "FATAL", 21
+    if level >= logging.ERROR:
+        return "ERROR", 17
+    if level >= logging.WARNING:
+        return "WARN", 13
+    if level >= logging.INFO:
+        return "INFO", 9
+    if level >= logging.DEBUG:
+        return "DEBUG", 5
+    return "TRACE", 1
+
+
+def _safe_scalar(value: object) -> bool:
+    return (
+        isinstance(value, (str, bool, int))
+        or isinstance(value, float)
+        and math.isfinite(value)
+    )
+
+
+def _safe_attributes(attributes: Mapping[str, object] | None) -> dict[str, object]:
+    if attributes is None:
+        return {}
+    return {
+        key: value
+        for key, value in attributes.items()
+        if isinstance(key, str)
+        and key
+        and key not in _RESERVED_FIELDS
+        and value is not None
+        and _safe_scalar(value)
+    }
+
+
+def _bounded(text: str, limit: int) -> tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    return text[:limit], True
+
+
+def _exception_fields(exc_info: tuple[type, BaseException, Any]) -> dict[str, str]:
+    """Keep the exception class and frame locations, never runtime text."""
+    exception = exc_info[1]
+    exception_type = type(exception)
+    qualified_type = exception_type.__qualname__
+    if exception_type.__module__ != "builtins":
+        qualified_type = f"{exception_type.__module__}.{qualified_type}"
+    fields = {"exception.type": qualified_type}
+    frames = [
+        f"{frame.f_code.co_filename}:{line_number} in {frame.f_code.co_name}"
+        for frame, line_number in traceback.walk_tb(exc_info[2])
+    ]
+    if frames:
+        fields["exception.stacktrace"] = "\n".join(frames)
+    return fields
+
+
+class _RedactSecrets:
+    """Redact every string that can pass the scalar allowlist."""
+
+    def __init__(self, redactor: Redactor) -> None:
+        self._redactor = redactor
+
+    def __call__(
+        self, logger: object, method_name: str, event_dict: dict[str, Any]
+    ) -> dict[str, Any]:
+        del logger, method_name
+        for key, value in event_dict.items():
+            if isinstance(value, str):
+                event_dict[key] = self._redactor.redact(value)
+            elif key == "exception" and isinstance(value, dict):
+                event_dict[key] = {
+                    nested_key: self._redactor.redact(nested_value)
+                    if isinstance(nested_value, str)
+                    else nested_value
+                    for nested_key, nested_value in value.items()
+                }
+        return event_dict
+
+
+def _otel_record(
+    logger: object, method_name: str, event_dict: dict[str, Any]
+) -> dict[str, object]:
+    """Allowlist and name the raw fields that the collector promotes."""
+    del logger, method_name
+    record = event_dict.get("_record")
+    if not isinstance(record, logging.LogRecord):
+        raise TypeError("structured log processing requires a LogRecord")
+
+    severity_text, severity_number = _severity(record.levelno)
+    event_name = getattr(record, EVENT_NAME, None)
+    deliberate = isinstance(event_name, str) and event_name.startswith("egma.")
+    if deliberate:
+        body, body_truncated = _bounded(
+            str(event_dict.get("event", "")), _BODY_LIMIT
+        )
+    else:
+        # Third-party and legacy messages can contain provider payloads,
+        # transcript text, or an invalid value repeated by a validator. Keep
+        # their severity, logger, and safe exception fields, but never copy the
+        # message itself into the platform log.
+        event_name = _DEFAULT_EVENT_NAME
+        body = "unstructured service log emitted"
+        body_truncated = False
+    if not isinstance(event_name, str) or not event_name:
+        event_name = _DEFAULT_EVENT_NAME
+
+    document: dict[str, object] = {
+        "timestamp": datetime.fromtimestamp(record.created, UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z"),
+        "severity_text": severity_text,
+        "severity_number": severity_number,
+        EVENT_NAME: event_name,
+        "body": body,
+        "egma.log_schema_version": LOG_SCHEMA_VERSION,
+        "logger.name": record.name,
+    }
+
+    attributes = _safe_attributes(getattr(record, LOG_ATTRIBUTES, None))
+    context_simulation_id = event_dict.get("egma.simulation_id")
+    if isinstance(context_simulation_id, str):
+        attributes["egma.simulation_id"] = context_simulation_id
+    exception = event_dict.get("exception")
+    if isinstance(exception, dict):
+        attributes.update(_safe_attributes(exception))
+
+    truncated = body_truncated
+    for key, value in attributes.items():
+        if isinstance(value, str):
+            limit = (
+                _STACKTRACE_LIMIT
+                if key == "exception.stacktrace"
+                else _ATTRIBUTE_LIMIT
+            )
+            value, value_truncated = _bounded(value, limit)
+            truncated = truncated or value_truncated
+        document[key] = value
+    if truncated:
+        document["egma.log_truncated"] = True
+
+    return document
+
+
+def json_log_formatter(redactor: Redactor) -> logging.Formatter:
+    """Build the structlog bridge for first-party and third-party records."""
+    return structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.ExceptionRenderer(_exception_fields),
+            _RedactSecrets(redactor),
+            _otel_record,
+        ],
+        processors=[
+            structlog.processors.JSONRenderer(
+                serializer=json.dumps,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+        ],
+    )
+
+
+@contextmanager
+def simulation_log_context(simulation_id: str) -> Iterator[None]:
+    """Bind one simulation ID to this task and all tasks it creates."""
+    with structlog.contextvars.bound_contextvars(
+        **{"egma.simulation_id": simulation_id}
+    ):
+        yield
+
+
+def log_event(
+    logger: logging.Logger,
+    level: int,
+    event_name: str,
+    body: str,
+    *args: object,
+    attributes: Mapping[str, object] | None = None,
+    exc_info: object = None,
+) -> None:
+    """Name one stdlib event and pass safe attributes to structlog."""
+    logger.log(
+        level,
+        body,
+        *args,
+        extra={
+            EVENT_NAME: event_name,
+            LOG_ATTRIBUTES: _safe_attributes(attributes),
+        },
+        exc_info=exc_info,
+    )

--- a/apps/simulator/src/egma_simulator/redaction.py
+++ b/apps/simulator/src/egma_simulator/redaction.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 
+from .platform_logging import LOG_ATTRIBUTES
+
 REDACTED = "[redacted]"
 
 
@@ -57,7 +59,10 @@ class RedactingFilter(logging.Filter):
     Installed on handlers, not loggers, so records from every library that
     logs through the stdlib pass through it. The record's message is
     rendered early and its args dropped: a lazy ``%s`` argument holding a
-    secret would otherwise be formatted after filtering.
+    secret would otherwise be formatted after filtering. Structured string
+    attributes take the same path. The structlog processor applies this same
+    registry after it extracts the safe exception class and frame locations,
+    so those fields are also scrubbed before output.
     """
 
     def __init__(self, registry: SecretRegistry) -> None:
@@ -67,4 +72,11 @@ class RedactingFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         record.msg = self._registry.redact(record.getMessage())
         record.args = ()
+
+        attributes = dict(getattr(record, LOG_ATTRIBUTES, {}))
+        for key, value in attributes.items():
+            if isinstance(value, str):
+                attributes[key] = self._registry.redact(value)
+
+        setattr(record, LOG_ATTRIBUTES, attributes)
         return True

--- a/apps/simulator/src/egma_simulator/reporting.py
+++ b/apps/simulator/src/egma_simulator/reporting.py
@@ -47,6 +47,7 @@ from pathlib import Path
 
 from .client import ControlPlaneClient, DocumentRejected, TransientDeliveryFailure
 from .contract import validate_report
+from .platform_logging import log_event
 
 logger = logging.getLogger(__name__)
 
@@ -205,11 +206,16 @@ class Reporter:
                 # life of the process. Delivery is allowed to fail; the
                 # sender is not allowed to die.
                 self.abandoned = True
-                logger.exception(
-                    "the report sender for %s hit a fault; the events are "
-                    "in %s and nothing further will be sent",
-                    self.simulation_id,
-                    self._wal_path,
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.report_failed",
+                    "simulation report sender failed",
+                    attributes={
+                        "egma.report_abandoned": True,
+                        "error.type": "unexpected_exception",
+                    },
+                    exc_info=True,
                 )
             finally:
                 self._queue.task_done()
@@ -230,11 +236,15 @@ class Reporter:
             try:
                 await send(self.simulation_id, serialized)
                 if attempt > 1:
-                    logger.info(
-                        "a %s document for %s landed on attempt %d",
-                        destination.value,
-                        self.simulation_id,
-                        attempt,
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        "egma.simulation.report_delivered",
+                        "simulation document landed after a retry",
+                        attributes={
+                            "egma.document_type": destination.value,
+                            "egma.attempt": attempt,
+                        },
                     )
                 return
             except DocumentRejected as refusal:
@@ -245,11 +255,17 @@ class Reporter:
                 # had already landed.
                 if destination is Destination.SPANS:
                     self.abandoned = True
-                logger.error(
-                    "control plane refused a %s document for %s: %s",
-                    destination.value,
-                    self.simulation_id,
-                    refusal,
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.report_failed",
+                    "control plane refused a simulation document",
+                    attributes={
+                        "egma.document_type": destination.value,
+                        "egma.attempt": attempt,
+                        "egma.report_abandoned": self.abandoned,
+                        "error.type": type(refusal).__name__,
+                    },
                 )
                 return
             except TransientDeliveryFailure as failure:
@@ -259,16 +275,20 @@ class Reporter:
                     # what comes next would report it out of order, and the
                     # control plane cannot be reached to receive it anyway.
                     self.abandoned = True
-                    logger.error(
-                        "gave up delivering for %s after %d attempt(s) "
-                        "over %.0fs (%s); everything it saw is in %s, and a "
-                        "simulator the control plane cannot hear is what its "
-                        "heartbeat sweep is for",
-                        self.simulation_id,
-                        attempt,
-                        self._delivery_deadline_seconds,
-                        failure,
-                        self._wal_path,
+                    log_event(
+                        logger,
+                        logging.ERROR,
+                        "egma.simulation.report_failed",
+                        "simulation document delivery deadline expired",
+                        attributes={
+                            "egma.document_type": destination.value,
+                            "egma.attempt": attempt,
+                            "egma.delivery_deadline_seconds": (
+                                self._delivery_deadline_seconds
+                            ),
+                            "egma.report_abandoned": True,
+                            "error.type": type(failure).__name__,
+                        },
                     )
                     return
                 await asyncio.sleep(min(backoff, remaining))

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -43,6 +43,7 @@ from .contract import ContractViolation
 from .model import build_model_client
 from .persona import Persona
 from .pipeline import Assembled, assemble
+from .platform_logging import log_event, simulation_log_context
 from .plugs import failed_ending, plug_for
 from .redaction import SecretRegistry
 from .reporting import Reporter
@@ -159,8 +160,20 @@ class AsyncioExecutor:
         self._running.discard(task)
         self._room.set()
         if not task.cancelled() and task.exception() is not None:
-            logger.error(
-                "a simulation task died unreported", exc_info=task.exception()
+            simulation_id = task.get_name().removeprefix("simulation:")
+            fault = task.exception()
+            assert fault is not None
+            log_event(
+                logger,
+                logging.ERROR,
+                "egma.simulation.finished",
+                "simulation task died before it could report",
+                attributes={
+                    "egma.simulation_id": simulation_id,
+                    "egma.outcome": "failed",
+                    "error.type": type(fault).__name__,
+                },
+                exc_info=fault,
             )
 
     async def wait_for_room(self) -> None:
@@ -250,6 +263,12 @@ class RunningSimulation:
         reporter = self._reporter
         reporter.running()
         self._spans.opened()
+        log_event(
+            logger,
+            logging.INFO,
+            "egma.simulation.started",
+            "simulation started",
+        )
         try:
             # The model first, because the pipeline below holds things that
             # have to be given back and only conducting gives them back.
@@ -339,14 +358,26 @@ class RunningSimulation:
             raise
         except Exception as fault:
             reason = self._secrets.redact(f"{type(fault).__name__}: {fault}")
-            logger.exception("conducting %s hit a fault", self.simulation_id)
             # Which failed ending this is belongs to whoever raised: a
             # phone that rang out is not the same record as a simulator
             # that broke, and only the plug knows the difference. See
             # `plugs.failed_ending`.
+            ending = failed_ending(fault)
+            log_event(
+                logger,
+                logging.ERROR,
+                "egma.simulation.finished",
+                "simulation failed",
+                attributes={
+                    "egma.outcome": "failed",
+                    "egma.ending": ending,
+                    "error.type": type(fault).__name__,
+                },
+                exc_info=True,
+            )
             self._spans.sealed()
             await reporter.drain()
-            reporter.failed(failed_ending(fault), reason)
+            reporter.failed(ending, reason)
             return
 
         await self._report_terminal(conducted)
@@ -362,8 +393,22 @@ class RunningSimulation:
         self._reporter.provider_reference = conducted.provider_reference
         if conducted.status == "canceled":
             self._reporter.canceled("cancel directive on heartbeat")
+            outcome = "canceled"
         else:
             self._reporter.completed(conducted.ending, conducted.reason)
+            outcome = "succeeded"
+        log_event(
+            logger,
+            logging.INFO,
+            "egma.simulation.finished",
+            "simulation finished",
+            attributes={
+                "egma.outcome": outcome,
+                "egma.ending": conducted.ending,
+                "egma.turn_count": self._reporter.turn_count,
+                "egma.report_abandoned": self._reporter.abandoned,
+            },
+        )
 
     async def _on_turn(self, speaker: str, text: str) -> None:
         # The turn itself goes one way only: into the spans. What the
@@ -469,8 +514,12 @@ class RunningSimulation:
             except HeartbeatFailure as failure:
                 # A missed beat is the control plane's signal to read, not
                 # ours to invent meaning for. Keep conducting, keep trying.
-                logger.warning(
-                    "heartbeat for %s did not land: %s", self.simulation_id, failure
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "egma.simulation.heartbeat_failed",
+                    "simulation heartbeat did not land",
+                    attributes={"error.type": type(failure).__name__},
                 )
             except asyncio.CancelledError:
                 raise
@@ -478,8 +527,13 @@ class RunningSimulation:
                 # Ending this loop would leave the simulation running with
                 # no way to ever hear a cancel directive. Nothing is worth
                 # that.
-                logger.exception(
-                    "heartbeat for %s hit an unexpected fault", self.simulation_id
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.heartbeat_failed",
+                    "simulation heartbeat failed unexpectedly",
+                    attributes={"error.type": "unexpected_exception"},
+                    exc_info=True,
                 )
             else:
                 await self._honor(directive)
@@ -552,11 +606,12 @@ class SimulatorService:
                 config.capacity,
                 start=lambda spec: self._conduct_one(spec, client),
             )
-            logger.info(
-                "simulator %s claiming from %s with capacity %d",
-                config.claimant,
-                config.control_plane_url,
-                config.capacity,
+            log_event(
+                logger,
+                logging.INFO,
+                "egma.service.started",
+                "simulator started",
+                attributes={"egma.capacity": config.capacity},
             )
             claiming = asyncio.ensure_future(
                 self._claim_forever(client, executor)
@@ -588,6 +643,12 @@ class SimulatorService:
                 claiming.cancel()
                 executor.cancel_all()
                 await executor.drain()
+        log_event(
+            logger,
+            logging.INFO,
+            "egma.service.stopped",
+            "simulator stopped",
+        )
 
     async def _claim_forever(
         self, client: ControlPlaneClient, executor: Executor
@@ -633,7 +694,16 @@ class SimulatorService:
             self._claim_failure_began = now
             self._claim_failure_said_at = now
             self._claim_failure_count = 1
-            logger.warning("claim did not land: %s", failure)
+            log_event(
+                logger,
+                logging.WARNING,
+                "egma.simulation.claim_failed",
+                "claim did not land",
+                attributes={
+                    "egma.attempt": self._claim_failure_count,
+                    "error.type": "claim_failure",
+                },
+            )
             return
 
         # The count is every attempt since this failure began, not since it
@@ -642,13 +712,28 @@ class SimulatorService:
         # so neither number has to be inferred from the other.
         self._claim_failure_count += 1
         if now - self._claim_failure_said_at < REPEATED_CLAIM_FAILURE_SECONDS:
-            logger.debug("claim did not land: %s", failure)
+            log_event(
+                logger,
+                logging.DEBUG,
+                "egma.simulation.claim_failed",
+                "claim did not land",
+                attributes={
+                    "egma.attempt": self._claim_failure_count,
+                    "error.type": "claim_failure",
+                },
+            )
             return
-        logger.warning(
-            "claim still not landing after %d attempts over %.0fs: %s",
+        log_event(
+            logger,
+            logging.WARNING,
+            "egma.simulation.claim_failed",
+            "claim still not landing after %d attempts over %.0fs",
             self._claim_failure_count,
             now - self._claim_failure_began,
-            failure,
+            attributes={
+                "egma.attempt": self._claim_failure_count,
+                "error.type": "claim_failure",
+            },
         )
         self._claim_failure_said_at = now
 
@@ -665,42 +750,56 @@ class SimulatorService:
         """
         for position, document in enumerate(documents):
             if executor.free_capacity < 1:
-                logger.error(
-                    "claim answer carried %d spec(s) past the %d declared; "
-                    "leaving %d unconducted",
-                    len(documents) - position,
-                    self._config.capacity,
-                    len(documents) - position,
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.claim_response_invalid",
+                    "claim response exceeded simulator capacity",
+                    attributes={
+                        "count": len(documents) - position,
+                        "egma.capacity": self._config.capacity,
+                        "error.type": "claim_capacity_exceeded",
+                    },
                 )
                 return
 
             try:
                 spec = SimulationSpec.from_document(document)
-            except ContractViolation as violation:
+            except ContractViolation:
                 # Refusing to conduct is not a simulation that went wrong,
                 # and reporting one would be a claim about a conversation
                 # that never started. Say nothing to the control plane and
                 # let its sweep account for the row it thinks is claimed.
-                logger.error(
-                    "refusing a claimed spec that does not speak the "
-                    "contract: %s",
-                    "; ".join(violation.complaints),
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.claim_response_invalid",
+                    "claimed simulation did not match the work contract",
+                    attributes={"error.type": "simulation_spec_invalid"},
                 )
                 continue
             except (KeyError, TypeError) as malformed:
-                logger.error("refusing an unreadable claimed spec: %r", malformed)
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.claim_response_invalid",
+                    "claimed simulation could not be read",
+                    attributes={"error.type": type(malformed).__name__},
+                )
                 continue
 
             try:
                 trace_id_for(spec.simulation_id)
-            except ValueError as invalid_identity:
+            except ValueError:
                 # OpenTelemetry reserves its all-zero trace id. Refuse before
                 # submission, so no `running` event can claim that an
                 # evidence-complete simulation started under no valid trace.
-                logger.error(
-                    "refusing claimed spec %s: %s",
-                    spec.simulation_id,
-                    invalid_identity,
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.claim_response_invalid",
+                    "claimed simulation had an invalid identifier",
+                    attributes={"error.type": "invalid_simulation_id"},
                 )
                 continue
 
@@ -708,11 +807,15 @@ class SimulatorService:
                 # Same shape as a contract refusal: conducting is not
                 # possible, so nothing is reported and the control plane's
                 # sweep accounts for the row it thinks is claimed.
-                logger.error(
-                    "refusing claimed spec %s: no platform plug for "
-                    "connection type %r",
-                    spec.simulation_id,
-                    spec.connection_type,
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.claim_response_invalid",
+                    "claimed simulation has no platform plug for its connection type",
+                    attributes={
+                        "egma.simulation_id": spec.simulation_id,
+                        "error.type": "unsupported_connection_type",
+                    },
                 )
                 continue
 
@@ -724,15 +827,23 @@ class SimulatorService:
             self._secrets.register(spec.credentials)
             self._secrets.register(list(spec.platform.secrets))
             executor.submit(spec)
+            log_event(
+                logger,
+                logging.INFO,
+                "egma.simulation.claimed",
+                "simulation claimed",
+                attributes={"egma.simulation_id": spec.simulation_id},
+            )
 
     async def _conduct_one(
         self, spec: SimulationSpec, client: ControlPlaneClient
     ) -> None:
-        simulation = RunningSimulation(
-            spec,
-            client=client,
-            config=self._config,
-            secrets=self._secrets,
-            blobs=self._blobs,
-        )
-        await simulation.run()
+        with simulation_log_context(spec.simulation_id):
+            simulation = RunningSimulation(
+                spec,
+                client=client,
+                config=self._config,
+                secrets=self._secrets,
+                blobs=self._blobs,
+            )
+            await simulation.run()

--- a/apps/simulator/tests/test_client_auth.py
+++ b/apps/simulator/tests/test_client_auth.py
@@ -99,10 +99,8 @@ async def quoting_control_plane() -> AsyncIterator[str]:
     """Refuses every claim by quoting the request back — a plain 400 shape.
 
     This is not a contrived leak. A control plane that says what it could
-    not parse is being helpful, and the claim loop logs the refusal's text
-    to say why work is not arriving. Between those two ordinary behaviors
-    the bearer ends up inside a log line, unless something put it in the
-    redacting filter first.
+    not parse is being helpful. The simulator must not copy that arbitrary
+    response into its platform log.
     """
 
     async def refuse(request: web.Request) -> web.Response:
@@ -126,13 +124,11 @@ async def quoting_control_plane() -> AsyncIterator[str]:
 async def test_a_configured_service_token_never_reaches_a_log_line(
     quoting_control_plane, start_simulator
 ):
-    """The token is registered at start-up, so no log line can carry it.
+    """A refusal body that quotes the token is not copied into a log line.
 
-    A spec's credentials are registered when the spec is claimed. A
-    service token arrives before any of that — it is configuration — so
-    only start-up can hand it over, and nothing else in the suite walks
-    that path. A real process, its real output, and a control plane doing
-    the one ordinary thing that would expose it.
+    The stable event is useful without storing arbitrary text returned by
+    the control plane. The registry is still the last defense for every
+    other log source.
     """
     simulator = start_simulator(
         SimpleNamespace(base_url=quoting_control_plane),
@@ -149,8 +145,7 @@ async def test_a_configured_service_token_never_reaches_a_log_line(
     simulator.stop()
     output = simulator.output()
 
-    # The line that would have carried it is there, and quotes the header
-    # it was sent with — so this is the leak happening, scrubbed.
-    assert "Authorization" in output, "the control plane's quote did not arrive"
+    assert "claim did not land" in output
+    assert "Authorization" not in output
     assert A_TOKEN not in output, "a log line carried the service token"
-    assert "Bearer [redacted]" in output
+    assert "Bearer" not in output

--- a/apps/simulator/tests/test_object_storage.py
+++ b/apps/simulator/tests/test_object_storage.py
@@ -15,6 +15,8 @@ fixture in `conftest.py`.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from conftest import (
     OBJECT_STORAGE_ACCESS_KEY_ID,
@@ -267,15 +269,8 @@ async def test_a_refused_credential_leaves_nothing_behind_either(
     behaviour on purpose and it is not a good one — see the spec's Further
     Notes, where the gap is written down.
 
-    **What makes this pass is narrower than it looks, and the difference
-    is worth knowing.** The redacting filter rewrites a record's message
-    and not its traceback: an exception rendered from ``exc_info`` goes
-    out unscrubbed, which was measured rather than assumed. So what keeps
-    the credential out of the log here is partly the store's own
-    discretion — MinIO's ``SignatureDoesNotMatch`` names neither half —
-    and a store that quoted the key id back would land it in this
-    traceback. That hole is `redaction.py`'s and predates object storage;
-    this test is where it will be noticed if a store ever exercises it.
+    The log keeps a stable failure event and exception class, but it does
+    not copy the object store's runtime error text or request details.
     """
     spec = loopback_spec(
         "sim-object-storage-refused",
@@ -302,10 +297,17 @@ async def test_a_refused_credential_leaves_nothing_behind_either(
     )
 
     simulator.stop()
-    assert "SignatureDoesNotMatch" in simulator.output(), (
-        "expected the store's refusal in the log; without it this test is "
-        "scanning output that never held the credential at all"
+    output = simulator.output()
+    platform_logs = [json.loads(line) for line in output.splitlines()]
+    recording_failure = next(
+        record
+        for record in platform_logs
+        if record["otel.event.name"] == "egma.simulation.recording_failed"
     )
+    assert recording_failure["body"] == "simulation recording upload failed"
+    assert recording_failure["error.type"] == "ClientError"
+    assert recording_failure["exception.type"] == "botocore.exceptions.ClientError"
+    assert "SignatureDoesNotMatch" not in output
     for half in (
         OBJECT_STORAGE_ACCESS_KEY_ID,
         WRONG_OBJECT_STORAGE_SECRET_ACCESS_KEY,

--- a/apps/simulator/tests/test_platform_logging.py
+++ b/apps/simulator/tests/test_platform_logging.py
@@ -1,0 +1,118 @@
+"""The simulator's stdout contract: JSON fields, context, and redaction."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+from contextlib import contextmanager
+
+from egma_simulator.platform_logging import (
+    json_log_formatter,
+    log_event,
+    simulation_log_context,
+)
+from egma_simulator.redaction import RedactingFilter, SecretRegistry
+
+
+@contextmanager
+def captured_logger(registry: SecretRegistry):
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.addFilter(RedactingFilter(registry))
+    handler.setFormatter(json_log_formatter(registry))
+    logger = logging.getLogger(f"{__name__}.{id(stream)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield logger, stream
+    finally:
+        logger.handlers = []
+        handler.close()
+
+
+async def test_each_async_simulation_gets_its_own_otel_json_record():
+    registry = SecretRegistry()
+    with captured_logger(registry) as (logger, stream):
+
+        async def emit(simulation_id: str) -> None:
+            with simulation_log_context(simulation_id):
+                await asyncio.sleep(0)
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "egma.simulation.started",
+                    "simulation started",
+                    attributes={
+                        "egma.outcome": simulation_id,
+                        "not.allowed": {"nested": "objects"},
+                    },
+                )
+
+        await asyncio.gather(emit("sim-one"), emit("sim-two"))
+
+    records = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert {record["egma.simulation_id"] for record in records} == {
+        "sim-one",
+        "sim-two",
+    }
+    for record in records:
+        assert record["timestamp"].endswith("Z")
+        assert record["severity_text"] == "INFO"
+        assert record["severity_number"] == 9
+        assert record["otel.event.name"] == "egma.simulation.started"
+        assert record["body"] == "simulation started"
+        assert record["egma.log_schema_version"] == 1
+        assert record["egma.outcome"] == record["egma.simulation_id"]
+        assert "not.allowed" not in record
+
+
+def test_exception_keeps_safe_frames_but_drops_runtime_message():
+    secret = "SENTINEL-platform-log-secret-91d7"
+    registry = SecretRegistry()
+    registry.register(secret)
+
+    with captured_logger(registry) as (logger, stream):
+        with simulation_log_context("sim-failed"):
+            try:
+                raise RuntimeError(f"provider refused {secret}")
+            except RuntimeError:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "egma.simulation.finished",
+                    "simulation failed",
+                    attributes={
+                        "egma.outcome": "failed",
+                        "error.type": "RuntimeError",
+                    },
+                    exc_info=True,
+                )
+
+    output = stream.getvalue()
+    record = json.loads(output)
+    assert secret not in output
+    assert record["severity_text"] == "ERROR"
+    assert record["severity_number"] == 17
+    assert record["exception.type"] == "RuntimeError"
+    assert "exception.message" not in record
+    assert "provider refused" not in output
+    assert "raise RuntimeError" not in output
+    assert "test_platform_logging.py:" in record["exception.stacktrace"]
+    assert "test_exception_keeps_safe_frames_but_drops_runtime_message" in record[
+        "exception.stacktrace"
+    ]
+
+
+def test_foreign_log_message_is_not_exported():
+    registry = SecretRegistry()
+    with captured_logger(registry) as (logger, stream):
+        logger.error("validator repeated credential %s", "private-value")
+
+    output = stream.getvalue()
+    record = json.loads(output)
+    assert "private-value" not in output
+    assert record["otel.event.name"] == "egma.log"
+    assert record["body"] == "unstructured service log emitted"

--- a/apps/simulator/tests/test_quarantine.py
+++ b/apps/simulator/tests/test_quarantine.py
@@ -44,6 +44,7 @@ ALLOWED_DEPENDENCIES = {
     "pipecat-ai",
     "livekit",
     "loguru",  # what pipecat logs through, gathered under one filter
+    "structlog",  # JSON rendering, context binding, and exception processing
     "nltk",  # pipecat's tokenizer, held to no downloads (see __init__)
     # Pipecat creates the service spans; the SDK gives those and egma's domain
     # spans one trace, and the proto-common encoder turns finished SDK spans into
@@ -147,6 +148,7 @@ def test_no_module_imports_anything_from_outside_the_app():
         "jsonschema",
         "pipecat",
         "loguru",
+        "structlog",
         "nltk",
         "livekit",
         "boto3",

--- a/apps/simulator/tests/test_service.py
+++ b/apps/simulator/tests/test_service.py
@@ -79,7 +79,7 @@ def test_an_over_granting_answer_is_clamped_not_raised_on(tmp_path, caplog):
         "sim-over-0",
         "sim-over-1",
     ]
-    assert "past the 2 declared" in caplog.text
+    assert "exceeded simulator capacity" in caplog.text
 
 
 def test_a_spec_that_does_not_speak_the_contract_never_becomes_a_simulation(
@@ -99,7 +99,7 @@ def test_a_spec_that_does_not_speak_the_contract_never_becomes_a_simulation(
     # The good one still gets through: one bad document does not spoil the
     # rest of the answer.
     assert [spec.simulation_id for spec in executor.accepted] == ["sim-good"]
-    assert "does not speak the" in caplog.text
+    assert "did not match the work contract" in caplog.text
 
 
 def test_credentials_from_an_accepted_spec_are_registered_for_redaction(tmp_path):
@@ -140,7 +140,7 @@ def test_an_id_that_would_make_an_invalid_otel_trace_is_refused_before_running(
     assert [spec.simulation_id for spec in executor.accepted] == [
         "sim-valid-after-zero"
     ]
-    assert "all-zero OpenTelemetry trace id" in caplog.text
+    assert "invalid identifier" in caplog.text
 
 
 class RefusingClient:

--- a/apps/simulator/uv.lock
+++ b/apps/simulator/uv.lock
@@ -365,6 +365,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pipecat-ai", extra = ["deepgram", "livekit", "tracing"] },
     { name = "rfc3339-validator" },
+    { name = "structlog" },
 ]
 
 [package.dev-dependencies]
@@ -387,6 +388,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = "==1.44.0" },
     { name = "pipecat-ai", extras = ["deepgram", "elevenlabs", "livekit", "tracing"], specifier = "==1.7.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.4" },
+    { name = "structlog", specifier = ">=26.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2203,6 +2205,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/f0/eea8b5f587a2531657dc5081d2543a5a845f271a3bea1c0fdee5cebde021/soxr-1.0.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:449acd1dfaf10f0ce6dfd75c7e2ef984890df94008765a6742dafb42061c1a24", size = 209541, upload-time = "2025-09-07T13:22:11.739Z" },
     { url = "https://files.pythonhosted.org/packages/64/59/2430a48c705565eb09e78346950b586f253a11bd5313426ced3ecd9b0feb/soxr-1.0.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38b35c99e408b8f440c9376a5e1dd48014857cd977c117bdaa4304865ae0edd0", size = 243025, upload-time = "2025-09-07T13:22:12.877Z" },
     { url = "https://files.pythonhosted.org/packages/3c/1b/f84a2570a74094e921bbad5450b2a22a85d58585916e131d9b98029c3e69/soxr-1.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a39b519acca2364aa726b24a6fd55acf29e4c8909102e0b858c23013c38328e5", size = 184850, upload-time = "2025-09-07T13:22:14.068Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,12 +121,18 @@ importers:
       '@egma/simulation-contract':
         specifier: workspace:*
         version: link:../../packages/simulation-contract
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       '@opentelemetry/instrumentation':
         specifier: ^0.221.0
         version: 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-http':
         specifier: ^0.221.0
         version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pino':
+        specifier: ^0.67.0
+        version: 0.67.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-pg':
         specifier: ^0.73.0
         version: 0.73.0(@opentelemetry/api@1.9.1)
@@ -136,6 +142,9 @@ importers:
       '@opentelemetry/sdk-node':
         specifier: ^0.221.0
         version: 0.221.0(@opentelemetry/api@1.9.1)
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       posthog-node:
         specifier: ^5.49.1
         version: 5.49.1


### PR DESCRIPTION
## What changed

- use Pino for API and grader logs
- use structlog for simulator logs
- emit stable Egma lifecycle events with safe run, simulation, job, trace, severity, and outcome fields
- remove request bodies, provider text, credentials, and raw exception messages from the log path
- keep API and grader logs correlated with OpenTelemetry traces

PostHog remains the current backend. The service code is vendor-neutral; the collector selects the backend.

Rollout dependency: merge egma-cloud PR #7 first.

## Proof

- 41 focused API and grader tests pass
- 33 focused simulator tests pass
- lint and TypeScript checks pass
- Ruff passes
- two independent privacy and correctness reviews found no remaining P0, P1, or P2 issues

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789773318&installation_model_id=431960&pr_number=149&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F149&signature=5b1501bcd46d62be8766591653b94ae11e46dc0ed4ede7363d8cac41dc9a6615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces API and grader logging with structured Pino events and introduces a structlog-based simulator logging pipeline designed to retain lifecycle correlation while excluding customer payloads, credentials, and raw exception messages.
- Adds stable, versioned lifecycle and request event fields across API, grader, and simulator services.
- Adds safe exception serialization, scalar attribute allowlisting, credential redaction, and structured request completion records.
- Correlates grader logs with active OpenTelemetry grading spans and adds simulation-scoped logging context.
- Updates focused tests and dependency locks for Pino, OpenTelemetry Pino instrumentation, and structlog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue established in the changed logging paths.

The API, grader, and simulator retain their existing request, queue, lease, reporting, and shutdown behavior while routing diagnostics through tested structured logging and redaction boundaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/api/src/platform-log.ts | Introduces versioned platform events and restrictive Pino serializers for exceptions, requests, responses, and provider details. |
| apps/api/src/server.ts | Disables Fastify’s raw request logs, emits route-template completion events, and removes sensitive fallback-email and identity-provider diagnostics. |
| apps/api/src/routes/claims.ts | Replaces free-form dispatch diagnostics with stable simulation and run lifecycle events without changing claim state transitions. |
| apps/grader/src/log.ts | Replaces the custom JSON writer with Pino and defines stable grader event and safe exception-type helpers. |
| apps/grader/src/service.ts | Adds per-job active spans and structured claim, heartbeat, completion, and release events while preserving lease handling. |
| apps/grader/src/telemetry.ts | Adds Pino OpenTelemetry instrumentation for trace correlation while retaining stdout as the sole log-export path. |
| apps/simulator/src/egma_simulator/platform_logging.py | Adds structured stdlib/structlog processing with bounded scalar fields, safe stack locations, context binding, and JSON rendering. |
| apps/simulator/src/egma_simulator/redaction.py | Extends credential redaction to structured string attributes before formatting. |
| apps/simulator/src/egma_simulator/service.py | Converts simulator lifecycle and failure diagnostics to stable events and binds logs to each asynchronous simulation. |
| apps/simulator/src/egma_simulator/reporting.py | Structures delivery and abandonment diagnostics without altering WAL ordering or retry behavior. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[API / Fastify] -->|Pino JSON| Collector[Deployment collector]
  Grader[Grader worker] -->|Pino JSON + trace IDs| Collector
  Simulator[Simulator worker] -->|structlog JSON + simulation ID| Collector
  Collector --> Backend[Configured telemetry backend]
  API -. safe serializers .-> API
  Grader -. lifecycle attributes .-> Grader
  Simulator -. scalar allowlist and secret redaction .-> Simulator
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep safe recording failure signal"](https://github.com/egma-ai/egma/commit/0777323e1afc8e2e80d96bba97b3bb17626fddf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54975637)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Egma API platform](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/api-platform.md)
- Knowledge Base — [Grader engine](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/grader-engine.md)
- Knowledge Base — [Egma simulation engine](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulation-engine.md)
- Knowledge Base — [Evaluation run lifecycle](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/evaluation-run-lifecycle.md)
</details>

<!-- /greptile_comment -->