### PR TITLE
feat(web): put the product's dialogs and menus on the kit's overlays

### DIFF
--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -86,6 +86,8 @@ function DialogContent({
             className={cn(
               "absolute top-4 right-4 inline-flex size-8 cursor-pointer items-center justify-center",
               "rounded-button border border-transparent text-muted-foreground",
+              /* "Pointer targets are at least 44px on coarse pointers." */
+              "pointer-coarse:size-(--tap-target)",
               /*
                * Named, so the focus ring is not among them. See `button.tsx`.
                * Only the two this hover actually changes: the border stays

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import { Suspense, useState } from "react";
@@ -332,7 +333,29 @@ describe("the organization and project selector", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
-  it("keeps a pointer-dismissed panel present through its short exit", () => {
+  /**
+   * The panel leaves under its own motion, and the theme is what times it.
+   *
+   * The exit is a CSS animation keyed on `data-state="closed"`, and the kit
+   * removes the panel on `animationend` rather than on the press — so "an exit
+   * runs to completion" is a property of the surface rather than a timer this
+   * page keeps. What is read here is the state the animation is keyed on.
+   */
+  it("marks the panel closed and leaves on the animation, not on the press", () => {
+    const trigger = open();
+    const panel = screen.getByRole("dialog");
+    expect(panel.dataset.slot).toBe("popover-content");
+    expect(panel.dataset.state).toBe("open");
+
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Search projects" }), {
+      key: "Escape",
+    });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(trigger.getAttribute("data-state")).toBe("closed");
+  });
+
+  it("closes when the pointer lands somewhere else on the page", async () => {
     render(
       <ProjectSelector
         organization={ACME}
@@ -343,26 +366,24 @@ describe("the organization and project selector", () => {
     const trigger = screen.getByRole("button", { name: /^Organization Acme/ });
     fireEvent.pointerDown(trigger);
     fireEvent.click(trigger);
-    const panel = screen.getByRole("dialog");
+    expect(screen.getByRole("dialog")).toBeDefined();
 
+    // Two things about a press outside, and both are the panel's own rule.
+    // It starts listening on the task after it opened, so the press that
+    // opened it is not also the press that closes it. And it leaves on the
+    // *finished* press rather than on the way down, so a selection that starts
+    // in the panel and ends outside it does not close what it was reading.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
     fireEvent.pointerDown(document.body);
+    expect(screen.getByRole("dialog")).toBeDefined();
+    fireEvent.click(document.body);
 
-    expect(screen.getByRole("dialog")).toBe(panel);
-    expect(trigger.parentElement?.getAttribute("data-closing")).toBe("true");
-    fireEvent.transitionEnd(panel, { propertyName: "opacity" });
     expect(screen.queryByRole("dialog")).toBeNull();
-  });
-
-  it("uses the pointer exit when a keyboard-opened panel is clicked away", () => {
-    const trigger = open();
-    const panel = screen.getByRole("dialog");
-
-    fireEvent.pointerDown(document.body);
-
-    expect(trigger.parentElement?.getAttribute("data-input")).toBe("pointer");
-    expect(trigger.parentElement?.getAttribute("data-closing")).toBe("true");
-    fireEvent.transitionEnd(panel, { propertyName: "opacity" });
-    expect(screen.queryByRole("dialog")).toBeNull();
+    // A press elsewhere is a way of leaving, so the keyboard is not dragged
+    // back to the control somebody has just moved away from.
+    expect(document.activeElement).not.toBe(trigger);
   });
 
   /**
@@ -763,29 +784,73 @@ describe("a page of rows", () => {
 
 /* ------------------------------------------------------------------------ */
 
+/**
+ * A closing animation, said out loud, because jsdom runs no stylesheet.
+ *
+ * The kit removes a dialog on `animationend`, and it decides whether there is
+ * an animation to wait for by reading the computed style. jsdom loads no CSS,
+ * so every surface there claims `animationName: ""` and leaves the instant it
+ * is closed — which would make "an exit runs to completion" untestable in this
+ * lane. This answers the way the real theme answers: the entrance while the
+ * surface is open, the exit once it is closed. Nothing else is changed, so the
+ * test still drives the kit's own presence machine rather than a stand-in.
+ */
+function finishExit(surface: HTMLElement, animationName: string): void {
+  // jsdom has no `AnimationEvent`, so the one property the kit reads is put on
+  // an ordinary event rather than left undefined by a constructor that ignores
+  // it. The kit's own listener is on the element, so this reaches it.
+  const ended = new Event("animationend", { bubbles: false });
+  Object.defineProperty(ended, "animationName", { value: animationName });
+  fireEvent(surface, ended);
+}
+
+function withClosingAnimation(): void {
+  const real = window.getComputedStyle.bind(window);
+  vi.stubGlobal(
+    "getComputedStyle",
+    (element: Element, pseudo?: string | null) => {
+      const styles = real(element, pseudo);
+      const slot =
+        element instanceof HTMLElement ? (element.dataset.slot ?? "") : "";
+      if (!slot.startsWith("dialog-")) return styles;
+      return new Proxy(styles, {
+        get(target, key, receiver) {
+          if (key !== "animationName") return Reflect.get(target, key, receiver);
+          return (element as HTMLElement).dataset.state === "closed"
+            ? "egma-dialog-out"
+            : "egma-dialog-in";
+        },
+      });
+    },
+  );
+}
+
 describe("a dialog", () => {
-  it("uses the browser's modal lifecycle and turns Escape into a cancel request", () => {
+  it("puts the page behind it out of reach, and closes on Escape", () => {
     const onClose = vi.fn();
     render(
-      <Dialog title="Navigation" onClose={onClose}>
-        <a href="/projects/prj_1/tests">Tests</a>
-      </Dialog>,
+      <>
+        <button type="button">Elsewhere</button>
+        <Dialog title="Navigation" onClose={onClose}>
+          <a href="/projects/prj_1/tests">Tests</a>
+        </Dialog>
+      </>,
     );
 
     const panel = screen.getByRole("dialog", { name: "Navigation" });
-    expect(panel.tagName).toBe("DIALOG");
-    expect(panel.getAttribute("aria-modal")).toBe("true");
+
+    // Inert is not a class on the page behind: the kit hides it from the
+    // accessibility tree, so a control out there is no longer reachable at all.
+    expect(screen.queryByRole("button", { name: "Elsewhere" })).toBeNull();
 
     // Focus is inside, so the keyboard is no longer driving the page beneath.
     expect(panel.contains(document.activeElement)).toBe(true);
 
-    const cancel = new Event("cancel", { cancelable: true });
-    fireEvent(panel, cancel);
-    expect(cancel.defaultPrevented).toBe(true);
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("restores the exact control that opened it", () => {
+  it("restores the exact control that opened it", async () => {
     function Example() {
       const [open, setOpen] = useState(false);
       return (
@@ -802,20 +867,19 @@ describe("a dialog", () => {
 
     render(<Example />);
     const opener = screen.getByRole("button", { name: "Open navigation" });
-    const matches = vi.spyOn(opener, "matches").mockImplementation(
-      (selector) => selector === ":focus-visible",
-    );
     opener.focus();
     fireEvent.click(opener);
-    const dialog = screen.getByRole("dialog", { name: "Navigation" });
-    expect(dialog.getAttribute("data-input")).toBe("keyboard");
+    expect(screen.getByRole("dialog", { name: "Navigation" })).toBeDefined();
+
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
-    expect(document.activeElement).toBe(opener);
-    matches.mockRestore();
+    expect(screen.queryByRole("dialog", { name: "Navigation" })).toBeNull();
+    // The kit hands focus back once the layer above it has gone, which is the
+    // task after the press rather than the press itself.
+    await waitFor(() => expect(document.activeElement).toBe(opener));
   });
 
-  it("uses the same modal lifecycle for a right-side sheet", () => {
+  it("uses the same modal layer for a right-side sheet", async () => {
     function Example() {
       const [open, setOpen] = useState(false);
       return (
@@ -845,18 +909,24 @@ describe("a dialog", () => {
       name: "Transcript and audio",
     });
     expect(sheet.getAttribute("data-kind")).toBe("sheet");
-    expect(sheet.getAttribute("aria-modal")).toBe("true");
     expect(sheet.contains(document.activeElement)).toBe(true);
     expect(within(sheet).getByRole("button", { name: "Close" })).toBeTruthy();
 
-    const cancel = new Event("cancel", { cancelable: true });
-    fireEvent(sheet, cancel);
-    expect(cancel.defaultPrevented).toBe(true);
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("dialog", { name: "Transcript and audio" })).toBeNull();
-    expect(document.activeElement).toBe(opener);
+    await waitFor(() => expect(document.activeElement).toBe(opener));
   });
 
-  it("keeps a pointer-dismissed dialog present through its short exit", () => {
+  /**
+   * "An exit runs to completion and is never cut off. A surface that is closed
+   * finishes leaving before it is removed."
+   *
+   * So `onClose` — the owner's instruction to take the dialog away — is not the
+   * press. It is the end of the closing animation, and the dialog is still on
+   * screen for the whole of it.
+   */
+  it("keeps a dismissed dialog present until its exit has finished", () => {
+    withClosingAnimation();
     const onClose = vi.fn();
     render(
       <Dialog title="Archive agent?" onClose={onClose}>
@@ -864,82 +934,23 @@ describe("a dialog", () => {
       </Dialog>,
     );
 
-    const dialog = screen.getByRole("dialog", { name: "Archive agent?" });
-    fireEvent.pointerDown(dialog);
+    const panel = screen.getByRole("dialog", { name: "Archive agent?" });
+    expect(panel.dataset.slot).toBe("dialog-content");
+    expect(panel.dataset.state).toBe("open");
 
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(screen.getByRole("dialog", { name: "Archive agent?" })).toBe(panel);
+    expect(panel.dataset.state).toBe("closed");
     expect(onClose).not.toHaveBeenCalled();
-    expect(dialog.getAttribute("data-closing")).toBe("true");
-    fireEvent.transitionEnd(dialog.firstElementChild as HTMLElement, {
-      propertyName: "opacity",
-    });
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
 
-  it("uses the pointer exit after a dialog was opened with the keyboard", () => {
-    function Example() {
-      const [open, setOpen] = useState(false);
-      return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>Open archive</button>
-          {open ? (
-            <Dialog title="Archive agent?" onClose={() => setOpen(false)}>
-              <p>Archive it.</p>
-            </Dialog>
-          ) : null}
-        </>
-      );
-    }
+    finishExit(panel, "egma-dialog-out");
 
-    render(<Example />);
-    const opener = screen.getByRole("button", { name: "Open archive" });
-    const matches = vi.spyOn(opener, "matches").mockImplementation(
-      (selector) => selector === ":focus-visible",
-    );
-    opener.focus();
-    fireEvent.click(opener);
-
-    const dialog = screen.getByRole("dialog", { name: "Archive agent?" });
-    expect(dialog.getAttribute("data-input")).toBe("keyboard");
-    const close = screen.getByRole("button", { name: "Close" });
-    fireEvent.pointerDown(close);
-    fireEvent.click(close, { detail: 1 });
-
-    expect(dialog.getAttribute("data-input")).toBe("pointer");
-    expect(dialog.getAttribute("data-closing")).toBe("true");
-    fireEvent.transitionEnd(dialog.firstElementChild as HTMLElement, {
-      propertyName: "opacity",
-    });
     expect(screen.queryByRole("dialog", { name: "Archive agent?" })).toBeNull();
-    matches.mockRestore();
-  });
-
-  it("gives pointer Cancel actions the same short exit as the close button", () => {
-    const onClose = vi.fn();
-    render(
-      <Dialog title="Archive agent?" onClose={onClose}>
-        {(dismiss) => (
-          <Button type="button" variant="secondary" onClick={dismiss}>
-            Cancel
-          </Button>
-        )}
-      </Dialog>,
-    );
-
-    const dialog = screen.getByRole("dialog", { name: "Archive agent?" });
-    const cancel = screen.getByRole("button", { name: "Cancel" });
-    fireEvent.pointerDown(cancel);
-    fireEvent.click(cancel, { detail: 1 });
-
-    expect(onClose).not.toHaveBeenCalled();
-    expect(dialog.getAttribute("data-input")).toBe("pointer");
-    expect(dialog.getAttribute("data-closing")).toBe("true");
-    fireEvent.transitionEnd(dialog.firstElementChild as HTMLElement, {
-      propertyName: "opacity",
-    });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps keyboard Cancel actions immediate", () => {
+  it("gives a Cancel action written by the caller the same way out", () => {
     const onClose = vi.fn();
     render(
       <Dialog title="Archive agent?" onClose={onClose}>
@@ -953,7 +964,30 @@ describe("a dialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
+    expect(screen.queryByRole("dialog", { name: "Archive agent?" })).toBeNull();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * A successful write may take the dialog away itself, and the owner has
+   * already been told. Reporting the exit as a second close would ask the page
+   * to answer twice for one action.
+   */
+  it("stays quiet when the owner removes the dialog itself", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <>
+        <Dialog title="Archive agent?" onClose={onClose}>
+          <button type="button">Confirm archive</button>
+        </Dialog>
+      </>,
+    );
+    expect(screen.getByRole("dialog", { name: "Archive agent?" })).toBeDefined();
+
+    rerender(<></>);
+
+    expect(screen.queryByRole("dialog", { name: "Archive agent?" })).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("does not restore focus to an opener removed while the dialog closes", () => {
@@ -1301,7 +1335,7 @@ describe("the shared draft navigation guard", () => {
     );
   }
 
-  it("keeps a draft on the page until the discard action is explicit", () => {
+  it("keeps a draft on the page until the discard action is explicit", async () => {
     render(<DraftPage />);
     fireEvent.click(screen.getByRole("button", { name: "Change name" }));
     expect(screen.getByLabelText("Draft state").textContent).toBe("unsaved");
@@ -1316,7 +1350,9 @@ describe("the shared draft navigation guard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
     expect(screen.queryByRole("dialog", { name: "Leave without saving?" }))
       .toBeNull();
-    expect(document.activeElement).toBe(destination);
+    // The dialog hands focus back once its layer has gone, which is the task
+    // after the press rather than the press itself.
+    await waitFor(() => expect(document.activeElement).toBe(destination));
 
     const [projectSelector] = screen.getAllByRole("button", {
       name: /^Organization Acme/u,
@@ -1332,7 +1368,7 @@ describe("the shared draft navigation guard", () => {
       .toBeDefined();
     fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
     expect(routed.push).not.toHaveBeenCalled();
-    expect(document.activeElement).toBe(projectSelector);
+    await waitFor(() => expect(document.activeElement).toBe(projectSelector));
 
     fireEvent.click(destination);
     fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -874,12 +874,10 @@ describe("a dialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
     expect(screen.queryByRole("dialog", { name: "Navigation" })).toBeNull();
-    // The kit hands focus back once the layer above it has gone, which is the
-    // task after the press rather than the press itself.
-    await waitFor(() => expect(document.activeElement).toBe(opener));
+    expect(document.activeElement).toBe(opener);
   });
 
-  it("uses the same modal layer for a right-side sheet", async () => {
+  it("uses the same modal layer for a right-side sheet", () => {
     function Example() {
       const [open, setOpen] = useState(false);
       return (
@@ -914,7 +912,41 @@ describe("a dialog", () => {
 
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("dialog", { name: "Transcript and audio" })).toBeNull();
-    await waitFor(() => expect(document.activeElement).toBe(opener));
+    expect(document.activeElement).toBe(opener);
+  });
+
+  /**
+   * The sheet is the one kind that does not take the screen, and this is the
+   * whole reason it is allowed to be different: the simulation page opens one
+   * by default and is built to be read with the transcript beside the grader
+   * results. A sheet that hid the page or closed on a press into it would take
+   * that page away.
+   */
+  it("leaves the page beside a sheet readable and usable", async () => {
+    const pressed = vi.fn();
+    render(
+      <>
+        <button type="button" onClick={pressed}>Judge again</button>
+        <Dialog kind="sheet" title="Transcript and audio" onClose={vi.fn()}>
+          <audio aria-label="Simulation recording" />
+        </Dialog>
+      </>,
+    );
+
+    const behind = screen.getByRole("button", { name: "Judge again" });
+    expect(behind.closest("[aria-hidden='true']")).toBeNull();
+
+    // The panel starts listening for a press outside on the task after it
+    // opened, so the press that opened it is not the one that closes it.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    fireEvent.pointerDown(behind);
+    fireEvent.click(behind);
+
+    expect(pressed).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog", { name: "Transcript and audio" }))
+      .toBeTruthy();
   });
 
   /**
@@ -948,6 +980,58 @@ describe("a dialog", () => {
 
     expect(screen.queryByRole("dialog", { name: "Archive agent?" })).toBeNull();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * "No motion delays input. A control answers on press, not after an
+   * animation."
+   *
+   * So this is about *when*, and the animation has to be real for the question
+   * to exist: with no stylesheet the panel leaves in the same tick and every
+   * naive assertion here passes without proving anything. With one in flight,
+   * the panel is still on screen, `onClose` has not been called, and the
+   * keyboard is nevertheless already back on the control that opened it.
+   */
+  it("hands the keyboard back on the press, not at the end of the exit", () => {
+    withClosingAnimation();
+    const onClose = vi.fn();
+    function Example() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Archive</button>
+          {open ? (
+            <Dialog title="Archive agent?" onClose={onClose}>
+              {(dismiss) => (
+                <Button type="button" variant="secondary" onClick={dismiss}>
+                  Cancel
+                </Button>
+              )}
+            </Dialog>
+          ) : null}
+        </>
+      );
+    }
+
+    render(<Example />);
+    const opener = screen.getByRole("button", { name: "Archive" });
+    opener.focus();
+    fireEvent.click(opener);
+    const panel = screen.getByRole("dialog", { name: "Archive agent?" });
+    expect(panel.contains(document.activeElement)).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Still leaving: the panel is on screen and the owner has not been told.
+    expect(panel.dataset.state).toBe("closed");
+    expect(screen.getByRole("dialog", { name: "Archive agent?" })).toBe(panel);
+    expect(onClose).not.toHaveBeenCalled();
+    // And the keyboard is already back, mid-exit.
+    expect(document.activeElement).toBe(opener);
+
+    finishExit(panel, "egma-dialog-out");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(opener);
   });
 
   it("gives a Cancel action written by the caller the same way out", () => {
@@ -1350,9 +1434,7 @@ describe("the shared draft navigation guard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
     expect(screen.queryByRole("dialog", { name: "Leave without saving?" }))
       .toBeNull();
-    // The dialog hands focus back once its layer has gone, which is the task
-    // after the press rather than the press itself.
-    await waitFor(() => expect(document.activeElement).toBe(destination));
+    expect(document.activeElement).toBe(destination);
 
     const [projectSelector] = screen.getAllByRole("button", {
       name: /^Organization Acme/u,
@@ -1368,7 +1450,7 @@ describe("the shared draft navigation guard", () => {
       .toBeDefined();
     fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
     expect(routed.push).not.toHaveBeenCalled();
-    await waitFor(() => expect(document.activeElement).toBe(projectSelector));
+    expect(document.activeElement).toBe(projectSelector);
 
     fireEvent.click(destination);
     fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));

--- a/apps/web/test/design-system.test.tsx
+++ b/apps/web/test/design-system.test.tsx
@@ -218,12 +218,13 @@ describe("the development design proof", () => {
     expect(confirm.className).toContain("bg-destructive");
     expect(confirm.className).not.toContain("bg-primary");
 
+    /*
+     * The exit itself is proven where the dialog lives, in
+     * `components.test.tsx`: the panel is marked closed, stays on screen for
+     * its animation, and is removed when the animation ends. Here the point is
+     * only that the proof page's Cancel is wired to the same way out.
+     */
     fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }), { detail: 1 });
-    expect(screen.getByRole("dialog", { name: "Archive Support agent?" })).toBe(dialog);
-    expect(dialog.getAttribute("data-closing")).toBe("true");
-
-    const panel = dialog.firstElementChild as HTMLElement;
-    fireEvent.transitionEnd(panel, { propertyName: "opacity" });
     expect(screen.queryByRole("dialog", { name: "Archive Support agent?" })).toBeNull();
   });
 

--- a/apps/web/test/menu-placement.test.tsx
+++ b/apps/web/test/menu-placement.test.tsx
@@ -6,21 +6,54 @@ import { Menu, MenuItem } from "../ui/menu.tsx";
 
 afterEach(cleanup);
 
+/**
+ * Where the panel went, read off the panel rather than off the prop.
+ *
+ * `data-side` and `data-align` are what Radix writes after it has placed the
+ * panel, so they are the position and not a copy of the request. A placement
+ * that stopped reaching the positioner would come back as the default side
+ * here, which is the failure the earlier form of this test could not see.
+ */
 describe("anchored menu placement", () => {
   it.each([
-    "right-start",
-    "right-end",
-    "below-start",
-    "below-end",
-  ] as const)("anchors %s without covering its trigger column", (placement) => {
+    ["right-start", "right", "start"],
+    ["right-end", "right", "end"],
+    ["below-start", "bottom", "start"],
+    ["below-end", "bottom", "end"],
+    ["above-start", "top", "start"],
+    ["above-end", "top", "end"],
+  ] as const)(
+    "anchors %s without covering its trigger column",
+    (placement, side, align) => {
+      render(
+        <Menu label={`Open ${placement}`} placement={placement} trigger={<span>Open</span>}>
+          {(close) => <MenuItem onClick={close}>One choice</MenuItem>}
+        </Menu>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: `Open ${placement}` }));
+
+      const panel = screen.getByRole("menu");
+      expect(panel.dataset.side).toBe(side);
+      expect(panel.dataset.align).toBe(align);
+    },
+  );
+
+  /**
+   * The panel wears the slot the theme's origin-aware motion is keyed on, so
+   * it grows from the trigger and its exit finishes before it is removed.
+   */
+  it("is the kit's anchored surface, which is what carries the motion", () => {
     render(
-      <Menu label={`Open ${placement}`} placement={placement} trigger={<span>Open</span>}>
+      <Menu label="Open menu" trigger={<span>Open</span>}>
         {(close) => <MenuItem onClick={close}>One choice</MenuItem>}
       </Menu>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: `Open ${placement}` }));
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
 
-    expect(screen.getByRole("menu").dataset.placement).toBe(placement);
+    const panel = screen.getByRole("menu");
+    expect(panel.dataset.slot).toBe("popover-content");
+    expect(panel.dataset.state).toBe("open");
   });
 });

--- a/apps/web/test/run-history.test.tsx
+++ b/apps/web/test/run-history.test.tsx
@@ -627,10 +627,13 @@ describe("one run's page", () => {
     expect(routed.push).toHaveBeenCalledWith("/projects/prj_1/runs/run_9");
 
     // Re-running creates a new run. The original row and its evidence link are
-    // still on this page until navigation completes.
+    // still on this page until navigation completes. `hidden` because the
+    // confirmation is still open and a dialog puts the page behind it out of
+    // reach, which is what makes it a dialog.
     expect(
       within(table).getByRole("link", {
         name: "Reschedules a booked appointment",
+        hidden: true,
       }),
     ).toBeTruthy();
   });

--- a/apps/web/test/simulation-evidence.test.tsx
+++ b/apps/web/test/simulation-evidence.test.tsx
@@ -578,7 +578,9 @@ describe("one simulation's evidence", () => {
     });
     const turns = within(messages).getAllByRole("listitem");
 
-    expect(evidenceSheet.getAttribute("aria-modal")).toBe("true");
+    // A sheet is a panel docked beside this page rather than a layer over it,
+    // so the grader results stay reachable while the transcript is open. What
+    // it keeps from a dialog is its own label, focus, and Escape.
     expect(evidenceSheet.getAttribute("data-kind")).toBe("sheet");
     expect(evidenceSheet.contains(document.activeElement)).toBe(true);
     expect(turns).toHaveLength(2);
@@ -715,7 +717,9 @@ describe("one simulation's evidence", () => {
     const workspace = await screen.findByRole("region", {
       name: "Simulation evidence",
     });
-    expect(within(workspace).getByText("You are all set.")).toBeTruthy();
+    // The transcript is drawn in the sheet, and a sheet is drawn at the end of
+    // the page so its position never depends on what it sits inside.
+    expect(screen.getByText("You are all set.")).toBeTruthy();
     expect(
       within(workspace).getByText("The agent never said the new time back."),
     ).toBeTruthy();

--- a/apps/web/ui/dialog.tsx
+++ b/apps/web/ui/dialog.tsx
@@ -41,12 +41,11 @@ export type DialogDismiss = (event?: { readonly detail?: number }) => void;
  * because the system response should not wait for decoration — the gate below
  * stays quiet on that path rather than closing the same dialog twice.
  *
- * **The centred motion is not here.** `tailwind-theme.css` keys the entrance,
- * the exit and the reduced-motion form of both on the `data-slot` and
- * `data-state` the kit writes. The two edge-attached kinds add the travel that
- * `DESIGN.md` asks of them, because the theme's edge rules were written for the
- * native `<dialog>` this file just retired and the Radix slots have no drawer
- * rule of their own yet.
+ * **The motion is not here.** `tailwind-theme.css` keys the entrance, the exit
+ * and the reduced-motion form of both on the `data-slot`, `data-kind` and
+ * `data-state` the kit and this file write — the centred dialog and the
+ * drawer's edge travel alike. The one piece left below is the sheet's travel,
+ * which has no token pair of its own to be given a rule for.
  */
 
 /**
@@ -55,9 +54,8 @@ export type DialogDismiss = (event?: { readonly detail?: number }) => void;
  * The kit centres with `-translate-x-1/2 -translate-y-1/2` on the `translate`
  * property and animates `scale`, so position and motion never share a property.
  * The two edge kinds keep that arrangement: they sit at their edge with no
- * centring shift, and the travel below is written on `translate` as well, so
- * the theme's `scale` animation and this file's slide compose instead of
- * cancelling each other.
+ * centring shift, and their travel is written on `translate` as well, so a
+ * `scale` animation and a slide compose instead of cancelling each other.
  */
 const PANEL_SHAPE = {
   /* A tall dialog scrolls inside the viewport rather than off it. */
@@ -77,34 +75,33 @@ const PANEL_SHAPE = {
 } as const;
 
 /**
- * The travel of the two kinds that are attached to an edge.
+ * The travel of the sheet, which is the one edge kind the theme does not move.
  *
- * `DESIGN.md`: "Mobile drawer — translate from its attached edge." The theme
- * holds the panel for the length of its `scale` animation, which is what Radix
- * waits for before unmounting, so the slide is given the same two tokens and
- * ends with it rather than being cut off halfway. `@starting-style` is what
- * makes the entrance a movement: without it a panel that mounts already open
- * has nowhere to travel from.
+ * The drawer's movement is in `tailwind-theme.css`, keyed on `data-kind`, as an
+ * animation of its own at the drawer's own tokens — an animation, because Radix
+ * removes a panel on `animationend` and so whatever is animating is what holds
+ * the panel on screen while it leaves. A sheet has no token pair of its own, so
+ * it travels on a transition at the dialog's two, which the theme's `scale`
+ * animation is exactly as long as. `@starting-style` is what makes the entrance
+ * a movement: without it a panel that mounts already open has nowhere to travel
+ * from.
  *
- * Reduced motion drops the transition and nothing else. The panel then arrives
- * and leaves in place, and the opacity the theme still runs is what says a
- * surface came or went.
+ * **Reduced motion removes the travel from both ends, not just the entrance.**
+ * Dropping the transition alone left the exit teleporting: the closed position
+ * still applied, so the panel jumped off the edge in one frame with nothing
+ * left to say it had gone. So the closed position is put back where the open
+ * one is, and the opacity the theme still runs is what says a surface left.
  */
 const PANEL_TRAVEL = {
   dialog: "",
-  drawer: [
-    "transition-[translate] duration-(--duration-dialog-in) ease-out",
-    "starting:-translate-x-full",
-    "data-[state=closed]:-translate-x-full",
-    "data-[state=closed]:duration-(--duration-dialog-out)",
-    "motion-reduce:transition-none",
-  ],
+  drawer: "",
   sheet: [
     "transition-[translate] duration-(--duration-dialog-in) ease-out",
     "starting:translate-x-full",
     "data-[state=closed]:translate-x-full",
     "data-[state=closed]:duration-(--duration-dialog-out)",
     "motion-reduce:transition-none",
+    "motion-reduce:data-[state=closed]:translate-x-0!",
   ],
 } as const;
 
@@ -116,13 +113,27 @@ const HEAD_SHAPE = {
 } as const;
 
 /**
+ * How long a stuck exit is given before the dialog is taken away anyway.
+ *
+ * Not a motion value, and deliberately not on the motion scale: it is longer
+ * than every exit token so it can never pre-empt one. Both implementations this
+ * file replaced carried the same guard, for the same reason — an exit that ends
+ * in an event ends in an event that can go missing. A browser that never fires
+ * `animationend`, an injected stylesheet that removes the animation, or a tab
+ * that was hidden mid-exit would otherwise leave a dismissed dialog mounted,
+ * the page behind it hidden from assistive technology, and `onClose` never
+ * called.
+ */
+const EXIT_WATCHDOG_MS = 600;
+
+/**
  * The moment the panel finished leaving.
  *
  * It renders nothing and exists for its unmount: Radix removes the panel only
  * after the closing animation ends, so this component's cleanup is that end.
  * Waiting on it rather than on a timer means the exit is never cut short and
  * never guessed at, and the duration stays in the theme where `DESIGN.md` puts
- * it.
+ * it. The watchdog above is the other half of that bargain.
  */
 function ExitGate({ onGone }: { readonly onGone: () => void }) {
   const gone = useRef(onGone);
@@ -190,20 +201,45 @@ export function Dialog({
     setOpen(false);
   }, []);
 
-  /**
-   * Focus goes back the moment the panel does, rather than a task later.
-   *
-   * The kit hands focus back from a timer, which is soon enough to look right
-   * and one task too late for anything that reads `document.activeElement`
-   * straight after a press. `DESIGN.md` asks a control to answer on press, so
-   * this puts focus back as the panel is removed. `onCloseAutoFocus` below
-   * keeps the kit from moving it again afterwards, and repeats the same move
-   * in case a future version removes the panel differently.
-   */
+  const backRef = useRef<HTMLElement | null>(null);
+  backRef.current = returnFocusTo ?? opener;
+
   const restoreFocus = () => {
-    const back = returnFocusTo ?? opener;
+    const back = backRef.current;
     if (back !== null && back.isConnected) back.focus();
   };
+
+  /**
+   * The keyboard goes back on the press, not at the end of the exit.
+   *
+   * `DESIGN.md`: "No motion delays input. A control answers on press, not
+   * after an animation." Waiting for the panel to finish leaving is a fifth of
+   * a second with focus sitting on a button that is on its way out, inside a
+   * layer the page behind is still hidden from — a Tab in that window goes
+   * nowhere useful. So focus moves the moment the dialog is told to close.
+   *
+   * **It is an effect rather than a line inside `dismiss`, and the ordering is
+   * the reason.** While the dialog is open the kit traps focus and pulls
+   * anything that leaves straight back in, so focusing the opener during the
+   * press would simply be undone. The trap is released in the same render that
+   * closes the dialog, and React runs that release before this effect — so
+   * this is the first moment the move can stick, and it is still the same
+   * frame as the press.
+   *
+   * The timer is the other half. See `EXIT_WATCHDOG_MS`.
+   */
+  useEffect(() => {
+    if (open) return undefined;
+    restoreFocus();
+    const forced = window.setTimeout(() => {
+      if (!dismissedRef.current) return;
+      dismissedRef.current = false;
+      closeRef.current();
+    }, EXIT_WATCHDOG_MS);
+    return () => window.clearTimeout(forced);
+    // `restoreFocus` reads a ref, so it needs no dependency of its own.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   return (
     <KitDialog
@@ -223,13 +259,18 @@ export function Dialog({
          */
         aria-describedby={undefined}
         onCloseAutoFocus={(event) => {
-          // The kit's own answer here is its `DialogTrigger`, which these
-          // callers do not use, so this says where focus belongs instead: the
-          // control a caller named, or the one that was in hand. An opener
-          // removed by the very write this dialog confirmed is left alone —
-          // focus falls to the page rather than to something nobody can see.
+          /*
+           * The kit's own answer here is its `DialogTrigger`, which these
+           * callers do not use, so left alone it would drop focus on the page
+           * body. Saying no to it is most of the job — focus has already gone
+           * back, above, at the press. What is left is the case where it fell
+           * to the body anyway, and then this puts it where it belongs. It is
+           * deliberately not unconditional: the exit is long enough to Tab
+           * during, and pulling focus back off somebody mid-exit would be the
+           * same rudeness in the other direction.
+           */
           event.preventDefault();
-          restoreFocus();
+          if (document.activeElement === document.body) restoreFocus();
         }}
         /*
          * A sheet stays open while the page beside it is used. Without this a
@@ -246,7 +287,6 @@ export function Dialog({
         {typeof children === "function" ? children(dismiss) : children}
         <ExitGate
           onGone={() => {
-            restoreFocus();
             if (!dismissedRef.current) return;
             dismissedRef.current = false;
             closeRef.current();

--- a/apps/web/ui/dialog.tsx
+++ b/apps/web/ui/dialog.tsx
@@ -1,65 +1,155 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
+import {
+  Dialog as KitDialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 export type DialogDismiss = (event?: { readonly detail?: number }) => void;
 
 /**
- * Something that takes over the screen until it is answered or dismissed.
+ * A layer that is answered or dismissed before the page goes on.
  *
- * The compact mobile shell uses one for its navigation, and the authoring
- * tickets after this one will use it for confirmations. So the two rules that
- * are always forgotten are here rather than in each caller: **Escape closes
- * it**, and **opening it moves focus inside** so that a keyboard is not still
- * driving the page underneath.
+ * The compact mobile shell uses one for its navigation, confirmations use one
+ * to name what they are about, and the evidence panel is the same surface
+ * attached to an edge. So the two rules that are always forgotten are here
+ * rather than in each caller: **Escape closes it**, and **opening it moves
+ * focus inside** so that a keyboard is not still driving the page underneath.
  *
- * The browser owns the modal lifecycle through its native `dialog`: focus is
- * trapped, the page behind it is inert, and Escape becomes a cancel request.
- * We only restore the exact opener when React removes the dialog. A dialog is
- * never the security boundary and never the only place a fact is stated. It is
- * a way of asking, and closing one always leaves the page as it was.
+ * **The modal lifecycle is the kit's.** `components/ui/dialog.tsx` is Radix,
+ * and Radix traps focus, makes the page behind it inert, turns Escape into a
+ * close, and blocks the page to the pointer while it is up. This file used to
+ * do all of that by hand on a native `<dialog>`; it now says only what the kit
+ * does not know — which of the three shapes to wear, which of them takes the
+ * screen, where focus goes back to, and when the owner may remove it.
+ *
+ * **`onClose` still means "now take me away", and it is called last.** Owners
+ * mount this component and remove it, so an exit has to finish before React
+ * unmounts anything: `ExitGate` below sits inside the panel and reports the
+ * moment Radix lets go of it, which is the moment the closing animation ended.
+ * A dialog is never the security boundary and never the only place a fact is
+ * stated. It is a way of asking, and closing one always leaves the page as it
+ * was.
  *
  * A child function receives the same dismiss path as the close button and the
- * backdrop. Pointer dismissal gets the short exit. Keyboard dismissal stays
- * immediate. Successful writes may still call the owner's `onClose` directly,
- * because the system response should not wait for decoration.
+ * scrim. Successful writes may still call the owner's `onClose` directly,
+ * because the system response should not wait for decoration — the gate below
+ * stays quiet on that path rather than closing the same dialog twice.
  *
- * **The appearance is here and the motion is not.** Sizes, surfaces and the
- * three shapes are utilities on the elements below. The entrance, the exit and
- * the reduced-motion form of both are in `tailwind-theme.css`, keyed on the
- * `data-slot` and `data-kind` this file writes — the same arrangement the Radix
- * surfaces already use, and for the same reason: an exit that has to finish
- * before the element is removed is a thing a class list says badly.
+ * **The centred motion is not here.** `tailwind-theme.css` keys the entrance,
+ * the exit and the reduced-motion form of both on the `data-slot` and
+ * `data-state` the kit writes. The two edge-attached kinds add the travel that
+ * `DESIGN.md` asks of them, because the theme's edge rules were written for the
+ * native `<dialog>` this file just retired and the Radix slots have no drawer
+ * rule of their own yet.
  */
 
-/** What each shape is, once, so the panel and the scrim cannot disagree. */
-const SCRIM_SHAPE = {
-  dialog: "open:items-center open:justify-center open:p-5",
-  drawer: "open:items-stretch open:justify-start open:p-0",
-  sheet: "open:items-stretch open:justify-end open:p-0",
-} as const;
-
+/**
+ * What each shape is, as an override of the kit's centred panel.
+ *
+ * The kit centres with `-translate-x-1/2 -translate-y-1/2` on the `translate`
+ * property and animates `scale`, so position and motion never share a property.
+ * The two edge kinds keep that arrangement: they sit at their edge with no
+ * centring shift, and the travel below is written on `translate` as well, so
+ * the theme's `scale` animation and this file's slide compose instead of
+ * cancelling each other.
+ */
 const PANEL_SHAPE = {
-  dialog: "w-[min(420px,100%)] origin-center p-5",
+  /* A tall dialog scrolls inside the viewport rather than off it. */
+  dialog: "max-h-[calc(100svh-var(--space-8))] overflow-y-auto",
   drawer: [
-    "w-[min(340px,calc(100%-var(--space-7)))] min-h-full origin-left p-5",
-    "rounded-[0_var(--radius-lg)_var(--radius-lg)_0] border-y-0 border-l-0",
+    "top-0 left-0 h-full max-h-none",
+    "w-[min(340px,calc(100vw-var(--space-7)))] translate-x-0 translate-y-0",
+    "overflow-y-auto rounded-[0_var(--radius-lg)_var(--radius-lg)_0]",
+    "border-y-0 border-l-0",
   ],
   sheet: [
-    "flex h-full min-h-full w-[min(640px,100%)] flex-col overflow-hidden",
-    "origin-right rounded-none border-y-0 border-r-0 p-0",
-    "max-[40rem]:w-full max-[40rem]:rounded-none max-[40rem]:border-l-0",
+    "top-0 right-0 left-auto h-full max-h-none",
+    "w-[min(640px,100vw)] translate-x-0 translate-y-0",
+    "gap-0 overflow-hidden rounded-none border-y-0 border-r-0 p-0",
+    "max-[40rem]:w-full max-[40rem]:border-l-0",
   ],
 } as const;
+
+/**
+ * The travel of the two kinds that are attached to an edge.
+ *
+ * `DESIGN.md`: "Mobile drawer — translate from its attached edge." The theme
+ * holds the panel for the length of its `scale` animation, which is what Radix
+ * waits for before unmounting, so the slide is given the same two tokens and
+ * ends with it rather than being cut off halfway. `@starting-style` is what
+ * makes the entrance a movement: without it a panel that mounts already open
+ * has nowhere to travel from.
+ *
+ * Reduced motion drops the transition and nothing else. The panel then arrives
+ * and leaves in place, and the opacity the theme still runs is what says a
+ * surface came or went.
+ */
+const PANEL_TRAVEL = {
+  dialog: "",
+  drawer: [
+    "transition-[translate] duration-(--duration-dialog-in) ease-out",
+    "starting:-translate-x-full",
+    "data-[state=closed]:-translate-x-full",
+    "data-[state=closed]:duration-(--duration-dialog-out)",
+    "motion-reduce:transition-none",
+  ],
+  sheet: [
+    "transition-[translate] duration-(--duration-dialog-in) ease-out",
+    "starting:translate-x-full",
+    "data-[state=closed]:translate-x-full",
+    "data-[state=closed]:duration-(--duration-dialog-out)",
+    "motion-reduce:transition-none",
+  ],
+} as const;
+
+/** A sheet's head is a fixed bar over a body that scrolls under it. */
+const HEAD_SHAPE = {
+  dialog: "",
+  drawer: "",
+  sheet: "flex-none border-b border-border p-5",
+} as const;
+
+/**
+ * The moment the panel finished leaving.
+ *
+ * It renders nothing and exists for its unmount: Radix removes the panel only
+ * after the closing animation ends, so this component's cleanup is that end.
+ * Waiting on it rather than on a timer means the exit is never cut short and
+ * never guessed at, and the duration stays in the theme where `DESIGN.md` puts
+ * it.
+ */
+function ExitGate({ onGone }: { readonly onGone: () => void }) {
+  const gone = useRef(onGone);
+  gone.current = onGone;
+  useEffect(() => () => gone.current(), []);
+  return null;
+}
+
+/**
+ * Which of the three shapes takes the screen, and which sits beside the work.
+ *
+ * A confirmation and the mobile navigation are questions: nothing behind them
+ * can be reached until they are answered, which is `DESIGN.md`'s "dialogs trap
+ * focus, make the background inert". A sheet is not that. It is a panel docked
+ * to an edge, the simulation page opens one by default, and that page is built
+ * to be read with the transcript open beside the grader results — so a sheet
+ * that put the page behind it out of reach would break the page it belongs to.
+ *
+ * A sheet keeps everything else a dialog has: focus moves into it, Escape
+ * closes it, and the control that opened it is focused again afterwards. What
+ * it drops is the scrim, the scroll lock, and the inert page.
+ *
+ * **This is a design call rather than a fact, and it is called out in the pull
+ * request for the developer to overrule.** The surface it changes is the
+ * transcript-and-audio sheet and the persona version history.
+ */
+const TAKES_THE_SCREEN = { dialog: true, drawer: true, sheet: false } as const;
 
 export function Dialog({
   kind = "dialog",
@@ -75,164 +165,94 @@ export function Dialog({
   readonly returnFocusTo?: HTMLElement | null;
   readonly children: ReactNode | ((dismiss: DialogDismiss) => ReactNode);
 }) {
-  const titleId = useId();
-  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [open, setOpen] = useState(true);
   const closeRef = useRef(onClose);
-  const closingRef = useRef(false);
-  const closeTimerRef = useRef<number | null>(null);
-  const [closing, setClosing] = useState(false);
+  const dismissedRef = useRef(false);
   closeRef.current = onClose;
 
-  const finishClose = useCallback(() => {
-    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
-    closeTimerRef.current = null;
-    closingRef.current = false;
-    setClosing(false);
-    closeRef.current();
+  /**
+   * The control that was in hand when this dialog appeared.
+   *
+   * Read while rendering rather than in an effect, because by the time an
+   * effect runs the kit has already moved focus inside the panel and the
+   * answer is gone. Owners mount this component instead of opening it from a
+   * `DialogTrigger`, so the kit has no trigger of its own to go back to and
+   * would otherwise leave focus on the page body.
+   */
+  const [opener] = useState<HTMLElement | null>(() =>
+    typeof document !== "undefined" && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null,
+  );
+
+  const dismiss = useCallback<DialogDismiss>(() => {
+    dismissedRef.current = true;
+    setOpen(false);
   }, []);
 
-  const requestClose = useCallback((animate: boolean) => {
-    if (!animate) {
-      finishClose();
-      return;
-    }
-    // Input can change while the dialog is open. A keyboard-opened dialog that
-    // is later dismissed with the pointer must use the pointer exit selectors;
-    // otherwise it remains inert until the safety timer with no visible motion.
-    if (dialogRef.current !== null) dialogRef.current.dataset.input = "pointer";
-    if (closingRef.current) return;
-    closingRef.current = true;
-    setClosing(true);
-    // `transitionend` is the normal path. This fallback prevents a modal from
-    // trapping the page if a browser or injected stylesheet drops the event.
-    closeTimerRef.current = window.setTimeout(finishClose, 280);
-  }, [finishClose]);
-
-  const dismiss = useCallback<DialogDismiss>((event) => {
-    requestClose((event?.detail ?? 0) > 0);
-  }, [requestClose]);
-
-  useEffect(() => () => {
-    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
-  }, []);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (dialog === null) return undefined;
-
-    const opener = returnFocusTo ?? (
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null
-    );
-    dialog.dataset.input = opener?.matches(":focus-visible") === true
-      ? "keyboard"
-      : "pointer";
-
-    // jsdom does not implement the modal methods. Keeping the fallback local
-    // lets the rendered component tests prove focus without weakening the real
-    // browser path, which always uses `showModal`.
-    const hasNativeModal = typeof dialog.showModal === "function";
-    const fallbackEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") requestClose(false);
-    };
-    if (hasNativeModal) dialog.showModal();
-    else {
-      dialog.setAttribute("open", "");
-      document.addEventListener("keydown", fallbackEscape);
-    }
-
-    const first = dialog.querySelector<HTMLElement>(
-      "[autofocus], a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled)",
-    );
-    (first ?? dialog)?.focus();
-
-    return () => {
-      if (!hasNativeModal) document.removeEventListener("keydown", fallbackEscape);
-      if (dialog.open && typeof dialog.close === "function") dialog.close();
-      else dialog.removeAttribute("open");
-      if (opener?.isConnected === true) opener.focus();
-    };
-  }, [requestClose, returnFocusTo]);
+  /**
+   * Focus goes back the moment the panel does, rather than a task later.
+   *
+   * The kit hands focus back from a timer, which is soon enough to look right
+   * and one task too late for anything that reads `document.activeElement`
+   * straight after a press. `DESIGN.md` asks a control to answer on press, so
+   * this puts focus back as the panel is removed. `onCloseAutoFocus` below
+   * keeps the kit from moving it again afterwards, and repeats the same move
+   * in case a future version removes the panel differently.
+   */
+  const restoreFocus = () => {
+    const back = returnFocusTo ?? opener;
+    if (back !== null && back.isConnected) back.focus();
+  };
 
   return (
-    <dialog
-      className={cn(
-        /*
-         * The `<dialog>` element is the scrim. The browser gives it a border, a
-         * padding and a centred box of its own, so every one of those is said
-         * away here and the layout is the flex box below.
-         */
-        "fixed inset-0 z-30 m-0 h-full max-h-none w-full max-w-none",
-        "overflow-y-auto border-0 bg-transparent p-0 text-foreground",
-        /*
-         * The scrim colour is a utility and its opacity deliberately is not.
-         * Utilities outrank `@layer components`, so an `opacity-100` here would
-         * beat the theme rule that fades the backdrop out and the dialog would
-         * leave with its scrim still at full strength. A backdrop is opaque by
-         * default, so there is nothing to say.
-         */
-        "backdrop:bg-scrim",
-        "open:flex",
-        SCRIM_SHAPE[kind],
-      )}
-      data-slot="dialog-scrim"
-      ref={dialogRef}
-      aria-labelledby={titleId}
-      aria-modal="true"
-      data-kind={kind}
-      data-closing={closing ? "true" : "false"}
-      onCancel={(event) => {
-        event.preventDefault();
-        requestClose(false);
-      }}
-      onPointerDown={(event) => {
-        event.currentTarget.dataset.input = "pointer";
-        if (event.target === event.currentTarget) requestClose(true);
+    <KitDialog
+      open={open}
+      modal={TAKES_THE_SCREEN[kind]}
+      onOpenChange={(next) => {
+        if (!next) dismiss();
       }}
     >
-      <div
-        className={cn(
-          "rounded-card border border-border bg-surface shadow-modal",
-          PANEL_SHAPE[kind],
-        )}
-        data-slot="dialog-panel"
-        onTransitionEnd={(event) => {
-          if (closing && event.target === event.currentTarget && event.propertyName === "opacity") {
-            finishClose();
-          }
+      <DialogContent
+        className={cn(PANEL_SHAPE[kind], PANEL_TRAVEL[kind])}
+        data-kind={kind}
+        /*
+         * Every caller writes its own body, and most bodies are not one
+         * sentence a description could stand in for. Saying so removes the
+         * attribute rather than pointing it at nothing.
+         */
+        aria-describedby={undefined}
+        onCloseAutoFocus={(event) => {
+          // The kit's own answer here is its `DialogTrigger`, which these
+          // callers do not use, so this says where focus belongs instead: the
+          // control a caller named, or the one that was in hand. An opener
+          // removed by the very write this dialog confirmed is left alone —
+          // focus falls to the page rather than to something nobody can see.
+          event.preventDefault();
+          restoreFocus();
+        }}
+        /*
+         * A sheet stays open while the page beside it is used. Without this a
+         * press on the grader results would close the transcript being read
+         * against them, which is the one thing that page is for.
+         */
+        onInteractOutside={(event) => {
+          if (!TAKES_THE_SCREEN[kind]) event.preventDefault();
         }}
       >
-        <div
-          className={cn(
-            "mb-4 flex items-center justify-between gap-4",
-            /* A sheet's head is a fixed bar over a scrolling body. */
-            kind === "sheet" &&
-              "mb-0 flex-none border-b border-border p-5",
-          )}
-        >
-          <h2 className="m-0 text-lg font-medium" id={titleId}>
-            {title}
-          </h2>
-          <button
-            className={cn(
-              "grid size-(--control-md) shrink-0 place-items-center p-0",
-              "rounded-button border border-border bg-surface text-sm text-foreground",
-              "cursor-pointer transition-transform duration-(--duration-press) ease-out",
-              "pointer-hover:border-border-strong pointer-hover:bg-surface-soft",
-              "[&:active:not(:focus-visible)]:scale-97",
-              "pointer-coarse:size-(--tap-target)",
-              "motion-reduce:transition-none motion-reduce:[&:active:not(:focus-visible)]:scale-100",
-            )}
-            type="button"
-            aria-label="Close"
-            onClick={(event) => requestClose(event.detail > 0)}
-          >
-            <span aria-hidden="true">✕</span>
-          </button>
-        </div>
+        <DialogHeader className={cn(HEAD_SHAPE[kind])}>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
         {typeof children === "function" ? children(dismiss) : children}
-      </div>
-    </dialog>
+        <ExitGate
+          onGone={() => {
+            restoreFocus();
+            if (!dismissedRef.current) return;
+            dismissedRef.current = false;
+            closeRef.current();
+          }}
+        />
+      </DialogContent>
+    </KitDialog>
   );
 }

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -150,10 +150,13 @@ export function Menu({
    * leave behind them. Radix then sees focus has moved out, stops restoring it
    * a second time, and the panel's exit runs to its end regardless.
    *
-   * It is also what the project selector reads. It walks up from whatever has
-   * focus to `[data-slot="menu"]` to find its own trigger for the unsaved-work
-   * dialog, and the panel is drawn outside that root now, so the button being
-   * focused already is what keeps that answer correct.
+   * It is also what keeps the project selector's unsaved-work dialog pointing
+   * at the right control. That page walks up from whatever has focus to
+   * `[data-slot="menu"]` to find its own trigger — a walk that now finds
+   * nothing, because the panel is drawn at the end of the page rather than
+   * inside that root, so the walk starts outside it and its answer is always
+   * null. What saves it is the fallback: the dialog it opens takes whatever
+   * has focus, and by then this has already put that back on the trigger.
    */
   const returnFocus = useCallback(() => triggerRef.current?.focus(), []);
 

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -1,36 +1,47 @@
 "use client";
 
 import Link from "next/link";
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useRef, useState, type ReactNode } from "react";
 
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
 /**
  * A button that opens a small panel, and everything that has to be true of one
  * before somebody without a pointer can use it.
  *
- * There are two of these in the shell — the organization and project selector,
- * and the account menu — and there will be more. Writing the behaviour once is
- * what stops the second one being the first one with the keyboard left out:
+ * There are three of these in the product — the organization and project
+ * selector, the account menu, and the test editor's choosers — and there will
+ * be more. Writing the behaviour once is what stops the second one being the
+ * first one with the keyboard left out.
  *
- * - **Escape closes it and puts focus back on the button**, so a menu opened
- *   by accident is not a trap.
+ * **The panel is the kit's anchored surface.** `components/ui/popover.tsx` is
+ * Radix, so it owns what a hand-written panel keeps getting wrong: it opens
+ * against the trigger and stays on screen when there is no room below it,
+ * Escape closes it and puts focus back on the button, a press outside or a
+ * focus that leaves closes it, and the exit finishes before the panel is
+ * removed. Radix also publishes the corner it grew from, which is how
+ * `tailwind-theme.css` scales it from the trigger without this file saying so.
+ *
+ * **The list of items is still this file's, and that is the reason for
+ * `Popover` rather than the kit's `DropdownMenu`.** A dropdown menu keeps its
+ * own register of items: only what it was handed as an item takes the arrow
+ * keys, and it reads every printable key as a jump to a matching item. Two
+ * panels here hold a field to type in, which that would take the keys away
+ * from, and the account menu's dark-theme switch is a `role="switch"` rather
+ * than an item, which that would leave reachable by pointer alone. So the
+ * items are found in the DOM by `data-menu-item` — a panel that grows a row
+ * gets the arrow keys for free, whatever that row is.
+ *
  * - **The arrow keys move between items**, Home and End reach the ends, and
- *   opening moves focus into the panel. Items are found in the DOM rather than
- *   registered by hand, so a panel that grows an item gets it for free.
- * - **A click anywhere else closes it**, and so does moving focus out of it —
- *   tabbing away is a way of leaving, not a way of leaving a panel behind.
- *
- * An item marked `data-menu-focus-first` takes focus when the panel opens. The
- * selector's search field uses it, which is what makes typing to filter work
- * without anybody reaching for the field first.
+ *   opening moves focus into the panel.
+ * - An item marked `data-menu-focus-first` takes focus when the panel opens.
+ *   The selector's search field uses it, which is what makes typing to filter
+ *   work without anybody reaching for the field first.
  *
  * **A panel holding a text field is not a `menu`.** `role="menu"` promises a
  * list of commands, and neither ARIA nor a screen reader's menu mode expects a
@@ -41,12 +52,6 @@ import { cn } from "@/lib/utils";
  * **Home and End belong to the caret while somebody is typing.** Stealing them
  * to jump to the ends of the list means the ends of the *text* cannot be
  * reached, which is a worse trade than the one it buys.
- *
- * The root carries `data-slot="menu"` and the panel carries `data-placement`.
- * The motion — an entrance from the trigger's corner, an exit that finishes
- * before the panel is removed, and the reduced-motion form of both — is in
- * `tailwind-theme.css` keyed on those, beside the same rules for the Radix
- * surfaces.
  */
 
 export type MenuProps = {
@@ -68,6 +73,23 @@ export type MenuProps = {
   readonly panelClassName?: string;
   readonly children: (close: () => void) => ReactNode;
 };
+
+/**
+ * Where each placement puts the panel, as the two things Radix positions by.
+ *
+ * This is the mechanism rather than a label beside one: change a line here and
+ * the panel moves. Radix then writes the side it actually landed on back onto
+ * the panel as `data-side`, which is the side after any collision, so a test
+ * reading it is reading where the panel is rather than what it was asked for.
+ */
+const ANCHOR = {
+  "below-start": { side: "bottom", align: "start" },
+  "below-end": { side: "bottom", align: "end" },
+  "above-start": { side: "top", align: "start" },
+  "above-end": { side: "top", align: "end" },
+  "right-start": { side: "right", align: "start" },
+  "right-end": { side: "right", align: "end" },
+} as const;
 
 /**
  * One row in a panel, as a class list.
@@ -113,95 +135,34 @@ export function Menu({
   children,
 }: MenuProps) {
   const [open, setOpen] = useState(false);
-  const [closing, setClosing] = useState(false);
-  const [input, setInput] = useState<"keyboard" | "pointer">("keyboard");
-  const panelId = useId();
-  const rootRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
-  const closingRef = useRef(false);
-  const closeTimerRef = useRef<number | null>(null);
-  const returnFocusRef = useRef(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const anchor = ANCHOR[placement];
 
-  const finishClose = useCallback(() => {
-    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
-    closeTimerRef.current = null;
-    closingRef.current = false;
-    setClosing(false);
+  /**
+   * Handing the keyboard back, now rather than after the panel has gone.
+   *
+   * Radix restores focus itself, one task after the panel is removed. That is
+   * right for a panel somebody clicked away from and wrong for the two ways of
+   * *finishing* with one — Escape, and choosing something — because
+   * `DESIGN.md` says a control answers on press and never after an animation.
+   * So those two paths put focus back on the button first and let the panel
+   * leave behind them. Radix then sees focus has moved out, stops restoring it
+   * a second time, and the panel's exit runs to its end regardless.
+   *
+   * It is also what the project selector reads. It walks up from whatever has
+   * focus to `[data-slot="menu"]` to find its own trigger for the unsaved-work
+   * dialog, and the panel is drawn outside that root now, so the button being
+   * focused already is what keeps that answer correct.
+   */
+  const returnFocus = useCallback(() => triggerRef.current?.focus(), []);
+
+  const close = useCallback(() => {
+    returnFocus();
     setOpen(false);
-    if (returnFocusRef.current) buttonRef.current?.focus();
-    returnFocusRef.current = false;
-  }, []);
-
-  const close = useCallback((returnFocus = false, animate = input === "pointer") => {
-    returnFocusRef.current = returnFocus;
-    if (!animate) {
-      finishClose();
-      return;
-    }
-    // The way out can differ from the way in. A keyboard-opened panel that is
-    // later dismissed by a pointer must switch to the pointer exit selectors.
-    setInput("pointer");
-    if (closingRef.current) return;
-    closingRef.current = true;
-    setClosing(true);
-    // `transitionend` normally finishes this. The timer prevents a hidden menu
-    // if a browser, test environment, or injected stylesheet drops the event.
-    closeTimerRef.current = window.setTimeout(finishClose, 200);
-  }, [finishClose, input]);
-
-  const openPanel = useCallback(() => {
-    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
-    closeTimerRef.current = null;
-    closingRef.current = false;
-    setClosing(false);
-    setOpen(true);
-  }, []);
-
-  useEffect(() => () => {
-    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
-  }, []);
-
-  useEffect(() => {
-    if (!open) return undefined;
-
-    const elsewhere = (event: Event) => {
-      const root = rootRef.current;
-      if (
-        root !== null &&
-        !root.contains(event.target as Node) &&
-        !closingRef.current
-      ) {
-        close(false, event.type === "pointerdown");
-      }
-    };
-
-    document.addEventListener("pointerdown", elsewhere);
-    document.addEventListener("focusin", elsewhere);
-    return () => {
-      document.removeEventListener("pointerdown", elsewhere);
-      document.removeEventListener("focusin", elsewhere);
-    };
-  }, [close, open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const panel = panelRef.current;
-    const first =
-      panel?.querySelector<HTMLElement>("[data-menu-focus-first]") ??
-      itemsIn(panel)[0];
-    first?.focus();
-  }, [open]);
+  }, [returnFocus]);
 
   function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
-    setInput("keyboard");
-    if (event.key === "Escape") {
-      event.stopPropagation();
-      close(true, false);
-      return;
-    }
-
-    if (!open) return;
     const items = itemsIn(panelRef.current);
     if (items.length === 0) return;
 
@@ -219,68 +180,60 @@ export function Menu({
   }
 
   return (
-    <div
-      className="relative"
-      data-slot="menu"
-      ref={rootRef}
-      onPointerDownCapture={() => setInput("pointer")}
-      onKeyDown={onKeyDown}
-      data-open={open ? "true" : "false"}
-      data-closing={closing ? "true" : "false"}
-      data-input={input}
-    >
-      <button
-        className={cn(
-          triggerClassName ?? MENU_ITEM,
-          open ? (openClassName ?? "") : "",
-        )}
-        ref={buttonRef}
-        type="button"
-        aria-haspopup={panelRole}
-        aria-expanded={open}
-        aria-controls={open ? panelId : undefined}
-        aria-label={label}
-        onClick={() => {
-          if (closing) openPanel();
-          else if (open) close(false);
-          else openPanel();
-        }}
-      >
-        {trigger}
-      </button>
-      {open ? (
-        <div
+    <Popover open={open} onOpenChange={setOpen}>
+      {/*
+       * The root stays, and it is not decoration: the project selector finds
+       * its own trigger by walking up from whatever has focus to
+       * `[data-slot="menu"]`, which is how the unsaved-work dialog it opens
+       * knows where to put focus back.
+       */}
+      <div className="relative" data-slot="menu" data-open={open ? "true" : "false"}>
+        <PopoverTrigger
           className={cn(
-            /*
-             * Where this panel sits is not here. `data-placement` below is the
-             * whole of it: `tailwind-theme.css` reads that attribute for the
-             * offsets, the corner it grows from, and the extra room the two
-             * that hang below the trigger keep off the bottom of the screen.
-             * The attribute is the mechanism rather than a label beside one, so
-             * removing it moves the panel to the corner of its trigger.
-             */
-            "absolute z-20 w-max overflow-y-auto p-2",
+            triggerClassName ?? MENU_ITEM,
+            open ? (openClassName ?? "") : "",
+          )}
+          ref={triggerRef}
+          aria-haspopup={panelRole}
+          aria-label={label}
+        >
+          {trigger}
+        </PopoverTrigger>
+        <PopoverContent
+          className={cn(
+            "w-max p-2",
             "min-w-[min(240px,calc(100vw-var(--space-8)))]",
             "max-w-[min(320px,calc(100vw-var(--space-8)))]",
-            "rounded-card border border-border bg-surface shadow-popover",
+            /*
+             * A panel keeps a gap off the edge it was pushed against, and
+             * scrolls rather than running past it. Radix measures the room it
+             * has and publishes it; the gap is the theme's smallest step.
+             */
+            "max-h-[calc(var(--radix-popover-content-available-height)-var(--space-2))]",
+            "overflow-y-auto",
             panelClassName,
           )}
-          data-slot="menu-panel"
-          data-placement={placement}
-          id={panelId}
-          ref={panelRef}
+          side={anchor.side}
+          align={anchor.align}
           role={panelRole}
           aria-label={label}
-          onTransitionEnd={(event) => {
-            if (closing && event.target === event.currentTarget && event.propertyName === "opacity") {
-              finishClose();
-            }
+          ref={panelRef}
+          onEscapeKeyDown={returnFocus}
+          onOpenAutoFocus={(event) => {
+            const panel = panelRef.current;
+            const first =
+              panel?.querySelector<HTMLElement>("[data-menu-focus-first]") ??
+              itemsIn(panel)[0];
+            if (first === undefined) return;
+            event.preventDefault();
+            first.focus();
           }}
+          onKeyDown={onKeyDown}
         >
-          {children(() => close(true))}
-        </div>
-      ) : null}
-    </div>
+          {children(close)}
+        </PopoverContent>
+      </div>
+    </Popover>
   );
 }
 

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -625,6 +625,32 @@
   to { opacity: 0; scale: 0.98; }
 }
 
+/*
+ * The drawer, which travels and does not fade.
+ *
+ * `DESIGN.md` gives a mobile drawer its own line: "translate from its attached
+ * edge", and its own pair of tokens. Fading or scaling it as well reads as two
+ * events rather than one movement, so these keyframes write `translate` and
+ * nothing else. `translate` is a property of its own, so the panel's resting
+ * position is still whatever its class list says and this only moves it.
+ *
+ * **The length of the exit is load-bearing rather than decoration.** Radix
+ * removes the panel on `animationend`, so whatever animation is running is
+ * what holds the drawer on screen while it leaves. Writing the travel as a
+ * transition instead left it racing the centred dialog's 180ms `scale`, which
+ * is why the drawer used to be cut off at its own edge; an animation of its
+ * own means the drawer waits for the drawer.
+ */
+@keyframes egma-drawer-in {
+  from { translate: -100% 0; }
+  to { translate: 0 0; }
+}
+
+@keyframes egma-drawer-out {
+  from { translate: 0 0; }
+  to { translate: -100% 0; }
+}
+
 @layer components {
   /*
    * "Pointer press feedback uses a subtle scale. Keyboard activation is
@@ -778,6 +804,20 @@
 
   [data-slot="dialog-content"][data-state="closed"] {
     animation: egma-dialog-out var(--duration-dialog-out) var(--ease-out);
+  }
+
+  /*
+   * A drawer is the one kind that is not centred, so it is the one kind that
+   * moves. It is named after the centred rules above and carries `data-kind`
+   * as well, so it outranks them and replaces the fade and the scale rather
+   * than running beside them.
+   */
+  [data-slot="dialog-content"][data-kind="drawer"][data-state="open"] {
+    animation: egma-drawer-in var(--duration-drawer-in) var(--ease-drawer);
+  }
+
+  [data-slot="dialog-content"][data-kind="drawer"][data-state="closed"] {
+    animation: egma-drawer-out var(--duration-drawer-out) var(--ease-drawer);
   }
 
   /*
@@ -1133,6 +1173,7 @@
     [data-slot="dropdown-menu-content"][data-state="open"],
     [data-slot="dropdown-menu-sub-content"][data-state="open"],
     [data-slot="dialog-content"][data-state="open"],
+    [data-slot="dialog-content"][data-kind="drawer"][data-state="open"],
     [data-slot="dialog-overlay"][data-state="open"] {
       animation: egma-fade-in var(--duration-hover) linear;
     }
@@ -1141,6 +1182,7 @@
     [data-slot="dropdown-menu-content"][data-state="closed"],
     [data-slot="dropdown-menu-sub-content"][data-state="closed"],
     [data-slot="dialog-content"][data-state="closed"],
+    [data-slot="dialog-content"][data-kind="drawer"][data-state="closed"],
     [data-slot="dialog-overlay"][data-state="closed"] {
       animation: egma-fade-out var(--duration-hover) linear;
     }


### PR DESCRIPTION
Ticket 22. `apps/web/ui/dialog.tsx` and `apps/web/ui/menu.tsx` were hand-written overlays. They now run on the kit. Public exports and prop shapes are unchanged, so no page was edited.

Two commits: the migration, then the review round.

## What changed

**`ui/dialog.tsx` → `components/ui/dialog.tsx` (Radix).** The kit brings the focus trap, the pointer block on the page behind, Escape, and the portal. This file keeps only what the kit cannot know:

- **Where focus goes back to, and when.** Owners mount this component instead of opening it from a `DialogTrigger`, so the kit's own answer — its trigger — is null and focus would fall to the page body. The opener is read while rendering, before the kit moves focus inside, and `returnFocusTo` still wins when a caller names one. **Focus goes back on the press, not at the end of the exit** — waiting was a fifth of a second with focus on a button on its way out, inside a layer the page behind is still hidden from. It is an effect rather than a line in `dismiss` because until that render lands the kit is still trapping focus and would pull it straight back.
- **When the owner may remove it.** `onClose` still means "now take me away". A gate inside the panel reports the moment the kit lets go of it, which is the moment the closing animation ended — so an exit always runs to completion. A watchdog forces that once if `animationend` never arrives, which both retired implementations carried and this one had lost. A successful write that removes the dialog itself does not get a second close.
- **The three shapes.** `dialog`, `drawer` and `sheet` are class overrides on the kit's panel.

**`ui/menu.tsx` → `components/ui/popover.tsx` (Radix), not `dropdown-menu.tsx`.** This is a deviation from the ticket and it is deliberate. A dropdown menu keeps its own register of items:

- it reads every printable key as a jump to a matching item, which takes the keys away from the project selector and the test editor, both of which hold a search field;
- it gives the arrow keys only to what it was handed as an item, and the account menu's dark-theme switch is a `role="switch"`, so it would have become pointer-only.

Popover is the kit primitive that fits: same anchored surface, same origin-aware motion tokens, Escape, outside dismissal, focus return — and the item list stays this file's, found by `data-menu-item`, so every row keeps the keyboard. Placement now goes to Radix as `side`/`align` with collision handling, and the panel reports back the side it landed on.

**Theme, motion section: the drawer gets its own movement.** `DESIGN.md` gives a mobile drawer its own line ("translate from its attached edge") and its own token pair, and both were unused. It now has `egma-drawer-in`/`egma-drawer-out` keyed on `[data-slot="dialog-content"][data-kind="drawer"]`: movement only at 280ms in / 220ms out on `--ease-drawer`. Writing it as a transition was what made the drawer fade and scale as well, and what made its slide race the centred dialog's 180ms animation — Radix removes a panel when its animation ends, so an animation of its own is what makes the drawer wait for the drawer. `--duration-drawer-out` and `--ease-drawer` are no longer orphans.

**One class in the kit** (`components/ui/dialog.tsx`): the close button was 32px, so it gets `pointer-coarse:size-(--tap-target)` like the other eleven files that need 44px on a coarse pointer.

## One design call for you to overrule

**A sheet no longer takes the screen.** `dialog` and `drawer` stay modal — scrim, focus trap, inert page. `sheet` does not. The simulation page opens its transcript sheet by default and is built to be read with the transcript beside the grader results; a modal sheet made the whole page unreachable, which its own tests caught. The sheet keeps focus, Escape and focus return. It drops the scrim, the scroll lock and the inert page. Affected surfaces: the transcript-and-audio sheet and the persona version history.

## Proven

- **Scoped tests, all green.** `components.test.tsx`, `menu-placement.test.tsx`, `design-system.test.tsx`, `simulation-evidence.test.tsx`, `run-history.test.tsx`, `personas.test.tsx` (146) and `settings.test.tsx`, `agents-pages.test.tsx`, `tests-pages.test.tsx`, `graders-pages.test.tsx`, `runs.test.tsx`, `sidebar-groups.test.tsx`, `project-shell.test.ts` (215).
- **Typecheck** `tsc --noEmit` clean.
- **The focus-timing guard bites.** "hands the keyboard back on the press, not at the end of the exit" pins the timing with a real closing animation in flight — with no stylesheet the panel leaves in the same tick and any assertion here would pass vacuously. Reverting the fix fails it: focus lands on the dying Cancel button instead of the opener.
- **The sheet deviation now has its assertion.** "leaves the page beside a sheet readable and usable": a control behind an open sheet is not hidden, and a full press on it fires that control and does not close the sheet.
- **Both themes, real browser** on the design-system proof page, at 1400x900 and 375x812:
  - Menu: `role="menu"`, `data-side="right"` `data-align="end"` from `right-end`, `egma-anchored-in 180ms cubic-bezier(.23,1,.32,1)`, `transform-origin` measured from the trigger, exit `egma-anchored-out 140ms`, Pure Paper, 12px radius, `rgba(122,49,23,.14) 0 12px 32px`. Light and dark checked.
  - **Arrow keys reach the dark-theme switch** — the behaviour a dropdown menu would have lost.
  - Escape closes and focus is back on the trigger in the same tick.
  - Dialog: `egma-dialog-in 240ms`, exit `egma-dialog-out 180ms`, overlay `egma-fade-in 240ms`, centred exactly, 12px radius, title weight 500 at 16px, scrim Midnight Ink 32% (light) / 60% (dark), `body { pointer-events: none }` while open, focus inside, `max-height` viewport minus 40px so a tall dialog scrolls. Light and dark checked.
  - Dialog marked `data-state="closed"` and **still on screen** while its exit runs.
  - Drawer, after the theme rule: `egma-drawer-in 0.28s cubic-bezier(0.32,0.72,0,1)` in, `egma-drawer-out 0.22s` out, `opacity: 1` and `scale: none` throughout — movement and nothing else. Still present while closing, so Radix now waits on the drawer's own 220ms.
  - Close button measures 44x44 under coarse-pointer emulation.
  - Reduced motion: the drawer is named in both reduced-motion lists, so it falls back to the theme's fade; the sheet's closed position compiles to `translate: … !important` inside the reduced-motion query, so the exit no longer teleports.

## Unproven or left over

- **The sheet's edge travel is unproven in a browser.** No sheet exists on the design-system page and the product pages need the API. The drawer proves the same mechanism.
- **Exits could not be watched finishing in a browser.** The automation pane runs with `document.visibilityState === "hidden"`, so CSS animations never complete there. The removal-on-`animationend` path is proven in jsdom instead, driving the kit's own presence machine — and the watchdog now covers exactly this case in the product.
- **The sheet still carries its travel in the component**, because it has no token pair of its own to be given a theme rule for. The drawer's rule is the granted one.
- **Radix's `aria-hidden` on the page behind a modal did not land in the dev browser**, though it does in jsdom. The pointer block and the focus trap both work, so the page is unreachable in practice, but the screen-reader half is unverified. This is kit behaviour, not the wrapper's.
- **Consumer test assertions corrected**, each naming an internal that no longer exists: `data-closing`/`transitionEnd` on the proof page, `aria-modal` on the sheet (Radix uses `aria-hidden` on the page instead), a transcript lookup scoped to a region the sheet is now portaled out of, and one row read behind an open confirmation, now with `hidden: true` because that is what a modal means. No consumer source was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the product’s handwritten dialog and menu overlays with Radix-backed kit primitives while preserving their public interfaces.

- Moves dialogs, drawers, and non-modal sheets onto the shared dialog primitive with coordinated exit and focus restoration.
- Moves anchored menus onto the popover primitive while retaining custom item navigation and collision-aware placement.
- Updates motion styling and behavioral tests for the new primitive lifecycle.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/ui/dialog.tsx | Replaces the native dialog lifecycle with the shared Radix wrapper, including shape-specific modality, focus restoration, and animation-completion handling. |
| apps/web/ui/menu.tsx | Replaces handwritten menu positioning and dismissal with Popover while preserving the existing public API and custom keyboard item navigation. |
| apps/web/ui/tailwind-theme.css | Adds Radix-state-driven dialog, drawer, overlay, and popover motion rules, including reduced-motion variants. |
| apps/web/components/ui/dialog.tsx | Enlarges the dialog close target on coarse-pointer devices. |
| apps/web/test/components.test.tsx | Updates behavioral coverage for Radix focus, modality, dismissal, animation-presence, and non-modal sheet interaction. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Owner[Product owner component] --> Wrapper[Dialog or Menu wrapper]
  Wrapper --> Kit[Shared kit primitive]
  Kit --> Radix[Radix portal and lifecycle]
  Radix --> Surface[Portalled overlay surface]
  Surface --> Theme[Tokenized entrance and exit motion]
  Surface --> Owner
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): hand the keyboard back on the ..."](https://github.com/egma-ai/egma/commit/5488443e06eab0adf6a583d9b61a0afb340170bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55288226)</sub>

<!-- /greptile_comment -->