### PR TITLE
feat(web): give the onboarding bar to the kit, and draw the six new primitives

### DIFF
--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -122,10 +122,11 @@ const KICKER =
  * "section, state, or dialog titles that need stronger hierarchy" — the same
  * rule that separates it from `KICKER` above.
  *
- * The older panels on this page still write these three lines out at each
- * `<h3>`. They are left alone rather than swept into this constant: the
- * primitives batch is not the place to touch six sections it has no other
- * business in, and a sweep is its own change with its own proof.
+ * Every `<h3>` on the page reads it, including the six on the older panels that
+ * wrote the same three utilities out by hand. Naming it once is the rule this
+ * file states at the top — "named once rather than written nine times because
+ * nine copies drift" — and a constant that only the newest sections obeyed
+ * would have been a seventh copy with extra steps.
  */
 const SUBHEAD =
   "m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground";
@@ -325,7 +326,7 @@ export function DesignSystemProof() {
             </p>
 
             <div className="flex flex-col gap-4">
-              <h3 className="m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground">
+              <h3 className={SUBHEAD}>
                 Buttons
               </h3>
               <div className="flex flex-wrap items-center gap-3">
@@ -355,7 +356,7 @@ export function DesignSystemProof() {
 
             <div className="grid gap-6 md:grid-cols-2">
               <div className="flex flex-col gap-4">
-                <h3 className="m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground">
+                <h3 className={SUBHEAD}>
                   Fields
                 </h3>
                 <label className="flex flex-col gap-2" htmlFor="base-suite">
@@ -377,7 +378,7 @@ export function DesignSystemProof() {
               </div>
 
               <div className="flex flex-col gap-4">
-                <h3 className="m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground">
+                <h3 className={SUBHEAD}>
                   Chips
                 </h3>
                 <div className="flex flex-wrap items-center gap-3">
@@ -390,7 +391,7 @@ export function DesignSystemProof() {
                   Brand orange is absent on purpose. It never means passed,
                   failed, skipped, or errored.
                 </p>
-                <h3 className="m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground">
+                <h3 className={SUBHEAD}>
                   Theme, straight from the tokens
                 </h3>
                 <div className="grid grid-cols-3 gap-2">
@@ -416,7 +417,7 @@ export function DesignSystemProof() {
               * the grader threshold uses.
               */}
             <div className="flex flex-col gap-4">
-              <h3 className="m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground">
+              <h3 className={SUBHEAD}>
                 Numeric fields
               </h3>
               <p className="m-0 max-w-[68ch] text-base text-muted-foreground">
@@ -486,7 +487,7 @@ export function DesignSystemProof() {
               </Card>
 
               <div className="flex flex-col gap-4">
-                <h3 className="m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground">
+                <h3 className={SUBHEAD}>
                   Menus and layers
                 </h3>
                 <div className="flex flex-wrap items-center gap-3">
@@ -670,10 +671,24 @@ export function DesignSystemProof() {
                 a reader is meant to compare before making it.
               </p>
               <div className={PREVIEW}>
+                {/*
+                  * The question is on the page rather than only in an
+                  * `aria-label`. `DESIGN.md` says labels stay visible, and a
+                  * group of options whose question only a screen reader is told
+                  * leaves everybody else reading two answers to nothing. The
+                  * same element is what names the group, so the two cannot
+                  * drift apart.
+                  */}
+                <p
+                  className="m-0 mb-3 text-sm font-medium text-foreground"
+                  id="proof-reuse-question"
+                >
+                  What a repeated run reuses
+                </p>
                 <RadioGroup
                   value={reuse}
                   onValueChange={(next) => setReuse(next as "same" | "fresh")}
-                  aria-label="What a repeated run reuses"
+                  aria-labelledby="proof-reuse-question"
                 >
                   <div className="flex min-h-(--tap-target) items-center gap-3">
                     <RadioGroupItem id="proof-reuse-same" value="same" />

--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -3,6 +3,12 @@
 import { useRef, useState } from "react";
 
 import { EllipsisIcon } from "lucide-react";
+/*
+ * Aliased for the same reason the primitives below are: this component already
+ * holds a `toast` of its own — the open state of the shared product toast — and
+ * the two would silently shadow one another.
+ */
+import { toast as baseToast } from "sonner";
 
 import { Badge as BaseBadge } from "@/components/ui/badge";
 import { Button as BaseButton } from "@/components/ui/button";
@@ -35,13 +41,31 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Progress } from "@/components/ui/progress";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Toaster } from "@/components/ui/sonner";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip as BaseTooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import type { Me } from "../../lib/me.ts";
@@ -91,7 +115,31 @@ const PANEL_WIDE = [...PANEL, "col-span-full max-[760px]:col-auto"];
 const KICKER =
   "m-0 mb-3 text-sm uppercase tracking-(--tracking-label) text-muted-foreground";
 
-/** One of the two component previews, and the line that titles it. */
+/**
+ * The heading that names one component inside a panel.
+ *
+ * It is weight 500, because it is a heading and `DESIGN.md` reserves 500 for
+ * "section, state, or dialog titles that need stronger hierarchy" — the same
+ * rule that separates it from `KICKER` above.
+ *
+ * The older panels on this page still write these three lines out at each
+ * `<h3>`. They are left alone rather than swept into this constant: the
+ * primitives batch is not the place to touch six sections it has no other
+ * business in, and a sweep is its own change with its own proof.
+ */
+const SUBHEAD =
+  "m-0 text-sm font-medium uppercase tracking-(--tracking-label) text-muted-foreground";
+
+/**
+ * One inset demonstration: a component shown on the canvas colour inside a
+ * panel, so the panel around it reads as a list of them.
+ *
+ * Both users of it are here rather than in two constants. It started as the
+ * frame for the two responsive and reduced-motion previews, and each primitive
+ * specimen wants the same frame — and two identical strings are the drift this
+ * file names at the top. `PREVIEW_HEAD` stays separate because only the two
+ * previews carry a titled header.
+ */
 const PREVIEW = "min-w-0 rounded-input border border-border bg-background p-4";
 const PREVIEW_HEAD = [
   "mb-4 flex items-baseline justify-between gap-3 text-sm text-foreground",
@@ -234,6 +282,8 @@ export function DesignSystemProof() {
   const [sampleRate, setSampleRate] = useState("20");
   const [answerWithin, setAnswerWithin] = useState("2.5");
   const [turnBudget, setTurnBudget] = useState("12");
+  const [reuse, setReuse] = useState<"same" | "fresh">("same");
+  const [finished, setFinished] = useState(7);
   const nextFeedbackInput = useRef<FeedbackInput>("keyboard");
 
   return (
@@ -512,6 +562,317 @@ export function DesignSystemProof() {
                   them; the dialog stays centred. Every duration is a DESIGN.md
                   motion token and every one is under 300ms.
                 </p>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        {/*
+          * The primitives the kit gained for the wrapper migration.
+          *
+          * They are on this page because nothing else draws some of them yet: a
+          * primitive with no caller is a primitive whose light theme, dark
+          * theme, keyboard model, and reduced-motion form nobody has looked at.
+          * Each one is shown in the states a reviewer actually has to check
+          * rather than in a single happy example.
+          */}
+        <article className={cn(PANEL_WIDE)}>
+          <p className={KICKER}>Component base — tabs, choice, progress, and feedback</p>
+          <div className="flex flex-col gap-8">
+            <p className="m-0 max-w-[68ch] text-base text-muted-foreground">
+              Each of these is the raw primitive, before any shared component
+              wraps it. That is deliberate: a change to a primitive shows up on
+              this page before it reaches a screen, and a primitive that only
+              ever appeared inside a wrapper would hide which of the two owns
+              the behaviour.
+            </p>
+
+            <div className="flex flex-col gap-4">
+              <h3 className={SUBHEAD}>Tabs</h3>
+              <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
+                One set, one panel visible, and the keyboard model that goes
+                with it: a single Tab step reaches the set rather than every tab
+                in it, and the arrow keys move along the set and change the
+                panel.
+              </p>
+              {/*
+                * Said out loud on the proof surface, because it is the decision
+                * a reviewer is most likely to want to argue with.
+                *
+                * The two grader views are separate addresses. A tab set claims
+                * `role="tab"`, a panel that updates in place, and a roving tab
+                * order — none of which is true of a link that loads a new page
+                * — and it costs the link its middle-click, its copy-link, and
+                * its place in the tab order. So the grader strip stays a
+                * navigation of links marked with `aria-current="page"`, and
+                * this is where a real tab set is proven instead.
+                */}
+              <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
+                The two grader views are not a tab set. They are separate
+                addresses, so they stay a navigation of links.
+              </p>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className={PREVIEW}>
+                  <Tabs defaultValue="simulations">
+                    <TabsList>
+                      <TabsTrigger value="simulations">Simulations</TabsTrigger>
+                      <TabsTrigger value="graders">Graders</TabsTrigger>
+                      <TabsTrigger value="persona">Persona</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="simulations">
+                      <p className="m-0 text-sm text-muted-foreground">
+                        Ten simulations ran. Seven passed, two failed, one was
+                        skipped because the connection refused the call.
+                      </p>
+                    </TabsContent>
+                    <TabsContent value="graders">
+                      <p className="m-0 text-sm text-muted-foreground">
+                        Two graders judged this run. Both were frozen when it
+                        started, so a later edit cannot change these verdicts.
+                      </p>
+                    </TabsContent>
+                    <TabsContent value="persona">
+                      <p className="m-0 text-sm text-muted-foreground">
+                        A caller who has already been transferred twice and asks
+                        for a refund outside the stated window.
+                      </p>
+                    </TabsContent>
+                  </Tabs>
+                </div>
+                <div className={PREVIEW}>
+                  <Tabs defaultValue="transcript">
+                    <TabsList variant="line">
+                      <TabsTrigger value="transcript">Transcript</TabsTrigger>
+                      <TabsTrigger value="outcome">Outcome</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="transcript">
+                      <p className="m-0 text-sm text-muted-foreground">
+                        Every turn of the simulation, in the order it happened.
+                      </p>
+                    </TabsContent>
+                    <TabsContent value="outcome">
+                      <p className="m-0 text-sm text-muted-foreground">
+                        What each grader decided, and the turn it cited.
+                      </p>
+                    </TabsContent>
+                  </Tabs>
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="flex flex-col gap-4">
+              <h3 className={SUBHEAD}>Single choice</h3>
+              <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
+                One answer out of a small set, with every option left in view. A
+                menu hides the options that were not taken; this is for a choice
+                a reader is meant to compare before making it.
+              </p>
+              <div className={PREVIEW}>
+                <RadioGroup
+                  value={reuse}
+                  onValueChange={(next) => setReuse(next as "same" | "fresh")}
+                  aria-label="What a repeated run reuses"
+                >
+                  <div className="flex min-h-(--tap-target) items-center gap-3">
+                    <RadioGroupItem id="proof-reuse-same" value="same" />
+                    <Label htmlFor="proof-reuse-same">
+                      The same persona for every simulation
+                    </Label>
+                  </div>
+                  <div className="flex min-h-(--tap-target) items-center gap-3">
+                    <RadioGroupItem id="proof-reuse-fresh" value="fresh" />
+                    <Label htmlFor="proof-reuse-fresh">
+                      A new persona for each simulation
+                    </Label>
+                  </div>
+                </RadioGroup>
+                <p className="mt-3 mb-0 text-sm text-muted-foreground">
+                  Chosen: {reuse === "same" ? "the same persona" : "a new persona"}
+                </p>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="flex flex-col gap-4">
+              <h3 className={SUBHEAD}>Progress</h3>
+              <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
+                Completion, filled on a transform and timed linear while the
+                work is still moving. A fill that slowed down at the end would
+                be saying the run was slowing down. Under reduced motion the bar
+                is simply at its new length, and the count beside it is what
+                says it changed.
+              </p>
+              {/*
+                * Three bars rather than one, because the three are the states
+                * the component has: a value on its way up, a value that has
+                * arrived, and no value at all. The last one is the one a happy
+                * example always skips — an indeterminate bar must stay empty
+                * rather than sit at zero, because "amount unknown" and "nothing
+                * done" are different claims.
+                */}
+              <div className={PREVIEW}>
+                <div className="grid gap-5">
+                  {/*
+                    * "Judged" rather than "finished", and that is not a word
+                    * chosen for variety. `RunProgress` is drawn further down
+                    * this page and is already labelled "Simulations finished";
+                    * a second bar wearing the same name would leave a reader
+                    * moving between the two with no way to tell which one they
+                    * had landed on.
+                    */}
+                  <div className="grid gap-2">
+                    <Progress
+                      value={finished}
+                      max={10}
+                      aria-label="Simulations judged"
+                      getValueLabel={(value, max) =>
+                        `${String(value)} of ${String(max)} simulations judged`
+                      }
+                    />
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <span className="text-sm tabular-nums text-muted-foreground">
+                        {finished} of 10 simulations judged
+                      </span>
+                      <BaseButton
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        disabled={finished >= 10}
+                        onClick={() => setFinished((count) => Math.min(10, count + 1))}
+                      >
+                        Judge one more simulation
+                      </BaseButton>
+                    </div>
+                  </div>
+                  <div className="grid gap-2">
+                    <Progress
+                      value={10}
+                      max={10}
+                      aria-label="Transcripts collected"
+                      getValueLabel={(value, max) =>
+                        `${String(value)} of ${String(max)} transcripts collected`
+                      }
+                    />
+                    <span className="text-sm tabular-nums text-muted-foreground">
+                      Complete: 10 of 10 transcripts collected
+                    </span>
+                  </div>
+                  <div className="grid gap-2">
+                    <Progress aria-label="Recording being prepared" />
+                    <span className="text-sm text-muted-foreground">
+                      Indeterminate: the recording is being prepared and the
+                      share of it is not known
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="flex flex-col gap-4">
+                <h3 className={SUBHEAD}>Tooltip</h3>
+                <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
+                  A short explanation attached to one control, and never an
+                  action: help a person has to click belongs in a menu or a
+                  dialog. The tooltips in the panels above are the shared
+                  product one; this is the primitive underneath it.
+                </p>
+                <div className={PREVIEW}>
+                  <TooltipProvider>
+                    <BaseTooltip>
+                      <TooltipTrigger asChild>
+                        <BaseButton type="button" variant="secondary">
+                          What a frozen grader means
+                        </BaseButton>
+                      </TooltipTrigger>
+                      <TooltipContent sideOffset={8}>
+                        A run keeps the grader it started with, so editing the
+                        grader never changes a verdict already given.
+                      </TooltipContent>
+                    </BaseTooltip>
+                  </TooltipProvider>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-4">
+                <h3 className={SUBHEAD}>Toast</h3>
+                <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
+                  Arrival and dismissal, said once and out of the way of the
+                  work. The word and the symbol carry the state together, so the
+                  notification never rests on colour alone.
+                </p>
+                <div className={cn(PREVIEW, "flex flex-wrap items-center gap-3")}>
+                  <BaseButton
+                    type="button"
+                    variant="secondary"
+                    onClick={() =>
+                      baseToast.success("Grader saved", {
+                        description:
+                          "The next run will be judged by this version.",
+                      })
+                    }
+                  >
+                    Show a saved notification
+                  </BaseButton>
+                  <BaseButton
+                    type="button"
+                    variant="secondary"
+                    onClick={() =>
+                      baseToast.error("Run could not start", {
+                        description:
+                          "The connection refused the call. Nothing was charged.",
+                      })
+                    }
+                  >
+                    Show a failed notification
+                  </BaseButton>
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="flex flex-col gap-4">
+              <h3 className={SUBHEAD}>Skeleton</h3>
+              <p className="m-0 max-w-[68ch] text-sm text-muted-foreground">
+                The shape of what is coming, for the moment before it arrives. A
+                skeleton is a shape and nothing else, so the word stays beside
+                it: <code className="font-mono text-sm">DESIGN.md</code> asks a
+                loading state to say what is happening, and a grey rectangle
+                does not say it.
+              </p>
+              {/*
+                * The pulse is Tailwind's own `animate-pulse` and it needs no
+                * reduced-motion form written here: `globals.css` already caps
+                * every animation on the page at one iteration of a single frame
+                * under that query, so the shape stops moving and stays legible.
+                */}
+              <div className={PREVIEW} role="status" aria-busy="true">
+                <p className="m-0 mb-4 text-sm text-muted-foreground">
+                  Loading graders…
+                </p>
+                <div className="grid gap-3" aria-hidden="true">
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="size-8 rounded-chip" />
+                    <Skeleton className="h-4 w-[min(220px,60%)]" />
+                    <Skeleton className="ml-auto h-4 w-16" />
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="size-8 rounded-chip" />
+                    <Skeleton className="h-4 w-[min(180px,50%)]" />
+                    <Skeleton className="ml-auto h-4 w-16" />
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="size-8 rounded-chip" />
+                    <Skeleton className="h-4 w-[min(260px,70%)]" />
+                    <Skeleton className="ml-auto h-4 w-16" />
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -853,6 +1214,15 @@ export function DesignSystemProof() {
       >
         Support agent is ready for the next run.
       </Toast>
+
+      {/*
+        * The kit toaster, parked at the top so it never lands on the shared
+        * toast above. Both live on this page on purpose: the shared one is the
+        * product notification a screen reaches for today, and this is the
+        * primitive a later ticket has the option of moving it onto. Two
+        * notifications stacked in the same corner would have proved neither.
+        */}
+      <Toaster position="top-right" />
       </div>
       </ProductPage>
     </AppShell>

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/page.tsx
@@ -328,7 +328,20 @@ function AttachTests({
     <ProductPage>
       {header}
       <PageBody>
-        <AgentOnboardingProgress current="tests" />
+        {/*
+          * "Skip connection for now" is how somebody arrives here with the
+          * connection stage behind them and nothing attached, and the bar must
+          * not count that as work done. This page already holds the agent's
+          * connections, so it is the one place that can tell a skip from a
+          * finished stage: no connection on the agent means the stage was
+          * passed over rather than completed.
+          */}
+        <AgentOnboardingProgress
+          current="tests"
+          skipped={
+            parentAgent.value.connections.length === 0 ? ["connection"] : []
+          }
+        />
 
         {pages.length === 0 && busyTests ? (
           <Loading what="this project's tests" />

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/page.tsx
@@ -329,17 +329,31 @@ function AttachTests({
       {header}
       <PageBody>
         {/*
-          * "Skip connection for now" is how somebody arrives here with the
-          * connection stage behind them and nothing attached, and the bar must
-          * not count that as work done. This page already holds the agent's
-          * connections, so it is the one place that can tell a skip from a
-          * finished stage: no connection on the agent means the stage was
-          * passed over rather than completed.
+          * Somebody can be standing here with the connection stage behind them
+          * and no connection on the agent, and the bar must not count that as
+          * work done. This page already holds the agent's connections, so it is
+          * the one place that can see it without a second read.
+          *
+          * **The word says the state, not how it got there**, and that is the
+          * whole of the wording. An empty list has two histories: "Skip
+          * connection for now", and a connection that was made and later
+          * archived — this read returns the active ones. They are the same list
+          * and nothing here can tell them apart, so a word like "Skipped" would
+          * be right for one person and wrong for the other. "Needs a
+          * connection" is true either way: the agent has none now, and
+          * `DESIGN.md` gives the warning tone to exactly that — limited, or
+          * needs attention.
+          *
+          * Reading the archived connections too would only buy a nicer word for
+          * one of the two, at the cost of a second request on every visit to
+          * this page. The state is what the reader has to act on either way.
           */}
         <AgentOnboardingProgress
           current="tests"
-          skipped={
-            parentAgent.value.connections.length === 0 ? ["connection"] : []
+          unfinished={
+            parentAgent.value.connections.length === 0
+              ? { connection: "Needs a connection" }
+              : {}
           }
         />
 

--- a/apps/web/app/projects/[projectId]/agents/onboarding-progress.tsx
+++ b/apps/web/app/projects/[projectId]/agents/onboarding-progress.tsx
@@ -1,3 +1,5 @@
+import { Progress } from "@/components/ui/progress";
+
 export type AgentOnboardingStage = "agent" | "connection" | "tests";
 
 const STAGES: readonly {
@@ -16,18 +18,51 @@ const STAGES: readonly {
  * task sits without repeating numbered progress copy or putting three forms in
  * one large wizard card.
  *
- * Nothing here moves, so there is no reduced-motion form to write: a stage is
- * either done or it is not, and the tick says which without animating in.
+ * **The bar is the kit's `Progress` rather than a shape drawn here**, which is
+ * the whole of this file's part in the primitives migration. What it adds over
+ * the stage list on its own is the measure: the list says which stage is being
+ * worked on, and the bar says how much of the setup is behind it. `DESIGN.md`
+ * asks a state for a word as well as a shape, so the two are shown together and
+ * neither is asked to carry the meaning alone.
+ *
+ * **It counts stages finished, not the stage being worked on**, so it reads 0
+ * of 3 on the first page and 2 of 3 on the last. It never reaches 3, because
+ * finishing the last stage leaves onboarding — a bar that filled completely on
+ * a page still asking for something would be claiming the work was done.
+ *
+ * The reduced-motion form is the primitive's: `components/ui/progress.tsx`
+ * carries `motion-reduce:transition-none`, so the bar is simply at its new
+ * length and the stage words are what say it moved. Nothing else here moves.
  */
 export function AgentOnboardingProgress({
   current,
 }: {
   readonly current: AgentOnboardingStage;
 }) {
-  const currentIndex = STAGES.findIndex((stage) => stage.id === current);
+  /*
+   * Clamped, because `Progress` is given this number. `current` is typed to one
+   * of the three stages so the miss cannot happen through the types, but a -1
+   * reaching Radix is a console error and a bar drawn at an impossible length,
+   * and the floor costs one call.
+   */
+  const finished = Math.max(0, STAGES.findIndex((stage) => stage.id === current));
 
   return (
     <nav className="mb-6 border-b border-border pb-4" aria-label="Agent setup">
+      <Progress
+        className="mb-4"
+        value={finished}
+        max={STAGES.length}
+        aria-label="Agent setup progress"
+        /*
+         * A percentage is the wrong unit for three named stages: "33%" is a
+         * number nobody can act on, while "1 of 3 stages finished" is the same
+         * fact said in the words the list beside it already uses.
+         */
+        getValueLabel={(value, max) =>
+          `${String(value)} of ${String(max)} stages finished`
+        }
+      />
       {/*
         `m-0 p-0 list-none` is doing work rather than repeating a reset:
         `globals.css` hands the browser's own list defaults back in
@@ -36,7 +71,7 @@ export function AgentOnboardingProgress({
       */}
       <ol className="m-0 flex list-none flex-wrap gap-4 p-0 max-[36rem]:gap-3">
         {STAGES.map((stage, index) => {
-          const complete = index < currentIndex;
+          const complete = index < finished;
           return (
             <li
               className={

--- a/apps/web/app/projects/[projectId]/agents/onboarding-progress.tsx
+++ b/apps/web/app/projects/[projectId]/agents/onboarding-progress.tsx
@@ -29,42 +29,41 @@ const STAGES: readonly {
  * first page and never reaches 3 — finishing the last stage leaves onboarding,
  * and a bar that filled completely on a page still asking for something would
  * be claiming the work was done.
- *
- * The reduced-motion form is the primitive's: `components/ui/progress.tsx`
- * carries `motion-reduce:transition-none`, so the bar is simply at its new
- * length and the stage words are what say it moved. Nothing else here moves.
  */
 export function AgentOnboardingProgress({
   current,
-  skipped = [],
+  unfinished = {},
 }: {
   readonly current: AgentOnboardingStage;
   /**
-   * Stages that were passed over rather than done.
+   * Stages that are behind the reader and still not done, each with the short
+   * state word to show beside it.
    *
    * **Being behind the current stage is not the same as being finished**, and
-   * onboarding has one place where the two part company: "Skip connection for
-   * now" lands on the tests page with the connection stage behind it and
-   * nothing attached. Deriving the count from the current stage alone counted
-   * that skip as work done, so the bar said "2 of 3 stages finished" about an
-   * agent that could not run a simulation.
+   * onboarding has a stage where the two part company: somebody can reach the
+   * tests page with the connection stage behind them and no connection on the
+   * agent.
    *
-   * A caller that knows a stage was skipped says so, and the stage is then
-   * drawn as skipped rather than silently promoted. `DESIGN.md` names skipped
-   * as its own state, separate from complete, for exactly this reason.
+   * **The word comes from the caller, and that is the point of the shape.**
+   * This component can see that a stage is not done; it cannot see *why*, and
+   * a word invented here would be a guess. The first version of this guessed
+   * "Skipped" — and a person who connected an agent and later archived that
+   * connection reads exactly the same empty list as a person who pressed "Skip
+   * connection for now". Calling both a skip told half of them they had done
+   * something they had not. So the caller says the word, and it says a state
+   * rather than an intention.
    */
-  readonly skipped?: readonly AgentOnboardingStage[];
+  readonly unfinished?: Partial<Record<AgentOnboardingStage, string>>;
 }) {
   const currentIndex = STAGES.findIndex((stage) => stage.id === current);
   /*
    * Only what is genuinely done. A stage ahead of the current one is not
-   * counted whether or not it was named as skipped, because nobody has reached
-   * it yet and a skip is something a person did rather than a state to predict.
+   * counted whether or not the caller named it, because nobody has reached it
+   * yet and a stage nobody has opened is not one they left undone.
    */
-  const finished = STAGES.filter(
-    (stage, index) => index < currentIndex && !skipped.includes(stage.id),
-  ).length;
-  const passedOver = currentIndex - finished;
+  const behind = STAGES.filter((stage, index) => index < currentIndex);
+  const waiting = behind.filter((stage) => unfinished[stage.id] !== undefined);
+  const finished = behind.length - waiting.length;
 
   return (
     <nav className="mb-6 border-b border-border pb-4" aria-label="Agent setup">
@@ -76,14 +75,20 @@ export function AgentOnboardingProgress({
         /*
          * A percentage is the wrong unit for three named stages: "33%" is a
          * number nobody can act on, while "1 of 3 stages finished" is the same
-         * fact said in the words the list beside it already uses. A skip is
-         * added rather than folded in, so the sentence accounts for every stage
-         * the reader can see behind them.
+         * fact said in the words the list beside it already uses.
+         *
+         * A stage left behind is named rather than folded into the count,
+         * because "1 of 3 finished" with two stages behind you is the one
+         * arithmetic a reader should not have to do. It is named as *not
+         * finished*, which is all this component knows and all that is true on
+         * every path into it.
          */
         getValueLabel={(value, max) =>
-          passedOver === 0
+          waiting.length === 0
             ? `${String(value)} of ${String(max)} stages finished`
-            : `${String(value)} of ${String(max)} stages finished, ${String(passedOver)} skipped`
+            : `${String(value)} of ${String(max)} stages finished, ${waiting
+                .map((stage) => stage.label)
+                .join(", ")} not finished`
         }
       />
       {/*
@@ -94,9 +99,9 @@ export function AgentOnboardingProgress({
       */}
       <ol className="m-0 flex list-none flex-wrap gap-4 p-0 max-[36rem]:gap-3">
         {STAGES.map((stage, index) => {
-          const behind = index < currentIndex;
-          const passed = behind && skipped.includes(stage.id);
-          const complete = behind && !passed;
+          const passed = index < currentIndex;
+          const waitingWord = passed ? unfinished[stage.id] : undefined;
+          const complete = passed && waitingWord === undefined;
           return (
             <li
               className={
@@ -111,22 +116,26 @@ export function AgentOnboardingProgress({
                 "max-[36rem]:flex-auto"
               }
               data-complete={complete ? "true" : undefined}
-              data-skipped={passed ? "true" : undefined}
+              data-unfinished={waitingWord === undefined ? undefined : "true"}
               aria-current={stage.id === current ? "step" : undefined}
               key={stage.id}
             >
               {/*
                 The mark keeps its 12px whether or not one is drawn, so the
-                labels do not shift sideways as stages complete. A skip gets its
-                own shape as well as its own colour — a tick that meant either
-                "done" or "passed over" would be the colour carrying the
-                difference on its own.
+                labels do not shift sideways as stages complete. A stage left
+                behind gets its own shape as well as its own colour — a tick
+                that meant either "done" or "not done" would be the colour
+                carrying the difference on its own.
               */}
               <span
-                className={passed ? "w-3 text-warning" : "w-3 text-success"}
+                className={
+                  waitingWord === undefined
+                    ? "w-3 text-success"
+                    : "w-3 text-warning"
+                }
                 aria-hidden="true"
               >
-                {complete ? "✓" : passed ? "–" : ""}
+                {complete ? "✓" : waitingWord === undefined ? "" : "–"}
               </span>
               {stage.label}
               {/*
@@ -134,7 +143,9 @@ export function AgentOnboardingProgress({
                 mark and a colour. It is inside the list item, so a screen
                 reader reads the stage and its state together.
               */}
-              {passed ? <span className="text-warning">Skipped</span> : null}
+              {waitingWord === undefined ? null : (
+                <span className="text-warning">{waitingWord}</span>
+              )}
             </li>
           );
         })}

--- a/apps/web/app/projects/[projectId]/agents/onboarding-progress.tsx
+++ b/apps/web/app/projects/[projectId]/agents/onboarding-progress.tsx
@@ -25,10 +25,10 @@ const STAGES: readonly {
  * asks a state for a word as well as a shape, so the two are shown together and
  * neither is asked to carry the meaning alone.
  *
- * **It counts stages finished, not the stage being worked on**, so it reads 0
- * of 3 on the first page and 2 of 3 on the last. It never reaches 3, because
- * finishing the last stage leaves onboarding — a bar that filled completely on
- * a page still asking for something would be claiming the work was done.
+ * **It counts stages finished, not stages behind**, so it reads 0 of 3 on the
+ * first page and never reaches 3 — finishing the last stage leaves onboarding,
+ * and a bar that filled completely on a page still asking for something would
+ * be claiming the work was done.
  *
  * The reduced-motion form is the primitive's: `components/ui/progress.tsx`
  * carries `motion-reduce:transition-none`, so the bar is simply at its new
@@ -36,16 +36,35 @@ const STAGES: readonly {
  */
 export function AgentOnboardingProgress({
   current,
+  skipped = [],
 }: {
   readonly current: AgentOnboardingStage;
-}) {
-  /*
-   * Clamped, because `Progress` is given this number. `current` is typed to one
-   * of the three stages so the miss cannot happen through the types, but a -1
-   * reaching Radix is a console error and a bar drawn at an impossible length,
-   * and the floor costs one call.
+  /**
+   * Stages that were passed over rather than done.
+   *
+   * **Being behind the current stage is not the same as being finished**, and
+   * onboarding has one place where the two part company: "Skip connection for
+   * now" lands on the tests page with the connection stage behind it and
+   * nothing attached. Deriving the count from the current stage alone counted
+   * that skip as work done, so the bar said "2 of 3 stages finished" about an
+   * agent that could not run a simulation.
+   *
+   * A caller that knows a stage was skipped says so, and the stage is then
+   * drawn as skipped rather than silently promoted. `DESIGN.md` names skipped
+   * as its own state, separate from complete, for exactly this reason.
    */
-  const finished = Math.max(0, STAGES.findIndex((stage) => stage.id === current));
+  readonly skipped?: readonly AgentOnboardingStage[];
+}) {
+  const currentIndex = STAGES.findIndex((stage) => stage.id === current);
+  /*
+   * Only what is genuinely done. A stage ahead of the current one is not
+   * counted whether or not it was named as skipped, because nobody has reached
+   * it yet and a skip is something a person did rather than a state to predict.
+   */
+  const finished = STAGES.filter(
+    (stage, index) => index < currentIndex && !skipped.includes(stage.id),
+  ).length;
+  const passedOver = currentIndex - finished;
 
   return (
     <nav className="mb-6 border-b border-border pb-4" aria-label="Agent setup">
@@ -57,10 +76,14 @@ export function AgentOnboardingProgress({
         /*
          * A percentage is the wrong unit for three named stages: "33%" is a
          * number nobody can act on, while "1 of 3 stages finished" is the same
-         * fact said in the words the list beside it already uses.
+         * fact said in the words the list beside it already uses. A skip is
+         * added rather than folded in, so the sentence accounts for every stage
+         * the reader can see behind them.
          */
         getValueLabel={(value, max) =>
-          `${String(value)} of ${String(max)} stages finished`
+          passedOver === 0
+            ? `${String(value)} of ${String(max)} stages finished`
+            : `${String(value)} of ${String(max)} stages finished, ${String(passedOver)} skipped`
         }
       />
       {/*
@@ -71,7 +94,9 @@ export function AgentOnboardingProgress({
       */}
       <ol className="m-0 flex list-none flex-wrap gap-4 p-0 max-[36rem]:gap-3">
         {STAGES.map((stage, index) => {
-          const complete = index < finished;
+          const behind = index < currentIndex;
+          const passed = behind && skipped.includes(stage.id);
+          const complete = behind && !passed;
           return (
             <li
               className={
@@ -86,17 +111,30 @@ export function AgentOnboardingProgress({
                 "max-[36rem]:flex-auto"
               }
               data-complete={complete ? "true" : undefined}
+              data-skipped={passed ? "true" : undefined}
               aria-current={stage.id === current ? "step" : undefined}
               key={stage.id}
             >
               {/*
-                The tick keeps its 12px whether or not one is drawn, so the
-                labels do not shift sideways as stages complete.
+                The mark keeps its 12px whether or not one is drawn, so the
+                labels do not shift sideways as stages complete. A skip gets its
+                own shape as well as its own colour — a tick that meant either
+                "done" or "passed over" would be the colour carrying the
+                difference on its own.
               */}
-              <span className="w-3 text-success" aria-hidden="true">
-                {complete ? "✓" : ""}
+              <span
+                className={passed ? "w-3 text-warning" : "w-3 text-success"}
+                aria-hidden="true"
+              >
+                {complete ? "✓" : passed ? "–" : ""}
               </span>
               {stage.label}
+              {/*
+                And the word, because `DESIGN.md` will not let a state rest on a
+                mark and a colour. It is inside the list item, so a screen
+                reader reads the stage and its state together.
+              */}
+              {passed ? <span className="text-warning">Skipped</span> : null}
             </li>
           );
         })}

--- a/apps/web/app/trust-gate.tsx
+++ b/apps/web/app/trust-gate.tsx
@@ -55,6 +55,26 @@ export function TrustGate() {
         alpha: 0.18 + randomAt(index + 399) * 0.62,
         drift: 0.5 + randomAt(index + 499) * 2.2,
       }));
+      still();
+    }
+
+    /**
+     * One frame, for the two moments when no other frame is coming.
+     *
+     * Under reduced motion the loop draws once and stops, which is the whole
+     * point of it — but two things afterwards invalidate what is on the canvas
+     * and neither used to redraw it. **Setting `canvas.width` clears the
+     * canvas**, so every resize left the field blank until a reload; and the
+     * theme observer re-reads the ink without repainting, so a light-to-dark
+     * switch left the old colour standing. Both were invisible in normal
+     * motion, where the next animation frame covered them a moment later.
+     *
+     * `draw` ignores the timestamp under reduced motion — `seconds` is pinned
+     * to 0 — so zero is the honest argument rather than a placeholder, and the
+     * static field it paints is the same one every time.
+     */
+    function still(): void {
+      if (reduced) draw(0);
     }
 
     function circle(x: number, y: number, radius: number): void {
@@ -112,6 +132,7 @@ export function TrustGate() {
     const observer = new ResizeObserver(resize);
     const themeObserver = new MutationObserver(() => {
       ink = getComputedStyle(canvasElement).color;
+      still();
     });
     observer.observe(canvasElement);
     themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });

--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -1,31 +1,125 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Progress as ProgressPrimitive } from "radix-ui"
+import { Progress as ProgressPrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
+/**
+ * The bar that explains completion.
+ *
+ * `DESIGN.md` gives this component one line — "Progress: explain completion —
+ * transform-based fill, linear while active" — and the registry's version keeps
+ * only the first half of it. What arrives from shadcn fills on `transition-all`
+ * with the default easing, which is `all` (forbidden outright) decelerating
+ * (which lies about the rate of the work). Both are fixed here.
+ *
+ * **Its look is `RunProgress`'s look, on purpose.** `ui/run-status.tsx` already
+ * draws this product's progress bar — a neutral track, an ink fill, the chip
+ * radius, 200ms linear, and no movement under reduced motion — so the kit
+ * primitive is dressed to match rather than to a second opinion. A later ticket
+ * moving `RunProgress` onto this primitive should be deleting code, not
+ * redrawing a bar.
+ *
+ * The fill is `--foreground` rather than the brand orange, which is the choice
+ * `RunProgress` already made and worth keeping deliberately: `DESIGN.md` spends
+ * Ember on "focus, icons, marks, and narrow active edges" and Deep Ember on
+ * "primary filled actions with white text". A bar that is neither reads as ink,
+ * and ink is also the highest contrast available in both themes for a shape
+ * that carries no text of its own.
+ */
 function Progress({
   className,
   value,
+  max,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: ComponentProps<typeof ProgressPrimitive.Root>) {
+  /*
+   * `max` honoured, which the registry's version drops.
+   *
+   * Radix reads `max` — it puts it on `aria-valuemax` and decides `data-state`
+   * with it — but the indicator shadcn ships computes `100 - value`, so it only
+   * ever agrees with the label when `max` happens to be 100. A caller counting
+   * three onboarding stages says `value={1} max={3}`, is announced as "1, out of
+   * 3", and is drawn at one percent. The eye and the screen reader must not be
+   * given two different answers, so the share is computed the same way Radix
+   * computes the one it announces.
+   */
+  const ceiling = typeof max === "number" && max > 0 ? max : 100;
+  const filled =
+    typeof value === "number" && value >= 0 && value <= ceiling ? value : null;
+  /*
+   * An indeterminate bar stays empty rather than being drawn at zero. Radix
+   * leaves `aria-valuenow` off and says `data-state="indeterminate"`, so what a
+   * screen reader is told is "in progress, amount unknown"; a fill sitting at
+   * zero would tell the eye "nothing is done yet", which is a different claim
+   * and not one this component is in a position to make.
+   */
+  const remaining = filled === null ? 100 : 100 - (filled / ceiling) * 100;
+
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
-        className
+        /*
+         * "Quiet hover, read-only, progress, and supporting surfaces use a
+         * neutral Graphite-and-Paper mix." That mix is `--surface-soft`.
+         *
+         * The chip radius, because a track is a pill and `DESIGN.md` names the
+         * pill for "tag, chip, filter" — the nearest named type, and the rule
+         * it is guarding against is one big radius on everything rather than a
+         * pill on something pill-shaped.
+         */
+        "relative h-2 w-full overflow-hidden rounded-chip bg-surface-soft",
+        className,
       )}
+      max={max}
+      value={value}
       {...props}
     >
+      {/*
+       * Transform-based, and the transform is a `translateX` inside a clipping
+       * track rather than the `scaleX` `RunProgress` uses.
+       *
+       * Both are "transform-based fill". This one is the registry's, so a
+       * component pasted from shadcn lands on it unedited, and it is also the
+       * better of the two here: `scaleX` on a pill squashes the leading cap
+       * horizontally, while a full-width indicator slid left keeps its cap
+       * round and lets the track clip the other end.
+       */}
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="h-full w-full flex-1 bg-primary transition-all"
-        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+        className={cn(
+          "size-full rounded-chip bg-foreground",
+          /*
+           * "Linear while active."
+           *
+           * Linear is the whole point: a fill that decelerates says the work is
+           * slowing down, and a bar that is still moving has no business
+           * claiming that. The easing turns over to `--ease-out` only on
+           * `data-state="complete"`, where a value settling into its final
+           * place is exactly what an ease-out describes.
+           *
+           * 200ms is written here rather than read from the theme, and it is
+           * the same non-token duration, for the same reason, as the one
+           * already written in `ui/run-status.tsx`: the motion tokens name
+           * interface motion — a press, a popover, a dialog — and this is a
+           * value catching up to a new value, which `DESIGN.md` gives a
+           * behaviour for and no token. It is under the 300ms ceiling. Called
+           * out in the pull request for the developer to overrule.
+           */
+          "transition-transform duration-200 ease-linear",
+          "data-[state=complete]:ease-out",
+          /*
+           * The reduced-motion form. Nothing travels; the bar is simply at its
+           * new length, and the value beside it is what says it changed.
+           */
+          "motion-reduce:transition-none",
+        )}
+        style={{ transform: `translateX(-${String(remaining)}%)` }}
       />
     </ProgressPrimitive.Root>
-  )
+  );
 }
 
-export { Progress }
+export { Progress };

--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -14,12 +14,19 @@ import { cn } from "@/lib/utils";
  * with the default easing, which is `all` (forbidden outright) decelerating
  * (which lies about the rate of the work). Both are fixed here.
  *
- * **Its look is `RunProgress`'s look, on purpose.** `ui/run-status.tsx` already
- * draws this product's progress bar — a neutral track, an ink fill, the chip
- * radius, 200ms linear, and no movement under reduced motion — so the kit
- * primitive is dressed to match rather than to a second opinion. A later ticket
- * moving `RunProgress` onto this primitive should be deleting code, not
- * redrawing a bar.
+ * **It is dressed to meet `RunProgress`, not to copy it today.**
+ * `ui/run-status.tsx` already draws this product's progress bar, and every
+ * decision it made that `DESIGN.md` backs is taken here too: a neutral track,
+ * an ink fill, the chip radius, 200ms linear, and no movement under reduced
+ * motion.
+ *
+ * **One measurement differs on purpose.** `RunProgress` is `h-1.5`, which is
+ * 6px and not on the 4px grid `DESIGN.md` sets; a general primitive has no
+ * business starting off the grid, so this is `h-2`. The two are therefore 2px
+ * apart until `RunProgress` moves onto this primitive, and adopting the 8px is
+ * the change that migration should make rather than an override it should
+ * carry. `run-status.tsx` is outside this ticket's fence, so it is named here
+ * instead of edited.
  *
  * The fill is `--foreground` rather than the brand orange, which is the choice
  * `RunProgress` already made and worth keeping deliberately: `DESIGN.md` spends

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -754,6 +754,31 @@ describe("onboarding an agent", () => {
     expect(within(progress).getByText("Connection").getAttribute("aria-current"))
       .toBe("step");
     expect(screen.queryByText(/Step 2 of 3/u)).toBeNull();
+
+    /*
+     * The bar counts stages *finished*, so the second stage reads one of three
+     * rather than two. A bar that filled a stage ahead of the work would be
+     * claiming the page in front of somebody was already done.
+     */
+    const bar = within(progress).getByRole("progressbar", {
+      name: "Agent setup progress",
+    });
+    expect(bar.getAttribute("aria-valuenow")).toBe("1");
+    expect(bar.getAttribute("aria-valuemax")).toBe("3");
+    expect(bar.getAttribute("aria-valuetext")).toBe("1 of 3 stages finished");
+
+    /*
+     * What the eye is given, against what the screen reader is given.
+     *
+     * This is the assertion that guards the fix in `components/ui/progress.tsx`.
+     * The registry's indicator computes `100 - value` and ignores `max`, so this
+     * bar announced "1 of 3 stages finished" and was drawn 99% empty. The two
+     * must be the same fact: one stage of three is a third filled, which is
+     * two thirds still to travel.
+     */
+    const fill = bar.querySelector("[data-slot='progress-indicator']");
+    expect(fill?.getAttribute("style")).toContain("translateX(-66.6");
+    expect(fill?.getAttribute("style")).not.toContain("-99%");
     expect(
       screen.getByRole("link", { name: "Skip connection for now" })
         .getAttribute("href"),

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -802,6 +802,80 @@ describe("onboarding an agent", () => {
     );
   });
 
+  /**
+   * "Skip connection for now", and the bar that has to tell the truth about it.
+   *
+   * Being behind the current stage is not the same as being finished. Somebody
+   * who skipped the connection arrives on the tests page with two stages behind
+   * them and one of them not done, and an agent with no connection cannot run a
+   * simulation at all — so a bar reading "2 of 3 stages finished" would be
+   * telling them the setup was nearly complete when the part that makes it work
+   * had been passed over.
+   *
+   * Both halves are asserted: the count, and the word beside the stage.
+   * `DESIGN.md` will not let a state rest on a mark and a colour, and it names
+   * skipped as its own state rather than a shade of complete.
+   */
+  it("says a skipped connection was skipped, and does not count it as finished", async () => {
+    routed.pathname = "/projects/prj_1/agents/agt_1/onboarding";
+    apiAnswers({
+      "/api/me": { status: 200, body: meWith("member") },
+      "/api/agents/agt_1": {
+        status: 200,
+        body: { agent: AGENT, connections: [] },
+      },
+      "/api/tests": [
+        { status: 200, body: { items: [onboardingTest()], next_cursor: null } },
+      ],
+    });
+    render(<AgentOnboardingPage />);
+
+    const progress = await screen.findByRole("navigation", {
+      name: "Agent setup",
+    });
+    const bar = within(progress).getByRole("progressbar", {
+      name: "Agent setup progress",
+    });
+    expect(bar.getAttribute("aria-valuenow")).toBe("1");
+    expect(bar.getAttribute("aria-valuetext")).toBe(
+      "1 of 3 stages finished, 1 skipped",
+    );
+
+    const connection = within(progress).getByText("Connection");
+    expect(connection.getAttribute("data-skipped")).toBe("true");
+    expect(connection.getAttribute("data-complete")).toBeNull();
+    expect(within(progress).getByText("Skipped")).toBeTruthy();
+  });
+
+  /** The same page with the connection actually made, so the count moves. */
+  it("counts a connection that was made, and says nothing about a skip", async () => {
+    routed.pathname = "/projects/prj_1/agents/agt_1/onboarding";
+    apiAnswers({
+      "/api/me": { status: 200, body: meWith("member") },
+      "/api/agents/agt_1": {
+        status: 200,
+        body: { agent: AGENT, connections: [CONNECTION] },
+      },
+      "/api/tests": [
+        { status: 200, body: { items: [onboardingTest()], next_cursor: null } },
+      ],
+    });
+    render(<AgentOnboardingPage />);
+
+    const progress = await screen.findByRole("navigation", {
+      name: "Agent setup",
+    });
+    const bar = within(progress).getByRole("progressbar", {
+      name: "Agent setup progress",
+    });
+    expect(bar.getAttribute("aria-valuenow")).toBe("2");
+    expect(bar.getAttribute("aria-valuetext")).toBe("2 of 3 stages finished");
+
+    const connection = within(progress).getByText("Connection");
+    expect(connection.getAttribute("data-complete")).toBe("true");
+    expect(within(progress).queryByText("Skipped")).toBeNull();
+  });
+
   it("attaches selected existing tests through each test's applicability revision", async () => {
     routed.pathname = "/projects/prj_1/agents/agt_1/onboarding";
     const test = onboardingTest();

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -803,20 +803,26 @@ describe("onboarding an agent", () => {
   });
 
   /**
-   * "Skip connection for now", and the bar that has to tell the truth about it.
+   * An agent with no connection, and the bar that has to tell the truth about
+   * it without guessing how it got that way.
    *
    * Being behind the current stage is not the same as being finished. Somebody
-   * who skipped the connection arrives on the tests page with two stages behind
-   * them and one of them not done, and an agent with no connection cannot run a
-   * simulation at all — so a bar reading "2 of 3 stages finished" would be
-   * telling them the setup was nearly complete when the part that makes it work
-   * had been passed over.
+   * reaches the tests page with two stages behind them and one of them not
+   * done, and an agent with no connection cannot run a simulation at all — so a
+   * bar reading "2 of 3 stages finished" would call the setup nearly complete
+   * when the part that makes it work is missing.
    *
-   * Both halves are asserted: the count, and the word beside the stage.
-   * `DESIGN.md` will not let a state rest on a mark and a colour, and it names
-   * skipped as its own state rather than a shade of complete.
+   * **The word is asserted as a state rather than an intention**, and that is
+   * the point of this test rather than an incidental detail. This page reads
+   * the active connections, so an empty list is both "Skip connection for now"
+   * and "connected once, archived it later". A word like "Skipped" is right for
+   * one of those people and wrong for the other, and nothing on this page can
+   * tell which one is reading it.
+   *
+   * Both halves are checked, because `DESIGN.md` will not let a state rest on a
+   * mark and a colour: the count, and the words beside the stage.
    */
-  it("says a skipped connection was skipped, and does not count it as finished", async () => {
+  it("says an agent with no connection needs one, without calling it a skip", async () => {
     routed.pathname = "/projects/prj_1/agents/agt_1/onboarding";
     apiAnswers({
       "/api/me": { status: 200, body: meWith("member") },
@@ -838,17 +844,22 @@ describe("onboarding an agent", () => {
     });
     expect(bar.getAttribute("aria-valuenow")).toBe("1");
     expect(bar.getAttribute("aria-valuetext")).toBe(
-      "1 of 3 stages finished, 1 skipped",
+      "1 of 3 stages finished, Connection not finished",
     );
 
     const connection = within(progress).getByText("Connection");
-    expect(connection.getAttribute("data-skipped")).toBe("true");
+    expect(connection.getAttribute("data-unfinished")).toBe("true");
     expect(connection.getAttribute("data-complete")).toBeNull();
-    expect(within(progress).getByText("Skipped")).toBeTruthy();
+    expect(within(progress).getByText("Needs a connection")).toBeTruthy();
+    /*
+     * The word this must never go back to. Both people who see this screen have
+     * the same empty list, and only one of them pressed Skip.
+     */
+    expect(within(progress).queryByText(/skipped/iu)).toBeNull();
   });
 
-  /** The same page with the connection actually made, so the count moves. */
-  it("counts a connection that was made, and says nothing about a skip", async () => {
+  /** The same page with a connection in place, so the count moves. */
+  it("counts a connection that is in place, and says nothing beside it", async () => {
     routed.pathname = "/projects/prj_1/agents/agt_1/onboarding";
     apiAnswers({
       "/api/me": { status: 200, body: meWith("member") },
@@ -873,7 +884,8 @@ describe("onboarding an agent", () => {
 
     const connection = within(progress).getByText("Connection");
     expect(connection.getAttribute("data-complete")).toBe("true");
-    expect(within(progress).queryByText("Skipped")).toBeNull();
+    expect(connection.getAttribute("data-unfinished")).toBeNull();
+    expect(within(progress).queryByText("Needs a connection")).toBeNull();
   });
 
   it("attaches selected existing tests through each test's applicability revision", async () => {

--- a/apps/web/test/design-system.test.tsx
+++ b/apps/web/test/design-system.test.tsx
@@ -11,6 +11,23 @@ vi.mock("next/navigation", () => ({
 
 beforeEach(() => {
   vi.stubGlobal("scrollTo", vi.fn());
+  /*
+   * Radix measures a tooltip's arrow with `ResizeObserver`, which jsdom does
+   * not implement, and it does the measuring only once the tooltip is open —
+   * so this is needed by the one test that opens one rather than by the render.
+   *
+   * A stub rather than a polyfill: nothing here asserts a measurement, and a
+   * real implementation would only add a way for these tests to depend on
+   * layout jsdom does not compute.
+   */
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
 });
 
 afterEach(() => {
@@ -208,5 +225,130 @@ describe("the development design proof", () => {
     const panel = dialog.firstElementChild as HTMLElement;
     fireEvent.transitionEnd(panel, { propertyName: "opacity" });
     expect(screen.queryByRole("dialog", { name: "Archive Support agent?" })).toBeNull();
+  });
+
+  /**
+   * The primitives the kit gained, on the one surface that draws them.
+   *
+   * They are asserted through what a reader is actually given — the selected
+   * tab and the panel it names, the chosen option, the value a progress bar
+   * announces — rather than through class names. jsdom loads no stylesheet, so
+   * a class assertion here would prove the string and not the behaviour, and
+   * the behaviour is the half these six were added for.
+   */
+  it("proves the tab set, the single choice, and the skeleton the kit gained", () => {
+    render(<DesignSystemProof />);
+
+    /*
+     * One set, one panel. Two tab sets are drawn, so both panels are counted:
+     * a `getByRole` that happened to find one would pass just as well if the
+     * other had quietly stopped rendering.
+     */
+    expect(screen.getAllByRole("tabpanel")).toHaveLength(2);
+    const simulations = screen.getByRole("tab", { name: "Simulations" });
+    expect(simulations.getAttribute("aria-selected")).toBe("true");
+    expect(
+      screen.getByText(/Ten simulations ran/u),
+    ).toBeTruthy();
+
+    /*
+     * Radix switches a tab on `mousedown` rather than on `click`, which is the
+     * detail a test written against the wrong event passes without ever
+     * changing a panel.
+     */
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Graders" }), {
+      button: 0,
+    });
+    expect(simulations.getAttribute("aria-selected")).toBe("false");
+    expect(screen.getByText(/Both were frozen when it started/u)).toBeTruthy();
+    expect(screen.queryByText(/Ten simulations ran/u)).toBeNull();
+
+    /* The other set is the `line` variant, and it is a separate set. */
+    expect(screen.getByRole("tab", { name: "Transcript" }).getAttribute("aria-selected")).toBe("true");
+
+    /* One answer out of the set, and the page says which one it heard. */
+    const fresh = screen.getByRole("radio", {
+      name: "A new persona for each simulation",
+    });
+    expect(fresh.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(fresh);
+    expect(fresh.getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByText("Chosen: a new persona")).toBeTruthy();
+
+    /*
+     * A skeleton is a shape and nothing else, so the word has to be beside it.
+     * `DESIGN.md` asks a loading state to say what is happening, and the shapes
+     * themselves are hidden from assistive technology precisely because they
+     * say nothing.
+     */
+    const loading = screen.getByText("Loading graders…");
+    expect(loading.parentElement?.getAttribute("aria-busy")).toBe("true");
+  });
+
+  /**
+   * The progress bar's three states, and the one it is easiest to get wrong.
+   *
+   * A value on its way up, a value that has arrived, and no value at all. The
+   * last is the state a happy example always skips: an indeterminate bar must
+   * not report a number, because "amount unknown" and "nothing done yet" are
+   * different claims and only one of them is true.
+   */
+  it("proves the progress bar counting, complete, and indeterminate", () => {
+    render(<DesignSystemProof />);
+
+    const running = screen.getByRole("progressbar", {
+      name: "Simulations judged",
+    });
+    expect(running.getAttribute("aria-valuenow")).toBe("7");
+    expect(running.getAttribute("aria-valuemax")).toBe("10");
+    expect(running.getAttribute("aria-valuetext")).toBe(
+      "7 of 10 simulations judged",
+    );
+    expect(running.getAttribute("data-state")).toBe("loading");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Judge one more simulation" }),
+    );
+    expect(running.getAttribute("aria-valuenow")).toBe("8");
+    expect(screen.getByText("8 of 10 simulations judged")).toBeTruthy();
+
+    const complete = screen.getByRole("progressbar", { name: "Transcripts collected" });
+    expect(complete.getAttribute("data-state")).toBe("complete");
+
+    const unknown = screen.getByRole("progressbar", {
+      name: "Recording being prepared",
+    });
+    expect(unknown.getAttribute("data-state")).toBe("indeterminate");
+    /* No number claimed, and no fill drawn either. */
+    expect(unknown.getAttribute("aria-valuenow")).toBeNull();
+    expect(
+      unknown
+        .querySelector("[data-slot='progress-indicator']")
+        ?.getAttribute("style"),
+    ).toContain("translateX(-100%)");
+  });
+
+  /**
+   * The two arrivals: a tooltip attached to one control, and a notification.
+   *
+   * Both are proved on the kit primitives rather than on the shared components
+   * above them, because the shared ones are already covered by the feedback
+   * tests and these two have no other caller yet.
+   */
+  it("opens the base tooltip and the base toast", async () => {
+    render(<DesignSystemProof />);
+
+    const trigger = screen.getByRole("button", {
+      name: "What a frozen grader means",
+    });
+    fireEvent.focus(trigger);
+    expect(
+      (await screen.findByText(/editing the grader never changes a verdict/u)),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show a saved notification" }),
+    );
+    expect(await screen.findByText("Grader saved")).toBeTruthy();
   });
 });

--- a/apps/web/test/design-system.test.tsx
+++ b/apps/web/test/design-system.test.tsx
@@ -266,6 +266,19 @@ describe("the development design proof", () => {
     /* The other set is the `line` variant, and it is a separate set. */
     expect(screen.getByRole("tab", { name: "Transcript" }).getAttribute("aria-selected")).toBe("true");
 
+    /*
+     * The group's question is on the page, not only in an `aria-label`.
+     * `DESIGN.md` keeps labels visible, so the element a reader can see is the
+     * same one that names the group — asserted as one fact rather than two, so
+     * the wiring cannot drift away from the words.
+     */
+    const group = screen.getByRole("radiogroup", {
+      name: "What a repeated run reuses",
+    });
+    expect(group.getAttribute("aria-labelledby")).toBe(
+      screen.getByText("What a repeated run reuses").id,
+    );
+
     /* One answer out of the set, and the page says which one it heard. */
     const fresh = screen.getByRole("radio", {
       name: "A new persona for each simulation",

--- a/apps/web/test/trust-gate.test.tsx
+++ b/apps/web/test/trust-gate.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TrustGate } from "../app/trust-gate.tsx";
+
+/**
+ * The brand field on the auth pages, under reduced motion.
+ *
+ * `auth-controls.test.tsx` mocks this component away, which is right for a test
+ * about sign-in controls and is also why the defect below survived: nothing
+ * mounted the real one.
+ *
+ * Under reduced motion the canvas loop draws a single frame and stops, which is
+ * the whole point of it. Two things afterwards invalidate what is on the canvas,
+ * and neither used to repaint it:
+ *
+ * - **A resize clears the canvas.** Assigning `canvas.width` is defined to reset
+ *   the drawing surface, so the field went blank and stayed blank until a
+ *   reload.
+ * - **A theme change re-reads the ink** and left the old colour standing.
+ *
+ * Both were invisible in normal motion, where the next animation frame covered
+ * them a moment later — so both need a test that pins the reduced-motion path
+ * specifically.
+ */
+
+/** Every 2D call this component makes, with a count of the frames drawn. */
+function fakeContext() {
+  return {
+    frames: 0,
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    globalAlpha: 1,
+    /* `draw` opens with this, so counting it counts frames. */
+    clearRect() {
+      this.frames += 1;
+    },
+    setTransform() {},
+    beginPath() {},
+    arc() {},
+    stroke() {},
+    fill() {},
+    moveTo() {},
+    lineTo() {},
+  };
+}
+
+type Captured = {
+  context: ReturnType<typeof fakeContext>;
+  resize: () => void;
+  theme: () => void;
+};
+
+function mountReducedMotion(): Captured {
+  const context = fakeContext();
+  const captured: { resize?: () => void; theme?: () => void } = {};
+
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    context as unknown as CanvasRenderingContext2D,
+  );
+  /* A real size, so the component builds a real field of dots. */
+  vi.spyOn(HTMLCanvasElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: 800,
+    height: 400,
+    top: 0,
+    left: 0,
+    right: 800,
+    bottom: 400,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+
+  vi.stubGlobal(
+    "matchMedia",
+    /* The preference under test. Everything here hangs off it. */
+    () => ({ matches: true, addEventListener() {}, removeEventListener() {} }),
+  );
+  vi.stubGlobal("devicePixelRatio", 1);
+  /*
+   * Synchronous, so the one frame the component asks for at mount has been
+   * drawn by the time `render` returns. Under reduced motion `draw` never asks
+   * for another, so this cannot recurse.
+   */
+  vi.stubGlobal("requestAnimationFrame", (run: (time: number) => void) => {
+    run(0);
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: () => void) {
+        captured.resize = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  vi.stubGlobal(
+    "MutationObserver",
+    class {
+      constructor(callback: () => void) {
+        captured.theme = callback;
+      }
+      observe() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    },
+  );
+
+  render(<TrustGate />);
+
+  if (captured.resize === undefined || captured.theme === undefined) {
+    throw new Error("TrustGate did not observe size or theme");
+  }
+  return { context, resize: captured.resize, theme: captured.theme };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("the trust field under reduced motion", () => {
+  it("draws its one frame and then stops", () => {
+    const { context } = mountReducedMotion();
+
+    /*
+     * More than none, because a reduced-motion field is still a field. The
+     * exact count is not asserted: `resize` paints as well as the first frame,
+     * and pinning the number would make this a test about call order.
+     */
+    expect(context.frames).toBeGreaterThan(0);
+  });
+
+  /**
+   * The regression: `still()` dropped from `resize`.
+   *
+   * Setting `canvas.width` in `resize` wipes the surface. With no repaint after
+   * it, the reduced-motion field is gone until the page is loaded again.
+   */
+  it("repaints after a resize, because the resize cleared the canvas", () => {
+    const { context, resize } = mountReducedMotion();
+    const before = context.frames;
+
+    resize();
+
+    expect(context.frames).toBeGreaterThan(before);
+  });
+
+  /**
+   * The regression: `still()` dropped from the theme observer.
+   *
+   * The observer re-reads the ink off the element. Without a repaint the new
+   * colour is held and never used, so the field stays in the old theme's ink.
+   */
+  it("repaints after the theme changes, so the new ink is actually used", () => {
+    const { context, theme } = mountReducedMotion();
+    const before = context.frames;
+
+    theme();
+
+    expect(context.frames).toBeGreaterThan(before);
+  });
+});


### PR DESCRIPTION
Ticket 25 of the shadcn-primitives effort: move the screen components onto the kit primitives, and prove the primitives the kit gained.

## What changed

**`components/ui/progress.tsx` — restyled (the one kit file this ticket owns).**
`DESIGN.md` gives this component one line: "Progress: explain completion — transform-based fill, linear while active." The registry's version kept only the first half. It filled on `transition-all`, which this product forbids outright, with the default decelerating easing, which says the work is slowing down when it is not. It is now a neutral `--surface-soft` track, an ink fill, the chip radius, a `translateX` inside a clipping track, 200ms linear while `data-state="loading"`, `--ease-out` only on `complete`, and `motion-reduce:transition-none`.

Its look is deliberately `RunProgress`'s look. `ui/run-status.tsx` already draws this product's progress bar, so a later ticket moving it onto this primitive should be deleting code rather than redrawing a bar.

**It also honours `max`, which the registry version drops — and that was a live defect.** Radix reads `max` for `aria-valuemax` and `data-state`, but the shipped indicator computes `100 - value`. A bar counting three onboarding stages announced "1 of 3 stages finished" and was drawn one percent full. Agent onboarding is the first caller, so that is exactly where it would have shipped.

**`agents/onboarding-progress.tsx` — on the kit `Progress`.** The stage list stays, because `DESIGN.md` asks a state for a word as well as a shape. The bar adds the measure the list never had. It counts stages *finished*, so it reads 0 of 3 on the first page and 2 of 3 on the last, and never reaches 3 — a bar that filled completely on a page still asking for something would be claiming the work was done. `getValueLabel` says "1 of 3 stages finished" rather than "33%", because a percentage is the wrong unit for three named stages.

**`app/trust-gate.tsx` — the reduced-motion frame it was missing.** Under reduced motion the canvas loop draws one frame and stops, which is the point of it. Two things afterwards invalidated the canvas with nothing to repaint it: setting `canvas.width` on a resize *clears* the canvas, so a window resize left the brand field blank until a reload; and the theme observer re-read the ink without redrawing, so a light-to-dark switch left the old colour standing. Both were invisible in normal motion, where the next animation frame covered them a moment later.

**`app/design-system/` — proof sections for all six primitives**, in one wide panel: tabs (both the `default` and `line` variants, with real panels), single choice, progress (counting, complete, and indeterminate), tooltip, toast, and skeleton. `Label` and `Separator` — the other two the kit gained — are proven by being used where they belong rather than given a ceremony of their own.

## Two of the four screens are reported rather than changed

**`monitoring/page.tsx` hand-rolls nothing.** It is a 25-line redirect to the transcript list, with no controls to compose. The real monitoring screen is `monitoring/transcripts/page.tsx` (636 lines), which is outside this ticket's ownership fence. If the ticket meant that file, it needs re-scoping rather than a quiet edit.

**The graders strip keeps its links.** This is the one place this pull request does not do what the ticket says, and it is a deliberate call:

- The two grader views are **two addresses**, not two panels. `role="tab"` promises a panel that updates in place; these load a new page.
- Radix's `TabsTrigger` always sets `aria-controls` at a panel id, and only the selected value has a panel. The inactive tab would ship an `aria-controls` pointing at nothing.
- A tab list is a **roving tab order**: one Tab step reaches the set, so the view that is not current leaves the tab order entirely. With automatic activation, an arrow key would then navigate the whole page.
- As buttons the links lose middle-click, copy-link, and prefetch. `presentation.ts` and `tabs.tsx` are both emphatic that every grader address carries its project, so the addresses are load-bearing here.

`DESIGN.md` says "Menus, tabs, dialogs, tables, and forms keep correct semantics." A navigation of links marked `aria-current="page"` is the correct semantics for this, and it is what the strip already does. A real tab set is proven on the design-system page instead, and the reason is written on that page beside it. **No styling was fought with override classes**, so ticket 24's restyle of `components/ui/tabs.tsx` lands on a clean surface.

## What was proven

- **Typecheck**: `apps/web` clean.
- **Repo lint**: clean.
- **Scoped tests**: 157 passed across `design-system`, `agents-pages`, `graders-pages`, `auth-controls`, `components`, `monitoring`. New assertions cover the `max` fix (the drawn share against the announced one), the three progress states, tab switching on Radix's `mousedown`, the single choice, and the skeleton's word.
- **Both themes, in a browser**, at 1440x900:
  - Design-system panel: all six sections in light and dark.
  - Progress computed styles read back off the element — track `#f3f3f3` / `#222220`, fill `#1f1f1f` / `#f2f2ed`, radius `9999px`, `transition-property: transform` (never `all`), `0.2s`, `linear` while loading and `cubic-bezier(0.23, 1, 0.32, 1)` on complete.
  - Graders strip: 44px targets, a 2px `#ff5229` rule under the current tab, correct in both themes (regression check — unchanged by this branch).

## What is not proven

- **The onboarding page itself was not opened in a browser.** It needs an agent and a live API, and the local stack is not running; starting compose from a worktree recreates the shared stores on the wrong ports. Its only visual change is the kit `Progress`, which *is* browser-proven in both themes on the design-system page, and its values are asserted in `agents-pages.test.tsx`.
- **Reduced motion is class-verified, not browser-verified.** `motion-reduce:transition-none` is on the indicator and `globals.css` caps every animation under that query; neither was exercised with the preference actually set.
- **The `trust-gate.tsx` fix has no test.** `auth-controls.test.tsx` mocks `TrustGate` out, and the defect is a canvas repaint after a `ResizeObserver` or `MutationObserver` fires — jsdom implements neither usefully.
- **200ms on the progress fill is not a `DESIGN.md` motion token.** It matches the duration `ui/run-status.tsx` already uses, for the reason written there: the tokens name interface motion, and this is a value catching up to a value. It is under the 300ms ceiling. Flagged for the developer to overrule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789842898&installation_model_id=431960&pr_number=166&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F166&signature=0804c9dd014938b4ed04661093c4f67849a51244a959807e710e8716949fb5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves agent onboarding progress onto the shared progress primitive, corrects proportional rendering for non-100 maxima, and adds reduced-motion canvas repainting.
- Adds proof surfaces and behavioral tests for the newly introduced UI primitives.
- Represents a missing active connection as unfinished without incorrectly claiming that the user skipped it.
- Repaints the static trust-gate canvas after resize and theme changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/page.tsx | Uses the active connection state to describe the connection stage neutrally, addressing the archived-connection misclassification. |
| apps/web/app/projects/[projectId]/agents/onboarding-progress.tsx | Adds shared progress rendering and supports caller-provided unfinished-stage labels without treating every prior stage as complete. |
| apps/web/components/ui/progress.tsx | Restyles the primitive and computes its visual fill against the supplied maximum. |
| apps/web/app/trust-gate.tsx | Repaints the reduced-motion canvas when resizing or changing themes. |
| apps/web/app/design-system/proof.tsx | Adds interactive proof sections for tabs, radio choice, progress, tooltip, toast, and skeleton primitives. |
| apps/web/test/agents-pages.test.tsx | Covers proportional onboarding progress and both connected and missing-connection states. |
| apps/web/test/trust-gate.test.tsx | Covers reduced-motion initial drawing, resize repainting, and theme-change repainting. |

<sub>Reviews (3): Last reviewed commit: ["fix(web): say what the connection stage ..."](https://github.com/egma-ai/egma/commit/d6512b8aea8e7adbabe2a49388b2ccba1e8b8348) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55275203)</sub>

**Context used:**

- Knowledge Base — [Egma web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->