### PR TITLE
feat(web): give every wait a pulse, and every route change a state

### DIFF
--- a/apps/web/app/invite/loading.tsx
+++ b/apps/web/app/invite/loading.tsx
@@ -1,0 +1,35 @@
+import { StatePage } from "../ui.tsx";
+
+/**
+ * What the router draws between the press and
+ * `/invite` arriving.
+ *
+ * **This one is not a product page and must not borrow the product's frame.**
+ * An invitation is opened by somebody who is not signed in yet, so the page
+ * behind this boundary composes the access surface — `AuthShell` through
+ * `StatePage` — and never `ProductStatePage`, which would draw an organization
+ * switcher and product navigation for a person who has neither. The fallback
+ * follows the page it stands in for.
+ *
+ * **No indicator, deliberately.** The page's own waiting state is this exact
+ * header and nothing under it, so adding a card here would put one on screen
+ * for the length of the route change and take it away the moment the page
+ * mounted. Same words, same shape, nothing added that the page then removes.
+ *
+ * **Its reach is honestly small.** An invitation link is followed from an
+ * email, which is a cold document load rather than a route change, and this
+ * page reads nothing on the server — so nothing streams and this boundary
+ * usually never renders. It is here because the route can also be reached from
+ * inside the application, and because a data-fetching segment without a
+ * boundary is a hole whether or not it is a common one.
+ */
+export default function InviteLoading() {
+  return (
+    <div data-slot="route-loading">
+      <StatePage
+        title="Loading invitation"
+        lead="Checking the invitation link."
+      />
+    </div>
+  );
+}

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -1,0 +1,25 @@
+import { ProductStatePage } from "../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and
+ * `/` arriving.
+ *
+ * **No indicator, deliberately.** The entrance's own waiting state is this
+ * header and nothing under it, so a fallback that added a card would put one
+ * on screen for the length of the route change and take it away again the
+ * moment the page mounted — the shape-change every other file here exists to
+ * remove. What the boundary buys is that the entrance paints at once instead
+ * of the previous page being held.
+ *
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
+ */
+export default function EntranceLoading() {
+  return (
+    <div data-slot="route-loading">
+      <ProductStatePage title="Opening Egma" lead="Checking your session." />
+    </div>
+  );
+}

--- a/apps/web/app/members/loading.tsx
+++ b/apps/web/app/members/loading.tsx
@@ -1,0 +1,24 @@
+import { ProductStatePage } from "../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and
+ * `/members` arriving.
+ *
+ * A forwarding address, reached from the account menu. Its page waits with a
+ * header and nothing under it, so this is that header — same words, same
+ * shape, nothing added that the page would then remove.
+ *
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
+ */
+export default function MembersLoading() {
+  return (
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow="Settings"
+        title="Opening organization settings"
+        lead="People and invitations moved into the product shell, beside the project selector." />
+    </div>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/[connectionId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/[connectionId]/loading.tsx
@@ -1,20 +1,39 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/agents/:agentId/connections/:connectionId` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/agents/:agentId/connections/:connectionId` arriving.
  *
  * How egma reaches an agent is the slowest read in this family — the
  * platform is asked about the target as well — so this is the boundary that
  * shows for longest, and the one that most needed to exist.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function ConnectionLoading() {
+  const { projectId, agentId } = useParams<{ projectId: string; agentId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Connection" title="Connection">
-      <Loading what="this connection" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Connection"
+        breadcrumbs={[
+          { label: "Agents", href: projectPath(projectId, "agents") },
+          { label: "Agent", href: projectPath(projectId, "agents", agentId) },
+          { label: "Connection" },
+        ]}
+      >
+        <Loading what="this connection" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/[connectionId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/[connectionId]/loading.tsx
@@ -1,0 +1,20 @@
+import { Loading } from "../../../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/agents/:agentId/connections/:connectionId` arriving.
+ *
+ * How egma reaches an agent is the slowest read in this family — the
+ * platform is asked about the target as well — so this is the boundary that
+ * shows for longest, and the one that most needed to exist.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function ConnectionLoading() {
+  return (
+    <ProductStatePage eyebrow="Connection" title="Connection">
+      <Loading what="this connection" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/loading.tsx
@@ -1,0 +1,21 @@
+import { Loading } from "../../../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/agents/:agentId/connections/new` arriving.
+ *
+ * The page titles itself **Connect the agent** when it is reached from
+ * setup and **Add a connection** otherwise. A fallback cannot read a query
+ * string, so it says the plain one: the wrong half of a choice is worse
+ * than the general word.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function NewConnectionLoading() {
+  return (
+    <ProductStatePage eyebrow="Connection" title="Add a connection">
+      <Loading what="this agent" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/connections/new/loading.tsx
@@ -1,21 +1,44 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/agents/:agentId/connections/new` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/agents/:agentId/connections/new` arriving.
  *
- * The page titles itself **Connect the agent** when it is reached from
- * setup and **Add a connection** otherwise. A fallback cannot read a query
- * string, so it says the plain one: the wrong half of a choice is worse
- * than the general word.
+ * **The title is the one word that is true on both ways in.** The page calls
+ * itself **Connect the agent** when it is reached from agent setup, which is
+ * the common path — registering an agent forwards straight into it — and
+ * **Add a connection** when it is reached from the agent later. A fallback
+ * cannot read a query string, so guessing would put the wrong half of that
+ * either/or on screen for whichever way in it guessed against. **New
+ * connection** is the page's own last crumb and is true on both, and the
+ * crumbs themselves do not differ between the two paths at all.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function NewConnectionLoading() {
+  const { projectId, agentId } = useParams<{ projectId: string; agentId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Connection" title="Add a connection">
-      <Loading what="this agent" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="New connection"
+        breadcrumbs={[
+          { label: "Agents", href: projectPath(projectId, "agents") },
+          { label: "Agent", href: projectPath(projectId, "agents", agentId) },
+          { label: "New connection" },
+        ]}
+      >
+        <Loading what="this agent" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/loading.tsx
@@ -1,20 +1,38 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/agents/:agentId` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/agents/:agentId` arriving.
  *
- * The title is the word rather than the agent's name, because the name is
- * in the answer that has not arrived. The page says the same word in its own
- * loading branch, so nothing is renamed twice on the way in.
+ * The last crumb is the word rather than the agent's name, because the name
+ * is in the answer that has not arrived. The page says the same word in its
+ * own loading branch, so nothing is renamed twice on the way in.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function AgentLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Agent" title="Agent">
-      <Loading what="this agent" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Agent"
+        breadcrumbs={[
+          { label: "Agents", href: projectPath(projectId, "agents") },
+          { label: "Agent" },
+        ]}
+      >
+        <Loading what="this agent" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/loading.tsx
@@ -1,0 +1,20 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/agents/:agentId` arriving.
+ *
+ * The title is the word rather than the agent's name, because the name is
+ * in the answer that has not arrived. The page says the same word in its own
+ * loading branch, so nothing is renamed twice on the way in.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function AgentLoading() {
+  return (
+    <ProductStatePage eyebrow="Agent" title="Agent">
+      <Loading what="this agent" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/agents/:agentId/onboarding` arriving.
+ *
+ * Setup is a sequence somebody is walked through, so the step's own title
+ * lands immediately and only the agent it is about is waited for.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function AgentOnboardingLoading() {
+  return (
+    <ProductStatePage eyebrow="Agent setup" title="Attach tests">
+      <Loading what="this agent" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/onboarding/loading.tsx
@@ -1,19 +1,40 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/agents/:agentId/onboarding` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/agents/:agentId/onboarding` arriving.
  *
  * Setup is a sequence somebody is walked through, so the step's own title
- * lands immediately and only the agent it is about is waited for.
+ * lands immediately and only the agent it is about is waited for. The middle
+ * crumb is the agent's name once the page has it and the word until then,
+ * which is exactly what the page itself shows while it waits.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function AgentOnboardingLoading() {
+  const { projectId, agentId } = useParams<{ projectId: string; agentId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Agent setup" title="Attach tests">
-      <Loading what="this agent" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Attach tests"
+        breadcrumbs={[
+          { label: "Agents", href: projectPath(projectId, "agents") },
+          { label: "Agent", href: projectPath(projectId, "agents", agentId) },
+          { label: "Attach tests" },
+        ]}
+      >
+        <Loading what="this agent" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/loading.tsx
@@ -1,0 +1,39 @@
+import { Loading } from "../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between pressing **Agents** and this page arriving.
+ *
+ * **This file, and the two dozen beside it, exist because the transition had
+ * no state at all.** Without a `loading.tsx` the App Router has nowhere to put
+ * a pending route, so it holds the *previous* page on screen until the next
+ * one is ready: press a navigation item on a slow connection and nothing
+ * happens, for as long as it takes. That is the one state `DESIGN.md` will not
+ * allow — "make every state truthful" — and it is also the state a person
+ * reads as a broken application.
+ *
+ * The boundary earns its place twice over. `<Link>` prefetches a dynamic route
+ * only as far as its nearest loading boundary, so adding one is also what lets
+ * the router answer the press from cache.
+ *
+ * **The frame is here and the data is not, which is the whole point.** The
+ * sidebar never moves — it belongs to `ProductShellBoundary` in the root
+ * layout, above every route — and this adds the page's own title on top of it,
+ * so a press is answered by arriving somewhere named rather than by a bare
+ * indicator floating in an empty column. The words are the page's own: the
+ * eyebrow, the title and what is being waited for are copied from
+ * `agents/page.tsx`, so the fallback and the page it stands in for cannot
+ * disagree about where somebody is.
+ *
+ * What it deliberately does not carry is the page's toolbar and controls,
+ * which it cannot know before the page mounts. So the header lands first and
+ * the rest fills in under it. That is progressive arrival rather than a jump,
+ * and it is the honest limit of a fallback that has not seen the data.
+ */
+export default function AgentsLoading() {
+  return (
+    <ProductStatePage eyebrow="Project" title="Agents">
+      <Loading what="agents" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/agents/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/loading.tsx
@@ -18,22 +18,29 @@ import { ProductStatePage } from "../../../../ui/shell.tsx";
  *
  * **The frame is here and the data is not, which is the whole point.** The
  * sidebar never moves — it belongs to `ProductShellBoundary` in the root
- * layout, above every route — and this adds the page's own title on top of it,
- * so a press is answered by arriving somewhere named rather than by a bare
- * indicator floating in an empty column. The words are the page's own: the
- * eyebrow, the title and what is being waited for are copied from
- * `agents/page.tsx`, so the fallback and the page it stands in for cannot
- * disagree about where somebody is.
+ * layout, above every route — and this adds the page's own header on top of
+ * it, so a press is answered by arriving somewhere named rather than by a bare
+ * indicator floating in an empty column. Every word is the page's own: the
+ * eyebrow or breadcrumbs, the title and what is being waited for are copied
+ * from the page this stands in for, **including the header's shape**, because
+ * an eyebrow that becomes a breadcrumb row on arrival is a header that moves.
  *
- * What it deliberately does not carry is the page's toolbar and controls,
- * which it cannot know before the page mounts. So the header lands first and
- * the rest fills in under it. That is progressive arrival rather than a jump,
- * and it is the honest limit of a fallback that has not seen the data.
+ * What a fallback cannot carry is the page's toolbar, its controls, or a
+ * second navigation column, none of which it can know before the page mounts.
+ * So the header lands first and the rest fills in under it. That is
+ * progressive arrival rather than a jump, and it is the honest limit of a
+ * fallback that has not seen the data.
+ *
+ * The whole composition arrives as one thing, after a wait, and neither is
+ * written here: `tailwind-theme.css` keys both to the `route-loading` slot
+ * below.
  */
 export default function AgentsLoading() {
   return (
-    <ProductStatePage eyebrow="Project" title="Agents">
-      <Loading what="agents" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow="Project" title="Agents">
+        <Loading what="agents" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/new/loading.tsx
@@ -1,20 +1,38 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/agents/new` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/agents/new` arriving.
  *
  * This page reads nothing of its own — it is an empty form — and it still
  * needs a boundary. Without one it would inherit the list's, and somebody
  * pressing **Register an agent** would be told egma was loading agents.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function NewAgentLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Agents" title="Register an agent">
-      <Loading what="the agent form" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Register an agent"
+        breadcrumbs={[
+          { label: "Agents", href: projectPath(projectId, "agents") },
+          { label: "New agent" },
+        ]}
+      >
+        <Loading what="the agent form" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/agents/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/agents/new/loading.tsx
@@ -1,0 +1,20 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/agents/new` arriving.
+ *
+ * This page reads nothing of its own — it is an empty form — and it still
+ * needs a boundary. Without one it would inherit the list's, and somebody
+ * pressing **Register an agent** would be told egma was loading agents.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function NewAgentLoading() {
+  return (
+    <ProductStatePage eyebrow="Agents" title="Register an agent">
+      <Loading what="the agent form" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/graders/loading.tsx
+++ b/apps/web/app/projects/[projectId]/graders/loading.tsx
@@ -1,0 +1,20 @@
+import { LIBRARY } from "../../../../lib/grader-library-copy.ts";
+import { Loading } from "../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/graders` arriving.
+ *
+ * The words come from the copy module the page reads, not from a second
+ * copy of them here. Two places to rename **Graders** is one too many.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function GradersLoading() {
+  return (
+    <ProductStatePage eyebrow="Project" title={LIBRARY.title}>
+      <Loading what={LIBRARY.loading} />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/graders/loading.tsx
+++ b/apps/web/app/projects/[projectId]/graders/loading.tsx
@@ -3,18 +3,23 @@ import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/graders` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/graders` arriving.
  *
- * The words come from the copy module the page reads, not from a second
- * copy of them here. Two places to rename **Graders** is one too many.
+ * The words come from the copy module the page reads, not from a second copy
+ * of them here. Two places to rename **Graders** is one too many.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function GradersLoading() {
   return (
-    <ProductStatePage eyebrow="Project" title={LIBRARY.title}>
-      <Loading what={LIBRARY.loading} />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow="Project" title={LIBRARY.title}>
+        <Loading what={LIBRARY.loading} />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/graders/running/loading.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/loading.tsx
@@ -1,21 +1,41 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { RUNNING } from "../../../../../lib/grader-running-copy.ts";
+import { GRADERS_SECTION } from "../../../../../lib/graders.ts";
+import { GRADER_VIEW_LABELS } from "../../../../../lib/presentation.ts";
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
-import { RUNNING } from "../../../../../lib/grader-running-copy.ts";
 
 /**
- * What the router draws between the press and `/projects/:projectId/graders/running` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/graders/running` arriving.
  *
- * The graders tab strip is a page rather than a tab panel, so moving
- * between **Library** and **Running** is a route change and needs its own
- * boundary to stay instant.
+ * The graders tab strip is a page rather than a tab panel, so moving between
+ * **Library** and **Running** is a route change and needs its own boundary to
+ * stay instant. Every word here is read from the same modules the page reads.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function RunningGradersLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Project" title={RUNNING.title}>
-      <Loading what={RUNNING.loading} />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title={RUNNING.title}
+        breadcrumbs={[
+          { label: "Graders", href: projectPath(projectId, GRADERS_SECTION) },
+          { label: GRADER_VIEW_LABELS.running },
+        ]}
+      >
+        <Loading what={RUNNING.loading} />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/graders/running/loading.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/loading.tsx
@@ -1,0 +1,21 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+import { RUNNING } from "../../../../../lib/grader-running-copy.ts";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/graders/running` arriving.
+ *
+ * The graders tab strip is a page rather than a tab panel, so moving
+ * between **Library** and **Running** is a route change and needs its own
+ * boundary to stay instant.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function RunningGradersLoading() {
+  return (
+    <ProductStatePage eyebrow="Project" title={RUNNING.title}>
+      <Loading what={RUNNING.loading} />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/loading.tsx
@@ -1,21 +1,39 @@
-import { DETAIL } from "../../../../../../lib/transcript-copy.ts";
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { DETAIL, LIST } from "../../../../../../lib/transcript-copy.ts";
+import { transcriptsPath } from "../../../../../../lib/transcripts.ts";
 import { Loading } from "../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/monitoring/transcripts/:transcriptId` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/monitoring/transcripts/:transcriptId` arriving.
  *
  * `DETAIL.loading` is the string “Loading…”, which is the sentence this
  * component exists to replace, so the subject is named here instead. The
- * title is still the copy module's.
+ * title and the crumbs are still the copy module's.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function TranscriptLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage title={DETAIL.title}>
-      <Loading what="this transcript" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title={DETAIL.title}
+        breadcrumbs={[
+          { label: LIST.title, href: transcriptsPath(projectId) },
+          { label: DETAIL.title },
+        ]}
+      >
+        <Loading what="this transcript" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/loading.tsx
@@ -1,0 +1,21 @@
+import { DETAIL } from "../../../../../../lib/transcript-copy.ts";
+import { Loading } from "../../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/monitoring/transcripts/:transcriptId` arriving.
+ *
+ * `DETAIL.loading` is the string “Loading…”, which is the sentence this
+ * component exists to replace, so the subject is named here instead. The
+ * title is still the copy module's.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function TranscriptLoading() {
+  return (
+    <ProductStatePage title={DETAIL.title}>
+      <Loading what="this transcript" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
@@ -1,0 +1,21 @@
+import { LIST } from "../../../../../lib/transcript-copy.ts";
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/monitoring/transcripts` arriving.
+ *
+ * Monitoring reads production traffic over a time window, so it is slow
+ * by nature and the sidebar points straight here rather than at the
+ * forwarding address above it.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function TranscriptsLoading() {
+  return (
+    <ProductStatePage eyebrow={LIST.eyebrow} title={LIST.title}>
+      <Loading what={LIST.loadingWhat} />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
@@ -3,19 +3,24 @@ import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/monitoring/transcripts` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/monitoring/transcripts` arriving.
  *
- * Monitoring reads production traffic over a time window, so it is slow
- * by nature and the sidebar points straight here rather than at the
- * forwarding address above it.
+ * Monitoring reads production traffic over a time window, so it is slow by
+ * nature and the sidebar points straight here rather than at the forwarding
+ * address above it.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function TranscriptsLoading() {
   return (
-    <ProductStatePage eyebrow={LIST.eyebrow} title={LIST.title}>
-      <Loading what={LIST.loadingWhat} />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow={LIST.eyebrow} title={LIST.title}>
+        <Loading what={LIST.loadingWhat} />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/personas/[personaId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/personas/[personaId]/loading.tsx
@@ -1,19 +1,38 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/personas/:personaId` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/personas/:personaId` arriving.
  *
- * No eyebrow: this page titles itself with the persona's name and carries
- * breadcrumbs instead, and a fallback knows neither.
+ * The page titles itself with the persona's name once it has one and with
+ * the word until then; this is the second half of that, which is the half a
+ * fallback can honestly say.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function PersonaLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage title="Persona">
-      <Loading what="this persona" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Persona"
+        breadcrumbs={[
+          { label: "Personas", href: projectPath(projectId, "personas") },
+          { label: "Persona" },
+        ]}
+      >
+        <Loading what="this persona" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/personas/[personaId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/personas/[personaId]/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/personas/:personaId` arriving.
+ *
+ * No eyebrow: this page titles itself with the persona's name and carries
+ * breadcrumbs instead, and a fallback knows neither.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function PersonaLoading() {
+  return (
+    <ProductStatePage title="Persona">
+      <Loading what="this persona" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/personas/loading.tsx
+++ b/apps/web/app/projects/[projectId]/personas/loading.tsx
@@ -1,0 +1,18 @@
+import { Loading } from "../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/personas` arriving.
+ *
+ * A sidebar destination.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function PersonasLoading() {
+  return (
+    <ProductStatePage eyebrow="Project" title="Personas">
+      <Loading what="personas" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/personas/loading.tsx
+++ b/apps/web/app/projects/[projectId]/personas/loading.tsx
@@ -2,17 +2,22 @@ import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/personas` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/personas` arriving.
  *
  * A sidebar destination.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function PersonasLoading() {
   return (
-    <ProductStatePage eyebrow="Project" title="Personas">
-      <Loading what="personas" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow="Project" title="Personas">
+        <Loading what="personas" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/personas/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/personas/new/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/personas/new` arriving.
+ *
+ * The form cannot be drawn until egma says which models a persona may
+ * speak with, so that read is what it names.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function NewPersonaLoading() {
+  return (
+    <ProductStatePage eyebrow="Personas" title="New persona">
+      <Loading what="the supported persona models" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/personas/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/personas/new/loading.tsx
@@ -1,19 +1,37 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/personas/new` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/personas/new` arriving.
  *
- * The form cannot be drawn until egma says which models a persona may
- * speak with, so that read is what it names.
+ * The form cannot be drawn until egma says which models a persona may speak
+ * with, so that read is what it names.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function NewPersonaLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Personas" title="New persona">
-      <Loading what="the supported persona models" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="New persona"
+        breadcrumbs={[
+          { label: "Personas", href: projectPath(projectId, "personas") },
+          { label: "New persona" },
+        ]}
+      >
+        <Loading what="the supported persona models" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/runs/[runId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/loading.tsx
@@ -1,0 +1,20 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/runs/:runId` arriving.
+ *
+ * A run is opened while it is still moving, often repeatedly. The wait is
+ * short and the flash it would otherwise make is exactly what the
+ * indicator's entrance delay is for.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function RunLoading() {
+  return (
+    <ProductStatePage eyebrow="Simulation runs" title="Run">
+      <Loading what="this run" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/runs/[runId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/loading.tsx
@@ -1,20 +1,38 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/runs/:runId` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/runs/:runId` arriving.
  *
  * A run is opened while it is still moving, often repeatedly. The wait is
- * short and the flash it would otherwise make is exactly what the
- * indicator's entrance delay is for.
+ * short and the flash it would otherwise make is exactly what the entrance
+ * delay in the theme is for.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function RunLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Simulation runs" title="Run">
-      <Loading what="this run" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Run"
+        breadcrumbs={[
+          { label: "Runs", href: projectPath(projectId, "runs") },
+          { label: "Run" },
+        ]}
+      >
+        <Loading what="this run" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/loading.tsx
@@ -1,0 +1,20 @@
+import { Loading } from "../../../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/runs/:runId/simulations/:simulationId` arriving.
+ *
+ * One simulation carries its transcript, its judgements and its evidence,
+ * which is the heaviest read in the product and the longest a person waits
+ * anywhere in it.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function SimulationLoading() {
+  return (
+    <ProductStatePage eyebrow="Simulation runs" title="Simulation">
+      <Loading what="this simulation" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/simulations/[simulationId]/loading.tsx
@@ -1,20 +1,39 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/runs/:runId/simulations/:simulationId` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/runs/:runId/simulations/:simulationId` arriving.
  *
  * One simulation carries its transcript, its judgements and its evidence,
  * which is the heaviest read in the product and the longest a person waits
  * anywhere in it.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function SimulationLoading() {
+  const { projectId, runId } = useParams<{ projectId: string; runId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Simulation runs" title="Simulation">
-      <Loading what="this simulation" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Simulation"
+        breadcrumbs={[
+          { label: "Runs", href: projectPath(projectId, "runs") },
+          { label: "Run", href: projectPath(projectId, "runs", runId) },
+          { label: "Simulation" },
+        ]}
+      >
+        <Loading what="this simulation" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/runs/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/runs` arriving.
+ *
+ * No eyebrow, because the page has none: **Simulation runs** is the whole
+ * label, and the header would otherwise gain a line on arrival.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function RunsLoading() {
+  return (
+    <ProductStatePage title="Simulation runs">
+      <Loading what="this project's runs" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/runs/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/loading.tsx
@@ -2,18 +2,24 @@ import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/runs` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/runs` arriving.
  *
- * No eyebrow, because the page has none: **Simulation runs** is the whole
- * label, and the header would otherwise gain a line on arrival.
+ * No eyebrow and no crumbs, because the page has neither: **Simulation
+ * runs** is the whole label, and either would be a line the header gains and
+ * then loses.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function RunsLoading() {
   return (
-    <ProductStatePage title="Simulation runs">
-      <Loading what="this project's runs" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage title="Simulation runs">
+        <Loading what="this project's runs" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/runs/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/new/loading.tsx
@@ -1,19 +1,37 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/runs/new` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/runs/new` arriving.
  *
  * Planning a run starts by choosing an agent, so the agents are what this
  * page is genuinely waiting for, and it says so.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function NewRunLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Simulation runs" title="Create a run">
-      <Loading what="the agents in this project" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Create a run"
+        breadcrumbs={[
+          { label: "Runs", href: projectPath(projectId, "runs") },
+          { label: "New run" },
+        ]}
+      >
+        <Loading what="the agents in this project" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/runs/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/runs/new/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/runs/new` arriving.
+ *
+ * Planning a run starts by choosing an agent, so the agents are what this
+ * page is genuinely waiting for, and it says so.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function NewRunLoading() {
+  return (
+    <ProductStatePage eyebrow="Simulation runs" title="Create a run">
+      <Loading what="the agents in this project" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
@@ -1,18 +1,36 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
 import { Loading } from "../../../../../ui/page-state.tsx";
+import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/settings/keys` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/settings/keys` arriving.
  *
  * Its own boundary, so moving between settings views stays instant.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function KeysSettingsLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Settings" title="API keys">
-      <Loading what="your keys" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="API keys"
+        breadcrumbs={[
+          { label: "Settings", href: settingsPath(projectId) },
+          { label: "API keys" },
+        ]}
+      >
+        <Loading what="your keys" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
@@ -1,0 +1,18 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/settings/keys` arriving.
+ *
+ * Its own boundary, so moving between settings views stays instant.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function KeysSettingsLoading() {
+  return (
+    <ProductStatePage eyebrow="Settings" title="API keys">
+      <Loading what="your keys" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/settings/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/loading.tsx
@@ -2,21 +2,28 @@ import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/settings` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/settings` arriving.
  *
- * Settings draws a second navigation column of its own, which arrives with
- * the page rather than with this. The card therefore moves once, on arrival.
- * Drawing that column here would mean reading the project out of the
- * address in a fallback, which is a client component and a slower boundary
- * for the sake of one shift.
+ * An eyebrow and no crumbs, which is what this one page in Settings shows —
+ * the three below it carry crumbs and say so themselves.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Settings also draws a second navigation column of its own, which arrives
+ * with the page rather than with this, so the card moves once on arrival.
+ * Drawing that column here would mean giving a fallback the settings
+ * navigation's own state for the sake of one shift.
+ *
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function SettingsLoading() {
   return (
-    <ProductStatePage eyebrow="Settings" title="Project">
-      <Loading what="this project" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow="Settings" title="Project">
+        <Loading what="this project" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/settings/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/loading.tsx
@@ -1,0 +1,22 @@
+import { Loading } from "../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/settings` arriving.
+ *
+ * Settings draws a second navigation column of its own, which arrives with
+ * the page rather than with this. The card therefore moves once, on arrival.
+ * Drawing that column here would mean reading the project out of the
+ * address in a fallback, which is a client component and a slower boundary
+ * for the sake of one shift.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function SettingsLoading() {
+  return (
+    <ProductStatePage eyebrow="Settings" title="Project">
+      <Loading what="this project" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
@@ -1,0 +1,18 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/settings/organization` arriving.
+ *
+ * Its own boundary, so moving between settings views stays instant.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function OrganizationSettingsLoading() {
+  return (
+    <ProductStatePage eyebrow="Settings" title="Organization">
+      <Loading what="this organization" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
@@ -1,18 +1,36 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
 import { Loading } from "../../../../../ui/page-state.tsx";
+import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/settings/organization` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/settings/organization` arriving.
  *
  * Its own boundary, so moving between settings views stays instant.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function OrganizationSettingsLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Settings" title="Organization">
-      <Loading what="this organization" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Organization"
+        breadcrumbs={[
+          { label: "Settings", href: settingsPath(projectId) },
+          { label: "Organization" },
+        ]}
+      >
+        <Loading what="this organization" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/settings/people/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/settings/people` arriving.
+ *
+ * People and invitations are two reads on one page; this names the first,
+ * which is the one that decides whether the page can be drawn at all.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function PeopleSettingsLoading() {
+  return (
+    <ProductStatePage eyebrow="Settings" title="People">
+      <Loading what="this organization's people" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/settings/people/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/loading.tsx
@@ -1,19 +1,37 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
 import { Loading } from "../../../../../ui/page-state.tsx";
+import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/settings/people` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/settings/people` arriving.
  *
  * People and invitations are two reads on one page; this names the first,
  * which is the one that decides whether the page can be drawn at all.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function PeopleSettingsLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Settings" title="People">
-      <Loading what="this organization's people" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="People"
+        breadcrumbs={[
+          { label: "Settings", href: settingsPath(projectId) },
+          { label: "People" },
+        ]}
+      >
+        <Loading what="this organization's people" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/tests/:testId` arriving.
+ *
+ * Reached by pressing a row, where the press has to be answered at once or
+ * it reads as a row that does not open.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function TestLoading() {
+  return (
+    <ProductStatePage eyebrow="Tests" title="Test">
+      <Loading what="this test" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
@@ -1,19 +1,37 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/tests/:testId` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/tests/:testId` arriving.
  *
  * Reached by pressing a row, where the press has to be answered at once or
  * it reads as a row that does not open.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function TestLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Tests" title="Test">
-      <Loading what="this test" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Test"
+        breadcrumbs={[
+          { label: "Tests", href: projectPath(projectId, "tests") },
+          { label: "Test" },
+        ]}
+      >
+        <Loading what="this test" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/tests/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/loading.tsx
@@ -2,18 +2,23 @@ import { Loading } from "../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/tests` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/tests` arriving.
  *
  * A sidebar destination, so this is one of the seven boundaries a person
  * crosses all day. It is also the one a prefetch fills first.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function TestsLoading() {
   return (
-    <ProductStatePage eyebrow="Project" title="Tests">
-      <Loading what="tests" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow="Project" title="Tests">
+        <Loading what="tests" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/tests/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/loading.tsx
@@ -1,0 +1,19 @@
+import { Loading } from "../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/tests` arriving.
+ *
+ * A sidebar destination, so this is one of the seven boundaries a person
+ * crosses all day. It is also the one a prefetch fills first.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function TestsLoading() {
+  return (
+    <ProductStatePage eyebrow="Project" title="Tests">
+      <Loading what="tests" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/projects/[projectId]/tests/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/new/loading.tsx
@@ -1,20 +1,37 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/projects/:projectId/tests/new` arriving.
+ * What the router draws between the press and
+ * `/projects/:projectId/tests/new` arriving.
  *
- * Its own boundary rather than the list's, for the same reason the new
- * agent form has one: **Write a test** must not be answered with
- * “Loading tests…”.
+ * Its own boundary rather than the list's, for the same reason the new agent
+ * form has one: **Write a test** must not be answered with “Loading tests…”.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function NewTestLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
   return (
-    <ProductStatePage eyebrow="Tests" title="Write a test">
-      <Loading what="the test form" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Write a test"
+        breadcrumbs={[
+          { label: "Tests", href: projectPath(projectId, "tests") },
+          { label: "New test" },
+        ]}
+      >
+        <Loading what="the test form" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/projects/[projectId]/tests/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/new/loading.tsx
@@ -1,0 +1,20 @@
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/projects/:projectId/tests/new` arriving.
+ *
+ * Its own boundary rather than the list's, for the same reason the new
+ * agent form has one: **Write a test** must not be answered with
+ * “Loading tests…”.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function NewTestLoading() {
+  return (
+    <ProductStatePage eyebrow="Tests" title="Write a test">
+      <Loading what="the test form" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/app/runs/[runId]/loading.tsx
+++ b/apps/web/app/runs/[runId]/loading.tsx
@@ -2,19 +2,24 @@ import { Loading } from "../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../ui/shell.tsx";
 
 /**
- * What the router draws between the press and `/runs/:runId` arriving.
+ * What the router draws between the press and
+ * `/runs/:runId` arriving.
  *
  * The address a terminal prints, which forwards into the run inside its
  * project. It is usually opened cold, and a link followed from inside the
  * product still crosses this boundary.
  *
- * The words are the page's own and the shell above never moves.
- * `agents/loading.tsx` carries the reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. `agents/loading.tsx` carries the
+ * reasoning every one of these shares.
  */
 export default function TerminalRunLoading() {
   return (
-    <ProductStatePage eyebrow="Simulation runs" title="Run">
-      <Loading what="this run" />
-    </ProductStatePage>
+    <div data-slot="route-loading">
+      <ProductStatePage eyebrow="Simulation runs" title="Run">
+        <Loading what="this run" />
+      </ProductStatePage>
+    </div>
   );
 }

--- a/apps/web/app/runs/[runId]/loading.tsx
+++ b/apps/web/app/runs/[runId]/loading.tsx
@@ -1,0 +1,20 @@
+import { Loading } from "../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and `/runs/:runId` arriving.
+ *
+ * The address a terminal prints, which forwards into the run inside its
+ * project. It is usually opened cold, and a link followed from inside the
+ * product still crosses this boundary.
+ *
+ * The words are the page's own and the shell above never moves.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function TerminalRunLoading() {
+  return (
+    <ProductStatePage eyebrow="Simulation runs" title="Run">
+      <Loading what="this run" />
+    </ProductStatePage>
+  );
+}

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,13 +1,69 @@
-import { cn } from "@/lib/utils"
+import type { ComponentProps } from "react";
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+import { cn } from "@/lib/utils";
+
+/**
+ * A quiet stand-in for content that has not arrived.
+ *
+ * `DESIGN.md` asks a loading state to "show progress" with a "fast, quiet
+ * indicator", and this is that indicator: a neutral bar that breathes. It
+ * claims no shape of its own — the caller gives it the height and the width of
+ * whatever is coming — so it never pretends to be a table it has not seen.
+ *
+ * **Three things about the stock shadcn skeleton are changed, and each one is
+ * a rule in `DESIGN.md` rather than a preference.**
+ *
+ * 1. **The bar reads `--border`, not `--surface-soft`.** shadcn draws it on
+ *    `bg-accent`, which this theme maps to `--surface-soft` — 6% Graphite on
+ *    paper. The application canvas is 3% Graphite on paper, so a skeleton on
+ *    the canvas was three percent of one colour away from the page it was
+ *    drawn on: present in the DOM, invisible to a person. `--border` is 18%,
+ *    still "a neutral Graphite-and-Paper mix" and still quiet, and it is
+ *    legible on the canvas, on Pure Paper and in dark theme alike.
+ * 2. **The pulse is timed by the theme.** `animate-pulse` carries Tailwind's
+ *    own `2s cubic-bezier(0.4, 0, 0.6, 1)`, and "do not put a colour, a
+ *    radius, a size, or a duration in a component" leaves no room for either
+ *    number. `--animate-pulse` is redeclared on the element instead, so the
+ *    utility still resolves `animation: var(--animate-pulse)` and what it
+ *    finds is egma's: `--duration-drawer-in` twice over per half-cycle, and
+ *    `--ease-in-out`. A declaration on the element beats the theme's own on
+ *    `:root` whatever the source order, so this needs no ordering luck. The
+ *    result is a 1.12s breath against shadcn's 2s — quicker, and still slow
+ *    enough to read as waiting rather than as alarm.
+ * 3. **The radius is named for a component.** `rounded-md` and
+ *    `rounded-input` are the same 8px today; only one of them says which of
+ *    egma's four radii it means, and only one of them moves if that step ever
+ *    does.
+ *
+ * Reduced motion stops the breath and leaves the bar. That is the whole
+ * reduced-motion form and it is enough, because a skeleton is never the only
+ * thing on screen: the state above it says what is being waited for in words,
+ * exactly as the run state mark's turn is dropped and its word is kept.
+ *
+ * **`--pulse-delay` is the one knob, and it is a custom property rather than
+ * an `animation-delay` utility on purpose.** A row of skeletons reads as one
+ * wave when its bars are out of phase, and the obvious way to say that —
+ * `[animation-delay:…]` beside `animate-pulse` — is two declarations of the
+ * same shorthand family racing on emitted source order: `animation:` resets
+ * `animation-delay` to zero, so whichever Tailwind happens to write second
+ * decides whether the stagger exists at all. Folding the offset into the
+ * shorthand as a variable removes the race. It defaults to `0ms`, so a lone
+ * skeleton says nothing about phase.
+ */
+function Skeleton({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-accent", className)}
+      className={cn(
+        "rounded-input bg-border",
+        "animate-pulse",
+        "[--animate-pulse:pulse_calc(var(--duration-drawer-in)*2)_var(--ease-in-out)_var(--pulse-delay,0ms)_infinite]",
+        "motion-reduce:animate-none",
+        className,
+      )}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -6,61 +6,43 @@ import { cn } from "@/lib/utils";
  * A quiet stand-in for content that has not arrived.
  *
  * `DESIGN.md` asks a loading state to "show progress" with a "fast, quiet
- * indicator", and this is that indicator: a neutral bar that breathes. It
- * claims no shape of its own — the caller gives it the height and the width of
- * whatever is coming — so it never pretends to be a table it has not seen.
+ * indicator", and this is the mark it does that with. It claims no shape of
+ * its own — the caller gives it the height and the width of whatever is coming
+ * — so it never pretends to be a table it has not seen.
  *
- * **Three things about the stock shadcn skeleton are changed, and each one is
- * a rule in `DESIGN.md` rather than a preference.**
+ * **Two things about the stock shadcn skeleton change here, and both are rules
+ * in `DESIGN.md` rather than preferences.**
  *
- * 1. **The bar reads `--border`, not `--surface-soft`.** shadcn draws it on
- *    `bg-accent`, which this theme maps to `--surface-soft` — 6% Graphite on
+ * 1. **The bar reads `--border`.** shadcn draws it on the quiet accent
+ *    surface, which this theme maps to `--surface-soft` — 6% Graphite on
  *    paper. The application canvas is 3% Graphite on paper, so a skeleton on
  *    the canvas was three percent of one colour away from the page it was
  *    drawn on: present in the DOM, invisible to a person. `--border` is 18%,
  *    still "a neutral Graphite-and-Paper mix" and still quiet, and it is
  *    legible on the canvas, on Pure Paper and in dark theme alike.
- * 2. **The pulse is timed by the theme.** `animate-pulse` carries Tailwind's
- *    own `2s cubic-bezier(0.4, 0, 0.6, 1)`, and "do not put a colour, a
- *    radius, a size, or a duration in a component" leaves no room for either
- *    number. `--animate-pulse` is redeclared on the element instead, so the
- *    utility still resolves `animation: var(--animate-pulse)` and what it
- *    finds is egma's: `--duration-drawer-in` twice over per half-cycle, and
- *    `--ease-in-out`. A declaration on the element beats the theme's own on
- *    `:root` whatever the source order, so this needs no ordering luck. The
- *    result is a 1.12s breath against shadcn's 2s — quicker, and still slow
- *    enough to read as waiting rather than as alarm.
- * 3. **The radius is named for a component.** `rounded-md` and
+ * 2. **The radius is named for a component.** shadcn's generic medium step and
  *    `rounded-input` are the same 8px today; only one of them says which of
  *    egma's four radii it means, and only one of them moves if that step ever
  *    does.
  *
- * Reduced motion stops the breath and leaves the bar. That is the whole
- * reduced-motion form and it is enough, because a skeleton is never the only
- * thing on screen: the state above it says what is being waited for in words,
- * exactly as the run state mark's turn is dropped and its word is kept.
+ * **The breath is not here.** shadcn hands a skeleton Tailwind's own pulse
+ * utility, which arrives welded to a two-second duration and an easing curve
+ * of Tailwind's own, and "do not put a colour, a radius, a size, or a duration
+ * in a component" leaves no room for either number. `tailwind-theme.css` owns
+ * it instead, keyed on this element's `data-slot`, beside the run state mark's
+ * turn and under the same rule in `DESIGN.md` — including the phase offset
+ * that makes a column of these read as one wave, and the reduced-motion form
+ * that stops it.
  *
- * **`--pulse-delay` is the one knob, and it is a custom property rather than
- * an `animation-delay` utility on purpose.** A row of skeletons reads as one
- * wave when its bars are out of phase, and the obvious way to say that —
- * `[animation-delay:…]` beside `animate-pulse` — is two declarations of the
- * same shorthand family racing on emitted source order: `animation:` resets
- * `animation-delay` to zero, so whichever Tailwind happens to write second
- * decides whether the stagger exists at all. Folding the offset into the
- * shorthand as a variable removes the race. It defaults to `0ms`, so a lone
- * skeleton says nothing about phase.
+ * Nothing in this file, prose included, may name a utility it does not use.
+ * Tailwind finds class names by reading these files as text, so a class named
+ * only to explain it is still a rule minted into the stylesheet.
  */
 function Skeleton({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn(
-        "rounded-input bg-border",
-        "animate-pulse",
-        "[--animate-pulse:pulse_calc(var(--duration-drawer-in)*2)_var(--ease-in-out)_var(--pulse-delay,0ms)_infinite]",
-        "motion-reduce:animate-none",
-        className,
-      )}
+      className={cn("rounded-input bg-border", className)}
       {...props}
     />
   );

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -16,6 +16,7 @@ import path from "node:path";
 import RunResultsAddress from "../app/runs/[runId]/page.tsx";
 import AgentsLoading from "../app/projects/[projectId]/agents/loading.tsx";
 import AgentsPage from "../app/projects/[projectId]/agents/page.tsx";
+import TestLoading from "../app/projects/[projectId]/tests/[testId]/loading.tsx";
 import type { Me } from "../lib/me.ts";
 import { EVERY_NAVIGATION_ITEM } from "../lib/navigation.ts";
 import { Button } from "@/components/ui/button";
@@ -1037,13 +1038,15 @@ describe("a page that is not showing its data", () => {
 /**
  * The loading state, which used to be a sentence and nothing else.
  *
- * `DESIGN.md` asks it for a "fast, quiet indicator", and the four rules below
- * are what "quiet" costs: theme timing rather than Tailwind's, a wait before
- * anything appears, a reduced-motion form, and a stagger that cannot be
- * cancelled by the order Tailwind happens to emit its rules in.
+ * `DESIGN.md` asks it for a "fast, quiet indicator", and none of what that
+ * costs is written in these components: the wait before anything appears, the
+ * breath in the bars, the phase between them and the reduced-motion form all
+ * live in `tailwind-theme.css`, keyed on the slots the components publish.
  *
- * The class lists are read directly because jsdom computes no animation. That
- * is the trade: these assert the declaration rather than the movement, and the
+ * So the tests come in two halves. The first reads the DOM and proves the
+ * components emit the hooks and say the true sentence. The second reads the
+ * theme and proves the rules keyed on those hooks are made of egma's tokens.
+ * Neither half watches anything move — jsdom computes no animation — and the
  * movement itself is proven in a browser.
  */
 describe("the state a page shows while it is still waiting", () => {
@@ -1052,12 +1055,8 @@ describe("the state a page shows while it is still waiting", () => {
     return screen.getByRole("status");
   }
 
-  function bars(within_: HTMLElement): readonly HTMLElement[] {
-    return [...within_.querySelectorAll<HTMLElement>('[data-slot="skeleton"]')];
-  }
-
-  function classStartingWith(on: HTMLElement, prefix: string): string | undefined {
-    return [...on.classList].find((one) => one.startsWith(prefix));
+  function bars(inside: HTMLElement): readonly HTMLElement[] {
+    return [...inside.querySelectorAll<HTMLElement>('[data-slot="skeleton"]')];
   }
 
   it("still says what it is waiting for, in the quiet tone it always had", () => {
@@ -1077,65 +1076,135 @@ describe("the state a page shows while it is still waiting", () => {
     expect(said.textContent).toBe("Loading agents…");
   });
 
-  it("is timed by the theme, never by the numbers shadcn shipped", () => {
-    const [first] = bars(loadingState());
-    const pulse = classStartingWith(first as HTMLElement, "[--animate-pulse:");
+  /**
+   * The hooks are the contract between the two halves. A rename here is a rule
+   * in the theme that silently stops matching anything, which is the one
+   * failure this arrangement can have and the one nothing else would catch.
+   */
+  it("publishes the slots the theme's motion is keyed on", () => {
+    const said = loadingState();
 
-    expect(pulse).toContain("var(--duration-drawer-in)");
-    expect(pulse).toContain("var(--ease-in-out)");
-    // Tailwind's own `2s cubic-bezier(0.4, 0, 0.6, 1)`, gone.
-    expect(pulse).not.toContain("2s");
-    expect(pulse).not.toContain("cubic-bezier");
+    expect(said.dataset.slot).toBe("page-state");
+    expect(said.querySelector('[data-slot="loading-indicator"]')).toBeTruthy();
+    expect(bars(said)).toHaveLength(3);
   });
 
-  /**
-   * The rule this proves is a number: a page that answers before the delay is
-   * up is drawn without the indicator ever having been on screen. So the token
-   * is read out of the theme and checked against the threshold, rather than
-   * the test agreeing with whatever the theme happens to say today.
-   */
-  it("waits longer than a fast answer takes, so nothing flashes", async () => {
+  it("writes no motion of its own, in either file", async () => {
     const said = loadingState();
-    const enter = classStartingWith(said, "[animation:egma-fade-in");
-
-    expect(enter).toContain("var(--duration-popover-in)");
-    // `both` is what holds it at nothing for the length of the wait.
-    expect(enter).toContain("both");
+    for (const element of [said, ...bars(said)]) {
+      expect(element.className).not.toContain("animate");
+      expect(element.className).not.toContain("animation");
+    }
 
     // `import.meta.dirname`, not a URL: this file runs under jsdom, where
     // `import.meta.url` is an http address rather than a path on disk.
-    const theme = await readFile(
+    const here = import.meta.dirname;
+    for (const file of ["../ui/page-state.tsx", "../components/ui/skeleton.tsx"]) {
+      const source = await readFile(path.join(here, file), "utf8");
+      expect(source, `${file} writes motion`).not.toContain("animation:");
+      expect(source, `${file} writes motion`).not.toContain("animate-");
+    }
+  });
+});
+
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The other half: the rules those slots are keyed on.
+ *
+ * `DESIGN.md` puts loading motion in the theme beside the run state mark's
+ * turn, so this reads the theme rather than a class list. What it checks is
+ * not the exact declarations but the rules that would be broken silently — a
+ * duration that stopped being a token, an entrance short enough to flash, a
+ * reduced-motion form that went missing.
+ */
+describe("the motion the theme gives a state that is waiting", () => {
+  async function theme(): Promise<string> {
+    return readFile(
       path.join(import.meta.dirname, "../ui/tailwind-theme.css"),
       "utf8",
     );
-    const waited = /--duration-popover-in:\s*(\d+)ms/.exec(theme)?.[1];
-    expect(Number(waited)).toBeGreaterThanOrEqual(150);
+  }
+
+  function ruleFor(css: string, selector: string): string {
+    const at = css.indexOf(selector);
+    expect(at, `no rule for ${selector}`).toBeGreaterThan(-1);
+    const opened = css.indexOf("{", at);
+    return css.slice(opened, css.indexOf("}", opened));
+  }
+
+  it("breathes on a keyframe of its own rather than one Tailwind might drop", async () => {
+    const css = await theme();
+
+    // Tailwind's `pulse` is only emitted while some class list still says
+    // `animate-pulse`. Reading it from a rule here would be a keyframe that
+    // exists as a side effect of a utility nothing uses.
+    expect(css).toContain("@keyframes egma-skeleton-pulse");
   });
 
-  it("keeps the meaning under reduced motion and drops the movement", () => {
-    for (const bar of bars(loadingState())) {
-      expect(bar.className).toContain("motion-reduce:animate-none");
-    }
+  it("times the breath with tokens, never with the numbers shadcn shipped", async () => {
+    const css = await theme();
+    const rule = ruleFor(css, '[data-slot="skeleton"] {');
+
+    expect(rule).toContain("var(--duration-drawer-in)");
+    expect(rule).toContain("var(--ease-in-out)");
+    expect(rule).not.toContain("cubic-bezier");
+    expect(rule).not.toMatch(/\d+m?s/);
   });
 
   /**
-   * The offset is a custom property rather than an `animation-delay` utility.
-   * Both would be on the same element, and `animation:` resets
-   * `animation-delay`, so a delay written as its own declaration lives or dies
-   * by which rule Tailwind emits second. Folding it into the shorthand removes
-   * the question.
+   * The rule this proves is a number: a route that answers before the wait is
+   * up is drawn without the indicator ever having been on screen. The token is
+   * read out of the same file and checked against the threshold, rather than
+   * the test agreeing with whatever the theme happens to say today.
    */
-  it("staggers the bars with a variable, not with a declaration that can be reset", () => {
-    const drawn = bars(loadingState());
-    const offsets = drawn
-      .map((bar) => classStartingWith(bar, "[--pulse-delay:"))
-      .filter((one) => one !== undefined);
+  it("waits longer than a fast answer takes, so nothing flashes", async () => {
+    const css = await theme();
+    const rule = ruleFor(css, '[data-slot="route-loading"],');
 
-    expect(offsets).toHaveLength(2);
-    expect(new Set(offsets).size).toBe(2);
-    for (const bar of drawn) {
-      expect(bar.className).not.toContain("[animation-delay:");
-    }
+    expect(rule).toContain("egma-fade-in");
+    expect(rule).toContain("var(--duration-popover-in)");
+    // `both` is what holds it at nothing for the length of the wait.
+    expect(rule).toContain("both");
+
+    const waited = /--duration-popover-in:\s*(\d+)ms/.exec(css)?.[1];
+    expect(Number(waited)).toBeGreaterThanOrEqual(150);
+  });
+
+  it("gives a route fallback one entrance rather than one for each layer", async () => {
+    const css = await theme();
+    const rule = ruleFor(
+      css,
+      '[data-slot="route-loading"]\n    [data-slot="page-state"]',
+    );
+
+    expect(rule).toContain("animation: none");
+  });
+
+  it("staggers the bars by a token, and by a negative one", async () => {
+    const css = await theme();
+    const second = ruleFor(css, ':nth-child(2) {');
+    const third = ruleFor(css, ':nth-child(3) {');
+
+    expect(second).toContain("calc(var(--duration-hover) * -1)");
+    expect(third).toContain("calc(var(--duration-hover) * -2)");
+  });
+
+  /**
+   * The breath stops and the bar stays. The entrance deliberately has no rule
+   * of its own here: it is already opacity and nothing else, and `globals.css`
+   * caps every animation at one frame under this query while leaving
+   * `animation-delay` alone — so the wait survives and only the fade goes.
+   */
+  it("stops the breath under reduced motion and leaves the bar", async () => {
+    const css = await theme();
+    const from = css.indexOf('[data-slot="skeleton"] {');
+    const reduced = css.slice(from, css.indexOf('[data-slot="popover-content"]', from));
+
+    expect(reduced).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(reduced.slice(reduced.indexOf("prefers-reduced-motion"))).toContain(
+      "animation: none",
+    );
   });
 });
 
@@ -1146,8 +1215,9 @@ describe("the state a page shows while it is still waiting", () => {
  *
  * A press on a navigation item used to hold the previous page on screen with
  * nothing said until the next one was ready. The fallback answers the press
- * instead: the shell never moves, the destination is named, and the same
- * indicator runs under it.
+ * instead: the shell never moves, the destination is named in the page's own
+ * words **and the page's own header shape**, and the whole composition arrives
+ * as one thing.
  */
 describe("what the router draws while a page is still coming", () => {
   it("keeps the frame, names where the press landed, and shows the one indicator", async () => {
@@ -1169,6 +1239,49 @@ describe("what the router draws while a page is still coming", () => {
     const said = screen.getByRole("status");
     expect(said.textContent).toBe("Loading agents…");
     expect(said.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(3);
+  });
+
+  /**
+   * One appearance, so there is one element for the theme to fade. Without it
+   * the header would paint at once and the card 180ms later, which is a
+   * sub-second navigation showing a title above a tall empty gap.
+   */
+  it("wraps the whole composition, header included, in one arrival", async () => {
+    apiAnswers({ "/api/me": { status: 200, body: meWith("admin") } });
+    const { container } = render(
+      <ProductShellBoundary>
+        <AgentsLoading />
+      </ProductShellBoundary>,
+    );
+    await screen.findAllByText("ada@acme.example");
+
+    const arrival = container.querySelector('[data-slot="route-loading"]');
+    expect(arrival).toBeTruthy();
+    expect(arrival?.querySelector("h1")?.textContent).toBe("Agents");
+    expect(arrival?.querySelector('[data-slot="loading-indicator"]')).toBeTruthy();
+  });
+
+  /**
+   * The header a fallback draws has to be the *shape* the page draws, not only
+   * the same words. `shell.tsx` hides the eyebrow whenever breadcrumbs are
+   * given, so a fallback with an eyebrow standing in for a page with crumbs
+   * swaps one line for another of a different height on arrival.
+   */
+  it("draws the page's own breadcrumbs, into this project, rather than an eyebrow", async () => {
+    apiAnswers({ "/api/me": { status: 200, body: meWith("admin") } });
+    render(
+      <ProductShellBoundary>
+        <TestLoading />
+      </ProductShellBoundary>,
+    );
+    await screen.findAllByText("ada@acme.example");
+
+    const crumbs = screen.getByRole("navigation", { name: "Breadcrumb" });
+    expect(within(crumbs).getByRole("link", { name: "Tests" }).getAttribute("href")).toBe(
+      "/projects/prj_1/tests",
+    );
+    expect(within(crumbs).getByText("Test")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("Loading this test…");
   });
 });
 

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -10,7 +10,11 @@ import {
 import { Suspense, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
 import RunResultsAddress from "../app/runs/[runId]/page.tsx";
+import AgentsLoading from "../app/projects/[projectId]/agents/loading.tsx";
 import AgentsPage from "../app/projects/[projectId]/agents/page.tsx";
 import type { Me } from "../lib/me.ts";
 import { EVERY_NAVIGATION_ITEM } from "../lib/navigation.ts";
@@ -20,7 +24,7 @@ import { Choice } from "../ui/choice.tsx";
 import { Field } from "../ui/form.tsx";
 import { DataTable, type Column } from "../ui/data-table.tsx";
 import { Dialog } from "../ui/dialog.tsx";
-import { Failure, NotFound } from "../ui/page-state.tsx";
+import { Failure, Loading, NotFound } from "../ui/page-state.tsx";
 import { PageNavigation } from "../ui/page-navigation.tsx";
 import { ProjectSelector } from "../ui/project-selector.tsx";
 import { RunProgress } from "../ui/run-status.tsx";
@@ -1025,6 +1029,146 @@ describe("a page that is not showing its data", () => {
 
     expect(screen.queryByRole("alert")).toBeNull();
     expect(screen.getByRole("status").textContent).toContain("Not available here");
+  });
+});
+
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The loading state, which used to be a sentence and nothing else.
+ *
+ * `DESIGN.md` asks it for a "fast, quiet indicator", and the four rules below
+ * are what "quiet" costs: theme timing rather than Tailwind's, a wait before
+ * anything appears, a reduced-motion form, and a stagger that cannot be
+ * cancelled by the order Tailwind happens to emit its rules in.
+ *
+ * The class lists are read directly because jsdom computes no animation. That
+ * is the trade: these assert the declaration rather than the movement, and the
+ * movement itself is proven in a browser.
+ */
+describe("the state a page shows while it is still waiting", () => {
+  function loadingState(): HTMLElement {
+    render(<Loading what="agents" />);
+    return screen.getByRole("status");
+  }
+
+  function bars(within_: HTMLElement): readonly HTMLElement[] {
+    return [...within_.querySelectorAll<HTMLElement>('[data-slot="skeleton"]')];
+  }
+
+  function classStartingWith(on: HTMLElement, prefix: string): string | undefined {
+    return [...on.classList].find((one) => one.startsWith(prefix));
+  }
+
+  it("still says what it is waiting for, in the quiet tone it always had", () => {
+    const said = loadingState();
+
+    expect(said.dataset.tone).toBe("quiet");
+    expect(screen.getByText("Loading agents…")).toBeTruthy();
+  });
+
+  it("shows the wait is alive without saying it twice to a screen reader", () => {
+    const said = loadingState();
+    const indicator = said.querySelector('[data-slot="loading-indicator"]');
+
+    expect(indicator?.getAttribute("aria-hidden")).toBe("true");
+    expect(bars(said)).toHaveLength(3);
+    // The sentence is announced once, by the heading above the bars.
+    expect(said.textContent).toBe("Loading agents…");
+  });
+
+  it("is timed by the theme, never by the numbers shadcn shipped", () => {
+    const [first] = bars(loadingState());
+    const pulse = classStartingWith(first as HTMLElement, "[--animate-pulse:");
+
+    expect(pulse).toContain("var(--duration-drawer-in)");
+    expect(pulse).toContain("var(--ease-in-out)");
+    // Tailwind's own `2s cubic-bezier(0.4, 0, 0.6, 1)`, gone.
+    expect(pulse).not.toContain("2s");
+    expect(pulse).not.toContain("cubic-bezier");
+  });
+
+  /**
+   * The rule this proves is a number: a page that answers before the delay is
+   * up is drawn without the indicator ever having been on screen. So the token
+   * is read out of the theme and checked against the threshold, rather than
+   * the test agreeing with whatever the theme happens to say today.
+   */
+  it("waits longer than a fast answer takes, so nothing flashes", async () => {
+    const said = loadingState();
+    const enter = classStartingWith(said, "[animation:egma-fade-in");
+
+    expect(enter).toContain("var(--duration-popover-in)");
+    // `both` is what holds it at nothing for the length of the wait.
+    expect(enter).toContain("both");
+
+    // `import.meta.dirname`, not a URL: this file runs under jsdom, where
+    // `import.meta.url` is an http address rather than a path on disk.
+    const theme = await readFile(
+      path.join(import.meta.dirname, "../ui/tailwind-theme.css"),
+      "utf8",
+    );
+    const waited = /--duration-popover-in:\s*(\d+)ms/.exec(theme)?.[1];
+    expect(Number(waited)).toBeGreaterThanOrEqual(150);
+  });
+
+  it("keeps the meaning under reduced motion and drops the movement", () => {
+    for (const bar of bars(loadingState())) {
+      expect(bar.className).toContain("motion-reduce:animate-none");
+    }
+  });
+
+  /**
+   * The offset is a custom property rather than an `animation-delay` utility.
+   * Both would be on the same element, and `animation:` resets
+   * `animation-delay`, so a delay written as its own declaration lives or dies
+   * by which rule Tailwind emits second. Folding it into the shorthand removes
+   * the question.
+   */
+  it("staggers the bars with a variable, not with a declaration that can be reset", () => {
+    const drawn = bars(loadingState());
+    const offsets = drawn
+      .map((bar) => classStartingWith(bar, "[--pulse-delay:"))
+      .filter((one) => one !== undefined);
+
+    expect(offsets).toHaveLength(2);
+    expect(new Set(offsets).size).toBe(2);
+    for (const bar of drawn) {
+      expect(bar.className).not.toContain("[animation-delay:");
+    }
+  });
+});
+
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The route boundary, which is the half of this a person actually meets.
+ *
+ * A press on a navigation item used to hold the previous page on screen with
+ * nothing said until the next one was ready. The fallback answers the press
+ * instead: the shell never moves, the destination is named, and the same
+ * indicator runs under it.
+ */
+describe("what the router draws while a page is still coming", () => {
+  it("keeps the frame, names where the press landed, and shows the one indicator", async () => {
+    apiAnswers({ "/api/me": { status: 200, body: meWith("admin") } });
+    render(
+      <ProductShellBoundary>
+        <AgentsLoading />
+      </ProductShellBoundary>,
+    );
+
+    // The shell is the root layout's, so the fallback must not draw a second
+    // one: one navigation, one account control, one session read.
+    expect(await screen.findAllByText("ada@acme.example")).toHaveLength(1);
+    expect(
+      screen.getAllByRole("navigation", { name: "Product navigation" }),
+    ).toHaveLength(1);
+
+    expect(screen.getByRole("heading", { name: "Agents" })).toBeTruthy();
+    const said = screen.getByRole("status");
+    expect(said.textContent).toBe("Loading agents…");
+    expect(said.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(3);
   });
 });
 

--- a/apps/web/ui/page-state.tsx
+++ b/apps/web/ui/page-state.tsx
@@ -29,7 +29,6 @@ function PageState({
   title,
   lead,
   action,
-  className,
   children,
 }: {
   readonly tone?: StateTone;
@@ -37,12 +36,12 @@ function PageState({
   readonly lead?: ReactNode;
   readonly action?: ReactNode;
   /**
-   * Internal, and it stays internal. The four exported states below are the
-   * whole vocabulary; a page that could pass classes in here could invent a
-   * fifth appearance, which is the one thing this component exists to stop.
+   * What a state draws under its sentence, and internal on purpose: only
+   * `Loading` has anything to put there. There is deliberately no way to pass
+   * classes in — the four states below are the whole vocabulary, and a page
+   * that could restyle one could invent a fifth appearance, which is the one
+   * thing this component exists to stop.
    */
-  readonly className?: string;
-  /** Internal too: what a state draws under its sentence. Only `Loading` does. */
   readonly children?: ReactNode;
 }) {
   return (
@@ -55,7 +54,6 @@ function PageState({
         "max-[900px]:px-5 max-[900px]:py-8",
         /* Quiet is an outline around an absence: nothing is raised off the page. */
         tone === "quiet" && "border-dashed bg-transparent",
-        className,
       )}
       role={tone === "bad" ? "alert" : "status"}
     >
@@ -84,39 +82,29 @@ function PageState({
  * above them is already announced by this section's `role="status"` and a
  * screen reader gains nothing from three rectangles.
  *
- * **Nothing flashes on a fast read.** The whole state waits
- * `--duration-popover-in` before it fades in over `--duration-hover`, held at
- * `opacity: 0` in the meantime by `both`. Anything that answers inside 180ms
- * — a warm cache, a prefetched route, a second visit — is drawn without this
- * ever having been visible, and the alternative is worse than no indicator:
- * a box that appears and vanishes inside a fifth of a second reads as a fault.
+ * **No motion is written here, and the slot names are why.** The wait before
+ * this appears, the breath in the bars and the phase between them are all in
+ * `tailwind-theme.css`, under the same `DESIGN.md` rule as the run state
+ * mark's turn and keyed on the two names this component publishes:
+ * `page-state` on the section and `loading-indicator` on the group below. That
+ * is what lets one rule treat a route fallback, the card inside it and the
+ * bars inside that as a single arrival rather than three overlapping ones —
+ * something three separate class lists could never agree on.
  *
- * **Reduced motion keeps the wait and drops the movement.** `globals.css`
- * caps every animation at a single 1ms frame under that query but leaves
- * `animation-delay` alone, so the same 180ms of quiet is followed by the state
- * simply being there, and `Skeleton` stops breathing and stays a bar. Opacity
- * and colour still carry the whole meaning, which is what the rule asks for.
- *
- * The bars are staggered by **negative** delays, so all three are already
- * moving on the first frame and merely out of phase with each other. A
- * positive delay would hold the second and third still while the first
- * breathed, which reads as two bars that failed to start.
+ * Nothing here flashes on a fast read, and reduced motion keeps the meaning:
+ * both are properties of those rules, and both are argued where they live.
  */
 export function Loading({ what }: { readonly what: string }) {
   return (
-    <PageState
-      tone="quiet"
-      title={`Loading ${what}…`}
-      className="[animation:egma-fade-in_var(--duration-hover)_var(--ease-out)_var(--duration-popover-in)_both]"
-    >
+    <PageState tone="quiet" title={`Loading ${what}…`}>
       <div
         data-slot="loading-indicator"
         className="flex w-full flex-col gap-2"
         aria-hidden="true"
       >
         <Skeleton className="h-3 w-64 max-w-full" />
-        <Skeleton className="h-3 w-48 max-w-full [--pulse-delay:calc(var(--duration-hover)*-1)]" />
-        <Skeleton className="h-3 w-32 max-w-full [--pulse-delay:calc(var(--duration-hover)*-2)]" />
+        <Skeleton className="h-3 w-48 max-w-full" />
+        <Skeleton className="h-3 w-32 max-w-full" />
       </div>
     </PageState>
   );

--- a/apps/web/ui/page-state.tsx
+++ b/apps/web/ui/page-state.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 /**
@@ -28,11 +29,21 @@ function PageState({
   title,
   lead,
   action,
+  className,
+  children,
 }: {
   readonly tone?: StateTone;
   readonly title: string;
   readonly lead?: ReactNode;
   readonly action?: ReactNode;
+  /**
+   * Internal, and it stays internal. The four exported states below are the
+   * whole vocabulary; a page that could pass classes in here could invent a
+   * fifth appearance, which is the one thing this component exists to stop.
+   */
+  readonly className?: string;
+  /** Internal too: what a state draws under its sentence. Only `Loading` does. */
+  readonly children?: ReactNode;
 }) {
   return (
     <section
@@ -44,6 +55,7 @@ function PageState({
         "max-[900px]:px-5 max-[900px]:py-8",
         /* Quiet is an outline around an absence: nothing is raised off the page. */
         tone === "quiet" && "border-dashed bg-transparent",
+        className,
       )}
       role={tone === "bad" ? "alert" : "status"}
     >
@@ -55,14 +67,59 @@ function PageState({
       {lead === undefined ? null : (
         <p className="m-0 max-w-[62ch] text-base text-muted-foreground">{lead}</p>
       )}
+      {children}
       {action}
     </section>
   );
 }
 
-/** Waiting on egma. It says what it is waiting for, not just that it is waiting. */
+/**
+ * Waiting on egma. It says what it is waiting for, not just that it is waiting.
+ *
+ * **The sentence is the state; the bars are the proof it is still running.**
+ * `DESIGN.md` asks a loading state for a "fast, quiet indicator", and a page
+ * that only wrote "Loading agents…" and then held perfectly still could not be
+ * told from one that had given up. Three neutral bars breathing under the
+ * sentence say the wait is alive. They are `aria-hidden`, because the sentence
+ * above them is already announced by this section's `role="status"` and a
+ * screen reader gains nothing from three rectangles.
+ *
+ * **Nothing flashes on a fast read.** The whole state waits
+ * `--duration-popover-in` before it fades in over `--duration-hover`, held at
+ * `opacity: 0` in the meantime by `both`. Anything that answers inside 180ms
+ * — a warm cache, a prefetched route, a second visit — is drawn without this
+ * ever having been visible, and the alternative is worse than no indicator:
+ * a box that appears and vanishes inside a fifth of a second reads as a fault.
+ *
+ * **Reduced motion keeps the wait and drops the movement.** `globals.css`
+ * caps every animation at a single 1ms frame under that query but leaves
+ * `animation-delay` alone, so the same 180ms of quiet is followed by the state
+ * simply being there, and `Skeleton` stops breathing and stays a bar. Opacity
+ * and colour still carry the whole meaning, which is what the rule asks for.
+ *
+ * The bars are staggered by **negative** delays, so all three are already
+ * moving on the first frame and merely out of phase with each other. A
+ * positive delay would hold the second and third still while the first
+ * breathed, which reads as two bars that failed to start.
+ */
 export function Loading({ what }: { readonly what: string }) {
-  return <PageState tone="quiet" title={`Loading ${what}…`} />;
+  return (
+    <PageState
+      tone="quiet"
+      title={`Loading ${what}…`}
+      className="[animation:egma-fade-in_var(--duration-hover)_var(--ease-out)_var(--duration-popover-in)_both]"
+    >
+      <div
+        data-slot="loading-indicator"
+        className="flex w-full flex-col gap-2"
+        aria-hidden="true"
+      >
+        <Skeleton className="h-3 w-64 max-w-full" />
+        <Skeleton className="h-3 w-48 max-w-full [--pulse-delay:calc(var(--duration-hover)*-1)]" />
+        <Skeleton className="h-3 w-32 max-w-full [--pulse-delay:calc(var(--duration-hover)*-2)]" />
+      </div>
+    </PageState>
+  );
 }
 
 /** There is nothing here, and that is a fact about the project, not a fault. */

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -583,6 +583,19 @@
 }
 
 /*
+ * The skeleton's breath: one dip and back, so a bar never leaves the page.
+ *
+ * It is written here rather than borrowed from Tailwind's own pulse, which is
+ * the same shape. Tailwind's arrives welded to two seconds and an easing curve
+ * of its own, and it is only emitted at all while some class list still asks
+ * for that utility — so reading it from a rule here would mean a keyframe that
+ * exists as a side effect of a class nothing wears.
+ */
+@keyframes egma-skeleton-pulse {
+  50% { opacity: 0.5; }
+}
+
+/*
  * The dialog scales on the `scale` property rather than inside `transform`,
  * and that is load-bearing rather than a style preference.
  *
@@ -648,6 +661,82 @@
 
   @media (prefers-reduced-motion: reduce) {
     [data-slot="state-mark"][data-motion="active"] {
+      animation: none;
+    }
+  }
+
+  /*
+   * The same rule's other half: a page, or a whole route, that is still
+   * waiting.
+   *
+   * **One appearance assembled out of three elements.** A route fallback wraps
+   * a whole page composition, that composition holds a state card, and the
+   * card holds the bars. Only a rule that can see all three can say "one
+   * entrance, not three", which is why this is here rather than in three class
+   * lists that cannot see each other.
+   *
+   * **The entrance waits before it draws anything.** `--duration-popover-in`
+   * of nothing, held there by `both`, and then a `--duration-hover` fade. A
+   * route that answers inside that wait — a prefetched one, a warm cache, a
+   * second visit — is drawn without this ever having been on screen, and a box
+   * that appears and vanishes inside a fifth of a second reads as a fault
+   * rather than as speed.
+   *
+   * **A fallback owns the entrance; the card inside it does not.** Otherwise
+   * the header would fade as one thing and the card as another, and the two
+   * opacities would multiply for as long as they overlapped.
+   *
+   * **Reduced motion is deliberately not given a rule of its own here.** This
+   * is already opacity and nothing else, and `globals.css` caps every
+   * animation at a single frame under that query while leaving
+   * `animation-delay` alone — so what survives is the wait, and what goes is
+   * the fade. Writing `animation: none` here would throw away the half worth
+   * keeping.
+   */
+  [data-slot="route-loading"],
+  [data-slot="page-state"]:has([data-slot="loading-indicator"]) {
+    animation: egma-fade-in var(--duration-hover) var(--ease-out)
+      var(--duration-popover-in) both;
+  }
+
+  [data-slot="route-loading"]
+    [data-slot="page-state"]:has([data-slot="loading-indicator"]) {
+    animation: none;
+  }
+
+  /*
+   * The bars themselves.
+   *
+   * One full breath is `--duration-drawer-in` twice over — 560ms, so each half
+   * of it is one drawer-enter — against the 2s a stock shadcn skeleton
+   * carries. Quicker, and still slow enough to read as waiting rather than as
+   * alarm.
+   *
+   * The stagger is `--duration-hover` per bar and **negative**, so all three
+   * are already moving on the first frame and merely out of phase. A positive
+   * delay would hold the second and third still while the first breathed,
+   * which reads as two bars that failed to start. It is a separate
+   * `animation-delay` and it is safe to be one: both declarations are in this
+   * file, in this order, and the offsets are the more specific of the two.
+   *
+   * The word above them carries the meaning, so reduced motion stops the
+   * breath and leaves the bar — the same trade the state mark makes.
+   */
+  [data-slot="skeleton"] {
+    animation: egma-skeleton-pulse calc(var(--duration-drawer-in) * 2)
+      var(--ease-in-out) infinite;
+  }
+
+  [data-slot="loading-indicator"] [data-slot="skeleton"]:nth-child(2) {
+    animation-delay: calc(var(--duration-hover) * -1);
+  }
+
+  [data-slot="loading-indicator"] [data-slot="skeleton"]:nth-child(3) {
+    animation-delay: calc(var(--duration-hover) * -2);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-slot="skeleton"] {
       animation: none;
     }
   }


### PR DESCRIPTION
Ticket 26 of the shadcn-primitives effort. Two commits: the build, then the fix round from review.

## What changed

**`Loading` shows that a wait is alive.** It wrote `Loading {what}…` and then held perfectly still, which reads the same as a page that has given up. It now draws three neutral bars breathing under the sentence, `aria-hidden` because the sentence is already announced by the section's `role="status"`. `Loading({ what })` and the `PageState` contract are unchanged, and no existing consumer was edited.

**`components/ui/skeleton.tsx` — the raw kit file, restyled.** The bar reads `--border` rather than the quiet accent surface: shadcn's maps to 6% Graphite on paper, the canvas is 3%, so a skeleton on the canvas was three percent of one colour away from the page it sat on. The radius is `rounded-input` — the same 8px, said in egma's vocabulary. It carries **no motion at all**.

**All of the motion lives in `ui/tailwind-theme.css`, in its motion section.** That file's own header says motion belongs to the theme rather than to each component, and `DESIGN.md`'s Loading row already has the run state mark's turn there keyed on a `data-slot`. This joins it rather than living beside it: the entrance and its wait, the breath, the phase between the bars and the reduced-motion form are all rules keyed on the `route-loading`, `page-state` and `loading-indicator` slots, on a new `egma-skeleton-pulse` keyframe. Consequences: `PageState` no longer needs the `className` escape hatch that had been opened for it, and no bracket literal is left in either component — including in prose, because Tailwind reads these files as text and a comment naming a class mints a rule from it.

**No flash, over the whole fallback.** The wait was on the card only, so a sub-second navigation painted a header above a tall empty gap and then swapped. Each fallback is one element now and the theme fades that, with the card inside it explicitly excused so the two delays never stack.

**28 `app/**/loading.tsx` files.** The App Router had none, so a press on a navigation item held the *previous* page on screen with nothing said until the next was ready. Each composes the same `Loading` inside the page's own header, so the shell — which belongs to `ProductShellBoundary` in the root layout — never moves. `<Link>` also prefetches a dynamic route only as far as its nearest loading boundary.

Each fallback mirrors its page's **header shape**, not only its words. `shell.tsx` hides the eyebrow whenever breadcrumbs are given; seventeen of these pages give breadcrumbs, so their fallbacks give the same breadcrumbs, into real routes, reading their ids from the router. Audited: zero shape mismatches across all 28. The new-connection fallback titles itself **New connection** — the page's own last crumb, and the one wording true on both ways in, since a fallback cannot read the `?onboarding=` that decides between "Connect the agent" and "Add a connection". `/`, `/members` and `/invite` wait with a header and no card, exactly as their pages do; `/invite` composes the access surface rather than the product shell.

**No new dependency, and no spinner kit file** — the product already has a rotating mark for progress, and a second would be two loading languages.

## What was proven

- **Scoped tests, 224 passed** on the rebased tree: `components.test.tsx` (69, of which 16 are new), `design-system.test.tsx`, `pages.test.ts`, `settings.test.tsx`, `agents-pages.test.tsx`, `presentation.test.ts`. The new tests split in two: the DOM half proves the components emit the slots and say the true sentence and write no motion in either file, prose included; the theme half reads `tailwind-theme.css` and proves the rules keyed on those slots are made of tokens, that the entrance token is at least 150ms, that a route fallback gets one entrance rather than one per layer, and that reduced motion stops the breath.
- **Typecheck** clean. **Production build** clean, all routes intact.
- **Emitted CSS reverified after the rebase**: `@keyframes egma-skeleton-pulse{50%{opacity:.5}}`, the entrance on both `page-state:has(loading-indicator)` and `route-loading`, the `animation:none` suppression inside a fallback, the skeleton rule in `var(--duration-drawer-in)`/`var(--ease-in-out)`, both stagger rules, and the reduced-motion rule. Zero `pulse-delay`, zero escaped `[animation…]` classes, zero ellipsis characters.
- **Live in a browser** (`next dev`): in-page card computes `egma-fade-in 0.14s cubic-bezier(0.23,1,0.32,1) 0.18s both`; bars compute `egma-skeleton-pulse 0.56s cubic-bezier(0.77,0,0.175,1) infinite` at `0s / -0.14s / -0.28s`. With a `route-loading` wrapper in place the wrapper takes the entrance and the card inside computes `animation: none` — the double-delay is verified absent, not assumed.
- **Both themes**, read live: light page `#f9f9f9` / bar `#dcdcdc`; dark `#151514` / `#30302d`; 8px radius in both.
- **Reduced motion**, read from the live CSSOM: the bar matches `[data-slot="skeleton"]{animation:none}`; the wrapper and card match only `globals.css`'s global cap, which sets duration and iteration count but no `animation-delay` — so the wait survives and only the fade goes.

## What is not proven, and one thing found

- **No screenshots.** The browser pane returned blank captures for this tab throughout, while DOM, computed-style and CSSOM reads worked. Every visual claim above is a computed value or a resolved colour, not a pixel.
- **The fallback was never caught mid-transition live.** The router payload proves what renders (`{"type":"loading","pagePath":"projects/[projectId]/tests/loading.tsx"}` with the serialized composition); a poll never landed inside the window because the tool's execution context is torn down between calls.
- **Mobile width fits by arithmetic**, not by measurement: the widest bar is 256px against a 320px card at 360px wide.
- **A fallback carries the page's header but not its toolbar, actions, or the settings sub-navigation**, none of which it can know before the page mounts. The header lands first and the rest fills in under it. Deliberate, and said in the files.
- **Found, and not mine to fix:** `app/design-system/proof.tsx:865` names `animate-pulse` in a JSX comment while applying it to nothing. Tailwind scans that file as text, so the prose alone mints `.animate-pulse`, `--animate-pulse` and `@keyframes pulse` into the stylesheet — verified by removing the same class name from my own theme comment and watching the rule survive. The sentence is also now wrong: after this change the kit skeleton pulses on `egma-skeleton-pulse` at 560ms with egma's easing, not on Tailwind's 2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces animated loading indicators and route-level loading boundaries while centralizing their motion behavior in the web theme.
- Adds route-specific loading fallbacks across product, access, settings, and resource-detail routes.
- Adds three decorative skeleton bars to the shared loading state.
- Moves loading entrance, pulse, staggering, and reduced-motion behavior into slot-keyed theme CSS.
- Restyles the shared skeleton primitive and expands component/theme contract tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/ui/page-state.tsx | Extends the shared loading state with an aria-hidden three-bar indicator while preserving its status sentence and public loading contract. |
| apps/web/ui/tailwind-theme.css | Centralizes route entrance, skeleton pulse, staggering, nested-animation suppression, and reduced-motion behavior using data-slot selectors. |
| apps/web/components/ui/skeleton.tsx | Replaces component-local pulse styling with tokenized radius and border color classes so motion is controlled by the theme. |
| apps/web/test/components.test.tsx | Adds DOM and stylesheet assertions for loading slots, accessible output, tokenized animation rules, single entrances, and reduced-motion behavior. |
| apps/web/app/loading.tsx | Adds a root route fallback that presents an immediate session-checking state. |
| apps/web/app/projects/[projectId]/agents/loading.tsx | Establishes the representative project-route fallback composition used across the newly covered route families. |
| apps/web/app/invite/loading.tsx | Adds an invitation fallback using the access surface rather than the product-shell composition. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Route navigation] --> B[Nearest loading.tsx boundary]
  B --> C[route-loading slot]
  C --> D[Page header and Loading state]
  D --> E[loading-indicator slot]
  E --> F[Three skeleton slots]
  G[tailwind-theme.css] --> C
  G --> D
  G --> F
  H[Reduced-motion preference] --> G
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): give the loader one home in th..."](https://github.com/egma-ai/egma/commit/bd5aed545325979a530054eb350dbc63c3d52c1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55280132)</sub>

<!-- /greptile_comment -->