### PR TITLE
feat(web): put the tab strip on the kit, and stop hover erasing the current state

### DIFF
--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -658,6 +658,42 @@ export function DesignSystemProof() {
                     </TabsContent>
                   </Tabs>
                 </div>
+                {/*
+                  * The third shape the component draws, and the one nothing in
+                  * the product uses yet.
+                  *
+                  * A vertical rail marks the current tab down its trailing edge
+                  * instead of under it, which is a separate set of rules from
+                  * the two above — and rules no page would have caught. It is
+                  * here so the shape is proven rather than dead: a strip of
+                  * evidence views is the layout it is waiting for.
+                  *
+                  * The disabled tab is the other half. "Disable rather than
+                  * hide" is this product's decision, so a set that can hold an
+                  * unavailable choice has to show what one looks like: still
+                  * read, still named, and not reachable by the arrow keys.
+                  */}
+                <div className={PREVIEW}>
+                  <Tabs defaultValue="turns" orientation="vertical">
+                    <TabsList variant="line">
+                      <TabsTrigger value="turns">Turns</TabsTrigger>
+                      <TabsTrigger value="metrics">Metrics</TabsTrigger>
+                      <TabsTrigger value="recording" disabled>
+                        Recording
+                      </TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="turns">
+                      <p className="m-0 text-sm text-muted-foreground">
+                        What the caller and the agent each said.
+                      </p>
+                    </TabsContent>
+                    <TabsContent value="metrics">
+                      <p className="m-0 text-sm text-muted-foreground">
+                        How long each turn took the agent to answer.
+                      </p>
+                    </TabsContent>
+                  </Tabs>
+                </div>
               </div>
             </div>
 

--- a/apps/web/components/ui/separator.tsx
+++ b/apps/web/components/ui/separator.tsx
@@ -1,28 +1,52 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Separator as SeparatorPrimitive } from "radix-ui"
+import { Separator as SeparatorPrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
+/**
+ * The neutral hairline that puts two groups of content apart.
+ *
+ * `DESIGN.md`: "Most structure comes from contrast and borders." A rule drawn
+ * with this rather than with a `border-b` on whichever element happens to be
+ * next to it says the line is a thing *between* two groups, so neither group
+ * carries the other's boundary.
+ *
+ * **It defaults to decorative, and that default is the honest one.** A rule is
+ * usually drawn because two groups look better apart, not because a reader who
+ * cannot see it is missing a fact — and Radix publishes a decorative separator
+ * as `role="none"`, so a screen reader is not told about a line that means
+ * nothing. A separator that *does* carry meaning says `decorative={false}` and
+ * becomes a real `role="separator"`.
+ *
+ * **Reach for a border instead when the rule changes edge with the viewport.**
+ * Orientation here is a DOM attribute, so a rule that is horizontal in a column
+ * and vertical once the same two groups sit side by side cannot be one element
+ * — it would need a class to beat `data-[orientation=…]` at a width, and that
+ * is a specificity race rather than a layout. `settings-nav.tsx` has exactly
+ * that rule and keeps it as a border for this reason.
+ */
 function Separator({
   className,
   orientation = "horizontal",
   decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: ComponentProps<typeof SeparatorPrimitive.Root>) {
   return (
     <SeparatorPrimitive.Root
       data-slot="separator"
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
-        className
+        "shrink-0 bg-border",
+        "data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full",
+        "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/apps/web/components/ui/tabs.tsx
+++ b/apps/web/components/ui/tabs.tsx
@@ -1,16 +1,33 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Tabs as TabsPrimitive } from "radix-ui"
+import { cva, type VariantProps } from "class-variance-authority";
+import { Tabs as TabsPrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
+/**
+ * Switching between peer views of one page.
+ *
+ * **Radix is here for the keyboard, not for the look.** The tabs pattern is a
+ * roving tab stop — one Tab step into the group, then Left, Right, Home and
+ * End inside it — and a hand-written version of that is a listener per strip
+ * that each has to get `dir`, looping, and the disabled tab right on its own.
+ * Radix publishes it once, and it publishes `data-state` and `data-orientation`
+ * alongside, which is what every rule below reads.
+ *
+ * `DESIGN.md` calls a tab strip navigation: "Navigation row — support routine
+ * navigation — colour feedback only." So nothing here moves. The transition
+ * names colour properties and nothing else, the active mark appears rather than
+ * fading in, and the label does not change weight — a weight change reflows the
+ * strip, and a strip that shifts under the arrow keys is movement whatever it
+ * is called.
+ */
 function Tabs({
   className,
   orientation = "horizontal",
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+}: ComponentProps<typeof TabsPrimitive.Root>) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
@@ -18,33 +35,50 @@ function Tabs({
       orientation={orientation}
       className={cn(
         "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
+/**
+ * The two shapes a strip of tabs takes in this product.
+ *
+ * - `default` is the segmented control: a quiet track holding the choices, and
+ *   the current one raised out of it on Ember Wash. It is for a small closed
+ *   set that belongs inside a row of other controls.
+ * - `line` is the rail: the choices sit on a hairline and the current one is
+ *   marked on it. It is for the top of a page or a panel, where the strip is
+ *   what a whole region is switched by.
+ *
+ * The track's 8px input radius holds 6px button radii on 4px of padding, which
+ * is the nesting the eye reads as one control rather than two.
+ */
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  [
+    "group/tabs-list inline-flex w-fit items-center gap-1",
+    "group-data-[orientation=vertical]/tabs:flex-col",
+    "group-data-[orientation=vertical]/tabs:items-stretch",
+  ],
   {
     variants: {
       variant: {
-        default: "bg-muted",
-        line: "gap-1 bg-transparent",
+        default: "justify-center rounded-input bg-surface-soft p-1",
+        line: "justify-start bg-transparent",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function TabsList({
   className,
   variant = "default",
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List> &
+}: ComponentProps<typeof TabsPrimitive.List> &
   VariantProps<typeof tabsListVariants>) {
   return (
     <TabsPrimitive.List
@@ -53,39 +87,145 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
+/**
+ * One choice in the strip.
+ *
+ * The current one is Ember Wash **and** a mark that survives a greyscale
+ * screenshot: the rail's 2px Ember rule under the `line` tab, and the raised
+ * bordered plate around the `default` one. `DESIGN.md`: "State is not
+ * communicated by colour alone."
+ *
+ * There is no `focus-visible` rule here on purpose. `globals.css` draws the
+ * product's Ember focus ring for everything a keyboard reaches, `[role="tab"]`
+ * named among them, from an unlayered rule that no utility can undo. A ring
+ * written here would be a second answer to a question already settled.
+ */
 function TabsTrigger({
   className,
+  onClick,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+}: ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
-        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
-        className
+        [
+          "relative inline-flex flex-1 cursor-pointer items-center justify-center gap-2",
+          "min-h-(--control-sm) rounded-button border border-transparent px-3",
+          "text-sm whitespace-nowrap text-muted-foreground",
+          "pointer-coarse:min-h-(--tap-target)",
+          /*
+           * Named properties, never `all`, and never `outline-color`: see
+           * `button.tsx`. A transition that includes the outline fades the
+           * focus ring in on every arrow-key step through the strip.
+           */
+          "transition-[color,background-color,border-color] duration-(--duration-hover) ease-out",
+          /*
+           * **Hover is for the tabs somebody might go to, not the one they are
+           * on.** The neutral plate and Ember Wash are both a background, and
+           * an unscoped hover wins: pointing at the current tab turned its wash
+           * grey and took the "current" half of the state with it. Found in a
+           * browser, because the two rules never meet until a pointer is on
+           * one. Scoping to `inactive` makes them mutually exclusive, so which
+           * of them Tailwind happens to emit first stops mattering.
+           */
+          "pointer-hover:data-[state=inactive]:bg-surface-soft",
+          "pointer-hover:text-foreground",
+          "disabled:cursor-not-allowed disabled:opacity-55",
+          "data-[state=active]:bg-selected data-[state=active]:text-foreground",
+          "[&_svg]:pointer-events-none [&_svg]:shrink-0",
+          "[&_svg:not([class*='size-'])]:size-4",
+        ],
+        [
+          /* The segmented plate: raised out of the track on a narrow Ember edge. */
+          "group-data-[variant=default]/tabs-list:data-[state=active]:border-brand",
+        ],
+        [
+          /*
+           * The rail tab: sized to its own label, sitting on the hairline
+           * rather than in a track, and squared off where it meets it.
+           */
+          "group-data-[variant=line]/tabs-list:flex-none",
+          "group-data-[variant=line]/tabs-list:min-h-(--control-lg)",
+          "group-data-[orientation=horizontal]/tabs:group-data-[variant=line]/tabs-list:rounded-b-none",
+          "group-data-[orientation=vertical]/tabs:group-data-[variant=line]/tabs-list:rounded-r-none",
+          /*
+           * The mark, drawn for the current tab and colourless for the rest.
+           *
+           * **The colour is the switch, and `content` cannot be.** Tailwind 4
+           * writes `content: var(--tw-content)` into *every* `after:` utility
+           * and declares `--tw-content` with an initial value of `""`, so the
+           * pseudo-element already exists the moment any `after:` class is on
+           * the element. Gating `content-['']` on the active state therefore
+           * turns nothing on or off — it was written that way first, and every
+           * tab in the strip drew a rule. The sidebar's active mark in
+           * `shell.tsx` had already settled this the other way round.
+           *
+           * The bar appears rather than fades: a transition on the trigger
+           * does not reach its own pseudo-element, and none is declared here.
+           * That is what `DESIGN.md` wants of a strip crossed by arrow key many
+           * times a day.
+           *
+           * One pixel of overhang is deliberate: the rule is 2px and the
+           * hairline it covers is 1px, so the mark reads as sitting *on* the
+           * rail rather than beside it.
+           */
+          "after:absolute after:rounded-chip after:bg-transparent",
+          "group-data-[variant=line]/tabs-list:data-[state=active]:after:bg-brand",
+          "group-data-[orientation=horizontal]/tabs:after:inset-x-0",
+          "group-data-[orientation=horizontal]/tabs:after:-bottom-px",
+          "group-data-[orientation=horizontal]/tabs:after:h-0.5",
+          "group-data-[orientation=vertical]/tabs:after:inset-y-0",
+          "group-data-[orientation=vertical]/tabs:after:-right-px",
+          "group-data-[orientation=vertical]/tabs:after:w-0.5",
+        ],
+        className,
       )}
       {...props}
+      onClick={(event) => {
+        onClick?.(event);
+        /*
+         * **A tab answers a press, so a click with no press behind it has to
+         * be given one.**
+         *
+         * Radix selects on `mousedown` rather than on `click`, which is right
+         * — `DESIGN.md`: "A control answers on press, not after an animation."
+         * A pointer press and a keyboard Enter both reach it, the first
+         * through `mousedown` and the second through `keydown`.
+         *
+         * What reaches neither is a bare `click` that nobody pressed: some
+         * assistive technology and automation activate a control by
+         * dispatching one directly, and `detail` is 0 because no pointer was
+         * involved. Against a strip listening only for a press, those people
+         * cannot change tab at all. So the press is re-issued rather than the
+         * selection being re-implemented here — Radix stays the one thing that
+         * decides what activating a tab means, and a duplicate reaches it as
+         * the same value it already holds, which its controlled state drops.
+         */
+        if (event.defaultPrevented || event.detail > 0) return;
+        event.currentTarget.dispatchEvent(
+          new MouseEvent("mousedown", { bubbles: true, button: 0 }),
+        );
+      }}
     />
-  )
+  );
 }
 
+/** The panel one tab reveals. Radix labels it by its trigger and hides the rest. */
 function TabsContent({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+}: ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn("flex-1", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/apps/web/components/ui/tabs.tsx
+++ b/apps/web/components/ui/tabs.tsx
@@ -114,6 +114,12 @@ function TabsTrigger({
       className={cn(
         [
           "relative inline-flex flex-1 cursor-pointer items-center justify-center gap-2",
+          /*
+           * Down a rail the labels start together. The list stretches its tabs
+           * to the widest one, so centring leaves every shorter label sitting
+           * at its own indent and the column reads ragged.
+           */
+          "group-data-[orientation=vertical]/tabs:justify-start",
           "min-h-(--control-sm) rounded-button border border-transparent px-3",
           "text-sm whitespace-nowrap text-muted-foreground",
           "pointer-coarse:min-h-(--tap-target)",
@@ -150,6 +156,32 @@ function TabsTrigger({
            */
           "group-data-[variant=line]/tabs-list:flex-none",
           "group-data-[variant=line]/tabs-list:min-h-(--control-lg)",
+          /*
+           * No border on a rail tab. The shared one is transparent and exists
+           * only to hold the room the segmented plate's Ember edge moves into,
+           * so on this variant it is a pixel that draws nothing — and it is the
+           * pixel between the first label and the column edge below.
+           */
+          "group-data-[variant=line]/tabs-list:border-0",
+          /*
+           * **The first label starts on the column's own left edge.** A rail
+           * strip leads a page, so its first word is read against the headings
+           * under it — and the shared `px-3` that gives every tab its plate had
+           * pushed that word 12px right of every `Section` title beside it.
+           * `DESIGN.md` asks for exact alignment.
+           *
+           * Padding rather than a negative margin on the list, which is the
+           * other way to do this: the Settings column is `overflow-y-auto`, so
+           * its `overflow-x` computes to `auto` as well, and anything pulled
+           * left of the content box is clipped with no scroll that can reach
+           * it. Dropping the first tab's own left padding moves the label and
+           * its plate together, and neither leaves the column.
+           *
+           * Horizontal only. Down a vertical rail the first tab is the top
+           * one, and taking its left padding away would step it out of line
+           * with every tab below it.
+           */
+          "group-data-[orientation=horizontal]/tabs:group-data-[variant=line]/tabs-list:first:pl-0",
           "group-data-[orientation=horizontal]/tabs:group-data-[variant=line]/tabs-list:rounded-b-none",
           "group-data-[orientation=vertical]/tabs:group-data-[variant=line]/tabs-list:rounded-r-none",
           /*
@@ -193,19 +225,33 @@ function TabsTrigger({
          *
          * Radix selects on `mousedown` rather than on `click`, which is right
          * — `DESIGN.md`: "A control answers on press, not after an animation."
-         * A pointer press and a keyboard Enter both reach it, the first
-         * through `mousedown` and the second through `keydown`.
+         * A pointer press reaches it through `mousedown` and a keyboard Enter
+         * through `keydown`, so both are already answered.
          *
-         * What reaches neither is a bare `click` that nobody pressed: some
-         * assistive technology and automation activate a control by
-         * dispatching one directly, and `detail` is 0 because no pointer was
-         * involved. Against a strip listening only for a press, those people
-         * cannot change tab at all. So the press is re-issued rather than the
-         * selection being re-implemented here — Radix stays the one thing that
-         * decides what activating a tab means, and a duplicate reaches it as
-         * the same value it already holds, which its controlled state drops.
+         * What reaches neither is a click that was *dispatched* rather than
+         * performed — a script, an automation harness, or this repository's
+         * own component tests, where `fireEvent.click` sends the click alone
+         * and no press ever happens. Eight Settings tests failed on exactly
+         * that. So the press is re-issued rather than the selection being
+         * re-implemented here, and Radix stays the one thing that decides what
+         * activating a tab means.
+         *
+         * **`isTrusted` is what keeps this off the keyboard path.** A browser
+         * fires a click with `detail === 0` after Enter or Space as well, so
+         * `detail` alone cannot tell a dispatched click from a keyboard one —
+         * and re-issuing there hands the consumer a second `onValueChange` for
+         * one press. Harmless against a page that commits the change straight
+         * away, and a trap for one that does not. Only a browser can set
+         * `isTrusted`, so a dispatched click is the one case left.
+         *
+         * **The re-issued press bubbles**, because React listens at the root
+         * and would not see it otherwise. It can therefore also reach an
+         * ancestor's `onMouseDown` or an outside-press handler. Nothing wraps a
+         * tab strip that way today; a component that does needs to know this is
+         * here.
          */
         if (event.defaultPrevented || event.detail > 0) return;
+        if (event.nativeEvent.isTrusted) return;
         event.currentTarget.dispatchEvent(
           new MouseEvent("mousedown", { bubbles: true, button: 0 }),
         );

--- a/apps/web/test/design-system.test.tsx
+++ b/apps/web/test/design-system.test.tsx
@@ -240,11 +240,11 @@ describe("the development design proof", () => {
     render(<DesignSystemProof />);
 
     /*
-     * One set, one panel. Two tab sets are drawn, so both panels are counted:
-     * a `getByRole` that happened to find one would pass just as well if the
-     * other had quietly stopped rendering.
+     * One set, one panel. Three tab sets are drawn, so all three panels are
+     * counted: a `getByRole` that happened to find one would pass just as well
+     * if another had quietly stopped rendering.
      */
-    expect(screen.getAllByRole("tabpanel")).toHaveLength(2);
+    expect(screen.getAllByRole("tabpanel")).toHaveLength(3);
     const simulations = screen.getByRole("tab", { name: "Simulations" });
     expect(simulations.getAttribute("aria-selected")).toBe("true");
     expect(
@@ -265,6 +265,18 @@ describe("the development design proof", () => {
 
     /* The other set is the `line` variant, and it is a separate set. */
     expect(screen.getByRole("tab", { name: "Transcript" }).getAttribute("aria-selected")).toBe("true");
+
+    /*
+     * The third set is the vertical rail, which nothing in the product uses
+     * yet — so this surface is the only place its shape is held to anything.
+     * Its disabled tab is asserted beside it because "disable rather than hide"
+     * is a product decision: the choice stays readable and named, and stays out
+     * of reach. A set drawn without one would prove the easy half only.
+     */
+    expect(screen.getByRole("tab", { name: "Turns" }).getAttribute("aria-selected")).toBe("true");
+    const recording = screen.getByRole("tab", { name: "Recording" });
+    expect((recording as HTMLButtonElement).disabled).toBe(true);
+    expect(recording.getAttribute("aria-selected")).toBe("false");
 
     /*
      * The group's question is on the page, not only in an `aria-label`.

--- a/apps/web/ui/page-navigation.tsx
+++ b/apps/web/ui/page-navigation.tsx
@@ -33,6 +33,17 @@ export type PageNavigationItems = readonly [
  * Operational controls never belong here. Cancel, Retry, Edit, Archive and
  * Save remain page actions because they change the current record rather than
  * move through its hierarchy.
+ *
+ * **This one is not built on a kit primitive, and that is the finding rather
+ * than an omission.** The structure-and-navigation migration rebuilt its two
+ * neighbours — a tab strip became the kit's tabs, a hand-drawn rule became the
+ * kit's separator — and looked for the same here. There is nothing to move to:
+ * the kit holds no breadcrumb, the trail is an ordered list because that is
+ * what a trail is, and the separator between two crumbs is a `/` a reader
+ * understands and not a rule. The rest of the file was already on the shared
+ * vocabulary — semantic tokens, the fine-pointer hover variant, a coarse-
+ * pointer target — and carries no motion, which is what `DESIGN.md` asks of a
+ * navigation row. Rewriting it would have been churn with a diff attached.
  */
 export function PageNavigation({
   items,
@@ -40,7 +51,11 @@ export function PageNavigation({
   readonly items: PageNavigationItems;
 }) {
   return (
-    <nav className="mb-3 min-w-0" aria-label="Breadcrumb">
+    <nav
+      className="mb-3 min-w-0"
+      data-slot="page-navigation"
+      aria-label="Breadcrumb"
+    >
       <ol className="m-0 flex min-w-0 list-none flex-wrap items-center gap-2 p-0">
         {items.map((item, index) => (
           <li

--- a/apps/web/ui/section.tsx
+++ b/apps/web/ui/section.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 
+import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 /**
@@ -152,12 +153,12 @@ export function Facts({
 }) {
   const panel = layout === "panel";
 
-  return (
+  const list = (
     <dl
       className={cn(
         "m-0 grid",
         panel
-          ? "grid-cols-2 gap-6 rounded-card border border-border bg-surface p-6 max-[40rem]:grid-cols-1 max-[40rem]:p-5"
+          ? "grid-cols-2 gap-6 max-[40rem]:grid-cols-1"
           : "grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-4",
       )}
     >
@@ -184,4 +185,22 @@ export function Facts({
       ))}
     </dl>
   );
+
+  if (!panel) return list;
+
+  /*
+   * **The panel is the shared card, not a second one written here.**
+   *
+   * It used to draw `rounded-card border border-border bg-surface p-6` itself,
+   * which is the kit `Card`'s declaration copied out — and `DESIGN.md` is
+   * explicit that no page or component adds a one-off where a shared component
+   * already owns the behaviour. Two copies is how a product ends up with two
+   * card looks: the next change to a card reaches one of them.
+   *
+   * `Card` is a `<div>` and cannot become the `<dl>`, so the list goes inside
+   * it rather than wearing it. That is the honest arrangement anyway — the card
+   * is the surface, the definition list is the content, and a screen reader
+   * still reads each fact with the name of the fact.
+   */
+  return <Card className="max-[40rem]:p-5">{list}</Card>;
 }

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -84,8 +84,16 @@ const NAV_ITEM = [
    * component that rule is written *against*: a person crosses this list many
    * times a day and never once needs it confirmed that a row was pressed —
    * the page changing says that. The transition names its two properties for
-   * the reason `button.tsx` gives, and there is no reduced-motion form to write
-   * because there is no motion left to reduce.
+   * the reason `button.tsx` gives.
+   *
+   * **`motion-reduce:transition-none` went with the movement, on purpose.**
+   * `sidebar.tsx` still carries it beside the same colour-only transition, so
+   * this is a deliberate difference rather than a line dropped by accident.
+   * `DESIGN.md` asks every movement for "a reduced-motion form with useful
+   * opacity or colour feedback" — a colour fade *is* that form. Switching it
+   * off under reduced motion removes the fallback instead of the motion, and
+   * leaves somebody who asked for less movement with less feedback than
+   * everybody else. The sidebar is the one that should come to this.
    */
   "transition-[color,background-color] duration-(--duration-hover) ease-out",
   "pointer-coarse:h-(--tap-target) pointer-coarse:min-h-(--tap-target)",

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useId, useRef, type ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
 import { projectPath } from "../lib/project-context.ts";
@@ -75,14 +77,35 @@ export function settingsPath(
 const NAV_ITEM = [
   "relative flex w-full min-h-(--control-lg) items-center px-3",
   "rounded-button text-base whitespace-nowrap text-muted-foreground no-underline",
-  "transition-transform duration-(--duration-press) ease-out",
+  /*
+   * **Colour, and nothing that moves.** `DESIGN.md`: "Navigation row — support
+   * routine navigation — colour feedback only." These rows used to answer a
+   * press with `scale(0.97)`, borrowed from the button, and a button is the one
+   * component that rule is written *against*: a person crosses this list many
+   * times a day and never once needs it confirmed that a row was pressed —
+   * the page changing says that. The transition names its two properties for
+   * the reason `button.tsx` gives, and there is no reduced-motion form to write
+   * because there is no motion left to reduce.
+   */
+  "transition-[color,background-color] duration-(--duration-hover) ease-out",
   "pointer-coarse:h-(--tap-target) pointer-coarse:min-h-(--tap-target)",
-  "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
-  "[&:active:not(:focus-visible)]:scale-97",
-  "motion-reduce:transition-none",
-  "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
   /* One row on a wide screen; a cell in a grid once the navigation wraps. */
   "max-[900px]:w-full max-[900px]:whitespace-normal",
+];
+
+/**
+ * The rows somebody might go to.
+ *
+ * **Hover belongs here rather than on every row, and a browser is what said
+ * so.** The neutral hover plate and Ember Wash are both a background, and with
+ * the hover written for all four rows it won: pointing at the row you are
+ * already on turned its wash grey, which is the "current" half of the state
+ * disappearing under the pointer. Naming the two sets apart is the fix that
+ * needs no rule to outrank another — a row is either current or it is not, and
+ * only one of these two lists ever reaches it.
+ */
+const NAV_ITEM_QUIET = [
+  "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
 ];
 
 const NAV_ITEM_CURRENT = [
@@ -147,7 +170,10 @@ export function SettingsNav({
           {items.map((item) => (
             <Link
               key={item.id}
-              className={cn(NAV_ITEM, item.id === current && NAV_ITEM_CURRENT)}
+              className={cn(
+                NAV_ITEM,
+                item.id === current ? NAV_ITEM_CURRENT : NAV_ITEM_QUIET,
+              )}
               href={settingsPath(projectId, item.id)}
               aria-current={item.id === current ? "page" : undefined}
             >
@@ -186,9 +212,24 @@ export function SettingsNav({
 /**
  * Switch between peer views inside one Settings page.
  *
- * This is a tab list, not a form choice: changing it changes the visible
- * panel and does not submit a value. Roving focus gives the group one Tab stop,
- * while arrow, Home and End keys follow the tabs pattern.
+ * This is a tab list, not a form choice: changing it changes the visible panel
+ * and does not submit a value. Roving focus gives the group one Tab stop, while
+ * arrow, Home and End keys follow the tabs pattern.
+ *
+ * **All of that now comes from the kit rather than from a listener here.** The
+ * hand-written version read every key itself, wrapped the index by hand, kept
+ * an array of refs so it could move focus, and mapped Up and Down onto a
+ * horizontal strip — which the tabs pattern does not do, because Up and Down in
+ * a horizontal tablist belong to whatever is around it. Radix publishes the
+ * roving tab stop once and gets `dir`, looping, and a disabled tab right in
+ * one place. Fifty lines of keyboard code left this file and no behaviour a
+ * person relies on left with them.
+ *
+ * **The panel is not ours.** A caller draws its own `role="tabpanel"` and names
+ * it `{id}-{value}-panel`, so the trigger's `id` and `aria-controls` are stated
+ * here rather than left to Radix's generated pair. Radix writes both before it
+ * spreads a caller's props, so saying them is enough to keep the promise every
+ * Settings page was already written against.
  */
 export function SettingsTabs<Value extends string>({
   id,
@@ -203,65 +244,31 @@ export function SettingsTabs<Value extends string>({
   readonly options: readonly { readonly value: Value; readonly label: string }[];
   readonly onChange: (value: Value) => void;
 }) {
-  const tabs = useRef<(HTMLButtonElement | null)[]>([]);
-  const move = (to: number) => {
-    const option = options[to];
-    if (option === undefined) return;
-    onChange(option.value);
-    tabs.current[to]?.focus();
-  };
-
   return (
-    <div
-      className="flex w-full items-end gap-5 border-b border-border"
-      role="tablist"
-      aria-label={label}
+    <Tabs
+      className="w-full items-start gap-0"
+      value={value}
+      onValueChange={(next) => onChange(next as Value)}
     >
-      {options.map((option, at) => (
-        <button
-          key={option.value}
-          ref={(held) => {
-            tabs.current[at] = held;
-          }}
-          className={cn(
-            "relative inline-flex min-h-(--control-lg) items-center px-0 pb-2",
-            "cursor-pointer border-0 bg-transparent text-sm text-muted-foreground",
-            "pointer-hover:text-foreground",
-            "aria-selected:font-medium aria-selected:text-foreground",
-            /* The chosen tab sits on the group's own line, not above it. */
-            "aria-selected:after:absolute aria-selected:after:-bottom-px",
-            "aria-selected:after:right-0 aria-selected:after:left-0",
-            "aria-selected:after:h-0.5 aria-selected:after:rounded-chip",
-            "aria-selected:after:bg-brand aria-selected:after:content-['']",
-          )}
-          id={`${id}-${option.value}-tab`}
-          type="button"
-          role="tab"
-          aria-selected={value === option.value}
-          aria-controls={`${id}-${option.value}-panel`}
-          tabIndex={value === option.value ? 0 : -1}
-          onClick={() => onChange(option.value)}
-          onKeyDown={(event) => {
-            const last = options.length - 1;
-            const next =
-              event.key === "ArrowRight" || event.key === "ArrowDown"
-                ? (at + 1) % options.length
-                : event.key === "ArrowLeft" || event.key === "ArrowUp"
-                  ? (at - 1 + options.length) % options.length
-                  : event.key === "Home"
-                    ? 0
-                    : event.key === "End"
-                      ? last
-                      : null;
-            if (next === null) return;
-            event.preventDefault();
-            move(next);
-          }}
-        >
-          {option.label}
-        </button>
-      ))}
-    </div>
+      <TabsList variant="line" aria-label={label}>
+        {options.map((option) => (
+          <TabsTrigger
+            key={option.value}
+            id={`${id}-${option.value}-tab`}
+            value={option.value}
+            aria-controls={`${id}-${option.value}-panel`}
+          >
+            {option.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {/*
+       * The rail the current tab is marked on, as the element it is rather
+       * than as a border belonging to the strip above it. The mark is 2px and
+       * overhangs by one, so it reads as sitting on this line.
+       */}
+      <Separator />
+    </Tabs>
   );
 }
 


### PR DESCRIPTION
Ticket 24. The structure and navigation wrappers are rebuilt on the kit, and the two raw registry files they needed are restyled to the house pattern.

## What changed

**`components/ui/tabs.tsx` and `components/ui/separator.tsx` (kit, restyled).** Both arrived from the registry raw. They now read the theme instead of shadcn's defaults: no `transition-all`, no `shadow-sm` (the shadow namespace is deleted, so that class never existed here), no `dark:` pairs, no `text-foreground/60`, no hand-written focus ring — `globals.css` already draws the product's Ember ring for `[role="tab"]` from an unlayered rule. Radii are the named ones: an 8px input radius on the segmented track holding 6px button radii on 4px of padding.

**`ui/settings-nav.tsx`.** `SettingsTabs` is the kit's tabs. Arrow, Home and End come from Radix's roving tab stop rather than from a listener that read every key, wrapped the index by hand, and held an array of refs to move focus — about fifty lines gone. The trigger states its own `id` and `aria-controls`, because the panel belongs to the calling page and every Settings page was written against `{id}-{value}-panel`; Radix writes both before it spreads a caller's props, so saying them is enough. The rail under the strip is the kit separator. Navigation rows lose the `scale(0.97)` they had borrowed from the button — `DESIGN.md` gives a navigation row colour feedback only.

**`ui/section.tsx`.** `Facts layout="panel"` drew `rounded-card border border-border bg-surface p-6`, which is the kit `Card`'s declaration copied out. It is now the `Card`, with the `<dl>` inside it — `Card` is a `<div>` and cannot become the definition list, and the surface-holds-the-content arrangement is the honest one anyway.

**`ui/page-navigation.tsx`.** Essentially unchanged, and that is the finding rather than an omission. There is no breadcrumb in the kit, the trail is an ordered list because that is what a trail is, and the `/` between two crumbs is a character a reader understands rather than a rule. It was already on semantic tokens, the fine-pointer hover variant and a coarse-pointer target, with no motion. Rewriting it would have been churn with a diff attached. It gains the `data-slot` its neighbours carry.

## Two bugs the browser proof found

Both are the same shape: two rules setting one property, with nothing making one win.

1. **Hover erased the current state.** The neutral hover plate and Ember Wash are both a background, and the hover was written for every row. Pointing at the Settings page you are already on turned its Ember Wash grey; so did pointing at the current tab. Measured, not guessed: `#fff5f2` became `srgb(0.954 0.954 0.954)` under the pointer. Fixed by making the two conditions mutually exclusive — `data-[state=inactive]` on the tab, and a separate quiet class list for the nav rows — so which rule Tailwind emits first stops mattering.

2. **Every tab drew the active rule, not just the active one.** Tailwind 4 writes `content: var(--tw-content)` into *every* `after:` utility and declares `--tw-content` with an initial value of `""`, so the pseudo-element exists the moment any `after:` class is present. Gating `content-['']` on the active state turns nothing on or off. The colour is the switch — which the sidebar's active mark in `shell.tsx` already knew.

## Proven

- **Tests, scoped, sequential:** 12 jsdom files, **320 passed / 320**. `settings.test.tsx` (54), `components.test.tsx` (56), `design-system.test.tsx` (9), `personas.test.tsx` (30), `monitoring.test.tsx` (14), `sidebar-groups.test.tsx` (15), `agents-pages.test.tsx` (34), `tests-pages.test.tsx` (19), `graders-pages.test.tsx` (40), `runs.test.tsx` (19), `run-history.test.tsx` (17), `simulation-evidence.test.tsx` (13). No consumer test was edited.
- **Typecheck:** `tsc -p apps/web/tsconfig.json --noEmit` clean.
- **Both themes**, on Settings navigation and on a sectioned page, at desktop and at 375px. Read back off the elements rather than eyeballed: active tab and current nav row on `#fff5f2` light and on `color-mix(#ff5229 16%, #1b1b1a)` dark, Ember mark `#ff5229` in both, foreground `#f2f2ed` on the dark wash, card `#1b1b1a` at the 12px radius.
- **Keyboard, in a real browser:** ArrowLeft and End move and select, focus follows, and the focus ring computes to `rgb(255,82,41) solid 2px`. Pointer activation goes through Radix's own press path.
- **Geometry:** the active tab's 2px mark sits at `bottom:-1px` against a separator whose top edge is the trigger's bottom edge, so the mark covers the hairline rather than stacking beside it. Radius `6px 6px 0 0`.
- Both kit variants drawn: the segmented control (with a disabled trigger) and the vertical rail.

## Unproven or left over

- **The `default` (segmented) and vertical variants still have no consumer in the product.** They are no longer unproven, though: the design-system proof draws all three shapes, the vertical rail and its disabled tab added here, and `design-system.test.tsx` holds them to it. Proven to render and to be reachable; not proven in use.
- **A tab answers a dispatched `click` as well as a press.** Radix selects on `mousedown`, which is right — but a click that was dispatched rather than performed (a script, an automation harness, this repository's own `fireEvent.click` tests) reaches nothing. The kit re-issues the press rather than re-implementing the selection, and `isTrusted` keeps it off the keyboard path, where Radix has already answered through `keydown`. Worth a reviewer's eye: it is the one place this file does something the registry does not. The re-issued press bubbles, so it can reach an ancestor's outside-press handler; nothing wraps a tab strip that way today.
- **`ui/shell.tsx` has bug 1.** The sidebar's active item writes `pointer-hover:bg-surface-soft` before `data-[active=true]:bg-selected`, so hovering the current section should erase its Ember Wash the same way. Outside this ticket's fence, unfixed, and worth its own change.
- **`GraderTabs` (`app/projects/[projectId]/graders/tabs.tsx`) is still a hand-rolled link strip** and now looks slightly different from the Settings strip — it has the Ember rule but no wash plate. It is link navigation rather than a tablist, so it is not simply the kit's tabs; worth deciding deliberately rather than drifting.
- **No production build was run** — this is scoped to the files touched, per the ticket's test scope. CI runs the rest.
- Twelve of these jsdom files run in parallel saturate this machine and flake a handful of async tests. Verified as pre-existing: on the unmodified base the same run failed 7 of 315, and `simulation-evidence.test.tsx > can leave the recording view after its waveform is ready` fails 2 runs in 5 on the base against 1 in 5 here. Run sequentially, everything passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves Settings tabs, separators, and fact panels onto shared UI primitives while preserving caller-owned panel identifiers and preventing hover styles from obscuring active navigation state.
- Replaces the hand-rolled Settings tab keyboard implementation with controlled Radix tabs.
- Restyles shared Tabs and Separator primitives to use product tokens and interaction conventions.
- Wraps panel-layout facts in the shared Card component.
- Adds vertical and disabled tab states to the design-system proof and its test.
- Adds the shared `data-slot` convention to page navigation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/components/ui/tabs.tsx | Restyles the Radix tab primitives, adds line and segmented variants, scopes hover feedback to inactive tabs, and supports click-only synthetic activation. |
| apps/web/ui/settings-nav.tsx | Replaces hand-rolled tab selection and keyboard handling with the shared controlled Tabs primitive while retaining the existing external panel ID contract. |
| apps/web/ui/section.tsx | Moves panel-layout Facts styling to the shared Card wrapper without changing the contained definition-list structure. |
| apps/web/components/ui/separator.tsx | Restyles and documents the shared Radix Separator while preserving its decorative default and orientation behavior. |
| apps/web/app/design-system/proof.tsx | Adds a vertical tab-rail proof with a disabled trigger. |
| apps/web/test/design-system.test.tsx | Extends design-system assertions to cover the added vertical tab set and disabled state. |
| apps/web/ui/page-navigation.tsx | Adds component-slot metadata without changing breadcrumb behavior. |

<sub>Reviews (2): Last reviewed commit: ["fix(web): keep the shim off the keyboard..."](https://github.com/egma-ai/egma/commit/33329e8fbd4bb21b8ce31da7728712d9b35892af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55286147)</sub>

**Context used:**

- Knowledge Base — [Egma web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->