### PR TITLE
fix(db): lift the run guard for 0038's snapshot backfill, as 0033 did

### DIFF
--- a/packages/db/migrations/0038_parched_goblin_queen.sql
+++ b/packages/db/migrations/0038_parched_goblin_queen.sql
@@ -145,6 +145,20 @@ SET
 -- Runs freeze the non-secret connection facts as camelCase JSON. Read the
 -- access variant from the historical snapshot, because the connection may
 -- have been edited after the run started.
+--
+-- **And around the guard, which is doing exactly its job.** A finished run's
+-- header is written once — `guard_run_lifecycle` has refused every update to
+-- one since 0007, and that refusal is what stops a straggling report reopening
+-- a run that already reported its numbers. This backfill is the one write that
+-- legitimately has to reach those rows, because it changes the vocabulary the
+-- snapshot is written in — `type` and `variant_id` become platform, kind, and
+-- access variant — and not one answer the run reported. So the guard is lifted
+-- for this statement and put back immediately, exactly as 0033 lifted it for
+-- its own backfill. It is lifted rather than taught an exception on purpose:
+-- an exception would live in the trigger forever and would be a hole in the
+-- rule for every write afterwards, while this is one statement in one
+-- migration.
+ALTER TABLE "run" DISABLE TRIGGER "run_lifecycle_guard";--> statement-breakpoint
 UPDATE "run"
 SET "connection_snapshot" = jsonb_build_object(
 	'agentPlatform', CASE "connection_snapshot" ->> 'type'
@@ -173,6 +187,7 @@ SET "connection_snapshot" = jsonb_build_object(
 )
 WHERE "connection_snapshot" ->> 'type' IN ('retell', 'phone', 'livekit');
 --> statement-breakpoint
+ALTER TABLE "run" ENABLE TRIGGER "run_lifecycle_guard";--> statement-breakpoint
 
 ALTER TABLE "connection" ALTER COLUMN "connection_kind" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "connection" ALTER COLUMN "access_variant" SET NOT NULL;--> statement-breakpoint

--- a/packages/db/test/migrations.test.ts
+++ b/packages/db/test/migrations.test.ts
@@ -3798,6 +3798,7 @@ describe("the direct Monitoring cutover (0038)", () => {
   let before: string;
   let client: pg.Client;
   let applied: readonly string[];
+  let frozenFinishedAt: Date;
 
   const organizationId = newId("org");
   const projectId = newId("prj");
@@ -3876,6 +3877,27 @@ describe("the direct Monitoring cutover (0038)", () => {
     connectionId: newId("con"),
     runId: newId("run"),
   };
+
+  /**
+   * A run that has already reported its numbers.
+   *
+   * `guard_run_lifecycle` refuses every update to a run whose `finished_at` is
+   * set, so 0038's snapshot backfill only meets that refusal where a database
+   * holds history. Every other run in this file is `pending` and every database
+   * this migration met before production was empty — which is how the backfill
+   * reached production, raised the guard, and rolled the deploy back without one
+   * test noticing. This row is that history, and the reason 0038 lifts the guard
+   * around its own statement and puts it straight back.
+   *
+   * It rides the LiveKit token-endpoint connection, so the branch reading
+   * `tokenEndpoint` out of the frozen config is exercised on a frozen row too.
+   */
+  const finishedRun = {
+    id: newId("run"),
+    reach: reaches[3],
+    counts: { completed: 3, failed: 1, canceled: 0, skipped: 0 },
+  } as const;
+
   const oldProductionJob = {
     id: newId("gjb"),
     traceId: "a".repeat(32),
@@ -3993,6 +4015,50 @@ describe("the direct Monitoring cutover (0038)", () => {
       config: { retellAgentId: "agent_retell_voice" },
     });
 
+    // Frozen before 0038 runs: the four counts land with `finished_at`, as
+    // `run_counts_written_together` requires, and the snapshot is still written
+    // in the old vocabulary.
+    await client.query(
+      `insert into run
+         (id, organization_id, project_id, agent_id, connection_id, status,
+          triggered_via, pinned_test_versions, requested_personas,
+          connection_snapshot, mock_tool_snapshot, expected_simulation_count,
+          started_at, finished_at,
+          completed_count, failed_count, canceled_count, skipped_count)
+       values ($1, $2, $3, $4, $5, 'completed', 'manual', $6::jsonb, $7::jsonb,
+          $8::jsonb, $9::jsonb, 4,
+          now() - interval '1 hour', now() - interval '30 minutes',
+          $10, $11, $12, $13)`,
+      [
+        finishedRun.id,
+        organizationId,
+        projectId,
+        agentId,
+        finishedRun.reach.connectionId,
+        JSON.stringify({ testVersionIds: [] }),
+        JSON.stringify({ personaIds: [] }),
+        JSON.stringify({
+          type: finishedRun.reach.type,
+          modality: finishedRun.reach.modality,
+          topology: finishedRun.reach.topology,
+          environment: null,
+          config: finishedRun.reach.config,
+        }),
+        JSON.stringify({ defaults: [], overrides: {} }),
+        finishedRun.counts.completed,
+        finishedRun.counts.failed,
+        finishedRun.counts.canceled,
+        finishedRun.counts.skipped,
+      ],
+    );
+    // Read back rather than computed here, so the assertion after the migration
+    // compares against the exact instant the row was frozen at.
+    const { rows: frozen } = await client.query<{ finished_at: Date }>(
+      "select finished_at from run where id = $1",
+      [finishedRun.id],
+    );
+    frozenFinishedAt = frozen[0]!.finished_at;
+
     await client.query(
       `insert into production_trace_claim
          (id, organization_id, project_id, connection_id, trace_id,
@@ -4063,6 +4129,68 @@ describe("the direct Monitoring cutover (0038)", () => {
         config: reach.config,
       });
     }
+  });
+
+  it("reaches the frozen snapshot of a run that had already finished", async () => {
+    const { rows } = await client.query<{
+      connection_snapshot: Record<string, unknown>;
+    }>("select connection_snapshot from run where id = $1", [finishedRun.id]);
+
+    expect(rows[0]?.connection_snapshot).toEqual({
+      agentPlatform: finishedRun.reach.expected.agentPlatform,
+      connectionKind: finishedRun.reach.expected.connectionKind,
+      accessVariant: finishedRun.reach.expected.accessVariant,
+      modality: finishedRun.reach.modality,
+      topology: finishedRun.reach.topology,
+      environment: null,
+      config: finishedRun.reach.config,
+    });
+  });
+
+  it("changes a finished run's vocabulary and none of the answers it reported", async () => {
+    const { rows } = await client.query<{
+      status: string;
+      finished_at: Date;
+      completed_count: number;
+      failed_count: number;
+      canceled_count: number;
+      skipped_count: number;
+    }>(
+      `select status, finished_at, completed_count, failed_count,
+              canceled_count, skipped_count
+         from run where id = $1`,
+      [finishedRun.id],
+    );
+
+    expect(rows[0]).toEqual({
+      status: "completed",
+      finished_at: frozenFinishedAt,
+      completed_count: finishedRun.counts.completed,
+      failed_count: finishedRun.counts.failed,
+      canceled_count: finishedRun.counts.canceled,
+      skipped_count: finishedRun.counts.skipped,
+    });
+  });
+
+  /**
+   * The guard is lifted for one statement, never taught an exception. Proving
+   * the lift ended is what stops a later edit leaving it off: without this, a
+   * migration that dropped the `ENABLE TRIGGER` line would still pass every
+   * other assertion here while quietly unguarding the table for good.
+   */
+  it("puts the lifecycle guard back, so a finished header is still written once", async () => {
+    await expect(
+      client.query(`update "run" set "status" = 'canceled' where "id" = $1`, [
+        finishedRun.id,
+      ]),
+    ).rejects.toThrow(
+      /is finished, and a finished run's header is written once/,
+    );
+
+    const { rows } = await client.query<{ tgenabled: string }>(
+      "select tgenabled from pg_trigger where tgname = 'run_lifecycle_guard'",
+    );
+    expect(rows).toEqual([{ tgenabled: "O" }]);
   });
 
   it("deletes the old unrepresentable Retell voice connection and its run", async () => {


### PR DESCRIPTION
## The defect

Production deploys have failed twice, on two SHAs, with the same boot error:

```
error: run run_01M0DK6573EFAA2Q6ZAPWEB1E5 is finished, and a finished run's header is written once
  where: PL/pgSQL function guard_run_lifecycle() line 6 at RAISE
```

`0038_parched_goblin_queen.sql` — the Monitoring cutover from #164 — moves every
run's frozen connection snapshot into the new vocabulary. `type` and `variant_id`
become `agentPlatform`, `connectionKind`, and `accessVariant`. It does that with
one `UPDATE "run"` across the whole table.

The run table has carried `run_lifecycle_guard` since `0007_runs.sql:163`. The
trigger refuses **any** update to a run whose `finished_at` is set, because a
finished run's header is written once and a straggling report must never reopen a
run that already reported its numbers.

Production has finished runs. The backfill reached one, the trigger raised, the
migration transaction rolled back, `runMigrations` threw, and the API exited 1.

**The guard was doing exactly its job.** The bug is not in the trigger.

### Why nothing on the way in caught it

No database this migration met before production held a single finished run.
CI's databases start empty, and the existing 0038 test in
`packages/db/test/migrations.test.ts` seeded every one of its runs as `'pending'`
with no `finished_at`. The defect needed real history to appear, and production
was the first place it found any.

The second commit here closes that gap, so this class of defect fails in CI from
now on.

## The fix — the pattern the repo already wrote

`0033_run_planning_and_grading_plans.sql:81-95` met this same guard with a
backfill of its own and wrote the canonical answer: lift the guard for the one
statement and put it straight back, rather than teach the trigger a permanent
exception that would be a hole in the rule for every write afterwards.

0038 now does the same, and says why in the same voice. This backfill qualifies
for the same reason 0033's did — it changes the *vocabulary* the snapshot is
written in, and not one *answer* the run reported.

```sql
ALTER TABLE "run" DISABLE TRIGGER "run_lifecycle_guard";--> statement-breakpoint
UPDATE "run" ... ;
--> statement-breakpoint
ALTER TABLE "run" ENABLE TRIGGER "run_lifecycle_guard";--> statement-breakpoint
```

The migration change is 15 lines — the comment and the two `ALTER TABLE` lines
around the single `UPDATE "run"`. Every other byte of 0038, including every
`--> statement-breakpoint`, is unchanged.

### Why 0038 is edited in place rather than corrected by a 0039

`packages/db/src/migrate.ts` wraps each migration file in `begin`/`commit` and
rolls back on failure, so the failed transaction left nothing behind. Production
is cleanly at 0037 and `egma_meta.migration` holds no 0038 row. An edited 0038 is
simply still pending there. This is asserted in the proof below.

There are no triggers on the `connection` table, so 0038's other `UPDATE` and
`DELETE`s were never affected.

## The regression test

`packages/db/test/migrations.test.ts`, in `the direct Monitoring cutover (0038)`,
now seeds a **finished run before 0038 applies** — `finished_at` set with all four
counts written alongside it, as `run_counts_written_together` requires. It rides
the LiveKit token-endpoint connection, so the branch reading `tokenEndpoint` out
of a frozen config is exercised on a frozen row and not only a live one. The four
existing `pending` runs stay as they are.

Three assertions follow it:

1. **`reaches the frozen snapshot of a run that had already finished`** — the
   backfill converts its snapshot, which is only possible if the guard was lifted.
2. **`changes a finished run's vocabulary and none of the answers it reported`** —
   `status`, the exact frozen `finished_at` read back at seed time, and the counts
   3/1/0/0 are untouched.
3. **`puts the lifecycle guard back, so a finished header is still written once`** —
   a plain header update rejects again, and `pg_trigger.tgenabled` reads `O`.

The third is what protects the `ENABLE TRIGGER` line specifically. Without it, a
future edit dropping the re-arm would pass every other assertion in the file while
leaving the table unguarded for good.

**It fails without the fix.** With the original 0038 restored, the suite fails in
`beforeAll` with production's own error:

```
FAIL packages/db/test/migrations.test.ts > the direct Monitoring cutover (0038)
Error: migration 0038_parched_goblin_queen.sql failed
Caused by: error: run run_01M0GM5XVCEDFAKWW35S3S75D1 is finished, and a finished run's header is written once
  where: 'PL/pgSQL function guard_run_lifecycle() line 6 at RAISE'
```

## The proof

Run against the **production data shape**, not an empty database — that shape is
the whole story of this defect. An isolated Postgres 18 container (plain
`docker run`, unique name and port, never compose), migrated to 0037 where
production sits, then seeded with:

- **one finished run** — `finished_at` set, `status = 'completed'`, all four
  counts written (3/1/0/0), old-shape LiveKit snapshot with project credentials
- **one unfinished run** — `finished_at` NULL, old-shape LiveKit snapshot with a
  customer token endpoint

Both stages ran against the same database, in order: RED reproduces the outage,
GREEN fixes it, ARMED proves the lift does not outlive its statement.

```
=== 1. A database at 0037, exactly where production is ===
applied 38 migrations, last = 0037_persona_library.sql
OK: database is at 0037, 0038 is pending

=== 2. Seed the production shape: one FINISHED run, one unfinished ===
finished run   = run_BGRQQ7P97AAX343KM4MAWK0YAV (finished_at set, counts written)
unfinished run = run_QTFR9F4NJVVN88XEETSSTRKBXN (finished_at NULL)

=== 2b. Pre-check — the guard is armed on the seeded finished run ===
guard says: run run_BGRQQ7P97AAX343KM4MAWK0YAV is finished, and a finished run's header is written once
OK: the seeded database reproduces production's guarded state

=== 3. RED — the ORIGINAL 0038 must fail exactly as production did ===
  migration 0038_parched_goblin_queen.sql failed
  run run_BGRQQ7P97AAX343KM4MAWK0YAV is finished, and a finished run's header is written once
  where: PL/pgSQL function guard_run_lifecycle() line 6 at RAISE
OK: production's boot failure reproduced
OK: transaction rolled back — no 0038 row, connection.type still there

=== 4. GREEN — the FIXED 0038, straight from the repo, must succeed ===
applied: ["0038_parched_goblin_queen.sql"]
finished run snapshot   = {"config":{"url":"wss://project.example.test","metadata":"{\"run\":\"old\"}"},"modality":"voice","topology":"agent-dials-out","environment":null,"accessVariant":"livekit_room.project_credentials","agentPlatform":"livekit_agents","connectionKind":"livekit_room"}
unfinished run snapshot = {"config":{"url":"wss://endpoint.example.test","tokenEndpoint":"https://auth.example.test/livekit-token"},"modality":"voice","topology":"agent-dials-out","environment":null,"accessVariant":"livekit_room.customer_token_endpoint","agentPlatform":"livekit_agents","connectionKind":"livekit_room"}
OK: both runs carry the new vocabulary, and the reach covers both
OK: answers untouched — status=completed finished_at set, counts 3/1/0/0

=== 5. ARMED — the lift must not outlive its statement ===
pg_trigger.tgenabled = {"tgenabled":"O"}
guard says: run run_BGRQQ7P97AAX343KM4MAWK0YAV is finished, and a finished run's header is written once
where: PL/pgSQL function guard_run_lifecycle() line 6 at RAISE
OK: the guard refuses a finished run's header again

=== ALL THREE STAGES PASSED ===
```

Every line above is an assertion, not a log. RED asserts the guard's exact
message names the finished run and comes from `guard_run_lifecycle()` line 6.
GREEN asserts the full snapshot object for both runs and that `status`,
`finished_at`, and all four counts are byte-for-byte what was seeded. ARMED
asserts `pg_trigger.tgenabled = 'O'` and that a plain header update raises again.

The run was repeated from scratch on a second fresh database with identical
results. That harness is what the second commit ports into the repo's own suite.

### The repo's own checks

Against isolated containers, so the live local stack was never touched:

```
✓ |fast| packages/db/test/migration-numbers.test.ts (2 tests) 3ms
✓ |fast| packages/db/test/runs-lifecycle-constraints.test.ts (33 tests) 334ms
✓ |fast| packages/db/test/migrations.test.ts (95 tests) 8299ms

Test Files  3 passed (3)
     Tests  130 passed (130)
```

`pnpm exec tsc -b` in `packages/db`, `tsc -p tsconfig.tests.json`, and `pnpm lint`
are all clean. No web changes, so no web typecheck.

## Caveat: dev databases that already applied the original 0038

`pendingMigrations()` refuses a file whose hash changed **only when that file is
already recorded as applied**. Production has no 0038 row, so it is unaffected.

Any *developer* database that applied the original 0038 will now refuse to boot
with the runner's own message:

```
migration 0038_parched_goblin_queen.sql has changed since it was applied;
applied migrations are immutable, add a new file instead
```

That message is the instruction. Those databases hold pre-launch data only —
drop and re-migrate.

## What this unblocks

The production deploy. With this merged, 0038 applies over production's real
history and the Monitoring cutover from #164 can finally land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
