### PR TITLE
First-look UI annotations: the sidebar, the filter rows, and the graders strip

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -887,9 +887,9 @@ describe("what a project recorded in production", () => {
         });
       });
 
-      // The six rows the three groups hold — Global's standing pair, the three
-      // Simulations rows, and Monitoring's one. Settings is not one of them and
-      // neither is a simulation.
+      // The six rows the three clusters hold — the unlabelled standing pair at
+      // the top, the three Simulations rows, and Monitoring's one. Settings is
+      // not one of them and neither is a simulation.
       for (const area of [
         "Agents",
         "Graders",
@@ -4037,7 +4037,10 @@ describe("the complete product, walked in order in a second project", () => {
         await walk.keyboard.press("Tab");
         expect(await focused()).toBe("Agents");
         // Graders, not Tests: the second row of the bar is the other half of
-        // the standing pair Global holds, and Tests begins the group below it.
+        // the standing pair at the top, and Tests begins the group below it.
+        // That pair sits under no heading now — the developer dropped the word
+        // "Global" rather than replace it — which changes nothing here, since a
+        // heading was never a Tab stop.
         await walk.keyboard.press("Tab");
         expect(await focused()).toBe("Graders");
       },

--- a/apps/web/app/projects/[projectId]/agents/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/page.tsx
@@ -15,7 +15,7 @@ import {
 import { firstProjectOf, roleOf } from "../../../../lib/me.ts";
 import { projectLanding, projectPath } from "../../../../lib/project-context.ts";
 import { canAuthor } from "../../../../lib/roles.ts";
-import { Toolbar } from "../../../../ui/section.tsx";
+import { Toolbar, TOOLBAR_SEARCH } from "../../../../ui/section.tsx";
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
 import { useMinuteClock } from "../../../../ui/relative-time.tsx";
@@ -359,28 +359,26 @@ function Agents({ projectId }: { readonly projectId: string }) {
     <ProductPage>
       {header}
       <PageBody>
+        {/*
+         * Search left and held to a readable width, Connect agent hard right.
+         *
+         * It read the other way round until the developer put it beside a
+         * competitor's dashboard: the button led the row, which made it look
+         * bigger than it is — it was and still is the default size — and the
+         * search box took every remaining pixel behind it, running past
+         * 1400px on a wide screen for a field holding an agent's name.
+         *
+         * The comment this replaces described a flex fight between the two,
+         * where the search box's `width: 100%` squeezed the button until the
+         * toolbar's gap disappeared. That fight is over rather than won: the
+         * action is its own `flex-none` slot now, and the search box has a
+         * maximum, so neither one is under pressure from the other.
+         */}
         {nothingHereYet ? null : (
-          <Toolbar>
-            {/*
-             * The reason a disabled control gives is a sentence, and the
-             * toolbar is one line. Wrapping the pair lets the sentence fall
-             * under its own control rather than squeezing the search box
-             * across the row.
-             *
-             * No `min-w-0` here, and that is the difference between a gap and
-             * no gap. The search box is `width: 100%` and shrinks to fit, so
-             * everything beside it is under shrinking pressure; a flex item
-             * told its minimum is zero gives way past its own contents, and
-             * this one did — measured at 105.5px around a 119.9px button,
-             * which put the button 2.3px over the search box and swallowed the
-             * toolbar's 12px gap whole. Left at `auto`, the minimum is the
-             * button, the sentence wraps under it, and the gap survives.
-             */}
-            <div className="flex flex-wrap items-center gap-3">
-              {connect()}
-            </div>
+          <Toolbar action={connect()}>
             <Input
               id="agent-search"
+              className={TOOLBAR_SEARCH}
               value={typed}
               aria-label="Search agents by name"
               placeholder="Search by name"

--- a/apps/web/app/projects/[projectId]/graders/running/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/page.tsx
@@ -473,7 +473,32 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
         ]}
       />
       <PageBody>
-        <GraderTabs projectId={projectId} active="running" />
+        {/*
+          **Add grader opens the library, because adopting an entry is the only
+          way a grader starts.** There is no create-a-grader flow in this
+          product and this button does not pretend there is one: a grader is a
+          copy of a library entry, made by pressing Use on the entry itself, and
+          the Use form is drawn from the entry it is opened on — so there is no
+          entry-less form for a page-level button to open. It takes somebody to
+          the shelf where the Use affordance is, which is the same journey this
+          screen's empty state has always offered, now offered before the screen
+          is empty as well.
+
+          It is on this screen and not the library's. There, the same button
+          would link to the page it is already on, and a control that does
+          nothing is worse than no control.
+        */}
+        <GraderTabs
+          projectId={projectId}
+          active="running"
+          action={
+            <Button asChild>
+              <Link href={projectPath(projectId, GRADERS_SECTION)}>
+                Add grader
+              </Link>
+            </Button>
+          }
+        />
         <div className={VIEW_CONTENT}>
           {/*
             What the last act came to, and it stays until the next one. Both

--- a/apps/web/app/projects/[projectId]/graders/tabs.tsx
+++ b/apps/web/app/projects/[projectId]/graders/tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import type { ReactNode } from "react";
 
 import { graderTabsFor, type GraderTab } from "../../../../lib/presentation.ts";
 
@@ -64,25 +65,40 @@ export const VIEW_CONTENT = "mt-5 flex flex-col gap-5 [&>section]:mt-0!";
 export function GraderTabs({
   projectId,
   active,
+  action,
 }: {
   readonly projectId: string;
   readonly active: GraderTab;
+  /**
+   * The one thing this section offers, drawn at the right end of the strip.
+   *
+   * The strip is what a grader screen has instead of a filter row, so the
+   * action goes where every list page in this product now keeps its action.
+   * The rule under the row belongs to the row rather than to the tabs, so it
+   * runs the full width whether or not an action is passed.
+   */
+  readonly action?: ReactNode;
 }) {
   return (
-    <nav
-      className="flex items-end gap-6 border-b border-border max-[640px]:gap-0"
-      aria-label="Grader views"
-    >
-      {graderTabsFor(projectId).map((tab) => (
-        <Link
-          key={tab.id}
-          className={`${TAB} ${active === tab.id ? TAB_CURRENT : ""}`}
-          href={tab.href}
-          aria-current={active === tab.id ? "page" : undefined}
-        >
-          {tab.label}
-        </Link>
-      ))}
-    </nav>
+    <div className="flex items-end justify-between gap-3 border-b border-border">
+      <nav
+        className="flex min-w-0 items-end gap-6 max-[640px]:flex-1 max-[640px]:gap-0"
+        aria-label="Grader views"
+      >
+        {graderTabsFor(projectId).map((tab) => (
+          <Link
+            key={tab.id}
+            className={`${TAB} ${active === tab.id ? TAB_CURRENT : ""}`}
+            href={tab.href}
+            aria-current={active === tab.id ? "page" : undefined}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+      {action === undefined ? null : (
+        <div className="flex flex-none items-center pb-2">{action}</div>
+      )}
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/graders/tabs.tsx
+++ b/apps/web/app/projects/[projectId]/graders/tabs.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
+import { cn } from "@/lib/utils";
+
 import { graderTabsFor, type GraderTab } from "../../../../lib/presentation.ts";
 
 /**
@@ -24,6 +26,18 @@ const TAB =
   "text-sm text-muted-foreground no-underline " +
   "max-[640px]:flex-1 max-[640px]:justify-center";
 
+/**
+ * **Merged with `cn` rather than joined with a space, and that is a bug fix.**
+ * Both halves set `border-bottom-color`, so a plain join left
+ * `border-b-transparent` and `border-b-brand` in one class list and let the
+ * stylesheet's own order decide — and transparent was winning. The current tab
+ * has been drawing a 2px rule nobody could see since the strip was written.
+ * `cn` is tailwind-merge, which drops the losing half instead of shipping both.
+ *
+ * Found by the proof pass for this batch, on the screen the batch moved to the
+ * front. `DESIGN.md` asks a current tab for a shape as well as a colour, and
+ * the shape was the half that was missing.
+ */
 const TAB_CURRENT = "border-b-brand text-foreground";
 
 /**
@@ -88,7 +102,7 @@ export function GraderTabs({
         {graderTabsFor(projectId).map((tab) => (
           <Link
             key={tab.id}
-            className={`${TAB} ${active === tab.id ? TAB_CURRENT : ""}`}
+            className={cn(TAB, active === tab.id && TAB_CURRENT)}
             href={tab.href}
             aria-current={active === tab.id ? "page" : undefined}
           >

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
@@ -46,6 +46,7 @@ import {
   useMinuteClock,
 } from "../../../../../ui/relative-time.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
+import { Toolbar, TOOLBAR_FILTER } from "../../../../../ui/section.tsx";
 import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { useOrganizationRead } from "../../../../../ui/settings-read.ts";
 import {
@@ -380,13 +381,21 @@ function Transcripts({ projectId }: { readonly projectId: string }) {
 
   return (
     <ProductPage wide>
-      <PageHeader
-        eyebrow={LIST.eyebrow}
-        title={LIST.title}
-        lead={LIST.lead}
-        action={
+      <PageHeader eyebrow={LIST.eyebrow} title={LIST.title} lead={LIST.lead} />
+      <PageBody>
+        {/*
+          The window is a filter, so it sits where every list page in this
+          product now keeps its filters: the left of the strip above the list.
+          It was in the page header's action slot, which is where a page keeps
+          the *act* it offers — and this page offers none, so the one control it
+          had was standing in a slot that means something else. A person moving
+          between Runs and Monitoring had to look in two places for the same
+          kind of control.
+        */}
+        <Toolbar>
           <Select
             id="window"
+            className={TOOLBAR_FILTER}
             value={choice ?? DEFAULT_WINDOW}
             aria-label={LIST.window}
             onChange={(event) => choose(event.target.value as WindowChoice)}
@@ -397,9 +406,7 @@ function Transcripts({ projectId }: { readonly projectId: string }) {
               </option>
             ))}
           </Select>
-        }
-      />
-      <PageBody>
+        </Toolbar>
         {state.status === "failed" ? (
           <Failure
             message={state.why}

--- a/apps/web/app/projects/[projectId]/personas/page.tsx
+++ b/apps/web/app/projects/[projectId]/personas/page.tsx
@@ -18,8 +18,6 @@ import {
   projectPath,
 } from "../../../../lib/project-context.ts";
 import { canAuthor } from "../../../../lib/roles.ts";
-import { Choice } from "../../../../ui/choice.tsx";
-import { Toolbar } from "../../../../ui/section.tsx";
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import {
   Empty,
@@ -130,7 +128,25 @@ function Personas({ projectId }: { readonly projectId: string }) {
   // admin their role cannot do something it can, on every load.
   const role = me === null ? null : roleOf(me);
 
-  const [shown, setShown] = useState<Shown>("active");
+  /**
+   * Which list this page asks the server for, and for now it is always the
+   * active one.
+   *
+   * **The archive filter's control came off every list page in this batch.**
+   * The developer wants a filter row to hold what somebody reaches for daily,
+   * and the archive is not that. Nothing under the control moved: the server
+   * still keeps the two lists apart, `personasPath` and `personasAfter` still
+   * carry the flag, the paging below still keys on which list it asked for, and
+   * the archive's own empty state is still written. Putting the control back is
+   * handing a `Choice` the setter this deliberately does not take.
+   *
+   * State rather than a constant, and that is not an oversight. A `const` here
+   * narrows to the literal `"active"`, and every `shown === "archived"` below
+   * it becomes a comparison TypeScript calls unintentional — so removing one
+   * control would mean rewriting the half of this page that knows the archive
+   * exists, which is exactly what "the route behavior stays" rules out.
+   */
+  const [shown] = useState<Shown>("active");
   const archived = shown === "archived";
   const { answer, reload } = useProjectRead<PersonaPage>(
     personasPath(archived),
@@ -347,16 +363,6 @@ function Personas({ projectId }: { readonly projectId: string }) {
     );
   }
 
-  /**
-   * The filter stays on screen while the list it chose is loading.
-   *
-   * Rendering it inside the state fold would unmount it on every change —
-   * which loses the keyboard's place in it, and makes the control somebody
-   * just pressed disappear while they are still looking at it. It goes when
-   * there is no list to filter at all, and only then.
-   */
-  const filterable = answer === null || answer.status === "ready";
-
   return (
     <ProductPage>
       <PageHeader
@@ -365,22 +371,14 @@ function Personas({ projectId }: { readonly projectId: string }) {
         lead="The synthetic people who speak with agents in this project. One persona is used in many situations; what they want in one simulation is the test's."
         action={author()}
       />
-      <PageBody>
-        {filterable ? (
-          <Toolbar>
-            <Choice<Shown>
-              label="Which personas to show"
-              value={shown}
-              options={[
-                { value: "active", label: "Active" },
-                { value: "archived", label: "Archived" },
-              ]}
-              onChange={setShown}
-            />
-          </Toolbar>
-        ) : null}
-        {body()}
-      </PageBody>
+      {/*
+        No toolbar at all, because the archive filter was the only thing in it
+        and this page has nothing else to filter by. An empty strip above the
+        list would be 12px of margin pretending to be a control set. The one
+        action this page offers is *New persona*, and it is where every list
+        page keeps its action: the right end of the page header.
+      */}
+      <PageBody>{body()}</PageBody>
     </ProductPage>
   );
 }

--- a/apps/web/app/projects/[projectId]/runs/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/page.tsx
@@ -27,7 +27,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
-import { Actions, Toolbar } from "../../../../ui/section.tsx";
+import {
+  Actions,
+  Toolbar,
+  TOOLBAR_FILTER,
+} from "../../../../ui/section.tsx";
 import { Refused } from "../../../../ui/form.tsx";
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
@@ -571,6 +575,7 @@ function Runs({ projectId }: { readonly projectId: string }) {
         <Toolbar>
           <Select
             id="runs-agent"
+            className={TOOLBAR_FILTER}
             value={agent}
             aria-label="Show only runs against one agent"
             onChange={(event) => setAgent(event.target.value)}
@@ -584,6 +589,7 @@ function Runs({ projectId }: { readonly projectId: string }) {
           </Select>
           <Select
             id="runs-connection"
+            className={TOOLBAR_FILTER}
             value={connection}
             aria-label="Show only runs over one connection"
             onChange={(event) => setConnection(event.target.value)}
@@ -597,6 +603,7 @@ function Runs({ projectId }: { readonly projectId: string }) {
           </Select>
           <Select
             id="runs-status"
+            className={TOOLBAR_FILTER}
             value={status}
             aria-label="Show only runs whose machinery is in one state"
             onChange={(event) =>
@@ -612,6 +619,7 @@ function Runs({ projectId }: { readonly projectId: string }) {
           </Select>
           <Select
             id="runs-verdict"
+            className={TOOLBAR_FILTER}
             value={verdict}
             aria-label="Show only runs with one verdict"
             onChange={(event) =>
@@ -634,6 +642,7 @@ function Runs({ projectId }: { readonly projectId: string }) {
           */}
           <Input
             id="runs-since"
+            className={TOOLBAR_FILTER}
             type="text"
             value={typedSince}
             aria-label="Show only runs started on or after a day"

--- a/apps/web/app/projects/[projectId]/tests/page.tsx
+++ b/apps/web/app/projects/[projectId]/tests/page.tsx
@@ -20,8 +20,11 @@ import {
   type ListedTest,
   type TestPage,
 } from "../../../../lib/tests.ts";
-import { Choice } from "../../../../ui/choice.tsx";
-import { Toolbar } from "../../../../ui/section.tsx";
+import {
+  Toolbar,
+  TOOLBAR_FILTER,
+  TOOLBAR_SEARCH,
+} from "../../../../ui/section.tsx";
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
 import {
@@ -159,7 +162,19 @@ function Tests({ projectId }: { readonly projectId: string }) {
   const now = useMinuteClock();
 
   /** Which shelf is being looked at: what can run, or what was taken out. */
-  const [archived, setArchived] = useState(false);
+  /**
+   * Which list this page asks the server for, and for now it is always the
+   * active one.
+   *
+   * **The archive filter's control came off every list page in this batch.**
+   * The developer wants a filter row to hold what somebody reaches for daily,
+   * and the archive is not that. Nothing under the control moved: the server
+   * still keeps the two lists apart, `testsPath` still carries the flag, and
+   * every branch below that draws the archive still draws it. Putting the
+   * control back is handing a `Choice` the setter this deliberately does not
+   * take.
+   */
+  const [archived] = useState(false);
   /** Narrowed to one agent's coverage, or to none. */
   const [agent, setAgent] = useState("");
   /** What somebody typed in the search box, and what has been asked for. */
@@ -400,6 +415,7 @@ function Tests({ projectId }: { readonly projectId: string }) {
         <Toolbar>
           <Input
             id="tests-search"
+            className={TOOLBAR_SEARCH}
             value={typed}
             aria-label="Search tests by name"
             placeholder="Search by name"
@@ -416,6 +432,7 @@ function Tests({ projectId }: { readonly projectId: string }) {
           />
           <Select
             id="tests-agent"
+            className={TOOLBAR_FILTER}
             value={agent}
             aria-label="Show only tests that apply to one agent"
             onChange={(event) => setAgent(event.target.value)}
@@ -427,15 +444,6 @@ function Tests({ projectId }: { readonly projectId: string }) {
               </option>
             ))}
           </Select>
-          <Choice
-            label="Which tests to show"
-            value={archived ? "archived" : "active"}
-            options={[
-              { value: "active", label: "Active" },
-              { value: "archived", label: "Archived" },
-            ]}
-            onChange={(which) => setArchived(which === "archived")}
-          />
         </Toolbar>
         {body()}
       </PageBody>

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -129,25 +129,37 @@ function SidebarFooter({ className, ...props }: ComponentProps<"div">) {
 }
 
 /**
- * A labelled set of rows.
+ * A set of rows, labelled or not.
  *
  * The label is tied to the group rather than left floating above it, so a
  * screen reader says which group it has entered instead of reading six links
  * with nothing between them. The id is made here and taken by the label,
  * because a group knows it has one and a caller should not have to invent a
  * unique string for every bar it draws.
+ *
+ * **`labelled={false}` is for the group that is drawn without a heading**, and
+ * it takes the region away with the heading rather than only hiding the word.
+ * A `role="group"` still pointing `aria-labelledby` at a heading that is not
+ * rendered is a named region with a dangling name — a screen reader announces a
+ * group and then has nothing to call it. So an unlabelled group is a plain
+ * wrapper: the rows inside it are still links in the same `<nav>`, and they are
+ * reached exactly as they were. It defaults to `true`, so every group that had
+ * a heading before this prop existed keeps the heading and the region it had.
  */
 const SidebarGroupLabelId = createContext<string | null>(null);
 
-function SidebarGroup({ className, ...props }: ComponentProps<"div">) {
+function SidebarGroup({
+  className,
+  labelled = true,
+  ...props
+}: ComponentProps<"div"> & { readonly labelled?: boolean }) {
   const labelId = useId();
 
   return (
-    <SidebarGroupLabelId.Provider value={labelId}>
+    <SidebarGroupLabelId.Provider value={labelled ? labelId : null}>
       <div
         data-slot="sidebar-group"
-        role="group"
-        aria-labelledby={labelId}
+        {...(labelled ? { role: "group", "aria-labelledby": labelId } : {})}
         className={cn("flex w-full min-w-0 flex-col gap-1", className)}
         {...props}
       />
@@ -162,8 +174,10 @@ function SidebarGroup({ className, ...props }: ComponentProps<"div">) {
  * `aria-labelledby` wiring above already gives the group its accessible name;
  * this is the other half, and they answer different questions. The name is what
  * a person hears once they are *inside* a group. A heading is how they get to
- * one at all — the heading list is Global, Simulations, Monitoring, and jumping
- * between them is one keystroke rather than six arrow presses.
+ * one at all — the heading list is Simulations and Monitoring, and jumping
+ * between them is one keystroke rather than six arrow presses. The top group
+ * is not in that list, because it is drawn with no heading at all: it is the
+ * two rows a person lands on, reached before any jump is needed.
  *
  * `h2` because the bar has no heading above it and the page's own title is the
  * `h1` beside it. It carries no size of its own — `DESIGN.md` removed those —
@@ -241,8 +255,13 @@ function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
  * arriving late, which is worse. Hover changes the background and the text and
  * nothing else, so those two are what move.
  *
- * The row is 44px tall in every theme and at every width, so a coarse pointer
- * needs no separate rule to reach it.
+ * **The row is 36px where the pointer is fine and 44px where it is coarse.** A
+ * bar of six rows is read as a block rather than pressed one row at a time, and
+ * at 44px each the block was loose enough to read as six boxes stacked instead
+ * of two or three clusters. 36px is `--control-md`, the height this product
+ * already gives a compact control. The 44px tap target is not traded away for
+ * that: `pointer-coarse` puts it straight back on every touch screen, which is
+ * the same rule the segmented choice control already uses.
  */
 function SidebarMenuButton({
   className,
@@ -264,11 +283,12 @@ function SidebarMenuButton({
       aria-current={isActive ? "page" : undefined}
       className={cn(
         "relative flex w-full min-w-0 items-center gap-3",
-        "min-h-(--control-lg) rounded-button px-3",
-        "text-base text-muted-foreground no-underline",
+        "min-h-(--control-md) rounded-button px-3",
+        "pointer-coarse:min-h-(--tap-target)",
+        "text-sm text-muted-foreground no-underline",
         "transition-[color,background-color] duration-(--duration-hover) ease-out",
         "motion-reduce:transition-none",
-        "before:absolute before:inset-y-3 before:left-0 before:w-0.5",
+        "before:absolute before:inset-y-2 before:left-0 before:w-0.5",
         "before:rounded-chip before:bg-transparent before:content-['']",
         "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
         "data-[active=true]:bg-selected data-[active=true]:text-foreground",

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -8,18 +8,26 @@ import { projectPath, sectionIn } from "./project-context.ts";
  * things both jobs share — the agent under test, and the graders that judge —
  * sit above them in a group of their own:
  *
- * - **Global**: Agents, Graders.
+ * - *(unlabelled)*: Agents, Graders.
  * - **Simulations**: Tests, Personas, Runs.
  * - **Monitoring**: Transcripts.
  *
- * **The objection to "Global", recorded because it was overruled rather than
- * answered.** It is not a glossary word, and nothing in this bar is global:
+ * **The first group has no label, and that is the whole of the change.** It
+ * used to say "Global". The objection was recorded here when the word was
+ * overruled: it is not a glossary word, and nothing in this bar is global —
  * every entry is project-scoped, so switching project changes what the group
- * holds, and a new reader may predict organization-wide settings behind the
- * label. The developer heard that and prefers the label anyway — the group
- * names what stands above both halves, and the word is theirs to spend. If
- * first-user evidence shows the misread happening, the label reopens. The
- * group itself is settled.
+ * holds, and a new reader may predict organization-wide settings behind it.
+ * Seeing it built, the developer dropped the word rather than replace it. No
+ * substitute was needed: the two rows that stand above both jobs are the two
+ * rows at the top of the bar, and their position already says so. A heading
+ * over them would name a category a person never has to think about.
+ *
+ * So the group keeps its identity in code and loses its voice on screen. It is
+ * still a group — the rows still cluster, still space as a cluster — and it is
+ * the one group with `label: null`. Nothing announces it either: with no
+ * heading there is no accessible name to point at, so the group is drawn as a
+ * plain wrapper rather than a named region reading a heading that is not
+ * there.
  *
  * **The groups are presentation, and only presentation.** Every href is the one
  * it was before the groups existed, `activeSectionIn` still reads the address
@@ -39,9 +47,9 @@ import { projectPath, sectionIn } from "./project-context.ts";
  * - **Personas rises into Simulations.** It is the one rank change a person
  *   feels: a persona is authored on its own and reused across tests, and it
  *   belongs beside the tests that use it rather than in a library shelf below.
- * - **Graders moves into Global.** A grader is switched on once and then judges
- *   everything in its scope without anybody visiting it again — which is what
- *   makes it standing rather than part of either job.
+ * - **Graders joins Agents in the top group.** A grader is switched on once and
+ *   then judges everything in its scope without anybody visiting it again —
+ *   which is what makes it standing rather than part of either job.
  * - **Settings lives in the account menu.** It is administrative work rather
  *   than a project destination, so it is in no group here.
  * - **A simulation has no navigation item at all.** It is evidence, reached
@@ -88,7 +96,15 @@ export type NavigationLink = NavigationItem & { readonly href: string };
 
 export type NavigationGroup<Item = NavigationItem> = {
   readonly id: NavigationGroupId;
-  readonly label: string;
+  /**
+   * The word over the group, or `null` where the group is drawn without one.
+   *
+   * `null` rather than an absent key, because a group either has decided to say
+   * nothing or has not been given a label yet, and those are different bugs. An
+   * unlabelled group gets no heading and no accessible name — not a hidden one,
+   * and not the group's id used as a stand-in.
+   */
+  readonly label: string | null;
   readonly items: readonly Item[];
 };
 
@@ -101,7 +117,7 @@ export type NavigationGroup<Item = NavigationItem> = {
 export const NAVIGATION_GROUPS: readonly NavigationGroup[] = [
   {
     id: "global",
-    label: "Global",
+    label: null,
     items: [
       { id: "agents", label: "Agents" },
       { id: "graders", label: "Graders" },

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -29,10 +29,22 @@ import { projectPath, sectionIn } from "./project-context.ts";
  * plain wrapper rather than a named region reading a heading that is not
  * there.
  *
- * **The groups are presentation, and only presentation.** Every href is the one
- * it was before the groups existed, `activeSectionIn` still reads the address
- * rather than the group, and a copied URL keeps meaning what it meant. Nothing
- * here can move a page.
+ * **The groups are presentation, and only presentation.** A group cannot move a
+ * page: `activeSectionIn` reads the address rather than the group, an item is
+ * found by its own id, and grouping these six rows moved no href at all.
+ *
+ * **What can move an href is a decision, taken here and written down.** The bar
+ * points at an address; it does not own one. Every address a row has ever
+ * pointed at still resolves, and a copied URL still opens what it opened — that
+ * is the invariant, and it is a different and smaller claim than the one this
+ * paragraph used to make.
+ *
+ * One row has moved, once. The 2026-08-20 annotation batch put Running at the
+ * front of the Graders strip, and Graders gained `opens: ["running"]` so the
+ * bar opens the tab the strip leads with — a first tab nobody lands on is not a
+ * first tab. `/projects/{projectId}/graders` is still the library and still
+ * opens it. Monitoring has pointed one step deeper since it was written, for
+ * its own reason, recorded on `opens` below.
  *
  * What the words do:
  *

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -83,11 +83,18 @@ export type NavigationItem = {
    * The page inside the area the item opens, where that is not the area's own
    * address.
    *
-   * Monitoring is the one that has it. `/projects/{projectId}/monitoring` is a
+   * Monitoring and Graders both have it. `/projects/{projectId}/monitoring` is a
    * real address and lands on the transcript list, but the item points straight
    * at the list rather than at a page whose whole job is to forward — a
    * navigation click should not cost a redirect, and a reserved neighbour under
    * the same area should never be able to become the landing by accident.
+   *
+   * Graders has it for a different reason: its section holds two screens behind
+   * one strip, and the strip now reads Running first. The shelf is read once
+   * and switched on; what is judging this project right now is the question a
+   * person comes back with. A first tab nobody lands on is not a first tab, so
+   * the bar opens the one the strip leads with. `/projects/{projectId}/graders`
+   * is still the library and still opens it — a copied link is unmoved.
    */
   readonly opens?: readonly string[];
 };
@@ -120,7 +127,7 @@ export const NAVIGATION_GROUPS: readonly NavigationGroup[] = [
     label: null,
     items: [
       { id: "agents", label: "Agents" },
-      { id: "graders", label: "Graders" },
+      { id: "graders", label: "Graders", opens: ["running"] },
     ],
   },
   {

--- a/apps/web/lib/presentation.ts
+++ b/apps/web/lib/presentation.ts
@@ -57,11 +57,25 @@ export function ownerDisplayName(owner: string): string {
 /**
  * The two screens inside the Graders section, and the order they read in.
  *
- * **The library first, because that is where a grader comes from.** A running
- * grader is a copy of a library entry, so somebody who has just arrived meets
- * the shelf, presses Use on something, and finds it on the second tab. The
- * reverse order would show a list of copies before anything explained what they
- * were copies of.
+ * **Running first, because that is the screen somebody comes back to.** The
+ * library led, on the argument that a running grader is a copy of a library
+ * entry and the shelf is where the idea starts. That is the right order for the
+ * first visit and the wrong one for every visit after it: the shelf is read
+ * once and switched on, and what is judging this project right now is the
+ * question a person returns with. Ordering a two-tab strip by where a thing
+ * comes from taught the product to somebody who already knew it, and charged
+ * everybody else a click on every arrival.
+ *
+ * The first visit keeps its answer. Running is the one screen in the product
+ * whose empty state has always pointed straight at the library, and it now says
+ * so twice — in the empty state, and in the *Add grader* action on the strip.
+ * Somebody who arrives at an empty Running screen is one press from the shelf,
+ * which is the same journey the old order made them take blind.
+ *
+ * The sidebar follows the strip. `navigation.ts` opens Graders on `running`
+ * through the same `opens` mechanism Monitoring already uses, because a first
+ * tab a person never lands on is not a first tab. Both addresses still work,
+ * and a link copied to either one still opens what it opened.
  *
  * Here rather than in either screen's copy file, because a strip whose labels
  * lived in one of the two pages would be a page naming its sibling — and the
@@ -81,8 +95,8 @@ export const GRADER_VIEW_LABELS = {
 } as const;
 
 const GRADER_TABS = [
-  { id: "library", label: GRADER_VIEW_LABELS.library, rest: [] },
   { id: "running", label: GRADER_VIEW_LABELS.running, rest: ["running"] },
+  { id: "library", label: GRADER_VIEW_LABELS.library, rest: [] },
 ] as const satisfies readonly {
   readonly id: string;
   readonly label: string;

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -544,7 +544,14 @@ describe("reading an agent's reach from the list", () => {
     expect(screen.getByText("No connections")).toBeDefined();
   });
 
-  it("leads the toolbar with Connect agent when there is a list to lead", async () => {
+  /**
+   * **The row reads left to right: narrow first, then act.** It led with the
+   * button until the developer put this page beside a competitor's dashboard,
+   * where the action is always the last thing on the strip. The button never
+   * changed size — it is the default and always was — but leading a row it
+   * shared with a full-width search box made it look like it had.
+   */
+  it("ends the toolbar with Connect agent, and holds the search box to a width", async () => {
     listOf(LISTED_AGENT);
     render(<AgentsPage />);
     await screen.findAllByText("Front desk");
@@ -552,9 +559,12 @@ describe("reading an agent's reach from the list", () => {
     const connect = await screen.findByRole("link", { name: "Connect agent" });
     expect(connect.getAttribute("href")).toBe("/projects/prj_1/agents/new");
 
-    // Leads: it is drawn before the search box rather than after it.
+    // Ends it: the search box is drawn before the action rather than after it.
     const search = screen.getByLabelText("Search agents by name");
-    expect(connect.compareDocumentPosition(search) & 4).toBe(4);
+    expect(search.compareDocumentPosition(connect) & 4).toBe(4);
+
+    // And the box stops somewhere. It used to take the whole remaining row.
+    expect(search.className).toContain("max-w-");
   });
 
   it("puts one Connect agent in the middle of a project with nothing in it", async () => {

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -16,6 +16,7 @@ import type { Me } from "../lib/me.ts";
 import { EVERY_NAVIGATION_ITEM } from "../lib/navigation.ts";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Choice } from "../ui/choice.tsx";
 import { Field } from "../ui/form.tsx";
 import { DataTable, type Column } from "../ui/data-table.tsx";
 import { Dialog } from "../ui/dialog.tsx";
@@ -539,6 +540,107 @@ describe("a binary choice", () => {
       "A required grader can stop the test from passing.",
     );
     expect(checkbox.getAttribute("aria-describedby")).toBe(hint.id);
+  });
+});
+
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The two-list choice, driven the way somebody without a pointer drives it.
+ *
+ * **This test moved here rather than being deleted, and where it came from is
+ * the point.** It lived on the Personas list, because that page was one of the
+ * two that drew this control — and the 2026-08-20 annotation batch took the
+ * archive filter's control off both of them. A test that clicks a control the
+ * page no longer draws is not a weakened test, it is a broken one, so it could
+ * not stay there. `Choice` itself is untouched by that batch: it still does
+ * every one of the things below, and after the removal there was no test in
+ * this repository that asked it to.
+ *
+ * So it is proven where the behavior lives. That is the better home anyway —
+ * `Choice` is a shared control, its keyboard contract belongs to it rather
+ * than to whichever page happened to mount it, and the proof now survives the
+ * next page that adopts or drops it.
+ *
+ * Nothing here is free. It is a `div` of `button`s wearing radio semantics, so
+ * every part of the radio group contract below is hand-written in
+ * `ui/choice.tsx` and every part of it can be lost in a refactor without one
+ * visible pixel changing.
+ */
+describe("a choice between two lists", () => {
+  const OPTIONS = [
+    { value: "active", label: "Active" },
+    { value: "archived", label: "Archived" },
+  ] as const;
+
+  type Shown = (typeof OPTIONS)[number]["value"];
+
+  function Example({ onChange }: { readonly onChange?: (value: Shown) => void }) {
+    const [shown, setShown] = useState<Shown>("active");
+    return (
+      <Choice<Shown>
+        label="Which personas to show"
+        value={shown}
+        options={OPTIONS}
+        onChange={(value) => {
+          setShown(value);
+          onChange?.(value);
+        }}
+      />
+    );
+  }
+
+  it("is one radio group, named, with the chosen option announced", () => {
+    render(<Example />);
+
+    const group = screen.getByRole("radiogroup", {
+      name: "Which personas to show",
+    });
+    expect(within(group).getAllByRole("radio").map((one) => one.textContent))
+      .toEqual(["Active", "Archived"]);
+    expect(screen.getByRole("radio", { name: "Active" }).getAttribute("aria-checked"))
+      .toBe("true");
+    expect(screen.getByRole("radio", { name: "Archived" }).getAttribute("aria-checked"))
+      .toBe("false");
+  });
+
+  /**
+   * **One Tab stop, an arrow key inside it, and selection following focus.**
+   * Roving `tabindex` is what keeps a two-option filter from costing two Tab
+   * presses on the way to the table — and a ten-option one from costing ten.
+   * Selection following focus is what keeps the keyboard and the announcement
+   * agreeing: a group that moved the highlight without moving focus would
+   * leave a screen reader saying one thing and the next keypress landing on
+   * another.
+   */
+  it("chooses the other list from the keyboard, and says which is chosen", () => {
+    const chose = vi.fn();
+    render(<Example onChange={chose} />);
+
+    const active = screen.getByRole("radio", { name: "Active" });
+    const archived = screen.getByRole("radio", { name: "Archived" });
+    expect(active.getAttribute("tabindex")).toBe("0");
+    expect(archived.getAttribute("tabindex")).toBe("-1");
+
+    active.focus();
+    fireEvent.keyDown(active, { key: "ArrowRight" });
+
+    expect(chose).toHaveBeenCalledWith("archived");
+    const now = screen.getByRole("radio", { name: "Archived" });
+    expect(now.getAttribute("aria-checked")).toBe("true");
+    expect(now.getAttribute("tabindex")).toBe("0");
+    expect(screen.getByRole("radio", { name: "Active" }).getAttribute("tabindex"))
+      .toBe("-1");
+    // Selection follows focus, so the keyboard and the announcement agree.
+    expect(document.activeElement).toBe(now);
+
+    // The same key again comes back round rather than stopping at the end: a
+    // closed set of two has no far edge to be stuck against.
+    fireEvent.keyDown(now, { key: "ArrowRight" });
+    expect(chose).toHaveBeenLastCalledWith("active");
+    expect(document.activeElement).toBe(
+      screen.getByRole("radio", { name: "Active" }),
+    );
   });
 });
 

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -1310,14 +1310,19 @@ describe("changing a running copy", () => {
 /* ------------------------------------------------------------------------ */
 
 describe("the strip between the two screens", () => {
-  it("carries the project in both addresses", () => {
+  /**
+   * Running leads now. The shelf is read once and switched on; what is judging
+   * this project right now is the question a person comes back with. Both
+   * addresses are unmoved — only the order they are offered in changed.
+   */
+  it("carries the project in both addresses, and leads with Running", () => {
     expect(graderTabsFor("prj_7")).toEqual([
-      { id: "library", label: "Library", href: "/projects/prj_7/graders" },
       {
         id: "running",
         label: "Running",
         href: "/projects/prj_7/graders/running",
       },
+      { id: "library", label: "Library", href: "/projects/prj_7/graders" },
     ]);
   });
 

--- a/apps/web/test/personas.test.tsx
+++ b/apps/web/test/personas.test.tsx
@@ -1220,9 +1220,16 @@ describe("one persona's page", () => {
  *
  * A second test sat here, on the archive filter: one Tab stop for the group, an
  * arrow key moving inside it, and selection following focus. The control came
- * off every list page in this batch and the test went with it. `ui/choice.tsx`
- * is untouched and still does all of that — `apps/web/test/components.test.tsx`
- * is where the shared control is proven, which is where that proof belongs.
+ * off every list page in this batch, so it could not stay on a page that no
+ * longer draws it. It was **moved, not deleted** — it is now
+ * `describe("a choice between two lists")` in
+ * `apps/web/test/components.test.tsx`, which renders `Choice` directly and
+ * drives the same radiogroup semantics.
+ *
+ * An earlier draft of this comment said that file already proved the control.
+ * It did not. Its `describe("a binary choice")` is about `Checkbox`, which is a
+ * different component with native semantics, and between the removal and the
+ * move there was no test anywhere asking `Choice` for any of this.
  */
 describe("driving the Personas area without a pointer", () => {
   it("traps focus in version history, closes it with Escape, and restores its trigger", async () => {

--- a/apps/web/test/personas.test.tsx
+++ b/apps/web/test/personas.test.tsx
@@ -282,50 +282,26 @@ describe("the Personas list", () => {
     expect(screen.getAllByRole("table")).toHaveLength(1);
   });
 
-  it("shows the archive as a separate list, asked for separately", async () => {
-    const archived: Persona = {
-      ...RITA,
-      id: "prs_9",
-      name: "Retired Rex",
-      archived_at: "2026-08-14T09:00:00.000Z",
-    };
-    const { asked } = apiAnswers({
-      "GET /api/me": { status: 200, body: meWith("admin") },
-      "GET /api/personas": [
-        { status: 200, body: { items: [RITA], next_cursor: null } },
-        { status: 200, body: { items: [archived], next_cursor: null } },
-      ],
-    });
-    render(<PersonasPage />);
-
-    expect(await screen.findAllByText("Impatient Rita")).not.toHaveLength(0);
-    fireEvent.click(screen.getByRole("radio", { name: "Archived" }));
-
-    expect(await screen.findAllByText("Retired Rex")).not.toHaveLength(0);
-    expect(screen.queryByText("Impatient Rita")).toBeNull();
-    expect(asked.map((one) => one.path)).toContain(
-      "/api/personas?archived=true&project=prj_1",
-    );
-  });
-
-  it("says an empty archive is empty rather than saying the project has no personas", async () => {
-    apiAnswers({
-      "GET /api/me": { status: 200, body: meWith("admin") },
-      "GET /api/personas": [
-        { status: 200, body: { items: [RITA], next_cursor: null } },
-        { status: 200, body: { items: [], next_cursor: null } },
-      ],
-    });
-    render(<PersonasPage />);
-
-    expect(await screen.findAllByText("Impatient Rita")).not.toHaveLength(0);
-    fireEvent.click(screen.getByRole("radio", { name: "Archived" }));
-
-    expect(
-      await screen.findByText("Nothing has been archived here"),
-    ).toBeDefined();
-    expect(screen.queryByRole("alert")).toBeNull();
-  });
+  /*
+   * **Three tests stood here and all three pressed the Archived radio.** The
+   * control came off every list page in this batch, so none of them could
+   * survive it — a test that clicks a control that is not drawn is not a
+   * weakened test, it is a broken one.
+   *
+   * What they proved, and where it still is:
+   *
+   * - *The archive is asked for separately.* Still true and still proven, on
+   *   the side that owns it: `apps/api/test/personas-routes.test.ts` asks
+   *   `/api/personas?archived=true` and reads the archived half back, keyset
+   *   cursor and all. `personasPath` and `personasAfter` still carry the flag.
+   * - *An empty archive says it is empty rather than saying the project has no
+   *   personas.* The branch is still written and still reachable the moment the
+   *   control returns, and it is now the one thing here with no test on it.
+   *   Recorded rather than quietly dropped.
+   * - *A next page that arrives after the filter changed is dropped.* The guard
+   *   is untouched, and the test directly above still drives the same guard
+   *   across a project change — the same state, the same race, one value along.
+   */
 
   /**
    * **An unanswered session is not a viewer.** A page that guessed the least
@@ -475,56 +451,6 @@ describe("the Personas list", () => {
     expect(screen.queryAllByText("Impatient Rita")).toHaveLength(0);
   });
 
-  /**
-   * The same race, one filter across instead of one project across. Both are
-   * the same component with another value in it, so the same state outlives
-   * both changes — and an archived page rendered into the active list would be
-   * a list of rows nobody can act on.
-   */
-  it("drops a next page that arrives after the filter changed", async () => {
-    let release: (answer: Response) => void = () => undefined;
-    const pending = new Promise<Response>((resolve) => {
-      release = resolve;
-    });
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string) => {
-        const at = new URL(String(input), "http://egma.test");
-        if (at.pathname === "/api/me") return json(200, meWith("admin"));
-        if (at.searchParams.has("cursor")) return pending;
-        const archived = at.searchParams.get("archived") === "true";
-        return json(200, {
-          items: [
-            {
-              ...RITA,
-              id: archived ? "prs_a" : "prs_b",
-              name: archived ? "Retired Rex" : "Impatient Rita",
-              archived_at: archived ? "2026-08-14T09:00:00.000Z" : null,
-            },
-          ],
-          next_cursor: "prs_cursor",
-        });
-      }),
-    );
-
-    render(<PersonasPage />);
-    expect(await screen.findAllByText("Impatient Rita")).not.toHaveLength(0);
-    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
-
-    fireEvent.click(screen.getByRole("radio", { name: "Archived" }));
-    expect(await screen.findAllByText("Retired Rex")).not.toHaveLength(0);
-
-    release(
-      json(200, {
-        items: [{ ...RITA, id: "prs_stale", name: "An active persona" }],
-        next_cursor: null,
-      }),
-    );
-    await new Promise((settle) => setTimeout(settle, 0));
-
-    expect(screen.queryByText("An active persona")).toBeNull();
-  });
 });
 
 /* ------------------------------------------------------------------------ */
@@ -1288,46 +1214,17 @@ describe("one persona's page", () => {
 /* ------------------------------------------------------------------------ */
 
 /**
- * The keyboard, on the two controls this area adds to the shared system.
+ * The keyboard, on the control this area adds to the shared system.
  *
- * Neither is a link and neither is a native radio, so neither gets any of this
- * for free — and a filter that only a pointer can reach is a filter half the
- * people using egma do not have.
+ * It is not a link and not a native dialog, so it gets none of this for free.
+ *
+ * A second test sat here, on the archive filter: one Tab stop for the group, an
+ * arrow key moving inside it, and selection following focus. The control came
+ * off every list page in this batch and the test went with it. `ui/choice.tsx`
+ * is untouched and still does all of that — `apps/web/test/components.test.tsx`
+ * is where the shared control is proven, which is where that proof belongs.
  */
 describe("driving the Personas area without a pointer", () => {
-  it("chooses the other list from the keyboard, and says which is chosen", async () => {
-    apiAnswers({
-      "GET /api/me": { status: 200, body: meWith("admin") },
-      "GET /api/personas": [
-        { status: 200, body: { items: [RITA], next_cursor: null } },
-        { status: 200, body: { items: [], next_cursor: null } },
-      ],
-    });
-    render(<PersonasPage />);
-
-    const archived = await screen.findByRole("radio", { name: "Archived" });
-    const active = screen.getByRole("radio", { name: "Active" });
-    expect(active.getAttribute("aria-checked")).toBe("true");
-    expect(archived.getAttribute("aria-checked")).toBe("false");
-
-    // One Tab stop for the group, and an arrow key moves inside it — which is
-    // what announcing a radiogroup promises anybody using a screen reader.
-    expect(active.getAttribute("tabindex")).toBe("0");
-    expect(archived.getAttribute("tabindex")).toBe("-1");
-
-    active.focus();
-    fireEvent.keyDown(active, { key: "ArrowRight" });
-
-    expect(
-      await screen.findByText("Nothing has been archived here"),
-    ).toBeDefined();
-    const now = screen.getByRole("radio", { name: "Archived" });
-    expect(now.getAttribute("aria-checked")).toBe("true");
-    expect(now.getAttribute("tabindex")).toBe("0");
-    // Selection follows focus, so the keyboard and the announcement agree.
-    expect(document.activeElement).toBe(now);
-  });
-
   it("traps focus in version history, closes it with Escape, and restores its trigger", async () => {
     apiAnswers({
       "GET /api/me": { status: 200, body: meWith("member") },

--- a/apps/web/test/project-shell.test.ts
+++ b/apps/web/test/project-shell.test.ts
@@ -116,9 +116,15 @@ describe("the product navigation", () => {
   const everyLink = (projectId: string) =>
     navigationFor(projectId).flatMap((group) => group.items);
 
-  it("names the two jobs, and the standing pair above them", () => {
+  /**
+   * **Two jobs are named and the pair above them is not.** The top group used
+   * to say "Global". The developer dropped the word on first sight of the built
+   * bar rather than replace it, and `null` is how the group says it has decided
+   * to stay quiet — an absent key would only mean nobody had got to it yet.
+   */
+  it("names the two jobs, and leaves the standing pair above them unnamed", () => {
     expect(NAVIGATION_GROUPS.map((group) => group.label)).toEqual([
-      "Global",
+      null,
       "Simulations",
       "Monitoring",
     ]);
@@ -126,13 +132,13 @@ describe("the product navigation", () => {
 
   /**
    * Agents stays the first row and stays the signed-in landing area. Graders
-   * moves up beside it: a grader is switched on once and then judges everything
-   * in its scope, which is what makes it standing rather than part of either
-   * job.
+   * sits beside it: a grader is switched on once and then judges everything in
+   * its scope, which is what makes it standing rather than part of either job.
    */
-  it("puts Agents and Graders under Global, Agents first", () => {
+  it("puts Agents and Graders in the unlabelled top group, Agents first", () => {
     const global = NAVIGATION_GROUPS[0];
     expect(global?.id).toBe("global");
+    expect(global?.label).toBeNull();
     expect(global?.items.map((item) => item.label)).toEqual([
       "Agents",
       "Graders",

--- a/apps/web/test/project-shell.test.ts
+++ b/apps/web/test/project-shell.test.ts
@@ -100,13 +100,19 @@ describe("the product navigation", () => {
    *
    * Written out rather than derived, because deriving them from the module
    * under test would make this assertion agree with whatever the module says
-   * today. The groups are presentation: a person who copied any one of these
-   * links before the regroup opens the same page afterwards, and this list is
-   * the only thing that can say so.
+   * today.
+   *
+   * Five are the addresses the flat bar offered, unmoved by the regroup: the
+   * groups are presentation, and a person who copied one of those links opens
+   * the same page afterwards. Graders is the sixth and it points one step
+   * deeper now, the way Monitoring already did — its strip leads with Running,
+   * and the bar opens the tab the strip leads with. The library did not move
+   * and `/projects/prj_2/graders` still opens it; this list says where the bar
+   * points.
    */
-  const HREFS_BEFORE_THE_GROUPS = [
+  const BAR_HREFS = [
     "/projects/prj_2/agents",
-    "/projects/prj_2/graders",
+    "/projects/prj_2/graders/running",
     "/projects/prj_2/monitoring/transcripts",
     "/projects/prj_2/personas",
     "/projects/prj_2/runs",
@@ -197,10 +203,10 @@ describe("the product navigation", () => {
    * on: six links before, the same six addresses after, whatever group each one
    * is drawn under now.
    */
-  it("offers the same addresses it offered before it had groups", () => {
+  it("offers the addresses the bar points at, five of them unmoved by the groups", () => {
     const hrefs = everyLink("prj_2").map((link) => link.href);
-    expect([...hrefs].sort()).toEqual(HREFS_BEFORE_THE_GROUPS);
-    expect(hrefs).toHaveLength(HREFS_BEFORE_THE_GROUPS.length);
+    expect([...hrefs].sort()).toEqual(BAR_HREFS);
+    expect(hrefs).toHaveLength(BAR_HREFS.length);
   });
 
   /** And the item stays lit on every page inside the area, list and one alike. */

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -47,11 +47,25 @@ const EVERY_ADDRESS = [
   "/projects/prj_2/tests",
 ];
 
-const GROUPS = [
-  { label: "Global", items: ["Agents", "Graders"] },
+/**
+ * The three clusters, top to bottom. The first has no label at all — the
+ * developer dropped the word "Global" on first sight of the built bar, and
+ * nothing replaced it: the two rows that stand above both jobs are the two rows
+ * at the top, and their position already says so.
+ */
+const GROUPS: readonly {
+  readonly label: string | null;
+  readonly items: readonly string[];
+}[] = [
+  { label: null, items: ["Agents", "Graders"] },
   { label: "Simulations", items: ["Tests", "Personas", "Runs"] },
   { label: "Monitoring", items: ["Transcripts"] },
 ];
+
+/** The clusters as drawn, labelled or not — a named region is only two of them. */
+function clustersIn(navigation: HTMLElement): readonly HTMLElement[] {
+  return [...navigation.querySelectorAll<HTMLElement>('[data-slot="sidebar-group"]')];
+}
 
 function drawShell(pathname = "/projects/prj_2/agents"): void {
   routed.pathname = pathname;
@@ -82,19 +96,22 @@ afterEach(() => {
 });
 
 describe("the grouped sidebar", () => {
-  it("draws three labelled groups, in the order the bar reads", () => {
+  it("draws three clusters in the order the bar reads, the first unlabelled", () => {
     drawShell();
 
-    const groups = groupsIn(sidebarNavigation());
-    expect(groups).toHaveLength(3);
-    expect(groups.map((group) => group.getAttribute("aria-labelledby"))).not.toContain(
-      null,
-    );
+    const navigation = sidebarNavigation();
+    const clusters = clustersIn(navigation);
+    expect(clusters).toHaveLength(3);
+
     for (const [index, expected] of GROUPS.entries()) {
-      const group = groups[index]!;
-      expect(within(group).getByText(expected.label)).toBeTruthy();
+      const cluster = clusters[index]!;
+      if (expected.label === null) {
+        expect(within(cluster).queryByRole("heading")).toBeNull();
+      } else {
+        expect(within(cluster).getByText(expected.label)).toBeTruthy();
+      }
       expect(
-        within(group)
+        within(cluster)
           .getAllByRole("link")
           .map((link) => link.textContent?.trim()),
       ).toEqual(expected.items);
@@ -102,15 +119,36 @@ describe("the grouped sidebar", () => {
   });
 
   /**
+   * **The word "Global" is gone, and it is gone from the accessible tree too.**
+   * A heading removed while `aria-labelledby` still pointed at it would leave
+   * the region named and the name unreadable, which is worse than the word was.
+   */
+  it("says Global nowhere, and leaves the top cluster unnamed rather than named badly", () => {
+    drawShell();
+
+    const navigation = sidebarNavigation();
+    expect(navigation.textContent).not.toContain("Global");
+
+    const top = clustersIn(navigation)[0]!;
+    expect(top.getAttribute("role")).toBeNull();
+    expect(top.getAttribute("aria-labelledby")).toBeNull();
+    expect(top.getAttribute("aria-label")).toBeNull();
+
+    // A named region is now only the two groups that kept a word.
+    expect(groupsIn(navigation)).toHaveLength(2);
+  });
+
+  /**
    * The label belongs to the group rather than floating over it, so a screen
    * reader says which group it has entered instead of reading six links with
    * nothing between them.
    */
-  it("gives each group its label as its accessible name", () => {
+  it("gives each labelled group its label as its accessible name", () => {
     drawShell();
 
     const navigation = sidebarNavigation();
     for (const { label } of GROUPS) {
+      if (label === null) continue;
       expect(within(navigation).getByRole("group", { name: label })).toBeTruthy();
     }
   });
@@ -119,19 +157,20 @@ describe("the grouped sidebar", () => {
    * **A sectioned navigation is walked by heading.**
    *
    * The accessible name above says which group somebody is *in*. This is how
-   * they get to one at all: the heading list is Global, Simulations,
-   * Monitoring, and moving between them is one keystroke rather than six arrow
-   * presses. The two mechanisms are wired to the same element on purpose — one
-   * word, said twice, that cannot come apart.
+   * they get to one at all: the heading list is Simulations and Monitoring, and
+   * moving between them is one keystroke rather than six arrow presses. The two
+   * mechanisms are wired to the same element on purpose — one word, said twice,
+   * that cannot come apart. The top cluster is in neither list, because it is
+   * drawn with no word at all: it is where a person already is.
    */
-  it("offers the three groups as headings, in the order the bar reads", () => {
+  it("offers every labelled group as a heading, in the order the bar reads", () => {
     drawShell();
 
     const navigation = sidebarNavigation();
     const headings = within(navigation).getAllByRole("heading");
 
     expect(headings.map((heading) => heading.textContent?.trim())).toEqual(
-      GROUPS.map((group) => group.label),
+      GROUPS.map((group) => group.label).filter((label) => label !== null),
     );
     for (const heading of headings) {
       expect(heading.tagName).toBe("H2");
@@ -254,7 +293,7 @@ describe("the grouped sidebar", () => {
    * drift into a shorter list — and it closes behind the choice it was opened
    * to make.
    */
-  it("shows the same three groups in the mobile drawer, and closes behind a choice", () => {
+  it("shows the same three clusters in the mobile drawer, and closes behind a choice", () => {
     drawShell();
 
     fireEvent.click(
@@ -266,11 +305,12 @@ describe("the grouped sidebar", () => {
       name: "Product navigation",
     });
 
-    const groups = within(inDrawer).getAllByRole("group");
-    expect(groups).toHaveLength(3);
+    const clusters = clustersIn(inDrawer);
+    expect(clusters).toHaveLength(3);
+    expect(inDrawer.textContent).not.toContain("Global");
     for (const [index, expected] of GROUPS.entries()) {
       expect(
-        within(groups[index]!)
+        within(clusters[index]!)
           .getAllByRole("link")
           .map((link) => link.textContent?.trim()),
       ).toEqual(expected.items);

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -37,10 +37,19 @@ const ADA: Me = {
   ],
 };
 
-/** The six addresses the bar offered before the groups existed. */
+/**
+ * The six addresses the bar offers, sorted.
+ *
+ * Five are the ones it offered before the groups existed. Graders is the one
+ * that moved, and it moved for the same reason Monitoring's did: its section
+ * holds two screens behind one strip, the strip now leads with Running, and a
+ * first tab nobody lands on is not a first tab. `/projects/prj_2/graders` is
+ * still the library and still opens it — this is where the *bar* points, not
+ * which addresses exist.
+ */
 const EVERY_ADDRESS = [
   "/projects/prj_2/agents",
-  "/projects/prj_2/graders",
+  "/projects/prj_2/graders/running",
   "/projects/prj_2/monitoring/transcripts",
   "/projects/prj_2/personas",
   "/projects/prj_2/runs",
@@ -188,7 +197,7 @@ describe("the grouped sidebar", () => {
    * addresses after, whatever group each is drawn under now — so a copied URL
    * keeps meaning what it meant.
    */
-  it("offers the same six addresses the flat bar offered", () => {
+  it("offers six addresses, one of them a step deeper than the flat bar\u2019s", () => {
     drawShell();
 
     const hrefs = within(sidebarNavigation())

--- a/apps/web/test/tests-pages.test.tsx
+++ b/apps/web/test/tests-pages.test.tsx
@@ -269,16 +269,16 @@ describe("the list of tests", () => {
     });
   });
 
-  it("asks for the archived shelf as a different list, never as a column", async () => {
-    list();
-    await screen.findAllByText("Front desk");
-
-    fireEvent.click(screen.getByRole("radio", { name: "Archived" }));
-
-    await waitFor(() => {
-      expect(sent.some((one) => one.url.includes("archived=true"))).toBe(true);
-    });
-  });
+  /*
+   * **The archive filter's control came off this row and the archive did not
+   * move.** The test that used to sit here pressed the Archived radio and
+   * watched for `archived=true` on the wire, so it could not survive the
+   * control going. What it proved still holds and is still proven: the server
+   * keeps the two lists apart, and `apps/api/test/tests-lifecycle.test.ts`
+   * asks `/api/tests?archived=true` for the archived one and reads it back.
+   * `testsPath` still carries the flag, and this page still asks with it —
+   * pinned to the active list, which is what the row above now says.
+   */
 
   it("gives a viewer the same page and a control that is genuinely inert", async () => {
     list("viewer");

--- a/apps/web/ui/project-selector.tsx
+++ b/apps/web/ui/project-selector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 
@@ -33,17 +34,35 @@ import { Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
  */
 
 /**
- * The trigger, which is a two-line control rather than a row in a list.
+ * The trigger, which is a card in the sidebar and a compact control on a phone.
  *
- * The compact form is the mobile top bar's, and the width it is held to used to
- * be a rule in the shell's stylesheet reaching in by class name. It is here
- * now, on the one prop that asks for it, because a shared component's own size
- * should not depend on which page happened to put it somewhere.
+ * **The card is what the developer asked for after seeing the bar beside a
+ * competitor's.** It carries four things and they answer four questions in one
+ * glance: a square mark with the organization's initial (*which* organization,
+ * before any word is read), a quiet eyebrow naming what the primary line is,
+ * the organization name, and the project under it. The chevron points the way
+ * the menu opens.
+ *
+ * **The Egma mark is deliberately not the avatar.** `DESIGN.md` keeps the full
+ * logo out of the signed-in sidebar, and a logo here would say *Egma* to a
+ * person asking *which of my organizations am I in*. The initial answers the
+ * question that is actually being asked.
+ *
+ * **This is a restyle of the trigger and nothing else.** Search, the keyboard
+ * path, Escape, focus return, the unsaved-work guard and the origin-aware open
+ * are the menu's, and none of them is touched below.
+ *
+ * The compact form is the mobile top bar's, and it stays two lines. A card with
+ * a mark and an eyebrow is a block, and the top bar is a 44px row shared with a
+ * drawer button and a page title. The width it is held to used to be a rule in
+ * the shell's stylesheet reaching in by class name. It is here now, on the one
+ * prop that asks for it, because a shared component's own size should not
+ * depend on which page happened to put it somewhere.
  */
 const TRIGGER = [
-  "grid w-full min-w-0 grid-cols-[minmax(0,1fr)_12px] items-center gap-2",
+  "grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3",
   "min-h-[calc(var(--control-lg)+var(--space-5))] p-3",
-  "rounded-input border border-border bg-surface text-left",
+  "rounded-card border border-border bg-surface text-left",
   "cursor-pointer transition-transform duration-(--duration-press) ease-out",
   "pointer-coarse:min-h-(--tap-target)",
   "pointer-hover:border-border-strong pointer-hover:bg-surface-soft",
@@ -53,8 +72,23 @@ const TRIGGER = [
 ];
 
 const TRIGGER_COMPACT = [
-  "min-h-(--control-lg) max-w-[220px] py-1",
+  "grid-cols-[minmax(0,1fr)_auto] gap-2",
+  "min-h-(--control-lg) max-w-[220px] rounded-input px-3 py-1",
   "max-[900px]:min-w-0 max-[900px]:max-w-[min(220px,56vw)]",
+];
+
+/**
+ * The square mark, which carries one letter and never a logo.
+ *
+ * It is neutral rather than Ember. Ember is this product's signal for focus,
+ * for the current row and for a state that wants attention, and an avatar that
+ * is always on would spend it on something that is never news. The open trigger
+ * still turns, because the menu hands it `border-brand bg-selected`.
+ */
+const MARK = [
+  "grid size-9 flex-none place-items-center",
+  "rounded-button border border-border bg-surface-soft",
+  "text-base leading-(--line-tight) font-medium text-foreground",
 ];
 
 export function ProjectSelector({
@@ -96,6 +130,16 @@ export function ProjectSelector({
   const projectName =
     current?.name ?? (projectId === null ? "No project" : "Unknown project");
 
+  /**
+   * The letter in the square, and a dash where there is no name to take one
+   * from. A membership with no organization would otherwise wear the N of
+   * "No organization" and look like an organization whose name starts with N.
+   */
+  const initial =
+    organization === undefined
+      ? "\u2013"
+      : organization.name.trim().slice(0, 1).toUpperCase() || "\u2013";
+
   function choose(project: Project, close: () => void): void {
     if (project.id === projectId) {
       close();
@@ -123,12 +167,22 @@ export function ProjectSelector({
       panelRole="dialog"
       trigger={
         <>
+          {compact ? null : (
+            <span className={cn(MARK)} aria-hidden="true">
+              {initial}
+            </span>
+          )}
           <span className="min-w-0">
             {/*
-             * Both lines are one line each, whatever the name. The tight line
-             * height is the 1.0 step rather than body text's 1.5, because these
-             * are two labels stacked and not a paragraph.
+             * Every line is one line, whatever the name. The tight line height
+             * is the 1.0 step rather than body text's 1.5, because these are
+             * labels stacked and not a paragraph.
              */}
+            {compact ? null : (
+              <span className="mb-1 block overflow-hidden text-sm leading-(--line-tight) text-ellipsis whitespace-nowrap text-faint uppercase tracking-(--tracking-label)">
+                Organization
+              </span>
+            )}
             <span className="block overflow-hidden text-base leading-(--line-tight) font-medium text-ellipsis whitespace-nowrap text-foreground">
               {organizationName}
             </span>
@@ -136,18 +190,24 @@ export function ProjectSelector({
               {projectName}
             </span>
           </span>
-          <svg
-            className="block size-3.5 text-muted-foreground"
-            aria-hidden="true"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.4}
-          >
-            <path d="M3.25 4.75 6 7.5l2.75-2.75" />
-          </svg>
+          {/*
+           * The chevron points where the menu goes: right out of the bar on a
+           * wide screen, down out of the top bar on a narrow one. Same control,
+           * and it never promises a direction the panel does not take.
+           */}
+          {compact ? (
+            <ChevronDownIcon
+              className="block size-4 flex-none text-muted-foreground"
+              aria-hidden="true"
+              strokeWidth={1.75}
+            />
+          ) : (
+            <ChevronRightIcon
+              className="block size-4 flex-none text-muted-foreground"
+              aria-hidden="true"
+              strokeWidth={1.75}
+            />
+          )}
         </>
       }
     >

--- a/apps/web/ui/project-selector.tsx
+++ b/apps/web/ui/project-selector.tsx
@@ -60,7 +60,8 @@ import { Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
  * depend on which page happened to put it somewhere.
  */
 const TRIGGER = [
-  "grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3",
+  "grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center",
+  "gap-x-3 gap-y-1",
   "min-h-[calc(var(--control-lg)+var(--space-5))] p-3",
   "rounded-card border border-border bg-surface text-left",
   "cursor-pointer transition-transform duration-(--duration-press) ease-out",
@@ -72,7 +73,7 @@ const TRIGGER = [
 ];
 
 const TRIGGER_COMPACT = [
-  "grid-cols-[minmax(0,1fr)_auto] gap-2",
+  "grid-cols-[minmax(0,1fr)_auto] gap-x-2 gap-y-0",
   "min-h-(--control-lg) max-w-[220px] rounded-input px-3 py-1",
   "max-[900px]:min-w-0 max-[900px]:max-w-[min(220px,56vw)]",
 ];
@@ -167,6 +168,19 @@ export function ProjectSelector({
       panelRole="dialog"
       trigger={
         <>
+          {/*
+           * The eyebrow takes the whole first row rather than sitting in the
+           * text column beside the mark, and it is measurement rather than
+           * taste: the docked bar is a 224px column, which leaves the text
+           * column 89px once the mark, the chevron and two gaps are out of it,
+           * and the word needs 119px. Across the card it has 167px. A fixed
+           * word that ellipses is a label saying it does not fit.
+           */}
+          {compact ? null : (
+            <span className="col-span-3 block text-sm leading-(--line-tight) whitespace-nowrap text-faint uppercase tracking-(--tracking-label)">
+              Organization
+            </span>
+          )}
           {compact ? null : (
             <span className={cn(MARK)} aria-hidden="true">
               {initial}
@@ -178,11 +192,6 @@ export function ProjectSelector({
              * is the 1.0 step rather than body text's 1.5, because these are
              * labels stacked and not a paragraph.
              */}
-            {compact ? null : (
-              <span className="mb-1 block overflow-hidden text-sm leading-(--line-tight) text-ellipsis whitespace-nowrap text-faint uppercase tracking-(--tracking-label)">
-                Organization
-              </span>
-            )}
             <span className="block overflow-hidden text-base leading-(--line-tight) font-medium text-ellipsis whitespace-nowrap text-foreground">
               {organizationName}
             </span>

--- a/apps/web/ui/section.tsx
+++ b/apps/web/ui/section.tsx
@@ -108,8 +108,15 @@ export function Toolbar({
  *
  * `min-w-*` keeps both usable at the wrap point, where the strip becomes two
  * rows and each control is on its own line.
+ *
+ * **`flex-1` on the search is load-bearing, and a screenshot is what found
+ * it.** The shared `Input` is `width: 100%`, which in a wrapping flex row means
+ * 100% *of the row* — so the search box claimed the whole line and pushed the
+ * agent filter beside it onto a second one. `flex-1` sets `flex-basis: 0%`,
+ * which wins the main axis back from `width`: the box grows into whatever the
+ * filters leave and stops at its maximum.
  */
-export const TOOLBAR_SEARCH = "w-full max-w-[380px] min-w-[180px]";
+export const TOOLBAR_SEARCH = "min-w-[180px] w-full max-w-[380px] flex-1";
 
 /** A filter that chooses one value, held narrower than the search beside it. */
 export const TOOLBAR_FILTER = "w-auto max-w-[240px] min-w-[160px]";

--- a/apps/web/ui/section.tsx
+++ b/apps/web/ui/section.tsx
@@ -63,16 +63,56 @@ export function Section({
 }
 
 /**
- * A strip of controls above a list: a search box, the filters, and nothing that
- * belongs in the page header.
+ * A strip of controls above a list: the filters, and the one action the list
+ * itself offers.
+ *
+ * **One shape on every list page, because the developer read five of them side
+ * by side and none of them agreed.** Filters go left, in the order a person
+ * narrows by; the action goes hard right. The Agents page used to do the
+ * opposite — an oversized-looking button leading the row and a search box
+ * running the whole remaining width behind it — and that single row is what
+ * made the product look like a side project beside a competitor's dashboard.
+ *
+ * The action is a slot rather than the last child, so a page cannot put it
+ * anywhere else by accident. It is `flex-none`: an action is the width of its
+ * own label, and the filters take what is left.
  */
-export function Toolbar({ children }: { readonly children: ReactNode }) {
+export function Toolbar({
+  children,
+  action,
+}: {
+  readonly children: ReactNode;
+  /** The one thing this list offers, drawn at the right end of the strip. */
+  readonly action?: ReactNode;
+}) {
   return (
-    <div className="mb-4 flex items-center gap-3 max-[900px]:flex-wrap">
-      {children}
+    <div className="mb-4 flex items-center justify-between gap-3 max-[900px]:flex-wrap">
+      <div className="flex min-w-0 flex-wrap items-center gap-3">{children}</div>
+      {action === undefined ? null : (
+        <div className="flex flex-none flex-wrap items-center justify-end gap-3">
+          {action}
+        </div>
+      )}
     </div>
   );
 }
+
+/**
+ * How wide a control in a toolbar is allowed to be.
+ *
+ * **Declared once here rather than page by page**, which is the whole point:
+ * five pages each choosing a width is what a person sees as five different
+ * products. A search box was `width: 100%` of whatever was left, so on a wide
+ * screen it ran to 1500px for a field holding a name; a filter that names one
+ * column never needs more room than its longest option.
+ *
+ * `min-w-*` keeps both usable at the wrap point, where the strip becomes two
+ * rows and each control is on its own line.
+ */
+export const TOOLBAR_SEARCH = "w-full max-w-[380px] min-w-[180px]";
+
+/** A filter that chooses one value, held narrower than the search beside it. */
+export const TOOLBAR_FILTER = "w-auto max-w-[240px] min-w-[160px]";
 
 /** A group of controls that act on the thing the page is about. */
 export function Actions({ children }: { readonly children: ReactNode }) {

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -1,5 +1,15 @@
 "use client";
 
+import {
+  BotIcon,
+  ClipboardCheckIcon,
+  MessageSquareTextIcon,
+  PlayIcon,
+  ScaleIcon,
+  SlidersHorizontalIcon,
+  UsersIcon,
+  type LucideIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -174,43 +184,44 @@ export function ProductShellBoundary({ children }: { readonly children: ReactNod
   return usesProductShell ? <AppShell>{children}</AppShell> : <>{children}</>;
 }
 
-const NAVIGATION_ICON_PATHS: Record<SectionId, readonly string[]> = {
-  agents: [
-    "M10 9.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
-    "M4.5 16.5c.55-3 2.4-4.5 5.5-4.5s4.95 1.5 5.5 4.5",
-  ],
-  tests: ["M5 3.5h10v13H5z", "M7.5 7h5", "M7.5 10h5", "M7.5 13h3"],
-  runs: ["m6.5 4.5 8 5.5-8 5.5z"],
-  // A live line: what production is doing, read left to right.
-  monitoring: ["M3 12.5h3l2.5-6 3 9 2.5-5h3"],
-  personas: [
-    "M7.5 9a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z",
-    "M3.5 16c.45-2.75 1.8-4.1 4-4.1 2.15 0 3.55 1.35 4 4.1",
-    "M13 5.1a2.2 2.2 0 0 1 0 4.2",
-    "M13.5 11.8c1.75.2 2.75 1.6 3 4.2",
-  ],
-  graders: [
-    "m10 3 2.05 4.15 4.58.67-3.32 3.22.78 4.55L10 12.9l-4.1 2.15.78-4.55-3.32-3.22 4.58-.67z",
-  ],
-  settings: ["M4 5h12", "M4 10h12", "M4 15h12", "M7 3v4", "M13 8v4", "M8.5 13v4"],
+/**
+ * One line symbol per product area, from one set.
+ *
+ * **They are lucide's, and the point is that they are all lucide's.** These
+ * were six hand-drawn path lists before, each authored against a different idea
+ * of how heavy a line should be and how much of a 20px box to fill — a star
+ * that read as solid beside a figure that read as a sketch. A person does not
+ * name that when they call a bar unprofessional; they see it. One set, drawn on
+ * one grid at one weight, is what removes it. lucide is already a dependency of
+ * this application, so nothing was added to get it.
+ *
+ * Each icon says what its row says. `MessageSquareText` for the monitoring row
+ * because the row says Transcripts, and `ScaleIcon` for graders because a
+ * grader weighs a thing and returns a verdict — neither imitates the Egma mark,
+ * which `DESIGN.md` forbids of a product icon.
+ */
+const NAVIGATION_ICONS: Record<SectionId, LucideIcon> = {
+  agents: BotIcon,
+  tests: ClipboardCheckIcon,
+  runs: PlayIcon,
+  monitoring: MessageSquareTextIcon,
+  personas: UsersIcon,
+  graders: ScaleIcon,
+  settings: SlidersHorizontalIcon,
 };
 
-/** Small line symbols make the stable product areas easier to scan. */
+/**
+ * Small line symbols make the stable product areas easier to scan.
+ *
+ * 16px and stroke 1.75 on every one of them. The size is the row's, the weight
+ * is lighter than lucide's own 2 because the bar is quiet type and a heavier
+ * line would make the symbol the loudest thing in the row.
+ */
 function NavigationIcon({ section }: { readonly section: SectionId }) {
+  const Icon = NAVIGATION_ICONS[section];
+
   return (
-    <svg
-      className="size-4 flex-none"
-      aria-hidden="true"
-      focusable="false"
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={1.35}
-    >
-      {NAVIGATION_ICON_PATHS[section].map((path) => <path d={path} key={path} />)}
-    </svg>
+    <Icon className="size-4 flex-none" aria-hidden="true" strokeWidth={1.75} />
   );
 }
 
@@ -243,8 +254,10 @@ function Navigation({
       <SidebarContent asChild>
         <nav aria-label="Product navigation">
           {groups.map((group) => (
-            <SidebarGroup key={group.id}>
-              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+            <SidebarGroup key={group.id} labelled={group.label !== null}>
+              {group.label === null ? null : (
+                <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+              )}
               <SidebarMenu>
                 {group.items.map((link) => (
                   <SidebarMenuItem key={link.id}>


### PR DESCRIPTION
The developer's first look at the shipped base, seven annotations against the Retell reference, one batch.

**The sidebar (annotations 1–3).** The switcher is a card now — a square mark with the organization's initial, a quiet eyebrow, organization over project, and a chevron pointing where the menu actually opens. The Egma mark is deliberately not the avatar, because DESIGN.md keeps the logo out of the signed-in bar. The polish is icons and density: six hand-drawn path lists become six lucide icons at one weight, and rows drop to 36px with the 44px tap target put straight back on touch. The top group has no label at all — position already says the two rows stand above both jobs — and dropping the heading drops the region with it, so nothing announces a group it cannot name. The matching glossary retirement is the planning PR beside this one: the label's own recorded reopen condition (first-user evidence of the misread) fired as the developer's first look.

**Toolbars and filters (annotations 4–6).** Five list pages, five different ideas of what a filter row is; now there is one — filters left, action hard right, one search width and one filter width declared once in the shared Toolbar. Connect agent moves to the right end of the agents toolbar (it was always the default size; leading a row shared with a full-bleed search is what made it look otherwise). The archive filter's control comes off the only two pages that had one, Tests and Personas, with nothing underneath moved: both path builders still carry the flag and the server still keeps the two lists apart. Five tests drove that control; the keyboard contract moved onto the Choice control itself (mutation-checked both ways) and each other removal records where its proof went.

**Graders (annotation 7).** Running leads the strip, and the sidebar follows it via the same opens mechanism Monitoring already used — a first tab nobody lands on is not a first tab; the old address still opens the library and the active mark lights for both. Add grader is an honest button: there is no create-a-grader flow in this product (the Use form draws from the entry it is opened on), so the button offers the journey the empty state already offered — the library — before the screen is empty, and is absent from the library page where it would link to itself. The proof pass also fixed a defect older than this branch: the current grader tab has been drawing its 2px rule in transparent since the strip was written.

An independent review verified the a11y shape of the unlabeled group, the strict-superset sidebar change, both frozen-href test updates (judged "the honest way to break a freeze"), and the trap sweep — then required the Choice-coverage fix and the navigation invariant rewrite, both in the final commits. Proof: typecheck, production build, 510 scoped tests, 14 both-theme screenshots including the pages with the largest deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789836765&installation_model_id=431960&pr_number=165&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F165&signature=7a780bb57431b1764c4c89e40bd21a640f15ba5ae09fa9e52457c87eb2c5f399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refreshes the project sidebar, standardizes list toolbars and filter sizing, and makes Running the leading grader view. It also removes archive selectors from Tests and Personas, which leaves archived authored resources without their normal discovery and restore path.

- Restyles the project selector and sidebar navigation with Lucide icons, denser rows, and an unlabeled top group.
- Adds a shared toolbar action slot and standardized search/filter widths across list pages.
- Reorders grader tabs, routes the sidebar to Running, and adds an Add grader journey to the library.
- Removes the Tests and Personas archive selectors while retaining otherwise unreachable archive branches.

<h3>Confidence Score: 4/5</h3>

The archived-resource discovery and restore path should be restored before merging.

Tests and Personas now permanently request only active records, while Restore remains on archived detail pages that users can no longer normally discover.

**Files Needing Attention:** apps/web/app/projects/[projectId]/tests/page.tsx and apps/web/app/projects/[projectId]/personas/page.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/page.tsx | Standardizes filters but fixes the archive state to false, removing the only discovery path to archived tests and their Restore action. |
| apps/web/app/projects/[projectId]/personas/page.tsx | Removes the archive selector and permanently shows active personas, making most archived personas undiscoverable. |
| apps/web/lib/navigation.ts | Updates sidebar grouping and routes Graders directly to Running while preserving active-section behavior for both grader URLs. |
| apps/web/ui/section.tsx | Introduces shared toolbar action placement and bounded responsive widths with wrapping behavior. |
| apps/web/ui/project-selector.tsx | Restyles the project selector while preserving its existing project-switching and draft-navigation behavior. |
| apps/web/app/projects/[projectId]/graders/tabs.tsx | Adds an optional action slot and reliably merges current-tab border utilities. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  L[Tests or Personas list] --> A[Active collection]
  L -. archive selector removed .-> X[Archived collection]
  A --> D[Active detail]
  X --> R[Archived detail with Restore]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22ui%2Fannotations-batch-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ui%2Fannotations-batch-1%22.%0A%0AGreploop%20egma-ai%2Fegma%20PR%20%23165%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=egma-ai%2Fegma&pr=165&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22ui%2Fannotations-batch-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ui%2Fannotations-batch-1%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fweb%2Fapp%2Fprojects%2F%5BprojectId%5D%2Ftests%2Fpage.tsx%3A177%0A**Archived%20resources%20become%20unreachable**%0A%0AWhen%20a%20user%20needs%20to%20inspect%20or%20restore%20an%20archived%20test%20or%20persona%2C%20fixing%20these%20list%20states%20to%20the%20active%20value%20prevents%20the%20archived%20collections%20from%20ever%20being%20requested%2C%20causing%20archived%20tests%E2%80%94and%20most%20archived%20personas%E2%80%94to%20lose%20their%20discoverable%20path%20to%20the%20detail-page%20Restore%20action.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=165&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fapp%2Fprojects%2F%5BprojectId%5D%2Ftests%2Fpage.tsx%3A177%0A**Archived%20resources%20become%20unreachable**%0A%0AWhen%20a%20user%20needs%20to%20inspect%20or%20restore%20an%20archived%20test%20or%20persona%2C%20fixing%20these%20list%20states%20to%20the%20active%20value%20prevents%20the%20archived%20collections%20from%20ever%20being%20requested%2C%20causing%20archived%20tests%E2%80%94and%20most%20archived%20personas%E2%80%94to%20lose%20their%20discoverable%20path%20to%20the%20detail-page%20Restore%20action.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=165&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(web): prove Choice&#39;s keyboard where ..."](https://github.com/egma-ai/egma/commit/bdd39bc74f30f20b0b20cfb83359cc76ea1ba37b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55235921)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Egma web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->