### PR TITLE
Fix the production health deployment order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -470,7 +470,7 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Replace what is running, and wait for it
+      - name: Replace what is running, and wait for its health checks
         if: steps.decide.outputs.platform == 'true'
         run: |
           set -euo pipefail
@@ -499,22 +499,6 @@ jobs:
             --command-id "$command_id" --instance-id "$INSTANCE" \
             --query Status --output text)
           [ "$status" = "Success" ] || { echo "Deployment failed: $status" >&2; exit 1; }
-
-      - name: Prove the platform answers
-        if: steps.decide.outputs.platform == 'true'
-        run: |
-          set -euo pipefail
-          url="${{ vars.PLATFORM_URL || 'https://app.egma.ai' }}/health"
-          for attempt in 1 2 3 4 5 6; do
-            code=$(curl -sS -o /tmp/platform.json -w '%{http_code}' --max-time 20 "$url" || echo 000)
-            if [ "$code" = "200" ]; then
-              echo "$url answered 200:"; cat /tmp/platform.json; exit 0
-            fi
-            echo "attempt $attempt: $code"
-            sleep 10
-          done
-          echo "$url never answered 200 after the deployment." >&2
-          exit 1
 
       - name: Yield when a newer merge owns the web deployment
         id: yield

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -85,9 +85,9 @@ const config: NextConfig = {
           source: "/api/password-reset/:path*",
           destination: `${api}/api/password-reset/:path*`,
         },
-        // The public origin proves the API and both stores, while
-        // `/api/health` continues to prove only this Next process.
-        { source: "/health", destination: `${api}/health` },
+        // `/api/health` proves only this Next process. The platform deployment
+        // waits for the API and its stores directly; it must not depend on a
+        // web deployment that has not happened yet.
         { source: "/openapi.json", destination: `${api}/openapi.json` },
         // The complete versioned platform API. The API remains the only routing
         // table; this process only keeps the browser on the page's origin.

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -420,7 +420,7 @@ describe("the pages", () => {
     expect(rewrites).toContain(
       '{ source: "/v1/:path*", destination: `${api}/v1/:path*` }',
     );
-    expect(rewrites).toContain(
+    expect(rewrites).not.toContain(
       '{ source: "/health", destination: `${api}/health` }',
     );
     expect(rewrites).toContain(


### PR DESCRIPTION
## What changed

- remove the web /health proxy
- remove the public health check that ran before Vercel deployed
- keep the existing Compose health gate inside the platform replacement
- let the Vercel deployment run immediately after the platform is healthy

## Why

PR #177 deployed the new platform, then checked app.egma.ai/health before deploying the web version that owned that rewrite. Vercel returned 404, so the workflow skipped the web deployment and left production on mixed versions.

The merged web tree has already been deployed manually to restore production. This PR prevents the same ordering failure on the next deployment.

## Verification

- focused web test: 52 passed
- web lint passed
- workflow YAML and deploy shell syntax passed
- two independent reviews found no actionable issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789936265&installation_model_id=431960&pr_number=179&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F179&signature=45c95aa0ba2ad266b584fa56e93b5b491facd5c7abc00977f0e37506fc8fc887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the web-owned public health proxy and the deployment workflow’s premature public-origin health check, allowing Vercel deployment to begin after the platform replacement command succeeds.

- Removes the workflow probe of the not-yet-deployed web route.
- Retains the SSM platform replacement step as the deployment gate.
- Removes the corresponding Next.js rewrite and updates its focused test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The revised ordering removes the dependency on a web rewrite that is unavailable before Vercel deploys, while existing repository health consumers continue using the API’s `/health` or the web application’s `/api/health`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | Removes the premature public `/health` probe while preserving successful completion of the platform replacement command as the gate before triggering Vercel. |
| apps/web/next.config.ts | Removes the web-origin `/health` rewrite while retaining the separate Next-process `/api/health` endpoint. |
| apps/web/test/pages.test.ts | Updates rewrite coverage to assert that the removed public `/health` proxy is not restored. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CI as GitHub Actions
  participant Platform as Platform deployment
  participant Compose as Compose health gates
  participant Vercel as Vercel
  CI->>Platform: Run deployment through SSM
  Platform->>Compose: Replace services and await health checks
  Compose-->>CI: Deployment command succeeds
  CI->>Vercel: Trigger web deployment
  Note over CI,Vercel: No request to the old web-owned /health rewrite
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): remove web health deployment de..."](https://github.com/egma-ai/egma/commit/024117e9cd1d5695318ba69414160bec08c6e871) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55709267)</sub>

<!-- /greptile_comment -->