### PR TITLE
test: make asynchronous checks deterministic

### DIFF
--- a/apps/cli/test/run-screen.test.ts
+++ b/apps/cli/test/run-screen.test.ts
@@ -226,6 +226,9 @@ describe("the run screen", () => {
       `◼ ${TESTS[0]}`,
       "passed",
       `✓ First verdict: ${TESTS[0]} passed`,
+      "passed 1",
+      "waiting 2",
+      "The suite keeps running on Egma",
     );
     expect(landed).toContain("passed 1");
     expect(landed).toContain("waiting 2");

--- a/packages/db/test/personas-named-by-tests.test.ts
+++ b/packages/db/test/personas-named-by-tests.test.ts
@@ -71,6 +71,16 @@ async function refusalFrom(
   return error as PersonaNamedByTestsError;
 }
 
+/** Observe an expected rejection now, even when the test releases its lock later. */
+function rejectionFrom(work: Promise<unknown>, ifResolved: string): Promise<unknown> {
+  return work.then(
+    () => {
+      throw new Error(ifResolved);
+    },
+    (thrown: unknown) => thrown,
+  );
+}
+
 describe("archiving a persona an active test names", () => {
   it("is refused, and the refusal names the test", async () => {
     const cass = await seedPersona(actingAsAcme(), "Called-On Cass");
@@ -286,10 +296,13 @@ describe("the race between archiving a persona and naming them", () => {
       );
 
       const before = await rowCounts();
-      const creating = createTest(actingAsAcme(), {
-        ...rescheduling,
-        personaIds: [cora],
-      });
+      const creating = rejectionFrom(
+        createTest(actingAsAcme(), {
+          ...rescheduling,
+          personaIds: [cora],
+        }),
+        "the concurrent create was expected to be refused",
+      );
 
       // The create cannot decide yet: checking that Cora is alive takes the
       // shared lock, and the Archive is holding the row exclusively.
@@ -302,7 +315,9 @@ describe("the race between archiving a persona and naming them", () => {
       // marker and refuses — rather than writing an active test naming an archived
       // persona, which is what a create deciding on its own snapshot would have
       // done.
-      await expect(creating).rejects.toThrow(/is archived/);
+      expect(await creating).toMatchObject({
+        message: expect.stringMatching(/is archived/),
+      });
       expect(await rowCounts()).toEqual(before);
     } finally {
       await connection.close();
@@ -328,7 +343,7 @@ describe("the race between archiving a persona and naming them", () => {
         name: "Races the Archive",
       });
 
-      const archiving = archivePersona(actingAsAcme(), cyrus);
+      const archiving = refusalFrom(archivePersona(actingAsAcme(), cyrus));
 
       // The Archive cannot decide yet: it takes the row exclusively before it
       // counts anything, and the create is holding it shared.
@@ -337,7 +352,7 @@ describe("the race between archiving a persona and naming them", () => {
       await connection.sql("commit");
 
       // It counts the rows the create committed while it waited, and refuses.
-      const refusal = await refusalFrom(archiving);
+      const refusal = await archiving;
       expect(refusal.tests).toEqual([
         { id: written.testId, name: "Races the Archive" },
       ]);
@@ -452,14 +467,17 @@ describe("the persona a project points at by default", () => {
         [newDefault, acme.outbound],
       );
 
-      const concurrentArchive = archiving.sql(
-        "update persona set archived_at = now() where id = $1",
-        [newDefault],
+      const concurrentArchive = rejectionFrom(
+        archiving.sql(
+          "update persona set archived_at = now() where id = $1",
+          [newDefault],
+        ),
+        "the concurrent Archive was expected to be refused",
       );
       await waitUntilBlockedBy(blockerPid);
 
       await choosing.sql("commit");
-      await expect(concurrentArchive).rejects.toMatchObject({
+      expect(await concurrentArchive).toMatchObject({
         code: "23503",
         constraint: "project_default_persona_availability",
       });
@@ -499,14 +517,17 @@ describe("the persona a project points at by default", () => {
         [candidate],
       );
 
-      const concurrentChoice = choosing.sql(
-        "update project set default_persona_id = $1 where id = $2",
-        [candidate, acme.outbound],
+      const concurrentChoice = rejectionFrom(
+        choosing.sql(
+          "update project set default_persona_id = $1 where id = $2",
+          [candidate, acme.outbound],
+        ),
+        "the concurrent default choice was expected to be refused",
       );
       await waitUntilBlockedBy(blockerPid);
 
       await archiving.sql("commit");
-      await expect(concurrentChoice).rejects.toMatchObject({
+      expect(await concurrentChoice).toMatchObject({
         code: "23503",
         constraint: "project_default_persona_availability",
       });
@@ -558,14 +579,14 @@ describe("the persona a project points at by default", () => {
         name: "Takes the default",
       });
 
-      const archiving = archivePersona(inOutbound, dixon);
+      const archiving = refusalFrom(archivePersona(inOutbound, dixon));
 
       await waitUntilBlockedBy(blockerPid);
 
       await connection.sql("commit");
 
       // The test that took the default is a test naming them like any other.
-      const refusal = await refusalFrom(archiving);
+      const refusal = await archiving;
       expect(refusal.tests).toEqual([
         { id: written.testId, name: "Takes the default" },
       ]);


### PR DESCRIPTION
## What changed

- wait for the complete run-screen tally and footer before reading its terminal frame
- attach rejection handlers when concurrent database writes start, before releasing the locks that make those writes fail
- keep every existing product and database invariant assertion

## Why

The post-merge Fast lane exposed two timing faults in tests:

1. The terminal test could capture an Ink frame after the first-verdict line but before its tally and footer.
2. The default-persona race test could receive an expected PostgreSQL refusal before Vitest attached its `rejects` handler.

The product screen and database guards behaved correctly. These changes make the tests wait for and observe the complete expected events.

## Proof

- run-screen test under `CI=true`: 5 consecutive passes
- full default-persona race file under `CI=true`: 5 consecutive passes, 70 assertions total
- both focused files together: 19/19
- `pnpm --filter @egma/cli build`
- `pnpm exec tsc -p tsconfig.tests.json --noEmit`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes timing variance from two asynchronous test paths.
- Waits for the complete Ink run screen, including tally and footer, before asserting the captured frame.
- Observes expected database-operation rejections immediately while concurrency tests retain blocking locks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/test/run-screen.test.ts | Extends the existing screen wait to include the tally and footer before preserving the same assertions. |
| packages/db/test/personas-named-by-tests.test.ts | Attaches rejection handlers before releasing transaction locks, preventing delayed awaits from being treated as unhandled rejections. |

<sub>Reviews (2): Last reviewed commit: ["test: observe concurrent database refusa..."](https://github.com/egma-ai/egma/commit/945319b017f69ba221132365e630e108c27ca8a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55072572)</sub>

**Context used:**

- Knowledge Base — [Egma CLI: from agent repository to runnable tests](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/cli.md)
- Knowledge Base — [Egma database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/db-persistence.md)

<!-- /greptile_comment -->