### PR TITLE
Group the navigation under Global, Simulations and Monitoring

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -888,15 +888,16 @@ describe("what a project recorded in production", () => {
         });
       });
 
-      // The four product areas, and Personas and Graders beside them. Settings
-      // is not one of them and neither is a simulation.
+      // The six rows the three groups hold — Global's standing pair, the three
+      // Simulations rows, and Monitoring's one. Settings is not one of them and
+      // neither is a simulation.
       for (const area of [
         "Agents",
-        "Tests",
-        "Simulation runs",
-        "Monitoring",
-        "Personas",
         "Graders",
+        "Tests",
+        "Personas",
+        "Runs",
+        "Transcripts",
       ]) {
         expect(
           await sidebar.getByRole("link", { name: area, exact: true }).count(),
@@ -913,17 +914,23 @@ describe("what a project recorded in production", () => {
        * its presence — an item pointing at the area's own address would cost a
        * redirect on every visit, and a reserved neighbour under the same area
        * could become the landing by accident.
+       *
+       * The word `Monitoring` is the group's now, so the item says what its
+       * page is. The address it carries did not move with the word.
        */
       expect(
         await sidebar
-          .getByRole("link", { name: "Monitoring", exact: true })
+          .getByRole("link", { name: "Transcripts", exact: true })
           .getAttribute("href"),
       ).toBe(`/projects/${project ?? ""}/monitoring/transcripts`);
 
-      // And the runs surface is reached by its new label. `Runs` on its own is
-      // what it said before this effort separated the two kinds of traffic.
+      // And the runs surface is reached by the word its group left it: the
+      // pairing a person reads is Simulations → Runs, so the two-word label
+      // that stood in for the group before the groups existed is gone.
       expect(
-        await sidebar.getByRole("link", { name: "Runs", exact: true }).count(),
+        await sidebar
+          .getByRole("link", { name: "Simulation runs", exact: true })
+          .count(),
       ).toBe(0);
       expect(await sidebar.getByRole("link", { name: "Home" }).count()).toBe(0);
       expect(
@@ -3254,14 +3261,29 @@ describe("the complete product, walked in order in a second project", () => {
 
             if (index === 0) {
               const sidebar = opened.locator("aside");
-              const navigation = await sidebar.innerText();
-              // Monitoring used to be banned here and is deliberately not:
-              // production traffic is a navigation item now — it is what the
-              // monitoring-surface effort added. What stays excluded is a
-              // Simulations area: a simulation is evidence, reached from the
-              // run that produced it. "Simulation runs" is that run surface's
-              // label and carries no "simulations" to trip the ban.
-              expect(navigation).not.toMatch(/simulations/iu);
+              /*
+               * Monitoring used to be banned here and is deliberately not:
+               * production traffic is a navigation item now. What stays
+               * excluded is a Simulations *destination* — a simulation is
+               * evidence, reached from the run that produced it, and no row in
+               * this bar may open a list of every one.
+               *
+               * **The word is no longer the test, and it cannot be.**
+               * `Simulations` is a group label now: it names the half of the
+               * product that proves trust before release. A sweep of the bar's
+               * text would fail on that label while the thing it guards is
+               * still absent. A destination is an address, so the addresses are
+               * what is read.
+               */
+              const addresses = await sidebar
+                .getByRole("link")
+                .evaluateAll((links) =>
+                  links.map((link) => link.getAttribute("href") ?? ""),
+                );
+              expect(addresses.length).toBeGreaterThan(0);
+              for (const address of addresses) {
+                expect(address, address).not.toContain("simulations");
+              }
               expect(
                 await sidebar
                   .getByRole("link", { name: "Simulations" })
@@ -3306,11 +3328,11 @@ describe("the complete product, walked in order in a second project", () => {
 
         await walk.getByRole("link", { name: "Tests", exact: true }).first().click();
         await walk.waitForURL(at("tests"));
-        // **Simulation runs** by its label, `/runs` by its address. The rename
-        // was a label and only a label — the addresses did not move — and this
-        // line is where the two have to be spelled differently on purpose.
+        // **Runs** by its label, `/runs` by its address. Both relabelings were
+        // labels and only labels — the addresses never moved — and this line is
+        // where the word and the address have to be spelled apart on purpose.
         await walk
-          .getByRole("link", { name: "Simulation runs", exact: true })
+          .getByRole("link", { name: "Runs", exact: true })
           .first()
           .click();
         await walk.waitForURL(at("runs"));
@@ -3984,8 +4006,10 @@ describe("the complete product, walked in order in a second project", () => {
         expect(await focused()).toMatch(/^Organization/u);
         await walk.keyboard.press("Tab");
         expect(await focused()).toBe("Agents");
+        // Graders, not Tests: the second row of the bar is the other half of
+        // the standing pair Global holds, and Tests begins the group below it.
         await walk.keyboard.press("Tab");
-        expect(await focused()).toBe("Tests");
+        expect(await focused()).toBe("Graders");
       },
       SETTLE,
     );

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -218,6 +218,15 @@ function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
  * dropped entirely under reduced motion the way the rest of the bar's
  * ancestors already drop theirs.
  *
+ * **The two properties are named rather than reached for as `transition-colors`,
+ * and a keyboard pass is what found the difference.** Tailwind's `colors` group
+ * sweeps in `outline-color`, and this product's focus indicator is an outline —
+ * so every Tab step through the bar faded its ring up from the row's text
+ * colour over 140ms. That is animating keyboard navigation, which `DESIGN.md`
+ * names first among the things not to animate, and it is a focus indicator
+ * arriving late, which is worse. Hover changes the background and the text and
+ * nothing else, so those two are what move.
+ *
  * The row is 44px tall in every theme and at every width, so a coarse pointer
  * needs no separate rule to reach it.
  */
@@ -243,7 +252,8 @@ function SidebarMenuButton({
         "relative flex w-full min-w-0 items-center gap-3",
         "min-h-(--control-lg) rounded-button px-3",
         "text-base text-muted-foreground no-underline",
-        "transition-colors duration-(--duration-hover) ease-out motion-reduce:transition-none",
+        "transition-[color,background-color] duration-(--duration-hover) ease-out",
+        "motion-reduce:transition-none",
         "before:absolute before:inset-y-3 before:left-0 before:w-0.5",
         "before:rounded-chip before:bg-transparent before:content-['']",
         "pointer-hover:bg-surface-soft pointer-hover:text-foreground",

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { Slot } from "radix-ui";
+import {
+  createContext,
+  useContext,
+  useId,
+  useMemo,
+  type ComponentProps,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The signed-in navigation bar, as parts.
+ *
+ * These are shadcn's Sidebar primitives with egma's theme on them and the parts
+ * this product has no use for left out. What is missing is missing on purpose:
+ *
+ * - **No collapsible rail, no icon mode, no persisted open state.** egma's bar
+ *   is always open on a wide screen and always a drawer on a narrow one, and
+ *   the shell already owns that switch at its one layout breakpoint. A second
+ *   opinion about when a sidebar is open would be a second navigation model.
+ * - **No `Sidebar` root.** The `<aside>` is the shell's own frame — it is a
+ *   column of the shell's grid and it is what the breakpoint hides — so it
+ *   stays where the shell keeps it. These primitives own everything inside it.
+ * - **No mobile `Sheet`.** The drawer is the product's existing one, and the
+ *   same three groups are drawn inside it rather than a second copy of them.
+ *
+ * Every value here is a theme key and every theme key is a `tokens.css`
+ * declaration, so this bar and the legacy CSS Modules pages beside it read one
+ * declaration rather than two copies of it.
+ */
+
+type SidebarContextValue = {
+  /**
+   * What to do after a person has chosen somewhere to go.
+   *
+   * The drawer copy of the bar has to close itself, and the docked copy has
+   * nothing to do. It is context rather than a prop because it belongs to the
+   * bar rather than to a row: a row that had to be told would be a row that can
+   * be forgotten, and the one that is forgotten leaves a drawer standing over
+   * the page it just opened.
+   */
+  readonly onNavigate?: () => void;
+};
+
+const SidebarContext = createContext<SidebarContextValue | null>(null);
+
+function useSidebar(): SidebarContextValue {
+  const value = useContext(SidebarContext);
+  if (value === null) {
+    throw new Error("useSidebar has to be used inside a SidebarProvider.");
+  }
+  return value;
+}
+
+function SidebarProvider({
+  onNavigate,
+  children,
+}: {
+  readonly onNavigate?: () => void;
+  readonly children: ReactNode;
+}) {
+  const value = useMemo<SidebarContextValue>(() => ({ onNavigate }), [onNavigate]);
+
+  return (
+    <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
+  );
+}
+
+/**
+ * The topmost slot, which holds the organization and project switcher.
+ *
+ * `min-w-0` is the load-bearing part: the switcher names an organization and a
+ * project, and a long name in a 224px column has to be allowed to shrink rather
+ * than push the bar wider than the grid column it is in.
+ */
+function SidebarHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      className={cn("flex w-full min-w-0 flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * The groups, and the one thing in the bar that scrolls.
+ *
+ * `min-h-0` is what lets it scroll rather than push the footer off a short
+ * screen: a flex child will not shrink below its content without it, and the
+ * account control would be the part that left.
+ *
+ * `asChild` is here because this is the product's navigation landmark. The
+ * caller supplies the `<nav>` and its label; this supplies the layout.
+ */
+function SidebarContent({
+  className,
+  asChild = false,
+  ...props
+}: ComponentProps<"div"> & { readonly asChild?: boolean }) {
+  const Component = asChild ? Slot.Root : "div";
+
+  return (
+    <Component
+      data-slot="sidebar-content"
+      className={cn(
+        "flex w-full min-w-0 min-h-0 flex-col gap-6 overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** The bottom slot, which holds the account control. */
+function SidebarFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      className={cn("mt-auto flex w-full min-w-0 flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * A labelled set of rows.
+ *
+ * The label is tied to the group rather than left floating above it, so a
+ * screen reader says which group it has entered instead of reading six links
+ * with nothing between them. The id is made here and taken by the label,
+ * because a group knows it has one and a caller should not have to invent a
+ * unique string for every bar it draws.
+ */
+const SidebarGroupLabelId = createContext<string | null>(null);
+
+function SidebarGroup({ className, ...props }: ComponentProps<"div">) {
+  const labelId = useId();
+
+  return (
+    <SidebarGroupLabelId.Provider value={labelId}>
+      <div
+        data-slot="sidebar-group"
+        role="group"
+        aria-labelledby={labelId}
+        className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+        {...props}
+      />
+    </SidebarGroupLabelId.Provider>
+  );
+}
+
+/**
+ * The word over a group.
+ *
+ * Weight 400 and the compact label treatment, which is what the bar already
+ * used for the one group label it had. It is quiet on purpose: the label says
+ * where a row belongs, and the row is the thing being read.
+ */
+function SidebarGroupLabel({ className, ...props }: ComponentProps<"div">) {
+  const labelId = useContext(SidebarGroupLabelId);
+
+  return (
+    <div
+      data-slot="sidebar-group-label"
+      id={labelId ?? undefined}
+      className={cn(
+        "mb-1 px-2 text-sm text-faint tracking-(--tracking-label) uppercase",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      className={cn(
+        "m-0 flex w-full min-w-0 list-none flex-col gap-1 p-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      className={cn("relative", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * One row of the bar.
+ *
+ * **The active row wears Ember Wash and a small Ember mark**, which is what
+ * `DESIGN.md` asks of a current item, and it says `aria-current="page"` as
+ * well — state is never colour alone. The mark is drawn on every row and
+ * coloured on the active one, so the row's text sits in the same place whether
+ * or not it is the one you are on.
+ *
+ * **The motion is colour and nothing else.** A sidebar row is the most-pressed
+ * control in the product and `DESIGN.md` is exact about that: do not animate
+ * actions used many times each day, and give routine navigation colour
+ * feedback. So there is no press scale here — the row answers on press rather
+ * than after a movement — and the 140ms hover is the theme's hover token,
+ * dropped entirely under reduced motion the way the rest of the bar's
+ * ancestors already drop theirs.
+ *
+ * The row is 44px tall in every theme and at every width, so a coarse pointer
+ * needs no separate rule to reach it.
+ */
+function SidebarMenuButton({
+  className,
+  isActive = false,
+  asChild = false,
+  onClick,
+  ...props
+}: ComponentProps<"button"> & {
+  readonly isActive?: boolean;
+  readonly asChild?: boolean;
+}) {
+  const { onNavigate } = useSidebar();
+  const Component = asChild ? Slot.Root : "button";
+
+  return (
+    <Component
+      data-slot="sidebar-menu-button"
+      data-active={isActive}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "relative flex w-full min-w-0 items-center gap-3",
+        "min-h-(--control-lg) rounded-button px-3",
+        "text-base text-muted-foreground no-underline",
+        "transition-colors duration-(--duration-hover) ease-out motion-reduce:transition-none",
+        "before:absolute before:inset-y-3 before:left-0 before:w-0.5",
+        "before:rounded-chip before:bg-transparent before:content-['']",
+        "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
+        "data-[active=true]:bg-selected data-[active=true]:text-foreground",
+        "data-[active=true]:before:bg-brand",
+        "data-[active=true]:[&_svg]:text-brand",
+        className,
+      )}
+      onClick={(event: MouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
+        onNavigate?.();
+      }}
+      {...props}
+    />
+  );
+}
+
+export {
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  useSidebar,
+};

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -158,19 +158,33 @@ function SidebarGroup({ className, ...props }: ComponentProps<"div">) {
 /**
  * The word over a group.
  *
+ * **It is a heading, because a sectioned navigation is walked by heading.** The
+ * `aria-labelledby` wiring above already gives the group its accessible name;
+ * this is the other half, and they answer different questions. The name is what
+ * a person hears once they are *inside* a group. A heading is how they get to
+ * one at all — the heading list is Global, Simulations, Monitoring, and jumping
+ * between them is one keystroke rather than six arrow presses.
+ *
+ * `h2` because the bar has no heading above it and the page's own title is the
+ * `h1` beside it. It carries no size of its own — `DESIGN.md` removed those —
+ * so `text-sm` is the size, and `globals.css` holds every heading at weight
+ * 400. `mt-0` is not decoration: `globals.css` gives headings the browser's own
+ * margins back for the legacy pages, and a heading here must not inherit them.
+ *
  * Weight 400 and the compact label treatment, which is what the bar already
  * used for the one group label it had. It is quiet on purpose: the label says
- * where a row belongs, and the row is the thing being read.
+ * where a row belongs, and the row is the thing being read. `px-3` is the row's
+ * own padding, so the label starts exactly where the row's content starts.
  */
-function SidebarGroupLabel({ className, ...props }: ComponentProps<"div">) {
+function SidebarGroupLabel({ className, ...props }: ComponentProps<"h2">) {
   const labelId = useContext(SidebarGroupLabelId);
 
   return (
-    <div
+    <h2
       data-slot="sidebar-group-label"
       id={labelId ?? undefined}
       className={cn(
-        "mb-1 px-2 text-sm text-faint tracking-(--tracking-label) uppercase",
+        "mt-0 mb-1 px-3 text-sm text-faint tracking-(--tracking-label) uppercase",
         className,
       )}
       {...props}

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -1,42 +1,56 @@
 import { projectPath, sectionIn } from "./project-context.ts";
 
 /**
- * The product areas, and which of them the navigation offers.
+ * The product areas, and how the navigation groups them.
  *
- * **Primary navigation is the four things a team works on today**: the agent
- * under test, the tests, the simulation runs that executed them, and the
- * monitoring of what the agent does in production. Everything else earns its
- * place separately:
+ * **The bar names the two jobs the product does.** Prove trust before release
+ * is *Simulations*; keep trust in production is *Monitoring*. The two standing
+ * things both jobs share — the agent under test, and the graders that judge —
+ * sit above them in a group of their own:
  *
- * - **Monitoring is a pillar rather than a library entry.** Production traffic
- *   is half of what a team looks at, and it was reachable at no address the
- *   product linked to at all until this item existed.
- * - **Simulation runs is a label, and only a label.** The addresses under
- *   `/projects/{projectId}/runs` do not move, the stored word stays `run`, and
- *   what changed is the two words a person reads — so that the runs surface and
- *   the monitoring surface say which kind of traffic each one holds.
+ * - **Global**: Agents, Graders.
+ * - **Simulations**: Tests, Personas, Runs.
+ * - **Monitoring**: Transcripts.
  *
- * - **Personas and Graders have direct paths and not primary slots.** A persona
- *   is authored on its own and reused across tests; a grader is switched on
- *   once and then judges everything in its scope without anybody visiting it
- *   again. Neither is one of the things a team works on all day — and neither
- *   may be reachable only from inside something else, which is how a reusable
- *   thing quietly becomes a field and how judging quietly becomes invisible.
+ * **The objection to "Global", recorded because it was overruled rather than
+ * answered.** It is not a glossary word, and nothing in this bar is global:
+ * every entry is project-scoped, so switching project changes what the group
+ * holds, and a new reader may predict organization-wide settings behind the
+ * label. The developer heard that and prefers the label anyway — the group
+ * names what stands above both halves, and the word is theirs to spend. If
+ * first-user evidence shows the misread happening, the label reopens. The
+ * group itself is settled.
  *
- *   **Graders had no item at all until wave two**, because the screens that
- *   replaced this effort's authoring surface arrived organization-wide: their
- *   addresses carried no project while the shell reads the project out of the
- *   address, so an item pointing at them would have shown whichever project was
- *   first in the viewer's list and pressing **Use** would have put a running
- *   copy on a project nobody was looking at. They are project-scoped now, so
- *   the item is back.
+ * **The groups are presentation, and only presentation.** Every href is the one
+ * it was before the groups existed, `activeSectionIn` still reads the address
+ * rather than the group, and a copied URL keeps meaning what it meant. Nothing
+ * here can move a page.
+ *
+ * What the words do:
+ *
+ * - **"Simulation runs" is now "Runs"**, because the group supplies the other
+ *   word. The pairing a person reads — Simulations → Runs — preserves the
+ *   settled reading that the runs surface holds simulated traffic and the
+ *   monitoring surface holds production traffic. The addresses under
+ *   `/projects/{projectId}/runs` do not move and the stored word stays `run`.
+ * - **The monitoring item says "Transcripts"**, because the group label now
+ *   carries the word "Monitoring" and an item should say what its page is.
+ *   Same id, same address, same `opens`.
+ * - **Personas rises into Simulations.** It is the one rank change a person
+ *   feels: a persona is authored on its own and reused across tests, and it
+ *   belongs beside the tests that use it rather than in a library shelf below.
+ * - **Graders moves into Global.** A grader is switched on once and then judges
+ *   everything in its scope without anybody visiting it again — which is what
+ *   makes it standing rather than part of either job.
  * - **Settings lives in the account menu.** It is administrative work rather
- *   than a project destination, so it does not consume a permanent sidebar
- *   slot beside Agents, Tests, Simulation runs, Monitoring, Personas, and
- *   Graders.
+ *   than a project destination, so it is in no group here.
  * - **A simulation has no navigation item at all.** It is evidence, reached
  *   from the run that produced it, and a top-level list of every simulation
  *   would be a different product.
+ *
+ * **No group holds a row for something that does not ship.** Measures joins
+ * Monitoring when the measures bridge lands and not one day before: a "soon"
+ * row is a state that is not truthful.
  *
  * Every item is a project's own, so every href carries the project. There is
  * no navigation to a page that is not in a project.
@@ -50,6 +64,9 @@ export type SectionId =
   | "personas"
   | "graders"
   | "settings";
+
+/** The three groups, which are labels over the items rather than addresses. */
+export type NavigationGroupId = "global" | "simulations" | "monitoring";
 
 export type NavigationItem = {
   readonly id: SectionId;
@@ -69,47 +86,62 @@ export type NavigationItem = {
 
 export type NavigationLink = NavigationItem & { readonly href: string };
 
-export const PRIMARY_NAVIGATION: readonly NavigationItem[] = [
-  { id: "agents", label: "Agents" },
-  { id: "tests", label: "Tests" },
-  { id: "runs", label: "Simulation runs" },
-  { id: "monitoring", label: "Monitoring", opens: ["transcripts"] },
+export type NavigationGroup<Item = NavigationItem> = {
+  readonly id: NavigationGroupId;
+  readonly label: string;
+  readonly items: readonly Item[];
+};
+
+/**
+ * The bar, top to bottom.
+ *
+ * Agents stays the first row, and stays the signed-in landing area. Everything
+ * below it is grouped rather than ranked.
+ */
+export const NAVIGATION_GROUPS: readonly NavigationGroup[] = [
+  {
+    id: "global",
+    label: "Global",
+    items: [
+      { id: "agents", label: "Agents" },
+      { id: "graders", label: "Graders" },
+    ],
+  },
+  {
+    id: "simulations",
+    label: "Simulations",
+    items: [
+      { id: "tests", label: "Tests" },
+      { id: "personas", label: "Personas" },
+      { id: "runs", label: "Runs" },
+    ],
+  },
+  {
+    id: "monitoring",
+    label: "Monitoring",
+    items: [{ id: "monitoring", label: "Transcripts", opens: ["transcripts"] }],
+  },
 ];
 
-export const SECONDARY_NAVIGATION: readonly NavigationItem[] = [
-  { id: "personas", label: "Personas" },
-  { id: "graders", label: "Graders" },
-];
+/** Every item the bar offers, in the order it offers them. */
+export const EVERY_NAVIGATION_ITEM: readonly NavigationItem[] =
+  NAVIGATION_GROUPS.flatMap((group) => group.items);
 
-export const MANAGEMENT_NAVIGATION: readonly NavigationItem[] = [];
-
-const EVERY_SECTION: readonly SectionId[] = [
-  ...PRIMARY_NAVIGATION,
-  ...SECONDARY_NAVIGATION,
-  ...MANAGEMENT_NAVIGATION,
-].map((item) => item.id);
-
-function linksFor(
-  items: readonly NavigationItem[],
-  projectId: string,
-): readonly NavigationLink[] {
-  return items.map((item) => ({
-    ...item,
-    href: projectPath(projectId, item.id, ...(item.opens ?? [])),
-  }));
-}
+const EVERY_SECTION: readonly SectionId[] = EVERY_NAVIGATION_ITEM.map(
+  (item) => item.id,
+);
 
 /** The navigation of one project, as the shell renders it. */
-export function navigationFor(projectId: string): {
-  readonly primary: readonly NavigationLink[];
-  readonly secondary: readonly NavigationLink[];
-  readonly management: readonly NavigationLink[];
-} {
-  return {
-    primary: linksFor(PRIMARY_NAVIGATION, projectId),
-    secondary: linksFor(SECONDARY_NAVIGATION, projectId),
-    management: linksFor(MANAGEMENT_NAVIGATION, projectId),
-  };
+export function navigationFor(
+  projectId: string,
+): readonly NavigationGroup<NavigationLink>[] {
+  return NAVIGATION_GROUPS.map((group) => ({
+    ...group,
+    items: group.items.map((item) => ({
+      ...item,
+      href: projectPath(projectId, item.id, ...(item.opens ?? [])),
+    })),
+  }));
 }
 
 /**
@@ -117,7 +149,9 @@ export function navigationFor(projectId: string): {
  *
  * Read from the address rather than passed down by each page: a page that has
  * to remember to say where it is, is a page that can be wrong about it, and
- * every detail page under an area would have to remember too.
+ * every detail page under an area would have to remember too. **The groups
+ * changed nothing here** — an item is found by its own id, so the same address
+ * lights the same item it lit before it had a group over it.
  */
 export function activeSectionIn(pathname: string): SectionId | null {
   const section = sectionIn(pathname);

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -13,10 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RunResultsAddress from "../app/runs/[runId]/page.tsx";
 import AgentsPage from "../app/projects/[projectId]/agents/page.tsx";
 import type { Me } from "../lib/me.ts";
-import {
-  PRIMARY_NAVIGATION,
-  SECONDARY_NAVIGATION,
-} from "../lib/navigation.ts";
+import { EVERY_NAVIGATION_ITEM } from "../lib/navigation.ts";
 import { Button, ButtonLink, Checkbox, Field } from "../ui/controls.tsx";
 import { DataTable, type Column } from "../ui/data-table.tsx";
 import { Dialog } from "../ui/dialog.tsx";
@@ -107,9 +104,7 @@ const ACME = { id: "org_1", name: "Acme", slug: "acme", role: "admin" };
  * and the test keeps passing while saying nothing about the item nobody
  * remembered — which is exactly what a navigation test is for.
  */
-const NAVIGATION_ITEMS = [...PRIMARY_NAVIGATION, ...SECONDARY_NAVIGATION].map(
-  (item) => item.label,
-);
+const NAVIGATION_ITEMS = EVERY_NAVIGATION_ITEM.map((item) => item.label);
 
 function meWith(role: string): Me {
   return {
@@ -1130,7 +1125,7 @@ describe("the role the shell shows", () => {
 
     expect(await screen.findByText("page")).toBeDefined();
     // No link into a project the address never named — not Agents, not Tests,
-    // not Simulation runs, not Monitoring, and no href under /projects at all.
+    // not Runs, not Transcripts, and no href under /projects at all.
     for (const item of NAVIGATION_ITEMS) {
       expect(screen.queryByRole("link", { name: item })).toBeNull();
     }
@@ -1171,10 +1166,11 @@ describe("the role the shell shows", () => {
    * asks the rendered shell for the item by the words on it, and follows where
    * it goes.
    *
-   * `Simulation runs` is asked for by the same name, which is the whole of the
-   * rename: one label changed, one address unmoved.
+   * The words are the ones the groups left behind: the Monitoring group's item
+   * says `Transcripts`, and the Simulations group's says `Runs`. Both addresses
+   * are the ones they always were.
    */
-  it("puts Monitoring in the sidebar, opening this project's transcript list", async () => {
+  it("puts Transcripts in the sidebar, opening this project's transcript list", async () => {
     routed.pathname = "/projects/prj_2/agents";
     apiAnswers({
       "/api/me": { status: 200, body: meWith("admin") },
@@ -1188,14 +1184,14 @@ describe("the role the shell shows", () => {
 
     expect(await screen.findByText("page")).toBeDefined();
 
-    const monitoring = screen.getAllByRole("link", { name: "Monitoring" })[0];
-    expect(monitoring?.getAttribute("href")).toBe(
+    const transcripts = screen.getAllByRole("link", { name: "Transcripts" })[0];
+    expect(transcripts?.getAttribute("href")).toBe(
       "/projects/prj_2/monitoring/transcripts",
     );
 
-    const runs = screen.getAllByRole("link", { name: "Simulation runs" })[0];
+    const runs = screen.getAllByRole("link", { name: "Runs" })[0];
     expect(runs?.getAttribute("href")).toBe("/projects/prj_2/runs");
-    expect(screen.queryByRole("link", { name: "Runs" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Simulation runs" })).toBeNull();
   });
 
   it("says the session is unavailable rather than that somebody is signed in", async () => {

--- a/apps/web/test/monitoring.test.tsx
+++ b/apps/web/test/monitoring.test.tsx
@@ -249,13 +249,20 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+/**
+ * **The level is the wait, not decoration.** The sidebar's Monitoring group
+ * label is a heading reading the same word, and it is drawn before any read
+ * answers — so an unlevelled wait here would be satisfied by the shell and
+ * would assert the query against a page that had not asked for anything yet.
+ * `level: 1` is the page's own heading, which only the settled page draws.
+ */
 describe("what the Monitoring list asks egma for", () => {
   it("names the project in the address, never one resolved for it", async () => {
     routed.projectId = "prj_1";
     const { asked } = stub({ rows: [ONE_ROW] });
     render(<MonitoringTranscriptsPage />);
 
-    await screen.findByRole("heading", { name: LIST.title });
+    await screen.findByRole("heading", { level: 1, name: LIST.title });
     expect(listedAt(asked).get("project_id")).toBe("prj_1");
   });
 
@@ -268,7 +275,7 @@ describe("what the Monitoring list asks egma for", () => {
     const { asked } = stub({ rows: [ONE_ROW] });
     render(<MonitoringTranscriptsPage />);
 
-    await screen.findByRole("heading", { name: LIST.title });
+    await screen.findByRole("heading", { level: 1, name: LIST.title });
     const query = listedAt(asked);
     expect(query.get("source")).toBe("production");
     // And a window, because the store refuses a read that bounded nothing.

--- a/apps/web/test/project-shell.test.ts
+++ b/apps/web/test/project-shell.test.ts
@@ -12,10 +12,9 @@ import {
 } from "../lib/me.ts";
 import {
   activeSectionIn,
-  MANAGEMENT_NAVIGATION,
+  EVERY_NAVIGATION_ITEM,
   navigationFor,
-  PRIMARY_NAVIGATION,
-  SECONDARY_NAVIGATION,
+  NAVIGATION_GROUPS,
 } from "../lib/navigation.ts";
 import {
   inProject,
@@ -96,46 +95,106 @@ describe("which project a tab is looking at", () => {
 });
 
 describe("the product navigation", () => {
-  it("offers Agents, Tests, Simulation runs and Monitoring, in that order and no others", () => {
-    expect(PRIMARY_NAVIGATION.map((item) => item.label)).toEqual([
-      "Agents",
-      "Tests",
-      "Simulation runs",
+  /**
+   * **The addresses this bar offered before it had groups.**
+   *
+   * Written out rather than derived, because deriving them from the module
+   * under test would make this assertion agree with whatever the module says
+   * today. The groups are presentation: a person who copied any one of these
+   * links before the regroup opens the same page afterwards, and this list is
+   * the only thing that can say so.
+   */
+  const HREFS_BEFORE_THE_GROUPS = [
+    "/projects/prj_2/agents",
+    "/projects/prj_2/graders",
+    "/projects/prj_2/monitoring/transcripts",
+    "/projects/prj_2/personas",
+    "/projects/prj_2/runs",
+    "/projects/prj_2/tests",
+  ];
+
+  const everyLink = (projectId: string) =>
+    navigationFor(projectId).flatMap((group) => group.items);
+
+  it("names the two jobs, and the standing pair above them", () => {
+    expect(NAVIGATION_GROUPS.map((group) => group.label)).toEqual([
+      "Global",
+      "Simulations",
       "Monitoring",
     ]);
-    expect(PRIMARY_NAVIGATION.map((item) => item.id)).not.toContain("graders");
   });
 
   /**
-   * **Simulation runs is a label and only a label.** The addresses do not move,
-   * the stored word stays `run`, and the two surfaces now say which kind of
-   * traffic each one holds — which is the whole reason the rename exists beside
-   * a Monitoring item.
+   * Agents stays the first row and stays the signed-in landing area. Graders
+   * moves up beside it: a grader is switched on once and then judges everything
+   * in its scope, which is what makes it standing rather than part of either
+   * job.
+   */
+  it("puts Agents and Graders under Global, Agents first", () => {
+    const global = NAVIGATION_GROUPS[0];
+    expect(global?.id).toBe("global");
+    expect(global?.items.map((item) => item.label)).toEqual([
+      "Agents",
+      "Graders",
+    ]);
+    expect(everyLink("prj_2")[0]?.href).toBe(projectLanding("prj_2"));
+  });
+
+  /**
+   * Personas rises out of the old library shelf and into Simulations — the one
+   * rank change a person feels. A persona is authored on its own and reused
+   * across tests, so it belongs beside the tests that use it.
+   */
+  it("puts Tests, Personas and Runs under Simulations", () => {
+    const simulations = NAVIGATION_GROUPS[1];
+    expect(simulations?.id).toBe("simulations");
+    expect(simulations?.items.map((item) => item.label)).toEqual([
+      "Tests",
+      "Personas",
+      "Runs",
+    ]);
+  });
+
+  /**
+   * **"Simulation runs" is now "Runs", and only the words changed.** The group
+   * supplies the other word, so the pairing a person reads — Simulations →
+   * Runs — keeps saying which kind of traffic that surface holds. The address
+   * does not move and the stored word stays `run`.
    */
   it("renames the runs surface without moving one address", () => {
-    const runs = PRIMARY_NAVIGATION.find((item) => item.id === "runs");
-    expect(runs?.label).toBe("Simulation runs");
-    expect(navigationFor("prj_2").primary.map((link) => link.href)).toContain(
-      "/projects/prj_2/runs",
-    );
+    const runs = everyLink("prj_2").find((link) => link.id === "runs");
+    expect(runs?.label).toBe("Runs");
+    expect(runs?.href).toBe("/projects/prj_2/runs");
     expect(activeSectionIn("/projects/prj_2/runs/run_9")).toBe("runs");
   });
 
   /**
-   * Monitoring is a pillar rather than a library entry, and its item opens the
-   * transcript list directly.
-   *
-   * The area's own address is real and lands there too, so an item pointing at
-   * either would work — but the link is the list, so a navigation click costs no
-   * redirect and the reserved neighbour under this area can never become the
-   * landing by accident.
+   * **The word "Monitoring" moved up to the group label, so the item says what
+   * its page is.** The item is the same item: same id, same `opens`, same
+   * address — the transcript list, reached without a redirect and without a
+   * reserved neighbour under the area being able to become the landing.
    */
-  it("opens the project's transcript list from Monitoring", () => {
-    const monitoring = navigationFor("prj_2").primary.find(
+  it("puts one Transcripts item under Monitoring, opening the transcript list", () => {
+    const monitoring = NAVIGATION_GROUPS[2];
+    expect(monitoring?.id).toBe("monitoring");
+    expect(monitoring?.items.map((item) => item.label)).toEqual(["Transcripts"]);
+
+    const transcripts = everyLink("prj_2").find(
       (link) => link.id === "monitoring",
     );
-    expect(monitoring?.label).toBe("Monitoring");
-    expect(monitoring?.href).toBe("/projects/prj_2/monitoring/transcripts");
+    expect(transcripts?.label).toBe("Transcripts");
+    expect(transcripts?.href).toBe("/projects/prj_2/monitoring/transcripts");
+  });
+
+  /**
+   * **The groups moved no page.** This is the assertion the whole regroup rests
+   * on: six links before, the same six addresses after, whatever group each one
+   * is drawn under now.
+   */
+  it("offers the same addresses it offered before it had groups", () => {
+    const hrefs = everyLink("prj_2").map((link) => link.href);
+    expect([...hrefs].sort()).toEqual(HREFS_BEFORE_THE_GROUPS);
+    expect(hrefs).toHaveLength(HREFS_BEFORE_THE_GROUPS.length);
   });
 
   /** And the item stays lit on every page inside the area, list and one alike. */
@@ -154,8 +213,21 @@ describe("the product navigation", () => {
    * navigation offers claims it.
    */
   it("claims nothing at the reserved dashboard address", () => {
-    for (const link of navigationFor("prj_2").primary) {
+    for (const link of everyLink("prj_2")) {
       expect(link.href, link.id).not.toContain("dashboard");
+    }
+  });
+
+  /**
+   * **No row for something that does not ship.** Measures joins the Monitoring
+   * group when the measures bridge lands and not one day before — a "soon" row
+   * is a state that is not truthful, and a row with nowhere to go is worse.
+   */
+  it("offers no row that leads nowhere", () => {
+    for (const link of everyLink("prj_2")) {
+      expect(link.label.trim(), link.id).not.toBe("");
+      expect(link.label, link.id).not.toMatch(/soon|coming/i);
+      expect(link.href.startsWith("/projects/prj_2/"), link.id).toBe(true);
     }
   });
 
@@ -174,34 +246,13 @@ describe("the product navigation", () => {
   });
 
   /**
-   * A persona is reusable and must never be reachable only from inside a test
-   * form; a grader is switched on once and then judges without anybody visiting
-   * it again. Neither is one of the things a team works on all day, so both
-   * have direct paths rather than primary slots.
-   *
-   * **Graders had no item at all until wave two.** The screens that replaced
-   * this effort's authoring surface arrived organization-wide — they sat at
-   * `/graders`, carried no project in the address, and this shell reads the
-   * project out of the path — so an item pointing at one would have landed a
-   * person with three projects on whichever came first in their list, and
-   * pressing Use there would have made a running copy in a project they were
-   * not looking at. They are under `/projects/:projectId/graders` now, which is
-   * what this asserts: the item is back, and its href carries the project.
+   * Settings is administrative work rather than a project destination, so it is
+   * in no group and its addresses light nothing.
    */
-  it("gives Personas and Graders direct paths outside the primary three", () => {
-    expect(SECONDARY_NAVIGATION.map((item) => item.id)).toEqual([
-      "personas",
-      "graders",
-    ]);
-    expect(navigationFor("prj_2").secondary.map((link) => link.href)).toEqual([
-      "/projects/prj_2/personas",
-      "/projects/prj_2/graders",
-    ]);
-  });
-
   it("keeps Settings in the account menu instead of the project navigation", () => {
-    expect(MANAGEMENT_NAVIGATION).toEqual([]);
-    expect(navigationFor("prj_2").management).toEqual([]);
+    expect(EVERY_NAVIGATION_ITEM.map((item) => item.id)).not.toContain(
+      "settings",
+    );
     expect(activeSectionIn("/projects/prj_2/settings/people")).toBeNull();
   });
 
@@ -217,13 +268,7 @@ describe("the product navigation", () => {
   });
 
   it("has no item for a simulation, which is evidence reached from its run", () => {
-    const every = [
-      ...PRIMARY_NAVIGATION,
-      ...SECONDARY_NAVIGATION,
-      ...MANAGEMENT_NAVIGATION,
-    ].map(
-      (item) => item.id,
-    );
+    const every = EVERY_NAVIGATION_ITEM.map((item) => item.id);
     expect(every).not.toContain("simulations");
     expect(activeSectionIn("/projects/prj_1/runs/run_9/simulations/sim_1")).toBe(
       "runs",
@@ -231,16 +276,24 @@ describe("the product navigation", () => {
   });
 
   it("carries the project in every link it offers", () => {
-    const { primary } = navigationFor("prj_2");
-    for (const link of primary) {
-      expect(link.href.startsWith("/projects/prj_2/")).toBe(true);
+    for (const link of everyLink("prj_2")) {
+      expect(link.href.startsWith("/projects/prj_2/"), link.id).toBe(true);
     }
-    expect(primary.map((link) => link.href)).toContain("/projects/prj_2/agents");
+    expect(everyLink("prj_2").map((link) => link.href)).toContain(
+      "/projects/prj_2/agents",
+    );
   });
 
+  /**
+   * **A group is presentation and never an address.** The item an address is
+   * under is found by its own id, so the same path lights the same item it lit
+   * when the bar was flat — and no group name is ever read out of a URL.
+   */
   it("knows which item an address is under, and says nothing outside the product", () => {
     expect(activeSectionIn("/projects/prj_1/agents")).toBe("agents");
     expect(activeSectionIn("/projects/prj_1/personas/prs_3")).toBe("personas");
+    expect(activeSectionIn("/projects/prj_1/global")).toBeNull();
+    expect(activeSectionIn("/projects/prj_1/simulations")).toBeNull();
     // The two addresses the transcript pages used to answer at. They are inside
     // the project now, and nothing here is under them.
     expect(activeSectionIn("/traces")).toBeNull();

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Me } from "../lib/me.ts";
+import { AppShell } from "../ui/shell.tsx";
+
+/**
+ * The grouped sidebar, drawn.
+ *
+ * The module test beside this one says what the three groups *are*. This says
+ * what a person meets: three labelled groups in one navigation landmark, the
+ * row they are on lit and saying so, the same six addresses the flat bar
+ * offered, and the same three groups inside the mobile drawer rather than a
+ * second, shorter list of where they may go.
+ *
+ * jsdom loads no stylesheet, so the Ember Wash and the Ember mark are asserted
+ * as the mapping that produces them — the class that turns them on is bound to
+ * the same `data-active` the row carries. The colours themselves were read back
+ * in a real browser, in both themes, at both widths.
+ */
+
+const routed = vi.hoisted(() => ({ pathname: "/projects/prj_2/agents" }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => routed.pathname,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useParams: () => ({ projectId: "prj_2" }),
+}));
+
+const ADA: Me = {
+  user: { id: "usr_1", email: "ada@acme.example" },
+  organizations: [{ id: "org_1", name: "Acme", slug: "acme", role: "admin" }],
+  projects: [
+    { id: "prj_1", name: "Default", slug: "default" },
+    { id: "prj_2", name: "Outbound", slug: "outbound" },
+  ],
+};
+
+/** The six addresses the bar offered before the groups existed. */
+const EVERY_ADDRESS = [
+  "/projects/prj_2/agents",
+  "/projects/prj_2/graders",
+  "/projects/prj_2/monitoring/transcripts",
+  "/projects/prj_2/personas",
+  "/projects/prj_2/runs",
+  "/projects/prj_2/tests",
+];
+
+const GROUPS = [
+  { label: "Global", items: ["Agents", "Graders"] },
+  { label: "Simulations", items: ["Tests", "Personas", "Runs"] },
+  { label: "Monitoring", items: ["Transcripts"] },
+];
+
+function drawShell(pathname = "/projects/prj_2/agents"): void {
+  routed.pathname = pathname;
+  render(
+    <AppShell initialMe={ADA}>
+      <p>page</p>
+    </AppShell>,
+  );
+}
+
+/** The docked bar's own navigation landmark, which is the first one drawn. */
+function sidebarNavigation(): HTMLElement {
+  return screen.getAllByRole("navigation", { name: "Product navigation" })[0]!;
+}
+
+function groupsIn(navigation: HTMLElement): readonly HTMLElement[] {
+  return within(navigation).getAllByRole("group");
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  routed.pathname = "/projects/prj_2/agents";
+});
+
+describe("the grouped sidebar", () => {
+  it("draws three labelled groups, in the order the bar reads", () => {
+    drawShell();
+
+    const groups = groupsIn(sidebarNavigation());
+    expect(groups).toHaveLength(3);
+    expect(groups.map((group) => group.getAttribute("aria-labelledby"))).not.toContain(
+      null,
+    );
+    for (const [index, expected] of GROUPS.entries()) {
+      const group = groups[index]!;
+      expect(within(group).getByText(expected.label)).toBeTruthy();
+      expect(
+        within(group)
+          .getAllByRole("link")
+          .map((link) => link.textContent?.trim()),
+      ).toEqual(expected.items);
+    }
+  });
+
+  /**
+   * The label belongs to the group rather than floating over it, so a screen
+   * reader says which group it has entered instead of reading six links with
+   * nothing between them.
+   */
+  it("gives each group its label as its accessible name", () => {
+    drawShell();
+
+    const navigation = sidebarNavigation();
+    for (const { label } of GROUPS) {
+      expect(within(navigation).getByRole("group", { name: label })).toBeTruthy();
+    }
+  });
+
+  /**
+   * **The assertion the regroup rests on.** Six links before, the same six
+   * addresses after, whatever group each is drawn under now — so a copied URL
+   * keeps meaning what it meant.
+   */
+  it("offers the same six addresses the flat bar offered", () => {
+    drawShell();
+
+    const hrefs = within(sidebarNavigation())
+      .getAllByRole("link")
+      .map((link) => link.getAttribute("href") ?? "");
+    expect([...hrefs].sort()).toEqual(EVERY_ADDRESS);
+  });
+
+  it("says Runs and Transcripts, and no longer says Simulation runs", () => {
+    drawShell();
+
+    const navigation = sidebarNavigation();
+    expect(
+      within(navigation).getByRole("link", { name: "Runs" }).getAttribute("href"),
+    ).toBe("/projects/prj_2/runs");
+    expect(
+      within(navigation)
+        .getByRole("link", { name: "Transcripts" })
+        .getAttribute("href"),
+    ).toBe("/projects/prj_2/monitoring/transcripts");
+    expect(
+      within(navigation).queryByRole("link", { name: "Simulation runs" }),
+    ).toBeNull();
+    expect(within(navigation).queryByRole("link", { name: "Monitoring" })).toBeNull();
+  });
+
+  /**
+   * One row lit per group, from the address and nothing else. Each of the three
+   * is checked, because a group that could never light one would be a group
+   * nobody could tell they were in.
+   */
+  it.each([
+    ["/projects/prj_2/agents", "Agents"],
+    ["/projects/prj_2/graders/running", "Graders"],
+    ["/projects/prj_2/personas/prs_3", "Personas"],
+    ["/projects/prj_2/runs/run_9", "Runs"],
+    ["/projects/prj_2/monitoring/transcripts/5c1e4b0f", "Transcripts"],
+  ])("lights one row on %s, and says which", (pathname, lit) => {
+    drawShell(pathname);
+
+    const navigation = sidebarNavigation();
+    const links = within(navigation).getAllByRole("link");
+    const active = links.filter(
+      (link) => link.getAttribute("data-active") === "true",
+    );
+
+    expect(active).toHaveLength(1);
+    expect(active[0]?.textContent?.trim()).toBe(lit);
+    // Never colour alone.
+    expect(active[0]?.getAttribute("aria-current")).toBe("page");
+    for (const quiet of links.filter((link) => link !== active[0])) {
+      expect(quiet.getAttribute("aria-current")).toBeNull();
+    }
+  });
+
+  /**
+   * **The Ember Wash and the small Ember mark, as the mapping that draws them.**
+   *
+   * jsdom loads no stylesheet, so what is guarded here is that the wash and the
+   * mark are bound to the same `data-active` the row above proved it carries —
+   * `bg-selected` is Ember Wash and `bg-brand` is Ember, both by way of
+   * `tailwind-theme.css`. Renaming either one would take the active state's
+   * whole appearance with it and nothing else in the suite would say so.
+   */
+  it("binds Ember Wash and the Ember mark to the row that is lit", () => {
+    drawShell();
+
+    const agents = within(sidebarNavigation()).getByRole("link", {
+      name: "Agents",
+    });
+    expect(agents.className).toContain("data-[active=true]:bg-selected");
+    expect(agents.className).toContain("data-[active=true]:before:bg-brand");
+    expect(agents.className).toContain("before:content-['']");
+    // And the row keeps the theme's hover, dropped under reduced motion.
+    expect(agents.className).toContain("motion-reduce:transition-none");
+    expect(agents.className).not.toContain("transition-all");
+  });
+
+  /**
+   * **One navigation model.** The drawer draws the same component, so it cannot
+   * drift into a shorter list — and it closes behind the choice it was opened
+   * to make.
+   */
+  it("shows the same three groups in the mobile drawer, and closes behind a choice", () => {
+    drawShell();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open product navigation" }),
+    );
+
+    const drawer = screen.getByRole("dialog", { name: "Navigation" });
+    const inDrawer = within(drawer).getByRole("navigation", {
+      name: "Product navigation",
+    });
+
+    const groups = within(inDrawer).getAllByRole("group");
+    expect(groups).toHaveLength(3);
+    for (const [index, expected] of GROUPS.entries()) {
+      expect(
+        within(groups[index]!)
+          .getAllByRole("link")
+          .map((link) => link.textContent?.trim()),
+      ).toEqual(expected.items);
+    }
+    expect(
+      within(inDrawer)
+        .getAllByRole("link")
+        .map((link) => link.getAttribute("href") ?? "")
+        .sort(),
+    ).toEqual(EVERY_ADDRESS);
+
+    fireEvent.click(within(inDrawer).getByRole("link", { name: "Tests" }));
+    expect(screen.queryByRole("dialog", { name: "Navigation" })).toBeNull();
+  });
+
+  /**
+   * The switcher stays topmost and the account control stays at the bottom.
+   * Both keep the implementations they shipped with; what this asserts is that
+   * the groups landed *between* them rather than around them — which is also
+   * the order a keyboard walks the bar in.
+   */
+  it("keeps the switcher above the groups and the account control below them", () => {
+    drawShell();
+
+    const bar = sidebarNavigation().closest("aside");
+    expect(bar).not.toBeNull();
+
+    const order = Array.from(
+      bar!.querySelectorAll<HTMLElement>("a[href], button"),
+    );
+    const at = (node: HTMLElement | null) =>
+      node === null ? -1 : order.indexOf(node);
+
+    const switcher = within(bar!).getByRole("button", { name: /^Organization Acme/ });
+    const account = within(bar!).getByRole("button", { name: /account menu$/ });
+    const agents = within(bar!).getByRole("link", { name: "Agents" });
+    const transcripts = within(bar!).getByRole("link", { name: "Transcripts" });
+
+    expect(at(switcher)).toBe(0);
+    expect(at(switcher)).toBeLessThan(at(agents));
+    expect(at(agents)).toBeLessThan(at(transcripts));
+    expect(at(transcripts)).toBeLessThan(at(account));
+    expect(at(account)).toBe(order.length - 1);
+  });
+});

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -194,9 +194,30 @@ describe("the grouped sidebar", () => {
     expect(agents.className).toContain("data-[active=true]:bg-selected");
     expect(agents.className).toContain("data-[active=true]:before:bg-brand");
     expect(agents.className).toContain("before:content-['']");
-    // And the row keeps the theme's hover, dropped under reduced motion.
-    expect(agents.className).toContain("motion-reduce:transition-none");
+  });
+
+  /**
+   * **The row moves two properties, and `outline-color` is deliberately not one
+   * of them.**
+   *
+   * `transition-colors` looks like the right class and is not: Tailwind's
+   * colour group sweeps in `outline-color`, this product's focus indicator is
+   * an outline, and the result was a focus ring that faded up from the row's
+   * text colour over 140ms on every Tab step. `DESIGN.md` names keyboard
+   * navigation first among the things not to animate, so the two properties
+   * hover actually changes are named instead. A keyboard pass found this; only
+   * this assertion can keep it found.
+   */
+  it("moves the hover colours without dragging the focus ring with them", () => {
+    drawShell();
+
+    const agents = within(sidebarNavigation()).getByRole("link", {
+      name: "Agents",
+    });
+    expect(agents.className).toContain("transition-[color,background-color]");
+    expect(agents.className).not.toContain("transition-colors");
     expect(agents.className).not.toContain("transition-all");
+    expect(agents.className).toContain("motion-reduce:transition-none");
   });
 
   /**

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -116,6 +116,35 @@ describe("the grouped sidebar", () => {
   });
 
   /**
+   * **A sectioned navigation is walked by heading.**
+   *
+   * The accessible name above says which group somebody is *in*. This is how
+   * they get to one at all: the heading list is Global, Simulations,
+   * Monitoring, and moving between them is one keystroke rather than six arrow
+   * presses. The two mechanisms are wired to the same element on purpose — one
+   * word, said twice, that cannot come apart.
+   */
+  it("offers the three groups as headings, in the order the bar reads", () => {
+    drawShell();
+
+    const navigation = sidebarNavigation();
+    const headings = within(navigation).getAllByRole("heading");
+
+    expect(headings.map((heading) => heading.textContent?.trim())).toEqual(
+      GROUPS.map((group) => group.label),
+    );
+    for (const heading of headings) {
+      expect(heading.tagName).toBe("H2");
+      const named = within(navigation).getByRole("group", {
+        name: heading.textContent?.trim() ?? "",
+      });
+      expect(named.getAttribute("aria-labelledby")).toBe(
+        heading.getAttribute("id"),
+      );
+    }
+  });
+
+  /**
    * **The assertion the regroup rests on.** Six links before, the same six
    * addresses after, whatever group each is drawn under now — so a copied URL
    * keeps meaning what it meant.

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -12,6 +12,18 @@ import {
   type ReactNode,
 } from "react";
 
+import {
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from "@/components/ui/sidebar";
+
 import { readJson } from "../lib/api.ts";
 import { organizationOf, roleOf, type Me, type Project } from "../lib/me.ts";
 import {
@@ -197,6 +209,18 @@ function NavigationIcon({ section }: { readonly section: SectionId }) {
   );
 }
 
+/**
+ * The three groups, drawn once for wherever the bar is being shown.
+ *
+ * **One navigation model.** The docked bar and the mobile drawer render this
+ * same component, so the drawer cannot drift into a second, shorter list of
+ * where a person may go. The drawer passes `onNavigate` and the bar does not,
+ * which is the only difference between them: a drawer closes behind the choice
+ * it was opened to make.
+ *
+ * Where an item is lit still comes from the address, never from which group it
+ * happens to be in.
+ */
 function Navigation({
   projectId,
   pathname,
@@ -206,33 +230,33 @@ function Navigation({
   readonly pathname: string;
   readonly onNavigate?: () => void;
 }) {
-  const { primary, secondary, management } = navigationFor(projectId);
+  const groups = navigationFor(projectId);
   const active = activeSectionIn(pathname);
 
-  const group = (links: ReturnType<typeof navigationFor>["primary"], label?: string) => (
-    <div className={styles.navGroup}>
-      {label === undefined ? null : <p className={styles.navLabel}>{label}</p>}
-      {links.map((link) => (
-        <Link
-          key={link.id}
-          className={`${styles.navItem} ${active === link.id ? styles.navItemActive : ""}`}
-          href={link.href}
-          aria-current={active === link.id ? "page" : undefined}
-          onClick={onNavigate}
-        >
-          <NavigationIcon section={link.id} />
-          {link.label}
-        </Link>
-      ))}
-    </div>
-  );
-
   return (
-    <nav className={styles.nav} aria-label="Product navigation">
-      {group(primary)}
-      {group(secondary, "Library")}
-      {management.length === 0 ? null : group(management, "Manage")}
-    </nav>
+    <SidebarProvider onNavigate={onNavigate}>
+      <SidebarContent asChild>
+        <nav aria-label="Product navigation">
+          {groups.map((group) => (
+            <SidebarGroup key={group.id}>
+              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+              <SidebarMenu>
+                {group.items.map((link) => (
+                  <SidebarMenuItem key={link.id}>
+                    <SidebarMenuButton asChild isActive={active === link.id}>
+                      <Link href={link.href}>
+                        <NavigationIcon section={link.id} />
+                        {link.label}
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroup>
+          ))}
+        </nav>
+      </SidebarContent>
+    </SidebarProvider>
   );
 }
 
@@ -449,10 +473,17 @@ function ShellFrame({
     <SessionContext.Provider value={session}>
     <DraftNavigationProvider>
     <div className={styles.shell}>
+      {/*
+       * The `<aside>` stays the shell's own: it is a column of the grid above
+       * and it is what the one layout breakpoint hides, so its class keeps
+       * living beside the breakpoint that reads it. Everything inside it is on
+       * the sidebar primitives — the switcher topmost in the header slot, the
+       * groups in the content, the account control in the footer slot.
+       */}
       <aside className={styles.sidebar}>
-        {selector(false)}
+        <SidebarHeader>{selector(false)}</SidebarHeader>
         {shown === null ? null : <Navigation projectId={shown} pathname={pathname} />}
-        <div className={styles.sidebarFoot}>
+        <SidebarFooter>
           {role !== null && !canAuthor(role) ? (
             <Badge title="Your role can read, not author">{VIEW_ONLY}</Badge>
           ) : null}
@@ -463,7 +494,7 @@ function ShellFrame({
             placement="right-end"
             projectId={shown}
           />
-        </div>
+        </SidebarFooter>
       </aside>
 
       <div className={styles.body}>


### PR DESCRIPTION
The sidebar names the two jobs the product does — prove trust before release, keep trust in production — and puts the standing pair both share above them. Global holds Agents and Graders, Simulations holds Tests, Personas and Runs, Monitoring holds Transcripts. It renders on new shadcn Sidebar primitives themed from `DESIGN.md`: the current row wears Ember Wash with the small Ember mark, and the quiet-paper look survives the base swap.

Two words change and no address does. "Simulation runs" becomes "Runs" because the group supplies the other word; the monitoring item's word moves up to the group label so the item says what its page is: Transcripts. Same ids, same six hrefs, same address-derived active item — a copied URL keeps meaning what it meant, and the test that says so writes the six addresses out rather than deriving them from the module it checks.

The objection to "Global" is recorded in the module rather than lost: nothing in that group is global, every entry is project-scoped, and the developer prefers the label anyway. The matching glossary reconciliation is egma-planning#41 — merge it together with this.

The group labels are real `h2` headings (screen readers jump Global → Simulations → Monitoring) with `aria-labelledby` kept on the same element; label and row content align at exactly 28px. Making the labels headings exposed two waits in the monitoring page tests that were satisfied by the sidebar rather than by the page's own settled heading — the "wait that exists and is empty" shape — and they now wait on heading level 1.

A keyboard pass found a defect worth knowing beyond this ticket: Tailwind's `transition-colors` includes `outline-color`, and egma's focus indicator is an outline, so the ring faded in over 140ms on every Tab step. The nav row names the two properties hover changes; the same defect in five base-primitive spots is assigned to the shared-components wave.

Proof: 209 scoped tests across 8 files (13 rendered sidebar tests plus the rewritten navigation block), type check, production build, and a real browser read back at desktop and mobile widths in both themes — wash `#fff5f2`, mark `#ff5229`, rows 44px, the Ember ring measured 2px at the keypress on a nav row, reduced motion still. The real-browser journey is updated for the new labels but could not run in the worktree; CI on the final integration PR is its first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789789168&installation_model_id=431960&pr_number=152&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F152&signature=a134a3885e544ee579f12008aff4d9ae694adf2ec6f2cccbaa3a06b2aeb7886f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reorganizes the project sidebar into Global, Simulations, and Monitoring groups without changing project routes or active-item derivation.
- Adds themed shadcn-style sidebar primitives and uses them in both desktop and drawer navigation.
- Replaces the flat navigation API with grouped navigation data while retaining all six existing destinations.
- Renames the sidebar rows to “Runs” and “Transcripts” and updates accessibility and browser/component tests accordingly.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defect identified.

The grouped navigation retains all existing project-scoped destinations and active-section behavior, while the new sidebar composition preserves link attributes, drawer closing, scrolling, and accessibility contracts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/components/ui/sidebar.tsx | Adds reusable sidebar layout, grouping, and menu primitives with active-state, accessibility, reduced-motion, and drawer-navigation behavior. |
| apps/web/lib/navigation.ts | Replaces primary/secondary navigation buckets with three presentation groups while preserving destination paths and address-derived active sections. |
| apps/web/ui/shell.tsx | Renders the grouped navigation through the new primitives in both the persistent desktop sidebar and mobile drawer. |
| apps/web/test/sidebar-groups.test.tsx | Adds rendered coverage for group headings, link ordering, active state, styling, focus behavior, and drawer closing. |
| apps/web/test/project-shell.test.ts | Updates navigation contract coverage and explicitly verifies that all six pre-existing hrefs remain unchanged. |
| apps/api/test/browser.test.ts | Updates the end-to-end journey for the new labels, group ordering, keyboard order, and unchanged navigation destinations. |

<sub>Reviews (1): Last reviewed commit: ["fix: make the group labels headings, and..."](https://github.com/egma-ai/egma/commit/ee55749f0ff2d3be4058f9d66c63e4fa7047cc47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55030292)</sub>

**Context used:**

- Knowledge Base — [Egma web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->