### PR TITLE
Take Settings and the signed-out surface onto the shadcn base

### DIFF
--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -64,6 +64,7 @@ import { Dialog } from "../../ui/dialog.tsx";
 import { Transcript } from "../../ui/evidence.tsx";
 import { Toast, Tooltip, type FeedbackInput } from "../../ui/feedback.tsx";
 import { Menu, MenuDivider, MenuItem, MenuLabel } from "../../ui/menu.tsx";
+import { NumberField } from "../../ui/number-field.tsx";
 import { Empty, Failure, Loading } from "../../ui/page-state.tsx";
 import { ProjectSelector } from "../../ui/project-selector.tsx";
 import { RunProgress, VerdictBadge } from "../../ui/run-status.tsx";
@@ -172,6 +173,9 @@ export function DesignSystemProof() {
   const [environment, setEnvironment] = useState<"staging" | "production">("production");
   const [list, setList] = useState<"active" | "archived">("active");
   const [onlyFailed, setOnlyFailed] = useState(true);
+  const [sampleRate, setSampleRate] = useState("20");
+  const [answerWithin, setAnswerWithin] = useState("2.5");
+  const [turnBudget, setTurnBudget] = useState("12");
   const nextFeedbackInput = useRef<FeedbackInput>("keyboard");
 
   return (
@@ -280,6 +284,63 @@ export function DesignSystemProof() {
                   <div className="h-10 rounded-input border border-border bg-brand" title="Ember" />
                   <div className="h-10 rounded-input border border-border bg-failure" title="Failure" />
                 </div>
+              </div>
+            </div>
+
+            {/*
+              * The numeric field, which the shared control set never had.
+              *
+              * Its whole reason for existing is that a bound and a unit belong
+              * on the control rather than in a sentence beside it, so the proof
+              * has to show all three shapes at once: a percentage, a value in
+              * seconds whose step is not a whole number, and a plain count with
+              * no unit at all. A field that only ever appeared with a unit
+              * would leave the unit-less layout unproven, and that is the one
+              * the grader threshold uses.
+              */}
+            <div className="flex flex-col gap-4">
+              <h3 className="m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground">
+                Numeric fields
+              </h3>
+              <p className="m-0 max-w-[68ch] text-base text-muted-foreground">
+                The bounds are the browser&apos;s own validation and its own
+                arrow-key stepping; the unit is read out with the value rather
+                than drawn beside it; the digits are tabular. The spin buttons
+                are hidden because every browser draws them differently and each
+                one is a target smaller than this product allows anywhere else.
+              </p>
+              <div className="grid gap-6 md:grid-cols-3">
+                <NumberField
+                  id="proof-sample-rate"
+                  label="Share of live traffic judged"
+                  value={sampleRate}
+                  onChange={setSampleRate}
+                  unit="%"
+                  min={0}
+                  max={100}
+                  step={1}
+                  hint="A whole percentage. The field refuses 900 rather than a sentence asking it not to."
+                />
+                <NumberField
+                  id="proof-answer-within"
+                  label="Answer within"
+                  value={answerWithin}
+                  onChange={setAnswerWithin}
+                  unit="seconds"
+                  min={0}
+                  max={30}
+                  step={0.1}
+                  hint="A step that is not whole asks a phone for the decimal keypad."
+                />
+                <NumberField
+                  id="proof-turn-budget"
+                  label="Turns before the caller gives up"
+                  value={turnBudget}
+                  onChange={setTurnBudget}
+                  min={1}
+                  max={40}
+                  hint="No unit: some numbers are a count and nothing else."
+                />
               </div>
             </div>
 

--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -304,8 +304,9 @@ export function DesignSystemProof() {
               </h3>
               <p className="m-0 max-w-[68ch] text-base text-muted-foreground">
                 The bounds are the browser&apos;s own validation and its own
-                arrow-key stepping; the unit is read out with the value rather
-                than drawn beside it; the digits are tabular. The spin buttons
+                arrow-key stepping; the unit sits beside the field rather than
+                inside it, and is read out with the value rather than left as
+                decoration; the digits are tabular. The spin buttons
                 are hidden because every browser draws them differently and each
                 one is a target smaller than this product allows anywhere else.
               </p>

--- a/apps/web/app/device/approve/page.tsx
+++ b/apps/web/app/device/approve/page.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useState } from "react";
 
 import { withReturnTo } from "../../../lib/return-to.ts";
-import { Button, Select } from "../../../ui/controls.tsx";
-import { AuthShell, Notice, StatePage, styles } from "../../ui.tsx";
+import { Button } from "@/components/ui/button";
+
+import { Select } from "../../../ui/controls.tsx";
+import { AuthShell, LinkLine, Notice, StatePage } from "../../ui.tsx";
 
 /**
  * Approving a terminal, and saying what it is being let into.
@@ -34,6 +36,13 @@ type State =
   | { at: "loading" }
   | { at: "ready"; authorization: Pending }
   | { at: "unreachable" };
+
+/** One labelled fact about what is being approved. */
+const ROWS = "m-0 border-t border-border";
+const ROW =
+  "flex min-h-[56px] items-center justify-between gap-5 border-b border-border py-3";
+const TERM = "text-sm text-muted-foreground";
+const FACT = "m-0 text-right font-normal";
 
 /** Where each ending sends the browser. */
 const ENDING: Record<string, string> = {
@@ -134,9 +143,9 @@ export default function ApproveDevicePage() {
         title="Egma could not be reached"
         lead="Nothing was approved. Check that your instance is running and try the code again."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href="/device">Enter the code again</a>
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -151,11 +160,7 @@ export default function ApproveDevicePage() {
       lead={
         <>
           A terminal showing the code{" "}
-          <strong
-            className={styles.mono}
-          >
-            {authorization.user_code}
-          </strong>{" "}
+          <strong className="font-mono">{authorization.user_code}</strong>{" "}
           is asking for access. Approve it only if that code is on your own
           screen.
         </>
@@ -163,38 +168,56 @@ export default function ApproveDevicePage() {
     >
       {problem === null ? null : <Notice tone="error">{problem}</Notice>}
 
-      <dl className={styles.definitionList}>
-        <div className={styles.definitionRow}><dt>Organization</dt><dd>{authorization.organization.name}</dd></div>
-
-      {projects.length > 1 ? (
-        <div className={styles.definitionRow}>
-          <dt><label htmlFor="project">Project</label></dt>
-          <dd>
-          <Select
-            id="project"
-            value={projectId}
-            options={projects.map((project) => ({
-              value: project.id,
-              label: project.name,
-            }))}
-            onChange={setProjectId}
-          />
-          </dd>
+      {/*
+       * What the terminal is being let into, as facts rather than as a form.
+       * The project is a control only when there is more than one to choose
+       * between; one project is a fact and a select over it is clutter.
+       */}
+      <dl className={ROWS}>
+        <div className={ROW}>
+          <dt className={TERM}>Organization</dt>
+          <dd className={FACT}>{authorization.organization.name}</dd>
         </div>
-      ) : (
-        <div className={styles.definitionRow}><dt>Project</dt><dd>{projects[0]?.name ?? "—"}</dd></div>
-      )}
+
+        {projects.length > 1 ? (
+          <div className={ROW}>
+            <dt className={TERM}>
+              <label htmlFor="project">Project</label>
+            </dt>
+            <dd className={`${FACT} [&_select]:min-w-40`}>
+              <Select
+                id="project"
+                value={projectId}
+                options={projects.map((project) => ({
+                  value: project.id,
+                  label: project.name,
+                }))}
+                onChange={setProjectId}
+              />
+            </dd>
+          </div>
+        ) : (
+          <div className={ROW}>
+            <dt className={TERM}>Project</dt>
+            <dd className={FACT}>{projects[0]?.name ?? "—"}</dd>
+          </div>
+        )}
       </dl>
 
-      <div className={styles.buttonRow}>
+      {/* Deny reads first and Approve is the filled one, so the stronger of the
+          two is never the one somebody reaches by habit. Stacked on a narrow
+          screen, Approve stays at the bottom under the thumb. */}
+      <div className="mt-6 flex gap-3 max-[620px]:flex-col-reverse [&>*]:flex-1">
         <Button
+          type="button"
+          variant="secondary"
           disabled={busy}
           onClick={() => void answer("/api/device/deny")}
         >
           Deny
         </Button>
         <Button
-          weight="strong"
+          type="button"
           disabled={busy}
           onClick={() => void answer("/api/device/approve")}
         >

--- a/apps/web/app/device/approve/page.tsx
+++ b/apps/web/app/device/approve/page.tsx
@@ -37,12 +37,16 @@ type State =
   | { at: "ready"; authorization: Pending }
   | { at: "unreachable" };
 
-/** One labelled fact about what is being approved. */
-const ROWS = "m-0 border-t border-border";
-const ROW =
+/*
+ * The facts about what is being approved: a list, a row, the name of a fact,
+ * and the fact itself. A row is 56px so that the one row carrying a control
+ * has room for a 44px target without the rows around it changing height.
+ */
+const FACT_LIST = "m-0 border-t border-border";
+const FACT_ROW =
   "flex min-h-[56px] items-center justify-between gap-5 border-b border-border py-3";
-const TERM = "text-sm text-muted-foreground";
-const FACT = "m-0 text-right font-normal";
+const FACT_NAME = "text-sm text-muted-foreground";
+const FACT_VALUE = "m-0 text-right font-normal";
 
 /** Where each ending sends the browser. */
 const ENDING: Record<string, string> = {
@@ -173,18 +177,18 @@ export default function ApproveDevicePage() {
        * The project is a control only when there is more than one to choose
        * between; one project is a fact and a select over it is clutter.
        */}
-      <dl className={ROWS}>
-        <div className={ROW}>
-          <dt className={TERM}>Organization</dt>
-          <dd className={FACT}>{authorization.organization.name}</dd>
+      <dl className={FACT_LIST}>
+        <div className={FACT_ROW}>
+          <dt className={FACT_NAME}>Organization</dt>
+          <dd className={FACT_VALUE}>{authorization.organization.name}</dd>
         </div>
 
         {projects.length > 1 ? (
-          <div className={ROW}>
-            <dt className={TERM}>
+          <div className={FACT_ROW}>
+            <dt className={FACT_NAME}>
               <label htmlFor="project">Project</label>
             </dt>
-            <dd className={`${FACT} [&_select]:min-w-40`}>
+            <dd className={`${FACT_VALUE} [&_select]:min-w-40`}>
               <Select
                 id="project"
                 value={projectId}
@@ -197,9 +201,9 @@ export default function ApproveDevicePage() {
             </dd>
           </div>
         ) : (
-          <div className={ROW}>
-            <dt className={TERM}>Project</dt>
-            <dd className={FACT}>{projects[0]?.name ?? "—"}</dd>
+          <div className={FACT_ROW}>
+            <dt className={FACT_NAME}>Project</dt>
+            <dd className={FACT_VALUE}>{projects[0]?.name ?? "—"}</dd>
           </div>
         )}
       </dl>

--- a/apps/web/app/device/denied/page.tsx
+++ b/apps/web/app/device/denied/page.tsx
@@ -1,4 +1,4 @@
-import { StatePage, styles } from "../../ui.tsx";
+import { LinkLine, StatePage } from "../../ui.tsx";
 
 /**
  * Nothing was authorized, and this page says what to do about it.
@@ -18,11 +18,11 @@ export default function DeviceDeniedPage() {
       title="That terminal was not authorized"
       lead="Nothing was granted and no key was created."
     >
-      <p className={styles.linkLine}>
+      <LinkLine>
         If you did not mean to deny it, check the code on your terminal and{" "}
         <a href="/device">enter it again</a>. If the code no longer matches, run{" "}
         <code>egma login</code> in your terminal for a fresh one.
-      </p>
+      </LinkLine>
     </StatePage>
   );
 }

--- a/apps/web/app/device/expired/page.tsx
+++ b/apps/web/app/device/expired/page.tsx
@@ -1,4 +1,4 @@
-import { StatePage, styles } from "../../ui.tsx";
+import { LinkLine, StatePage } from "../../ui.tsx";
 
 /**
  * The code timed out, and saying so specifically is the whole job of this page.
@@ -13,10 +13,10 @@ export default function DeviceExpiredPage() {
       title="That code expired"
       lead="Codes are short-lived, so one left sitting for a while stops working. Nothing went wrong and nothing was granted."
     >
-      <p className={styles.linkLine}>
+      <LinkLine>
         Run <code>egma login</code> in your terminal again for a fresh code, or{" "}
         <a href="/device">enter a code</a> if you already have a new one.
-      </p>
+      </LinkLine>
     </StatePage>
   );
 }

--- a/apps/web/app/device/page.tsx
+++ b/apps/web/app/device/page.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useState } from "react";
 
-import { Button, Field, Form, TextInput } from "../../ui/controls.tsx";
-import { AuthShell, styles } from "../ui.tsx";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import { Field } from "../../ui/controls.tsx";
+import { AuthForm, AuthShell } from "../ui.tsx";
 
 /**
  * The code from your terminal.
@@ -46,26 +49,28 @@ export default function DeviceCodePage() {
           : "Type the code your terminal is showing."
       }
     >
-      <Form onSubmit={submit}>
+      <AuthForm onSubmit={submit}>
         <Field label="Code" htmlFor="user_code">
-          <div className={styles.codeInput}>
-            <TextInput
-              id="user_code"
-              name="user_code"
-              autoComplete="off"
-              autoCapitalize="characters"
-              spellCheck={false}
-              required
-              value={code}
-              onChange={setCode}
-            />
-          </div>
+          {/*
+           * Eight characters read off another screen, so the field is drawn the
+           * way the terminal draws them: monospaced, spaced out, and upper case
+           * whatever was typed.
+           */}
+          <Input
+            className="text-center font-mono text-lg tracking-[0.18em] uppercase"
+            id="user_code"
+            name="user_code"
+            autoComplete="off"
+            autoCapitalize="characters"
+            spellCheck={false}
+            required
+            value={code}
+            onChange={(event) => setCode(event.target.value)}
+          />
         </Field>
 
-        <Button weight="strong" type="submit">
-          Continue
-        </Button>
-      </Form>
+        <Button type="submit">Continue</Button>
+      </AuthForm>
     </AuthShell>
   );
 }

--- a/apps/web/app/device/success/page.tsx
+++ b/apps/web/app/device/success/page.tsx
@@ -1,4 +1,4 @@
-import { StatePage, styles } from "../../ui.tsx";
+import { LinkLine, StatePage } from "../../ui.tsx";
 
 /**
  * The end of it. The browser has nothing left to do and says so, because a page
@@ -11,13 +11,13 @@ export default function DeviceApprovedPage() {
       title="Your terminal is connected"
       lead="Go back to your terminal — it has what it needs and has already carried on."
     >
-      <p className={styles.linkLine}>
+      <LinkLine>
         The key it received is stored on that machine and was never shown here.
         You can see and revoke it later from your keys.
-      </p>
-      <p className={styles.linkLine}>
+      </LinkLine>
+      <LinkLine>
         You can close this window.
-      </p>
+      </LinkLine>
     </StatePage>
   );
 }

--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -3,8 +3,11 @@
 import { useEffect, useState } from "react";
 
 import { returnPathIn, withReturnTo } from "../../lib/return-to.ts";
-import { Button, Field, Form, TextInput } from "../../ui/controls.tsx";
-import { AuthShell, Notice, StatePage, styles } from "../ui.tsx";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import { Field } from "../../ui/controls.tsx";
+import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
  * Asking for a way back in.
@@ -68,8 +71,11 @@ export default function ForgotPasswordPage() {
         title="Check your email"
         lead={
           <>
-            If <span className={styles.emphasizedEmail}>{email}</span> has an
-            account, a link to reset password has been sent
+            If{" "}
+            <span className="text-foreground underline decoration-brand decoration-1 underline-offset-4">
+              {email}
+            </span>{" "}
+            has an account, a link to reset password has been sent
           </>
         }
       />
@@ -81,27 +87,28 @@ export default function ForgotPasswordPage() {
       eyebrow="Forgotten password"
       title="Set a new password."
     >
-      <Form onSubmit={() => void submit()}>
+      <AuthForm onSubmit={() => void submit()}>
         {problem === null ? null : <Notice tone="error">{problem}</Notice>}
 
         <Field label="Email" htmlFor="email">
-          <TextInput
+          <Input
             id="email"
             name="email"
             type="email"
             autoComplete="email"
+            spellCheck={false}
             required
             value={email}
-            onChange={setEmail}
+            onChange={(event) => setEmail(event.target.value)}
           />
         </Field>
 
-        <Button weight="strong" type="submit" disabled={submitting}>
+        <Button type="submit" disabled={submitting}>
           {submitting ? "Sending…" : "Send reset link"}
         </Button>
-      </Form>
+      </AuthForm>
 
-      <p className={styles.linkLine}>
+      <LinkLine>
         Remembered it?{" "}
         <a
           href={
@@ -111,7 +118,7 @@ export default function ForgotPasswordPage() {
           Sign in
         </a>
         .
-      </p>
+      </LinkLine>
     </AuthShell>
   );
 }

--- a/apps/web/app/invite/page.tsx
+++ b/apps/web/app/invite/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import {
   DEFAULT_SIGNED_IN_PATH,
   withReturnTo,
 } from "../../lib/return-to.ts";
-import { Button, Field, Form, TextInput } from "../../ui/controls.tsx";
-import { AuthShell, Notice, StatePage, styles } from "../ui.tsx";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import { Field } from "../../ui/controls.tsx";
+import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
  * The page a colleague lands on.
@@ -41,6 +44,9 @@ type State =
   | { status: "ready"; invitation: Lookup; signedInAs: string | null };
 
 export default function InvitePage() {
+  /* The hint's id, named by the field it belongs to. The base input reads no
+     context, so the page that writes the sentence is the page that names it. */
+  const emailHint = useId();
   const [state, setState] = useState<State>({ status: "loading" });
   const [token, setToken] = useState("");
   const [password, setPassword] = useState("");
@@ -140,7 +146,7 @@ export default function InvitePage() {
     return (
       <StatePage title="The invitation could not be checked" lead="Egma could not reach the invitation service right now.">
         <Button
-          weight="strong"
+          type="button"
           onClick={() => {
             setState({ status: "loading" });
             setAttempt((value) => value + 1);
@@ -158,9 +164,9 @@ export default function InvitePage() {
         title="That link is missing something"
         lead="An invitation link carries a token. Check it was copied whole, or ask whoever sent it for another."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href="/sign-in">Sign in</a> if you already have an account.
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -171,9 +177,9 @@ export default function InvitePage() {
         title="That invitation does not name anything"
         lead="Check the link was copied whole, or ask whoever sent it for another."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href="/sign-in">Sign in</a> if you already have an account.
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -186,9 +192,9 @@ export default function InvitePage() {
         title="That invitation has expired"
         lead={`Ask an admin of ${invitation.organization.name} to send another one.`}
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href="/sign-in">Sign in</a> if you already have an account.
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -199,9 +205,9 @@ export default function InvitePage() {
         title="That invitation has already been accepted"
         lead="If it was you, you are already in — sign in instead."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href="/sign-in">Sign in</a>
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -217,7 +223,7 @@ export default function InvitePage() {
       >
         {problem === null ? null : <Notice tone="error">{problem}</Notice>}
         <Button
-          weight="strong"
+          type="button"
           disabled={submitting}
           onClick={() => {
             void post("/api/invitations/accept", { token });
@@ -237,7 +243,7 @@ export default function InvitePage() {
         invitation.role === "admin" ? "an" : "a"
       } ${invitation.role}.`}
     >
-      <Form
+      <AuthForm
         onSubmit={() => {
           void post("/api/signup", {
             email: invitation.email,
@@ -248,35 +254,42 @@ export default function InvitePage() {
       >
         {problem === null ? null : <Notice tone="error">{problem}</Notice>}
 
-        <Field label="Email" hint="The address this invitation was sent to." htmlFor="email">
-          <TextInput
+        <Field label="Email" htmlFor="email">
+          <Input
             id="email"
             name="email"
             type="email"
+            autoComplete="off"
+            spellCheck={false}
             readOnly
+            aria-describedby={emailHint}
             value={invitation.email}
           />
+          <p className="m-0 text-sm text-faint" id={emailHint}>
+            The address this invitation was sent to.
+          </p>
         </Field>
 
         <Field label="Choose a password" htmlFor="password">
-          <TextInput
+          <Input
             id="password"
             name="password"
             type="password"
             autoComplete="new-password"
+            spellCheck={false}
             required
             minLength={8}
             value={password}
-            onChange={setPassword}
+            onChange={(event) => setPassword(event.target.value)}
           />
         </Field>
 
-        <Button weight="strong" type="submit" disabled={submitting}>
+        <Button type="submit" disabled={submitting}>
           {submitting ? "Joining…" : `Join ${invitation.organization.name}`}
         </Button>
-      </Form>
+      </AuthForm>
 
-      <p className={styles.linkLine}>
+      <LinkLine>
         Already have an Egma account?{" "}
         <a
           href={withReturnTo(
@@ -287,7 +300,7 @@ export default function InvitePage() {
           Sign in
         </a>{" "}
         and this page will let you join.
-      </p>
+      </LinkLine>
     </AuthShell>
   );
 }

--- a/apps/web/app/invite/page.tsx
+++ b/apps/web/app/invite/page.tsx
@@ -265,7 +265,7 @@ export default function InvitePage() {
             aria-describedby={emailHint}
             value={invitation.email}
           />
-          <p className="m-0 text-sm text-faint" id={emailHint}>
+          <p className="m-0 text-sm leading-(--line-normal) text-faint" id={emailHint}>
             The address this invitation was sent to.
           </p>
         </Field>

--- a/apps/web/app/members/page.tsx
+++ b/apps/web/app/members/page.tsx
@@ -6,7 +6,8 @@ import { useEffect, useState } from "react";
 import { readJson, type Answer } from "../../lib/api.ts";
 import { firstProjectOf, type Me } from "../../lib/me.ts";
 import { NEW_PROJECT_PATH } from "../../lib/settings.ts";
-import { Button } from "../../ui/controls.tsx";
+import { Button } from "@/components/ui/button";
+
 import { settingsPath } from "../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../ui/shell.tsx";
 
@@ -79,7 +80,13 @@ export default function MembersPage() {
           : answer.refusal.message
       }
     >
-      <Button onClick={() => setAttempt((one) => one + 1)}>Try again</Button>
+      <Button
+        type="button"
+        variant="secondary"
+        onClick={() => setAttempt((one) => one + 1)}
+      >
+        Try again
+      </Button>
     </ProductStatePage>
   );
 }

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -40,13 +40,13 @@ import {
   RelativeInstant,
   useMinuteClock,
 } from "../../../../../../ui/relative-time.tsx";
+import styles from "../../../../../ui.module.css";
 import {
   AppShell,
   Notice,
   ProductPage,
   ProductStatePage,
   StatePage,
-  styles,
 } from "../../../../../ui.tsx";
 
 type State =

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
@@ -52,7 +52,8 @@ import {
   PageHeader,
   ProductPage,
 } from "../../../../../ui/shell.tsx";
-import { Notice, styles } from "../../../../ui.tsx";
+import styles from "../../../../ui.module.css";
+import { Notice } from "../../../../ui.tsx";
 import setup from "./setup.module.css";
 
 /**

--- a/apps/web/app/projects/[projectId]/settings/judge/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/judge/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
@@ -18,17 +19,17 @@ import {
   type ProjectJudge,
 } from "../../../../../lib/judge.ts";
 import { roleOf } from "../../../../../lib/me.ts";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 import {
-  Badge,
-  Button,
-  ButtonLink,
   Field,
   Form,
   FormActions,
   Help,
   Section,
   Select,
-  TextInput,
 } from "../../../../../ui/controls.tsx";
 import { Failure, Loading } from "../../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
@@ -294,7 +295,7 @@ function JudgeSettings({ projectId }: { readonly projectId: string }) {
           >
             {judge.value.state === "needs_setup" ? (
               <Help>
-                <Badge tone="warn">Needs setup</Badge> This project has no judge, so
+                <Badge variant="warning">Needs setup</Badge> This project has no judge, so
                 a grader that judges by asking a model cannot run — the predefined
                 expected-behaviors grader among them, which every project starts
                 with. Add a judge credential under Organization settings, then
@@ -331,13 +332,15 @@ function JudgeSettings({ projectId }: { readonly projectId: string }) {
 
             <Form onSubmit={() => void saveChoice()}>
               <Field label="Model" htmlFor="judge-model">
-                <TextInput
+                <Input
                   id="judge-model"
                   value={model}
+                  autoComplete="off"
+                  spellCheck={false}
                   disabled={!mayAdminister}
-                  onChange={(chosen) => {
+                  onChange={(event) => {
                     editVersion.current += 1;
-                    setModel(chosen);
+                    setModel(event.target.value);
                   }}
                 />
               </Field>
@@ -454,7 +457,6 @@ function JudgeSettings({ projectId }: { readonly projectId: string }) {
 
               <FormActions>
                 <Button
-                  weight="strong"
                   type="submit"
                   disabled={!mayAdminister || !complete || !changed || saving}
                 >
@@ -477,9 +479,11 @@ function JudgeSettings({ projectId }: { readonly projectId: string }) {
               A judge key belongs to the organization rather than to this project,
               so one key can serve every project. Add, label and replace them
               under{" "}
-              <ButtonLink href={settingsPath(projectId, "organization")}>
-                Organization settings
-              </ButtonLink>
+              <Button asChild variant="secondary">
+                <Link href={settingsPath(projectId, "organization")}>
+                  Organization settings
+                </Link>
+              </Button>
               .
             </Help>
           </Section>

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import { writeJson, type Refusal } from "../../../../../lib/api.ts";
 import { roleOf, type Project } from "../../../../../lib/me.ts";
@@ -16,8 +16,10 @@ import {
   type ListedApiKey,
   type MintedApiKey,
 } from "../../../../../lib/settings.ts";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 import {
-  Button,
   Field,
   Form,
   FormActions,
@@ -26,7 +28,6 @@ import {
   Refused,
   Section,
   Select,
-  TextInput,
 } from "../../../../../ui/controls.tsx";
 import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
 import { Dialog } from "../../../../../ui/dialog.tsx";
@@ -118,10 +119,12 @@ function ApiKeyReceipt({
         <strong>Here is your key. Copy it now.</strong> Egma will not show it
         again, and cannot: only its hash was kept. <code>{keyValue.secret}</code>
       </p>
-      <Button weight="strong" onClick={() => void copy()}>
+      <Button type="button" onClick={() => void copy()}>
         Copy key
       </Button>{" "}
-      <Button onClick={onDismiss}>Dismiss</Button>
+      <Button type="button" variant="secondary" onClick={onDismiss}>
+        Dismiss
+      </Button>
       {copyState === "copied" ? <Help>Copied.</Help> : null}
       {copyState === "failed" ? (
         <Refused message="Egma could not copy the key. Select it above and copy it before you dismiss this message." />
@@ -138,6 +141,8 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
 
   const { answer, reload } = useOrganizationRead<ApiKeyList>(API_KEYS_PATH);
 
+  /* Why Create is not available, named by the control it belongs to. */
+  const whyNotCreate = useId();
   const [name, setName] = useState("");
   const [scope, setScope] = useState<string>(projectId);
   const [minted, setMinted] = useState<MintedApiKey | null>(null);
@@ -231,7 +236,12 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
         key: "actions",
         header: "Actions",
         cell: (key) => (
-          <Button disabled={busy} onClick={() => setConfirmingRevoke(key)}>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={busy}
+            onClick={() => setConfirmingRevoke(key)}
+          >
             Revoke
           </Button>
         ),
@@ -249,6 +259,15 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
     activeKeys,
     me?.user.id,
   );
+
+  /*
+   * Why creating another key is not available: there is a secret on screen
+   * that exists nowhere else, and a second create would draw over it.
+   */
+  const whyNot =
+    minted === null
+      ? undefined
+      : "Copy and dismiss the key above before you create another one.";
 
   return (
     <ProductPage viewport>
@@ -289,11 +308,13 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
                 <Form onSubmit={() => void mint()}>
                   <FormRow>
                     <Field label="Name" htmlFor="key-name">
-                      <TextInput
+                      <Input
                         id="key-name"
                         value={name}
+                        autoComplete="off"
+                        spellCheck={false}
                         disabled={busy}
-                        onChange={setName}
+                        onChange={(event) => setName(event.target.value)}
                       />
                     </Field>
                     <Field label="Scope" htmlFor="key-scope">
@@ -317,17 +338,23 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
                   </FormRow>
                   <FormActions>
                     <Button
-                      weight="strong"
                       type="submit"
                       disabled={busy || minted !== null}
-                      why={
-                        minted === null
-                          ? undefined
-                          : "Copy and dismiss the key above before you create another one."
+                      title={whyNot}
+                      aria-describedby={
+                        whyNot === undefined ? undefined : whyNotCreate
                       }
                     >
                       {busy ? "Creating…" : "Create key"}
                     </Button>
+                    {whyNot === undefined ? null : (
+                      <span
+                        className="max-w-[56ch] text-sm text-muted-foreground"
+                        id={whyNotCreate}
+                      >
+                        {whyNot}
+                      </span>
+                    )}
                   </FormActions>
                 </Form>
               </Section>
@@ -392,9 +419,12 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
                 {confirmingRevoke.name ?? "This key"} will stop working on its next
                 request. This action cannot be undone.
               </p>
-              <Button onClick={dismiss}>Cancel</Button>{" "}
+              <Button type="button" variant="secondary" onClick={dismiss}>
+                Cancel
+              </Button>{" "}
               <Button
-                tone="destructive"
+                type="button"
+                variant="destructive"
                 disabled={busy}
                 onClick={() => {
                   const key = confirmingRevoke;

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -349,7 +349,7 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
                     </Button>
                     {whyNot === undefined ? null : (
                       <span
-                        className="max-w-[56ch] text-sm text-muted-foreground"
+                        className="max-w-[56ch] text-sm leading-(--line-normal) text-muted-foreground"
                         id={whyNotCreate}
                       >
                         {whyNot}

--- a/apps/web/app/projects/[projectId]/settings/organization/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { writeJson, type Refusal } from "../../../../../lib/api.ts";
 import {
@@ -17,8 +17,10 @@ import {
   ORGANIZATION_PATH,
   type OrganizationSettings,
 } from "../../../../../lib/settings.ts";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 import {
-  Button,
   Field,
   Form,
   FormActions,
@@ -26,7 +28,6 @@ import {
   Problem,
   Refused,
   Section,
-  TextInput,
 } from "../../../../../ui/controls.tsx";
 import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
 import { Dialog } from "../../../../../ui/dialog.tsx";
@@ -95,6 +96,11 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
    */
   const mayAdminister = settled?.may_manage_organization === true;
 
+  /* The hint, and the sentence saying why Save is not available. The base
+     input and the base button both read nothing they are not given, so this
+     page names both and cannot leave either unpointed-at. */
+  const nameHint = useId();
+  const whyNotSave = useId();
   const [name, setName] = useState("");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -126,6 +132,11 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
   }, [answer, credentials]);
 
   const named = name.trim() !== "";
+  /** Said only to somebody the server would refuse, and only once it has said so. */
+  const whyNot =
+    mayAdminister || role === null
+      ? undefined
+      : `Your ${role} role cannot change organization settings. Ask an organization admin.`;
   const changed = settled !== null && name.trim() !== settled.name;
   const confirming = confirmingSave.current;
   const changedWhileConfirming =
@@ -226,22 +237,25 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
             {refused === null ? null : <Refused message={refused.message} />}
 
             <Form onSubmit={() => void save()}>
-              <Field
-                label="Name"
-                htmlFor="organization-name"
-                hint="What Egma calls your organization. Changing it breaks no link and no invitation."
-              >
-                <TextInput
+              <Field label="Name" htmlFor="organization-name">
+                <Input
                   id="organization-name"
                   value={name}
+                  autoComplete="off"
+                  spellCheck={false}
                   disabled={!mayAdminister}
-                  invalid={!named}
-                  onChange={(next) => {
+                  aria-invalid={named ? undefined : true}
+                  aria-describedby={nameHint}
+                  onChange={(event) => {
                     editVersion.current += 1;
-                    setName(next);
+                    setName(event.target.value);
                     setSaved(false);
                   }}
                 />
+                <p className="m-0 text-sm text-faint" id={nameHint}>
+                  What Egma calls your organization. Changing it breaks no link
+                  and no invitation.
+                </p>
               </Field>
 
               {named ? null : <Problem>An organization needs a name.</Problem>}
@@ -249,17 +263,21 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
 
               <FormActions>
                 <Button
-                  weight="strong"
                   type="submit"
                   disabled={!mayAdminister || !named || !changed || saving}
-                  why={
-                    mayAdminister || role === null
-                      ? undefined
-                      : `Your ${role} role cannot change organization settings. Ask an organization admin.`
-                  }
+                  title={whyNot}
+                  aria-describedby={whyNot === undefined ? undefined : whyNotSave}
                 >
                   {saving ? "Saving…" : "Save organization"}
                 </Button>
+                {whyNot === undefined ? null : (
+                  <span
+                    className="max-w-[56ch] text-sm text-muted-foreground"
+                    id={whyNotSave}
+                  >
+                    {whyNot}
+                  </span>
+                )}
               </FormActions>
             </Form>
           </Section>
@@ -317,6 +335,7 @@ function Credentials({
   readonly mayAdminister: boolean;
   readonly onChanged: () => void;
 }) {
+  const replacementHint = useId();
   const [label, setLabel] = useState("");
   const [key, setKey] = useState("");
   const [rotating, setRotating] = useState<string | null>(null);
@@ -475,6 +494,8 @@ function Credentials({
       width: "110px",
       cell: (credential) => (
         <Button
+          type="button"
+          variant="secondary"
           disabled={!mayAdminister || busy}
           onClick={() => setConfirmingArchive(credential)}
         >
@@ -488,6 +509,8 @@ function Credentials({
       width: "150px",
       cell: (credential) => (
         <Button
+          type="button"
+          variant="secondary"
           disabled={!mayAdminister || busy}
           onClick={() => {
             // One form under the table means one `replacement` and one `failed`
@@ -562,22 +585,24 @@ function Credentials({
              */}
             {rotatingCredential === undefined ? null : (
               <Form onSubmit={() => void rotate(rotatingCredential)}>
-                <Field
-                  label="New key"
-                  htmlFor={`rotate-${rotatingCredential.id}`}
-                  hint="Replaces the stored key whole. You do not need the old one, and Egma will not show it to you."
-                >
-                  <TextInput
+                <Field label="New key" htmlFor={`rotate-${rotatingCredential.id}`}>
+                  <Input
                     id={`rotate-${rotatingCredential.id}`}
                     value={replacement}
-                    secret
+                    type="password"
+                    autoComplete="new-password"
+                    spellCheck={false}
                     disabled={!mayAdminister || busy}
-                    onChange={setReplacement}
+                    aria-describedby={replacementHint}
+                    onChange={(event) => setReplacement(event.target.value)}
                   />
+                  <p className="m-0 text-sm text-faint" id={replacementHint}>
+                    Replaces the stored key whole. You do not need the old one,
+                    and Egma will not show it to you.
+                  </p>
                 </Field>
                 <FormActions>
                   <Button
-                    weight="strong"
                     type="submit"
                     disabled={!mayAdminister || busy || replacement.trim() === ""}
                   >
@@ -596,25 +621,28 @@ function Credentials({
       >
         <Form onSubmit={() => void add()}>
           <Field label="Label" htmlFor="credential-label">
-            <TextInput
+            <Input
               id="credential-label"
               value={label}
+              autoComplete="off"
+              spellCheck={false}
               disabled={!mayAdminister || busy}
-              onChange={setLabel}
+              onChange={(event) => setLabel(event.target.value)}
             />
           </Field>
           <Field label="OpenAI key" htmlFor="credential-key">
-            <TextInput
+            <Input
               id="credential-key"
               value={key}
-              secret
+              type="password"
+              autoComplete="new-password"
+              spellCheck={false}
               disabled={!mayAdminister || busy}
-              onChange={setKey}
+              onChange={(event) => setKey(event.target.value)}
             />
           </Field>
           <FormActions>
             <Button
-              weight="strong"
               type="submit"
               disabled={!mayAdminister || busy || label.trim() === "" || key.trim() === ""}
             >
@@ -636,9 +664,12 @@ function Credentials({
                 Egma will refuse this action if a project or an active run still uses
                 it.
               </p>
-              <Button onClick={dismiss}>Cancel</Button>{" "}
+              <Button type="button" variant="secondary" onClick={dismiss}>
+                Cancel
+              </Button>{" "}
               <Button
-                tone="destructive"
+                type="button"
+                variant="destructive"
                 disabled={busy}
                 onClick={() => {
                   const credential = confirmingArchive;

--- a/apps/web/app/projects/[projectId]/settings/organization/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/page.tsx
@@ -252,7 +252,7 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
                     setSaved(false);
                   }}
                 />
-                <p className="m-0 text-sm text-faint" id={nameHint}>
+                <p className="m-0 text-sm leading-(--line-normal) text-faint" id={nameHint}>
                   What Egma calls your organization. Changing it breaks no link
                   and no invitation.
                 </p>
@@ -272,7 +272,7 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
                 </Button>
                 {whyNot === undefined ? null : (
                   <span
-                    className="max-w-[56ch] text-sm text-muted-foreground"
+                    className="max-w-[56ch] text-sm leading-(--line-normal) text-muted-foreground"
                     id={whyNotSave}
                   >
                     {whyNot}
@@ -596,7 +596,7 @@ function Credentials({
                     aria-describedby={replacementHint}
                     onChange={(event) => setReplacement(event.target.value)}
                   />
-                  <p className="m-0 text-sm text-faint" id={replacementHint}>
+                  <p className="m-0 text-sm leading-(--line-normal) text-faint" id={replacementHint}>
                     Replaces the stored key whole. You do not need the old one,
                     and Egma will not show it to you.
                   </p>

--- a/apps/web/app/projects/[projectId]/settings/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/page.tsx
@@ -323,7 +323,7 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
                 </Button>
                 {whyNot === undefined ? null : (
                   <span
-                    className="max-w-[56ch] text-sm text-muted-foreground"
+                    className="max-w-[56ch] text-sm leading-(--line-normal) text-muted-foreground"
                     id={whyNotSave}
                   >
                     {whyNot}

--- a/apps/web/app/projects/[projectId]/settings/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/page.tsx
@@ -259,7 +259,13 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
                 message={refused.message}
                 action={
                   refused.error === IDENTITY_CONFLICT ? (
-                    <Button onClick={reload}>Read this project again</Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={reload}
+                    >
+                      Read this project again
+                    </Button>
                   ) : undefined
                 }
               />

--- a/apps/web/app/projects/[projectId]/settings/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { IDENTITY_CONFLICT, writeJson, type Refusal } from "../../../../lib/api.ts";
 import { roleOf } from "../../../../lib/me.ts";
@@ -9,8 +9,10 @@ import {
   projectSettingsPath,
   type ProjectSettings,
 } from "../../../../lib/settings.ts";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 import {
-  Button,
   Field,
   Form,
   FormActions,
@@ -19,7 +21,6 @@ import {
   Refused,
   Section,
   TextArea,
-  TextInput,
 } from "../../../../ui/controls.tsx";
 import { Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
 import { SettingsLayout } from "../../../../ui/settings-nav.tsx";
@@ -91,6 +92,15 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
    */
   const mayAdminister = settled?.may_manage_projects ?? false;
 
+  /*
+   * The id of the sentence saying why Save is not available.
+   *
+   * The base button is a `<button>` and draws nothing beside itself, so the
+   * page writes the sentence and names it. A disabled control cannot take
+   * focus, which is exactly why the reason may not live in a `title` alone:
+   * that is a reason only a pointer can reach.
+   */
+  const whyNotSave = useId();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [saving, setSaving] = useState(false);
@@ -135,6 +145,11 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
   }, [answer]);
 
   const named = name.trim() !== "";
+  /** Said only to somebody the server would refuse, and only once it has said so. */
+  const whyNot =
+    mayAdminister || role === null
+      ? undefined
+      : `Your ${role} role cannot change project settings. Ask an organization admin.`;
   const changed =
     settled !== null &&
     (name.trim() !== settled.name ||
@@ -252,14 +267,16 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
 
             <Form onSubmit={() => void save()}>
               <Field label="Name" htmlFor="project-name">
-                <TextInput
+                <Input
                   id="project-name"
                   value={name}
+                  autoComplete="off"
+                  spellCheck={false}
                   disabled={!mayAdminister}
-                  invalid={name.trim() === ""}
-                  onChange={(next) => {
+                  aria-invalid={name.trim() === "" ? true : undefined}
+                  onChange={(event) => {
                     editVersion.current += 1;
-                    setName(next);
+                    setName(event.target.value);
                     setSaved(false);
                   }}
                 />
@@ -291,17 +308,21 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
 
               <FormActions>
                 <Button
-                  weight="strong"
                   type="submit"
                   disabled={!mayAdminister || !named || !changed || saving}
-                  why={
-                    mayAdminister || role === null
-                      ? undefined
-                      : `Your ${role} role cannot change project settings. Ask an organization admin.`
-                  }
+                  title={whyNot}
+                  aria-describedby={whyNot === undefined ? undefined : whyNotSave}
                 >
                   {saving ? "Saving…" : "Save project"}
                 </Button>
+                {whyNot === undefined ? null : (
+                  <span
+                    className="max-w-[56ch] text-sm text-muted-foreground"
+                    id={whyNotSave}
+                  >
+                    {whyNot}
+                  </span>
+                )}
               </FormActions>
             </Form>
           </Section>

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -327,7 +327,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
           </Button>
           {whyNot === undefined ? null : (
             <span
-              className="max-w-[56ch] text-sm text-muted-foreground"
+              className="max-w-[56ch] text-sm leading-(--line-normal) text-muted-foreground"
               id={`${whyNotManage}-${member.user_id}`}
             >
               {whyNot}

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import {
   readJson,
@@ -22,9 +22,11 @@ import {
   type Member,
   type Roster,
 } from "../../../../../lib/settings.ts";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 import {
-  Badge,
-  Button,
   Field,
   Form,
   FormActions,
@@ -33,7 +35,6 @@ import {
   Refused,
   Section,
   Select,
-  TextInput,
 } from "../../../../../ui/controls.tsx";
 import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
 import { Dialog } from "../../../../../ui/dialog.tsx";
@@ -97,6 +98,8 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
   const settled = answer?.status === "ready" ? answer.value : null;
   const mayManage = settled?.may_manage_members === true;
 
+  /* Why the membership controls are not available, for whoever asks. */
+  const whyNotManage = useId();
   const [tab, setTab] = useState<Tab>("people");
   const tabRef = useRef<Tab>("people");
   const [invitations, setInvitations] =
@@ -212,6 +215,11 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
   }
 
   const shownTab: Tab = mayManage ? tab : "people";
+  /** Said only to somebody the server would refuse, and only once it has said so. */
+  const whyNot =
+    mayManage || role === null
+      ? undefined
+      : `Your ${role} role cannot manage members. Ask an organization admin.`;
 
   if (answer === null) {
     return (
@@ -293,9 +301,9 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
       header: "Standing",
       cell: (member) =>
         member.deactivated_at === null ? (
-          <Badge tone="good">Active</Badge>
+          <Badge variant="success">Active</Badge>
         ) : (
-          <Badge tone="warn">Deactivated</Badge>
+          <Badge variant="warning">Deactivated</Badge>
         ),
     },
     {
@@ -304,17 +312,30 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
       cell: (member) => (
         <>
           <Button
+            type="button"
+            variant="secondary"
             disabled={!mayManage || busy}
-            why={
-              mayManage || role === null
+            title={whyNot}
+            aria-describedby={
+              whyNot === undefined
                 ? undefined
-                : `Your ${role} role cannot manage members. Ask an organization admin.`
+                : `${whyNotManage}-${member.user_id}`
             }
             onClick={() => setConfirming({ action: "deactivate", member })}
           >
             Deactivate
-          </Button>{" "}
+          </Button>
+          {whyNot === undefined ? null : (
+            <span
+              className="max-w-[56ch] text-sm text-muted-foreground"
+              id={`${whyNotManage}-${member.user_id}`}
+            >
+              {whyNot}
+            </span>
+          )}{" "}
           <Button
+            type="button"
+            variant="secondary"
             disabled={!mayManage || busy}
             onClick={() => setConfirming({ action: "remove", member })}
           >
@@ -408,9 +429,12 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
                   ? "will lose membership in this organization. Everything they authored stays where it is, with their name on it."
                   : "will no longer be able to use this organization, and every key they minted stops working on the next request."}
               </p>
-              <Button onClick={dismiss}>Cancel</Button>{" "}
+              <Button type="button" variant="secondary" onClick={dismiss}>
+                Cancel
+              </Button>{" "}
               <Button
-                tone="destructive"
+                type="button"
+                variant="destructive"
                 disabled={busy}
                 onClick={() => {
                   const chosen = confirming;
@@ -532,7 +556,7 @@ function Invitations({
       header: "Standing",
       cell: (invitation) =>
         standingOf(invitation) === "expired" ? (
-          <Badge tone="warn">Expired</Badge>
+          <Badge variant="warning">Expired</Badge>
         ) : (
           <Badge>Pending</Badge>
         ),
@@ -553,6 +577,8 @@ function Invitations({
       cell: (invitation) =>
         standingOf(invitation) === "expired" ? (
           <Button
+            type="button"
+            variant="secondary"
             disabled={busy}
             onClick={() => void send(invitation.email, invitation.role)}
           >
@@ -583,11 +609,13 @@ function Invitations({
         <Form onSubmit={() => void invite()}>
           <FormRow>
             <Field label="Email" htmlFor="invite-email">
-              <TextInput
+              <Input
                 id="invite-email"
                 value={email}
+                autoComplete="off"
+                spellCheck={false}
                 disabled={busy}
-                onChange={setEmail}
+                onChange={(event) => setEmail(event.target.value)}
               />
             </Field>
             <Field label="Role" htmlFor="invite-role">
@@ -604,11 +632,7 @@ function Invitations({
             </Field>
           </FormRow>
           <FormActions>
-            <Button
-              weight="strong"
-              type="submit"
-              disabled={busy || email.trim() === ""}
-            >
+            <Button type="submit" disabled={busy || email.trim() === ""}>
               {busy ? "Inviting…" : "Send invitation"}
             </Button>
           </FormActions>

--- a/apps/web/app/recording-player.tsx
+++ b/apps/web/app/recording-player.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 
 import { offersNothing } from "../lib/recording-refusals.ts";
-import { Notice, styles } from "./ui.tsx";
+import styles from "./ui.module.css";
+import { Notice } from "./ui.tsx";
 
 /**
  * The audio egma recorded of one voice conversation, wherever somebody is

--- a/apps/web/app/reset-password/page.tsx
+++ b/apps/web/app/reset-password/page.tsx
@@ -3,8 +3,11 @@
 import { useEffect, useState } from "react";
 
 import { returnPathIn, withReturnTo } from "../../lib/return-to.ts";
-import { Button, Field, Form, TextInput } from "../../ui/controls.tsx";
-import { AuthShell, Notice, StatePage, styles } from "../ui.tsx";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import { Field } from "../../ui/controls.tsx";
+import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
  * The page behind the link, and it asks for one thing.
@@ -100,9 +103,9 @@ export default function ResetPasswordPage() {
         title="That password is set"
         lead="Sign in with the new one. The old one no longer works."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href={signInHref}>Sign in</a>
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -117,9 +120,9 @@ export default function ResetPasswordPage() {
         title="That link is missing something"
         lead="A reset link carries a token. Check it was copied whole, or ask for another."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href={forgotHref}>Ask for another link</a>
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -132,10 +135,10 @@ export default function ResetPasswordPage() {
         title="That link has already been used"
         lead="The password behind it has been set. Sign in with it — or ask for another link if it was not you who used it."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href={signInHref}>Sign in</a> ·{" "}
           <a href={forgotHref}>Ask for another link</a>
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -150,10 +153,10 @@ export default function ResetPasswordPage() {
         title="That link no longer works"
         lead="It is too old now for Egma to say whether it was used before it ran out. If you set a password with it, sign in with that one. If nothing happened, ask for another link."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href={signInHref}>Sign in</a> ·{" "}
           <a href={forgotHref}>Ask for another link</a>
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -161,9 +164,9 @@ export default function ResetPasswordPage() {
   if (refused !== null) {
     return (
       <StatePage title="That link could not be used" lead={refused.message}>
-        <p className={styles.linkLine}>
+        <LinkLine>
           <a href={forgotHref}>Ask for another link</a>
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -174,26 +177,27 @@ export default function ResetPasswordPage() {
       title="Choose a new password."
       lead="This link names your account, so a password is all Egma needs."
     >
-      <Form onSubmit={() => void submit()}>
+      <AuthForm onSubmit={() => void submit()}>
         {problem === null ? null : <Notice tone="error">{problem}</Notice>}
 
         <Field label="New password" htmlFor="password">
-          <TextInput
+          <Input
             id="password"
             name="password"
             type="password"
             autoComplete="new-password"
+            spellCheck={false}
             required
             minLength={8}
             value={password}
-            onChange={setPassword}
+            onChange={(event) => setPassword(event.target.value)}
           />
         </Field>
 
-        <Button weight="strong" type="submit" disabled={submitting}>
+        <Button type="submit" disabled={submitting}>
           {submitting ? "Setting…" : "Set the password"}
         </Button>
-      </Form>
+      </AuthForm>
     </AuthShell>
   );
 }

--- a/apps/web/app/sign-in/page.tsx
+++ b/apps/web/app/sign-in/page.tsx
@@ -7,12 +7,31 @@ import {
   returnPathIn,
   withReturnTo,
 } from "../../lib/return-to.ts";
-import { Button, Field, Form, TextInput } from "../../ui/controls.tsx";
-import { AuthShell, Notice, styles } from "../ui.tsx";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import { Field } from "../../ui/controls.tsx";
+import { AuthForm, AuthShell, LinkLine, Notice } from "../ui.tsx";
 
 function PasswordVisibilityIcon({ visible }: { readonly visible: boolean }) {
   return (
-    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+    /*
+     * `size-5` is on the icon rather than on the control. The base button sizes
+     * any icon that does not carry a size of its own, and this one is 20px
+     * inside a 36px target rather than the 16px a row action wears.
+     */
+    <svg
+      className="size-5"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+    >
       <path d="M2.5 12s3.4-5.5 9.5-5.5 9.5 5.5 9.5 5.5-3.4 5.5-9.5 5.5S2.5 12 2.5 12Z" />
       <circle cx="12" cy="12" r="2.75" />
       {visible ? <path d="m4 4 16 16" /> : null}
@@ -70,53 +89,68 @@ export default function SignInPage() {
       title="Sign in"
       lead="Sign in to continue to your organization."
     >
-      <Form onSubmit={() => void submit()}>
+      <AuthForm onSubmit={() => void submit()}>
         {problem === null ? null : <Notice tone="error">{problem}</Notice>}
 
         <Field label="Email" htmlFor="email">
-          <TextInput
+          <Input
             id="email"
             name="email"
             type="email"
             autoComplete="email"
+            spellCheck={false}
             required
             value={email}
-            onChange={setEmail}
+            onChange={(event) => setEmail(event.target.value)}
           />
         </Field>
 
         <Field label="Password" htmlFor="password">
-          <div className={styles.passwordControl}>
-            <TextInput
+          <div className="relative min-w-0">
+            <Input
+              className="min-w-0 pr-[calc(var(--tap-target)+var(--space-2))]"
               id="password"
               name="password"
               type={passwordVisible ? "text" : "password"}
               autoComplete="current-password"
+              spellCheck={false}
               required
               value={password}
-              onChange={setPassword}
+              onChange={(event) => setPassword(event.target.value)}
             />
-            <button
-              className={styles.passwordToggle}
+            {/*
+             * The one control in this product that sits inside another one, so
+             * it is the base button resized rather than a second kind of
+             * button: a 36px target inside a 44px field for a fine pointer, and
+             * the full 44px where a finger has to find it.
+             */}
+            <Button
+              className={cn(
+                "absolute top-1/2 right-1 size-(--control-md) min-h-(--control-md)",
+                "-translate-y-1/2 p-0 text-muted-foreground",
+                "pointer-coarse:right-0 pointer-coarse:size-(--tap-target)",
+                "pointer-coarse:min-h-(--tap-target)",
+              )}
+              variant="ghost"
               type="button"
               aria-label={passwordVisible ? "Hide password" : "Show password"}
               aria-controls="password"
               onClick={() => setPasswordVisible((visible) => !visible)}
             >
               <PasswordVisibilityIcon visible={passwordVisible} />
-            </button>
+            </Button>
           </div>
         </Field>
 
-        <Button weight="strong" type="submit" disabled={submitting}>
+        <Button type="submit" disabled={submitting}>
           {submitting ? "Signing in…" : "Sign in"}
         </Button>
-      </Form>
+      </AuthForm>
 
       {/* Carrying where they were headed, exactly as the signup link does.
           Somebody sent here by a terminal's approval page who turns out to have
           forgotten their password is still on their way to that page. */}
-      <p className={styles.linkLine}>
+      <LinkLine>
         <a
           href={
             returnTo === null
@@ -126,15 +160,15 @@ export default function SignInPage() {
         >
           Forgot your password?
         </a>
-      </p>
+      </LinkLine>
 
-      <p className={styles.linkLine}>
+      <LinkLine>
         No account yet?{" "}
         <a href={returnTo === null ? "/signup" : withReturnTo("/signup", returnTo)}>
           Sign up
         </a>
         .
-      </p>
+      </LinkLine>
     </AuthShell>
   );
 }

--- a/apps/web/app/sign-in/page.tsx
+++ b/apps/web/app/sign-in/page.tsx
@@ -128,6 +128,14 @@ export default function SignInPage() {
               className={cn(
                 "absolute top-1/2 right-1 size-(--control-md) min-h-(--control-md)",
                 "-translate-y-1/2 p-0 text-muted-foreground",
+                /*
+                 * The icon brightens under a fine pointer. The base ghost
+                 * variant changes only the background, and the quiet colour
+                 * pinned above wins over its `text-foreground` at rest *and* on
+                 * hover — so the hover half has to be said here too, or the
+                 * only answer to pointing at the control is a faint wash.
+                 */
+                "pointer-hover:text-foreground",
                 "pointer-coarse:right-0 pointer-coarse:size-(--tap-target)",
                 "pointer-coarse:min-h-(--tap-target)",
               )}

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import {
   DEFAULT_SIGNED_IN_PATH,
@@ -11,8 +11,11 @@ import {
   DEFAULT_PROJECT_NAME,
   organizationNameFromEmail,
 } from "../../lib/signup-defaults.ts";
-import { Button, Field, Form, TextInput } from "../../ui/controls.tsx";
-import { AuthShell, Notice, StatePage, styles } from "../ui.tsx";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import { Field } from "../../ui/controls.tsx";
+import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
  * Signing up: one page, one submit, and an organization and a project at the
@@ -30,6 +33,14 @@ import { AuthShell, Notice, StatePage, styles } from "../ui.tsx";
 type Availability = { open: boolean; message?: string };
 
 export default function SignUpPage() {
+  /*
+   * The hint's own id, held here rather than inside `Field`.
+   *
+   * A hint nothing points at is a hint only a sighted reader ever gets, and the
+   * base input is a plain `<input>` that reads no context. So the page that
+   * writes the sentence is the page that names it, and the two cannot drift.
+   */
+  const organizationHint = useId();
   const [availability, setAvailability] = useState<Availability | null>(null);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -114,7 +125,7 @@ export default function SignUpPage() {
         animated
         title="Ask an admin for an invitation to this Egma instance."
       >
-        <p className={styles.linkLine}>
+        <LinkLine>
           Already have an account?{" "}
           <a
             href={
@@ -124,7 +135,7 @@ export default function SignUpPage() {
             Sign in
           </a>
           .
-        </p>
+        </LinkLine>
       </StatePage>
     );
   }
@@ -136,63 +147,73 @@ export default function SignUpPage() {
       title="Set up Egma"
       lead="One step. Your organization and your first project are created together."
     >
-      <Form onSubmit={() => void submit()}>
+      <AuthForm onSubmit={() => void submit()}>
         {problem === null ? null : <Notice tone="error">{problem}</Notice>}
 
         <Field label="Email" htmlFor="email">
-          <TextInput
+          <Input
             id="email"
             name="email"
             type="email"
             autoComplete="email"
+            spellCheck={false}
             required
             value={email}
-            onChange={onEmailChange}
+            onChange={(event) => onEmailChange(event.target.value)}
           />
         </Field>
 
         <Field label="Password" htmlFor="password">
-          <TextInput
+          <Input
             id="password"
             name="password"
             type="password"
             autoComplete="new-password"
+            spellCheck={false}
             required
             minLength={8}
             value={password}
-            onChange={setPassword}
+            onChange={(event) => setPassword(event.target.value)}
           />
         </Field>
 
-        <Field label="Organization" hint="Filled in from your email. Change it if you like." htmlFor="organizationName">
-          <TextInput
+        <Field label="Organization" htmlFor="organizationName">
+          <Input
             id="organizationName"
             name="organizationName"
+            autoComplete="off"
+            spellCheck={false}
             required
+            aria-describedby={organizationHint}
             value={organizationName}
-            onChange={(value) => {
+            onChange={(event) => {
               setOrganizationEdited(true);
-              setOrganizationName(value);
+              setOrganizationName(event.target.value);
             }}
           />
+          <p className="m-0 text-sm text-faint" id={organizationHint}>
+            Filled in from your email. Change it if you like.
+          </p>
         </Field>
 
         <Field label="First project" htmlFor="projectName">
-          <TextInput
+          <Input
             id="projectName"
             name="projectName"
+            autoComplete="off"
+            spellCheck={false}
             required
             value={projectName}
-            onChange={setProjectName}
+            onChange={(event) => setProjectName(event.target.value)}
           />
         </Field>
 
-        <Button weight="strong" type="submit" disabled={submitting}>
+        <Button type="submit" disabled={submitting}>
           {submitting ? "Setting up…" : "Create my Egma instance"}
         </Button>
-      </Form>
+      </AuthForm>
 
-      <p className={styles.linkLine}>
+      <LinkLine>
         Already have an account?{" "}
         <a
           href={returnTo === null ? "/sign-in" : withReturnTo("/sign-in", returnTo)}
@@ -200,7 +221,7 @@ export default function SignUpPage() {
           Sign in
         </a>
         .
-      </p>
+      </LinkLine>
     </AuthShell>
   );
 }

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -191,7 +191,7 @@ export default function SignUpPage() {
               setOrganizationName(event.target.value);
             }}
           />
-          <p className="m-0 text-sm text-faint" id={organizationHint}>
+          <p className="m-0 text-sm leading-(--line-normal) text-faint" id={organizationHint}>
             Filled in from your email. Change it if you like.
           </p>
         </Field>

--- a/apps/web/app/trust-gate.tsx
+++ b/apps/web/app/trust-gate.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef } from "react";
 
-import styles from "./ui.module.css";
+import { cn } from "@/lib/utils";
 
 type Dot = {
   phase: number;
@@ -126,5 +126,23 @@ export function TrustGate() {
     };
   }, [seed]);
 
-  return <canvas ref={canvasRef} className={styles.trustGate} aria-hidden="true" />;
+  return (
+    <canvas
+      ref={canvasRef}
+      /*
+       * The ink is read back off this element with `getComputedStyle`, so the
+       * colour has to be a real declaration rather than a value passed in: the
+       * canvas follows the theme because `text-foreground` does.
+       *
+       * It leaves the page entirely on a narrow screen. The brand panel is a
+       * strip there, and a field of moving dots in a 144px band is decoration
+       * competing with the one sentence somebody came to read.
+       */
+      className={cn(
+        "absolute inset-0 block h-full w-full text-foreground opacity-[0.42]",
+        "max-[620px]:hidden",
+      )}
+      aria-hidden="true"
+    />
+  );
 }

--- a/apps/web/app/ui.module.css
+++ b/apps/web/app/ui.module.css
@@ -1,46 +1,10 @@
-.brand { display: block; width: 151px; height: auto; }
-:global(:root[data-theme="dark"]) .brand { filter: invert(1); }
 .eyebrow { margin: 0 0 var(--space-3); color: var(--muted); font-family: var(--mono); font-size: var(--text-caption); letter-spacing: .08em; line-height: var(--line-caption); text-transform: uppercase; }
-.themeToggle { display: grid; width: var(--tap-target); height: var(--tap-target); flex: 0 0 auto; padding: 0; place-items: center; border: 1px solid var(--foreground); border-radius: var(--radius-sm); background: var(--surface); cursor: pointer; }
 
-.authShell { display: grid; min-height: 100svh; grid-template-columns: minmax(340px, .92fr) minmax(520px, 1.08fr); background: var(--background); }
-.authBrandPanel { position: relative; min-width: 0; overflow: hidden; border-right: 1px solid var(--border); background: var(--surface-soft); }
-.authBrandPanel::after { position: absolute; right: var(--space-6); bottom: var(--space-6); width: var(--space-4); height: var(--space-4); background: var(--accent); content: ""; }
-.trustGate { position: absolute; inset: 0; display: block; width: 100%; height: 100%; color: var(--foreground); opacity: .42; }
-.authBrandOverlay { position: absolute; z-index: 1; inset: 0; display: flex; flex-direction: column; justify-content: space-between; padding: clamp(var(--space-7), 5vw, var(--space-10)); pointer-events: none; }
-.authStatement { max-width: 520px; }
-.authStatement > p:last-child { max-width: 480px; margin: 0; font-size: clamp(var(--text-lead), 2.8vw, var(--text-heading-sm)); letter-spacing: var(--tracking-heading-sm); line-height: 1.08; }
-.authContent { position: relative; display: grid; min-height: 100svh; padding: var(--space-12) var(--space-10); place-items: center; }
-.authTheme { position: absolute; top: var(--space-6); right: var(--space-6); }
-.authCard { width: 100%; max-width: 520px; padding: var(--space-8); border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); box-shadow: var(--shadow-menu); }
-.authCard h1 { max-width: 440px; margin: 0; font-size: clamp(var(--text-heading-sm), 3.4vw, var(--text-heading)); font-weight: 400; letter-spacing: var(--tracking-heading); line-height: var(--line-heading); }
-.authLead { max-width: 440px; margin: var(--space-3) 0 var(--space-7); color: var(--muted); font-size: var(--text-body); letter-spacing: var(--tracking-body); line-height: var(--line-body); }
-.emphasizedEmail { color: var(--foreground); text-decoration: underline; text-decoration-color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 4px; }
-.authCard form { max-width: none; padding: 0; border: 0; border-radius: 0; background: transparent; }
-.authCard form + .linkLine { margin-top: var(--space-6); padding-top: var(--space-5); border-top: 1px solid var(--border); }
-.passwordControl { position: relative; min-width: 0; }
-.passwordControl input { min-width: 0; padding-right: calc(var(--tap-target) + var(--space-2)); }
-.passwordToggle { position: absolute; top: 50%; right: 4px; display: grid; width: var(--control-md); height: var(--control-md); padding: 0; transform: translateY(-50%); place-items: center; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--muted); cursor: pointer; }
-.passwordToggle svg { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.5; }
 
-.codeInput input { font-family: var(--mono); font-size: var(--text-lead); letter-spacing: .18em; text-align: center; text-transform: uppercase; }
-.buttonRow { display: flex; gap: var(--space-3); }
-.definitionList + .buttonRow { margin-top: var(--space-6); }
-.buttonRow > * { flex: 1; }
 .linkLine { margin: var(--space-5) 0 0; color: var(--muted); font-size: var(--text-caption); letter-spacing: var(--tracking-caption); line-height: var(--line-caption); }
 .linkLine + .linkLine { margin-top: var(--space-3); }
 .linkLine a { display: inline-block; color: var(--foreground); text-decoration-color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 4px; }
-.notice { margin-bottom: var(--space-5); padding: var(--space-3) var(--space-4); border: 1px solid var(--border); border-left-width: 3px; border-radius: var(--radius-md); background: var(--surface-soft); color: var(--foreground); font-size: var(--text-caption); line-height: var(--line-caption); }
-.notice-error { border-left-color: var(--accent); }
-.notice-success { border-left-color: var(--foreground); }
-.notice p { margin: 0; }
-.notice p + p { margin-top: var(--space-2); }
 
-.definitionList { margin: 0; border-top: 1px solid var(--border); }
-.definitionRow { display: flex; min-height: 56px; align-items: center; justify-content: space-between; gap: var(--space-5); padding: var(--space-3) 0; border-bottom: 1px solid var(--border); }
-.definitionRow dt { color: var(--muted); font-size: var(--text-caption); letter-spacing: var(--tracking-caption); line-height: var(--line-caption); }
-.definitionRow dd { margin: 0; font-weight: 400; text-align: right; }
-.definitionRow select { min-width: 160px; height: var(--tap-target); padding: 0 var(--space-3); border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface); }
 .mono { font-family: var(--mono); }
 .muted { color: var(--muted); }
 .wrong { color: var(--bad); }
@@ -70,7 +34,7 @@
 .traceViewTabs button.traceViewTabActive { border-bottom-color: var(--accent); color: var(--foreground); }
 .issueNavigator { display: flex; align-items: center; gap: var(--space-2); color: var(--foreground); font-size: var(--text-caption); }
 .issueNavigator button { display: grid; width: var(--tap-target); height: var(--tap-target); padding: 0; place-items: center; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface); color: var(--foreground); cursor: pointer; }
-.traceToolbar + .notice { margin-top: var(--space-5); }
+.traceToolbar + [data-slot="notice"] { margin-top: var(--space-5); }
 .traceLayout { display: grid; min-width: 0; grid-template-columns: minmax(0, 1fr) 360px; gap: var(--space-7); margin-top: var(--space-7); align-items: start; }
 .traceViews { min-width: 0; }
 .traceViewHeading { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-6); margin-bottom: var(--space-4); }
@@ -122,7 +86,7 @@
 .runFacts .contextFact strong { overflow-wrap: anywhere; font-size: var(--text-caption); }
 .runFacts .contextFact[data-verdict="passed"] strong { color: var(--good); }
 .runFacts .contextFact[data-verdict="failed"] strong, .runFacts .contextFact[data-verdict="errored"] strong { color: var(--bad); }
-.runFacts + .notice { margin-top: var(--space-5); }
+.runFacts + [data-slot="notice"] { margin-top: var(--space-5); }
 .traceOutcome { grid-template-columns: repeat(3, minmax(0, 1fr)); background: var(--surface-soft); }
 .traceOutcome .contextFact:first-child { padding-left: var(--space-4); }
 .traceOutcome .contextFact:last-child { padding-right: var(--space-4); }
@@ -199,15 +163,13 @@
 .executionRow > span:last-child { flex: 0 0 auto; font-family: var(--mono); font-size: var(--text-caption); }
 
 /* Pointer feedback follows the same motion contract as the Product UI. */
-:is(.themeToggle, .linkLine a, .traceViewTabs button, .issueNavigator button, .inspectorLink a) { transition: transform var(--duration-press) var(--ease-out), color var(--duration-hover) ease, border-color var(--duration-hover) ease, background-color var(--duration-hover) ease; }
-:is(.themeToggle, .linkLine a, .traceViewTabs button, .issueNavigator button, .inspectorLink a):active:not(:focus-visible):not(:disabled) { transform: scale(.97); }
+:is(.linkLine a, .traceViewTabs button, .issueNavigator button, .inspectorLink a) { transition: transform var(--duration-press) var(--ease-out), color var(--duration-hover) ease, border-color var(--duration-hover) ease, background-color var(--duration-hover) ease; }
+:is(.linkLine a, .traceViewTabs button, .issueNavigator button, .inspectorLink a):active:not(:focus-visible):not(:disabled) { transform: scale(.97); }
 .timelineRow, .executionRow { transition: background-color var(--duration-hover) ease; }
 :is(.turn summary, .step summary):active { background: var(--surface-soft); }
 
 /* Hover feedback belongs only to a device that can keep a fine pointer there. */
 @media (hover: hover) and (pointer: fine) {
-  .themeToggle:hover { border-color: var(--foreground); background: var(--surface-soft); }
-  .passwordToggle:hover { background: var(--surface-soft); color: var(--foreground); }
   .linkLine a:hover { text-decoration-thickness: 2px; }
   .timelineRow:hover, .executionRow:hover { background: var(--surface-soft); }
   .traceViewTabs button:hover { color: var(--foreground); }
@@ -215,7 +177,6 @@
 }
 
 @media (pointer: coarse) {
-  .passwordToggle { right: 0; width: var(--tap-target); height: var(--tap-target); }
   :is(.linkLine a, .traceViewTabs button, .inspectorLink a) { min-height: var(--tap-target); align-items: center; }
   :is(.linkLine a, .inspectorLink a) { display: inline-flex; }
   .issueNavigator button { width: var(--tap-target); height: var(--tap-target); }
@@ -224,7 +185,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  :is(.themeToggle, .linkLine a, .traceViewTabs button, .issueNavigator button, .inspectorLink a):active:not(:focus-visible):not(:disabled) { transform: none; }
+  :is(.linkLine a, .traceViewTabs button, .issueNavigator button, .inspectorLink a):active:not(:focus-visible):not(:disabled) { transform: none; }
   .turnMarker { transition: none; }
 }
 
@@ -234,12 +195,6 @@
 }
 
 @media (max-width: 900px) {
-  .authShell { display: block; }
-  .authBrandPanel { min-height: 220px; border-right: 0; border-bottom: 1px solid var(--border); }
-  .authBrandOverlay { padding: var(--space-7); }
-  .authContent { min-height: auto; padding: var(--space-10) var(--space-6) var(--space-12); }
-  .authStatic .authBrandPanel { min-height: 144px; }
-  .authStatic .authStatement { display: none; }
   .runFacts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .runFacts .contextFact { padding: var(--space-4); border-top: 1px solid var(--border); }
   .runFacts .contextFact:nth-child(even) { border-right: 0; }
@@ -247,13 +202,6 @@
 }
 
 @media (max-width: 620px) {
-  .authBrandPanel, .authStatic .authBrandPanel { min-height: 144px; }
-  .authBrandOverlay { padding: var(--space-6); }
-  .authStatement, .trustGate { display: none; }
-  .authContent { padding: var(--space-11) var(--space-4) var(--space-8); }
-  .authTheme { top: var(--space-3); right: var(--space-4); }
-  .authCard { padding: var(--space-6); box-shadow: none; }
-  .authCard h1 { font-size: var(--text-heading-sm); letter-spacing: var(--tracking-heading-sm); }
   .detailHeader h1 { font-size: 39px; }
   .detailHeader { align-items: flex-start; flex-direction: column; }
   .detailFacts { grid-template-columns: repeat(2, 1fr); }
@@ -276,5 +224,4 @@
   .timelineRow { grid-template-columns: minmax(0, 1fr) 56px; padding-left: calc(10px + var(--timeline-indent)); }
   .timelineTrack { grid-row: 2; grid-column: 1 / -1; }
   .timelineDuration { grid-row: 1; grid-column: 2; }
-  .buttonRow { flex-direction: column-reverse; }
 }

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -73,7 +73,13 @@ export function ThemeToggle() {
         "transition-[transform,background-color] duration-(--duration-press) ease-out",
         "pointer-hover:bg-surface-soft",
         "[&:active:not(:focus-visible)]:scale-97",
-        "motion-reduce:transition-none",
+        /*
+         * Reduced motion takes the movement away and leaves the colour. The
+         * transition itself stays: `DESIGN.md` asks every movement for "a
+         * reduced-motion form with useful opacity or color feedback", and
+         * removing the transition outright leaves the control answering a
+         * press with nothing at all.
+         */
         "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
       )}
       type="button"
@@ -113,7 +119,7 @@ export function LinkLine({ children }: { readonly children: ReactNode }) {
         "[&_a]:pointer-coarse:min-h-(--tap-target)",
         "[&_a]:transition-transform [&_a]:duration-(--duration-press) [&_a]:ease-out",
         "[&_a:active:not(:focus-visible)]:scale-97",
-        "motion-reduce:[&_a]:transition-none",
+        /* The movement goes; the colour feedback stays. See ThemeToggle. */
         "motion-reduce:[&_a:active:not(:focus-visible)]:scale-100",
       )}
     >

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -3,11 +3,10 @@
 import Image from "next/image";
 import type { ReactNode } from "react";
 
+import { cn } from "@/lib/utils";
+
 import { useTheme } from "../ui/theme.tsx";
 import { TrustGate } from "./trust-gate.tsx";
-import styles from "./ui.module.css";
-
-export { styles };
 
 /**
  * The access pages' own shell, and nothing else.
@@ -15,12 +14,18 @@ export { styles };
  * Signing in, signing up, accepting an invitation and authorizing a terminal
  * are not product pages: nobody has a project yet, there is nothing to navigate
  * between, and the page is the whole of what somebody is doing. They keep the
- * wide, unhurried composition here.
+ * wide, unhurried composition here, and the large type `DESIGN.md` reserves for
+ * auth, onboarding and public pages.
  *
  * **Everything a signed-in product page is drawn inside lives in `ui/`** — the
  * compact shell, the selector, the navigation, the page states, the lists and
  * the controls. This file re-exports the four pieces that pages already name so
  * that a page composes its own subject and never its own frame.
+ *
+ * **The controls here are the product's controls.** This surface once carried
+ * its own `Button`, `TextInput` and `Field`; they are gone, and what is left is
+ * composition — a shell, a card, a notice and a line of links. There is one
+ * control vocabulary in this product and it is the shadcn base.
  */
 export {
   AppShell,
@@ -30,10 +35,18 @@ export {
   ProductStatePage,
 } from "../ui/shell.tsx";
 
+/**
+ * The full Egma logo, which belongs here and not in the signed-in sidebar.
+ *
+ * The dark-theme treatment is an arbitrary variant rather than a `dark:` one
+ * because this product has no `dark:` variant: every other surface changes with
+ * the token values, and a two-colour SVG has no token to change. `data-theme`
+ * is written on the document element, so the ancestor selector is the theme.
+ */
 export function Brand() {
   return (
     <Image
-      className={styles.brand}
+      className="block h-auto w-[151px] [[data-theme=dark]_&]:invert"
       src="/brand/egma-wordmark.svg"
       alt="Egma"
       width={151}
@@ -48,7 +61,21 @@ export function ThemeToggle() {
 
   return (
     <button
-      className={styles.themeToggle}
+      className={cn(
+        "grid size-(--tap-target) shrink-0 cursor-pointer place-items-center p-0",
+        "rounded-button border border-foreground bg-surface",
+        /*
+         * Named properties, never `all`, and never `outline-color`: the focus
+         * ring is drawn from outside every layer and must not fade in on a Tab
+         * step. One duration for both, and `DESIGN.md` says to take the shorter
+         * of two that would each explain the change.
+         */
+        "transition-[transform,background-color] duration-(--duration-press) ease-out",
+        "pointer-hover:bg-surface-soft",
+        "[&:active:not(:focus-visible)]:scale-97",
+        "motion-reduce:transition-none",
+        "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
+      )}
       type="button"
       aria-label={`Use ${theme === "light" ? "dark" : "light"} theme`}
       onClick={toggle}
@@ -58,6 +85,84 @@ export function ThemeToggle() {
   );
 }
 
+/**
+ * A quiet line of links under an access card: the way to sign up, the way back
+ * to signing in, the way to ask for another link.
+ *
+ * It is a component rather than a class list repeated eleven times because the
+ * link inside it carries five decisions — the Ember underline, the offset, the
+ * thickening on hover, the 44px target a coarse pointer needs, and the press
+ * feedback — and a page that wrote four of them would look right.
+ *
+ * The two spacing rules are relationships rather than properties: the first
+ * line after a form is separated from it by a rule, and a second line follows
+ * the first more closely than it follows the form.
+ */
+export function LinkLine({ children }: { readonly children: ReactNode }) {
+  return (
+    <p
+      data-slot="link-line"
+      className={cn(
+        "mt-5 text-sm text-muted-foreground",
+        "[[data-slot=link-line]+&]:mt-3",
+        "[form+&]:mt-6 [form+&]:border-t [form+&]:border-border [form+&]:pt-5",
+        "[&_a]:inline-block [&_a]:text-foreground",
+        "[&_a]:decoration-brand [&_a]:decoration-1 [&_a]:underline-offset-4",
+        "[&_a]:pointer-hover:decoration-2",
+        "[&_a]:pointer-coarse:inline-flex [&_a]:pointer-coarse:items-center",
+        "[&_a]:pointer-coarse:min-h-(--tap-target)",
+        "[&_a]:transition-transform [&_a]:duration-(--duration-press) [&_a]:ease-out",
+        "[&_a:active:not(:focus-visible)]:scale-97",
+        "motion-reduce:[&_a]:transition-none",
+        "motion-reduce:[&_a:active:not(:focus-visible)]:scale-100",
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * The fields of an access page, in a column.
+ *
+ * **The shared `Form` draws a card, and this surface is already one.** The old
+ * arrangement kept it and then reached into it from the access stylesheet —
+ * `.authCard form { border: 0; background: transparent; … }` — to undo four of
+ * its five declarations. That is a route styling the inside of a shared
+ * component, which is the thing this migration exists to remove, and it stopped
+ * working the moment the card became Tailwind.
+ *
+ * So the access surface composes its own form. What is left after the undoing
+ * was a flex column and one gap, and that is what this is.
+ */
+export function AuthForm({
+  onSubmit,
+  children,
+}: {
+  readonly onSubmit?: () => void;
+  readonly children: ReactNode;
+}) {
+  return (
+    <form
+      className="flex flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit?.();
+      }}
+    >
+      {children}
+    </form>
+  );
+}
+
+/**
+ * The access composition: a brand panel, and the card that holds the work.
+ *
+ * `animated` is what the sign-in and sign-up pages ask for — the trust field
+ * drawn behind the brand. A state page does not animate, and on a narrow screen
+ * it also gives up the statement and most of the panel, because a person who is
+ * being told one sentence should not scroll past a picture to reach it.
+ */
 export function AuthShell({
   eyebrow,
   title,
@@ -72,22 +177,99 @@ export function AuthShell({
   children: ReactNode;
 }) {
   return (
-    <main className={`${styles.authShell} ${animated ? "" : styles.authStatic}`}>
-      <aside className={styles.authBrandPanel}>
+    <main
+      className={cn(
+        "grid min-h-[100svh] bg-background",
+        "grid-cols-[minmax(340px,0.92fr)_minmax(520px,1.08fr)]",
+        "max-[900px]:block",
+      )}
+    >
+      <aside
+        className={cn(
+          "relative min-w-0 overflow-hidden border-r border-border bg-surface-soft",
+          /* The small Ember square in the corner, which is the panel's only mark. */
+          "after:absolute after:right-6 after:bottom-6 after:size-4",
+          "after:bg-brand after:content-['']",
+          "max-[900px]:min-h-[220px] max-[900px]:border-r-0 max-[900px]:border-b",
+          "max-[620px]:min-h-[144px]",
+          !animated && "max-[900px]:min-h-[144px]",
+        )}
+      >
         {animated ? <TrustGate /> : null}
-        <div className={styles.authBrandOverlay}>
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-0 z-[1] flex flex-col justify-between",
+            "p-[clamp(var(--space-7),5vw,var(--space-10))]",
+            "max-[900px]:p-8 max-[620px]:p-6",
+          )}
+        >
           <Brand />
-          <div className={styles.authStatement}>
-            <p>Trust the voice agents you ship in production.</p>
+          <div
+            className={cn(
+              "max-w-[520px] max-[620px]:hidden",
+              !animated && "max-[900px]:hidden",
+            )}
+          >
+            <p
+              className={cn(
+                "m-0 max-w-[480px] tracking-(--tracking-heading-sm)",
+                "text-[clamp(var(--text-lead),2.8vw,var(--text-heading-sm))]",
+                /* After the font size, never before it: tailwind-merge counts a
+                   font size as conflicting with a line height, so a `leading-`
+                   ahead of a `text-` is dropped and the heading silently takes
+                   the body's 1.5. */
+                "leading-[1.08]",
+              )}
+            >
+              Trust the voice agents you ship in production.
+            </p>
           </div>
         </div>
       </aside>
-      <section className={styles.authContent}>
-        <div className={styles.authTheme}><ThemeToggle /></div>
-        <div className={styles.authCard}>
-          {eyebrow === undefined ? null : <p className={styles.eyebrow}>{eyebrow}</p>}
-          <h1>{title}</h1>
-          {lead === undefined ? null : <div className={styles.authLead}>{lead}</div>}
+      <section
+        className={cn(
+          "relative grid min-h-[100svh] place-items-center px-16 py-20",
+          "max-[900px]:min-h-auto max-[900px]:px-6 max-[900px]:pt-16 max-[900px]:pb-20",
+          "max-[620px]:px-4 max-[620px]:pt-18 max-[620px]:pb-10",
+        )}
+      >
+        <div className="absolute top-6 right-6 max-[620px]:top-3 max-[620px]:right-4">
+          <ThemeToggle />
+        </div>
+        <div
+          data-slot="auth-card"
+          className={cn(
+            "w-full max-w-[520px] rounded-card border border-border bg-surface p-10",
+            "shadow-popover",
+            "max-[620px]:p-6 max-[620px]:shadow-none",
+          )}
+        >
+          {eyebrow === undefined ? null : (
+            <p className="m-0 mb-3 font-mono text-sm tracking-(--tracking-label) text-muted-foreground uppercase">
+              {eyebrow}
+            </p>
+          )}
+          {/*
+           * "Headings carry no size of their own." This one takes the large
+           * steps `DESIGN.md` reserves for auth: Small heading up to Heading,
+           * and Small heading alone once the card is the whole screen.
+           */}
+          <h1
+            className={cn(
+              "m-0 max-w-[440px] tracking-(--tracking-heading)",
+              "text-[clamp(var(--text-heading-sm),3.4vw,var(--text-heading))]",
+              /* See the statement above: the line height follows the size. */
+              "leading-(--line-heading)",
+              "max-[620px]:text-2xl",
+            )}
+          >
+            {title}
+          </h1>
+          {lead === undefined ? null : (
+            <div className="mt-3 mb-8 max-w-[440px] text-base text-muted-foreground">
+              {lead}
+            </div>
+          )}
           {children}
         </div>
       </section>
@@ -113,6 +295,18 @@ export function StatePage({
   );
 }
 
+/**
+ * One thing worth saying above the form it is about.
+ *
+ * The tone decides the edge and the announcement, never the words: an error is
+ * an `alert` because somebody has to hear it without looking, and a neutral
+ * notice is neither, because a page that announces everything announces
+ * nothing.
+ *
+ * `data-slot` is on it because the transcript pages space themselves against a
+ * notice from their own stylesheet, and a class name they cannot see is not
+ * something they can point at.
+ */
 export function Notice({
   tone = "neutral",
   children,
@@ -120,7 +314,22 @@ export function Notice({
   tone?: "neutral" | "error" | "success";
   children: ReactNode;
 }) {
-  const toneClass = tone === "neutral" ? "" : styles[`notice-${tone}`];
   const role = tone === "error" ? "alert" : tone === "success" ? "status" : undefined;
-  return <div className={`${styles.notice} ${toneClass}`} role={role}>{children}</div>;
+
+  return (
+    <div
+      data-slot="notice"
+      data-tone={tone}
+      className={cn(
+        "mb-5 rounded-input border border-l-[3px] border-border bg-surface-soft",
+        "px-4 py-3 text-sm text-foreground",
+        "[&_p]:m-0 [&_p+p]:mt-2",
+        tone === "error" && "border-l-brand",
+        tone === "success" && "border-l-foreground",
+      )}
+      role={role}
+    >
+      {children}
+    </div>
+  );
 }

--- a/apps/web/test/design-system.test.tsx
+++ b/apps/web/test/design-system.test.tsx
@@ -59,6 +59,55 @@ describe("the development design proof", () => {
     expect(screen.queryByText("Agent saved")).toBeNull();
   });
 
+  /**
+   * The numeric field's three shapes, on the one surface that draws them.
+   *
+   * The control exists because a bound and a unit belong on the field rather
+   * than in a sentence beside it, and the unit-less shape is the one the grader
+   * threshold uses — so a proof holding only the percentage would leave the
+   * layout that ships unproven. All three are asserted through what a reader is
+   * actually given: the described words, and the keypad the field asks for.
+   */
+  it("proves the numeric field with a unit, with a decimal step, and with neither", () => {
+    render(<DesignSystemProof />);
+
+    /** What the field is described by, resolved to the words a reader gets. */
+    const describedWords = (field: HTMLElement): string =>
+      (field.getAttribute("aria-describedby") ?? "")
+        .split(" ")
+        .filter((one) => one !== "")
+        .map((one) => document.getElementById(one)?.textContent ?? "")
+        .join(" ");
+
+    const percent = screen.getByRole("spinbutton", {
+      name: "Share of live traffic judged",
+    });
+    expect((percent as HTMLInputElement).value).toBe("20");
+    expect(percent.getAttribute("min")).toBe("0");
+    expect(percent.getAttribute("max")).toBe("100");
+    expect(percent.getAttribute("inputmode")).toBe("numeric");
+    expect(describedWords(percent)).toContain("%");
+
+    const seconds = screen.getByRole("spinbutton", { name: "Answer within" });
+    // A step that is not whole needs the separator, so the phone keypad has to
+    // be the one that has it.
+    expect(seconds.getAttribute("step")).toBe("0.1");
+    expect(seconds.getAttribute("inputmode")).toBe("decimal");
+    expect(describedWords(seconds)).toContain("seconds");
+
+    const count = screen.getByRole("spinbutton", {
+      name: "Turns before the caller gives up",
+    });
+    expect(count.getAttribute("inputmode")).toBe("numeric");
+    expect(describedWords(count)).toContain("a count and nothing else");
+    // No unit at all, rather than an empty one: the words a reader is given
+    // must not gain a stray separator where a unit would have been.
+    expect(describedWords(count)).not.toContain("%");
+
+    fireEvent.change(percent, { target: { value: "35" } });
+    expect((percent as HTMLInputElement).value).toBe("35");
+  });
+
   it("draws the shadcn base wearing egma's theme", () => {
     render(<DesignSystemProof />);
 

--- a/apps/web/test/settings.test.tsx
+++ b/apps/web/test/settings.test.tsx
@@ -1950,10 +1950,6 @@ describe("people and invitations", () => {
   });
 
   /**
-   * Removing somebody is not a click. The dialog says what happens and to whom,
-   * and closing it leaves the page exactly as it was.
-   */
-  /**
    * The reason sits in the row it is about, and every row names its own copy.
    *
    * A table is where one sentence hoisted above it would be cheapest and
@@ -1977,6 +1973,10 @@ describe("people and invitations", () => {
     expect(new Set(said.map((one) => one.id)).size).toBe(said.length);
   });
 
+  /**
+   * Removing somebody is not a click. The dialog says what happens and to whom,
+   * and closing it leaves the page exactly as it was.
+   */
   it("asks before removing somebody, and posts only once it is answered", async () => {
     open();
 

--- a/apps/web/test/settings.test.tsx
+++ b/apps/web/test/settings.test.tsx
@@ -626,6 +626,30 @@ describe("project settings", () => {
   );
 
   /**
+   * The half of "disable, do not hide" that a pointer never needed.
+   *
+   * A disabled control cannot take focus, so a reason reachable only through a
+   * `title` is a reason only a mouse gets. The CSS Modules button drew the
+   * sentence itself and pointed the control at it; the base button is a bare
+   * `<button>` and draws nothing beside itself, so the page now does both.
+   *
+   * **This asserts the link and not the sentence.** The sentence is already
+   * asserted above, and it went on passing while the link did not exist — which
+   * is exactly the failure worth a test of its own.
+   */
+  it("points a disabled Save at the sentence that says why", async () => {
+    open("viewer", { ...PROJECT, may_manage_projects: false });
+
+    // Waited for rather than read: the reason needs the session to have
+    // settled, and a control with no reason yet is not a control with none.
+    const said = await screen.findByText(/cannot change project settings/);
+    const save = screen.getByRole("button", { name: "Save project" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+    expect(save.getAttribute("aria-describedby")).toBe(said.id);
+    expect(said.id).not.toBe("");
+  });
+
+  /**
    * The server says who may edit, and this page believes it.
    *
    * The two tests above cannot tell the difference, and that is the point: for
@@ -1072,6 +1096,32 @@ describe("organization settings", () => {
       ).toBeTruthy();
     },
   );
+
+  /**
+   * A hint nothing points at is a hint only a sighted reader ever gets.
+   *
+   * `Field` hands its hint id through React context and only the CSS Modules
+   * input read it. The base input reads nothing it is not given, so these two
+   * fields write the sentence and the `aria-describedby` in one place. Both are
+   * asserted because they are wired separately and either could be dropped
+   * without the page looking any different.
+   */
+  it("names the hint under each field that has one", async () => {
+    open("admin", ORGANIZATION, [CREDENTIAL]);
+
+    const nameHint = await screen.findByText(/breaks no link and no invitation/);
+    expect(screen.getByLabelText("Name").getAttribute("aria-describedby")).toBe(
+      nameHint.id,
+    );
+
+    const keys = await screen.findByRole("table", { name: "Organization keys" });
+    fireEvent.click(within(keys).getByRole("button", { name: "Replace key" }));
+    const replacementHint = screen.getByText(/Egma will not show it to you/);
+    expect(
+      screen.getByLabelText("New key").getAttribute("aria-describedby"),
+    ).toBe(replacementHint.id);
+    expect(replacementHint.id).not.toBe("");
+  });
 
   /**
    * The whole point of the credential design, asserted from the page: what is
@@ -1903,6 +1953,30 @@ describe("people and invitations", () => {
    * Removing somebody is not a click. The dialog says what happens and to whom,
    * and closing it leaves the page exactly as it was.
    */
+  /**
+   * The reason sits in the row it is about, and every row names its own copy.
+   *
+   * A table is where one sentence hoisted above it would be cheapest and
+   * wrongest: the control a person is looking at would describe something
+   * somewhere else on the page. So there is one per row, and the ids are per
+   * row too — the same shape as the field and the retry that had to be cleared
+   * when a different row opened.
+   */
+  it("gives each row's disabled control its own reason", async () => {
+    open("member", false);
+
+    const said = await screen.findAllByText(/cannot manage members/);
+    const controls = screen.getAllByRole("button", { name: "Deactivate" });
+    expect(controls).toHaveLength(said.length);
+    expect(controls.length).toBeGreaterThan(1);
+    for (const [at, control] of controls.entries()) {
+      expect(control.hasAttribute("disabled")).toBe(true);
+      expect(control.getAttribute("aria-describedby")).toBe(said[at]!.id);
+    }
+    // Distinct, because two elements of one id is one element to a browser.
+    expect(new Set(said.map((one) => one.id)).size).toBe(said.length);
+  });
+
   it("asks before removing somebody, and posts only once it is answered", async () => {
     open();
 

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -303,12 +303,24 @@ export function SettingsLayout({
         className={cn(
           "flex h-full min-w-0 min-h-0 flex-col gap-8 overflow-y-auto",
           "overscroll-contain pr-2 pb-10 [scrollbar-gutter:stable]",
-          "[&>section]:mt-0",
+          /*
+           * The `!` is load-bearing until the shared `Section` migrates.
+           *
+           * `Section` still carries `margin-top: var(--space-7)` from
+           * `system.module.css`, and a CSS Module is unlayered: it beats every
+           * Tailwind utility whatever the specificity, because a layer loses to
+           * no layer. Without this the gap between two Settings groups is 32px
+           * of margin on top of this container's 32px gap, and the first group
+           * starts 32px below where the navigation does. It is measured at
+           * `margin-top: 0px` in a browser, and the `!` goes when the class it
+           * is overriding does.
+           */
+          "[&>section]:mt-0!",
           "[&>[role=region]]:flex [&>[role=region]]:flex-col [&>[role=region]]:gap-8",
-          "[&>[role=region]>section]:mt-0",
+          "[&>[role=region]>section]:mt-0!",
           "[&>[role=tabpanel]]:flex [&>[role=tabpanel]]:flex-col",
           "[&>[role=tabpanel]]:gap-8",
-          "[&>[role=tabpanel]>section]:mt-0",
+          "[&>[role=tabpanel]>section]:mt-0!",
         )}
       >
         {children}


### PR DESCRIPTION
One control vocabulary reaches the access surface — ticket 14's absorption — and all five Settings sections move onto the shadcn base, with the numeric field gaining its proof slot on the design-system page. Eleven signed-out pages (sign-in, signup, forgot/reset password, invite, members, the five device pages) and the five settings sections; 26 files, +934/−332; the access half of `app/ui.module.css` deleted (52 rules), the file kept because four files outside this wave still read it.

Three things a reviewer must know:

1. **A Tailwind child-override of a CSS-Modules class is a silent no-op.** Unlayered module rules beat every layered utility regardless of specificity. This wave found and fixed a wave-0 regression it caused (`SettingsLayout`'s `[&>section]:mt-0` — a stray 32px on every settings group, invisible to tests, measured in the browser). Where a module rule must be cancelled before its file migrates, the utility carries `!` and a comment saying it dies with the module.
2. **`tailwind-merge` deletes a `leading-*` that precedes a `text-*`** (`text-lg/7` sets both, so the merger treats `text-*` as owning line-height). The auth heading briefly rendered 48px type on a 72px line with every test green; type utilities are now verified by computed style, not by tests alone.
3. **Four call sites hand-wire what G1's `Button why=` now owns** — they keep working (plain HTML props) and share one greppable marker class; they collapse onto `why=` in the merge-adaptation pass after both waves land.

Parity was measured, not eyeballed: quiet button, chip, notice, auth type steps, link-line spacing relationships, hint metrics, password-toggle targets (36px fine / 44px coarse), reduced-motion forms — all read back from a real browser against the legacy values. Focus rings measured at the keypress on an auth input and a settings control: `2px solid rgb(255,82,41)`, offset 3. Draft protection proven live: `beforeunload` inert with no draft, preventing with one, the navigation dialog shown, the draft still in the field.

Carried over verbatim and flagged rather than changed: the error notice's left edge is brand orange (`--accent`), which DESIGN.md says must not mean errored — `--color-failure` exists; parity kept, developer's call requested before more surfaces copy it.

Proof at the head commit: typecheck (app + tests), lint, production build (46 routes), 286 scoped tests including four new ones each proven by sabotage, 29 screenshots in `.proofs/` with repeatable capture scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789797290&installation_model_id=431960&pr_number=156&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F156&signature=5b158ff6e9d9f625a5f2deb6a2f6582d508adf1c81d93ef8f6e02f91caa11ff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates the signed-out access surface and five Settings sections from legacy controls and access CSS modules to the shared shadcn/Tailwind foundation.
- Replaces legacy buttons and text inputs while preserving validation, disabled-state explanations, draft protection, and accessible descriptions.
- Introduces shared access-page compositions for forms, notices, link lines, responsive shells, theme controls, and state pages.
- Adds the numeric-field proof states and updates focused Settings and design-system tests.
- Retains the remaining transcript, judgment, and recording CSS-module styles for their existing consumers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The migrated controls preserve their existing submission, validation, accessibility, permission, and draft-state contracts, and remaining CSS-module consumers continue to resolve all referenced selectors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/ui.tsx | Rebuilds the shared signed-out shell and supporting presentation components on Tailwind without an identified behavioral regression. |
| apps/web/app/ui.module.css | Removes migrated access styles while retaining every selector still referenced by transcript, judgment, and recording surfaces. |
| apps/web/app/projects/[projectId]/settings/organization/page.tsx | Migrates organization and judge-credential controls while preserving permissions, draft tracking, confirmation reads, and secret-handling behavior. |
| apps/web/app/projects/[projectId]/settings/keys/page.tsx | Migrates API-key actions and fields while retaining the one-time secret receipt, scoping, and revocation flows. |
| apps/web/app/projects/[projectId]/settings/judge/page.tsx | Migrates judge configuration controls without changing project-scoped reads, credential selection, or save confirmation. |
| apps/web/app/sign-in/page.tsx | Moves sign-in controls to the shared access composition while preserving password visibility, submission, and return-path behavior. |
| apps/web/test/settings.test.tsx | Extends coverage around migrated Settings presentation and preserved draft and permission behavior. |
| apps/web/test/design-system.test.tsx | Adds assertions for the migrated component vocabulary and numeric-field proof surface. |

<sub>Reviews (1): Last reviewed commit: ["fix: answer the five review findings tha..."](https://github.com/egma-ai/egma/commit/fb5f1a13ef933233127fa6521b057a3f923f31a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55053407)</sub>

**Context used:**

- Knowledge Base — [Egma web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->