### PR TITLE
fix(web): reconcile the monitoring and shadcn rewrites of the transcript surface

### DIFF
--- a/apps/web/app/projects/[projectId]/monitoring/setup/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/setup/loading.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { projectPath } from "../../../../../lib/project-context.ts";
+import { Loading } from "../../../../../ui/page-state.tsx";
+import { ProductStatePage } from "../../../../../ui/shell.tsx";
+
+/**
+ * What the router draws between the press and
+ * `/projects/:projectId/monitoring/setup` arriving.
+ *
+ * **This route arrived without one.** The boundary sweep gave every route in
+ * the application a pending state; production monitoring added this page in a
+ * separate lane, and the two merged without meeting, so the one new route was
+ * the one route left holding the previous page on press.
+ *
+ * Its header is the page's own down to its shape — the same eyebrow or the
+ * same crumbs, never one standing in for the other — so nothing is redrawn a
+ * second way when the page arrives. The page reads its setups behind these
+ * crumbs, so a slow read is answered here rather than by a still screen.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
+ */
+export default function MonitoringSetupLoading() {
+  const { projectId } = useParams<{ projectId: string }>();
+
+  return (
+    <div data-slot="route-loading">
+      <ProductStatePage
+        title="Set up monitoring"
+        breadcrumbs={[
+          {
+            label: "Monitoring",
+            href: projectPath(projectId, "monitoring", "transcripts"),
+          },
+          { label: "Setup" },
+        ]}
+      >
+        <Loading what="Monitoring setup" />
+      </ProductStatePage>
+    </div>
+  );
+}

--- a/apps/web/test/transcript-detail.test.tsx
+++ b/apps/web/test/transcript-detail.test.tsx
@@ -94,8 +94,15 @@ const TRACE: TraceFacts = {
   source: "production",
   emitter: "agent",
   environment: "default",
-  connection_type: "livekit",
+  // Nothing egma dialled: production telemetry arrives by export, so a
+  // monitored exchange names the platform that ran the agent and no egma
+  // connection. `transcripts.test.ts` reads the same shape off the API.
+  connection_kind: "",
   provider_call_id: "egma-fixture-capture-1",
+  agent_platform: "livekit_agents",
+  platform_agent_id: "agent_7f3c",
+  platform_agent_name: "kelly",
+  platform_agent_version: "2026.08.02",
   run_id: "",
   agent_id: "",
 };
@@ -316,6 +323,22 @@ function inspectorFactsIn(inspector: HTMLElement): HTMLElement {
   const facts = inspector.querySelector("dl");
   if (facts === null) throw new Error("the inspector drew no facts");
   return facts as HTMLElement;
+}
+
+/**
+ * The provenance disclosure at the foot of the inspector, found by its own
+ * summary rather than by position: it is the third description list on the
+ * page, and counting to three would break on the day a fourth arrives.
+ */
+function whereItCameFrom(): HTMLElement {
+  const inspector = screen.getByLabelText(DETAIL.inspector);
+  const disclosure = within(inspector)
+    .getByText(DETAIL.whereItCameFrom)
+    .closest("details");
+  if (disclosure === null) {
+    throw new Error("where it came from is not a disclosure");
+  }
+  return disclosure as HTMLElement;
 }
 
 beforeEach(() => {
@@ -889,6 +912,70 @@ describe("the inspector", () => {
     const inspector = screen.getByLabelText(DETAIL.inspector);
     expect(within(inspector).getByText(DETAIL.whereItCameFrom)).toBeTruthy();
     expect(within(inspector).getByText(DETAIL.technicalDetails)).toBeTruthy();
+  });
+
+  /**
+   * **Provenance names the platform that ran the agent**, which is the answer
+   * production monitoring replaced a single *Connection* row with: a person
+   * looking at a production exchange cannot open the connection egma dialled,
+   * because egma dialled nothing. What identifies the agent is the platform's
+   * own name for it, its identifier there, and the version that answered.
+   *
+   * The platform is read out in a reader's words rather than in the wire's —
+   * `livekit_agents` is what arrives and **LiveKit Agents** is what is drawn.
+   */
+  it("names the platform, and the agent the platform ran", async () => {
+    stub({ status: 200, body: detail() });
+    await open();
+    await settled();
+
+    const came = whereItCameFrom();
+    for (const [label, value] of [
+      [FACTS.platform, "LiveKit Agents"],
+      [FACTS.platformAgentName, TRACE.platform_agent_name],
+      [FACTS.platformAgentId, TRACE.platform_agent_id],
+      [FACTS.platformAgentVersion, TRACE.platform_agent_version],
+      [FACTS.reference, TRACE.provider_call_id],
+    ]) {
+      expect(within(came).getByText(label), label).toBeTruthy();
+      expect(within(came).getByText(value), value).toBeTruthy();
+    }
+  });
+
+  /**
+   * A capture that carried no platform identity draws no row for it, rather
+   * than a label above a blank — `DESIGN.md`: "Make every state truthful."
+   * A trace exported before its agent named itself is the ordinary case, and
+   * four empty rows would read as four facts egma failed to show.
+   */
+  it("leaves out a fact the capture did not carry", async () => {
+    stub({
+      status: 200,
+      body: detail({
+        trace: {
+          ...TRACE,
+          agent_platform: "",
+          platform_agent_id: "",
+          platform_agent_name: "",
+          platform_agent_version: "",
+        },
+      }),
+    });
+    await open();
+    await settled();
+
+    const came = whereItCameFrom();
+    for (const label of [
+      FACTS.platform,
+      FACTS.platformAgentName,
+      FACTS.platformAgentId,
+      FACTS.platformAgentVersion,
+    ]) {
+      expect(within(came).queryByText(label), label).toBeNull();
+    }
+    // What did arrive is still there, so the disclosure is not simply empty.
+    expect(within(came).getByText(FACTS.source)).toBeTruthy();
+    expect(within(came).getByText(TRACE.source)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## The collision

Two rewrites of the transcript surface merged into main minutes apart, each
green alone, never run together.

- **#164** (`dc7cfb49`), production monitoring for Retell and LiveKit Agents,
  changed what the transcript says about where an exchange came from. In
  `lib/transcripts.ts` `connection_type` became `connection_kind`, and
  `agent_platform`, `platform_agent_id`, `platform_agent_name` and
  `platform_agent_version` joined `Facts`. On the detail page it replaced one
  **Connection** row with four rows naming the platform and the agent that
  platform ran.
- **#173** (`2551acd6`), the shadcn primitives effort, rewrote the same page
  onto the kit and brought the first render proof this page ever had —
  39 states in `test/transcript-detail.test.tsx`, written against the older
  `Facts`, because the rename did not exist on that branch.

**The page merged cleanly, and it is coherent.** `git merge-tree` on the two
parents reproduces main's tree for `apps/web`, `apps/api` and `packages`
exactly, and per file the union is #173's rewrite carrying #164's five-line
hunk — no duplicated section, no dead branch, no old-style block beside a kit
block. Nothing on the page needed reconciling: the kit draws it, and
monitoring decides what it says.

**The proof is what broke.** Its one fixture still supplied `connection_type`,
which typecheck refused (`TS2353`), and `agentPlatformLabel` read `undefined`
off that fixture and threw inside `WhereItCameFrom` — so **34 of 39 states
failed on one missing field**, including every state with nothing to do with
provenance. CI's fast lane reported the eight it reached.

## What was reconciled, per file

| File | Decision |
| --- | --- |
| `monitoring/transcripts/[transcriptId]/page.tsx` | **Nothing changed.** #164 wins on what is shown (platform, platform agent name, ID, version, in place of the connection row); #173 wins on how it is drawn (kit primitives, semantic tokens, no CSS Module). The auto-merge already says exactly that. |
| `test/transcript-detail.test.tsx` | **Repaired.** Fixture moved to the shape the API sends, taken from `transcripts.test.ts`, which #164 updated in the same PR. Two cases added for the states the rename introduced. |
| `monitoring/setup/loading.tsx` | **Added.** New route from #164, added after #167's boundary sweep had already run. |
| `lib/transcript-copy.ts` | Checked, unchanged. #164's copy with #173's one removal (`DETAIL.loading`, whose wait is now the route boundary's). Coherent. |
| `monitoring/transcripts/page.tsx`, `monitoring/setup/page.tsx`, `agents/[agentId]/page.tsx`, `agents/connection-facts.tsx`, the four connections files, `runs/page.tsx`, `runs/new/page.tsx`, `ui/data-table.tsx` | Checked, unchanged. Only #164 touched them, and every one is already drawn through the kit: `Field`, `Select`, `Help`, `DetailFacts`, `SurfaceHeader`, `DataTable`, `PageHeader`, `Empty`. No raw colour, no inline style, no hand-rolled tab, dialog, radio or progress. #164's pagination strip on `DataTable` copies the show-more strip beside it. |
| `test/agents-pages.test.tsx`, `test/components.test.tsx`, `test/run-history.test.tsx` | Checked, unchanged. Both sides landed in disjoint regions; no duplicated title, describe or helper in any of them. |

## What the tests now pin

The fixture is a production LiveKit Agents capture: no egma connection —
production telemetry arrives by export rather than by something egma dialled —
with a platform identity beside it. Two cases were added, because the rename
passed through a 39-state render test without one assertion noticing:

- **the platform is named in a reader's words** — `livekit_agents` arrives and
  **LiveKit Agents** is drawn — with the agent's name, identifier and version
  beside it, and the provider reference under them
- **a capture that carried none of that draws no row for it**, rather than four
  labels above four blanks, and what did arrive is still shown

## What is unproven

- **No browser proof and no screenshots.** The reconciliation changed one test
  file and added one fallback; the page's pixels are #173's, already proven on
  its own lane, and the browser lane was green on main through the collision.
- **The new `loading.tsx` has no test of its own.** The boundary rules are
  proven by two representative cases in `components.test.tsx`
  (`agents/loading.tsx` and `tests/[testId]/loading.tsx`); no test enumerates
  every route.
- **Found, not fixed** — pre-existing in #164, not caused by the merge, and a
  copy decision rather than a merge one: the transcripts list header button
  spells `Set up monitoring` as a literal while `QUIET.setUp.action` holds the
  same words, so `monitoring.test.tsx` matches the header button by
  coincidence rather than by intent. The empty state that tells a reader to
  complete setup relies on that header button for the way there.

## Checks

- Scoped tests, 247 passed in 8 files: `transcript-detail`, `transcripts`,
  `monitoring`, `monitoring-setup`, `agents-pages`, `runs`, `run-history`,
  `pages`. `transcript-detail` is 41 of 41, up from 5 of 39.
- `pnpm --filter @egma/web exec tsc -p tsconfig.json --noEmit` — clean.
- `pnpm lint` — clean.
- `pnpm --filter @egma/web build` — clean, all 35 routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789852777&installation_model_id=431960&pr_number=174&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F174&signature=a4a977d67020eb3595da2414c5f6407ed199b4aa66ff9c32794fcc6f4fa3bd4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reconciles the monitoring transcript contract with its render tests and adds the missing pending state for the monitoring setup route.
- Updates the transcript-detail fixture to use `connection_kind` and platform-agent provenance fields.
- Adds coverage for readable platform provenance and omission of absent provenance facts.
- Adds a monitoring setup loading boundary consistent with the destination page.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or quality issues identified.

The loading boundary follows existing project-route conventions, and the test changes accurately exercise the current transcript provenance contract without changing production behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/monitoring/setup/loading.tsx | Adds a route-level pending state whose title, breadcrumbs, and project-scoped link match established loading-boundary conventions. |
| apps/web/test/transcript-detail.test.tsx | Repairs the transcript fixture for the current trace contract and verifies both populated and absent platform provenance rendering. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): give monitoring setup the pend..."](https://github.com/egma-ai/egma/commit/c2a5a8cbbd34e16e4f4d5c0240fd277932946217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55338802)</sub>

<!-- /greptile_comment -->