### PR TITLE
Restore immutable ClickHouse migration bytes

### DIFF
--- a/packages/db/clickhouse-migrations/0002_verdicts.sql
+++ b/packages/db/clickhouse-migrations/0002_verdicts.sql
@@ -97,9 +97,9 @@ CREATE TABLE IF NOT EXISTS verdicts
 --
 -- The sorting key **is** the identity, and every part of it earns its place:
 --
---   grader version — production grading at a newer current version writes beside
---     the old row, which makes "v3 said pass, v4 says fail" a comparison rather
---     than a loss; simulation re-grades reuse their pinned version;
+--   grader version — re-grading at a tightened grader writes rows beside the old
+--     ones instead of over them, which is what makes "v3 said pass, v4 says
+--     fail" a comparison rather than a loss;
 --   dimension      — one behavior's verdict is not another's;
 --   source         — the same grader judges simulations and production traffic,
 --     and those are two answers about two different conversations;

--- a/packages/db/clickhouse-migrations/0003_verdicts_speak_the_redesign.sql
+++ b/packages/db/clickhouse-migrations/0003_verdicts_speak_the_redesign.sql
@@ -98,9 +98,9 @@ CREATE TABLE IF NOT EXISTS verdicts
 --
 -- The sorting key **is** the identity, and every part of it earns its place:
 --
---   grader version — production grading at a newer current version writes beside
---     the old row, which makes "v3 said pass, v4 says fail" a comparison rather
---     than a loss; simulation re-grades reuse their pinned version;
+--   grader version — re-grading at a tightened grader writes rows beside the old
+--     ones instead of over them, which is what makes "v3 said pass, v4 says
+--     fail" a comparison rather than a loss;
 --   assertion      — one assertion's verdict is not another's;
 --   source         — the same grader judges simulations and production traffic,
 --     and those are two answers about two different conversations.

--- a/packages/db/test/clickhouse-migrations.test.ts
+++ b/packages/db/test/clickhouse-migrations.test.ts
@@ -44,6 +44,26 @@ const VERDICT_IDENTITY =
  */
 const THE_ONE_FILE_THAT_DROPS_A_TABLE = "0003_verdicts_speak_the_redesign.sql";
 
+/**
+ * These files have run in production. Even a comment edit changes the hash in
+ * the migration ledger and makes the API refuse to boot. Corrections therefore
+ * belong in a new migration file; these bytes never change again.
+ */
+const RELEASED_MIGRATION_HASHES = {
+  "0000_spans.sql":
+    "1e7bbb7ea92573fb662c4ffe61534a6dc872ef8e8c3e18bd2b7fc20197c23bf6",
+  "0001_rename_digital_human_version_id.sql":
+    "1e2574fc06f86c387dd89c6a0c511bba70aba40c7a46ae1b1d50c98a33e67901",
+  "0002_verdicts.sql":
+    "2efa180c0e84bc8af53564af28b5ae5469a809205af0f7c4aa3f275a0bde817e",
+  "0003_verdicts_speak_the_redesign.sql":
+    "c344b6678cecac6a865108d3c3728f265612c4e4ba7d186a70cd837a22154a1d",
+  "0004_retire_normalised_otlp_audio_columns.sql":
+    "981367806805a95b51bfb196a436ce0dc633023b7b3554d60c566ae5f4c1a792",
+  "0005_drop_retired_audio_columns.sql":
+    "bcce5a059cce8a67f03ef75c615297e13ed8e2589e00ffd8a66ccfa9d3868319",
+} as const;
+
 type Table = {
   readonly name: string;
   readonly engine: string;
@@ -143,6 +163,19 @@ function statementsOf(sql: string): string[] {
 
 
 describe("the trace store's migration files", () => {
+  it("never rewrites a migration already released to production", async () => {
+    const migrations = await readMigrations(CLICKHOUSE_MIGRATIONS_DIRECTORY);
+    const currentHashes = new Map(
+      migrations.map((migration) => [migration.name, migration.hash]),
+    );
+
+    for (const [name, releasedHash] of Object.entries(
+      RELEASED_MIGRATION_HASHES,
+    )) {
+      expect(currentHashes.get(name), name).toBe(releasedHash);
+    }
+  });
+
   it("are numbered plain SQL, applied in that order", async () => {
     const migrations = await readMigrations(CLICKHOUSE_MIGRATIONS_DIRECTORY);
     expect(migrations.length).toBeGreaterThan(0);


### PR DESCRIPTION
Production boot refused PR #158 because comment edits changed the recorded hashes of ClickHouse migrations 0002 and 0003.

This change:
- restores both released migration files byte-for-byte to their pre-PR #158 contents;
- adds a focused guard for every ClickHouse migration already released to production, so future edits fail in CI.

Focused proof:
- released 0002/0003 files are byte-identical to the pre-PR #158 versions;
- `packages/db/test/clickhouse-migrations.test.ts`: 27/27 passed;
- test TypeScript check passed;
- `git diff --check` passed.

This is a forward recovery. Postgres migration 0037 already applied before ClickHouse startup refused the changed bytes, so an old-image rollback is not safe.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789804644&installation_model_id=431960&pr_number=161&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F161&signature=14b6bbfcaacc7684ca520b9d44e96136d6d7b1791e4dde2542c1ace99cedcec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the immutable bytes of two released ClickHouse migrations after comment edits caused production hash validation to reject startup.

- Restores migrations 0002 and 0003 to their pre-PR #158 contents without changing executable SQL.
- Adds fixed SHA-256 expectations for every ClickHouse migration already released to production.
- Ensures future edits to released migration files fail in the normal test suite.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly restores production compatibility while preventing future edits to released ClickHouse migration bytes.

The executable SQL is unchanged, the affected files are restored to their previously released bytes, and the added test exercises the same migration hashing implementation used by startup.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/clickhouse-migrations/0002_verdicts.sql | Restores the released migration’s comment bytes to the pre-PR #158 version while leaving its executable schema unchanged. |
| packages/db/clickhouse-migrations/0003_verdicts_speak_the_redesign.sql | Restores the released redesign migration’s comment bytes to the pre-PR #158 version while leaving its executable schema unchanged. |
| packages/db/test/clickhouse-migrations.test.ts | Adds a focused test that compares all currently released ClickHouse migrations against fixed ledger-compatible hashes. |

<sub>Reviews (1): Last reviewed commit: ["fix: restore released ClickHouse migrati..."](https://github.com/egma-ai/egma/commit/897555fd64bc7b3757711b44ae9b6ff5dc8590d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55078040)</sub>

**Context used:**

- Knowledge Base — [Egma database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/db-persistence.md)

<!-- /greptile_comment -->