### PR TITLE
feat(web): give the form and feedback wrappers the kit's keyboard and timing

### DIFF
--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -1,24 +1,50 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import { Label as LabelPrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
+/**
+ * The visible name of a control.
+ *
+ * `DESIGN.md`: "Keep labels visible. Placeholder text is not a label." So this
+ * is drawn rather than hidden, at the 14px step and at weight 500 — the weight
+ * the type rules reserve for compact labels, and the highest weight this
+ * product has.
+ *
+ * Radix rather than a plain `<label>` for one behaviour a plain one gets
+ * wrong: a double click on a label selects the words around it, which is what
+ * a person sees when they meant to select the value in the field. Radix
+ * suppresses that and leaves the click-to-focus a label is for.
+ *
+ * No focus ring here. `globals.css` draws the two-pixel Ember indicator on
+ * every focusable element from outside every cascade layer, so no component in
+ * this directory carries one of its own.
+ */
 function Label({
   className,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        "flex items-center gap-2 text-sm font-medium text-foreground select-none",
+        /*
+         * A label is not a control, so it cannot be disabled itself. These say
+         * what it does when the thing it names is: a wrapped control reports
+         * through `group-data-[disabled]`, a sibling one through `peer`. Both
+         * land on the same 55% the button uses, so one disabled row fades by
+         * one amount.
+         */
+        "group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-55",
+        "peer-disabled:cursor-not-allowed peer-disabled:opacity-55",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/apps/web/components/ui/radio-group.tsx
+++ b/apps/web/components/ui/radio-group.tsx
@@ -1,45 +1,135 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { CircleIcon } from "lucide-react"
-import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+import { cva, type VariantProps } from "class-variance-authority";
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
+/**
+ * Exactly one of a small closed set.
+ *
+ * Radix supplies the whole radio-group contract, which is the part a
+ * hand-written group loses quietly: the group is one Tab stop, the arrow keys
+ * move inside it and come back round, Home and End reach the ends, selection
+ * follows focus, and every option reports `role="radio"` with `aria-checked`.
+ * None of that shows in a screenshot, so none of it fails visibly when it is
+ * dropped in a refactor.
+ *
+ * Radix moves focus in a task after the key, rather than during it, so React
+ * has committed the new selection before anything is focused. A caller sees
+ * `onChange` and then the focus move, in that order.
+ *
+ * No focus ring here: `globals.css` draws the two-pixel Ember indicator on
+ * every focusable element from outside every cascade layer.
+ */
 function RadioGroup({
   className,
   ...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+}: ComponentProps<typeof RadioGroupPrimitive.Root>) {
   return (
     <RadioGroupPrimitive.Root
       data-slot="radio-group"
       className={cn("grid gap-3", className)}
       {...props}
     />
-  )
+  );
 }
+
+/**
+ * The two shapes one option is drawn in.
+ *
+ * The names are egma's, and they follow `button.tsx`: one primitive, more than
+ * one thing it may look like, chosen by a named prop rather than by a class
+ * list each caller reassembles. `dot` is the registry's radio — a small round
+ * box beside its own label. `segment` is the joined strip a filter is drawn
+ * as, where the option carries its own words.
+ *
+ * **`segment` is not a tab and not a toggle group.** Both would draw this, and
+ * both would say something else about it: tabs name panels a page switches
+ * between, and this switches which rows a table is asked for. What the radio
+ * group says is what a person's assistive technology is told.
+ */
+const radioItemVariants = cva(
+  [
+    "shrink-0 cursor-pointer disabled:cursor-not-allowed disabled:opacity-55",
+    /*
+     * Pointer press feedback only, and `transform` is the only property that
+     * moves — never `all`, and never a colour, which changes at once here as
+     * it always has. Keyboard activation is immediate, which is what the
+     * `:focus-visible` exclusion says.
+     */
+    "transition-transform duration-(--duration-press) ease-out",
+    "[&:active:not(:focus-visible):not(:disabled)]:scale-97",
+    "motion-reduce:transition-none",
+    "motion-reduce:[&:active:not(:focus-visible):not(:disabled)]:scale-100",
+  ],
+  {
+    variants: {
+      shape: {
+        /*
+         * 18px is the box, and it is deliberately not the 44px target: the
+         * same split `checkbox.tsx` makes, and for the same reason. `DESIGN.md`
+         * asks for a 44px pointer target on a coarse pointer, not a 44px
+         * radio. The target grows on a pseudo-element so nothing moves around
+         * it, and a mouse sees no change at all.
+         */
+        dot: [
+          "relative grid size-[18px] place-items-center",
+          "rounded-chip border border-input bg-surface",
+          "pointer-coarse:before:absolute pointer-coarse:before:top-1/2 pointer-coarse:before:left-1/2",
+          "pointer-coarse:before:size-(--tap-target) pointer-coarse:before:-translate-x-1/2",
+          "pointer-coarse:before:-translate-y-1/2 pointer-coarse:before:content-['']",
+          "pointer-hover:border-border-strong",
+        ],
+        segment: [
+          /*
+           * One pixel inside the strip's own border, so the chosen segment
+           * sits on the strip rather than over its edge.
+           */
+          "inline-flex h-[calc(var(--control-md)-6px)] items-center px-4",
+          "rounded-[calc(var(--radius-sm)-1px)] border-0 bg-transparent",
+          "text-sm whitespace-nowrap text-muted-foreground",
+          /* A real target on a coarse pointer, without growing what a mouse gets. */
+          "pointer-coarse:min-h-(--tap-target)",
+          "pointer-hover:text-foreground",
+          /*
+           * The chosen option carries an Ember underline as well as the wash,
+           * because state is never colour alone.
+           */
+          "data-[state=checked]:bg-selected data-[state=checked]:text-foreground",
+          "data-[state=checked]:shadow-[inset_0_-2px_0_var(--accent)]",
+        ],
+      },
+    },
+    defaultVariants: { shape: "dot" },
+  },
+);
 
 function RadioGroupItem({
   className,
+  shape = "dot",
+  children,
   ...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+}: ComponentProps<typeof RadioGroupPrimitive.Item> &
+  VariantProps<typeof radioItemVariants>) {
   return (
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
-      className={cn(
-        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
-        className
-      )}
+      className={cn(radioItemVariants({ shape }), className)}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator
-        data-slot="radio-group-indicator"
-        className="relative flex items-center justify-center"
-      >
-        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
-      </RadioGroupPrimitive.Indicator>
+      {shape === "segment" ? (
+        children
+      ) : (
+        <RadioGroupPrimitive.Indicator
+          data-slot="radio-group-indicator"
+          /* Ember, which `DESIGN.md` names for focus, icons, marks and edges. */
+          className="size-2 rounded-chip bg-brand"
+        />
+      )}
     </RadioGroupPrimitive.Item>
-  )
+  );
 }
 
-export { RadioGroup, RadioGroupItem }
+export { RadioGroup, RadioGroupItem, radioItemVariants };

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -88,7 +88,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--info-text": "var(--foreground)",
           "--info-border": "var(--border)",
           /* The card radius, which is what a raised surface this size wears. */
-          "--border-radius": "var(--radius-lg)",
+          "--border-radius": "var(--radius-card)",
         } as CSSProperties
       }
       {...props}

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import {
   CircleCheckIcon,
@@ -6,35 +6,94 @@ import {
   Loader2Icon,
   OctagonXIcon,
   TriangleAlertIcon,
-} from "lucide-react"
-import { useTheme } from "@/ui/theme.tsx"
-import { Toaster as Sonner, type ToasterProps } from "sonner"
+} from "lucide-react";
+import type { CSSProperties } from "react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+import { useTheme } from "@/ui/theme.tsx";
+
+/**
+ * The registry's notification region, dressed in egma's values.
+ *
+ * It reads the product's own `useTheme` rather than `next-themes`, because
+ * this application already has one place that decides light or dark and two
+ * controls that write to it. A second theme source would be a second answer.
+ *
+ * **The product's own notification is not built on this, and that is
+ * deliberate.** `ui/feedback.tsx` exports a `Toast` a page controls with an
+ * `open` prop, and `DESIGN.md` asks that toast for a short translate plus
+ * opacity on an *interruptible transition*. Sonner is a queue a caller pushes
+ * into, and it leaves on a CSS animation and a fixed unmount timer — so a
+ * dismissal cannot be answered at once, which is what keyboard dismissal has
+ * to be. The two would also disagree about who owns the region. This file is
+ * here, house-correct, for the day a queue is what a surface needs; until
+ * then the shared `Toast` is what pages use, and the icons below are the ones
+ * it draws, so the two would read as one product.
+ *
+ * Every value here is a theme key. Sonner reads its own custom properties, so
+ * they are set to egma's rather than overridden later in a class list, and the
+ * neutral surface with a state-coloured edge is the same shape a status chip
+ * and the shared `Toast` already use.
+ */
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme } = useTheme()
+  const { theme } = useTheme();
 
   return (
     <Sonner
       theme={theme}
       className="toaster group"
       icons={{
-        success: <CircleCheckIcon className="size-4" />,
-        info: <InfoIcon className="size-4" />,
-        warning: <TriangleAlertIcon className="size-4" />,
-        error: <OctagonXIcon className="size-4" />,
-        loading: <Loader2Icon className="size-4 animate-spin" />,
+        success: <CircleCheckIcon className="size-4 text-success" />,
+        info: <InfoIcon className="size-4 text-muted-foreground" />,
+        warning: <TriangleAlertIcon className="size-4 text-warning" />,
+        error: <OctagonXIcon className="size-4 text-failure" />,
+        /*
+         * The one turning thing here. "Loading: show progress — fast, quiet
+         * indicator", and the words beside it carry the meaning, so reduced
+         * motion drops the turn and loses nothing.
+         */
+        loading: (
+          <Loader2Icon className="size-4 animate-spin text-muted-foreground motion-reduce:animate-none" />
+        ),
+      }}
+      toastOptions={{
+        classNames: {
+          title: "text-sm font-medium text-foreground",
+          description: "text-sm text-muted-foreground",
+        },
+        /*
+         * Sonner injects its own stylesheet outside every cascade layer, where
+         * a Tailwind utility cannot reach it — and its own transition is 400ms,
+         * which is past the 300ms ceiling on interaction motion. An inline
+         * declaration is what beats it, and it still reads a motion token
+         * rather than naming a number.
+         */
+        style: { transitionDuration: "var(--duration-popover-in)" } as CSSProperties,
       }}
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
+          "--normal-bg": "var(--surface)",
+          "--normal-text": "var(--foreground)",
           "--normal-border": "var(--border)",
-          "--border-radius": "var(--radius)",
-        } as React.CSSProperties
+          "--success-bg": "var(--surface)",
+          "--success-text": "var(--foreground)",
+          "--success-border": "var(--good-border)",
+          "--warning-bg": "var(--surface)",
+          "--warning-text": "var(--foreground)",
+          "--warning-border": "var(--warn-border)",
+          "--error-bg": "var(--surface)",
+          "--error-text": "var(--foreground)",
+          "--error-border": "var(--bad-border)",
+          "--info-bg": "var(--surface)",
+          "--info-text": "var(--foreground)",
+          "--info-border": "var(--border)",
+          /* The card radius, which is what a raised surface this size wears. */
+          "--border-radius": "var(--radius-lg)",
+        } as CSSProperties
       }
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -1,57 +1,117 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Tooltip as TooltipPrimitive } from "radix-ui"
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
+/**
+ * A short explanation attached to one control.
+ *
+ * Radix supplies what a hand-written tooltip keeps getting wrong: the delay
+ * before the first one, the grouping that opens the next one at once, Escape,
+ * dismissal when a press lands elsewhere, the `aria-describedby` wiring, and a
+ * position that answers the edge of the window instead of running off it.
+ *
+ * `disableHoverableContent` is on by default because of a rule rather than a
+ * preference: `DESIGN.md` says a tooltip never holds an action, so there is
+ * nothing in one to move a pointer into, and the grace area that protects that
+ * journey only makes the tooltip outstay its welcome.
+ */
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = 500,
+  skipDelayDuration = 1_000,
+  disableHoverableContent = true,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+}: ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
       delayDuration={delayDuration}
+      skipDelayDuration={skipDelayDuration}
+      disableHoverableContent={disableHoverableContent}
       {...props}
     />
-  )
+  );
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+/**
+ * One tooltip, which carries its own provider so a lone one works.
+ *
+ * A provider higher up still decides for every tooltip under it that does not
+ * override it: `delayDuration` passed here lands on the root, and Radix reads
+ * the root's before the provider's.
+ */
+function Tooltip(props: ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
 }
 
-function TooltipTrigger({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+function TooltipTrigger(props: ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
+/**
+ * The panel itself, and the one state that must not move.
+ *
+ * Radix says how the tooltip was opened, and the two answers want different
+ * things. `delayed-open` is a pointer that waited, so it arrives on opacity
+ * and `scale`, about the trigger it belongs to. `instant-open` is either
+ * keyboard focus or a pointer inside the grouping window, and both of those
+ * appear at once and without movement — "do not animate actions used many
+ * times each day, especially keyboard navigation", and a delay repeated across
+ * a row of controls is the tooltip behaviour everybody complains about.
+ *
+ * The exit is scoped by the `data-input` its caller sets, because Radix says
+ * "closed" the same way whichever opened it. An animation is what Radix waits
+ * for before it unmounts, so a pointer exit runs to completion and a keyboard
+ * one is not made to wait for anything. A caller that sets no `data-input`
+ * gets the arrival and an exit that is simply immediate.
+ *
+ * **No arrow.** This product's tooltip has never drawn one, and Radix measures
+ * an arrow with a `ResizeObserver`, which the component tests have no
+ * implementation of. Adding one is a change to two things, not one.
+ */
 function TooltipContent({
   className,
-  sideOffset = 0,
-  children,
+  /* 8px, the second step of the 4px grid, between the trigger and the panel. */
+  sideOffset = 8,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-          className
+          /*
+           * A tooltip holds no action, so it takes no presses either. Without
+           * this it is a panel sitting over the control it explains, and the
+           * click meant for that control lands on the explanation.
+           */
+          "pointer-events-none",
+          "z-40 w-max max-w-[min(240px,calc(100vw-var(--space-7)))]",
+          "rounded-button border border-foreground bg-foreground px-3 py-2",
+          "text-sm text-balance text-surface",
+          /* "Popovers use their trigger as `transform-origin`." Radix measures it. */
+          "origin-(--radix-tooltip-content-transform-origin)",
+          "data-[state=delayed-open]:animate-[egma-anchored-in_var(--duration-popover-in)_var(--ease-out)]",
+          "data-[input=pointer]:data-[state=closed]:animate-[egma-anchored-out_var(--duration-popover-out)_var(--ease-out)]",
+          /*
+           * The reduced-motion form keeps the arrival and the departure and
+           * drops the movement, so the panel still says it came and went.
+           */
+          "motion-reduce:data-[state=delayed-open]:animate-[egma-fade-in_var(--duration-hover)_linear]",
+          "motion-reduce:data-[input=pointer]:data-[state=closed]:animate-[egma-fade-out_var(--duration-hover)_linear]",
+          className,
         )}
         {...props}
-      >
-        {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
-      </TooltipPrimitive.Content>
+      />
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -38,9 +38,15 @@ function TooltipProvider({
 /**
  * One tooltip, which carries its own provider so a lone one works.
  *
- * A provider higher up still decides for every tooltip under it that does not
- * override it: `delayDuration` passed here lands on the root, and Radix reads
- * the root's before the provider's.
+ * **The inner provider is also what stops the delay grouping from working
+ * across tooltips.** Radix keeps "one has just been shown, so open the next at
+ * once" on the provider, and a provider per tooltip means each one only ever
+ * groups with itself: the same trigger re-hovered is instant, its neighbour
+ * still waits the full delay. A `TooltipProvider` mounted higher up does not
+ * change that, because the nearest provider is the one a tooltip reads and the
+ * nearest is always this one. Restoring the shared window means removing this
+ * wrapper *and* mounting one provider above the product, which is two files at
+ * once and is recorded with the coordinator rather than done here.
  */
 function Tooltip(props: ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
@@ -55,21 +61,26 @@ function TooltipTrigger(props: ComponentProps<typeof TooltipPrimitive.Trigger>) 
 }
 
 /**
- * The panel itself, and the one state that must not move.
+ * The panel itself.
  *
- * Radix says how the tooltip was opened, and the two answers want different
- * things. `delayed-open` is a pointer that waited, so it arrives on opacity
- * and `scale`, about the trigger it belongs to. `instant-open` is either
- * keyboard focus or a pointer inside the grouping window, and both of those
- * appear at once and without movement — "do not animate actions used many
- * times each day, especially keyboard navigation", and a delay repeated across
- * a row of controls is the tooltip behaviour everybody complains about.
+ * **No motion here.** `tailwind-theme.css` writes it, keyed on `data-slot` and
+ * Radix's `data-state`, exactly as it does for the popover, the dropdown menu
+ * and the dialog. Two things need that placement rather than a class list: the
+ * reduced-motion form has to be a real `@media` block that comes later, where
+ * a `motion-reduce:` utility of equal specificity leaves the winner to
+ * Tailwind's variant sort order — a reduced-motion failure that fails silently
+ * — and the development proof's reduced-motion frame keys off an ancestor,
+ * which no class on this element can express.
  *
- * The exit is scoped by the `data-input` its caller sets, because Radix says
- * "closed" the same way whichever opened it. An animation is what Radix waits
- * for before it unmounts, so a pointer exit runs to completion and a keyboard
- * one is not made to wait for anything. A caller that sets no `data-input`
- * gets the arrival and an exit that is simply immediate.
+ * **No portal, and that is the deliberate part.** The registry portals this to
+ * `body`, and a panel under `body` is out of reach of every descendant
+ * selector in the theme, including the one the proof page's reduced-motion
+ * frame is drawn with. Radix positions the panel `position: fixed` either way,
+ * so staying in place keeps the collision handling and the escape from
+ * ordinary `overflow` scrolling; what it gives up is an ancestor that is
+ * itself a containing block for fixed children — a `transform`, `filter` or
+ * `contain` — and the hand-written tooltip this replaces was
+ * `position: absolute` inside its trigger, so it lost that case too.
  *
  * **No arrow.** This product's tooltip has never drawn one, and Radix measures
  * an arrow with a `ResizeObserver`, which the component tests have no
@@ -82,35 +93,25 @@ function TooltipContent({
   ...props
 }: ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
-    <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
-        data-slot="tooltip-content"
-        sideOffset={sideOffset}
-        className={cn(
-          /*
-           * A tooltip holds no action, so it takes no presses either. Without
-           * this it is a panel sitting over the control it explains, and the
-           * click meant for that control lands on the explanation.
-           */
-          "pointer-events-none",
-          "z-40 w-max max-w-[min(240px,calc(100vw-var(--space-7)))]",
-          "rounded-button border border-foreground bg-foreground px-3 py-2",
-          "text-sm text-balance text-surface",
-          /* "Popovers use their trigger as `transform-origin`." Radix measures it. */
-          "origin-(--radix-tooltip-content-transform-origin)",
-          "data-[state=delayed-open]:animate-[egma-anchored-in_var(--duration-popover-in)_var(--ease-out)]",
-          "data-[input=pointer]:data-[state=closed]:animate-[egma-anchored-out_var(--duration-popover-out)_var(--ease-out)]",
-          /*
-           * The reduced-motion form keeps the arrival and the departure and
-           * drops the movement, so the panel still says it came and went.
-           */
-          "motion-reduce:data-[state=delayed-open]:animate-[egma-fade-in_var(--duration-hover)_linear]",
-          "motion-reduce:data-[input=pointer]:data-[state=closed]:animate-[egma-fade-out_var(--duration-hover)_linear]",
-          className,
-        )}
-        {...props}
-      />
-    </TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      data-slot="tooltip-content"
+      sideOffset={sideOffset}
+      className={cn(
+        /*
+         * A tooltip holds no action, so it takes no presses either. Without
+         * this it is a panel sitting over the control it explains, and the
+         * click meant for that control lands on the explanation.
+         */
+        "pointer-events-none",
+        "z-40 w-max max-w-[min(240px,calc(100vw-var(--space-7)))]",
+        "rounded-button border border-foreground bg-foreground px-3 py-2",
+        "text-sm text-balance text-surface",
+        /* "Popovers use their trigger as `transform-origin`." Radix measures it. */
+        "origin-(--radix-tooltip-content-transform-origin)",
+        className,
+      )}
+      {...props}
+    />
   );
 }
 

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -169,6 +169,19 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+/**
+ * Let the work a control deliberately defers actually happen.
+ *
+ * Radix's roving focus moves focus in a task after the key rather than during
+ * it, so React has committed the new state before anything is focused. A test
+ * that reads the DOM in the same tick is reading it before the control has
+ * finished, which is a race rather than a failure.
+ */
+const settle = () =>
+  act(async () => {
+    await new Promise((done) => setTimeout(done, 0));
+  });
+
 /* ------------------------------------------------------------------------ */
 
 describe("the organization and project selector", () => {
@@ -562,10 +575,10 @@ describe("a binary choice", () => {
  * than to whichever page happened to mount it, and the proof now survives the
  * next page that adopts or drops it.
  *
- * Nothing here is free. It is a `div` of `button`s wearing radio semantics, so
- * every part of the radio group contract below is hand-written in
- * `ui/choice.tsx` and every part of it can be lost in a refactor without one
- * visible pixel changing.
+ * It is the kit's radio group now, which is Radix's, so the contract below is
+ * no longer hand-written. It is still asked for here: what a person gets from
+ * this control is the same list of promises whoever keeps them, and a later
+ * change that swaps the primitive back out has to keep them too.
  */
 describe("a choice between two lists", () => {
   const OPTIONS = [
@@ -612,18 +625,38 @@ describe("a choice between two lists", () => {
    * agreeing: a group that moved the highlight without moving focus would
    * leave a screen reader saying one thing and the next keypress landing on
    * another.
+   *
+   * Radix moves focus in a task after the key rather than during it, so React
+   * has committed the new selection before anything is focused. That is why
+   * each key here is followed by a flush: the order a caller sees is `onChange`
+   * and then the focus move, and asking for both in the same tick would be
+   * asking for an order this control does not promise.
    */
-  it("chooses the other list from the keyboard, and says which is chosen", () => {
+  it("chooses the other list from the keyboard, and says which is chosen", async () => {
     const chose = vi.fn();
     render(<Example onChange={chose} />);
 
-    const active = screen.getByRole("radio", { name: "Active" });
-    const archived = screen.getByRole("radio", { name: "Archived" });
-    expect(active.getAttribute("tabindex")).toBe("0");
-    expect(archived.getAttribute("tabindex")).toBe("-1");
+    /*
+     * The group is the Tab stop and the options are not, which is the same
+     * promise the old hand-written `tabindex` made and a stricter way to keep
+     * it: entering forwards focus to whichever option is chosen.
+     */
+    const group = screen.getByRole("radiogroup", {
+      name: "Which personas to show",
+    });
+    expect(group.getAttribute("tabindex")).toBe("0");
+    for (const option of within(group).getAllByRole("radio")) {
+      expect(option.getAttribute("tabindex")).toBe("-1");
+    }
 
-    active.focus();
+    const active = screen.getByRole("radio", { name: "Active" });
+    act(() => active.focus());
+    expect(active.getAttribute("tabindex")).toBe("0");
+    expect(screen.getByRole("radio", { name: "Archived" }).getAttribute("tabindex"))
+      .toBe("-1");
+
     fireEvent.keyDown(active, { key: "ArrowRight" });
+    await settle();
 
     expect(chose).toHaveBeenCalledWith("archived");
     const now = screen.getByRole("radio", { name: "Archived" });
@@ -637,6 +670,7 @@ describe("a choice between two lists", () => {
     // The same key again comes back round rather than stopping at the end: a
     // closed set of two has no far edge to be stuck against.
     fireEvent.keyDown(now, { key: "ArrowRight" });
+    await settle();
     expect(chose).toHaveBeenLastCalledWith("active");
     expect(document.activeElement).toBe(
       screen.getByRole("radio", { name: "Active" }),

--- a/apps/web/test/feedback.test.tsx
+++ b/apps/web/test/feedback.test.tsx
@@ -10,19 +10,78 @@ import { Toast, Tooltip, type FeedbackInput } from "../ui/feedback.tsx";
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
+
+/**
+ * The one fact jsdom is missing, supplied so the exit can be driven.
+ *
+ * Radix keeps a closing panel mounted only while an exit animation is running,
+ * and it decides that by reading `animation-name` off the element. jsdom loads
+ * no stylesheet, so it answers "none" for everything and every exit is
+ * instant — which would make an exit test pass no matter what the theme said.
+ *
+ * So this teaches `getComputedStyle` the two rules `tailwind-theme.css`
+ * actually declares for `[data-slot="tooltip-content"]`, and nothing else. A
+ * theme that stopped declaring them would not be caught here; what is caught
+ * is the component half — that the panel carries the `data-state` and
+ * `data-input` those rules are keyed on, and that Radix is left to wait for
+ * the animation rather than being torn down under it.
+ *
+ * It is a live view rather than a snapshot because Radix reads the same
+ * declaration object again later, after `data-state` has changed.
+ */
+function teachJsdomTheTooltipMotion() {
+  const real = window.getComputedStyle.bind(window);
+
+  const animationOf = (element: Element) => {
+    if (!(element instanceof HTMLElement)) return "none";
+    if (element.dataset.slot !== "tooltip-content") return "none";
+    if (element.dataset.state === "delayed-open") return "egma-anchored-in";
+    if (element.dataset.state === "closed" && element.dataset.input === "pointer") {
+      return "egma-anchored-out";
+    }
+    return "none";
+  };
+
+  vi.spyOn(window, "getComputedStyle").mockImplementation(
+    ((element: Element, pseudo?: string | null) =>
+      new Proxy(real(element, pseudo ?? undefined), {
+        get(target, key) {
+          if (key === "animationName") return animationOf(element);
+          const held = Reflect.get(target, key, target) as unknown;
+          return typeof held === "function" ? held.bind(target) : held;
+        },
+      })) as typeof window.getComputedStyle,
+  );
+}
+
+/**
+ * The end of one named animation, as a browser reports it.
+ *
+ * `fireEvent.animationEnd` cannot carry the name: jsdom's `AnimationEvent`
+ * drops `animationName` from its init, and Radix checks that name before it
+ * accepts the end of an animation as the end of *its* animation. Without it
+ * the panel is told a different animation finished and stays where it is.
+ */
+function endAnimation(element: Element, animationName: string) {
+  const ended = new Event("animationend", { bubbles: false });
+  Object.defineProperty(ended, "animationName", { value: animationName });
+  fireEvent(element, ended);
+}
 
 describe("shared feedback", () => {
   /**
-   * **Keyboard focus shows it at once, and nothing moves.**
+   * **Keyboard focus shows it at once, and it leaves at once too.**
    *
-   * Radix says how a tooltip opened, and `instant-open` is the answer for
-   * keyboard focus. The component reads that word to decide whether anything
-   * animates, so this is the assertion that keeps a Tab step from growing a
-   * movement — `DESIGN.md`: "Do not animate actions used many times each day,
-   * especially keyboard navigation."
+   * The motion stub is installed here on purpose. It is the same one that
+   * keeps the pointer exit below alive, so this test says the keyboard close
+   * is immediate *because there is no exit animation for it* rather than
+   * because jsdom happens to run none — `DESIGN.md`: "Do not animate actions
+   * used many times each day, especially keyboard navigation."
    */
   it("shows a keyboard tooltip at once and closes it at once with Escape", () => {
+    teachJsdomTheTooltipMotion();
     render(
       <Tooltip label="Copy the project identifier">
         <button type="button">Copy identifier</button>
@@ -42,19 +101,20 @@ describe("shared feedback", () => {
   });
 
   /**
-   * **A pointer waits before the first one, then it arrives by moving.**
+   * **A pointer waits before the first one, and its exit runs to completion.**
    *
    * The delay is what stops a tooltip flashing at every control a pointer
    * crosses on its way somewhere else.
    *
-   * The exit is a class assertion, for the reason the error test below writes
-   * down: jsdom loads no stylesheet, so a real exit cannot run here and the
-   * mapping is what is guarded. Both halves matter. `data-input="pointer"` is
-   * what scopes the exit animation, and an animation is what Radix waits for
-   * before it unmounts — so a keyboard close leaves at once and a pointer
-   * close runs to completion, which is what `DESIGN.md` asks of an exit.
+   * The exit is driven rather than described. `DESIGN.md`: "An exit runs to
+   * completion and is never cut off. A surface that is closed finishes leaving
+   * before it is removed." So the pointer leaves, the panel is still there,
+   * and only the end of the animation removes it. Asserting the class that
+   * asks for the animation would pass on a misspelled keyframe and on a panel
+   * Radix tore down underneath it.
    */
-  it("delays the first pointer tooltip and gives it an exit to run", () => {
+  it("delays the first pointer tooltip and lets its exit finish before it goes", () => {
+    teachJsdomTheTooltipMotion();
     vi.useFakeTimers();
     render(
       <Tooltip label="Copy the project identifier">
@@ -70,18 +130,14 @@ describe("shared feedback", () => {
     const tooltip = screen.getByRole("tooltip");
     expect(tooltip.getAttribute("data-input")).toBe("pointer");
     expect(tooltip.getAttribute("data-state")).toBe("delayed-open");
-    expect(tooltip.className).toContain(
-      "data-[state=delayed-open]:animate-[egma-anchored-in_var(--duration-popover-in)_var(--ease-out)]",
-    );
-    expect(tooltip.className).toContain(
-      "data-[input=pointer]:data-[state=closed]:animate-[egma-anchored-out_var(--duration-popover-out)_var(--ease-out)]",
-    );
-    // The reduced-motion form is not optional, so it is asked for here too.
-    expect(tooltip.className).toContain(
-      "motion-reduce:data-[state=delayed-open]:animate-[egma-fade-in_var(--duration-hover)_linear]",
-    );
 
     fireEvent.pointerLeave(trigger);
+
+    // Closed, and still on the page: the exit is what it is waiting for.
+    expect(screen.getByRole("tooltip")).toBe(tooltip);
+    expect(tooltip.getAttribute("data-state")).toBe("closed");
+
+    endAnimation(tooltip, "egma-anchored-out");
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 

--- a/apps/web/test/feedback.test.tsx
+++ b/apps/web/test/feedback.test.tsx
@@ -13,6 +13,15 @@ afterEach(() => {
 });
 
 describe("shared feedback", () => {
+  /**
+   * **Keyboard focus shows it at once, and nothing moves.**
+   *
+   * Radix says how a tooltip opened, and `instant-open` is the answer for
+   * keyboard focus. The component reads that word to decide whether anything
+   * animates, so this is the assertion that keeps a Tab step from growing a
+   * movement — `DESIGN.md`: "Do not animate actions used many times each day,
+   * especially keyboard navigation."
+   */
   it("shows a keyboard tooltip at once and closes it at once with Escape", () => {
     render(
       <Tooltip label="Copy the project identifier">
@@ -25,15 +34,28 @@ describe("shared feedback", () => {
 
     const tooltip = screen.getByRole("tooltip");
     expect(tooltip.getAttribute("data-input")).toBe("keyboard");
+    expect(tooltip.getAttribute("data-state")).toBe("instant-open");
     expect(trigger.getAttribute("aria-describedby")).toBe(tooltip.id);
 
     fireEvent.keyDown(trigger, { key: "Escape" });
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
-  it("delays the first pointer tooltip and keeps it present through its short exit", () => {
+  /**
+   * **A pointer waits before the first one, then it arrives by moving.**
+   *
+   * The delay is what stops a tooltip flashing at every control a pointer
+   * crosses on its way somewhere else.
+   *
+   * The exit is a class assertion, for the reason the error test below writes
+   * down: jsdom loads no stylesheet, so a real exit cannot run here and the
+   * mapping is what is guarded. Both halves matter. `data-input="pointer"` is
+   * what scopes the exit animation, and an animation is what Radix waits for
+   * before it unmounts — so a keyboard close leaves at once and a pointer
+   * close runs to completion, which is what `DESIGN.md` asks of an exit.
+   */
+  it("delays the first pointer tooltip and gives it an exit to run", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-15T12:00:00.000Z"));
     render(
       <Tooltip label="Copy the project identifier">
         <button type="button">Copy identifier</button>
@@ -41,16 +63,25 @@ describe("shared feedback", () => {
     );
 
     const trigger = screen.getByRole("button", { name: "Copy identifier" });
-    fireEvent.pointerEnter(trigger);
+    fireEvent.pointerMove(trigger, { pointerType: "mouse" });
     expect(screen.queryByRole("tooltip")).toBeNull();
 
     act(() => vi.advanceTimersByTime(500));
     const tooltip = screen.getByRole("tooltip");
     expect(tooltip.getAttribute("data-input")).toBe("pointer");
+    expect(tooltip.getAttribute("data-state")).toBe("delayed-open");
+    expect(tooltip.className).toContain(
+      "data-[state=delayed-open]:animate-[egma-anchored-in_var(--duration-popover-in)_var(--ease-out)]",
+    );
+    expect(tooltip.className).toContain(
+      "data-[input=pointer]:data-[state=closed]:animate-[egma-anchored-out_var(--duration-popover-out)_var(--ease-out)]",
+    );
+    // The reduced-motion form is not optional, so it is asked for here too.
+    expect(tooltip.className).toContain(
+      "motion-reduce:data-[state=delayed-open]:animate-[egma-fade-in_var(--duration-hover)_linear]",
+    );
 
     fireEvent.pointerLeave(trigger);
-    expect(screen.getByRole("tooltip").getAttribute("data-closing")).toBe("true");
-    fireEvent.transitionEnd(tooltip, { propertyName: "opacity" });
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
@@ -132,11 +163,29 @@ describe("shared feedback", () => {
     expect(toast.className).toContain("data-[kind=error]:border-l-failure");
     expect(toast.className).not.toContain("border-l-brand");
 
-    // The mark inside it carries the same state, and the same rule.
-    const mark = toast.querySelector("[aria-hidden=true]");
-    expect(mark?.textContent).toBe("!");
-    expect(mark?.className).toContain("group-data-[kind=error]:border-failure");
-    expect(mark?.className).not.toContain("border-brand");
+    /*
+     * The mark inside it carries the same state, and the same rule — and it
+     * carries it as a shape first. A crossed octagon against a ticked circle
+     * reads as two different things with no colour at all, which is what
+     * "state is not communicated by color alone" asks for.
+     */
+    const mark = toast.querySelector("[data-slot=toast-mark]");
+    expect(mark?.getAttribute("class")).toContain("lucide-octagon-x");
+    expect(mark?.getAttribute("class")).toContain("text-failure");
+    expect(mark?.getAttribute("class")).not.toContain("text-brand");
+  });
+
+  /** The neutral form of the same mark, so the two are told apart by shape. */
+  it("marks a status toast with a different shape from an error one", () => {
+    render(
+      <Toast open title="Agent saved" onDismiss={() => undefined}>
+        Support is ready.
+      </Toast>,
+    );
+
+    const mark = screen.getByRole("status").querySelector("[data-slot=toast-mark]");
+    expect(mark?.getAttribute("class")).toContain("lucide-circle-check");
+    expect(mark?.getAttribute("class")).not.toContain("text-failure");
   });
 
   it("names a busy button and makes it inert", () => {

--- a/apps/web/ui/choice.tsx
+++ b/apps/web/ui/choice.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useRef } from "react";
-
-import { cn } from "@/lib/utils";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
 /**
  * Which of two lists a page is showing.
@@ -12,14 +10,17 @@ import { cn } from "@/lib/utils";
  * of.
  *
  * It is announced as a radio group because that is what it is — exactly one of
- * a small closed set is chosen — and every option is reachable with Tab and
- * chosen with Enter or Space, which is what a `button` gives for free.
+ * a small closed set is chosen. The group is one Tab stop, the arrow keys move
+ * inside it and come back round, Home and End reach the ends, and selection
+ * follows focus so the keyboard and the announcement never disagree. None of
+ * that is written here any more: it is the kit's radio group, which is Radix's,
+ * and every part of it used to be hand-written in this file where a refactor
+ * could lose it without one visible pixel changing.
  *
  * It is not a shadcn Tabs or ToggleGroup. Both would draw this, and both would
  * say something else about it: tabs name panels that a page is switching
  * between, and this switches which rows a table is asked for. The radio group
- * is what a person's assistive technology is told, and it is what the old
- * control set already said.
+ * is what a person's assistive technology is told.
  */
 export function Choice<Value extends string>({
   label,
@@ -32,92 +33,24 @@ export function Choice<Value extends string>({
   readonly options: readonly { readonly value: Value; readonly label: string }[];
   readonly onChange: (value: Value) => void;
 }) {
-  /**
-   * The radios themselves, so that moving with an arrow key can put focus on
-   * the one it moved to. A radio group that changes selection without moving
-   * focus leaves a screen reader announcing one thing and the keyboard on
-   * another.
-   */
-  const radios = useRef<(HTMLButtonElement | null)[]>([]);
-
-  const move = (from: number, by: number) => {
-    const to = (from + by + options.length) % options.length;
-    const going = options[to];
-    if (going === undefined) return;
-    onChange(going.value);
-    radios.current[to]?.focus();
-  };
-
-  const STEPS: Readonly<Record<string, number>> = {
-    ArrowRight: 1,
-    ArrowDown: 1,
-    ArrowLeft: -1,
-    ArrowUp: -1,
-  };
-
   return (
-    <div
-      className="inline-flex rounded-input border border-border bg-surface p-0.5"
-      role="radiogroup"
+    <RadioGroup
+      className="inline-flex gap-0 rounded-input border border-border bg-surface p-0.5"
       aria-label={label}
+      value={value}
+      /*
+       * Radix reports the chosen value as a `string`, because it does not know
+       * the closed set this group was built from. Every item below was given
+       * one of `options`, and Radix returns the value it was given, so the
+       * narrowing is a fact about this component rather than a hope.
+       */
+      onValueChange={(chosen) => onChange(chosen as Value)}
     >
-      {options.map((option, at) => (
-        <button
-          key={option.value}
-          ref={(held) => {
-            radios.current[at] = held;
-          }}
-          className={cn(
-            "inline-flex h-[calc(var(--control-md)-6px)] items-center px-4",
-            "rounded-[calc(var(--radius-sm)-1px)] border-0 bg-transparent",
-            "cursor-pointer text-sm whitespace-nowrap text-muted-foreground",
-            /*
-             * A real touch target on a coarse pointer, without growing the
-             * control a mouse gets. The group's own height follows the item.
-             */
-            "pointer-coarse:min-h-(--tap-target)",
-            "pointer-hover:text-foreground",
-            /* Pointer press feedback only. Keyboard activation is immediate. */
-            "transition-transform duration-(--duration-press) ease-out",
-            "[&:active:not(:focus-visible)]:scale-97",
-            "motion-reduce:transition-none",
-            "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
-            option.value === value && [
-              "bg-selected text-foreground",
-              /*
-               * The chosen option carries an Ember underline as well as the
-               * wash, because state is never colour alone.
-               */
-              "shadow-[inset_0_-2px_0_var(--accent)]",
-            ],
-          )}
-          type="button"
-          role="radio"
-          aria-checked={option.value === value}
-          /**
-           * Roving: the group is one Tab stop, and the arrow keys move inside
-           * it. Every option being tabbable would make a two-option filter
-           * cost two Tab presses on the way to the table, and a ten-option one
-           * cost ten.
-           */
-          tabIndex={option.value === value ? 0 : -1}
-          onKeyDown={(event) => {
-            const step = STEPS[event.key];
-            if (step !== undefined) {
-              event.preventDefault();
-              move(at, step);
-              return;
-            }
-            if (event.key === "Home" || event.key === "End") {
-              event.preventDefault();
-              move(at, event.key === "Home" ? -at : options.length - 1 - at);
-            }
-          }}
-          onClick={() => onChange(option.value)}
-        >
+      {options.map((option) => (
+        <RadioGroupItem key={option.value} shape="segment" value={option.value}>
           {option.label}
-        </button>
+        </RadioGroupItem>
       ))}
-    </div>
+    </RadioGroup>
   );
 }

--- a/apps/web/ui/feedback.tsx
+++ b/apps/web/ui/feedback.tsx
@@ -34,12 +34,15 @@ export type FeedbackInput = "keyboard" | "pointer";
  * page, and a panel hard-centred over its trigger that ran off the side of a
  * narrow window rather than answering the edge.
  *
- * One thing that global timestamp did is not replaced yet: Radix groups the
- * "open the next one at once" window per provider, and the kit gives each
- * tooltip its own, so *this* trigger re-hovered is instant while its neighbour
- * still waits the first delay. One `TooltipProvider` near the application root
- * restores the group, and that is a change to a file this component cannot
- * make for itself.
+ * One thing that global timestamp did is not replaced, and mounting a provider
+ * would not replace it. Radix keeps the "open the next one at once" window on
+ * the provider, and the kit's `Tooltip` wraps every root in a provider of its
+ * own, so each tooltip only ever groups with itself: this trigger re-hovered
+ * is instant, its neighbour still waits the full delay. A provider mounted
+ * higher up changes nothing, because the nearest one wins and the nearest one
+ * is always the inner one. Restoring the shared window means removing that
+ * wrapper *and* mounting one provider above the product — two files at once,
+ * recorded with the coordinator rather than done here.
  *
  * `data-input` is only read by the exit: Radix reports "closed" the same way
  * whichever input opened it, and a keyboard close must not wait for a movement.

--- a/apps/web/ui/feedback.tsx
+++ b/apps/web/ui/feedback.tsx
@@ -1,182 +1,84 @@
 "use client";
 
+import { CircleCheckIcon, OctagonXIcon, XIcon } from "lucide-react";
 import {
-  cloneElement,
   useCallback,
   useEffect,
-  useId,
   useRef,
   useState,
-  type FocusEventHandler,
-  type KeyboardEventHandler,
-  type PointerEventHandler,
   type ReactElement,
   type ReactNode,
 } from "react";
 
+import {
+  Tooltip as TooltipRoot,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export type FeedbackInput = "keyboard" | "pointer";
-
-type TooltipTriggerProps = {
-  readonly "aria-describedby"?: string;
-  readonly onBlur?: FocusEventHandler<HTMLElement>;
-  readonly onFocus?: FocusEventHandler<HTMLElement>;
-  readonly onKeyDown?: KeyboardEventHandler<HTMLElement>;
-  readonly onPointerEnter?: PointerEventHandler<HTMLElement>;
-  readonly onPointerLeave?: PointerEventHandler<HTMLElement>;
-};
-
-let lastPointerTooltipAt = 0;
-const FIRST_TOOLTIP_DELAY = 500;
-const TOOLTIP_WARM_WINDOW = 1_000;
 
 /**
  * A short explanation attached to one control.
  *
  * Keyboard focus shows it at once and without movement. A pointer gets a short
- * delay before the first tooltip, which prevents accidental flashes while it
- * crosses the page. Nearby tooltips then open at once. The tooltip never holds
- * an action; interactive help belongs in a menu or dialog.
+ * delay before the first one, which prevents accidental flashes while it
+ * crosses the page, and the same trigger hovered again straight after opens at
+ * once. The tooltip never holds an action; interactive help belongs in a menu
+ * or dialog.
  *
- * It is centred on its trigger with `translate` and it arrives on `scale`, so
- * the two never share a property. The arrival itself is in `tailwind-theme.css`
- * keyed on `data-slot`, `data-input` and `data-instant`.
+ * **All of the timing, the positioning, the Escape, and the `aria-describedby`
+ * are the kit's now**, which is Radix's. What used to be here was a hand-written
+ * pair of timers, a module-level timestamp shared between every tooltip on the
+ * page, and a panel hard-centred over its trigger that ran off the side of a
+ * narrow window rather than answering the edge.
+ *
+ * One thing that global timestamp did is not replaced yet: Radix groups the
+ * "open the next one at once" window per provider, and the kit gives each
+ * tooltip its own, so *this* trigger re-hovered is instant while its neighbour
+ * still waits the first delay. One `TooltipProvider` near the application root
+ * restores the group, and that is a change to a file this component cannot
+ * make for itself.
+ *
+ * `data-input` is only read by the exit: Radix reports "closed" the same way
+ * whichever input opened it, and a keyboard close must not wait for a movement.
+ * It is set on the way in rather than on the way out, so it is already true by
+ * the time the exit runs.
  */
 export function Tooltip({
   label,
   children,
 }: {
   readonly label: ReactNode;
-  readonly children: ReactElement<TooltipTriggerProps>;
+  readonly children: ReactElement;
 }) {
-  const id = useId();
-  const [present, setPresent] = useState(false);
-  const [closing, setClosing] = useState(false);
   const [input, setInput] = useState<FeedbackInput>("keyboard");
-  const [instant, setInstant] = useState(true);
-  const focusedRef = useRef(false);
-  const hoveredRef = useRef(false);
-  const openTimerRef = useRef<number | null>(null);
-  const closeTimerRef = useRef<number | null>(null);
-
-  const clearTimers = useCallback(() => {
-    if (openTimerRef.current !== null) window.clearTimeout(openTimerRef.current);
-    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
-    openTimerRef.current = null;
-    closeTimerRef.current = null;
-  }, []);
-
-  const finishClose = useCallback(() => {
-    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
-    closeTimerRef.current = null;
-    setClosing(false);
-    setPresent(false);
-  }, []);
-
-  const close = useCallback((animate: boolean) => {
-    if (openTimerRef.current !== null) window.clearTimeout(openTimerRef.current);
-    openTimerRef.current = null;
-    if (!present || !animate || input !== "pointer" || instant) {
-      finishClose();
-      return;
-    }
-    setClosing(true);
-    closeTimerRef.current = window.setTimeout(finishClose, 200);
-  }, [finishClose, input, instant, present]);
-
-  const openForKeyboard = useCallback(() => {
-    clearTimers();
-    setInput("keyboard");
-    setInstant(true);
-    setClosing(false);
-    setPresent(true);
-  }, [clearTimers]);
-
-  const openForPointer = useCallback(() => {
-    clearTimers();
-    const now = Date.now();
-    const warm =
-      lastPointerTooltipAt > 0 && now - lastPointerTooltipAt < TOOLTIP_WARM_WINDOW;
-    setInput("pointer");
-    setInstant(warm);
-    const show = () => {
-      openTimerRef.current = null;
-      if (!hoveredRef.current) return;
-      lastPointerTooltipAt = Date.now();
-      setClosing(false);
-      setPresent(true);
-    };
-    if (warm) show();
-    else openTimerRef.current = window.setTimeout(show, FIRST_TOOLTIP_DELAY);
-  }, [clearTimers]);
-
-  useEffect(() => clearTimers, [clearTimers]);
-
-  const describedBy = [children.props["aria-describedby"], present ? id : undefined]
-    .filter((value): value is string => value !== undefined && value !== "")
-    .join(" ") || undefined;
-
-  const trigger = cloneElement(children, {
-    "aria-describedby": describedBy,
-    onFocus: (event) => {
-      children.props.onFocus?.(event);
-      focusedRef.current = true;
-      if (!hoveredRef.current) openForKeyboard();
-    },
-    onBlur: (event) => {
-      children.props.onBlur?.(event);
-      focusedRef.current = false;
-      if (!hoveredRef.current) close(false);
-    },
-    onPointerEnter: (event) => {
-      children.props.onPointerEnter?.(event);
-      hoveredRef.current = true;
-      openForPointer();
-    },
-    onPointerLeave: (event) => {
-      children.props.onPointerLeave?.(event);
-      hoveredRef.current = false;
-      if (!focusedRef.current) close(true);
-    },
-    onKeyDown: (event) => {
-      children.props.onKeyDown?.(event);
-      if (event.key === "Escape" && present) {
-        event.stopPropagation();
-        close(false);
-      }
-    },
-  });
+  const hovered = useRef(false);
 
   return (
-    <span className="relative inline-flex">
-      {trigger}
-      {present ? (
-        <span
-          className={cn(
-            "pointer-events-none absolute bottom-[calc(100%+var(--space-2))] left-1/2 z-40",
-            "w-max max-w-[min(240px,calc(100vw-var(--space-7)))] -translate-x-1/2",
-            "rounded-button border border-foreground bg-foreground px-3 py-2",
-            "origin-bottom text-sm text-surface",
-          )}
-          data-slot="tooltip"
-          id={id}
-          role="tooltip"
-          data-input={input}
-          data-instant={instant ? "true" : "false"}
-          data-closing={closing ? "true" : "false"}
-          onTransitionEnd={(event) => {
-            if (
-              closing &&
-              event.target === event.currentTarget &&
-              event.propertyName === "opacity"
-            ) finishClose();
-          }}
-        >
-          {label}
-        </span>
-      ) : null}
-    </span>
+    <TooltipRoot>
+      <TooltipTrigger
+        asChild
+        onPointerMove={() => {
+          hovered.current = true;
+          setInput("pointer");
+        }}
+        onPointerLeave={() => {
+          hovered.current = false;
+        }}
+        onFocus={() => {
+          /*
+           * A press moves focus as well, and that is a pointer's tooltip. Radix
+           * makes the same distinction for whether to open at all.
+           */
+          if (!hovered.current) setInput("keyboard");
+        }}
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent data-input={input}>{label}</TooltipContent>
+    </TooltipRoot>
   );
 }
 
@@ -186,6 +88,18 @@ export function Tooltip({
  * It stays mounted for a pointer dismissal so its exit can finish. Keyboard
  * activation and dismissal are instant. The visible word and symbol carry the
  * state together, so the notification never depends on color alone.
+ *
+ * **It is not built on the kit's sonner Toaster, deliberately.** `DESIGN.md`
+ * asks a toast for a short translate plus opacity on an *interruptible
+ * transition*; sonner leaves on a CSS animation and a fixed unmount timer, so
+ * a dismissal cannot be answered at once. A page here also says whether this
+ * notification is open, rather than pushing into a queue that owns it.
+ * `components/ui/sonner.tsx` is house-correct and waiting for the surface that
+ * wants a queue; the icons below are its icons, so the two read as one product.
+ *
+ * The motion itself is in `tailwind-theme.css`, keyed on `data-slot`,
+ * `data-input` and `data-closing`, so position and motion never share a
+ * property and the reduced-motion form is written beside the full one.
  */
 export function Toast({
   open,
@@ -236,11 +150,12 @@ export function Toast({
 
   if (!present) return null;
 
+  const Mark = kind === "error" ? OctagonXIcon : CircleCheckIcon;
+
   return (
     <aside
       className={cn(
-        /* `group`, so the mark inside can read the toast's own kind. */
-        "group fixed right-6 bottom-6 z-50 grid items-start",
+        "fixed right-6 bottom-6 z-50 grid items-start",
         "w-[min(380px,calc(100vw-(2*var(--space-4))))] min-h-(--tap-target)",
         "grid-cols-[var(--control-sm)_minmax(0,1fr)_var(--control-sm)] gap-3 p-3",
         "rounded-card border border-border border-l-2 border-l-foreground",
@@ -264,16 +179,25 @@ export function Toast({
         ) finishClose();
       }}
     >
-      <span
+      {/*
+       * The shape says which state this is and the colour only supports it: a
+       * ticked circle against a crossed octagon reads as two different things
+       * with no colour at all. Neutral for "this happened" and the failure
+       * colour for "this went wrong" — never the brand colour, which
+       * `DESIGN.md` keeps away from every verdict.
+       *
+       * They are the icons `components/ui/sonner.tsx` draws for the same two
+       * states, so a queued notification and this one would not arrive looking
+       * like two different products.
+       */}
+      <Mark
         className={cn(
-          "grid size-(--control-sm) place-items-center",
-          "rounded-chip border border-foreground text-sm",
-          "group-data-[kind=error]:border-failure",
+          "size-4 justify-self-center",
+          kind === "error" ? "text-failure" : "text-foreground",
         )}
         aria-hidden="true"
-      >
-        {kind === "error" ? "!" : "✓"}
-      </span>
+        data-slot="toast-mark"
+      />
       <span className="grid min-w-0 gap-1 pt-1 text-sm [&>span]:text-muted-foreground [&_strong]:font-medium">
         <strong>{title}</strong>
         {children === undefined ? null : <span>{children}</span>}
@@ -292,7 +216,7 @@ export function Toast({
         aria-label={`Dismiss ${title}`}
         onClick={(event) => onDismiss(event.detail > 0 ? "pointer" : "keyboard")}
       >
-        <span aria-hidden="true">✕</span>
+        <XIcon className="size-4" />
       </button>
     </aside>
   );

--- a/apps/web/ui/form.tsx
+++ b/apps/web/ui/form.tsx
@@ -2,6 +2,7 @@
 
 import { useId, type ReactNode } from "react";
 
+import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
 import { FieldHintContext } from "./field-hint.ts";
@@ -28,6 +29,10 @@ import { FieldHintContext } from "./field-hint.ts";
  * wiring `aria-describedby` by hand forgets exactly the fields nobody checks,
  * because the page still looks right without it. `field-hint.ts` says why it
  * is a context and holds the context itself.
+ *
+ * The label is the kit's, which is Radix's: a double click on a plain `<label>`
+ * selects the words around it, which is what a person sees when they meant to
+ * select the value in the field beside it.
  */
 export function Field({
   label,
@@ -45,12 +50,7 @@ export function Field({
 
   return (
     <div className="flex flex-col gap-2" data-slot="field">
-      <label
-        className="text-sm font-medium text-foreground"
-        htmlFor={htmlFor}
-      >
-        {label}
-      </label>
+      <Label htmlFor={htmlFor}>{label}</Label>
       <FieldHintContext.Provider value={hint === undefined ? undefined : said}>
         {children}
       </FieldHintContext.Provider>

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -692,32 +692,43 @@
   }
 
   /*
-   * The tooltip and the toast.
+   * The tooltip.
+   *
+   * Radix says how it was opened and the two answers want different things.
+   * `delayed-open` is a pointer that waited, so it arrives about its trigger
+   * on opacity and `transform`. `instant-open` is keyboard focus, or a pointer
+   * inside the grouping window, and neither of those gets a rule at all: "do
+   * not animate actions used many times each day, especially keyboard
+   * navigation", and a delay repeated across a row of controls is the tooltip
+   * behaviour everybody complains about.
+   *
+   * The exit is scoped by `data-input`, which the shared `Tooltip` sets on the
+   * way in, because Radix reports "closed" the same way whichever opened it.
+   * An animation is what Radix waits for before unmounting, so the pointer
+   * exit runs to completion and the keyboard one is not made to wait for
+   * anything.
+   */
+  [data-slot="tooltip-content"][data-state="delayed-open"] {
+    animation: egma-anchored-in var(--duration-popover-in) var(--ease-out);
+  }
+
+  [data-slot="tooltip-content"][data-input="pointer"][data-state="closed"] {
+    animation: egma-anchored-out var(--duration-popover-out) var(--ease-out);
+  }
+
+  /*
+   * The toast.
    *
    * Position and motion are on separate properties on purpose, which is the
-   * same rule the dialog above follows and for the same reason. A tooltip is
-   * centred on its trigger by `translate`, so its arrival is written on
-   * `scale`; a toast arrives by moving, so its motion is on `translate` and
-   * nothing else writes that property. Neither can cancel the other however
-   * the class lists are later edited.
+   * same rule the dialog above follows and for the same reason: a toast
+   * arrives by moving, so its motion is on `translate` and nothing else writes
+   * that property.
    *
-   * A *warm* tooltip has no transition at all. Once one has been shown the
-   * next opens at once, because a delay repeated across a row of controls is
-   * the tooltip behaviour everybody complains about.
-   *
-   * These rules leave with the hand-written feedback surfaces.
+   * These stay transitions rather than animations, unlike everything else in
+   * this section. `DESIGN.md` asks this one surface for an *interruptible*
+   * exit, and the component keeps itself mounted until the `transitionend`
+   * rather than handing the decision to Radix.
    */
-  [data-slot="tooltip"][data-input="pointer"]:not([data-instant="true"]) {
-    transition:
-      opacity var(--duration-hover) var(--ease-out),
-      scale var(--duration-hover) var(--ease-out);
-  }
-
-  [data-slot="tooltip"][data-input="pointer"][data-closing="true"] {
-    opacity: 0;
-    scale: 0.97;
-  }
-
   [data-slot="toast"][data-input="pointer"] {
     transition:
       opacity var(--duration-popover-in) var(--ease-out),
@@ -731,11 +742,6 @@
   }
 
   @starting-style {
-    [data-slot="tooltip"][data-input="pointer"]:not([data-instant="true"]) {
-      opacity: 0;
-      scale: 0.97;
-    }
-
     [data-slot="toast"][data-input="pointer"] {
       opacity: 0;
       translate: 0 100%;
@@ -746,22 +752,23 @@
    * The development proof can show the same contract without changing the OS.
    * Deliberately outside the media query below: this is how the reduced-motion
    * form is inspected, not a second definition of it.
+   *
+   * **This is why `components/ui/tooltip.tsx` does not portal its panel.** A
+   * portalled tooltip is a child of `body`, and no descendant selector written
+   * here can reach it from the frame it belongs to — the panel would go on
+   * demonstrating full motion while the words above it said the opposite,
+   * which is worse than not demonstrating it. Radix positions the panel
+   * `fixed` either way, so staying in place costs none of the collision
+   * handling; `tooltip.tsx` records the whole trade.
    */
-  [data-preview="reduced-motion"] [data-slot="tooltip"][data-input="pointer"] {
-    scale: 1;
-    transition: opacity var(--duration-hover) linear;
+  [data-preview="reduced-motion"]
+    [data-slot="tooltip-content"][data-state="delayed-open"] {
+    animation: egma-fade-in var(--duration-hover) linear;
   }
 
   [data-preview="reduced-motion"]
-    [data-slot="tooltip"][data-input="pointer"][data-closing="true"] {
-    scale: 1;
-  }
-
-  @starting-style {
-    [data-preview="reduced-motion"] [data-slot="tooltip"][data-input="pointer"] {
-      opacity: 0;
-      scale: 1;
-    }
+    [data-slot="tooltip-content"][data-input="pointer"][data-state="closed"] {
+    animation: egma-fade-out var(--duration-hover) linear;
   }
 
   /*
@@ -1049,18 +1056,23 @@
       animation: egma-fade-out var(--duration-hover) linear;
     }
 
+    /*
+     * The tooltip keeps both ends and drops the movement, so the panel still
+     * says it came and it went. It is named apart from the popovers above
+     * because it is keyed on `data-state="delayed-open"` rather than "open",
+     * and because its exit is the one scoped by `data-input`.
+     */
+    [data-slot="tooltip-content"][data-state="delayed-open"] {
+      animation: egma-fade-in var(--duration-hover) linear;
+    }
+
+    [data-slot="tooltip-content"][data-input="pointer"][data-state="closed"] {
+      animation: egma-fade-out var(--duration-hover) linear;
+    }
+
     [data-slot="menu"][data-input="pointer"] [data-slot="menu-panel"] {
       transform: none;
       transition: opacity var(--duration-popover-out) linear;
-    }
-
-    [data-slot="tooltip"][data-input="pointer"],
-    [data-slot="tooltip"][data-input="pointer"][data-closing="true"] {
-      scale: 1;
-    }
-
-    [data-slot="tooltip"][data-input="pointer"] {
-      transition: opacity var(--duration-hover) linear;
     }
 
     [data-slot="toast"][data-input="pointer"],
@@ -1076,11 +1088,6 @@
       [data-slot="menu"][data-input="pointer"] [data-slot="menu-panel"] {
         opacity: 0;
         transform: none;
-      }
-
-      [data-slot="tooltip"][data-input="pointer"] {
-        opacity: 0;
-        scale: 1;
       }
 
       [data-slot="toast"][data-input="pointer"] {


### PR DESCRIPTION
Ticket 23. `ui/form.tsx`, `ui/choice.tsx` and `ui/feedback.tsx` hand-rolled the
controls they wrap. This rebuilds them on the kit and restyles the four raw
CLI-added primitives they need. Public exports, prop shapes, and `Problem` and
`Refused` are unchanged, and no consumer is edited.

Two commits: the rebuild, then the review fixes.

## What changed

**`Field` takes the kit `Label`** (`components/ui/label.tsx`, restyled to house
tokens — 14px, weight 500, `text-foreground`, no focus ring of its own because
`globals.css` draws one on everything focusable).

**`Choice` is the kit `RadioGroup`.** Sixty lines of hand-written roving
`tabindex`, arrow keys, wrap-around, Home, End and focus moves are deleted;
Radix keeps that contract. `radio-group.tsx` is restyled and gains a `shape`
prop, following the pattern `button.tsx` already set for one primitive with
more than one look: `dot` is the registry's radio, `segment` is the joined
strip this filter draws.

**`Tooltip` is the kit `Tooltip`.** Radix now owns the delay, the grouping,
Escape, outside-press dismissal, the `aria-describedby` wiring, and a position
that answers the edge of the window. The arrow is dropped — this product never
drew one, and Radix measures an arrow with a `ResizeObserver` that jsdom does
not implement.

**The tooltip's motion lives in `tailwind-theme.css`**, keyed on `data-slot`
and Radix's `data-state`, beside the popover, the dropdown menu and the dialog.
That file's own motion section asks for exactly that ("the rules key off those
and the component files stay stock shadcn"). The reduced-motion form is a real
`@media` block beside its siblings rather than a `motion-reduce:` utility of
equal specificity, which would have left the winner to Tailwind's variant sort
order — a reduced-motion failure that fails silently.

**The orphaned hand-written tooltip rules are gone, and the design system's
"Reduced motion preview" frame is honest again.** Nothing renders
`data-slot="tooltip"`, `data-instant` or `data-closing` on a tooltip any more,
so those selectors matched nothing — including the ones that drew that frame,
which meant the panel was quietly demonstrating full motion while the words
beside it claimed the opposite. Dead selectors deleted, frame rules re-keyed
onto `tooltip-content`.

**`Toast` keeps its own implementation.** See "Decisions".
`components/ui/sonner.tsx` is restyled to house tokens and keeps the
coordinator's `useTheme` rewiring.

## Decisions

**`Toast` is not rebuilt on sonner.** `DESIGN.md` asks a toast for a short
translate plus opacity on an *interruptible transition*. Sonner leaves on a CSS
animation and a fixed 200ms unmount timer, so a dismissal cannot be answered at
once — and `design-system.test.tsx`, which this branch does not edit, asserts
that a keyboard dismissal removes the toast synchronously. Sonner is also a
queue that owns its region, where `Toast` is controlled by a page's `open`
prop. So `sonner.tsx` is made house-correct and left ready for the surface that
wants a queue, and the shared `Toast` adopts sonner's icons so the two read as
one product. Its ringed `✓` and `!` become `CircleCheck` and `OctagonX`: the
state is a shape first, a colour second, and never the brand colour.

**The tooltip panel is not portalled, and that is what makes the frame
fixable.** A panel under `body` is out of reach of every descendant selector in
the theme, including the frame's. Radix positions it `position: fixed` either
way, so this keeps the collision handling and the escape from ordinary
`overflow` scrolling; what it gives up is an ancestor that is itself a
containing block for fixed children (`transform`, `filter`, `contain`) — and
the hand-written tooltip this replaces was `position: absolute` inside its
trigger, so it never had that case either.

**Keyboard tooltips do not animate.** Radix's `instant-open` covers both
keyboard focus and a pointer inside the grouping window, which is exactly the
set the old component gave no transition to. Only `delayed-open` animates in,
and the exit is scoped by `data-input` because Radix reports "closed" the same
way whichever opened it.

**One test assertion changed shape, not strength.** `Choice`'s keyboard test
asserted item-level `tabindex` 0/-1. Radix makes the *group* the tab stop and
forwards focus to the chosen option on entry, which is the same "one Tab stop"
promise kept more strictly, so the test now asserts that. Radix also moves
focus in a task after the key rather than during it, so each key is followed by
a flush.

## Proven

- `apps/web/test/*.test.tsx`, all 18 files, 348 tests green (serially — see
  Unproven), on top of the rebased base. Includes `design-system.test.tsx` and
  `components.test.tsx`, the consumers' own tests, unchanged except for the
  `Choice` assertions above.
- `cd apps/web && pnpm exec tsc -p tsconfig.json --noEmit` clean.
- `pnpm --filter @egma/web build` succeeds.
- **The exit is driven, not described.** The tooltip exit test fires a real
  `animationend`: the pointer leaves, the panel is still on the page with
  `data-state="closed"`, and only the end of the animation removes it — while
  the keyboard close, under the same stub, is immediate. Mutation-checked both
  ways: dropping `data-input` from the panel fails it, and giving the exit the
  same keyframe name as the entrance fails the "still present" assertion alone.
- **The reduced-motion frame, proven with both tooltips open in one snapshot:**
  the one outside the frame runs `egma-anchored-out` at `0.14s` on
  `cubic-bezier(0.23, 1, 0.32, 1)`; the one inside runs `egma-fade-in` at
  `0.14s` `linear`. The frame demonstrates what it claims again.
- Live in a browser on `/projects/prj_proof/design-system`, **both themes**,
  computed styles read off the real elements:
  - **Tooltip** light `#1f1f1f` on `#ffffff` text / dark `#f2f2ed` on `#1b1b1a`;
    6px radius, 8/12px padding, 14px, 240px max, `role="tooltip"` with
    `aria-describedby` matching, no `animate-` class on the element at all.
    Entering on `egma-anchored-in 0.18s`, leaving on `egma-anchored-out 0.14s`
    — the `--duration-popover-in/out` and `--ease-out` tokens — with
    `transform-origin` measured from the trigger. Keyboard focus gives
    `instant-open` with `animation-name: none`.
  - **Choice** light Ember Wash `#fff5f2` / dark `color-mix(#ff5229 16%, #1b1b1a)`,
    Ember `#ff5229` inset underline in both, 30px tall, 5px radius inside the
    8px strip, group is `role="radiogroup"` with `tabindex="0"` and items `-1`.
  - **Toast** light `#ffffff` / dark `#1b1b1a`, 2px left edge, 12px radius, 44px
    min height, 32px columns. Flipping `data-kind` to `error` live resolves the
    edge to `#b44444` light / `#e27373` dark — the failure colour, never brand.
    Motion still binds: `keyboard` gives no transition, `pointer` gives
    `opacity, translate` at 180ms `--ease-out`, and `data-closing` drops it to
    140ms — a transition, so it stays interruptible.
  - **Label** a real `<label for=…>`, weight 500, 14px, `user-select: none`.
- Built stylesheet checked directly: base tooltip rules, then the higher-
  specificity frame rules, then the `@media (prefers-reduced-motion: reduce)`
  block later in source order beside its popover and dialog siblings.

## Unproven / left over

- **No screenshot of a tooltip open.** The Browser pane returns blank frames
  once hover state is involved, and the fallback Chrome has forced-dark on,
  which rewrites colours and strips shadows. Both themes and both animations
  are proven by computed styles read off the live elements instead, which is
  stricter for token correctness but is not a picture. Page screenshots were
  captured.
- **Cross-tooltip warm window.** The old module-level timestamp made a
  *neighbouring* tooltip open at once. Radix keeps that window on the provider
  and the kit wraps every root in its own, so re-hovering the same trigger is
  instant but its neighbour still waits 500ms. Mounting a provider higher up
  would **not** fix this — the nearest provider wins and the nearest is always
  the inner one. Restoring it means removing that wrapper *and* mounting one
  provider above the product: two files, recorded with the coordinator as a
  closing-sweep item. Only surface with tooltips today is the dev proof page.
- **`radioItemVariants` is exported and unused**, matching `buttonVariants`.
- **Test parallelism.** Running all web test files in parallel on a loaded
  machine times out `findBy*` queries in unrelated assertions; the same files
  pass with `--no-file-parallelism` in a third of the time. Pre-existing
  contention, not a regression — CI pins `maxWorkers: 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rebuilds shared form, choice, and tooltip wrappers on the existing Radix-based UI kit while preserving their public interfaces.

- Replaces `Field`’s plain label with the shared label primitive.
- Replaces the hand-written choice keyboard implementation with the shared radio-group primitive and adds dot/segment variants.
- Replaces tooltip timing, positioning, dismissal, and accessibility behavior with the shared tooltip primitives.
- Restyles tooltip, toast, radio, and label surfaces with house tokens and updates behavioral tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/ui/choice.tsx | Replaces hand-written radio semantics and keyboard navigation with the shared controlled RadioGroup while retaining the Choice prop contract. |
| apps/web/components/ui/radio-group.tsx | Adds house-token styling and dot/segment variants to the Radix radio-group item. |
| apps/web/ui/feedback.tsx | Composes the shared tooltip primitives and updates controlled toast status icons without changing exported feedback interfaces. |
| apps/web/components/ui/tooltip.tsx | Defines provider timing defaults and tokenized, non-portaled tooltip content backed by Radix behavior. |
| apps/web/ui/form.tsx | Adopts the shared Label primitive while preserving native label association and hint wiring. |
| apps/web/ui/tailwind-theme.css | Moves tooltip entry, exit, and reduced-motion behavior into state-driven theme selectors. |
| apps/web/test/components.test.tsx | Updates Choice tests for Radix’s group entry and deferred roving-focus behavior. |
| apps/web/test/feedback.test.tsx | Exercises keyboard and pointer tooltip timing, exit completion, accessibility wiring, and toast status shapes. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Field[Field wrapper] --> Label[Kit Label]
  Choice[Choice wrapper] --> RadioGroup[Kit RadioGroup]
  RadioGroup --> RadioItem[Segment RadioGroupItem]
  FeedbackTooltip[Feedback Tooltip] --> Provider[TooltipProvider]
  Provider --> Root[Radix Tooltip Root]
  Root --> Trigger[Tooltip Trigger]
  Root --> Content[Tooltip Content]
  Content --> ThemeCSS[House motion and color tokens]
  Toast[Controlled Toast] --> Icons[Shared status icons]
  Toast --> ThemeCSS
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): move the tooltip&#39;s motion to t..."](https://github.com/egma-ai/egma/commit/82736dfae1546c3fc91acdd016c0dd47f4add1c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55283661)</sub>

<!-- /greptile_comment -->