### PR TITLE
Durable acceptance and drain path for production evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,8 +976,14 @@ Five things about the contract are worth knowing before you build on it:
   exactly as an id nobody ever minted does.
 - **The stored payload is not in either response.** It is by a wide margin the
   largest thing on a span, and a transcript carrying it would be megabytes of
-  JSON nobody asked to render. Safe Direct OTLP and Retell provider payloads
-  stay on their rows after credential-like values are redacted.
+  JSON nobody asked to render. Direct OTLP and Retell provider payloads stay on
+  their rows exactly as they arrived — nothing is scanned for credential-looking
+  names or values, so a transcript keeps every word of what was said. The only
+  fields Egma leaves out are Retell's own transport credentials: the top-level
+  `access_token`, and the values of `authorization`, `proxy-authorization`,
+  `cookie`, `set-cookie`, `api-key` and `x-api-key` inside Retell's
+  `custom_sip_headers` map. They are omitted, with no marker written where they
+  were.
 - **A transcript of more than 10,000 spans is a prefix, and says so.**
   `spansTruncated` is then `true`, and it means exactly one thing: `turns` and
   `spans` hold the first 10,000 spans in time order, while `spanCount` and every

--- a/apps/api/src/ingestion/accept.ts
+++ b/apps/api/src/ingestion/accept.ts
@@ -168,6 +168,17 @@ type Group = {
   readonly scope: SegmentScope;
   waiting: Staged[];
   sealed: Sealed[];
+  /**
+   * Uploads of this group's sealed head that have failed since one last
+   * succeeded. Zero the moment one does.
+   */
+  failedAttempts: number;
+  /**
+   * When this group may be offered to the store again. Always in the past
+   * while nothing has failed, which is what makes the ordinary path free of
+   * any wait at all.
+   */
+  nextAttemptAtMilliseconds: number;
 };
 
 type Standing = {
@@ -203,7 +214,13 @@ function groupFor(held: Standing, scope: SegmentScope): Group {
   const key = keyFor(scope);
   const found = held.groups.get(key);
   if (found !== undefined) return found;
-  const made: Group = { scope, waiting: [], sealed: [] };
+  const made: Group = {
+    scope,
+    waiting: [],
+    sealed: [],
+    failedAttempts: 0,
+    nextAttemptAtMilliseconds: 0,
+  };
   held.groups.set(key, made);
   return made;
 }
@@ -238,6 +255,34 @@ function stagedFor(
       settle(cause);
     },
   };
+}
+
+/**
+ * How long a group whose upload just failed waits before it is offered again.
+ *
+ * **A sealed segment whose upload failed stays sealed**, which is what keeps
+ * the evidence — and it also leaves the group permanently due. Without a wait
+ * the loop would fail, wake and fail again with nothing in between: capacity
+ * spent here, and a flood landing on the store at the moment it is least able
+ * to take one. What paces that today is whichever retry policy the store
+ * client happens to apply inside one call, which is a dependency's property and
+ * not a promise this module can make.
+ *
+ * It doubles from the flush interval up to the request bound, and it borrows
+ * both rather than introducing a third number nobody has tuned. The floor is
+ * the interval a low-volume deployment already waits to seal, so the first
+ * retry costs no more than one ordinary flush; the ceiling is the longest a
+ * request is ever held open for this store, which is this path's own statement
+ * about how long the store is worth waiting on.
+ */
+function nextAttemptAfter(held: Standing, failedAttempts: number): number {
+  const longest = Math.max(
+    held.bounds.flushMilliseconds,
+    held.requestTimeoutMilliseconds,
+  );
+  const doubled =
+    held.bounds.flushMilliseconds * 2 ** Math.max(0, failedAttempts - 1);
+  return Math.min(doubled, longest);
 }
 
 /**
@@ -341,6 +386,11 @@ async function upload(held: Standing, group: Group): Promise<void> {
       group.sealed.shift();
       group.waiting = [...attempt.staged, ...group.waiting];
       held.log.release([attempt.sealEntry]);
+      // The store answered, and these records are about to be sealed under an
+      // identity of their own. Nothing here says the store will refuse the
+      // next one.
+      group.failedAttempts = 0;
+      group.nextAttemptAtMilliseconds = 0;
       return;
     }
 
@@ -352,6 +402,14 @@ async function upload(held: Standing, group: Group): Promise<void> {
       { err: cause, segmentId: attempt.segment.segmentId },
       "a sealed segment did not reach the ingestion bucket",
     );
+    // The waiting calls are told at once and keep their own bound: a sender
+    // learning about this is not something to make slower. What waits is the
+    // *next attempt* on this group, so a store that is refusing is asked again
+    // at a pace rather than as fast as it can say no.
+    group.failedAttempts += 1;
+    group.nextAttemptAtMilliseconds =
+      Date.now() + nextAttemptAfter(held, group.failedAttempts);
+
     const refusal = new IngestionUnavailableError(
       "this evidence was staged and could not be made durable in the " +
         "ingestion object store. It has not been discarded — send it again.",
@@ -362,6 +420,8 @@ async function upload(held: Standing, group: Group): Promise<void> {
   }
 
   group.sealed.shift();
+  group.failedAttempts = 0;
+  group.nextAttemptAtMilliseconds = 0;
   held.log.release([
     attempt.sealEntry,
     ...attempt.staged.map((staged) => staged.entry),
@@ -395,7 +455,15 @@ async function flush(held: Standing): Promise<void> {
     ) {
       seal(held, group);
     }
-    if (group.sealed.length > 0) await upload(held, group);
+    // A group whose last attempt failed is left alone until its wait is over.
+    // Read from the clock rather than from the pass's own start, because an
+    // earlier group's upload may have taken a while to fail.
+    if (
+      group.sealed.length > 0 &&
+      Date.now() >= group.nextAttemptAtMilliseconds
+    ) {
+      await upload(held, group);
+    }
     if (group.waiting.length === 0 && group.sealed.length === 0) {
       held.groups.delete(keyFor(group.scope));
     }
@@ -404,7 +472,8 @@ async function flush(held: Standing): Promise<void> {
 
 /**
  * Wake when the earliest group is due — or at once, where something is already
- * sealed or already over a bound.
+ * sealed or already over a bound, unless that group is waiting out a failed
+ * attempt.
  *
  * One timer for every group rather than one each: the answer is the smallest
  * wait any of them wants, and the pass that follows looks at all of them.
@@ -421,7 +490,7 @@ function schedule(held: Standing): void {
   for (const group of held.groups.values()) {
     const wait =
       group.sealed.length > 0
-        ? 0
+        ? Math.max(0, group.nextAttemptAtMilliseconds - now)
         : millisecondsUntilSeal(pendingGroup(group.waiting), held.bounds, now);
     if (wait === undefined) continue;
     soonest = soonest === undefined ? wait : Math.min(soonest, wait);

--- a/apps/api/src/ingestion/accept.ts
+++ b/apps/api/src/ingestion/accept.ts
@@ -332,9 +332,10 @@ async function upload(held: Standing, group: Group): Promise<void> {
       // One identity holding two different sets of bytes, which is this side's
       // defect and never a sender's. The stored object is left exactly as it
       // is, and this attempt's identity is abandoned rather than retried into:
-      // the records are evidence and go back to the front of the queue to be
-      // sealed under an identity of their own, while the seal frame that named
-      // the abandoned one is released because it now describes nothing.
+      // the records are evidence and go back in front of everything still
+      // waiting, to be sealed under an identity of their own, while the seal
+      // frame that named the abandoned one is released because it now
+      // describes nothing.
       held.logger.error(
         { err: cause, segmentId: attempt.segment.segmentId },
         "a sealed segment collided with a different object under its own identity",
@@ -347,8 +348,8 @@ async function upload(held: Standing, group: Group): Promise<void> {
 
     // Anything else is *not yet*: the store was unreachable, slow, or refused
     // the moment rather than the bytes. Nothing is released, the sealed segment
-    // stays at the head of the queue with its identity intact, and every call
-    // waiting on it is told to try again.
+    // stays where it is with its identity intact, and every call waiting on it
+    // is told to try again.
     held.logger.error(
       { err: cause, segmentId: attempt.segment.segmentId },
       "a sealed segment did not reach the ingestion bucket",
@@ -385,6 +386,11 @@ async function upload(held: Standing, group: Group): Promise<void> {
 async function flush(held: Standing): Promise<void> {
   const now = Date.now();
   for (const group of [...held.groups.values()]) {
+    // A stop that arrived mid-pass takes effect at the next group rather than
+    // after all of them, so what a shutdown can wait on is one upload's request
+    // bound and never the whole backlog's. Nothing is lost by stopping here:
+    // every record is framed on the disk and the next start recovers it.
+    if (held.closing) return;
     if (
       group.sealed.length === 0 &&
       shouldSeal(pendingGroup(group.waiting), held.bounds, now)

--- a/apps/api/src/ingestion/accept.ts
+++ b/apps/api/src/ingestion/accept.ts
@@ -1,0 +1,770 @@
+import {
+  OversizeRecordError,
+  refuseOversizeRecord,
+  type AuthContext,
+  type NewSpan,
+} from "@egma/db";
+import type { FastifyBaseLogger } from "fastify";
+
+import type { IngestionSettings } from "../config.ts";
+import {
+  pendingObjectStore,
+  SegmentIdentityConflictError,
+  type PendingObjectStore,
+} from "./object-store.ts";
+import { recordFor, type IngestionRecord } from "./record.ts";
+import {
+  groupedByProject,
+  millisecondsUntilSeal,
+  recordBytes,
+  sealSegment,
+  shouldSeal,
+  stagedFramePayload,
+  stagedFrameFrom,
+  type SealedSegment,
+  type SegmentBounds,
+  type SegmentScope,
+} from "./segment.ts";
+import {
+  IngestionBackpressureError,
+  openWriteAheadLog,
+  type StagedEntry,
+  type WriteAheadLog,
+} from "./write-ahead-log.ts";
+
+/**
+ * Acceptance: the one place evidence becomes Egma's problem.
+ *
+ * Every path that takes production or simulation evidence ends here — the two
+ * branches of the OTLP door and, in-process, the Retell poller. There is one
+ * seam because there is one promise, and a promise made twice is a promise two
+ * pieces of code can disagree about: **nothing is answered as accepted until it
+ * is durable in the object store.** Not when it is normalized, not when it
+ * reaches the local log, not when a row is written somewhere.
+ *
+ * ## What a caller hands over, and what it may not
+ *
+ * Normalized spans, plus the organization and project **the credential resolved
+ * to**. Tenancy is a parameter here and is never read out of evidence: a record
+ * has no field that could name a tenant, and a segment is sealed for the scope
+ * this module was told, so an attribute claiming an organization decides
+ * nothing even in principle.
+ *
+ * ## The order, and why every step is where it is
+ *
+ * 1. **Refuse what will not fit.** A record over a documented field bound is
+ *    refused by name before anything is staged, and reported back so the door
+ *    can put it in OTLP partial success. Refusing after acceptance would mean
+ *    telling a sender their evidence landed and then dropping it.
+ * 2. **Append to the local log.** Length-framed and checksummed, so a crash
+ *    leaves complete records recoverable and a torn tail recognisable. The log
+ *    is bounded; over the bound it refuses, and a refusal is retryable rather
+ *    than a silent discard of something older.
+ * 3. **Group by project and wait for company.** One segment belongs to exactly
+ *    one project. A group seals when it reaches a size bound or when the flush
+ *    timer expires, whichever comes first — the timer is what a low-volume
+ *    deployment lives on, and the size bound is what stops one segment growing
+ *    without one.
+ * 4. **Seal, then record the identity, then upload.** The segment id is minted
+ *    and written into the log *before* the upload starts, so an upload whose
+ *    answer was lost is retried against the same key with the same bytes. That
+ *    is the whole idempotency story, and it only works in that order.
+ * 5. **Answer.** The call resolves when every segment carrying its records is
+ *    durable, and refuses retryably otherwise. Records stay staged either way:
+ *    a refusal is *not yet*, never *gone*.
+ *
+ * ## A refusal is retryable, and staging survives it
+ *
+ * `IngestionUnavailableError` means the object store did not confirm durability
+ * inside the request's bound, or the local log will take no more. Both are
+ * conditions that pass. The route answers `503`, the exporter retries, and the
+ * staged copy is uploaded by whichever attempt gets there first — span identity
+ * is stable, so the two meeting is a replay rather than a duplicate.
+ */
+
+/**
+ * One evidence group: trusted scope, and the spans filed under it.
+ *
+ * The scope is an `AuthContext` rather than a bare pair because the caller has
+ * already resolved one and re-deriving tenancy from two loose strings is how
+ * the two come apart. Only the organization and the project are read.
+ */
+export type EvidenceGroup = {
+  readonly auth: AuthContext;
+  readonly spans: readonly NewSpan[];
+};
+
+/** One record this side will not store, and the sentence the sender is owed. */
+export type RefusedRecord = {
+  readonly reason: string;
+};
+
+/** What one acceptance call did. */
+export type Acceptance = {
+  /** Records staged and made durable. */
+  readonly accepted: number;
+  /**
+   * Records refused before staging, with a reason each. Never a partial store:
+   * a refused record left no trace anywhere.
+   */
+  readonly refused: readonly RefusedRecord[];
+};
+
+/**
+ * Evidence could not be made durable **yet**.
+ *
+ * The one refusal this module raises, and it is deliberately one: an object
+ * store that did not answer in time and a local log that is full are the same
+ * news to a sender — *not now, send it again* — and answering them differently
+ * would give an exporter two behaviours to implement for one situation. It is
+ * never raised for anything a sender did; bad input is refused as a rejected
+ * record and reported in the response body.
+ */
+export class IngestionUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "IngestionUnavailableError";
+  }
+}
+
+/** What the standing acceptance loop is told when it is opened. */
+export type AcceptanceOptions = {
+  readonly settings: IngestionSettings;
+  readonly log: FastifyBaseLogger;
+  /**
+   * Told the moment a segment is durable, so a drainer in the same process can
+   * start on it without waiting for its own scan.
+   *
+   * A **speed hint and never the recovery authority**: a listener that throws,
+   * blocks or is simply not there costs nothing, because the pending prefix is
+   * the durable work record and a full scan finds every object whatever
+   * happened here.
+   */
+  readonly onSegmentDurable?: (segment: SealedSegment) => void;
+  /** Stands in for the real bucket client in the suites that fault it. */
+  readonly store?: PendingObjectStore;
+};
+
+/** One record staged in the log, and the call waiting on it. */
+type Staged = {
+  readonly scope: SegmentScope;
+  readonly record: IngestionRecord;
+  readonly entry: StagedEntry;
+  /** Uncompressed NDJSON cost, for the segment's size bound. */
+  readonly bytes: number;
+  readonly stagedAtMilliseconds: number;
+  readonly durable: Promise<void>;
+  settled(cause?: unknown): void;
+};
+
+/** One segment sealed and not yet durable. Retried as it is, never re-sealed. */
+type Sealed = {
+  readonly segment: SealedSegment;
+  readonly staged: readonly Staged[];
+  /** The frame in the log that recorded this identity before the upload began. */
+  readonly sealEntry: StagedEntry;
+};
+
+/** One project's staged records, and whatever it has already sealed. */
+type Group = {
+  readonly scope: SegmentScope;
+  waiting: Staged[];
+  sealed: Sealed[];
+};
+
+type Standing = {
+  readonly log: WriteAheadLog;
+  readonly store: PendingObjectStore;
+  readonly bounds: SegmentBounds;
+  readonly requestTimeoutMilliseconds: number;
+  readonly groups: Map<string, Group>;
+  readonly logger: FastifyBaseLogger;
+  readonly onSegmentDurable: (segment: SealedSegment) => void;
+  timer: NodeJS.Timeout | undefined;
+  running: Promise<void> | undefined;
+  closing: boolean;
+};
+
+/**
+ * The one standing acceptance loop, or nothing on a process that never opened
+ * one.
+ *
+ * Module-level for the same reason the trace store's client is: acceptance owns
+ * a local log directory and a bucket connection, and two of them in one process
+ * would be two logs staging the same evidence with neither knowing about the
+ * other. A caller asks for acceptance rather than being handed one, so no route
+ * can be given the wrong one.
+ */
+let standing: Standing | undefined;
+
+function keyFor(scope: SegmentScope): string {
+  return `${scope.organizationId}/${scope.projectId}`;
+}
+
+function groupFor(held: Standing, scope: SegmentScope): Group {
+  const key = keyFor(scope);
+  const found = held.groups.get(key);
+  if (found !== undefined) return found;
+  const made: Group = { scope, waiting: [], sealed: [] };
+  held.groups.set(key, made);
+  return made;
+}
+
+/** A promise somebody else settles, with nothing left to report it unhandled. */
+function stagedFor(
+  scope: SegmentScope,
+  record: IngestionRecord,
+  entry: StagedEntry,
+  stagedAtMilliseconds: number,
+): Staged {
+  let settle: (cause?: unknown) => void = () => undefined;
+  const durable = new Promise<void>((resolve, reject) => {
+    settle = (cause?: unknown) => {
+      if (cause === undefined) resolve();
+      else reject(cause);
+    };
+  });
+  // A call that has already given up on its bound is gone before this settles,
+  // and a rejection nobody is listening for is reported as a process-level
+  // fault. The caller's own `await` still sees the rejection; this only says
+  // that the runtime has heard about it too.
+  durable.catch(() => undefined);
+  return {
+    scope,
+    record,
+    entry,
+    bytes: recordBytes(record),
+    stagedAtMilliseconds,
+    durable,
+    settled: (cause?: unknown) => {
+      settle(cause);
+    },
+  };
+}
+
+/**
+ * How much of a group goes into the next segment.
+ *
+ * Everything waiting, unless a bound is reached partway — in which case the
+ * record that reached it goes in and the rest wait for the next one. Crossing a
+ * bound by one record is deliberate and is why the bound sits under the trace
+ * store's own insert bound: holding that record back instead would make a
+ * segment's bytes depend on what arrived after it, and a retry that re-grouped
+ * the same records would then seal different bytes under an identity that has
+ * already been recorded.
+ */
+function takeForSegment(
+  waiting: readonly Staged[],
+  bounds: SegmentBounds,
+): readonly Staged[] {
+  let bytes = 0;
+  for (const [index, staged] of waiting.entries()) {
+    bytes += staged.bytes;
+    if (index + 1 >= bounds.maxRecords || bytes >= bounds.maxBytes) {
+      return waiting.slice(0, index + 1);
+    }
+  }
+  return waiting;
+}
+
+/** What a group looks like to the sealing rule. */
+function pendingGroup(waiting: readonly Staged[]): {
+  readonly records: number;
+  readonly bytes: number;
+  readonly oldestAtMilliseconds: number;
+} {
+  return {
+    records: waiting.length,
+    bytes: waiting.reduce((sum, staged) => sum + staged.bytes, 0),
+    oldestAtMilliseconds: waiting[0]?.stagedAtMilliseconds ?? 0,
+  };
+}
+
+/**
+ * Seal one segment out of a group, recording its identity in the log first.
+ *
+ * The seal frame is written before the upload and released with it, so what
+ * survives a crash is exactly the set of identities whose upload never
+ * finished — which is what recovery needs and nothing more.
+ */
+function seal(held: Standing, group: Group): void {
+  const taking = takeForSegment(group.waiting, held.bounds);
+  if (taking.length === 0) return;
+
+  const segment = sealSegment({
+    scope: group.scope,
+    records: taking.map((staged) => staged.record),
+  });
+
+  const sealEntry = held.log.append(
+    stagedFramePayload({
+      e: "seal",
+      segment_id: segment.segmentId,
+      organization_id: group.scope.organizationId,
+      project_id: group.scope.projectId,
+      record_count: segment.header.record_count,
+      content_sha256: segment.header.content_sha256,
+    }),
+  );
+
+  group.waiting = group.waiting.slice(taking.length);
+  group.sealed.push({ segment, staged: taking, sealEntry });
+}
+
+/**
+ * Upload the oldest sealed segment of a group, and let its records go once the
+ * store has it.
+ *
+ * `sync()` first, so what reaches the bucket was on this disk before it left —
+ * which is what makes recovery after an ambiguous upload find the same records
+ * and reach for the same identity.
+ */
+async function upload(held: Standing, group: Group): Promise<void> {
+  const attempt = group.sealed[0];
+  if (attempt === undefined) return;
+
+  held.log.sync();
+
+  try {
+    await held.store.create(attempt.segment);
+  } catch (cause) {
+    if (cause instanceof SegmentIdentityConflictError) {
+      // One identity holding two different sets of bytes, which is this side's
+      // defect and never a sender's. The stored object is left exactly as it
+      // is, and this attempt's identity is abandoned rather than retried into:
+      // the records are evidence and go back to the front of the queue to be
+      // sealed under an identity of their own, while the seal frame that named
+      // the abandoned one is released because it now describes nothing.
+      held.logger.error(
+        { err: cause, segmentId: attempt.segment.segmentId },
+        "a sealed segment collided with a different object under its own identity",
+      );
+      group.sealed.shift();
+      group.waiting = [...attempt.staged, ...group.waiting];
+      held.log.release([attempt.sealEntry]);
+      return;
+    }
+
+    // Anything else is *not yet*: the store was unreachable, slow, or refused
+    // the moment rather than the bytes. Nothing is released, the sealed segment
+    // stays at the head of the queue with its identity intact, and every call
+    // waiting on it is told to try again.
+    held.logger.error(
+      { err: cause, segmentId: attempt.segment.segmentId },
+      "a sealed segment did not reach the ingestion bucket",
+    );
+    const refusal = new IngestionUnavailableError(
+      "this evidence was staged and could not be made durable in the " +
+        "ingestion object store. It has not been discarded — send it again.",
+      { cause },
+    );
+    for (const staged of attempt.staged) staged.settled(refusal);
+    return;
+  }
+
+  group.sealed.shift();
+  held.log.release([
+    attempt.sealEntry,
+    ...attempt.staged.map((staged) => staged.entry),
+  ]);
+  for (const staged of attempt.staged) staged.settled();
+
+  try {
+    held.onSegmentDurable(attempt.segment);
+  } catch (cause) {
+    // A wake-up hint, and the pending prefix is the work record. A listener
+    // that fails costs a scan interval and never an object.
+    held.logger.warn(
+      { err: cause, segmentId: attempt.segment.segmentId },
+      "the in-process drain hint refused a durable segment",
+    );
+  }
+}
+
+/** One pass: every group that has something sealed or something due. */
+async function flush(held: Standing): Promise<void> {
+  const now = Date.now();
+  for (const group of [...held.groups.values()]) {
+    if (
+      group.sealed.length === 0 &&
+      shouldSeal(pendingGroup(group.waiting), held.bounds, now)
+    ) {
+      seal(held, group);
+    }
+    if (group.sealed.length > 0) await upload(held, group);
+    if (group.waiting.length === 0 && group.sealed.length === 0) {
+      held.groups.delete(keyFor(group.scope));
+    }
+  }
+}
+
+/**
+ * Wake when the earliest group is due — or at once, where something is already
+ * sealed or already over a bound.
+ *
+ * One timer for every group rather than one each: the answer is the smallest
+ * wait any of them wants, and the pass that follows looks at all of them.
+ */
+function schedule(held: Standing): void {
+  if (held.closing) return;
+  if (held.timer !== undefined) {
+    clearTimeout(held.timer);
+    held.timer = undefined;
+  }
+
+  const now = Date.now();
+  let soonest: number | undefined;
+  for (const group of held.groups.values()) {
+    const wait =
+      group.sealed.length > 0
+        ? 0
+        : millisecondsUntilSeal(pendingGroup(group.waiting), held.bounds, now);
+    if (wait === undefined) continue;
+    soonest = soonest === undefined ? wait : Math.min(soonest, wait);
+  }
+  if (soonest === undefined) return;
+
+  held.timer = setTimeout(() => {
+    held.timer = undefined;
+    void tick(held);
+  }, soonest);
+  // A shutdown never waits on a flush that has not happened; what is staged is
+  // on the disk and the next start picks it up.
+  held.timer.unref();
+}
+
+/** One pass at a time, and another scheduled behind it. */
+function tick(held: Standing): Promise<void> {
+  if (held.running !== undefined) return held.running;
+  const pass = flush(held)
+    .catch((cause: unknown) => {
+      held.logger.error({ err: cause }, "an acceptance flush did not finish");
+    })
+    .finally(() => {
+      held.running = undefined;
+      schedule(held);
+    });
+  held.running = pass;
+  return pass;
+}
+
+/**
+ * Open the standing acceptance loop, recovering whatever the last stop staged.
+ *
+ * A deployment that has named no ingestion store opens nothing, and every
+ * acceptance call then refuses retryably — which is the honest answer: without
+ * a bucket there is nowhere for evidence to become durable, and a door that
+ * answered success would be promising something no part of this process can
+ * keep.
+ */
+export function openAcceptance(options: AcceptanceOptions): void {
+  const { settings } = options;
+  if (standing !== undefined) {
+    throw new Error("this process already has a standing acceptance loop");
+  }
+  if (settings.store === undefined && options.store === undefined) {
+    return;
+  }
+
+  const log = openWriteAheadLog(settings.logDirectory, {
+    maxBytes: settings.logMaxBytes,
+    maxRecords: settings.logMaxRecords,
+    maxFileBytes: settings.segmentMaxBytes,
+  });
+
+  const held: Standing = {
+    log,
+    store:
+      options.store ??
+      pendingObjectStore(
+        // Checked immediately above: one of the two is present.
+        settings.store as NonNullable<IngestionSettings["store"]>,
+        { requestTimeoutMilliseconds: settings.requestTimeoutMilliseconds },
+      ),
+    bounds: {
+      maxBytes: settings.segmentMaxBytes,
+      maxRecords: settings.segmentMaxRecords,
+      flushMilliseconds: settings.flushMilliseconds,
+    },
+    requestTimeoutMilliseconds: settings.requestTimeoutMilliseconds,
+    groups: new Map(),
+    logger: options.log,
+    onSegmentDurable: options.onSegmentDurable ?? (() => undefined),
+    timer: undefined,
+    running: undefined,
+    closing: false,
+  };
+
+  recover(held);
+  standing = held;
+  // What was recovered has been waiting since before this process started, so
+  // it does not wait out a flush window as well.
+  if (held.groups.size > 0) void tick(held);
+}
+
+/**
+ * Everything the previous process staged and did not finish, back in the
+ * groups it was staged in.
+ *
+ * Records first, then the seals that claimed them. A seal frame names a count
+ * rather than a list of identities, and it does not need to name one: records
+ * are appended in arrival order and a segment always takes the oldest of its
+ * project, so the first unclaimed `record_count` of that project *are* the ones
+ * it sealed. The checksum recorded beside the count is what proves that pairing
+ * — where it does not match, the identity is abandoned rather than reused,
+ * because an identity uploaded with bytes other than the ones already under it
+ * is exactly the integrity defect this whole path exists to rule out.
+ */
+function recover(held: Standing): void {
+  const now = Date.now();
+  const seals: {
+    readonly frame: {
+      readonly segment_id: string;
+      readonly organization_id: string;
+      readonly project_id: string;
+      readonly record_count: number;
+      readonly content_sha256: string;
+    };
+    readonly entry: StagedEntry;
+  }[] = [];
+
+  for (const entry of held.log.staged()) {
+    let frame;
+    try {
+      frame = stagedFrameFrom(entry.payload);
+    } catch (cause) {
+      // A frame this version cannot read is left where it is and reported. It
+      // passed its checksum, so the bytes are whole; what they are not is
+      // anything this build knows how to stage.
+      held.logger.error(
+        { err: cause, file: entry.file, offset: entry.offset },
+        "a staged frame in the local ingestion log could not be read",
+      );
+      continue;
+    }
+
+    if (frame.e === "record") {
+      const scope: SegmentScope = {
+        organizationId: frame.organization_id,
+        projectId: frame.project_id,
+      };
+      groupFor(held, scope).waiting.push(
+        stagedFor(scope, frame.record, entry, now),
+      );
+      continue;
+    }
+    seals.push({ frame, entry });
+  }
+
+  for (const { frame, entry } of seals) {
+    const group = groupFor(held, {
+      organizationId: frame.organization_id,
+      projectId: frame.project_id,
+    });
+    const taking = group.waiting.slice(0, frame.record_count);
+    const segment =
+      taking.length === frame.record_count
+        ? sealSegment({
+            scope: group.scope,
+            records: taking.map((staged) => staged.record),
+            segmentId: frame.segment_id,
+          })
+        : undefined;
+
+    if (segment === undefined || segment.header.content_sha256 !== frame.content_sha256) {
+      held.logger.error(
+        { segmentId: frame.segment_id },
+        "a recorded segment identity no longer matches the records it named",
+      );
+      held.log.release([entry]);
+      continue;
+    }
+
+    group.waiting = group.waiting.slice(frame.record_count);
+    group.sealed.push({ segment, staged: taking, sealEntry: entry });
+  }
+}
+
+/** Stop the standing loop. Nothing staged is deleted and nothing is uploaded. */
+export async function closeAcceptance(): Promise<void> {
+  const held = standing;
+  standing = undefined;
+  if (held === undefined) return;
+
+  held.closing = true;
+  if (held.timer !== undefined) {
+    clearTimeout(held.timer);
+    held.timer = undefined;
+  }
+  await held.running;
+  held.log.close();
+}
+
+/** What a call was told when this process accepts nothing. */
+const NO_ACCEPTANCE =
+  "this Egma has no ingestion object store configured, so there is nowhere " +
+  "for evidence to become durable. Nothing was stored.";
+
+/**
+ * Stage one credential's evidence and answer when it is durable.
+ *
+ * The ordinary path, and the one both the customer OTLP branch and the Retell
+ * poller take: one trusted scope, one project, one segment unless the bounds
+ * cut it.
+ */
+export function acceptEvidence(
+  spans: readonly NewSpan[],
+  options: { readonly auth: AuthContext },
+): Promise<Acceptance> {
+  return acceptEvidenceForProjects([{ auth: options.auth, spans }]);
+}
+
+/**
+ * Stage several projects' evidence in one call and answer when **every** one of
+ * them is durable.
+ *
+ * The trusted simulator service batch, which may carry resources belonging to
+ * more than one project. Each project gets a segment of its own — evidence from
+ * two projects may not share a durable object — and the call succeeds only when
+ * all of them have landed. A partial answer would tell the sender the whole
+ * batch was accepted while one project's evidence sat in a log; the groups that
+ * did land are replayed by the retry, which stable span identity makes a no-op.
+ */
+export async function acceptEvidenceForProjects(
+  groups: readonly EvidenceGroup[],
+): Promise<Acceptance> {
+  const held = standing;
+  if (held === undefined) throw new IngestionUnavailableError(NO_ACCEPTANCE);
+
+  const refused: RefusedRecord[] = [];
+  const staging: { readonly scope: SegmentScope; readonly record: IngestionRecord }[] =
+    [];
+
+  for (const group of groups) {
+    const { organizationId, projectId } = group.auth;
+    if (projectId === undefined) {
+      throw new Error("evidence is accepted under a project-scoped context");
+    }
+    const scope: SegmentScope = { organizationId, projectId };
+
+    for (const span of group.spans) {
+      try {
+        // Before anything is staged, so a record Egma will not store never
+        // enters the log, never rides a segment, and is reported to whoever
+        // sent it while their request is still open.
+        refuseOversizeRecord(span);
+      } catch (cause) {
+        if (!(cause instanceof OversizeRecordError)) throw cause;
+        refused.push({ reason: cause.message });
+        continue;
+      }
+      staging.push({ scope, record: recordFor(span) });
+    }
+  }
+
+  if (staging.length === 0) return { accepted: 0, refused };
+
+  const now = Date.now();
+  const waiting: Staged[] = [];
+  // Grouped before the first append so that the log holds one project's
+  // records together, which is the order a segment seals them in.
+  for (const grouped of groupedByProject(staging)) {
+    for (const record of grouped.records) {
+      let entry: StagedEntry;
+      try {
+        entry = held.log.append(
+          stagedFramePayload({
+            e: "record",
+            organization_id: grouped.scope.organizationId,
+            project_id: grouped.scope.projectId,
+            record,
+          }),
+        );
+      } catch (cause) {
+        if (!(cause instanceof IngestionBackpressureError)) throw cause;
+        // Everything already appended by this call stays staged and will be
+        // uploaded; nothing older is discarded to make room. The sender is told
+        // to send the whole request again, and the part that did land is a
+        // replay of itself.
+        schedule(held);
+        throw new IngestionUnavailableError(
+          "this Egma is holding as much staged evidence as it is allowed to " +
+            "and cannot take more right now. Nothing already staged has been " +
+            "discarded — send this again.",
+          { cause },
+        );
+      }
+      const staged = stagedFor(grouped.scope, record, entry, now);
+      groupFor(held, grouped.scope).waiting.push(staged);
+      waiting.push(staged);
+    }
+  }
+
+  schedule(held);
+  await durableWithin(held, waiting);
+  return { accepted: waiting.length, refused };
+}
+
+/**
+ * Wait for every staged record of one call, and no longer than the request is
+ * allowed to be held open.
+ *
+ * The bound is the whole reason this is not a plain `Promise.all`: a store that
+ * has stopped answering would otherwise hold a request open for as long as the
+ * client's own timeout, and the sender would learn nothing it could act on. On
+ * the bound the records stay staged and the sender is told to retry, which is
+ * the one answer that is true whichever way the upload in flight ends.
+ */
+async function durableWithin(
+  held: Standing,
+  waiting: readonly Staged[],
+): Promise<void> {
+  let bound: NodeJS.Timeout | undefined;
+  const overdue = new Promise<never>((_resolve, reject) => {
+    bound = setTimeout(() => {
+      reject(
+        new IngestionUnavailableError(
+          `this evidence was staged and was not durable in the ingestion ` +
+            `object store within ${held.requestTimeoutMilliseconds}ms. It has ` +
+            `not been discarded — send it again.`,
+        ),
+      );
+    }, held.requestTimeoutMilliseconds);
+    bound.unref();
+  });
+
+  try {
+    await Promise.race([
+      Promise.all(waiting.map((staged) => staged.durable)),
+      overdue,
+    ]);
+  } finally {
+    if (bound !== undefined) clearTimeout(bound);
+  }
+}
+
+/**
+ * Every record staged and not yet durable, oldest first.
+ *
+ * The write-readiness surface and the suites that prove a refusal kept its
+ * evidence both need to be able to say what is still in hand, and reading the
+ * log's frames back is the only answer that cannot drift from what is on the
+ * disk.
+ */
+export function stagedEvidence(): readonly {
+  readonly scope: SegmentScope;
+  readonly record: IngestionRecord;
+}[] {
+  const held = standing;
+  if (held === undefined) return [];
+  const found: { scope: SegmentScope; record: IngestionRecord }[] = [];
+  for (const group of held.groups.values()) {
+    for (const staged of [
+      ...group.sealed.flatMap((sealed) => sealed.staged),
+      ...group.waiting,
+    ]) {
+      found.push({ scope: staged.scope, record: staged.record });
+    }
+  }
+  return found;
+}

--- a/apps/api/src/ingestion/accept.ts
+++ b/apps/api/src/ingestion/accept.ts
@@ -141,8 +141,6 @@ export type AcceptanceOptions = {
    * happened here.
    */
   readonly onSegmentDurable?: (segment: SealedSegment) => void;
-  /** Stands in for the real bucket client in the suites that fault it. */
-  readonly store?: PendingObjectStore;
 };
 
 /** One record staged in the log, and the call waiting on it. */
@@ -468,9 +466,8 @@ export function openAcceptance(options: AcceptanceOptions): void {
   if (standing !== undefined) {
     throw new Error("this process already has a standing acceptance loop");
   }
-  if (settings.store === undefined && options.store === undefined) {
-    return;
-  }
+  const { store } = settings;
+  if (store === undefined) return;
 
   const log = openWriteAheadLog(settings.logDirectory, {
     maxBytes: settings.logMaxBytes,
@@ -480,13 +477,9 @@ export function openAcceptance(options: AcceptanceOptions): void {
 
   const held: Standing = {
     log,
-    store:
-      options.store ??
-      pendingObjectStore(
-        // Checked immediately above: one of the two is present.
-        settings.store as NonNullable<IngestionSettings["store"]>,
-        { requestTimeoutMilliseconds: settings.requestTimeoutMilliseconds },
-      ),
+    store: pendingObjectStore(store, {
+      requestTimeoutMilliseconds: settings.requestTimeoutMilliseconds,
+    }),
     bounds: {
       maxBytes: settings.segmentMaxBytes,
       maxRecords: settings.segmentMaxRecords,
@@ -503,14 +496,17 @@ export function openAcceptance(options: AcceptanceOptions): void {
 
   recover(held);
   standing = held;
-  // What was recovered has been waiting since before this process started, so
-  // it does not wait out a flush window as well.
+  // Recovery stamps what it found as already past its flush window, so the
+  // first pass seals and uploads it rather than starting its wait again.
   if (held.groups.size > 0) void tick(held);
 }
 
 /**
  * Everything the previous process staged and did not finish, back in the
  * groups it was staged in.
+ *
+ * Everything found here is due immediately — see the stamp below — so the first
+ * pass seals it and sends it rather than making it wait out another window.
  *
  * Records first, then the seals that claimed them. A seal frame names a count
  * rather than a list of identities, and it does not need to name one: records
@@ -522,7 +518,11 @@ export function openAcceptance(options: AcceptanceOptions): void {
  * is exactly the integrity defect this whole path exists to rule out.
  */
 function recover(held: Standing): void {
-  const now = Date.now();
+  // What is in the log has been waiting since before this process started, so
+  // it is stamped as having already waited out a flush window: a record whose
+  // wait began again at every restart would be a record a restart loop could
+  // hold forever.
+  const now = Date.now() - held.bounds.flushMilliseconds;
   const seals: {
     readonly frame: {
       readonly segment_id: string;
@@ -750,12 +750,13 @@ async function durableWithin(
 }
 
 /**
- * Every record staged and not yet durable, oldest first.
+ * Every record this process has staged and not yet made durable, oldest first,
+ * each with the trusted scope it was accepted under.
  *
- * The write-readiness surface and the suites that prove a refusal kept its
- * evidence both need to be able to say what is still in hand, and reading the
- * log's frames back is the only answer that cannot drift from what is on the
- * disk.
+ * It answers one question — *what is still in hand* — and answers it from the
+ * groups the standing loop is holding, which are the frames the local log holds
+ * on disk. A process that has opened no acceptance loop is holding nothing and
+ * answers so.
  */
 export function stagedEvidence(): readonly {
   readonly scope: SegmentScope;

--- a/apps/api/src/ingestion/defects.ts
+++ b/apps/api/src/ingestion/defects.ts
@@ -1,0 +1,114 @@
+import type { FastifyBaseLogger } from "fastify";
+
+import { UnreadableSegmentError, type SegmentDefect } from "./verify.ts";
+
+/**
+ * An accepted segment this Egma could not turn into rows, and what is done
+ * about it: **nothing is deleted, and an operator is told.**
+ *
+ * The rule is one sentence and everything here follows from it. *Egma promised
+ * this evidence was safe before it ever read it back.* The request was answered
+ * `200`, the sender stopped owing the bytes, and the local copy is long gone —
+ * so an object that then turns out to be corrupt, to state a version this build
+ * does not read, or to disagree with evidence already stored is **Egma's
+ * problem, permanently**. It is not a validation failure, because the moment to
+ * refuse customer input passed at the door. It is not a reason to delete
+ * anything, because deleting it is the one action nobody can undo. The object
+ * stays under its key, retained and visible, and a person decides.
+ *
+ * Automatic deletion of a retained object is deliberately out of scope: the
+ * repair or the explicit discard is operational work somebody chooses to do.
+ *
+ * ## One event and one metric, and the shape of both
+ *
+ * A defect is reported twice, on purpose, because two different people need it.
+ * The **event** is for whoever is going to go and look at the object: it names
+ * the key, so it can be found. The **metric** is for whoever is watching a
+ * deployment: it carries the reason class and nothing else — no key, no
+ * organization, no project, no segment id — because every one of those is
+ * unbounded, and an unbounded metric label is how a monitoring system is taken
+ * down by the incident it was supposed to report.
+ *
+ * ## What is never in either
+ *
+ * No evidence value and no credential. Not a transcript, not a tool argument,
+ * not a payload, not an access key. A log line is copied into places a sealed
+ * object is not, and the reason this release stopped rewriting evidence is the
+ * same reason it must not print it.
+ */
+
+/**
+ * The little of a logger this path uses, named rather than taken whole.
+ *
+ * Draining reports two things — something was left behind, and something did
+ * not work this time — so it asks for two methods. Fastify's own logger
+ * satisfies it without being mentioned at a call site, and nothing here can
+ * quietly start depending on a child logger, a level or a serializer.
+ */
+export type IngestionLog = Pick<FastifyBaseLogger, "warn" | "error">;
+
+/** How a defect is named wherever it is counted. One stable, low-cardinality set. */
+export type IngestionDefect =
+  | SegmentDefect
+  /**
+   * The store already holds one of these spans with different content. The
+   * stored evidence stays authoritative and this object is retained; see
+   * `drainer.ts` for why the first account wins.
+   */
+  | "identity_conflict"
+  /** The trace store refused these rows and would refuse the same bytes again. */
+  | "store_refused";
+
+/** The one event name a retained defect is reported under. */
+export const RETAINED_DEFECT_EVENT = "ingestion.segment.retained";
+
+/** And the one metric it is counted in, by reason class alone. */
+export const RETAINED_DEFECT_METRIC = "ingestion_segment_retained_total";
+
+/** How many retained objects this process has seen, by reason. */
+const counted = new Map<IngestionDefect, number>();
+
+/**
+ * Report one retained object.
+ *
+ * Called where the drainer gives up on an object and leaves it, which is every
+ * place it cannot make progress that is not simply *not yet*. A store that is
+ * unreachable is not a defect and is not reported here — the object is pending,
+ * the next pass takes it, and counting that as retained would turn a ClickHouse
+ * restart into a page about corrupt evidence.
+ */
+export function retainedDefect(
+  log: IngestionLog,
+  defect: IngestionDefect,
+  key: string,
+  cause: unknown,
+): void {
+  counted.set(defect, (counted.get(defect) ?? 0) + 1);
+  log.error(
+    {
+      event: RETAINED_DEFECT_EVENT,
+      metric: RETAINED_DEFECT_METRIC,
+      reason: defect,
+      key,
+      // The error's own class, which is a bounded set of names this codebase
+      // wrote. Never its message: a message can carry a store's echo of a row.
+      errorName: cause instanceof Error ? cause.name : typeof cause,
+    },
+    "an accepted segment could not be drained and has been retained for repair",
+  );
+}
+
+/** The reason class one unreadable object is counted under. */
+export function defectOf(cause: unknown): IngestionDefect | undefined {
+  return cause instanceof UnreadableSegmentError ? cause.reason : undefined;
+}
+
+/** What this process has retained, by reason. For the operator surfaces. */
+export function retainedDefects(): ReadonlyMap<IngestionDefect, number> {
+  return new Map(counted);
+}
+
+/** Forget the counts. For a suite that asserts one pass in isolation. */
+export function forgetRetainedDefects(): void {
+  counted.clear();
+}

--- a/apps/api/src/ingestion/defects.ts
+++ b/apps/api/src/ingestion/defects.ts
@@ -56,6 +56,12 @@ export type IngestionDefect =
    * `drainer.ts` for why the first account wins.
    */
   | "identity_conflict"
+  /**
+   * The header names a project that is not its organization's. The checksum
+   * covers that binding, so the pair is the one the segment was sealed with —
+   * and it is a pair the control database has never agreed to.
+   */
+  | "impossible_tenant_binding"
   /** The trace store refused these rows and would refuse the same bytes again. */
   | "store_refused";
 

--- a/apps/api/src/ingestion/drainer.ts
+++ b/apps/api/src/ingestion/drainer.ts
@@ -1,0 +1,472 @@
+import {
+  appendSpans,
+  committedSpans,
+  recordProductionEvidenceReceived,
+  recordProductionTraces,
+  TraceStoreRefusedError,
+  type AuthContext,
+  type NewSpan,
+} from "@egma/db";
+
+import { defectOf, retainedDefect, type IngestionLog } from "./defects.ts";
+import type { PendingObjectStore } from "./object-store.ts";
+import { contentHashOf, spanFor, type IngestionRecord } from "./record.ts";
+import type { SegmentScope } from "./segment.ts";
+import { verifiedSegment, type VerifiedSegment } from "./verify.ts";
+
+/**
+ * The drainer: pending objects in, query-visible evidence out, and the object
+ * gone only once everything that depends on it has happened.
+ *
+ * A pending object **is** the work record. There is no row saying it exists and
+ * no notification anybody has to receive, which is the whole reason this
+ * release adds no broker: the bucket already remembers, and remembering is the
+ * only thing a broker would have been for. Everything else here follows from
+ * that one choice.
+ *
+ * ## Finding work
+ *
+ * Two ways, and only one of them is authority. A successful upload hands the
+ * key straight over, which is what makes a conversation visible in about a
+ * second at the volumes this release serves. And at startup and on an interval
+ * the whole pending prefix is listed, **every page of it**, which is what makes
+ * that speed optional: an in-process hand-off lost to a crash, a restart, a
+ * missed notification or a bug costs latency and never evidence. A listing that
+ * stopped at the first page would be worse than no listing at all — it would
+ * report a clean backlog while a thousand accepted segments sat behind it.
+ *
+ * ## The order, which is the whole correctness argument
+ *
+ * Per object, in this order and no other:
+ *
+ * 1. **Verify.** Identity, version, scope, compression, checksum, shape.
+ * 2. **Check integrity against what is already stored.** A batched probe of the
+ *    identities this segment carries. An identity already held with the same
+ *    content is an exact replay; one held with *different* content is a defect,
+ *    and the object is retained without a single row being written.
+ * 3. **Write ClickHouse**, the complete segment, under the segment's own
+ *    deduplication token.
+ * 4. **Monitoring bookkeeping**, monotone, so a replay cannot wind a customer's
+ *    "last heard from" backwards.
+ * 5. **The evidence-ready handoff**, which says only that this trace's evidence
+ *    is now readable. Not that it is complete, not that a grader applies, not
+ *    that anything is scheduled.
+ * 6. **Delete.**
+ *
+ * A failure at any step leaves the object exactly where it is, and the next
+ * pass runs the whole object again. That is safe because every step above is
+ * idempotent — identity for the rows, `greatest` for the bookkeeping, an upsert
+ * that touches nothing already claimed for the handoff — and it is why the
+ * delete is last: an object deleted before its handoffs would leave a
+ * conversation stored and unreportable, with nothing left to replay from.
+ *
+ * A failed delete is not special. The object stays, the next scan finds it, and
+ * draining it again is a no-op that tries the delete again. **Rediscovery is
+ * harmless** is not a hope here; it is the retry.
+ *
+ * ## Why the handoffs are after the write, and never before
+ *
+ * The evidence-ready boundary is a promise that the named trace can be read.
+ * Raising it before the rows are visible would wake a grader for a conversation
+ * it would then read as empty, and an empty conversation judged is worse than
+ * one judged late — the verdict looks like an answer.
+ *
+ * ## One drainer
+ *
+ * One active drainer per deployment in this release, and no claim, shard or
+ * ownership protocol to make several safe. Sequential per object, batched
+ * inside one. That is enough for the volume this release serves, and the seam
+ * for splitting it later is the role setting rather than a second protocol.
+ */
+
+export type DrainerOptions = {
+  readonly store: PendingObjectStore;
+  readonly log: IngestionLog;
+  /** How often the whole pending prefix is listed. The startup scan is extra. */
+  readonly scanIntervalMilliseconds: number;
+};
+
+export type Drainer = {
+  /**
+   * A segment just became durable. A **speed hint**: losing it costs a scan
+   * interval and never an object, which is why nothing here answers whether the
+   * key was taken.
+   */
+  wake(key: string): void;
+  /**
+   * List the whole pending prefix and drain everything in it, then answer how
+   * many objects were deleted.
+   *
+   * The recovery path, and what the interval calls. Also the seam a suite drives
+   * when it wants one pass to have finished rather than to have started.
+   */
+  drainNow(): Promise<number>;
+  stop(): Promise<void>;
+};
+
+type Running = {
+  readonly options: DrainerOptions;
+  /** Keys handed over by a successful upload and not yet tried. */
+  readonly hinted: Set<string>;
+  timer: NodeJS.Timeout | undefined;
+  /** The tail of the pass chain. Passes never overlap. */
+  chain: Promise<number>;
+  /** A pass that is waiting to start, so callers arriving together share it. */
+  waiting: Promise<number> | undefined;
+  stopped: boolean;
+};
+
+/**
+ * The context one segment's effects are written under.
+ *
+ * Built from the **sealed header** and from nothing else — not from the key,
+ * not from anything a caller remembered, not from an attribute on the evidence.
+ * A segment states its own organization and project inside the bytes the
+ * checksum covers, so this is the one tenancy statement that exists and there
+ * is nothing for it to disagree with.
+ *
+ * `monitoring` for the same reason `claimDueRetellMonitoringAgent` uses it: this
+ * names no person, it came from egma's own record of accepted work rather than
+ * from a credential, and it opens neither the grading service's capabilities nor
+ * the conductor's.
+ */
+function authFor(scope: SegmentScope): AuthContext {
+  return {
+    userId: "",
+    organizationId: scope.organizationId,
+    projectId: scope.projectId,
+    role: "admin",
+    via: "monitoring",
+  };
+}
+
+/**
+ * Wide enough to hold every span this segment carries, and no wider.
+ *
+ * Measured off the evidence rather than off the clock, deliberately. The trace
+ * store is partitioned by span time, so a probe with no window is a scan of
+ * every month a customer ever had — and a window measured from `now` would stop
+ * recognising a segment's own evidence the moment the segment was old enough,
+ * which is exactly the case a replay is.
+ */
+function windowOf(records: readonly IngestionRecord[]): {
+  readonly from: bigint;
+  readonly to: bigint;
+} {
+  let from = BigInt(records[0]?.started_at_microseconds ?? "0");
+  let to = from;
+  for (const record of records) {
+    const at = BigInt(record.started_at_microseconds);
+    if (at < from) from = at;
+    if (at > to) to = at;
+  }
+  // The read is half-open, so the latest span has to be inside it.
+  return { from, to: to + 1n };
+}
+
+/**
+ * A segment's identities held against what the store already says about them.
+ *
+ * Answers nothing and throws on a conflict, because there is only one thing to
+ * do about one: **stop before writing anything.** A conflicting segment that
+ * had written half its rows would have made the defect it reports partly true.
+ *
+ * A stored row whose content hash is empty is evidence written before the
+ * fingerprint existed — the simulation evidence carried through the identity
+ * rebuild. It is treated as an exact replay and never as a conflict: the row is
+ * there, it is authoritative, and a comparison that cannot be made is not a
+ * disagreement.
+ */
+async function refuseConflictingEvidence(
+  auth: AuthContext,
+  segment: VerifiedSegment,
+): Promise<void> {
+  if (segment.records.length === 0) return;
+
+  const held = await committedSpans(
+    auth,
+    segment.records.map((record) => ({
+      traceId: record.trace_id,
+      spanId: record.span_id,
+    })),
+    { window: windowOf(segment.records) },
+  );
+  if (held.length === 0) return;
+
+  const stored = new Map(
+    held.map((one) => [`${one.traceId}/${one.spanId}`, one.contentHash]),
+  );
+  for (const record of segment.records) {
+    const fingerprint = stored.get(`${record.trace_id}/${record.span_id}`);
+    if (fingerprint === undefined || fingerprint === "") continue;
+    if (fingerprint === contentHashOf(record)) continue;
+    throw new IdentityConflictInSegmentError(
+      `span ${record.span_id} of trace ${record.trace_id} is already stored ` +
+        `with different evidence, so this segment is retained and the stored ` +
+        `evidence stays authoritative. A span is immutable: one identity holds ` +
+        `one account of one moment, and replacing it would rewrite a record ` +
+        `somebody may already have read.`,
+    );
+  }
+}
+
+/** Two accounts of one immutable span. The stored one wins; see the module doc. */
+export class IdentityConflictInSegmentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IdentityConflictInSegmentError";
+  }
+}
+
+/**
+ * Which platform's Monitoring state this segment moves, and to when.
+ *
+ * Gathered per `(platform, selected agent)` rather than per conversation — one
+ * segment carrying two hundred calls of one agent is one statement — and the
+ * instant comes from **the evidence** rather than from the clock. That is what
+ * makes a replay monotone in practice as well as in the merge: a segment
+ * drained today carrying yesterday's calls says yesterday, so it cannot move a
+ * customer's "last production conversation" forward to a moment nothing
+ * happened at.
+ */
+function monitoringFactsIn(
+  records: readonly IngestionRecord[],
+): readonly {
+  readonly agentPlatform: "retell" | "livekit_agents";
+  readonly platformAgentId: string;
+  readonly receivedAt: Date;
+}[] {
+  const latest = new Map<string, { platform: string; agent: string; at: bigint }>();
+  for (const record of records) {
+    if (record.source !== "production") continue;
+    if (record.agent_platform !== "retell" && record.agent_platform !== "livekit_agents") {
+      continue;
+    }
+    const key = `${record.agent_platform}/${record.platform_agent_id}`;
+    const at = BigInt(record.started_at_microseconds);
+    const found = latest.get(key);
+    if (found === undefined) {
+      latest.set(key, {
+        platform: record.agent_platform,
+        agent: record.platform_agent_id,
+        at,
+      });
+      continue;
+    }
+    if (at > found.at) found.at = at;
+  }
+
+  return [...latest.values()].map((one) => ({
+    agentPlatform: one.platform as "retell" | "livekit_agents",
+    platformAgentId: one.agent,
+    // Milliseconds, which is what a timestamp column reads back into.
+    receivedAt: new Date(Number(one.at / 1_000n)),
+  }));
+}
+
+/**
+ * One object, all the way through — or left exactly where it was found.
+ *
+ * Answers whether the object was drained and deleted. A `false` is never a
+ * discard: either the object is retained as a defect and reported, or the step
+ * that failed is one that passes, and the next pass runs the whole object
+ * again.
+ */
+async function drainOne(held: Running, key: string): Promise<boolean> {
+  const { log, store } = held.options;
+
+  let segment: VerifiedSegment;
+  try {
+    segment = verifiedSegment(key, await store.read(key));
+  } catch (cause) {
+    const defect = defectOf(cause);
+    if (defect === undefined) {
+      // The bucket did not answer. Not a defect and not this object's fault:
+      // the next pass reads it again.
+      log.warn({ err: cause, key }, "a pending object could not be read");
+      return false;
+    }
+    retainedDefect(log, defect, key, cause);
+    return false;
+  }
+
+  const auth = authFor(segment.scope);
+  const spans: readonly NewSpan[] = segment.records.map(spanFor);
+
+  try {
+    await refuseConflictingEvidence(auth, segment);
+  } catch (cause) {
+    if (cause instanceof IdentityConflictInSegmentError) {
+      retainedDefect(log, "identity_conflict", key, cause);
+      return false;
+    }
+    // The probe itself failed — an unreachable store, a query that timed out.
+    // Nothing has been written and the object is untouched.
+    log.warn({ err: cause, key }, "a segment's identities could not be checked");
+    return false;
+  }
+
+  try {
+    // The complete segment, every time. A replay that wrote only the records it
+    // found missing would form different blocks under the same deduplication
+    // token, and the token would then suppress the very rows the replay existed
+    // to write. Identity is what makes the repeat free; the token only makes it
+    // cheap.
+    await appendSpans(auth, spans, { segmentId: segment.segmentId });
+  } catch (cause) {
+    if (cause instanceof TraceStoreRefusedError) {
+      // Rows the store has looked at and will refuse forever. Retained rather
+      // than replayed into a loop, and never answered to a customer — the
+      // request that carried them was accepted long ago.
+      retainedDefect(log, "store_refused", key, cause);
+      return false;
+    }
+    log.warn({ err: cause, key }, "a segment did not reach the trace store");
+    return false;
+  }
+
+  try {
+    for (const fact of monitoringFactsIn(segment.records)) {
+      await recordProductionEvidenceReceived(auth, fact);
+    }
+    // Says only that this trace's evidence is readable. Every span goes in,
+    // because which of them count is a question this seam already answers —
+    // and answering it twice is how two readers of span shape come to disagree.
+    await recordProductionTraces(auth, spans);
+  } catch (cause) {
+    // The rows are visible and the handoffs are not. The object stays, and the
+    // replay finishes the missing half: the write it repeats is a no-op.
+    log.warn({ err: cause, key }, "a drained segment's handoffs did not finish");
+    return false;
+  }
+
+  try {
+    await store.delete(key);
+  } catch (cause) {
+    // Everything that depends on this object has happened, so the object is
+    // spent. Leaving it costs one more harmless drain when the next scan finds
+    // it, which is also what retries the delete.
+    log.warn({ err: cause, key }, "a drained segment could not be deleted");
+    return false;
+  }
+
+  return true;
+}
+
+/** Everything discoverable right now, oldest first, one object at a time. */
+async function pass(held: Running): Promise<number> {
+  const { log, store } = held.options;
+
+  let keys: string[];
+  try {
+    keys = (await store.list()).map((object) => object.key).sort();
+  } catch (cause) {
+    log.warn({ err: cause }, "the pending prefix could not be listed");
+    keys = [];
+  }
+
+  // Anything an upload handed over since the last pass, in case it is newer
+  // than the listing. A key that is in both is drained once.
+  for (const hinted of held.hinted) {
+    if (!keys.includes(hinted)) keys.push(hinted);
+  }
+  held.hinted.clear();
+
+  let drained = 0;
+  for (const key of keys) {
+    if (held.stopped) break;
+    if (await drainOne(held, key)) drained += 1;
+  }
+  return drained;
+}
+
+/**
+ * One pass at a time, and every caller gets a pass that **starts after it
+ * asked**.
+ *
+ * Returning a pass already in flight would be the cheaper answer and the wrong
+ * one: that pass has already listed the prefix, so a key that became durable a
+ * moment ago is not in it, and a caller told "drained" would have been told
+ * about somebody else's work. So a call that arrives mid-pass waits behind it —
+ * and every caller that arrives while one is already waiting shares that one,
+ * which is what keeps a burst of uploads from becoming a burst of listings.
+ */
+function drainNow(held: Running): Promise<number> {
+  if (held.waiting !== undefined) return held.waiting;
+  const next = held.chain
+    .catch(() => 0)
+    .then(() => {
+      held.waiting = undefined;
+      return pass(held);
+    });
+  held.waiting = next;
+  held.chain = next;
+  return next;
+}
+
+/**
+ * Start the one drainer.
+ *
+ * The startup scan runs immediately rather than after the first interval: a
+ * process that has just come back is the process most likely to have a backlog,
+ * and making it wait out a scan interval would make every restart cost one.
+ */
+export function startDrainer(options: DrainerOptions): Drainer {
+  const held: Running = {
+    options,
+    hinted: new Set(),
+    timer: undefined,
+    chain: Promise.resolve(0),
+    waiting: undefined,
+    stopped: false,
+  };
+
+  const again = (): void => {
+    if (held.stopped) return;
+    held.timer = setTimeout(() => {
+      void drainNow(held)
+        .catch((cause: unknown) => {
+          options.log.error({ err: cause }, "a drain pass did not finish");
+        })
+        .finally(again);
+    }, options.scanIntervalMilliseconds);
+    // A shutdown never waits for the next scan; what is pending is in the
+    // bucket, and the next start finds it.
+    held.timer.unref();
+  };
+
+  void drainNow(held)
+    .catch((cause: unknown) => {
+      options.log.error({ err: cause }, "the startup drain scan did not finish");
+    })
+    .finally(again);
+
+  return {
+    wake(key) {
+      if (held.stopped) return;
+      held.hinted.add(key);
+      // Not awaited and not scheduled behind the interval: the hand-off is what
+      // makes a conversation visible in about a second, and a pass already
+      // running will be followed by this one.
+      void drainNow(held).catch((cause: unknown) => {
+        options.log.error({ err: cause }, "a hinted drain did not finish");
+      });
+    },
+
+    drainNow() {
+      return drainNow(held);
+    },
+
+    async stop() {
+      held.stopped = true;
+      if (held.timer !== undefined) {
+        clearTimeout(held.timer);
+        held.timer = undefined;
+      }
+      // Whatever is in flight finishes the object it is on and then stops: the
+      // pass checks for a stop between objects, so what a shutdown waits on is
+      // one segment and never the backlog.
+      await held.chain.catch(() => undefined);
+    },
+  };
+}

--- a/apps/api/src/ingestion/drainer.ts
+++ b/apps/api/src/ingestion/drainer.ts
@@ -1,14 +1,22 @@
 import {
   appendSpans,
   committedSpans,
+  isProjectOfOrganization,
+  MONITORING_PLATFORMS,
   recordProductionEvidenceReceived,
   recordProductionTraces,
   TraceStoreRefusedError,
   type AuthContext,
+  type MonitoringPlatform,
   type NewSpan,
 } from "@egma/db";
 
-import { defectOf, retainedDefect, type IngestionLog } from "./defects.ts";
+import {
+  defectOf,
+  retainedDefect,
+  type IngestionDefect,
+  type IngestionLog,
+} from "./defects.ts";
 import type { PendingObjectStore } from "./object-store.ts";
 import { contentHashOf, spanFor, type IngestionRecord } from "./record.ts";
 import type { SegmentScope } from "./segment.ts";
@@ -108,6 +116,17 @@ type Running = {
   readonly options: DrainerOptions;
   /** Keys handed over by a successful upload and not yet tried. */
   readonly hinted: Set<string>;
+  /**
+   * Objects this process has already reported and left behind.
+   *
+   * A retained object stays under its key forever until a person deals with
+   * it, so every scan finds it again — and reporting it again would turn one
+   * damaged object into a rising count that measures how long the process has
+   * been up. It is reported once and then skipped. A restart reports it once
+   * more, which is honest: a new process has genuinely met it for the first
+   * time, and an operator who repaired the object wants it looked at again.
+   */
+  readonly retained: Set<string>;
   timer: NodeJS.Timeout | undefined;
   /** The tail of the pass chain. Passes never overlap. */
   chain: Promise<number>;
@@ -116,6 +135,9 @@ type Running = {
   stopped: boolean;
 };
 
+/** Who the drainer is, wherever a context has to name somebody. */
+const INTERNAL_USER = "ingestion-drainer";
+
 /**
  * The context one segment's effects are written under.
  *
@@ -123,19 +145,24 @@ type Running = {
  * not from anything a caller remembered, not from an attribute on the evidence.
  * A segment states its own organization and project inside the bytes the
  * checksum covers, so this is the one tenancy statement that exists and there
- * is nothing for it to disagree with.
+ * is nothing for it to disagree with. That the pair is a real one is a separate
+ * question and is asked below, against Postgres, before anything is written.
  *
  * `monitoring` for the same reason `claimDueRetellMonitoringAgent` uses it: this
  * names no person, it came from egma's own record of accepted work rather than
  * from a credential, and it opens neither the grading service's capabilities nor
  * the conductor's.
+ *
+ * `member` because that is the role `ingest_traces` admits, and a context that
+ * carried more than the work needs is a context somebody later reaches for to
+ * do something else with.
  */
 function authFor(scope: SegmentScope): AuthContext {
   return {
-    userId: "",
+    userId: INTERNAL_USER,
     organizationId: scope.organizationId,
     projectId: scope.projectId,
-    role: "admin",
+    role: "member",
     via: "monitoring",
   };
 }
@@ -218,6 +245,14 @@ export class IdentityConflictInSegmentError extends Error {
   }
 }
 
+/** A header naming a project that is not its organization's. */
+export class ImpossibleTenantBindingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImpossibleTenantBindingError";
+  }
+}
+
 /**
  * Which platform's Monitoring state this segment moves, and to when.
  *
@@ -229,19 +264,30 @@ export class IdentityConflictInSegmentError extends Error {
  * customer's "last production conversation" forward to a moment nothing
  * happened at.
  */
-function monitoringFactsIn(
-  records: readonly IngestionRecord[],
-): readonly {
-  readonly agentPlatform: "retell" | "livekit_agents";
+type MonitoringFact = {
+  readonly agentPlatform: MonitoringPlatform;
   readonly platformAgentId: string;
   readonly receivedAt: Date;
-}[] {
-  const latest = new Map<string, { platform: string; agent: string; at: bigint }>();
+};
+
+/** Whether this word is a platform Monitoring keeps a setup for. */
+function monitored(platform: string): platform is MonitoringPlatform {
+  return (MONITORING_PLATFORMS as readonly string[]).includes(platform);
+}
+
+function monitoringFactsIn(
+  records: readonly IngestionRecord[],
+): readonly MonitoringFact[] {
+  const latest = new Map<
+    string,
+    { platform: MonitoringPlatform; agent: string; at: bigint }
+  >();
   for (const record of records) {
     if (record.source !== "production") continue;
-    if (record.agent_platform !== "retell" && record.agent_platform !== "livekit_agents") {
-      continue;
-    }
+    // Asked of the shipped list rather than of two names written out here, so
+    // a platform added to Monitoring gets its bookkeeping instead of silently
+    // losing it.
+    if (!monitored(record.agent_platform)) continue;
     const key = `${record.agent_platform}/${record.platform_agent_id}`;
     const at = BigInt(record.started_at_microseconds);
     const found = latest.get(key);
@@ -257,7 +303,7 @@ function monitoringFactsIn(
   }
 
   return [...latest.values()].map((one) => ({
-    agentPlatform: one.platform as "retell" | "livekit_agents",
+    agentPlatform: one.platform,
     platformAgentId: one.agent,
     // Milliseconds, which is what a timestamp column reads back into.
     receivedAt: new Date(Number(one.at / 1_000n)),
@@ -275,6 +321,13 @@ function monitoringFactsIn(
 async function drainOne(held: Running, key: string): Promise<boolean> {
   const { log, store } = held.options;
 
+  /** Leave it where it is, tell an operator, and stop looking at it. */
+  const retain = (defect: IngestionDefect, cause: unknown): false => {
+    held.retained.add(key);
+    retainedDefect(log, defect, key, cause);
+    return false;
+  };
+
   let segment: VerifiedSegment;
   try {
     segment = verifiedSegment(key, await store.read(key));
@@ -286,19 +339,41 @@ async function drainOne(held: Running, key: string): Promise<boolean> {
       log.warn({ err: cause, key }, "a pending object could not be read");
       return false;
     }
-    retainedDefect(log, defect, key, cause);
-    return false;
+    return retain(defect, cause);
   }
 
   const auth = authFor(segment.scope);
   const spans: readonly NewSpan[] = segment.records.map(spanFor);
 
+  // The header binds a project to an organization and the checksum covers that
+  // binding, so nothing can have edited it — but a pair that was never real is
+  // a different failure, and it is one only Postgres can answer. Asked before a
+  // row is written, because a write under a pair the control database has never
+  // agreed to is one customer's evidence filed under another's name.
+  try {
+    if (!(await isProjectOfOrganization(auth, segment.scope.projectId))) {
+      return retain(
+        "impossible_tenant_binding",
+        new ImpossibleTenantBindingError(
+          `this segment names project ${segment.scope.projectId} under ` +
+            `organization ${segment.scope.organizationId}, and that project is ` +
+            `not one of theirs. It is retained: evidence whose customer cannot ` +
+            `be established is not evidence to write anywhere.`,
+        ),
+      );
+    }
+  } catch (cause) {
+    // The control database did not answer. Not a defect, and the object is
+    // untouched.
+    log.warn({ err: cause, key }, "a segment's tenancy could not be checked");
+    return false;
+  }
+
   try {
     await refuseConflictingEvidence(auth, segment);
   } catch (cause) {
     if (cause instanceof IdentityConflictInSegmentError) {
-      retainedDefect(log, "identity_conflict", key, cause);
-      return false;
+      return retain("identity_conflict", cause);
     }
     // The probe itself failed — an unreachable store, a query that timed out.
     // Nothing has been written and the object is untouched.
@@ -318,8 +393,7 @@ async function drainOne(held: Running, key: string): Promise<boolean> {
       // Rows the store has looked at and will refuse forever. Retained rather
       // than replayed into a loop, and never answered to a customer — the
       // request that carried them was accepted long ago.
-      retainedDefect(log, "store_refused", key, cause);
-      return false;
+      return retain("store_refused", cause);
     }
     log.warn({ err: cause, key }, "a segment did not reach the trace store");
     return false;
@@ -375,6 +449,7 @@ async function pass(held: Running): Promise<number> {
   let drained = 0;
   for (const key of keys) {
     if (held.stopped) break;
+    if (held.retained.has(key)) continue;
     if (await drainOne(held, key)) drained += 1;
   }
   return drained;
@@ -415,6 +490,7 @@ export function startDrainer(options: DrainerOptions): Drainer {
   const held: Running = {
     options,
     hinted: new Set(),
+    retained: new Set(),
     timer: undefined,
     chain: Promise.resolve(0),
     waiting: undefined,

--- a/apps/api/src/ingestion/object-store.ts
+++ b/apps/api/src/ingestion/object-store.ts
@@ -142,6 +142,13 @@ export function pendingObjectStore(
           requestHandler: {
             requestTimeout: options.requestTimeoutMilliseconds,
             connectionTimeout: options.requestTimeoutMilliseconds,
+            // Required, and the bound is inert without it: the client's default
+            // is to log a warning and keep waiting, because `requestTimeout`
+            // was once a socket-idle setting and turning it into a refusal is
+            // opt-in. A bound that only warns is a request held open for as
+            // long as the store stays quiet — which is the exact failure the
+            // whole acceptance timeout exists to answer.
+            throwOnRequestTimeout: true,
           },
         }),
   });

--- a/apps/api/src/ingestion/record.ts
+++ b/apps/api/src/ingestion/record.ts
@@ -246,7 +246,7 @@ export function recordFor(span: NewSpan): IngestionRecord {
     test_version_id: span.testVersionId,
     persona_version_id: span.personaVersionId,
     payload: span.payload,
-    ends_trace: span.endsTrace ?? false,
+    ends_trace: span.endsTrace,
   };
 }
 

--- a/apps/api/src/ingestion/segment.ts
+++ b/apps/api/src/ingestion/segment.ts
@@ -45,14 +45,22 @@ import {
  * ## The bytes
  *
  * Gzip-compressed NDJSON. The first line is the header — format version,
- * segment identity, trusted scope, record count and the checksum of everything
- * after it. Then one canonical record per line.
+ * segment identity, trusted scope, record count and one checksum binding all of
+ * it together. Then one canonical record per line.
  *
- * The header cannot cover itself, so `content_sha256` is over the **record
- * lines only**, uncompressed, exactly as they are written. A reader
- * decompresses, splits off the first line, hashes the rest and compares. That
- * is a check on the evidence rather than on the compression, so it still holds
- * if a store or a proxy ever re-encodes the transfer.
+ * **The checksum covers the header as well as the records**, which is what
+ * makes the sealed scope a fact rather than a label. A digest over the records
+ * alone would leave `organization_id` and `project_id` bound to nothing, and
+ * the drainer builds the context it writes under out of exactly those two
+ * fields — so an object whose header had been edited would file one customer's
+ * evidence under another's, and every checksum in the path would still agree.
+ * A field cannot cover itself, so what is hashed is the header **without**
+ * `content_sha256`, in one fixed field order, followed by the record lines
+ * exactly as they are written. A reader rebuilds that form from the fields it
+ * validated and compares.
+ *
+ * It is a check on the evidence and its binding rather than on the compression,
+ * so it still holds if a store or a proxy ever re-encodes the transfer.
  *
  * **The compressed object is deterministic for one sealed segment**, which is
  * what makes "same identity, same bytes" a fact a retry can be judged against
@@ -95,16 +103,51 @@ export type SegmentScope = {
   readonly projectId: string;
 };
 
-/** The first line of every segment. */
-export type SegmentHeader = {
+/**
+ * Everything the checksum binds: the header without the checksum itself.
+ *
+ * Its own type so that the one thing which may not be inside the digest is
+ * absent by construction rather than deleted by whoever remembers to.
+ */
+export type SegmentBinding = {
   readonly v: number;
   readonly segment_id: string;
   readonly organization_id: string;
   readonly project_id: string;
   readonly record_count: number;
-  /** SHA-256, lower-case hex, over the uncompressed record lines. */
+};
+
+/** The first line of every segment. */
+export type SegmentHeader = SegmentBinding & {
+  /** SHA-256, lower-case hex. See `segmentChecksum`. */
   readonly content_sha256: string;
 };
+
+/**
+ * The one digest a sealed segment is judged against, over the one canonical
+ * form of what it binds.
+ *
+ * The field order is written out here rather than taken from an object literal,
+ * for the reason `canonicalRecordJson` writes its own out: insertion order is a
+ * property of whichever construction site built the object, and a reader
+ * rebuilding the header from fields it parsed would otherwise hash a different
+ * string from the one the writer hashed.
+ */
+export function segmentChecksum(
+  binding: SegmentBinding,
+  recordLines: string,
+): string {
+  const bound = JSON.stringify({
+    organization_id: binding.organization_id,
+    project_id: binding.project_id,
+    record_count: binding.record_count,
+    segment_id: binding.segment_id,
+    v: binding.v,
+  });
+  return createHash("sha256")
+    .update(`${bound}\n${recordLines}`, "utf8")
+    .digest("hex");
+}
 
 /** One sealed segment: its identity, its key and its immutable bytes. */
 export type SealedSegment = {
@@ -318,13 +361,16 @@ export function sealSegment(options: {
   const lines = options.records.map((record) => canonicalRecordJson(record));
   const body = `${lines.join("\n")}\n`;
 
-  const header: SegmentHeader = {
+  const binding: SegmentBinding = {
     v: RECORD_FORMAT_VERSION,
     segment_id: segmentId,
     organization_id: options.scope.organizationId,
     project_id: options.scope.projectId,
     record_count: options.records.length,
-    content_sha256: createHash("sha256").update(body, "utf8").digest("hex"),
+  };
+  const header: SegmentHeader = {
+    ...binding,
+    content_sha256: segmentChecksum(binding, body),
   };
 
   return {

--- a/apps/api/src/ingestion/verify.ts
+++ b/apps/api/src/ingestion/verify.ts
@@ -1,9 +1,14 @@
-import { createHash } from "node:crypto";
 import { gunzipSync } from "node:zlib";
 
-import { recordFrom, type IngestionRecord } from "./record.ts";
 import {
+  recordFrom,
+  RECORD_FORMAT_VERSION,
+  type IngestionRecord,
+} from "./record.ts";
+import {
+  segmentChecksum,
   segmentIdIn,
+  type SegmentBinding,
   type SegmentHeader,
   type SegmentScope,
 } from "./segment.ts";
@@ -31,21 +36,27 @@ import {
  *   states one; a key that has been copied or renamed makes them disagree, and
  *   a drainer that believed the key would file evidence under a segment it is
  *   not.
- * - **Checksum.** SHA-256 over the record lines exactly as they are written,
- *   uncompressed. It covers the evidence rather than the compression, so it
- *   still holds if a store or a proxy ever re-encodes the transfer. The header
- *   cannot cover itself, which is why the count and the scope are checked
- *   against the lines instead.
+ * - **Checksum.** One SHA-256 over the header and the record lines together,
+ *   uncompressed and in the canonical form `segmentChecksum` defines. It covers
+ *   the evidence rather than the compression, so it still holds if a store or a
+ *   proxy ever re-encodes the transfer — and it covers the scope, which is what
+ *   makes the two fields below safe to write under.
  * - **Record count and record shape.** Every line is a record of this version,
  *   with every field present and of the right type, and there are exactly as
  *   many of them as the header says.
  *
  * ## Tenancy comes from inside, and only from inside
  *
- * The scope is read from the sealed header, which the checksum's siblings sit
- * beside and which no rename can touch. It is never read from the key: the key
- * is a name, and a name a person can type is not a thing to file a customer's
- * evidence by.
+ * The scope is read from the sealed header and is **inside the checksum**, so
+ * an object whose organization or project has been edited fails verification
+ * rather than filing one customer's evidence under another's. It is never read
+ * from the key: the key is a name, and a name a person can type is not a thing
+ * to file a customer's evidence by.
+ *
+ * Whether the project the header names is *that organization's* project is a
+ * question this module cannot answer — it needs Postgres — so it is asked by
+ * the drainer, before any row is written, and a header that fails it is an
+ * impossible tenant binding rather than a corrupt object.
  */
 
 /** One pending object, opened and checked far enough to be written. */
@@ -95,8 +106,6 @@ export type SegmentDefect =
   | "record_count_mismatch"
   | "malformed_record";
 
-const RECORD_FORMAT_VERSION_READ = 1;
-
 function headerFrom(key: string, line: string): SegmentHeader {
   let parsed: unknown;
   try {
@@ -137,18 +146,18 @@ function headerFrom(key: string, line: string): SegmentHeader {
       `this segment's header states a record count of ${String(count)}`,
     );
   }
-  if (held["v"] !== RECORD_FORMAT_VERSION_READ) {
+  if (held["v"] !== RECORD_FORMAT_VERSION) {
     throw new UnreadableSegmentError(
       "unsupported_version",
       key,
       `this segment states format version ${String(held["v"])} and this Egma ` +
-        `reads ${RECORD_FORMAT_VERSION_READ}. It is left where it is: the ` +
+        `reads ${RECORD_FORMAT_VERSION}. It is left where it is: the ` +
         `deployment that can read it is the one that should.`,
     );
   }
 
   return {
-    v: RECORD_FORMAT_VERSION_READ,
+    v: RECORD_FORMAT_VERSION,
     segment_id: text("segment_id"),
     organization_id: text("organization_id"),
     project_id: text("project_id"),
@@ -203,12 +212,22 @@ export function verifiedSegment(key: string, body: Uint8Array): VerifiedSegment 
   // Everything after the first line, byte for byte as it was hashed — the
   // trailing newline included, because it was written and therefore counted.
   const body_ = text.slice(firstBreak + 1);
-  const digest = createHash("sha256").update(body_, "utf8").digest("hex");
+  // Rebuilt from the fields checked above rather than re-serialised from what
+  // was parsed, so the string hashed here is the string the writer hashed
+  // whatever order the object arrived in.
+  const binding: SegmentBinding = {
+    v: header.v,
+    segment_id: header.segment_id,
+    organization_id: header.organization_id,
+    project_id: header.project_id,
+    record_count: header.record_count,
+  };
+  const digest = segmentChecksum(binding, body_);
   if (digest !== header.content_sha256) {
     throw new UnreadableSegmentError(
       "checksum_mismatch",
       key,
-      `this segment's records hash to ${digest} and its header states ` +
+      `this segment hashes to ${digest} and its header states ` +
         `${header.content_sha256}`,
     );
   }

--- a/apps/api/src/ingestion/verify.ts
+++ b/apps/api/src/ingestion/verify.ts
@@ -1,0 +1,253 @@
+import { createHash } from "node:crypto";
+import { gunzipSync } from "node:zlib";
+
+import { recordFrom, type IngestionRecord } from "./record.ts";
+import {
+  segmentIdIn,
+  type SegmentHeader,
+  type SegmentScope,
+} from "./segment.ts";
+
+/**
+ * Opening a pending object, and refusing to believe one that does not add up.
+ *
+ * The drainer reads bytes it did not write. They came off a network, sat in a
+ * bucket, and may have been sealed by an Egma older than this one — so every
+ * claim the object makes is checked against the object itself before a single
+ * row is formed from it. **Nothing here repairs anything.** A segment that does
+ * not verify is retained where it is and reported; it is never partly written,
+ * never trimmed to the part that parses, and never reclassified as bad customer
+ * input, because the request that carried this evidence was answered as
+ * accepted long before anybody read it back.
+ *
+ * ## What is checked, and what each check is for
+ *
+ * - **Gzip.** The bytes decompress, or the object is damaged.
+ * - **A header line.** The first line is the header and parses as one.
+ * - **Format version.** This Egma reads version 1. A later version is not a
+ *   corrupt object — it is an object this build has no business guessing at,
+ *   and the deployment that can read it is the one that should.
+ * - **Key against identity.** The key spells one segment id and the header
+ *   states one; a key that has been copied or renamed makes them disagree, and
+ *   a drainer that believed the key would file evidence under a segment it is
+ *   not.
+ * - **Checksum.** SHA-256 over the record lines exactly as they are written,
+ *   uncompressed. It covers the evidence rather than the compression, so it
+ *   still holds if a store or a proxy ever re-encodes the transfer. The header
+ *   cannot cover itself, which is why the count and the scope are checked
+ *   against the lines instead.
+ * - **Record count and record shape.** Every line is a record of this version,
+ *   with every field present and of the right type, and there are exactly as
+ *   many of them as the header says.
+ *
+ * ## Tenancy comes from inside, and only from inside
+ *
+ * The scope is read from the sealed header, which the checksum's siblings sit
+ * beside and which no rename can touch. It is never read from the key: the key
+ * is a name, and a name a person can type is not a thing to file a customer's
+ * evidence by.
+ */
+
+/** One pending object, opened and checked far enough to be written. */
+export type VerifiedSegment = {
+  readonly key: string;
+  readonly segmentId: string;
+  /** From the sealed header, never from the key. */
+  readonly scope: SegmentScope;
+  readonly records: readonly IngestionRecord[];
+};
+
+/**
+ * A pending object this Egma will not turn into rows.
+ *
+ * Always an internal defect and never a customer's mistake — see the module
+ * doc. It carries a low-cardinality `reason` beside the sentence so an operator
+ * surface can count the kinds without ever putting an object key in a metric
+ * label.
+ */
+export class UnreadableSegmentError extends Error {
+  readonly reason: SegmentDefect;
+  readonly key: string;
+
+  constructor(reason: SegmentDefect, key: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "UnreadableSegmentError";
+    this.reason = reason;
+    this.key = key;
+  }
+}
+
+/**
+ * Why an object could not be read, as a fixed and small set.
+ *
+ * Fixed because it is a metric label. A reason derived from a message, a key or
+ * an error's own text would put an unbounded set of values into a time series,
+ * and the first bucket with a thousand damaged objects in it would be the one
+ * that took the metrics down.
+ */
+export type SegmentDefect =
+  | "not_a_pending_key"
+  | "not_gzip"
+  | "no_header"
+  | "unsupported_version"
+  | "identity_mismatch"
+  | "checksum_mismatch"
+  | "record_count_mismatch"
+  | "malformed_record";
+
+const RECORD_FORMAT_VERSION_READ = 1;
+
+function headerFrom(key: string, line: string): SegmentHeader {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (cause) {
+    throw new UnreadableSegmentError(
+      "no_header",
+      key,
+      "this segment's first line is not a JSON header",
+      { cause },
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new UnreadableSegmentError(
+      "no_header",
+      key,
+      "this segment's first line is not a JSON object",
+    );
+  }
+
+  const held = parsed as Record<string, unknown>;
+  const text = (name: string): string => {
+    const value = held[name];
+    if (typeof value !== "string" || value === "") {
+      throw new UnreadableSegmentError(
+        "no_header",
+        key,
+        `this segment's header has no ${name}`,
+      );
+    }
+    return value;
+  };
+  const count = held["record_count"];
+  if (!Number.isInteger(count) || (count as number) < 0) {
+    throw new UnreadableSegmentError(
+      "no_header",
+      key,
+      `this segment's header states a record count of ${String(count)}`,
+    );
+  }
+  if (held["v"] !== RECORD_FORMAT_VERSION_READ) {
+    throw new UnreadableSegmentError(
+      "unsupported_version",
+      key,
+      `this segment states format version ${String(held["v"])} and this Egma ` +
+        `reads ${RECORD_FORMAT_VERSION_READ}. It is left where it is: the ` +
+        `deployment that can read it is the one that should.`,
+    );
+  }
+
+  return {
+    v: RECORD_FORMAT_VERSION_READ,
+    segment_id: text("segment_id"),
+    organization_id: text("organization_id"),
+    project_id: text("project_id"),
+    record_count: count as number,
+    content_sha256: text("content_sha256"),
+  };
+}
+
+/** One pending object, opened. Every failure is an `UnreadableSegmentError`. */
+export function verifiedSegment(key: string, body: Uint8Array): VerifiedSegment {
+  const segmentId = segmentIdIn(key);
+  if (segmentId === undefined) {
+    throw new UnreadableSegmentError(
+      "not_a_pending_key",
+      key,
+      "this key is not one the pending prefix spells",
+    );
+  }
+
+  let opened: Buffer;
+  try {
+    opened = gunzipSync(Buffer.from(body));
+  } catch (cause) {
+    throw new UnreadableSegmentError(
+      "not_gzip",
+      key,
+      "this segment does not decompress",
+      { cause },
+    );
+  }
+
+  const text = opened.toString("utf8");
+  const firstBreak = text.indexOf("\n");
+  if (firstBreak < 0) {
+    throw new UnreadableSegmentError(
+      "no_header",
+      key,
+      "this segment has no line after its first",
+    );
+  }
+  const header = headerFrom(key, text.slice(0, firstBreak));
+
+  if (header.segment_id !== segmentId) {
+    throw new UnreadableSegmentError(
+      "identity_mismatch",
+      key,
+      `this object's key spells segment ${segmentId} and its header states ` +
+        `${header.segment_id}`,
+    );
+  }
+
+  // Everything after the first line, byte for byte as it was hashed — the
+  // trailing newline included, because it was written and therefore counted.
+  const body_ = text.slice(firstBreak + 1);
+  const digest = createHash("sha256").update(body_, "utf8").digest("hex");
+  if (digest !== header.content_sha256) {
+    throw new UnreadableSegmentError(
+      "checksum_mismatch",
+      key,
+      `this segment's records hash to ${digest} and its header states ` +
+        `${header.content_sha256}`,
+    );
+  }
+
+  // A sealed segment always ends its last record with a newline, so the split
+  // leaves one empty tail to drop. A segment of no records is a header and
+  // nothing after it.
+  const lines = body_ === "" ? [] : body_.split("\n").slice(0, -1);
+  if (lines.length !== header.record_count) {
+    throw new UnreadableSegmentError(
+      "record_count_mismatch",
+      key,
+      `this segment holds ${lines.length} record lines and its header states ` +
+        `${header.record_count}`,
+    );
+  }
+
+  const records: IngestionRecord[] = [];
+  for (const [index, line] of lines.entries()) {
+    try {
+      records.push(recordFrom(JSON.parse(line)));
+    } catch (cause) {
+      throw new UnreadableSegmentError(
+        "malformed_record",
+        key,
+        `this segment's record ${index} is not one this Egma reads: ` +
+          `${cause instanceof Error ? cause.message : String(cause)}`,
+        { cause },
+      );
+    }
+  }
+
+  return {
+    key,
+    segmentId,
+    scope: {
+      organizationId: header.organization_id,
+      projectId: header.project_id,
+    },
+    records,
+  };
+}

--- a/apps/api/src/otlp/normalise.ts
+++ b/apps/api/src/otlp/normalise.ts
@@ -24,10 +24,15 @@ import type {
  * per-turn spans — inventing structure that was never measured would corrupt
  * every comparison the numbers exist for.
  *
- * **Safe provider data is kept.** What the columns do not have a place for
- * stays in the payload, resource and scope attributes included. Credential
- * fields and bearer-like values are redacted before any field is read or any
- * payload is serialized.
+ * **Everything that arrives is kept, exactly.** What the columns do not have a
+ * place for stays in the payload, resource and scope attributes included, byte
+ * for byte. Nothing here reads an attribute's name or a value's shape and
+ * decides it looks like a credential: a transcript containing the word
+ * `password`, a tool argument called `secret`, an attribute whose value starts
+ * with `Bearer` are all evidence, and a scanner that rewrote them would have
+ * edited the one thing the product exists to show a team. Operational
+ * credentials are excluded by position instead — the HTTP `Authorization`
+ * header and the service token live outside the payload and never reach here.
  *
  * **Tenancy is not the payload's business.** A resource attribute naming an
  * organization or a project is read by nothing here, deliberately. The customer
@@ -253,56 +258,6 @@ const PLATFORM_AGENT_NAME_ATTRIBUTES = ["lk.agent_name"];
 const PLATFORM_AGENT_VERSION_ATTRIBUTES = ["lk.agent_version"];
 const CONNECTION_KIND_ATTRIBUTES = ["egma.connection_kind"];
 
-/** The visible marker left where an OTLP producer supplied a credential. */
-const OTLP_REDACTED = "[REDACTED]";
-
-function normalizedKey(value: string): string {
-  return value.trim().toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
-}
-
-function isCredentialKey(key: string): boolean {
-  const normalized = normalizedKey(key);
-  return /(?:^|-)(?:access-token|api-key|auth|authorization|credential|cookie|password|secret|signature|token)(?:-|$)/u.test(
-    normalized,
-  );
-}
-
-const AUTHORIZATION_VALUE = /\b(?:bearer|basic)\s+[^\s,;]+/giu;
-const CREDENTIAL_ASSIGNMENT =
-  /([?&;]\s*(?:access[_-]?token|api[_-]?key|auth|authorization|credential|password|secret|signature|token)=)[^&#;\s]+/giu;
-
-function safeString(value: string): string {
-  return value
-    .replace(AUTHORIZATION_VALUE, OTLP_REDACTED)
-    .replace(CREDENTIAL_ASSIGNMENT, `$1${OTLP_REDACTED}`);
-}
-
-/** Copy one decoded OTLP document after removing credential-bearing values. */
-function safeOtlpProviderData<T>(value: T): T {
-  const copied = (held: unknown): unknown => {
-    if (typeof held === "string") return safeString(held);
-    if (Array.isArray(held)) return held.map(copied);
-    if (typeof held !== "object" || held === null) return held;
-
-    const row = held as Readonly<Record<string, unknown>>;
-    const attributeKey = typeof row["key"] === "string" ? row["key"] : "";
-    const redactsAttribute =
-      attributeKey !== "" && isCredentialKey(attributeKey);
-    const safe: Record<string, unknown> = {};
-    for (const [key, nested] of Object.entries(row)) {
-      if (redactsAttribute && key === "value") {
-        safe[key] = { stringValue: OTLP_REDACTED };
-      } else if (isCredentialKey(key)) {
-        safe[key] = OTLP_REDACTED;
-      } else {
-        safe[key] = copied(nested);
-      }
-    }
-    return safe;
-  };
-  return copied(value) as T;
-}
-
 /**
  * How much of one export egma will turn into rows.
  *
@@ -315,7 +270,7 @@ function safeOtlpProviderData<T>(value: T): T {
  * Both caps are needed because they answer different requests. A body inside
  * the wire limit can still carry a hundred thousand tiny spans, which is what
  * the count is for; and it can carry two thousand spans sharing one enormous
- * resource, where every row repeats the safe resource and a 1.3 MiB
+ * resource, where every row repeats that resource and a 1.3 MiB
  * request becomes gigabytes of rows. The byte budget is measured on what the
  * rows actually weigh, which is the only number that predicts the memory.
  */
@@ -351,9 +306,7 @@ function attribute(
   key: string,
 ): string {
   const found = (attributes ?? []).find((entry) => entry.key === key);
-  if (found === undefined) return "";
-  const value = textOf(found.value);
-  return value === OTLP_REDACTED ? "" : value;
+  return found === undefined ? "" : textOf(found.value);
 }
 
 function firstAttribute(
@@ -516,7 +469,7 @@ function environmentOf(
  * Everything on a row except the span itself, serialised once for the whole
  * scope rather than once per span.
  *
- * The safe resource and scope ride every row on purpose — a row has to say
+ * The resource and the scope ride every row on purpose — a row has to say
  * where it came from without a join — but they are the same two objects for
  * every span in the group. Built lazily, so a group whose spans are all
  * refused never pays for serialization.
@@ -543,7 +496,7 @@ const TOO_MANY_SPANS =
 
 const TOO_MANY_BYTES =
   `this export's spans came to more than the ${MAXIMUM_NORMALISED_BYTES / (1024 * 1024)} MiB of rows Egma ` +
-  "writes from one request — every span carries its safe resource and scope, " +
+  "writes from one request — every span carries its resource and scope, " +
   "so a large resource repeated across many spans reaches this long " +
   "before the body does. The spans that fitted were stored and the rest were " +
   "refused rather than retried; flush smaller batches.";
@@ -572,8 +525,7 @@ export function normaliseOtlpExport(
   let excess: RejectedSpan | undefined;
   let normalisedBytes = 0;
 
-  for (const receivedResourceSpans of request.resourceSpans ?? []) {
-    const resourceSpans = safeOtlpProviderData(receivedResourceSpans);
+  for (const resourceSpans of request.resourceSpans ?? []) {
     const environment = environmentOf(resourceSpans);
     const attribution =
       attributionFor?.(resourceSpans) ?? INGESTED_AT_THIS_DOOR;
@@ -639,6 +591,7 @@ export function normaliseOtlpExport(
         const attributes = span.attributes;
         const kind = kindOf(scope, span);
         const tool = TOOL_KEYS_BY_SCOPE[scope?.name ?? ""];
+        const agentPlatform = AGENT_PLATFORM_BY_SCOPE[scope?.name ?? ""] ?? "";
 
         payloadPrefix ??= payloadPrefixFor(resourceSpans, scopeSpans);
         const payload = `${payloadPrefix}${JSON.stringify(span)}}`;
@@ -681,7 +634,7 @@ export function normaliseOtlpExport(
             [attributes, resourceSpans.resource?.attributes],
             PROVIDER_CALL_ID_ATTRIBUTES,
           ),
-          agentPlatform: AGENT_PLATFORM_BY_SCOPE[scope?.name ?? ""] ?? "",
+          agentPlatform,
           platformAgentId: firstAttribute(
             [attributes, resourceSpans.resource?.attributes],
             PLATFORM_AGENT_ID_ATTRIBUTES,
@@ -715,6 +668,26 @@ export function normaliseOtlpExport(
           testVersionId: attribution.testVersionId,
           personaVersionId: attribution.personaVersionId,
           payload,
+          /*
+           * The platform's own statement that the conversation is over, and
+           * only where a platform this door recognises made it.
+           *
+           * Two conditions, both required. `root` says the framework's session
+           * span arrived — the one span the whole trace happened inside, named
+           * in that framework's own vocabulary rather than guessed from the
+           * shape of the trace. `agentPlatform` says the scope is a production
+           * platform this release supports. A scope nobody recognises reaches
+           * `other` and says nothing here, which is the point: a parentless
+           * span is not an ending, and an exporter flush whose parent never
+           * arrived produces one.
+           *
+           * A simulation's root is deliberately `false`. Its scope maps to no
+           * production platform, and the completion fact for a simulation
+           * belongs to the lifecycle that ends the run — asserting it here as
+           * well would be two producers of one fact, which is how one
+           * conversation comes to be graded twice.
+           */
+          endsTrace: kind === "root" && agentPlatform !== "",
         });
       }
     }

--- a/apps/api/src/retell/normalise.ts
+++ b/apps/api/src/retell/normalise.ts
@@ -614,6 +614,10 @@ function span(
     agentVersionId: "",
     testVersionId: "",
     personaVersionId: "",
+    // Only the root span of a call Retell reported an end for says otherwise,
+    // and it says so in so many words. Every turn and every tool call inside a
+    // conversation is mid-conversation by construction.
+    endsTrace: false,
     ...fields,
   };
 }
@@ -670,11 +674,28 @@ export function normaliseRetellCall(
     span({
       ...shared,
       spanId: rootId,
-      // Empty, which is how a root is recognised everywhere in this store —
-      // and how the grading bookkeeping learns the conversation is over.
+      // Empty, which is how a root is recognised everywhere in this store.
+      // Recognising a root is not the same fact as knowing a conversation
+      // ended, and this span carries the second one separately.
       parentSpanId: "",
       name: "retell_call",
       kind: "conversation",
+      /*
+       * Retell's own answer, and only Retell's.
+       *
+       * `endReported` is the same fact the poller's cursor already refuses to
+       * move without: `true` means the provider named an end timestamp for this
+       * call, and `false` means Egma stood in a plausible instant because the
+       * payload carried none. The two must not be confused — a call still in
+       * progress reads back with a start and no end, and treating that as an
+       * ending would close a conversation while the caller is still talking.
+       *
+       * It was already computed here and already surfaced on the normalised
+       * trace; carrying it onto the span is what lets everything downstream of
+       * storage read the platform's statement instead of inferring one from
+       * this span having no parent.
+       */
+      endsTrace: times.reported,
       startedAtMicroseconds: startedAt,
       durationNanoseconds: (endedAt - startedAt) * 1000n,
       status: degraded || providerFailed ? "error" : "ok",

--- a/apps/api/src/retell/write.ts
+++ b/apps/api/src/retell/write.ts
@@ -2,9 +2,8 @@ import {
   appendSpans,
   claimProductionTrace,
   finishProductionTrace,
+  recordProductionEvidenceReceived,
   recordProductionTraces,
-  recordRetellCallReceived,
-  recordRetellMonitoringReceived,
   type AuthContext,
   type ProductionTraceClaim,
 } from "@egma/db";
@@ -53,8 +52,7 @@ export type RetellProductionWriteStore = {
   readonly appendSpans: typeof appendSpans;
   readonly recordProductionTraces: typeof recordProductionTraces;
   readonly finishProductionTrace: typeof finishProductionTrace;
-  readonly recordRetellCallReceived: typeof recordRetellCallReceived;
-  readonly recordRetellMonitoringReceived: typeof recordRetellMonitoringReceived;
+  readonly recordProductionEvidenceReceived: typeof recordProductionEvidenceReceived;
 };
 
 const STORES: RetellProductionWriteStore = {
@@ -62,8 +60,7 @@ const STORES: RetellProductionWriteStore = {
   appendSpans,
   recordProductionTraces,
   finishProductionTrace,
-  recordRetellCallReceived,
-  recordRetellMonitoringReceived,
+  recordProductionEvidenceReceived,
 };
 
 function projectIdOf(target: Pick<RetellProductionWriteTarget, "auth">): string {
@@ -177,7 +174,11 @@ export async function writeRetellCall(
   // provider conversation is durable. If this health update fails, the claim
   // remains stale and replay can finish it instead of leaving Monitoring in
   // "waiting" after the trace already arrived.
-  await stores.recordRetellCallReceived(target.auth, target, receivedAt);
+  await stores.recordProductionEvidenceReceived(target.auth, {
+    agentPlatform: "retell",
+    platformAgentId: target.platformAgentId,
+    receivedAt,
+  });
   await stores.finishProductionTrace(target.auth, {
     traceId: normalised.traceId,
     degraded: normalised.degraded,
@@ -228,8 +229,10 @@ export async function replayProductionClaim(
   ) {
     await stores.recordProductionTraces(claim.auth, normalised.spans);
   }
-  await stores.recordRetellMonitoringReceived(claim.auth, {
+  await stores.recordProductionEvidenceReceived(claim.auth, {
+    agentPlatform: "retell",
     platformAgentId: claim.platformAgentId,
+    receivedAt: new Date(),
   });
   await stores.finishProductionTrace(claim.auth, {
     traceId: claim.traceId,

--- a/apps/api/src/routes/traces.ts
+++ b/apps/api/src/routes/traces.ts
@@ -1,13 +1,9 @@
 import { gunzipSync } from "node:zlib";
 
 import {
-  appendSpans,
   authorize,
   NotPermittedError,
-  recordLiveKitMonitoringReceived,
-  recordProductionTraces,
   resolveSimulationStanding,
-  TraceStoreRefusedError,
   type AuthContext,
   type NewSpan,
   type SimulationStanding,
@@ -16,6 +12,12 @@ import { traceIdOfSimulation } from "@egma/simulation-contract";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
 import { requesterOf } from "../http/credentialed.ts";
+import {
+  acceptEvidence,
+  acceptEvidenceForProjects,
+  IngestionUnavailableError,
+  type EvidenceGroup,
+} from "../ingestion/accept.ts";
 import {
   notAuthenticated,
   tooManyRequests,
@@ -91,18 +93,22 @@ import {
  * because the specification is explicit that rejected data must not be retried
  * and the client must be told how much of it there was.
  *
- * **A conversation ending here becomes grading work, and nothing more.** The
- * spans are stored, and then one row per trace goes to the grading queue saying
- * when this trace was last heard from and whether its root span closed. That is
- * bookkeeping: a queue write and a notification, on the same terms as the
- * transaction that ends a simulation raising one. No grader is resolved here, no
- * conversation is read back, no judgment is made and no model is called.
- * Judging belongs to a service that holds no request open, and it stays there:
- * a door that judged would make an exporter's timeout depend on how many
- * graders a customer wrote and on how fast somebody else's judge model felt
- * like answering. The service path writes no queue row at all — a simulation's
- * grading work is minted by the transaction that lands it terminal, so a span
- * arriving here has nothing to add.
+ * **The door decodes and hands over, and that is the whole of what it does.**
+ * Authentication, decompression, decoding, tenant resolution and normalization
+ * happen here, and then the evidence goes to the one acceptance module — which
+ * answers when it is durable in the object store and not before. Nothing here
+ * writes a trace row, updates Monitoring health or names a grader. Those are
+ * effects of evidence being *query-visible*, which happens later and elsewhere,
+ * and a door that performed them would be claiming an outcome it cannot see:
+ * an exporter's timeout would depend on a store's cold start, and a request
+ * answered before a durable copy existed would be a promise nothing kept.
+ *
+ * **`503` is the one new answer, and it means *not yet*.** Evidence that could
+ * not be made durable inside the request's bound is still staged and is
+ * retryable, which is exactly what an OTLP exporter does with a 5xx. Evidence
+ * this side refuses — a malformed span, a reserved environment, a record over a
+ * documented bound — is still reported the way the specification says to report
+ * data that must not be retried: a 200 carrying a count and a reason.
  */
 
 export type TraceRoutesOptions = {
@@ -128,12 +134,15 @@ export const OTLP_TRACES_PATH = "/v1/traces";
 const MAXIMUM_BODY_BYTES = 20 * 1024 * 1024;
 
 /**
- * The gRPC status codes the specification's `Status` uses, and the two egma
+ * The gRPC status codes the specification's `Status` uses, and the three egma
  * answers with. `INVALID_ARGUMENT` is what a body egma cannot read is;
- * `PERMISSION_DENIED` is what a credential that may not write is.
+ * `PERMISSION_DENIED` is what a credential that may not write is; `UNAVAILABLE`
+ * is evidence this side could not make durable yet, which is the one refusal a
+ * sender is meant to try again.
  */
 const RPC_INVALID_ARGUMENT = 3;
 const RPC_PERMISSION_DENIED = 7;
+const RPC_UNAVAILABLE = 14;
 
 /**
  * The one compression OTLP/HTTP names, and what most exporters are configured
@@ -451,7 +460,7 @@ async function simulatorExport(
     count: 0,
     firstReason: "",
   };
-  const appends: { auth: AuthContext; spans: readonly NewSpan[] }[] = [];
+  const accepting: EvidenceGroup[] = [];
   for (const group of groups.values()) {
     // Normalised per gathering, so the row caps guard each customer's append
     // rather than the request: a bound loosened only by naming more
@@ -462,42 +471,31 @@ async function simulatorExport(
     );
     rejected.count += normalised.rejected.length;
     rejected.firstReason ||= normalised.rejected[0]?.reason ?? "";
-    appends.push({ auth: group.auth, spans: normalised.spans });
-  }
 
-  // Every group is attempted, whatever happened to the one before it: one
-  // customer's refused rows must never sink another customer's evidence, and
-  // never claim it was sunk. A store that *refuses* a group — rows it has
-  // looked at and will refuse forever — costs exactly that group, counted and
-  // answered as rejected below so the sender stops resending it. A store that
-  // merely *fails* still escapes as the error it is: the whole document comes
-  // back as a retry. Groups that landed are sent again as the same deterministic
-  // blocks, which is the recent exact-repeat case ClickHouse can suppress.
-  const storeRefused: { spans: number; firstMessage: string } = {
-    spans: 0,
-    firstMessage: "",
-  };
-  for (const append of appends) {
     // The same function every write in the product goes through, asked with
     // the narrowed context the row resolved to. It cannot refuse a context
     // the module itself built — which is the point of asking: a change that
     // made it refusable would surface here, not in a customer's missing rows.
-    authorize(append.auth, "ingest_traces", {
-      organizationId: append.auth.organizationId,
-      projectId: append.auth.projectId,
+    authorize(group.auth, "ingest_traces", {
+      organizationId: group.auth.organizationId,
+      projectId: group.auth.projectId,
     });
 
-    try {
-      await appendSpans(append.auth, append.spans);
-    } catch (cause) {
-      if (!(cause instanceof TraceStoreRefusedError)) throw cause;
+    accepting.push({ auth: group.auth, spans: normalised.spans });
+  }
 
-      request.log.error({ err: cause }, "the trace store refused a batch");
-      storeRefused.spans += append.spans.length;
-      storeRefused.firstMessage ||=
-        `the trace store refused these spans: ${cause.message}. They were ` +
-        "not stored and re-sending the same batch will not change that.";
-    }
+  // Every group in one call, and one answer for all of them: a batch naming
+  // several projects gets a segment each, and it is a success only once every
+  // one of them is durable. A per-group answer would tell the simulator its
+  // whole flush landed while one project's evidence was still in a local log —
+  // and the retry that follows a refusal replays the groups that did land,
+  // which stable span identity makes a no-op rather than a duplicate.
+  let accepted;
+  try {
+    accepted = await acceptEvidenceForProjects(accepting);
+  } catch (cause) {
+    if (!(cause instanceof IngestionUnavailableError)) throw cause;
+    return unavailable(request, reply, encoding, cause);
   }
 
   // And nothing goes to the grading queue, deliberately: a simulation's
@@ -505,15 +503,37 @@ async function simulatorExport(
   // telemetry path has nothing to add — a queue row from here would be the
   // second job the landing already guards against.
   //
-  // One truthful answer: what was rejected is the normaliser's rejects plus
-  // the refused groups' spans, and nothing that landed. The field is one
-  // string, and a store refusal is the graver news, so it speaks first.
+  // One truthful answer: the normaliser's rejects plus the records acceptance
+  // refused by name, and nothing that landed. The field is one string, and a
+  // named field over its bound is the more actionable of the two, so it speaks
+  // first.
   return exportResponse(
     reply,
     encoding,
-    rejected.count + storeRefused.spans,
-    storeRefused.firstMessage || rejected.firstReason,
+    rejected.count + accepted.refused.length,
+    accepted.refused[0]?.reason ?? rejected.firstReason,
   );
+}
+
+/**
+ * Evidence that could not be made durable in time, answered as *not yet*.
+ *
+ * `503` rather than a rejection, because the two are read differently and only
+ * one of them is true here: an OTLP exporter retries a 5xx and stops resending
+ * data reported as rejected. The staged copy is still on this side's disk and
+ * still on its way to the object store, so a retry meeting it is a replay of
+ * one immutable identity and produces one visible span. The body is the same
+ * `google.rpc.Status` every other refusal on this door uses, in the encoding
+ * the request arrived in.
+ */
+function unavailable(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  encoding: OtlpEncoding,
+  cause: IngestionUnavailableError,
+): FastifyReply {
+  request.log.error({ err: cause }, "evidence could not be made durable");
+  return statusResponse(reply, encoding, 503, RPC_UNAVAILABLE, cause.message);
 }
 
 export async function traceRoutes(
@@ -669,64 +689,28 @@ export async function traceRoutes(
       throw cause;
     }
 
-    // Appended once and complete: nothing is read first, nothing is patched,
-    // and a batch too large for one insert is split rather than trimmed.
+    // Handed over once and complete, and answered only when it is durable in
+    // the ingestion object store. Monitoring health and the grader-owned
+    // evidence-ready handoff are effects of that evidence becoming
+    // query-visible, so they belong to whatever reads the segment back — not
+    // to a door that would be asserting them about rows nobody has written.
+    let accepted;
     try {
-      await appendSpans(auth, normalised.spans);
+      accepted = await acceptEvidence(normalised.spans, { auth });
     } catch (cause) {
-      if (!(cause instanceof TraceStoreRefusedError)) throw cause;
-
-      // The store looked at these rows and said no, and it will say no to the
-      // identical bytes forever. A 5xx would be read as "try again later" and
-      // an exporter would retry this batch until its queue overflowed, so it
-      // is answered the way the specification says to answer data that must
-      // not be retried: accepted request, every span rejected, reason given.
-      request.log.error({ err: cause }, "the trace store refused a batch");
-      return exportResponse(
-        reply,
-        encoding,
-        normalised.spans.length + normalised.rejected.length,
-        `the trace store refused these spans: ${cause.message}. They were ` +
-          "not stored and re-sending the same batch will not change that.",
-      );
+      if (!(cause instanceof IngestionUnavailableError)) throw cause;
+      return unavailable(request, reply, encoding, cause);
     }
-
-    // Monitoring health means that a valid LiveKit Agents span reached the
-    // shared store. Update it only after the append succeeds. Other OTLP
-    // scopes do not prove a LiveKit Monitoring setup is working, and an empty
-    // or fully rejected export proves nothing arrived.
-    if (
-      normalised.spans.some(
-        (span) =>
-          span.source === "production" &&
-          span.agentPlatform === "livekit_agents",
-      )
-    ) {
-      await recordLiveKitMonitoringReceived(auth);
-    }
-
-    // And the conversations those spans belong to become known to the grading
-    // queue: one row per trace, saying when egma last heard about it and whether
-    // its root span closed. The same spans go to both calls, so what completion
-    // means is read off the telemetry in one place rather than agreed between
-    // two.
-    //
-    // Deliberately not caught. A trace nothing recorded is a trace nothing will
-    // ever grade, so an export whose bookkeeping did not land was not accepted:
-    // the failure reaches the exporter as a 5xx, which OTLP says to retry, and
-    // the retry is byte-identical so the store drops the spans it already has.
-    // The door's availability already depends on this database — the credential
-    // is resolved from it before a byte of the body is read — so this couples
-    // nothing that was not coupled.
-    await recordProductionTraces(auth, normalised.spans);
 
     return exportResponse(
       reply,
       encoding,
-      normalised.rejected.length,
-      // One message, because the field is one string. The first refusal is the
-      // one a developer needs; the rest are the same mistake repeated.
-      normalised.rejected[0]?.reason ?? "",
+      normalised.rejected.length + accepted.refused.length,
+      // One message, because the field is one string. A record over a
+      // documented bound names the field and the two numbers, which is the
+      // more actionable of the two, so it speaks first; the rest of either
+      // kind is the same mistake repeated.
+      accepted.refused[0]?.reason ?? normalised.rejected[0]?.reason ?? "",
     );
   });
 }

--- a/apps/api/src/routes/traces.ts
+++ b/apps/api/src/routes/traces.ts
@@ -498,11 +498,6 @@ async function simulatorExport(
     return unavailable(request, reply, encoding, cause);
   }
 
-  // And nothing goes to the grading queue, deliberately: a simulation's
-  // grading work is minted by the transaction that lands it terminal, so the
-  // telemetry path has nothing to add — a queue row from here would be the
-  // second job the landing already guards against.
-  //
   // One truthful answer: the normaliser's rejects plus the records acceptance
   // refused by name, and nothing that landed. The field is one string, and a
   // named field over its bound is the more actionable of the two, so it speaks

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,6 +14,7 @@ import {
   type EmailSender,
 } from "./auth/email.ts";
 import { admitIdentity, onIdentityCreated } from "./auth/provisioning.ts";
+import { closeAcceptance, openAcceptance } from "./ingestion/accept.ts";
 import { claimRoutes } from "./routes/claims.ts";
 import { deviceRoutes } from "./routes/device.ts";
 import { heartbeatRoutes } from "./routes/heartbeats.ts";
@@ -361,6 +362,11 @@ export function buildApi(options: ServerOptions): Api {
   // the same loop without overlapping one target.
   let retellProductionIngestion: RetellProductionIngestion | undefined;
   app.addHook("onReady", async () => {
+    // Before anything can be accepted, and before the drainer that will read
+    // the same bucket: opening it recovers whatever the last stop left staged,
+    // so evidence that was in hand when a process died is on its way again
+    // within the first tick rather than after the first new request.
+    openAcceptance({ settings: config.ingestion, log: app.log });
     orphanSweep = startOrphanSweep({
       log: app.log,
       ...(options.orphanSweepIntervalMilliseconds === undefined
@@ -383,6 +389,9 @@ export function buildApi(options: ServerOptions): Api {
     // and then the stores knows the sweep holds no connection to them.
     await orphanSweep?.stop();
     await retellProductionIngestion?.stop();
+    // Last, and it uploads nothing on the way out: what is staged is on the
+    // disk with its checksums, and the next start is what sends it.
+    await closeAcceptance();
   });
 
   return { app, identity };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -15,6 +15,8 @@ import {
 } from "./auth/email.ts";
 import { admitIdentity, onIdentityCreated } from "./auth/provisioning.ts";
 import { closeAcceptance, openAcceptance } from "./ingestion/accept.ts";
+import { startDrainer, type Drainer } from "./ingestion/drainer.ts";
+import { pendingObjectStore } from "./ingestion/object-store.ts";
 import { claimRoutes } from "./routes/claims.ts";
 import { deviceRoutes } from "./routes/device.ts";
 import { heartbeatRoutes } from "./routes/heartbeats.ts";
@@ -89,6 +91,18 @@ export type ServerOptions = {
   readonly deviceAuthorizationInterval?: IdentityOptions["deviceAuthorizationInterval"];
   /** Test seam for Retell account reads. Production uses the global fetch. */
   readonly retellFetch?: RetellFetch | undefined;
+  /**
+   * Whether this process runs the standing drainer. Defaults to running it,
+   * which is what every deployment does today.
+   *
+   * It is here because acceptance and draining are already two halves that a
+   * later release separates by role — a process that only accepts is a shape
+   * this design promises, not one invented for a suite. Until the role setting
+   * decides it, this is what lets a proof hold a sealed segment still and look
+   * inside it: in a running deployment that state lasts about as long as one
+   * upload, and a proof that raced it would be a proof about timing.
+   */
+  readonly drainsPendingEvidence?: boolean;
 };
 
 export type Api = {
@@ -99,6 +113,15 @@ export type Api = {
    * nobody can reach is a thing nobody can test.
    */
   readonly identity: Identity;
+  /**
+   * This process's drainer once the server is ready, or nothing where it names
+   * no ingestion store or was built not to drain.
+   *
+   * Handed back on the same terms as the identity provider: whoever owns the
+   * server owns its standing work, and `drainNow` is how a caller waits for a
+   * pass to have *finished* rather than to have been scheduled.
+   */
+  drainer(): Drainer | undefined;
 };
 
 export function buildApi(options: ServerOptions): Api {
@@ -361,12 +384,38 @@ export function buildApi(options: ServerOptions): Api {
   // agent is DB-leased before a provider request, so every API replica can run
   // the same loop without overlapping one target.
   let retellProductionIngestion: RetellProductionIngestion | undefined;
+  // One active drainer per deployment: pending objects into ClickHouse, the
+  // replay-safe handoffs, and then the object. It runs on every process for
+  // now; which processes accept and which drain becomes the role setting's
+  // question, not this file's.
+  let drainer: Drainer | undefined;
   app.addHook("onReady", async () => {
-    // Before anything can be accepted, and before the drainer that will read
-    // the same bucket: opening it recovers whatever the last stop left staged,
-    // so evidence that was in hand when a process died is on its way again
-    // within the first tick rather than after the first new request.
-    openAcceptance({ settings: config.ingestion, log: app.log });
+    // The drainer first, so the hand-off below has somewhere to hand to. Its
+    // own startup scan is what makes that hand-off optional: a segment whose
+    // hint is lost costs a scan interval and never an object.
+    const ingestion = config.ingestion.store;
+    drainer =
+      ingestion === undefined || options.drainsPendingEvidence === false
+        ? undefined
+        : startDrainer({
+            store: pendingObjectStore(ingestion, {
+              requestTimeoutMilliseconds:
+                config.ingestion.requestTimeoutMilliseconds,
+            }),
+            log: app.log,
+            scanIntervalMilliseconds: config.ingestion.scanIntervalMilliseconds,
+          });
+
+    // Opening acceptance recovers whatever the last stop left staged, so
+    // evidence that was in hand when a process died is on its way again within
+    // the first tick rather than after the first new request.
+    openAcceptance({
+      settings: config.ingestion,
+      log: app.log,
+      onSegmentDurable: (segment) => {
+        drainer?.wake(segment.key);
+      },
+    });
     orphanSweep = startOrphanSweep({
       log: app.log,
       ...(options.orphanSweepIntervalMilliseconds === undefined
@@ -389,10 +438,13 @@ export function buildApi(options: ServerOptions): Api {
     // and then the stores knows the sweep holds no connection to them.
     await orphanSweep?.stop();
     await retellProductionIngestion?.stop();
-    // Last, and it uploads nothing on the way out: what is staged is on the
-    // disk with its checksums, and the next start is what sends it.
+    // Acceptance before the drainer, so nothing new is uploaded into a bucket
+    // nobody is reading; and neither uploads nor drains anything on the way
+    // out. What is staged is on the disk with its checksums and what is pending
+    // is in the bucket, and the next start is what moves both.
     await closeAcceptance();
+    await drainer?.stop();
   });
 
-  return { app, identity };
+  return { app, identity, drainer: () => drainer };
 }

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -148,6 +148,7 @@ beforeAll(async () => {
     retellFetch: browserRetellFetch,
     platformSettings: BROWSER_PHONE_SETTINGS,
     ...(storage.available ? { blob: storage.store } : {}),
+    ...(storage.available ? { ingestStore: storage.ingestStore } : {}),
   });
   origin = instance.origin;
 
@@ -1932,13 +1933,13 @@ describe.skipIf(!storage.available)("hearing a recording from a transcript", () 
       // two views of one conversation.
       const at = new Date(AT.getTime() - 5 * 60 * 1000);
       const heard = await fileTranscriptOf(
-        instance.api,
+        instance,
         run.heard,
         { human: "I need to move my cleaning.", agent: "Of course — when to?" },
         at,
       );
       const silent = await fileTranscriptOf(
-        instance.api,
+        instance,
         run.silent,
         { human: "Hello? Is anybody there?", agent: "" },
         at,
@@ -3019,7 +3020,7 @@ describe("the complete product, walked in order in a second project", () => {
         );
       }
       await fileTranscriptOf(
-        instance.api,
+        instance,
         landed,
         {
           human: "I need to move my cleaning to next week.",

--- a/apps/api/test/ingestion-accept.test.ts
+++ b/apps/api/test/ingestion-accept.test.ts
@@ -403,6 +403,9 @@ describe.skipIf(!storage.available)("an object store that has gone quiet", () =>
         ingestion: { ...api.config.ingestion, store: running.ingestStore },
       },
       retellProductionIngestionIntervalMilliseconds: 60 * 60_000,
+      // The recovered segment is left in the bucket to be looked at, which is
+      // this file's claim; that it is then drained is the drain suite's.
+      drainsPendingEvidence: false,
     });
     await restarted.app.ready();
 

--- a/apps/api/test/ingestion-accept.test.ts
+++ b/apps/api/test/ingestion-accept.test.ts
@@ -1,10 +1,19 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer as createProxy, request } from "node:http";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import type { NewSpan } from "@egma/db";
+
+import {
+  acceptEvidenceForProjects,
+  IngestionUnavailableError,
+  stagedEvidence,
+  type EvidenceGroup,
+} from "../src/ingestion/accept.ts";
 import { buildApi } from "../src/server.ts";
 import type { IngestionStore } from "../src/ingestion/object-store.ts";
 import { RECORD_FORMAT_VERSION } from "../src/ingestion/record.ts";
@@ -83,6 +92,128 @@ async function aStoreThatNeverAnswers(): Promise<{
       held.close();
       held.unref();
     },
+  };
+}
+
+/**
+ * Something wearing the store's address that refuses the Nth object it is asked
+ * to create, and forwards everything else untouched.
+ *
+ * A proxy rather than a stand-in client, because what has to be proved is the
+ * real client meeting a real refusal: the request is signed for this address
+ * and passed on byte for byte, headers included, so the store validates the
+ * signature it was given and the only thing that changes is which call comes
+ * back as a `503`.
+ */
+type RefusingStore = {
+  readonly store: IngestionStore;
+  /**
+   * Let this many object creations through and refuse every one after them.
+   *
+   * Every one, rather than a single call, because the client retries a `503`
+   * on its own: refusing once would be answered by a retry that succeeded, and
+   * the acceptance module would never see a failure at all.
+   */
+  refuseEveryPutAfter(calls: number): void;
+  /** Answer normally again. */
+  stopRefusing(): void;
+  close(): void;
+};
+
+async function aStoreRefusingOnePut(
+  real: IngestionStore,
+): Promise<RefusingStore> {
+  const upstream = new URL(real.endpoint);
+  let putsUntilRefusal: number | undefined;
+
+  const held = createProxy((incoming, answering) => {
+    if (incoming.method === "PUT" && putsUntilRefusal !== undefined) {
+      if (putsUntilRefusal === 0) {
+        answering.writeHead(503, { "content-type": "application/xml" });
+        answering.end(
+          "<Error><Code>SlowDown</Code><Message>not now</Message></Error>",
+        );
+        incoming.resume();
+        return;
+      }
+      putsUntilRefusal -= 1;
+    }
+
+    const forwarded = request(
+      {
+        host: upstream.hostname,
+        port: upstream.port,
+        method: incoming.method,
+        path: incoming.url,
+        headers: incoming.headers,
+      },
+      (answer) => {
+        answering.writeHead(answer.statusCode ?? 502, answer.headers);
+        answer.pipe(answering);
+      },
+    );
+    forwarded.on("error", () => {
+      answering.writeHead(502).end();
+      incoming.resume();
+    });
+    incoming.pipe(forwarded);
+  });
+
+  await new Promise<void>((listening) => {
+    held.listen(0, "127.0.0.1", listening);
+  });
+  const address = held.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("the refusing store did not take a port");
+  }
+
+  return {
+    store: { ...real, endpoint: `http://127.0.0.1:${address.port}` },
+    refuseEveryPutAfter(calls) {
+      putsUntilRefusal = calls;
+    },
+    stopRefusing() {
+      putsUntilRefusal = undefined;
+    },
+    close() {
+      held.close();
+      held.unref();
+    },
+  };
+}
+
+/** One normalized span, as a door hands one over. */
+function aSpanOf(spanId: string): NewSpan {
+  return {
+    traceId: `${spanId}${spanId}`,
+    spanId,
+    parentSpanId: "",
+    source: "production",
+    emitter: "agent",
+    environment: "default",
+    startedAtMicroseconds: BigInt(Date.parse("2026-08-20T09:00:00Z")) * 1_000n,
+    durationNanoseconds: 1_000_000_000n,
+    name: "agent_session",
+    kind: "root",
+    status: "ok",
+    text: "",
+    audioUrl: "",
+    toolName: "",
+    toolArguments: "",
+    toolResult: "",
+    providerCallId: "",
+    agentPlatform: "livekit_agents",
+    platformAgentId: "",
+    platformAgentName: "",
+    platformAgentVersion: "",
+    connectionKind: "livekit",
+    runId: "",
+    agentId: "",
+    agentVersionId: "",
+    testVersionId: "",
+    personaVersionId: "",
+    payload: "{}",
+    endsTrace: true,
   };
 }
 
@@ -447,5 +578,110 @@ describe.skipIf(!storage.available)("an object store that has gone quiet", () =>
         "where trace_id = 'ee55ee55ee55ee55ee55ee55ee55ee55'",
     );
     expect(Number(turns?.n)).toBe(1);
+  });
+});
+
+/**
+ * A batch naming two projects, one of whose segments the store refuses.
+ *
+ * **The answer is all or nothing, and no evidence is discarded either way.** A
+ * trusted service batch may carry more than one project, each project gets a
+ * segment of its own, and the request is a success only once every one of them
+ * is durable — so a store that takes one and refuses the other is a retryable
+ * refusal for the whole call.
+ *
+ * What the two halves then are is deliberately different, and both are safe.
+ * The project whose segment landed is **durable**, and stays so: an object in
+ * the store is not un-made by another project's failure. The project whose
+ * segment was refused is **still staged**, and stays so until the store
+ * confirms it. A sender's retry meets one of each, and stable identity makes
+ * the meeting a replay rather than a duplicate.
+ *
+ * The fault sits on the wire rather than behind an injected client, so what is
+ * proved is the real client meeting a real refusal from something wearing the
+ * store's address.
+ */
+describe.skipIf(!storage.available)("a store that refuses one project's segment", () => {
+  const running = storage as Extract<ObjectStorage, { available: true }>;
+
+  let refusing: RefusingStore;
+  let api: TestApi;
+  let acme: Customer;
+  let globex: Customer;
+
+  function groupFor(person: Customer, spanId: string): EvidenceGroup {
+    return {
+      auth: {
+        userId: person.userId,
+        organizationId: person.organizationId,
+        projectId: person.projectId,
+        role: "member",
+        via: "api_key",
+      },
+      spans: [aSpanOf(spanId)],
+    };
+  }
+
+  beforeAll(async () => {
+    if (!storage.available) return;
+    refusing = await aStoreRefusingOnePut(running.ingestStore);
+    api = await createApi("ingestion_partial_batch", {
+      traceStore: true,
+      ingestStore: refusing.store,
+      // Long enough that the refused segment is still staged when the
+      // assertions read it, and short enough that the retry below is prompt.
+      ingestionRequestTimeoutMilliseconds: 2_000,
+    });
+    acme = await signUp(api.app, "ada@acme.example", "Acme");
+    globex = await signUp(api.app, "grace@globex.example", "Globex");
+  });
+
+  afterAll(async () => {
+    await api?.close();
+    refusing?.close();
+  });
+
+  it("refuses the whole call retryably and keeps both projects' records staged", async () => {
+    refusing.refuseEveryPutAfter(1);
+
+    await expect(
+      acceptEvidenceForProjects([
+        groupFor(acme, "9a9a9a9a00000001"),
+        groupFor(globex, "9b9b9b9b00000001"),
+      ]),
+    ).rejects.toBeInstanceOf(IngestionUnavailableError);
+
+    // Nothing was discarded to make the refusal look tidy. One project's
+    // segment reached the store and stays there — a durable object is not
+    // un-made by another project's failure — and the project whose segment was
+    // refused is still staged, still in hand, still on its way.
+    const landed = await pendingSegments(running.ingestStore);
+    expect(landed).toHaveLength(1);
+    const stillStaged = stagedEvidence();
+    expect(stillStaged).toHaveLength(1);
+    expect(
+      [
+        ...landed.map((segment) => segment.header.project_id),
+        ...stillStaged.map((one) => one.scope.projectId),
+      ].sort(),
+    ).toEqual([acme.projectId, globex.projectId].sort());
+
+    // And with the store answering again, the standing loop finishes what is
+    // left: one segment for each project, the one that already landed
+    // untouched under the identity it was sealed with.
+    refusing.stopRefusing();
+    await expect
+      .poll(async () => (await pendingSegments(running.ingestStore)).length, {
+        timeout: 10_000,
+      })
+      .toBe(2);
+    expect(stagedEvidence()).toHaveLength(0);
+
+    const projects = (await pendingSegments(running.ingestStore))
+      .map((segment) => segment.header.project_id)
+      .sort();
+    expect(projects).toEqual([acme.projectId, globex.projectId].sort());
+
+    await drainPendingEvidence(running.ingestStore);
   });
 });

--- a/apps/api/test/ingestion-accept.test.ts
+++ b/apps/api/test/ingestion-accept.test.ts
@@ -1,0 +1,448 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { buildApi } from "../src/server.ts";
+import type { IngestionStore } from "../src/ingestion/object-store.ts";
+import { RECORD_FORMAT_VERSION } from "../src/ingestion/record.ts";
+import { PENDING_PREFIX } from "../src/ingestion/segment.ts";
+import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import {
+  drainPendingEvidence,
+  pendingSegments,
+} from "./support/ingestion.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
+import { mintKey, signUp, type Customer } from "./support/traces.ts";
+
+/**
+ * The acceptance boundary, entered through the door a customer really uses.
+ *
+ * One promise is under test here and it is the whole design: **a request is
+ * answered as accepted only when its evidence is durable in the object store.**
+ * Not when it normalized, not when it reached the local log, and — the change
+ * this release is — not when a row was written. So every question this file
+ * asks is asked in the gap the door now leaves: what is in the bucket before
+ * anything drains it, what is in the bucket when the request was refused, and
+ * what a sender was told either way.
+ *
+ * It runs against a real MinIO, a real Postgres and a real ClickHouse, because
+ * every one of those answers a question no stand-in can. The door tests next
+ * door still own the wire contract; what is proved here is the boundary behind
+ * it.
+ */
+
+const storage: ObjectStorage = await startObjectStorage("ingestion-accept");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the acceptance suite — ${storage.why}\n\n`,
+  );
+}
+
+/**
+ * A store that answers a connection and then nothing at all.
+ *
+ * The failure this exists to reproduce is the one the request bound is for: not
+ * a bucket that refuses — that would answer instantly — but a bucket that has
+ * gone quiet while holding the request open. A refused connection would prove
+ * the error path and say nothing about the bound, which is the part a customer
+ * feels.
+ */
+async function aStoreThatNeverAnswers(): Promise<{
+  readonly store: IngestionStore;
+  readonly close: () => void;
+}> {
+  const held: Server = createServer((socket) => {
+    // Accepted and then ignored, deliberately. The socket is kept so the
+    // client sees an open connection rather than a reset.
+    socket.on("error", () => undefined);
+  });
+  await new Promise<void>((listening) => {
+    held.listen(0, "127.0.0.1", listening);
+  });
+  const address = held.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("the silent store did not take a port");
+  }
+  return {
+    store: {
+      endpoint: `http://127.0.0.1:${address.port}`,
+      bucket: "egma-ingestion",
+      region: "us-east-1",
+      accessKeyId: "SENTINEL-silent-store-key-id",
+      secretAccessKey: "SENTINEL-silent-store-secret",
+    },
+    close: () => {
+      held.close();
+      held.unref();
+    },
+  };
+}
+
+function jsonSpan(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    traceId: "c0ffee00c0ffee00c0ffee00c0ffee00",
+    spanId: "c0ffee0000000001",
+    name: "agent_turn",
+    startTimeUnixNano: "1785693880281989804",
+    endTimeUnixNano: "1785693881281989804",
+    attributes: [
+      { key: "lk.response.text", value: { stringValue: "I am here." } },
+    ],
+    ...overrides,
+  };
+}
+
+function jsonExport(spans: readonly Record<string, unknown>[]): string {
+  return JSON.stringify({
+    resourceSpans: [
+      {
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: "livekit-agents" }, spans }],
+      },
+    ],
+  });
+}
+
+describe.skipIf(!storage.available)("evidence at the acceptance boundary", () => {
+  const running = storage as Extract<ObjectStorage, { available: true }>;
+
+  let api: TestApi;
+  let acme: Customer;
+  let secret: string;
+
+  async function post(
+    body: string,
+    headers: Record<string, string> = {},
+  ): Promise<{ statusCode: number; body: string }> {
+    const answer = await api.app.inject({
+      method: "POST",
+      url: OTLP_TRACES_PATH,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`,
+        ...headers,
+      },
+      payload: body,
+    });
+    return { statusCode: answer.statusCode, body: answer.body };
+  }
+
+  async function countOf(query: string): Promise<number> {
+    const traceStore = api.traceStore;
+    if (traceStore === undefined) throw new Error("this API has no trace store");
+    const [row] = await traceStore.rows<{ n: string }>(query);
+    return Number(row?.n ?? -1);
+  }
+
+  beforeAll(async () => {
+    api = await createApi("ingestion_accept", {
+      traceStore: true,
+      ingestStore: running.ingestStore,
+    });
+    acme = await signUp(api.app, "ada@acme.example", "Acme");
+    secret = await mintKey(api.app, acme.cookie, "the outbound agent", acme.projectId);
+  });
+
+  afterAll(async () => {
+    await api?.close();
+  });
+
+  it("is in the object store before the request is answered, and in no row yet", async () => {
+    const before = await countOf("select count() as n from spans final");
+
+    const answered = await post(jsonExport([jsonSpan()]));
+    expect(answered.statusCode, answered.body).toBe(200);
+
+    // The request has been answered, so the promise has been made. Nothing has
+    // drained yet, so the only place that promise can be kept is the bucket.
+    const pending = await pendingSegments(running.ingestStore);
+    expect(pending).toHaveLength(1);
+    expect(await countOf("select count() as n from spans final")).toBe(before);
+
+    expect(await drainPendingEvidence(running.ingestStore)).toBe(1);
+    expect(await countOf("select count() as n from spans final")).toBe(before + 1);
+  });
+
+  it("is one sealed object naming a version, one trusted project, and no credential", async () => {
+    const answered = await post(
+      jsonExport([
+        jsonSpan({
+          traceId: "aa11aa11aa11aa11aa11aa11aa11aa11",
+          spanId: "aa11aa1100000001",
+        }),
+      ]),
+    );
+    expect(answered.statusCode, answered.body).toBe(200);
+
+    const [pending] = await pendingSegments(running.ingestStore);
+    if (pending === undefined) throw new Error("nothing was staged");
+
+    expect(pending.key.startsWith(PENDING_PREFIX)).toBe(true);
+    expect(pending.header).toMatchObject({
+      v: RECORD_FORMAT_VERSION,
+      organization_id: acme.organizationId,
+      project_id: acme.projectId,
+      record_count: 1,
+    });
+    expect(pending.records).toHaveLength(1);
+    expect(pending.records[0]).toMatchObject({
+      v: RECORD_FORMAT_VERSION,
+      trace_id: "aa11aa11aa11aa11aa11aa11aa11aa11",
+      span_id: "aa11aa1100000001",
+      source: "production",
+    });
+
+    // The key names the segment and nothing else: tenancy is sealed inside the
+    // object, where the checksum covers it, so no rename can make an object
+    // claim a customer it does not hold.
+    expect(pending.key).not.toContain(acme.organizationId);
+    expect(pending.key).not.toContain(acme.projectId);
+
+    // And nothing operational rode along. The credential that authenticated
+    // the request lives outside the evidence and never enters a record.
+    const bytes = JSON.stringify(pending);
+    expect(bytes).not.toContain(secret);
+    expect(bytes).not.toContain(running.ingestStore.secretAccessKey);
+    expect(bytes).not.toContain(running.ingestStore.accessKeyId);
+
+    await drainPendingEvidence(running.ingestStore);
+  });
+
+  it("keeps a customer's credential-looking values byte for byte", async () => {
+    const transcript =
+      "My password is hunter2 and the header said Authorization: Bearer abc.123";
+    const answered = await post(
+      jsonExport([
+        jsonSpan({
+          traceId: "bb22bb22bb22bb22bb22bb22bb22bb22",
+          spanId: "bb22bb2200000001",
+          attributes: [
+            { key: "lk.response.text", value: { stringValue: transcript } },
+            { key: "api_key", value: { stringValue: "customer-named-this" } },
+            {
+              key: "session.id",
+              value: { stringValue: "Bearer looks-like-one-and-is-not" },
+            },
+          ],
+        }),
+      ]),
+    );
+    expect(answered.statusCode, answered.body).toBe(200);
+
+    const [pending] = await pendingSegments(running.ingestStore);
+    const record = pending?.records[0];
+    if (record === undefined) throw new Error("nothing was staged");
+
+    expect(record.text).toBe(transcript);
+    expect(record.payload).toContain("customer-named-this");
+    expect(record.payload).toContain("Bearer looks-like-one-and-is-not");
+    expect(JSON.stringify(pending)).not.toContain("REDACTED");
+
+    await drainPendingEvidence(running.ingestStore);
+  });
+
+  it("stages nothing at all for a credential the door will not take", async () => {
+    const anonymous = await post(jsonExport([jsonSpan()]), {
+      authorization: "Bearer egma_sk_not-a-key-this-deployment-minted",
+    });
+    expect(anonymous.statusCode).toBe(401);
+    expect(await pendingSegments(running.ingestStore)).toHaveLength(0);
+  });
+
+  it("stages nothing at all for a body the door cannot read", async () => {
+    const unreadable = await post("{ not json at all");
+    expect(unreadable.statusCode).toBe(400);
+    expect(await pendingSegments(running.ingestStore)).toHaveLength(0);
+  });
+
+  it("stages only the valid remainder when part of an export is refused", async () => {
+    const answered = await post(
+      jsonExport([
+        jsonSpan({
+          traceId: "cc33cc33cc33cc33cc33cc33cc33cc33",
+          spanId: "cc33cc3300000001",
+        }),
+        jsonSpan({ traceId: "not-an-otel-trace-id", spanId: "not-an-id" }),
+      ]),
+    );
+    expect(answered.statusCode, answered.body).toBe(200);
+    expect(JSON.parse(answered.body)).toEqual({
+      partialSuccess: {
+        rejectedSpans: "1",
+        errorMessage: expect.any(String),
+      },
+    });
+
+    const [pending] = await pendingSegments(running.ingestStore);
+    expect(pending?.records).toHaveLength(1);
+    expect(pending?.records[0]).toMatchObject({
+      span_id: "cc33cc3300000001",
+    });
+
+    await drainPendingEvidence(running.ingestStore);
+  });
+
+  it("refuses a record over a documented bound by name, and stages neither it nor a shortened one", async () => {
+    const tooLong = "n".repeat(1_100);
+    const answered = await post(
+      jsonExport([
+        jsonSpan({
+          traceId: "dd44dd44dd44dd44dd44dd44dd44dd44",
+          spanId: "dd44dd4400000001",
+          name: tooLong,
+        }),
+        jsonSpan({
+          traceId: "dd44dd44dd44dd44dd44dd44dd44dd44",
+          spanId: "dd44dd4400000002",
+        }),
+      ]),
+    );
+
+    // A 200 with a count and a reason, which is what the specification says to
+    // answer data that must not be retried — never a 5xx an exporter would
+    // resend forever, and never a truncated row that reads as a whole one.
+    expect(answered.statusCode, answered.body).toBe(200);
+    const refusal = JSON.parse(answered.body) as {
+      partialSuccess: { rejectedSpans: string; errorMessage: string };
+    };
+    expect(refusal.partialSuccess.rejectedSpans).toBe("1");
+    expect(refusal.partialSuccess.errorMessage).toContain("name");
+    expect(refusal.partialSuccess.errorMessage).toContain("1024");
+    expect(refusal.partialSuccess.errorMessage).toContain("1100");
+
+    const [pending] = await pendingSegments(running.ingestStore);
+    expect(pending?.records).toHaveLength(1);
+    expect(pending?.records[0]?.span_id).toBe("dd44dd4400000002");
+    expect(JSON.stringify(pending)).not.toContain(tooLong);
+
+    await drainPendingEvidence(running.ingestStore);
+  });
+});
+
+/**
+ * The store stops answering, and the whole promise is tested at once: the
+ * refusal a sender can act on, the staged evidence nothing threw away, the
+ * upload a later start finishes, and the one visible span a client's retry
+ * leaves behind.
+ *
+ * It gets its own instance because it needs two of them over one local log —
+ * which is what a restart is — and because the bound it proves is a second
+ * rather than the deployment's ten.
+ */
+describe.skipIf(!storage.available)("an object store that has gone quiet", () => {
+  const running = storage as Extract<ObjectStorage, { available: true }>;
+  const logDirectory = mkdtempSync(
+    path.join(tmpdir(), "egma-ingestion-restart-"),
+  );
+
+  let silent: Awaited<ReturnType<typeof aStoreThatNeverAnswers>>;
+  let api: TestApi;
+  let restarted: ReturnType<typeof buildApi> | undefined;
+  let acme: Customer;
+  let secret: string;
+
+  beforeAll(async () => {
+    silent = await aStoreThatNeverAnswers();
+    api = await createApi("ingestion_unreachable", {
+      traceStore: true,
+      ingestStore: silent.store,
+      ingestionLogDirectory: logDirectory,
+      ingestionRequestTimeoutMilliseconds: 700,
+    });
+    acme = await signUp(api.app, "ada@acme.example", "Acme");
+    secret = await mintKey(api.app, acme.cookie, "the outbound agent", acme.projectId);
+  });
+
+  afterAll(async () => {
+    await restarted?.app.close();
+    await api?.close();
+    silent?.close();
+    rmSync(logDirectory, { recursive: true, force: true });
+  });
+
+  it("answers 503, keeps the staged evidence, and lands it once on the next start", async () => {
+    const body = jsonExport([
+      jsonSpan({
+        traceId: "ee55ee55ee55ee55ee55ee55ee55ee55",
+        spanId: "ee55ee5500000001",
+      }),
+    ]);
+
+    const refused = await api.app.inject({
+      method: "POST",
+      url: OTLP_TRACES_PATH,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`,
+      },
+      payload: body,
+    });
+    // Not a rejection: an exporter stops resending what it is told was
+    // rejected, and this evidence is still on its way.
+    expect(refused.statusCode).toBe(503);
+    expect(refused.json()).toMatchObject({
+      code: 14,
+      message: expect.stringContaining("send it again"),
+    });
+    expect(await pendingSegments(running.ingestStore)).toHaveLength(0);
+
+    // The process stops with the record staged and starts again against a
+    // store that answers — the same local log, and nothing in it discarded.
+    await api.app.close();
+    restarted = buildApi({
+      config: {
+        ...api.config,
+        ingestion: { ...api.config.ingestion, store: running.ingestStore },
+      },
+      retellProductionIngestionIntervalMilliseconds: 60 * 60_000,
+    });
+    await restarted.app.ready();
+
+    await expect
+      .poll(async () => (await pendingSegments(running.ingestStore)).length, {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    // And the client's retry, which meets evidence already on its way. One
+    // immutable identity, so the two are a replay of each other.
+    const retried = await restarted.app.inject({
+      method: "POST",
+      url: OTLP_TRACES_PATH,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`,
+      },
+      payload: body,
+    });
+    expect(retried.statusCode, retried.body).toBe(200);
+
+    await expect
+      .poll(async () => (await pendingSegments(running.ingestStore)).length, {
+        timeout: 10_000,
+      })
+      .toBe(2);
+    await drainPendingEvidence(running.ingestStore);
+
+    const traceStore = api.traceStore;
+    if (traceStore === undefined) throw new Error("this API has no trace store");
+    const [spans] = await traceStore.rows<{ n: string }>(
+      "select count() as n from spans final " +
+        "where trace_id = 'ee55ee55ee55ee55ee55ee55ee55ee55'",
+    );
+    expect(Number(spans?.n)).toBe(1);
+    const [turns] = await traceStore.rows<{ n: string }>(
+      "select count() as n from turns final " +
+        "where trace_id = 'ee55ee55ee55ee55ee55ee55ee55ee55'",
+    );
+    expect(Number(turns?.n)).toBe(1);
+  });
+});

--- a/apps/api/test/ingestion-accept.test.ts
+++ b/apps/api/test/ingestion-accept.test.ts
@@ -117,6 +117,8 @@ type RefusingStore = {
   refuseEveryPutAfter(calls: number): void;
   /** Answer normally again. */
   stopRefusing(): void;
+  /** How many object creations have been asked for, refused ones included. */
+  putsSeen(): number;
   close(): void;
 };
 
@@ -125,13 +127,15 @@ async function aStoreRefusingOnePut(
 ): Promise<RefusingStore> {
   const upstream = new URL(real.endpoint);
   let putsUntilRefusal: number | undefined;
+  let puts = 0;
 
   const held = createProxy((incoming, answering) => {
+    if (incoming.method === "PUT") puts += 1;
     if (incoming.method === "PUT" && putsUntilRefusal !== undefined) {
       if (putsUntilRefusal === 0) {
-        answering.writeHead(503, { "content-type": "application/xml" });
+        answering.writeHead(403, { "content-type": "application/xml" });
         answering.end(
-          "<Error><Code>SlowDown</Code><Message>not now</Message></Error>",
+          "<Error><Code>AccessDenied</Code><Message>not now</Message></Error>",
         );
         incoming.resume();
         return;
@@ -174,6 +178,9 @@ async function aStoreRefusingOnePut(
     },
     stopRefusing() {
       putsUntilRefusal = undefined;
+    },
+    putsSeen() {
+      return puts;
     },
     close() {
       held.close();
@@ -683,5 +690,103 @@ describe.skipIf(!storage.available)("a store that refuses one project's segment"
     expect(projects).toEqual([acme.projectId, globex.projectId].sort());
 
     await drainPendingEvidence(running.ingestStore);
+  });
+});
+
+/**
+ * A store that keeps refusing, and the pace at which Egma asks it again.
+ *
+ * A sealed segment whose upload failed stays sealed, which is what keeps the
+ * evidence — and it also means the group is permanently *due*, so the standing
+ * loop would otherwise wake, fail and wake again with nothing between the
+ * attempts. Against a store that is refusing quickly, that is a loop as fast as
+ * the network answers: it spends this service's capacity and lands on the
+ * failing store as a flood, at exactly the moment the store is least able to
+ * take one.
+ *
+ * So an attempt that failed puts its own group aside for a while. The wait
+ * starts at the flush interval and doubles up to the request bound — two
+ * settings this path already has, rather than a third nobody has tuned — and it
+ * ends the moment an attempt succeeds. Nothing is discarded while it waits, and
+ * a request that is waiting keeps its own bound and its own `503`.
+ */
+describe.skipIf(!storage.available)("a store that keeps refusing", () => {
+  const running = storage as Extract<ObjectStorage, { available: true }>;
+
+  let refusing: RefusingStore;
+  let api: TestApi;
+  let acme: Customer;
+
+  beforeAll(async () => {
+    if (!storage.available) return;
+    refusing = await aStoreRefusingOnePut(running.ingestStore);
+    api = await createApi("ingestion_refusing_store", {
+      traceStore: true,
+      ingestStore: refusing.store,
+      ingestionFlushMilliseconds: 100,
+      ingestionRequestTimeoutMilliseconds: 1_000,
+    });
+    acme = await signUp(api.app, "ada@acme.example", "Acme");
+  });
+
+  afterAll(async () => {
+    await api?.close();
+    refusing?.close();
+  });
+
+  it("spaces its attempts, keeps the evidence, and lands it once the store answers", async () => {
+    refusing.refuseEveryPutAfter(0);
+
+    await expect(
+      acceptEvidenceForProjects([
+        {
+          auth: {
+            userId: acme.userId,
+            organizationId: acme.organizationId,
+            projectId: acme.projectId,
+            role: "member",
+            via: "api_key",
+          },
+          spans: [aSpanOf("9c9c9c9c00000001")],
+        },
+      ]),
+    ).rejects.toBeInstanceOf(IngestionUnavailableError);
+
+    // Two seconds of a store saying no. Backing off from a 100ms flush toward
+    // a 1s bound is a handful of attempts; rescheduling for *now* on every
+    // failure measures in the hundreds against a store on loopback.
+    //
+    // The refusal is one the store client will not retry inside a single call,
+    // deliberately. A retryable status would be paced by that client's own
+    // policy — a dependency's property, and one that says nothing about
+    // whether this loop waits.
+    const before = refusing.putsSeen();
+    await new Promise((waited) => setTimeout(waited, 2_000));
+    const asked = refusing.putsSeen() - before;
+    expect(asked).toBeLessThan(15);
+    // And it has not given up either — the segment is still being offered.
+    expect(asked).toBeGreaterThan(0);
+
+    // Nothing was discarded to make the waiting cheap.
+    expect(stagedEvidence().map((one) => one.record.span_id)).toEqual([
+      "9c9c9c9c00000001",
+    ]);
+
+    // The first attempt that is answered lands it, once.
+    refusing.stopRefusing();
+    await expect
+      .poll(async () => (await pendingSegments(running.ingestStore)).length, {
+        timeout: 10_000,
+      })
+      .toBe(1);
+    expect(stagedEvidence()).toHaveLength(0);
+
+    expect(await drainPendingEvidence(running.ingestStore)).toBe(1);
+    const traceStore = api.traceStore;
+    if (traceStore === undefined) throw new Error("this API has no trace store");
+    const [row] = await traceStore.rows<{ n: string }>(
+      "select count() as n from spans final where span_id = '9c9c9c9c00000001'",
+    );
+    expect(Number(row?.n)).toBe(1);
   });
 });

--- a/apps/api/test/ingestion-drain.test.ts
+++ b/apps/api/test/ingestion-drain.test.ts
@@ -499,13 +499,60 @@ describe.skipIf(!storage.available)("draining an accepted segment", () => {
     // organization or a segment id in a metric label is an unbounded set of
     // values, and the first bucket full of damaged objects would be the one
     // that took the metrics down.
-    expect([...retainedDefects().keys()].sort()).toEqual([
+    const counted = retainedDefects();
+    expect([...counted.keys()].sort()).toEqual([
       "checksum_mismatch",
       "not_gzip",
     ]);
+    expect([...counted.values()]).toEqual([1, 1]);
+
+    // A retained object stays under its key until a person deals with it, so
+    // every scan finds it again. It is reported once: a count that grew on
+    // every pass would measure how long this process has been up rather than
+    // how many objects are stuck.
+    expect(await drainer.drainNow()).toBe(0);
+    expect([...retainedDefects().values()]).toEqual([1, 1]);
+    expect((await pending()).map((object) => object.key)).toContain(
+      pendingKeyFor(damaged),
+    );
 
     await bucket.delete(pendingKeyFor(damaged));
     await bucket.delete(pendingKeyFor(lying));
+  });
+
+  /**
+   * **A tenancy the control database has never agreed to is not a tenancy.**
+   *
+   * The checksum covers the header, so the organization and project a segment
+   * names are the pair it was sealed with and nothing can have edited them.
+   * That the pair is a *real* one is a separate question and only Postgres can
+   * answer it — so it is asked before a row is written, because a write under a
+   * pair nobody owns is one customer's evidence filed under another's name.
+   */
+  it("retains a segment naming a project outside its own organization", async () => {
+    const traceId = "6600000000000000000000000000f600";
+    const elsewhere = await signUp(api.app, "grace@globex.example", "Globex");
+
+    const sealed = sealSegment({
+      // Acme's organization, Globex's project. Sealed and checksummed as such,
+      // so it verifies perfectly and is still a pair that does not exist.
+      scope: {
+        organizationId: acme.organizationId,
+        projectId: elsewhere.projectId,
+      },
+      records: aConversation(traceId),
+    });
+    await bucket.create(sealed);
+
+    expect(await drainer.drainNow()).toBe(0);
+    expect((await pending()).map((object) => object.key)).toContain(sealed.key);
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(0);
+
+    await bucket.delete(sealed.key);
   });
 
   it("leaves an object it could not read where it is, and takes it on the next pass", async () => {

--- a/apps/api/test/ingestion-drain.test.ts
+++ b/apps/api/test/ingestion-drain.test.ts
@@ -1,0 +1,754 @@
+import {
+  committedSpans,
+  configureLiveKitMonitoring,
+  connectClickHouse,
+  disconnectClickHouse,
+  listMonitoringSetups,
+  type AuthContext,
+} from "@egma/db";
+import { gzipSync } from "node:zlib";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  forgetRetainedDefects,
+  retainedDefects,
+} from "../src/ingestion/defects.ts";
+import { startDrainer, type Drainer } from "../src/ingestion/drainer.ts";
+import {
+  pendingObjectStore,
+  type PendingObject,
+  type PendingObjectStore,
+} from "../src/ingestion/object-store.ts";
+import { contentHashOf, type IngestionRecord } from "../src/ingestion/record.ts";
+import {
+  pendingKeyFor,
+  sealSegment,
+  type SegmentScope,
+} from "../src/ingestion/segment.ts";
+import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
+import { createApi, type TestApi } from "./support/api.ts";
+import { aRecord } from "./support/ingestion.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
+import { mintKey, signUp, type Customer } from "./support/traces.ts";
+
+/**
+ * The segment lifecycle, with the faults that decide whether it is correct.
+ *
+ * Everything before this point can be proved by a request answering. Draining
+ * cannot: it is the half of ingestion where nobody is waiting, where every step
+ * can stop between two others, and where the only thing standing between a
+ * customer's evidence and a silent loss is that each step is safe to do again.
+ * So this is the one deep-module family the design allows, and every case in it
+ * is a failure rather than a feature.
+ *
+ * ## What is faulted, and where each fault comes from
+ *
+ * The object store is wrapped, so a read, a listing or a deletion can be made
+ * to fail exactly once — which is what a store timing out really looks like.
+ * ClickHouse is disconnected, which is what a cold start really looks like. The
+ * handoffs are stopped with a constraint the upsert violates, which is the one
+ * way to make Postgres refuse a specific write without making it refuse every
+ * write. Nothing here reaches inside the drainer to count calls: every claim is
+ * about what is in the bucket, in the store, and in the tables afterwards.
+ *
+ * ## The one crash point proved next door
+ *
+ * A crash after the local append and before the upload is proved at the
+ * acceptance seam in `ingestion-accept.test.ts`, because that is where the
+ * staged record lives and where the restart that recovers it happens. Repeating
+ * it here would be a second stack for one claim.
+ */
+
+const storage: ObjectStorage = await startObjectStorage("ingestion-drain");
+
+if (!storage.available) {
+  process.stderr.write(`\nskipping the drain suite — ${storage.why}\n\n`);
+}
+
+afterAll(() => {
+  if (storage.available) storage.stop();
+});
+
+/** Faults a suite arms, one at a time, on the way to the real bucket. */
+type Faults = {
+  /** The next `read` of this key throws instead of answering. */
+  failReadOf?: string | undefined;
+  /** The next `delete` of this key throws instead of removing it. */
+  failDeleteOf?: string | undefined;
+  /** Every listing throws. */
+  failListing?: boolean | undefined;
+};
+
+function faulting(real: PendingObjectStore, faults: Faults): PendingObjectStore {
+  return {
+    create: (segment) => real.create(segment),
+    async read(key) {
+      if (faults.failReadOf === key) {
+        faults.failReadOf = undefined;
+        throw new Error("the ingestion bucket did not answer this read");
+      }
+      return real.read(key);
+    },
+    async list() {
+      if (faults.failListing === true) {
+        throw new Error("the ingestion bucket did not answer this listing");
+      }
+      return real.list();
+    },
+    async delete(key) {
+      if (faults.failDeleteOf === key) {
+        faults.failDeleteOf = undefined;
+        throw new Error("the ingestion bucket did not remove this object");
+      }
+      await real.delete(key);
+    },
+  };
+}
+
+describe.skipIf(!storage.available)("draining an accepted segment", () => {
+  const running = storage as Extract<ObjectStorage, { available: true }>;
+
+  let api: TestApi;
+  let acme: Customer;
+  let scope: SegmentScope;
+  let auth: AuthContext;
+  let bucket: PendingObjectStore;
+
+  const faults: Faults = {};
+  let drainer: Drainer;
+
+  /**
+   * One conversation as the LiveKit normalizer would have produced it: two
+   * turns inside a session span the platform said ends the trace.
+   */
+  function aConversation(
+    traceId: string,
+    overrides: Partial<IngestionRecord> = {},
+  ): readonly IngestionRecord[] {
+    const at = BigInt(Date.parse("2026-08-20T09:00:00.000Z")) * 1_000n;
+    const root = `${traceId.slice(0, 14)}01`;
+    return [
+      aRecord({
+        trace_id: traceId,
+        span_id: root,
+        parent_span_id: "",
+        name: "agent_session",
+        kind: "root",
+        source: "production",
+        agent_platform: "livekit_agents",
+        platform_agent_id: "agent-under-test",
+        started_at_microseconds: String(at),
+        ends_trace: true,
+        ...overrides,
+      }),
+      aRecord({
+        trace_id: traceId,
+        span_id: `${traceId.slice(0, 14)}02`,
+        parent_span_id: root,
+        name: "agent_turn",
+        kind: "turn:agent",
+        source: "production",
+        agent_platform: "livekit_agents",
+        platform_agent_id: "agent-under-test",
+        started_at_microseconds: String(at + 1_000_000n),
+        text: "Of course — Tuesday at four works.",
+        ...overrides,
+      }),
+    ];
+  }
+
+  /** Put one sealed segment in the bucket and tell nobody, which is the crash. */
+  async function accepted(
+    records: readonly IngestionRecord[],
+    segmentId?: string,
+  ): Promise<string> {
+    const sealed = sealSegment({
+      scope,
+      records,
+      ...(segmentId === undefined ? {} : { segmentId }),
+    });
+    await bucket.create(sealed);
+    return sealed.key;
+  }
+
+  async function pending(): Promise<readonly PendingObject[]> {
+    return bucket.list();
+  }
+
+  /**
+   * Bytes straight into the bucket under a pending key, whatever they are.
+   *
+   * Nothing in the product can produce a damaged object, which is the point of
+   * the cases that need one: they are about what the drainer does with bytes
+   * the product would never have written.
+   */
+  async function put(segmentId: string, body: Uint8Array): Promise<void> {
+    await bucket.create({
+      segmentId,
+      key: pendingKeyFor(segmentId),
+      scope,
+      header: {
+        v: 1,
+        segment_id: segmentId,
+        organization_id: scope.organizationId,
+        project_id: scope.projectId,
+        record_count: 0,
+        content_sha256: "",
+      },
+      body,
+    });
+  }
+
+  async function countOf(query: string): Promise<number> {
+    const traceStore = api.traceStore;
+    if (traceStore === undefined) throw new Error("this API has no trace store");
+    const [row] = await traceStore.rows<{ n: string }>(query);
+    return Number(row?.n ?? -1);
+  }
+
+  async function gradingJobsFor(traceId: string): Promise<
+    readonly { root_closed_at: Date | null; last_seen_at: Date }[]
+  > {
+    const { rows } = await api.database.sql<{
+      root_closed_at: Date | null;
+      last_seen_at: Date;
+    }>("select root_closed_at, last_seen_at from grading_job where trace_id = $1", [
+      traceId,
+    ]);
+    return rows;
+  }
+
+  beforeAll(async () => {
+    if (!storage.available) return;
+    api = await createApi("ingestion_drain", { traceStore: true });
+    acme = await signUp(api.app, "ada@acme.example", "Acme");
+    scope = { organizationId: acme.organizationId, projectId: acme.projectId };
+    auth = {
+      userId: acme.userId,
+      organizationId: acme.organizationId,
+      projectId: acme.projectId,
+      role: "admin",
+      via: "session",
+    };
+    await configureLiveKitMonitoring(auth);
+
+    bucket = pendingObjectStore(running.ingestStore);
+    drainer = startDrainer({
+      // Two keys a page, so the recovery walk needs several of them without
+      // putting a thousand objects in a bucket.
+      store: faulting(
+        pendingObjectStore(running.ingestStore, { listingPageSize: 2 }),
+        faults,
+      ),
+      log: { warn: () => undefined, error: () => undefined },
+      // Long: every pass in this file is asked for, so nothing arrives between
+      // an arrangement and its assertion.
+      scanIntervalMilliseconds: 60 * 60_000,
+    });
+  });
+
+  afterAll(async () => {
+    await drainer?.stop();
+    await api?.close();
+  });
+
+  it("finds an object nobody told it about, and finishes every effect before deleting it", async () => {
+    const traceId = "aa00000000000000000000000000aa00";
+    const key = await accepted(aConversation(traceId));
+
+    // The upload succeeded and the process died before the hand-off. Nothing
+    // in memory knows this object exists.
+    expect(await drainer.drainNow()).toBe(1);
+
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+    expect(
+      await countOf(
+        `select count() as n from turns final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(1);
+    // The platform said the conversation ended, so the handoff says so too.
+    expect(await gradingJobsFor(traceId)).toEqual([
+      { root_closed_at: expect.any(Date), last_seen_at: expect.any(Date) },
+    ]);
+    expect(
+      (await listMonitoringSetups(auth)).find(
+        (setup) => setup.agentPlatform === "livekit_agents",
+      )?.lastReceivedAt,
+    ).toBeInstanceOf(Date);
+
+    // And only then is the object gone.
+    expect((await pending()).map((object) => object.key)).not.toContain(key);
+  });
+
+  it("is harmless to rediscover after a deletion that failed", async () => {
+    const traceId = "bb00000000000000000000000000bb00";
+    const key = await accepted(aConversation(traceId));
+
+    faults.failDeleteOf = key;
+    expect(await drainer.drainNow()).toBe(0);
+    // Everything that depends on the object has happened; the object is still
+    // there, which is exactly the state a delete timeout leaves.
+    expect((await pending()).map((object) => object.key)).toContain(key);
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+
+    // The next pass is the retry, and running the whole object again changes
+    // nothing a reader can see.
+    expect(await drainer.drainNow()).toBe(1);
+    expect((await pending()).map((object) => object.key)).not.toContain(key);
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+    expect(
+      await countOf(
+        `select count() as n from turns final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(1);
+    expect(await gradingJobsFor(traceId)).toHaveLength(1);
+  });
+
+  it("leaves the object pending when the trace store is unavailable, and finishes on the next pass", async () => {
+    const traceId = "cc00000000000000000000000000cc00";
+    const key = await accepted(aConversation(traceId));
+
+    await disconnectClickHouse();
+    try {
+      expect(await drainer.drainNow()).toBe(0);
+    } finally {
+      const traceStore = api.traceStore;
+      if (traceStore === undefined) throw new Error("this API has no trace store");
+      connectClickHouse({ clickhouseUrl: traceStore.url, maxOpenConnections: 4 });
+    }
+
+    // Nothing was written and nothing was deleted: the complete segment is
+    // still there to be replayed.
+    expect((await pending()).map((object) => object.key)).toContain(key);
+    expect(await gradingJobsFor(traceId)).toHaveLength(0);
+
+    expect(await drainer.drainNow()).toBe(1);
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+    expect(await gradingJobsFor(traceId)).toHaveLength(1);
+  });
+
+  it("keeps the object when the handoff fails, and replays only the missing effect", async () => {
+    const traceId = "dd00000000000000000000000000dd00";
+    const key = await accepted(aConversation(traceId));
+
+    // The one way to make Postgres refuse this write and no other. The rows
+    // reach ClickHouse; the handoff behind them does not.
+    // A literal rather than a bind parameter, because Postgres takes no
+    // parameters in DDL. The value is this file's own hex id.
+    await api.database.sql(
+      "alter table grading_job add constraint refuses_this_trace " +
+        `check (trace_id is null or trace_id <> '${traceId}')`,
+    );
+    try {
+      expect(await drainer.drainNow()).toBe(0);
+
+      expect((await pending()).map((object) => object.key)).toContain(key);
+      // Query-visible already, which is the point: the evidence is not held
+      // hostage to a bookkeeping row.
+      expect(
+        await countOf(
+          `select count() as n from spans final where trace_id = '${traceId}'`,
+        ),
+      ).toBe(2);
+      expect(await gradingJobsFor(traceId)).toHaveLength(0);
+    } finally {
+      await api.database.sql(
+        "alter table grading_job drop constraint refuses_this_trace",
+      );
+    }
+
+    // The replay repeats the write it already did — a no-op against evidence
+    // already visible — and completes the one effect that was missing.
+    expect(await drainer.drainNow()).toBe(1);
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+    expect(await gradingJobsFor(traceId)).toEqual([
+      { root_closed_at: expect.any(Date), last_seen_at: expect.any(Date) },
+    ]);
+  });
+
+  it("leaves one visible span and turn when the same evidence is drained under a new identity", async () => {
+    const traceId = "ee00000000000000000000000000ee00";
+    const records = aConversation(traceId);
+    await accepted(records);
+    expect(await drainer.drainNow()).toBe(1);
+
+    // A second segment, same evidence, different identity — which is what a
+    // re-sealed replay is, and what a drain beyond the store's own recent-block
+    // window looks like: a token it has never seen. Identity is the guarantee;
+    // the token is only the shield in front of it.
+    await accepted(records);
+    expect(await drainer.drainNow()).toBe(1);
+
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+    expect(
+      await countOf(
+        `select count() as n from turns final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(1);
+    expect(await gradingJobsFor(traceId)).toHaveLength(1);
+  });
+
+  it("retains a segment whose evidence disagrees with what is already stored, and changes nothing", async () => {
+    const traceId = "ff00000000000000000000000000ff00";
+    const original = aConversation(traceId);
+    await accepted(original);
+    expect(await drainer.drainNow()).toBe(1);
+
+    const changed = original.map((record) =>
+      record.kind === "turn:agent"
+        ? { ...record, text: "Something else entirely." }
+        : record,
+    );
+    const key = await accepted(changed);
+
+    expect(await drainer.drainNow()).toBe(0);
+    // The first account of that moment is still the one a reader gets.
+    expect((await pending()).map((object) => object.key)).toContain(key);
+    const [stored] = await committedSpans(
+      auth,
+      [{ traceId, spanId: `${traceId.slice(0, 14)}02` }],
+      {
+        window: {
+          from: BigInt(Date.parse("2026-08-20T00:00:00.000Z")) * 1_000n,
+          to: BigInt(Date.parse("2026-08-21T00:00:00.000Z")) * 1_000n,
+        },
+      },
+    );
+    expect(stored?.contentHash).toBe(
+      contentHashOf(original[1] as IngestionRecord),
+    );
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}' ` +
+          "and text = 'Something else entirely.'",
+      ),
+    ).toBe(0);
+
+    // The object is retained for repair rather than deleted, and rediscovering
+    // it changes nothing either.
+    expect(await drainer.drainNow()).toBe(0);
+    expect((await pending()).map((object) => object.key)).toContain(key);
+    await bucket.delete(key);
+  });
+
+  it("retains a corrupt object without making any of it visible, and counts it by reason alone", async () => {
+    forgetRetainedDefects();
+    const traceId = "11000000000000000000000000001100";
+    const sealed = sealSegment({ scope, records: aConversation(traceId) });
+
+    // Bytes that are not gzip at all, under a key the pending prefix spells.
+    const damaged = "sgm_01M0000000000000000000CORRUPT";
+    await put(damaged, Buffer.from("not gzip, and never was"));
+    // And a segment whose header states a checksum its records do not have.
+    const lying = "sgm_01M00000000000000000000LYING";
+    await put(
+      lying,
+      gzipSync(
+        Buffer.from(
+          `${JSON.stringify({
+            ...sealed.header,
+            segment_id: lying,
+            content_sha256: "0".repeat(64),
+          })}\n{"v":1}\n`,
+          "utf8",
+        ),
+      ),
+    );
+
+    expect(await drainer.drainNow()).toBe(0);
+
+    // Both are still there, and nothing they carried became visible.
+    const keys = (await pending()).map((object) => object.key);
+    expect(keys).toContain(pendingKeyFor(damaged));
+    expect(keys).toContain(pendingKeyFor(lying));
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(0);
+
+    // Counted for an operator by reason class and by nothing else. A key, an
+    // organization or a segment id in a metric label is an unbounded set of
+    // values, and the first bucket full of damaged objects would be the one
+    // that took the metrics down.
+    expect([...retainedDefects().keys()].sort()).toEqual([
+      "checksum_mismatch",
+      "not_gzip",
+    ]);
+
+    await bucket.delete(pendingKeyFor(damaged));
+    await bucket.delete(pendingKeyFor(lying));
+  });
+
+  it("leaves an object it could not read where it is, and takes it on the next pass", async () => {
+    const traceId = "2200000000000000000000000000d200";
+    const key = await accepted(aConversation(traceId));
+
+    faults.failReadOf = key;
+    expect(await drainer.drainNow()).toBe(0);
+    expect((await pending()).map((object) => object.key)).toContain(key);
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(0);
+
+    expect(await drainer.drainNow()).toBe(1);
+    expect(
+      await countOf(
+        `select count() as n from spans final where trace_id = '${traceId}'`,
+      ),
+    ).toBe(2);
+  });
+
+  it("follows every listing page, so a backlog cannot hide behind the first", async () => {
+    // Five objects and two keys a page: a drainer that stopped at the first
+    // page would report a clean prefix with three segments still in it.
+    const traceIds = [
+      "3300000000000000000000000000a301",
+      "3300000000000000000000000000a302",
+      "3300000000000000000000000000a303",
+      "3300000000000000000000000000a304",
+      "3300000000000000000000000000a305",
+    ];
+    for (const traceId of traceIds) await accepted(aConversation(traceId));
+
+    expect(await drainer.drainNow()).toBe(traceIds.length);
+    expect(await pending()).toHaveLength(0);
+    for (const traceId of traceIds) {
+      expect(
+        await countOf(
+          `select count() as n from spans final where trace_id = '${traceId}'`,
+        ),
+      ).toBe(2);
+    }
+  });
+
+  it("does nothing at all when the prefix cannot be listed", async () => {
+    faults.failListing = true;
+    try {
+      expect(await drainer.drainNow()).toBe(0);
+    } finally {
+      faults.failListing = false;
+    }
+  });
+});
+
+/**
+ * The two facts a production conversation hands over — its evidence being
+ * readable, and the platform saying it ended — arriving in either order.
+ *
+ * They are separate facts on separate spans, and an exporter is free to send
+ * them in separate flushes that become separate segments and drain in either
+ * order. A grader that read the trace on the first of them must find evidence
+ * there, and the completion that arrives second must not create a second piece
+ * of work.
+ */
+describe.skipIf(!storage.available)("the end fact and the evidence, in either order", () => {
+  const running = storage as Extract<ObjectStorage, { available: true }>;
+
+  let api: TestApi;
+  let acme: Customer;
+  let scope: SegmentScope;
+  let bucket: PendingObjectStore;
+  let drainer: Drainer;
+
+  const at = BigInt(Date.parse("2026-08-20T10:00:00.000Z")) * 1_000n;
+
+  function turn(traceId: string): IngestionRecord {
+    return aRecord({
+      trace_id: traceId,
+      span_id: `${traceId.slice(0, 14)}02`,
+      parent_span_id: `${traceId.slice(0, 14)}01`,
+      name: "agent_turn",
+      kind: "turn:agent",
+      source: "production",
+      agent_platform: "livekit_agents",
+      started_at_microseconds: String(at + 1_000_000n),
+      text: "Tuesday at four, then.",
+    });
+  }
+
+  function ending(traceId: string): IngestionRecord {
+    return aRecord({
+      trace_id: traceId,
+      span_id: `${traceId.slice(0, 14)}01`,
+      parent_span_id: "",
+      name: "agent_session",
+      kind: "root",
+      source: "production",
+      agent_platform: "livekit_agents",
+      started_at_microseconds: String(at),
+      ends_trace: true,
+    });
+  }
+
+  async function drain(records: readonly IngestionRecord[]): Promise<void> {
+    await bucket.create(sealSegment({ scope, records }));
+    expect(await drainer.drainNow()).toBe(1);
+  }
+
+  async function jobFor(
+    traceId: string,
+  ): Promise<{ root_closed_at: Date | null } | undefined> {
+    const { rows } = await api.database.sql<{ root_closed_at: Date | null }>(
+      "select root_closed_at from grading_job where trace_id = $1",
+      [traceId],
+    );
+    expect(rows.length).toBeLessThanOrEqual(1);
+    return rows[0];
+  }
+
+  beforeAll(async () => {
+    if (!storage.available) return;
+    api = await createApi("ingestion_drain_order", { traceStore: true });
+    acme = await signUp(api.app, "ada@acme.example", "Acme");
+    scope = { organizationId: acme.organizationId, projectId: acme.projectId };
+    bucket = pendingObjectStore(running.ingestStore);
+    drainer = startDrainer({
+      store: bucket,
+      log: { warn: () => undefined, error: () => undefined },
+      scanIntervalMilliseconds: 60 * 60_000,
+    });
+  });
+
+  afterAll(async () => {
+    await drainer?.stop();
+    await api?.close();
+  });
+
+  it("reports the evidence first and completes it when the ending arrives", async () => {
+    const traceId = "4400000000000000000000000000e401";
+
+    await drain([turn(traceId)]);
+    // Known and readable, and deliberately not finished: nothing has said the
+    // conversation is over.
+    expect(await jobFor(traceId)).toEqual({ root_closed_at: null });
+
+    await drain([ending(traceId)]);
+    expect(await jobFor(traceId)).toEqual({ root_closed_at: expect.any(Date) });
+  });
+
+  it("takes the ending first and still reports the evidence that follows it", async () => {
+    const traceId = "4400000000000000000000000000e402";
+
+    await drain([ending(traceId)]);
+    expect(await jobFor(traceId)).toEqual({ root_closed_at: expect.any(Date) });
+
+    await drain([turn(traceId)]);
+    // One piece of work either way, and a completion that a later flush cannot
+    // undo.
+    expect(await jobFor(traceId)).toEqual({ root_closed_at: expect.any(Date) });
+  });
+});
+
+/**
+ * The local log's bound, reached.
+ *
+ * Its own instance because the bound is a setting and this is the only claim
+ * about it: a deployment holding as much staged evidence as it is allowed to
+ * answers retryably and **discards nothing**, which is the difference between
+ * an overloaded Egma and one that silently loses what it already promised to
+ * keep.
+ */
+describe.skipIf(!storage.available)("a local log that will take no more", () => {
+  const running = storage as Extract<ObjectStorage, { available: true }>;
+
+  let api: TestApi;
+  let secret: string;
+
+  beforeAll(async () => {
+    if (!storage.available) return;
+    api = await createApi("ingestion_backpressure", {
+      traceStore: true,
+      ingestStore: running.ingestStore,
+      // Small enough that one ordinary export reaches it, and large enough
+      // that the first one does not.
+      ingestionLogMaxBytes: 4_096,
+      // Long, so the bound is reached before anything is uploaded and released.
+      ingestionFlushMilliseconds: 60_000,
+      // Longer than the flush window above, so what this case meets is the log
+      // bound rather than the request's own.
+      ingestionRequestTimeoutMilliseconds: 120_000,
+    });
+    const acme = await signUp(api.app, "ada@acme.example", "Acme");
+    secret = await mintKey(api.app, acme.cookie, "a busy agent", acme.projectId);
+  });
+
+  afterAll(async () => {
+    await api?.close();
+  });
+
+  it("answers retryably rather than discarding what is already staged", async () => {
+    // One export carrying more than the whole log will hold. The first records
+    // are framed on the disk; the one that would cross the bound is refused,
+    // and the refusal is the whole answer — nothing older is thrown away to
+    // make room for it.
+    const spans = Array.from({ length: 24 }, (_, index) => ({
+      traceId: "5500000000000000000000000000d500",
+      spanId: `55000000000${String(index).padStart(5, "0")}`,
+      name: "agent_turn",
+      startTimeUnixNano: "1785693880281989804",
+      endTimeUnixNano: "1785693881281989804",
+      attributes: [
+        {
+          key: "lk.response.text",
+          value: { stringValue: "x".repeat(600) },
+        },
+      ],
+    }));
+
+    const refused = await api.app.inject({
+      method: "POST",
+      url: OTLP_TRACES_PATH,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`,
+      },
+      payload: JSON.stringify({
+        resourceSpans: [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [{ scope: { name: "livekit-agents" }, spans }],
+          },
+        ],
+      }),
+    });
+
+    expect(refused.statusCode).toBe(503);
+    expect(refused.json()).toMatchObject({
+      code: 14,
+      // Not a discard, and the sentence says so: an operator reading this must
+      // not go looking for evidence that was thrown away.
+      message: expect.stringContaining("has been discarded"),
+    });
+  });
+});

--- a/apps/api/test/ingestion-segment.test.ts
+++ b/apps/api/test/ingestion-segment.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { gunzipSync } from "node:zlib";
+import { gunzipSync, gzipSync } from "node:zlib";
 
 import { describe, expect, it } from "vitest";
 
@@ -16,6 +16,10 @@ import {
   RECORD_FORMAT_VERSION,
   spanFor,
 } from "../src/ingestion/record.ts";
+import {
+  UnreadableSegmentError,
+  verifiedSegment,
+} from "../src/ingestion/verify.ts";
 import {
   groupedByProject,
   millisecondsUntilSeal,
@@ -110,13 +114,48 @@ describe("what a segment is allowed to contain", () => {
     expect(header["record_count"]).toBe(2);
     expect(read).toHaveLength(2);
 
-    // The checksum covers the record lines and not the header, because the
-    // header cannot cover itself. A reader splits off the first line, hashes
-    // what is left, and compares — which is what this does.
+    // The checksum covers the header as well as the records, which is what
+    // makes the scope above a fact rather than a label: an object whose
+    // `organization_id` had been edited would fail this comparison, and the
+    // drainer builds the context it writes under out of exactly that field.
+    // A field cannot cover itself, so what is hashed is everything except the
+    // checksum, in one fixed order, then the record lines.
     const body = gunzipSync(Buffer.from(sealed.body)).toString("utf8");
     const afterTheHeader = body.slice(body.indexOf("\n") + 1);
+    const bound = JSON.stringify({
+      organization_id: SCOPE.organizationId,
+      project_id: SCOPE.projectId,
+      record_count: 2,
+      segment_id: sealed.segmentId,
+      v: RECORD_FORMAT_VERSION,
+    });
     expect(header["content_sha256"]).toBe(
-      createHash("sha256").update(afterTheHeader, "utf8").digest("hex"),
+      createHash("sha256")
+        .update(`${bound}\n${afterTheHeader}`, "utf8")
+        .digest("hex"),
+    );
+  });
+
+  it("binds the scope it was sealed for, so an edited header cannot be read", () => {
+    // The whole point of the digest reaching over the header: a pending object
+    // whose tenancy has been rewritten — by a copy, a restore, or a hand — is
+    // refused rather than filed under whoever the new name says.
+    const sealed = sealSegment({ scope: SCOPE, records: [aRecord()] });
+    const lines = gunzipSync(Buffer.from(sealed.body)).toString("utf8").split("\n");
+    const header = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
+
+    const rewritten = gzipSync(
+      Buffer.from(
+        [
+          JSON.stringify({ ...header, organization_id: "org_somebody_else" }),
+          ...lines.slice(1),
+        ].join("\n"),
+        "utf8",
+      ),
+    );
+
+    expect(() => verifiedSegment(sealed.key, rewritten)).toThrow(
+      UnreadableSegmentError,
     );
   });
 

--- a/apps/api/test/monitoring-routes.test.ts
+++ b/apps/api/test/monitoring-routes.test.ts
@@ -3,10 +3,20 @@ import {
   finishRetellMonitoringScan,
   recordRetellIngestionFailure,
 } from "@egma/db";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 
+import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
 import { createApi, type TestApi } from "./support/api.ts";
-import { colleagueOf, signUp } from "./support/traces.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
+import {
+  colleagueOf,
+  mintKey,
+  signUp,
+  syntheticExport,
+} from "./support/traces.ts";
 
 let api: TestApi;
 
@@ -76,6 +86,29 @@ function provider(
   }) as typeof fetch;
   return { asked, fetchImpl };
 }
+
+/**
+ * The one case here that files evidence at the door needs somewhere for that
+ * evidence to become durable — Monitoring's "last heard from" is written where
+ * a segment is drained. Every other case in this file talks to a Retell-shaped
+ * server on loopback and needs no container.
+ */
+const storage: ObjectStorage = await startObjectStorage("monitoring-routes");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the Monitoring last-received case — ${storage.why}\n\n`,
+  );
+}
+
+function running(): Extract<ObjectStorage, { available: true }> {
+  if (!storage.available) throw new Error("this suite has no object store");
+  return storage;
+}
+
+afterAll(() => {
+  if (storage.available) storage.stop();
+});
 
 describe("platform-first Monitoring setup", () => {
   it("discovers voice agents, proves call-history access, and stores one sealed key", async () => {
@@ -379,6 +412,88 @@ describe("platform-first Monitoring setup", () => {
         new URL(request.url).pathname === `/v2/get-call/${providerCallId}`,
     );
     expect(getCalls).toHaveLength(1);
+  });
+
+  /**
+   * **Monitoring's "last heard from" is a fact about evidence being readable**,
+   * so it is written where the segment is drained rather than where the request
+   * is answered.
+   *
+   * The door used to set it the moment a valid LiveKit span reached the store,
+   * which was true only while the door was the writer. It is not any more: a
+   * request is answered as accepted on object-store durability, and the
+   * conversation becomes readable afterwards. Setting it at the door would tell
+   * a customer their Monitoring was live while a store was still cold.
+   */
+  it.skipIf(!storage.available)("reports LiveKit as heard from once the accepted evidence is drained", async () => {
+    api = await createApi("monitoring_routes_livekit_received", {
+      traceStore: true,
+      ingestStore: running().ingestStore,
+    });
+    const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+    const configured = await api.app.inject({
+      method: "PUT",
+      url: `/v1/monitoring/livekit-agents?projectId=${ada.projectId}`,
+      headers: { cookie: ada.cookie },
+    });
+    expect(configured.statusCode, configured.body).toBe(200);
+    expect(
+      (
+        configured.json() as {
+          monitoringSource: { health: { lastReceivedAt: unknown } };
+        }
+      ).monitoringSource.health.lastReceivedAt,
+    ).toBeNull();
+
+    const secret = await mintKey(
+      api.app,
+      ada.cookie,
+      "the agent under test",
+      ada.projectId,
+    );
+    const posted = await api.app.inject({
+      method: "POST",
+      url: OTLP_TRACES_PATH,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`,
+      },
+      payload: syntheticExport({
+        traceId: "8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d",
+        startedAt: new Date("2026-08-09T11:00:00Z"),
+      }),
+    });
+    expect(posted.statusCode, posted.body).toBe(200);
+
+    // Accepted, and deliberately not yet heard from.
+    const staged = await api.app.inject({
+      method: "GET",
+      url: `/v1/monitoring?projectId=${ada.projectId}`,
+      headers: { cookie: ada.cookie },
+    });
+    expect(
+      (
+        staged.json() as {
+          monitoringSources: { health: { lastReceivedAt: unknown } }[];
+        }
+      ).monitoringSources[0]?.health.lastReceivedAt,
+    ).toBeNull();
+
+    await api.drainEvidence();
+
+    const heard = await api.app.inject({
+      method: "GET",
+      url: `/v1/monitoring?projectId=${ada.projectId}`,
+      headers: { cookie: ada.cookie },
+    });
+    expect(
+      (
+        heard.json() as {
+          monitoringSources: { health: { lastReceivedAt: string | null } }[];
+        }
+      ).monitoringSources[0]?.health.lastReceivedAt,
+    ).toEqual(expect.any(String));
   });
 
   it("creates and removes the separate LiveKit Agents setup", async () => {

--- a/apps/api/test/monitoring-routes.test.ts
+++ b/apps/api/test/monitoring-routes.test.ts
@@ -419,11 +419,10 @@ describe("platform-first Monitoring setup", () => {
    * so it is written where the segment is drained rather than where the request
    * is answered.
    *
-   * The door used to set it the moment a valid LiveKit span reached the store,
-   * which was true only while the door was the writer. It is not any more: a
-   * request is answered as accepted on object-store durability, and the
-   * conversation becomes readable afterwards. Setting it at the door would tell
-   * a customer their Monitoring was live while a store was still cold.
+   * A request is answered as accepted on object-store durability, and the
+   * conversation becomes readable afterwards. Setting this at the door would
+   * tell a customer their Monitoring was live while a trace store was still
+   * cold and their conversation could not be opened.
    */
   it.skipIf(!storage.available)("reports LiveKit as heard from once the accepted evidence is drained", async () => {
     api = await createApi("monitoring_routes_livekit_received", {

--- a/apps/api/test/otlp-derived-measures.test.ts
+++ b/apps/api/test/otlp-derived-measures.test.ts
@@ -166,7 +166,7 @@ beforeAll(async () => {
     "Acme production telemetry",
     acme.projectId,
   );
-  await replayFixture(api.app, telemetrySecret);
+  await replayFixture(api, telemetrySecret);
   // The door stops at object-store durability, so the evidence is carried the
   // rest of the way here — the measures are read out of rows.
   await api.drainEvidence();

--- a/apps/api/test/otlp-derived-measures.test.ts
+++ b/apps/api/test/otlp-derived-measures.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { createApi, type TestApi } from "./support/api.ts";
+import { startObjectStorage, type ObjectStorage } from "./support/object-storage.ts";
 import {
   mintKey,
   readTraceOverHttp,
@@ -31,6 +32,14 @@ import {
  * What is proved here is that a real conversation, through the real path,
  * arrives measured.
  */
+
+const storage: ObjectStorage = await startObjectStorage("otlp-measures");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the derived-measures suite — ${storage.why}\n\n`,
+  );
+}
 
 let api: TestApi;
 let acme: Customer;
@@ -144,7 +153,11 @@ function measure(
 }
 
 beforeAll(async () => {
-  api = await createApi("otlp_derived_measures", { traceStore: true });
+  if (!storage.available) return;
+  api = await createApi("otlp_derived_measures", {
+    traceStore: true,
+    ingestStore: storage.ingestStore,
+  });
   acme = await signUp(api.app, "ada@acme.example", "Acme");
   // The fourteen flushes, byte for byte as the exporter sent them.
   const telemetrySecret = await mintKey(
@@ -154,13 +167,17 @@ beforeAll(async () => {
     acme.projectId,
   );
   await replayFixture(api.app, telemetrySecret);
+  // The door stops at object-store durability, so the evidence is carried the
+  // rest of the way here — the measures are read out of rows.
+  await api.drainEvidence();
 });
 
 afterAll(async () => {
   await api?.close();
+  if (storage.available) storage.stop();
 });
 
-describe("the captured LiveKit conversation, read back through the door", () => {
+describe.skipIf(!storage.available)("the captured LiveKit conversation, read back through the door", () => {
   it("carries exactly the three derived measures, and says they were derived", async () => {
     const measures = await measuresOfTheCapture();
 

--- a/apps/api/test/otlp-door.test.ts
+++ b/apps/api/test/otlp-door.test.ts
@@ -169,11 +169,11 @@ describe.skipIf(!storage.available)("what the door stages for Monitoring", () =>
 
   /**
    * Monitoring's "last heard from" is a fact about evidence being
-   * *query-visible*, so the door no longer asserts it: it accepts, and what the
-   * drainer finds in the object is what moves that state. What the door still
-   * decides is which of these exports produces evidence at all, and that is
-   * what is read out of the pending object here — the setup's own bookkeeping is
-   * proved where the drainer writes it.
+   * *query-visible*, so the door does not assert it: it accepts, and what the
+   * drainer finds in the object is what moves that state. What the door decides
+   * is which of these exports produces evidence at all, and that is what is read
+   * out of the pending object here — the setup's own bookkeeping is proved where
+   * the drainer writes it.
    */
   it("stages nothing for evidence it refuses, and platform identity for what it takes", async () => {
     const configured = await configureLiveKitMonitoring(auth());
@@ -291,15 +291,14 @@ describe.skipIf(!storage.available)("the JSON encoding", () => {
    * The rule this replaced a scrubber with: **egma does not read evidence to
    * decide what evidence is.**
    *
-   * The old test asserted the opposite — that a value which looked like a
-   * credential was rewritten wherever it appeared. What that cost is exactly
-   * what is asserted here: a transcript containing the word `Bearer`, a tool
-   * argument a customer called `password`, an attribute named `api_key`, a
-   * metadata field called `access_token`. Every one of them is a thing a real
-   * caller says or a real customer names, and every one of them was being
-   * edited. Operational credentials are excluded by *position* instead — the
-   * `Authorization` header and the service token live outside the payload and
-   * never reach normalization at all — so nothing here has to guess.
+   * Each sentinel below is a thing a real caller says or a real customer names:
+   * a transcript containing the word `Bearer`, a tool argument called
+   * `password`, an attribute named `api_key`, a metadata field called
+   * `access_token`. A scanner that rewrote any of them would have edited the
+   * one thing the product exists to show a team. Operational credentials are
+   * excluded by *position* instead — the `Authorization` header and the service
+   * token live outside the payload and never reach normalization at all — so
+   * nothing here has to guess.
    */
   it("keeps every value a sender wrote, credential-looking ones included", async () => {
     const traceId = "19191919191919191919191919191919";
@@ -410,15 +409,14 @@ describe.skipIf(!storage.available)("the JSON encoding", () => {
       expect(stored).toContain(sentinel);
     }
 
-    // And the lifted columns hold what arrived rather than the blank a
-    // rewritten value used to leave behind.
+    // And the lifted columns hold exactly what arrived.
     expect(row).toMatchObject({
       provider_call_id: "Bearer resource-secret",
       text: "Bearer transcript-secret",
       platform_agent_name: "Basic agent-secret",
     });
 
-    // Nothing was written where anything used to be taken out.
+    // Nothing is written anywhere in place of anything.
     expect(stored).not.toContain("REDACTED");
   });
 

--- a/apps/api/test/otlp-door.test.ts
+++ b/apps/api/test/otlp-door.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@egma/db";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import type { IngestionStore } from "../src/ingestion/object-store.ts";
 import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
 import {
   EXPORT_TRACE_SERVICE_REQUEST,
@@ -14,6 +15,11 @@ import {
   RPC_STATUS_MESSAGE as RPC_STATUS,
 } from "../src/otlp/schema.ts";
 import { cookiesFrom, createApi, type TestApi } from "./support/api.ts";
+import { pendingSegments } from "./support/ingestion.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
 
 /**
  * What the door accepts, what it refuses, and what it says either way.
@@ -23,7 +29,18 @@ import { cookiesFrom, createApi, type TestApi } from "./support/api.ts";
  * behaving well: the other encoding, a body that is not what it claims, a
  * client that tries to name its own customer, and the shape of a refusal an
  * OpenTelemetry SDK is going to parse rather than read.
+ *
+ * The door answers on object-store durability and writes no row, so a post here
+ * is followed by a drain wherever the claim is about what a reader sees. What
+ * the door itself decided is read out of the pending object instead, which is
+ * the only place it has put anything by the time it answers.
  */
+
+const storage: ObjectStorage = await startObjectStorage("otlp-door");
+
+if (!storage.available) {
+  process.stderr.write(`\nskipping the OTLP door suite — ${storage.why}\n\n`);
+}
 
 let api: TestApi;
 let secret: string;
@@ -65,6 +82,13 @@ function jsonExport(
 }
 
 async function post(body: Buffer | string, headers: Record<string, string> = {}) {
+  const response = await stage(body, headers);
+  await api.drainEvidence();
+  return response;
+}
+
+/** The same post, stopping where the door does: durable and not yet drained. */
+async function stage(body: Buffer | string, headers: Record<string, string> = {}) {
   return api.app.inject({
     method: "POST",
     url: OTLP_TRACES_PATH,
@@ -83,8 +107,18 @@ function store(): NonNullable<TestApi["traceStore"]> {
   return traceStore;
 }
 
+/** The ingestion bucket this instance accepts into, for reading it back. */
+function ingestStore(): IngestionStore {
+  if (!storage.available) throw new Error("this suite has no object store");
+  return storage.ingestStore;
+}
+
 beforeAll(async () => {
-  api = await createApi("otlp_door", { traceStore: true });
+  if (!storage.available) return;
+  api = await createApi("otlp_door", {
+    traceStore: true,
+    ingestStore: storage.ingestStore,
+  });
 
   const created = await api.app.inject({
     method: "POST",
@@ -119,9 +153,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await api?.close();
+  if (storage.available) storage.stop();
 });
 
-describe("LiveKit Monitoring health", () => {
+describe.skipIf(!storage.available)("what the door stages for Monitoring", () => {
   function auth(): AuthContext {
     return {
       userId,
@@ -132,11 +167,19 @@ describe("LiveKit Monitoring health", () => {
     };
   }
 
-  it("changes only after a valid LiveKit production span reaches storage", async () => {
+  /**
+   * Monitoring's "last heard from" is a fact about evidence being
+   * *query-visible*, so the door no longer asserts it: it accepts, and what the
+   * drainer finds in the object is what moves that state. What the door still
+   * decides is which of these exports produces evidence at all, and that is
+   * what is read out of the pending object here — the setup's own bookkeeping is
+   * proved where the drainer writes it.
+   */
+  it("stages nothing for evidence it refuses, and platform identity for what it takes", async () => {
     const configured = await configureLiveKitMonitoring(auth());
     expect(configured.lastReceivedAt).toBeNull();
 
-    const refused = await post(
+    const refused = await stage(
       jsonExport([
         jsonSpan({
           traceId: "not-an-otel-trace-id",
@@ -145,13 +188,9 @@ describe("LiveKit Monitoring health", () => {
       ]),
     );
     expect(refused.statusCode).toBe(200);
-    expect(
-      (await listMonitoringSetups(auth())).find(
-        (setup) => setup.agentPlatform === "livekit_agents",
-      )?.lastReceivedAt,
-    ).toBeNull();
+    expect(await pendingSegments(ingestStore())).toHaveLength(0);
 
-    const anotherPlatform = await post(
+    const anotherPlatform = await stage(
       jsonExport(
         [
           jsonSpan({
@@ -164,30 +203,41 @@ describe("LiveKit Monitoring health", () => {
       ),
     );
     expect(anotherPlatform.statusCode).toBe(200);
-    expect(
-      (await listMonitoringSetups(auth())).find(
-        (setup) => setup.agentPlatform === "livekit_agents",
-      )?.lastReceivedAt,
-    ).toBeNull();
+    const [foreign] = await pendingSegments(ingestStore());
+    expect(foreign?.records[0]).toMatchObject({
+      agent_platform: "",
+      ends_trace: false,
+    });
+    await api.drainEvidence();
 
-    const accepted = await post(
+    const accepted = await stage(
       jsonExport([
         jsonSpan({
           traceId: "45454545454545454545454545454545",
           spanId: "4545454545454545",
+          name: "agent_session",
         }),
       ]),
     );
     expect(accepted.statusCode).toBe(200);
+    const [livekit] = await pendingSegments(ingestStore());
+    expect(livekit?.records[0]).toMatchObject({
+      agent_platform: "livekit_agents",
+      // The framework's own session span, which is the platform saying the
+      // conversation is over. Nothing infers it from the span having no parent.
+      ends_trace: true,
+    });
+    await api.drainEvidence();
+
     expect(
       (await listMonitoringSetups(auth())).find(
         (setup) => setup.agentPlatform === "livekit_agents",
-      )?.lastReceivedAt,
-    ).toBeInstanceOf(Date);
+      ),
+    ).toBeDefined();
   });
 });
 
-describe("the JSON encoding", () => {
+describe.skipIf(!storage.available)("the JSON encoding", () => {
   it("lands the same way protobuf does, ids and nanoseconds included", async () => {
     const response = await post(jsonExport([jsonSpan()]));
     expect(response.statusCode).toBe(200);
@@ -237,7 +287,21 @@ describe("the JSON encoding", () => {
     expect(row).toEqual({ organization_id: organizationId, project_id: projectId });
   });
 
-  it("redacts credential-like OTLP data before fields or payload are stored", async () => {
+  /**
+   * The rule this replaced a scrubber with: **egma does not read evidence to
+   * decide what evidence is.**
+   *
+   * The old test asserted the opposite — that a value which looked like a
+   * credential was rewritten wherever it appeared. What that cost is exactly
+   * what is asserted here: a transcript containing the word `Bearer`, a tool
+   * argument a customer called `password`, an attribute named `api_key`, a
+   * metadata field called `access_token`. Every one of them is a thing a real
+   * caller says or a real customer names, and every one of them was being
+   * edited. Operational credentials are excluded by *position* instead — the
+   * `Authorization` header and the service token live outside the payload and
+   * never reach normalization at all — so nothing here has to guess.
+   */
+  it("keeps every value a sender wrote, credential-looking ones included", async () => {
     const traceId = "19191919191919191919191919191919";
     const response = await post(
       JSON.stringify({
@@ -325,29 +389,37 @@ describe("the JSON encoding", () => {
       text: string;
       platform_agent_name: string;
     }>(
-      `select payload, provider_call_id, text, platform_agent_name from spans ` +
+      `select payload, provider_call_id, text, platform_agent_name from spans final ` +
         `where trace_id = '${traceId}'`,
     );
     expect(row).toBeDefined();
+
+    // Every one of them, byte for byte, wherever it sat: on the resource, on
+    // the scope, on the span, nested in a kvlist, and on an event.
     const stored = JSON.stringify(row);
-    for (const secretValue of [
-      "resource-secret",
+    for (const sentinel of [
+      "Bearer resource-secret",
       "resource-api-secret",
-      "scope-secret",
-      "transcript-secret",
-      "agent-secret",
+      "Bearer scope-secret",
+      "Bearer transcript-secret",
+      "Basic agent-secret",
       "span-password-secret",
       "nested-token-secret",
       "event-client-secret",
     ]) {
-      expect(stored).not.toContain(secretValue);
+      expect(stored).toContain(sentinel);
     }
+
+    // And the lifted columns hold what arrived rather than the blank a
+    // rewritten value used to leave behind.
     expect(row).toMatchObject({
-      provider_call_id: "",
-      text: "",
-      platform_agent_name: "",
+      provider_call_id: "Bearer resource-secret",
+      text: "Bearer transcript-secret",
+      platform_agent_name: "Basic agent-secret",
     });
-    expect(row?.payload).toContain("[REDACTED]");
+
+    // Nothing was written where anything used to be taken out.
+    expect(stored).not.toContain("REDACTED");
   });
 
   it("keeps a Pipecat service span whole without making a transcript turn", async () => {
@@ -451,7 +523,7 @@ describe("the JSON encoding", () => {
   });
 });
 
-describe("a payload that names a customer", () => {
+describe.skipIf(!storage.available)("a payload that names a customer", () => {
   /**
    * A client can send whatever attributes it likes. Which account its
    * telemetry lands in is not one of them — the request's own claim is not
@@ -515,7 +587,7 @@ describe("a payload that names a customer", () => {
   });
 });
 
-describe("the environment a span was recorded in", () => {
+describe.skipIf(!storage.available)("the environment a span was recorded in", () => {
   it("is discovered from the telemetry, with no declaration step anywhere", async () => {
     const traceId = "00001111222233334444555566667777";
     const response = await post(
@@ -572,7 +644,7 @@ describe("the environment a span was recorded in", () => {
   });
 });
 
-describe("a span that named itself nothing", () => {
+describe.skipIf(!storage.available)("a span that named itself nothing", () => {
   it("is rejected rather than given an id egma made up", async () => {
     const good = jsonSpan({
       traceId: "12121212121212121212121212121212",
@@ -613,7 +685,7 @@ describe("a span that named itself nothing", () => {
  * lost: the two timestamps it was measured from are in the payload as they
  * arrived.
  */
-describe("a span that says it ran for longer than Int64 holds", () => {
+describe.skipIf(!storage.available)("a span that says it ran for longer than Int64 holds", () => {
   it("is stored with its duration clamped rather than wrapped", async () => {
     const traceId = "13131313131313131313131313131313";
     const response = await post(
@@ -642,7 +714,7 @@ describe("a span that says it ran for longer than Int64 holds", () => {
   });
 });
 
-describe("a body the door cannot read", () => {
+describe.skipIf(!storage.available)("a body the door cannot read", () => {
   it("is refused with a reason, rather than accepted and lost", async () => {
     const notProtobuf = await post(Buffer.from([0xff, 0xff, 0xff, 0xff]), {
       "content-type": "application/x-protobuf",
@@ -697,7 +769,7 @@ describe("a body the door cannot read", () => {
   });
 });
 
-describe("a compressed export", () => {
+describe.skipIf(!storage.available)("a compressed export", () => {
   it("is read, because that is how most exporters are configured", async () => {
     const traceId = "55556666777788889999000011112222";
     const body = EXPORT_TRACE_SERVICE_REQUEST.encode(
@@ -751,7 +823,7 @@ describe("a compressed export", () => {
   });
 });
 
-describe("an export carrying nothing", () => {
+describe.skipIf(!storage.available)("an export carrying nothing", () => {
   it("is a perfectly good request and stores no rows", async () => {
     const before = (
       await store().rows<{ n: number }>("select count() as n from spans")
@@ -777,7 +849,7 @@ describe("an export carrying nothing", () => {
  * exporter is told how much was refused rather than left to believe all of it
  * landed.
  */
-describe("an export asking for more than egma turns into rows", () => {
+describe.skipIf(!storage.available)("an export asking for more than egma turns into rows", () => {
   it("stores what fits and reports the rest, when one fat resource rides every span", async () => {
     const traceId = "cafe0000cafe0000cafe0000cafe0000";
     const spans = 100;
@@ -849,7 +921,7 @@ describe("an export asking for more than egma turns into rows", () => {
  * the same base64 text here, so a span means the same thing whichever way its
  * exporter is configured.
  */
-describe("an attribute carrying bytes", () => {
+describe.skipIf(!storage.available)("an attribute carrying bytes", () => {
   const raw = Buffer.from([0x00, 0x01, 0xfe, 0xff]);
   const asBase64 = raw.toString("base64");
 
@@ -935,7 +1007,7 @@ describe("an attribute carrying bytes", () => {
   });
 });
 
-describe("an id shouted in uppercase hex", () => {
+describe.skipIf(!storage.available)("an id shouted in uppercase hex", () => {
   /**
    * The JSON mapping says lowercase and every exporter obeys, but a
    * hand-written client that writes its hex in capitals means the same trace —
@@ -960,7 +1032,7 @@ describe("an id shouted in uppercase hex", () => {
   });
 });
 
-describe("a span whose parent is not an id", () => {
+describe.skipIf(!storage.available)("a span whose parent is not an id", () => {
   /**
    * The parent is normalised to empty, which is how a root is recognised — so a
    * span with a malformed parent reads as a second root rather than as the
@@ -993,7 +1065,7 @@ describe("a span whose parent is not an id", () => {
   });
 });
 
-describe("a request carrying no credential at all", () => {
+describe.skipIf(!storage.available)("a request carrying no credential at all", () => {
   /**
    * The body is the expensive part of an export, and reading it for somebody
    * who named nobody is how an unauthenticated flood costs a server the memory
@@ -1020,7 +1092,7 @@ describe("a request carrying no credential at all", () => {
   });
 });
 
-describe("the role the key's holder acts at", () => {
+describe.skipIf(!storage.available)("the role the key's holder acts at", () => {
   let viewerSecret: string;
   let viewerOrganizationId: string;
 
@@ -1105,58 +1177,11 @@ describe("the role the key's holder acts at", () => {
     });
 
     expect(response.statusCode).toBe(200);
+    await api.drainEvidence();
 
     const [row] = await store().rows<{ organization_id: string }>(
-      `select organization_id from spans where trace_id = '${traceId}'`,
+      `select organization_id from spans final where trace_id = '${traceId}'`,
     );
     expect(row?.organization_id).toBe(viewerOrganizationId);
-  });
-});
-
-describe("a batch the trace store will never take", () => {
-  /**
-   * The specification's rule is the whole of the design here: rejected data
-   * must not be retried, and a 5xx is read by every exporter as *try again
-   * later*. So a store that has looked at these rows and refused them — a
-   * constraint they violate, a column they no longer fit — is answered as a
-   * rejection, which stops the retry loop and says why. A store that is merely
-   * unreachable is the opposite case and stays an error, because those rows
-   * would land perfectly well a minute from now.
-   */
-  it("is answered as a rejection rather than as an error an exporter will retry", async () => {
-    const traceId = "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0";
-    await store().command(
-      "alter table spans add constraint takes_nothing check length(span_id) < 0",
-    );
-
-    try {
-      const response = await post(
-        jsonExport([jsonSpan({ traceId, spanId: "f0f0f0f0f0f0f0f0" })]),
-      );
-
-      expect(response.statusCode).toBe(200);
-      expect(response.json()).toEqual({
-        partialSuccess: {
-          rejectedSpans: "1",
-          errorMessage: expect.stringContaining("the trace store refused"),
-        },
-      });
-    } finally {
-      await store().command(
-        "alter table spans drop constraint takes_nothing",
-      );
-    }
-
-    const [row] = await store().rows<{ n: number }>(
-      `select count() as n from spans where trace_id = '${traceId}'`,
-    );
-    expect(row?.n).toBe(0);
-
-    // And the door still works: the refusal was about those rows.
-    const after = await post(
-      jsonExport([jsonSpan({ traceId, spanId: "f0f0f0f0f0f0f0f0" })]),
-    );
-    expect(after.statusCode).toBe(200);
-    expect(after.json()).toEqual({});
   });
 });

--- a/apps/api/test/otlp-grading.test.ts
+++ b/apps/api/test/otlp-grading.test.ts
@@ -2,6 +2,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
 import { cookiesFrom, createApi, type TestApi } from "./support/api.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
 import { capturedRequests, type CapturedRequest } from "./support/fixture.ts";
 
 /**
@@ -25,6 +29,12 @@ import { capturedRequests, type CapturedRequest } from "./support/fixture.ts";
  * it arrives on a key that names a project, and the ingest file's key names the
  * whole customer on purpose.
  */
+
+const storage: ObjectStorage = await startObjectStorage("otlp-grading");
+
+if (!storage.available) {
+  process.stderr.write(`\nskipping the OTLP grading suite — ${storage.why}\n\n`);
+}
 
 let api: TestApi;
 let requests: CapturedRequest[];
@@ -83,7 +93,15 @@ async function mintKey(
   return (minted.json() as { secret: string }).secret;
 }
 
-/** Replay the whole capture, in order, as the exporter's fourteen flushes. */
+/**
+ * Replay the whole capture, in order, as the exporter's fourteen flushes, and
+ * then drain.
+ *
+ * The evidence-ready handoff is an effect of the evidence becoming
+ * query-visible, so it happens where the segment is drained rather than where
+ * the request is answered. A suite about that handoff therefore has to carry
+ * the evidence all the way, not just to the acceptance boundary.
+ */
 async function replay(secret: string): Promise<void> {
   for (const request of requests) {
     const response = await api.app.inject({
@@ -97,6 +115,7 @@ async function replay(secret: string): Promise<void> {
     });
     expect(response.statusCode, request.file).toBe(200);
   }
+  await api.drainEvidence();
 }
 
 async function jobsFor(organizationId: string): Promise<JobRow[]> {
@@ -112,8 +131,12 @@ let globex: Customer;
 let globexOrganizationKey: string;
 
 beforeAll(async () => {
+  if (!storage.available) return;
   requests = await capturedRequests();
-  api = await createApi("otlp_grading", { traceStore: true });
+  api = await createApi("otlp_grading", {
+    traceStore: true,
+    ingestStore: storage.ingestStore,
+  });
 
   acme = await signUp("ada@acme.example", "Acme");
   await replay(await mintKey(acme, "Acme's agent", acme.projectId));
@@ -124,9 +147,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await api?.close();
+  if (storage.available) storage.stop();
 });
 
-describe("a captured conversation arriving on a project's key", () => {
+describe.skipIf(!storage.available)("a captured conversation arriving on a project's key", () => {
   it("becomes exactly one piece of grading work, however many flushes carried it", async () => {
     const jobs = await jobsFor(acme.organizationId);
 
@@ -148,14 +172,72 @@ describe("a captured conversation arriving on a project's key", () => {
     expect(job?.simulation_id).toBeNull();
   });
 
-  it("is complete, because the root span closed it in the fourteenth flush", async () => {
+  it("is complete, because LiveKit's own session span said so in the fourteenth flush", async () => {
     const [job] = await jobsFor(acme.organizationId);
 
-    // An exporter sends a span when the span *ends*, so `agent_session` reaching
-    // the door is the conversation having ended. This capture's root arrives
-    // alone, last, which is exactly the case a door that guessed from the first
-    // flush would get wrong.
+    // `agent_session` is LiveKit's own word for the span the whole conversation
+    // happened inside, and the normalizer carries that statement through as the
+    // completion fact. This capture's session span arrives alone, last, which is
+    // exactly the case a reader that guessed from the first flush would get
+    // wrong.
     expect(job?.root_closed_at).toBeInstanceOf(Date);
+  });
+
+  /**
+   * **A span with no parent is not an ending**, and this is the case that used
+   * to say otherwise.
+   *
+   * Completion was inferred from any parentless span, so a scope Egma does not
+   * recognise could complete a conversation by flushing a span whose parent had
+   * not arrived — and a mangled parent id, which normalises to no parent at all,
+   * did the same. Neither says anything about whether the caller hung up. A
+   * platform this release has no explicit end fact for gets no completion here,
+   * and the idle sweep is what eventually picks such a trace up.
+   */
+  it("is not completed by a parentless span from a platform Egma does not recognise", async () => {
+    const traceId = "5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a";
+    const secret = await mintKey(acme, "another framework", acme.projectId);
+    const posted = await api.app.inject({
+      method: "POST",
+      url: OTLP_TRACES_PATH,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`,
+      },
+      payload: JSON.stringify({
+        resourceSpans: [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "another-agent-platform" },
+                spans: [
+                  {
+                    traceId,
+                    spanId: "5a5a5a5a5a5a5a5a",
+                    // No parent at all, which is what a lost flush leaves.
+                    parentSpanId: "",
+                    name: "agent_session",
+                    startTimeUnixNano: "1785693880281989804",
+                    endTimeUnixNano: "1785693881281989804",
+                    attributes: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(posted.statusCode, posted.body).toBe(200);
+    await api.drainEvidence();
+
+    const job = (await jobsFor(acme.organizationId)).find(
+      (each) => each.trace_id === traceId,
+    );
+    // Known, and deliberately not finished.
+    expect(job).toMatchObject({ source: "production", status: "pending" });
+    expect(job?.root_closed_at).toBeNull();
   });
 
   it("records the window the whole conversation happened inside", async () => {
@@ -182,7 +264,7 @@ describe("a captured conversation arriving on a project's key", () => {
   });
 });
 
-describe("telemetry sent with a key for the whole customer", () => {
+describe.skipIf(!storage.available)("telemetry sent with a key for the whole customer", () => {
   it("is refused before its body is decoded or any trace is stored", async () => {
     const response = await api.app.inject({
       method: "POST",

--- a/apps/api/test/otlp-ingest.test.ts
+++ b/apps/api/test/otlp-ingest.test.ts
@@ -10,6 +10,7 @@ import {
   FIXTURE_WINDOW,
   type CapturedRequest,
 } from "./support/fixture.ts";
+import { startObjectStorage, type ObjectStorage } from "./support/object-storage.ts";
 
 /**
  * A real LiveKit agent's telemetry, replayed at the door it will really arrive
@@ -17,15 +18,32 @@ import {
  *
  * This is the spine: fourteen captured OTLP bodies, byte for byte as an
  * exporter sent them, posted over HTTP to the running API with an ordinary egma
- * API key, landing in a real ClickHouse. It exercises the credential, the
- * protobuf decoding, the normalisation, the tenancy stamp and the append in one
- * pass — because every one of those is a place the path could be right in
- * isolation and wrong end to end.
+ * API key, staged into a real ingestion bucket and drained into a real
+ * ClickHouse. It exercises the credential, the protobuf decoding, the
+ * normalisation, the tenancy stamp, the segment and the insert in one pass —
+ * because every one of those is a place the path could be right in isolation
+ * and wrong end to end.
+ *
+ * The door answers on object-store durability and writes no row, so each post
+ * is followed by a drain. That is the one seam this file stands in for, and it
+ * stands in for it the way the drainer does the work: scope out of the sealed
+ * object's own header, the segment identity as the insert's deduplication
+ * token.
  *
  * What is asserted is the landed shape rather than the code's own opinion of
  * it. The read functions over `spans` belong to the next ticket, so the store
- * is queried directly here, the way the migration tests already do.
+ * is queried directly here, the way the migration tests already do — with
+ * `final`, because two physical copies of one replayed identity are not two
+ * spans.
  */
+
+const storage: ObjectStorage = await startObjectStorage("otlp-ingest");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the captured-trace ingest suite — ${storage.why}\n\n`,
+  );
+}
 
 let api: TestApi;
 let requests: CapturedRequest[];
@@ -76,7 +94,7 @@ async function post(
   body: Buffer | string,
   contentType = "application/x-protobuf",
 ) {
-  return api.app.inject({
+  const response = await api.app.inject({
     method: "POST",
     url: OTLP_TRACES_PATH,
     headers: {
@@ -85,6 +103,8 @@ async function post(
     },
     payload: body,
   });
+  await api.drainEvidence();
+  return response;
 }
 
 /** Replay the whole capture, in order, as one exporter's fourteen flushes. */
@@ -113,17 +133,22 @@ const inTheWindow =
 let acme: Customer;
 
 beforeAll(async () => {
+  if (!storage.available) return;
   requests = await capturedRequests();
-  api = await createApi("otlp_ingest", { traceStore: true });
+  api = await createApi("otlp_ingest", {
+    traceStore: true,
+    ingestStore: storage.ingestStore,
+  });
   acme = await signUpWithAKey("ada@acme.example", "Acme");
   await replay(acme.secret);
 });
 
 afterAll(async () => {
   await api?.close();
+  if (storage.available) storage.stop();
 });
 
-describe("the captured trace, posted at the door", () => {
+describe.skipIf(!storage.available)("the captured trace, posted at the door", () => {
   it("is fourteen requests the exporter really sent, and every one of them is protobuf", () => {
     expect(requests).toHaveLength(14);
     for (const request of requests) {
@@ -133,17 +158,17 @@ describe("the captured trace, posted at the door", () => {
   });
 
   it("lands as one trace of the spans that arrived, and not one more", async () => {
-    expect(await countOf("select count() as n from spans")).toBe(
+    expect(await countOf("select count() as n from spans final")).toBe(
       FIXTURE_TRACE.spans,
     );
     expect(
-      await countOf("select uniqExact(trace_id) as n from spans"),
+      await countOf("select uniqExact(trace_id) as n from spans final"),
     ).toBe(1);
   });
 
   it("adopts the ids off the wire rather than minting any", async () => {
     const rows = await store().rows<{ trace_id: string; span_id: string }>(
-      "select distinct trace_id, span_id from spans limit 200",
+      "select distinct trace_id, span_id from spans final limit 200",
     );
     expect(rows).toHaveLength(FIXTURE_TRACE.spans);
     for (const row of rows) {
@@ -157,7 +182,7 @@ describe("the captured trace, posted at the door", () => {
     const rows = await store().rows<{
       organization_id: string;
       project_id: string;
-    }>("select distinct organization_id, project_id from spans");
+    }>("select distinct organization_id, project_id from spans final");
 
     expect(rows).toEqual([
       { organization_id: acme.organizationId, project_id: acme.projectId },
@@ -169,7 +194,7 @@ describe("the captured trace, posted at the door", () => {
       source: string;
       emitter: string;
       environment: string;
-    }>("select distinct source, emitter, environment from spans");
+    }>("select distinct source, emitter, environment from spans final");
 
     expect(rows).toEqual([
       { source: "production", emitter: "agent", environment: "default" },
@@ -178,18 +203,18 @@ describe("the captured trace, posted at the door", () => {
 
   it("keeps the vendor's own identifier for this trace on every row", async () => {
     const rows = await store().rows<{ provider_call_id: string }>(
-      "select distinct provider_call_id from spans",
+      "select distinct provider_call_id from spans final",
     );
     expect(rows).toEqual([{ provider_call_id: FIXTURE_PROVIDER_CALL_ID }]);
   });
 
   it("records when the trace happened, to the microsecond it was stamped", async () => {
     expect(
-      await countOf(`select count() as n from spans where ${inTheWindow}`),
+      await countOf(`select count() as n from spans final where ${inTheWindow}`),
     ).toBe(FIXTURE_TRACE.spans);
 
     const [root] = await store().rows<{ started_at: string; duration_ns: number }>(
-      "select started_at, duration_ns from spans where parent_span_id = '' limit 1",
+      "select started_at, duration_ns from spans final where parent_span_id = '' limit 1",
     );
     // The wire said 1785693880281989804 nanoseconds. Microseconds is what the
     // column holds, and the sub-microsecond digits are dropped rather than
@@ -202,7 +227,7 @@ describe("the captured trace, posted at the door", () => {
 
   it("reads the transcript as turns, five from the human and eight from the agent", async () => {
     const rows = await store().rows<{ kind: string; n: number }>(
-      "select kind, count() as n from turns group by kind order by kind",
+      "select kind, count() as n from turns final group by kind order by kind",
     );
     expect(rows).toEqual([
       { kind: "turn:agent", n: FIXTURE_TRACE.agentTurns },
@@ -210,7 +235,7 @@ describe("the captured trace, posted at the door", () => {
     ]);
 
     const [first] = await store().rows<{ text_preview: string }>(
-      "select text_preview from turns where kind = 'turn:human' order by started_at limit 1",
+      "select text_preview from turns final where kind = 'turn:human' order by started_at limit 1",
     );
     expect(first?.text_preview).toBe("Hi Kelly, my name is Sam.");
   });
@@ -221,7 +246,7 @@ describe("the captured trace, posted at the door", () => {
       tool_arguments: string;
       tool_result: string;
     }>(
-      "select tool_name, tool_arguments, tool_result from spans " +
+      "select tool_name, tool_arguments, tool_result from spans final " +
         "where kind = 'tool' order by started_at",
     );
 
@@ -244,7 +269,7 @@ describe("the captured trace, posted at the door", () => {
    */
   it("keeps the spans that failed, and what they said about it", async () => {
     const rows = await store().rows<{ name: string; payload: string }>(
-      "select name, payload from spans where status = 'error' order by started_at",
+      "select name, payload from spans final where status = 'error' order by started_at",
     );
 
     expect(rows).toHaveLength(FIXTURE_TRACE.erroredSpans);
@@ -270,7 +295,7 @@ describe("the captured trace, posted at the door", () => {
    */
   it("stores one row per span that arrived, under the name it arrived with", async () => {
     const rows = await store().rows<{ name: string; n: string }>(
-      "select name, count() as n from spans group by name order by name",
+      "select name, count() as n from spans final group by name order by name",
     );
 
     expect(Object.fromEntries(rows.map((row) => [row.name, Number(row.n)]))).toEqual(
@@ -298,14 +323,14 @@ describe("the captured trace, posted at the door", () => {
       },
     );
 
-    expect(await countOf("select count() as n from spans where kind = 'stt'")).toBe(
+    expect(await countOf("select count() as n from spans final where kind = 'stt'")).toBe(
       0,
     );
   });
 
   it("keeps the whole of what the human said, and the framework's own attributes with it", async () => {
     const [row] = await store().rows<{ text: string; payload: string }>(
-      "select text, payload from spans where kind = 'turn:human' " +
+      "select text, payload from spans final where kind = 'turn:human' " +
         "order by started_at limit 1",
     );
 
@@ -324,7 +349,7 @@ describe("the captured trace, posted at the door", () => {
       agent_platform: string;
       connection_type: string;
     }>(
-      "select distinct agent_platform, connection_type from spans",
+      "select distinct agent_platform, connection_type from spans final",
     );
     expect(rows).toEqual([
       { agent_platform: "livekit_agents", connection_type: "" },
@@ -333,11 +358,11 @@ describe("the captured trace, posted at the door", () => {
 
   it("keeps an unproven LiveKit agent label in payload without calling it an agent name", async () => {
     const rows = await store().rows<{ platform_agent_name: string }>(
-      "select distinct platform_agent_name from spans",
+      "select distinct platform_agent_name from spans final",
     );
     expect(rows).toEqual([{ platform_agent_name: "" }]);
     const [root] = await store().rows<{ payload: string }>(
-      "select payload from spans where kind = 'root' limit 1",
+      "select payload from spans final where kind = 'root' limit 1",
     );
     expect(root?.payload).toContain("lk.agent_label");
     expect(root?.payload).toContain("kelly");
@@ -346,7 +371,7 @@ describe("the captured trace, posted at the door", () => {
   it("pins no run, no agent and no versions, because nothing here started one", async () => {
     expect(
       await countOf(
-        "select count() as n from spans where run_id != '' or agent_id != '' " +
+        "select count() as n from spans final where run_id != '' or agent_id != '' " +
           "or agent_version_id != '' or test_version_id != '' " +
           "or persona_version_id != ''",
       ),
@@ -373,13 +398,13 @@ describe("the captured trace, posted at the door", () => {
    * times over, and the row counts have to be exactly what they were.
    */
   it("is the same trace after being sent a second time, not two of it", async () => {
-    const before = await countOf("select count() as n from spans");
-    const turnsBefore = await countOf("select count() as n from turns");
+    const before = await countOf("select count() as n from spans final");
+    const turnsBefore = await countOf("select count() as n from turns final");
 
     await replay(acme.secret);
 
-    expect(await countOf("select count() as n from spans")).toBe(before);
-    expect(await countOf("select count() as n from turns")).toBe(turnsBefore);
+    expect(await countOf("select count() as n from spans final")).toBe(before);
+    expect(await countOf("select count() as n from turns final")).toBe(turnsBefore);
   });
 });
 
@@ -401,7 +426,7 @@ describe("two organizations sending the very same trace", () => {
 
   it("each hold the whole of it, and only their own copy", async () => {
     const rows = await store().rows<{ organization_id: string; n: number }>(
-      "select organization_id, count() as n from spans " +
+      "select organization_id, count() as n from spans final " +
         "group by organization_id order by organization_id",
     );
 
@@ -424,7 +449,7 @@ describe("two organizations sending the very same trace", () => {
    */
   it("keeps each organization's copy separable by the organization, not by the trace id", async () => {
     const [row] = await store().rows<{ trace_id: string }>(
-      "select distinct trace_id from spans limit 1",
+      "select distinct trace_id from spans final limit 1",
     );
     const traceId = row?.trace_id ?? "";
     expect(traceId).not.toBe("");
@@ -433,7 +458,7 @@ describe("two organizations sending the very same trace", () => {
     // is exactly what the organization leading the filing order is for.
     expect(
       await countOf(
-        `select count() as n from spans where trace_id = '${traceId}' ` +
+        `select count() as n from spans final where trace_id = '${traceId}' ` +
           `and organization_id = '${globex.organizationId}'`,
       ),
     ).toBe(FIXTURE_TRACE.spans);
@@ -445,7 +470,7 @@ describe("a request with no usable credential", () => {
     const request = requests[0];
     if (request === undefined) throw new Error("the capture is empty");
 
-    const before = await countOf("select count() as n from spans");
+    const before = await countOf("select count() as n from spans final");
 
     const anonymous = await post(null, request.body);
     expect(anonymous.statusCode).toBe(401);
@@ -464,6 +489,6 @@ describe("a request with no usable credential", () => {
     });
     expect(wrongScheme.statusCode).toBe(401);
 
-    expect(await countOf("select count() as n from spans")).toBe(before);
+    expect(await countOf("select count() as n from spans final")).toBe(before);
   });
 });

--- a/apps/api/test/otlp-simulation-ingest.test.ts
+++ b/apps/api/test/otlp-simulation-ingest.test.ts
@@ -613,18 +613,15 @@ describe.skipIf(!storage.available)("the same path in the other encoding", () =>
    * **One immutable identity holds one account of one span, and the first
    * account is the one that stands.**
    *
-   * This case used to assert the opposite — that a second, different account of
-   * a span already stored was kept beside the first, so a reader met two rows
-   * saying different things about one moment and had no rule for choosing.
-   *
-   * What happens now is three things at once, and all three matter. The door
+   * Three things happen at once here, and all three matter. The door
    * **accepts** the changed bytes, because a sender resending is ordinary and
    * refusing at a wire boundary would be answering a storage question there.
    * The drainer **refuses to write them**, because the stored evidence is
-   * already somebody's record of that moment. And the object is **retained**
-   * rather than deleted, because Egma promised those bytes were safe before it
-   * ever read them back — so a defect in Egma is not a reason to throw a
-   * customer's evidence away.
+   * already somebody's record of that moment, and two rows saying different
+   * things about one moment leave a reader no rule for choosing. And the object
+   * is **retained** rather than deleted, because Egma promised those bytes were
+   * safe before it ever read them back — so a defect in Egma is not a reason to
+   * throw a customer's evidence away.
    */
   it("keeps the stored account and retains the object when protobuf evidence reuses span ids", async () => {
     const before = await countOf(
@@ -988,11 +985,11 @@ describe.skipIf(!storage.available)("a batch carrying two customers' evidence", 
   /**
    * **A trace store that is down is not an ingestion failure any more.**
    *
-   * This used to be answered as a 500 an exporter would retry, because the door
-   * wrote ClickHouse before it answered. The acceptance boundary is the object
-   * store now, so a ClickHouse outage costs query visibility and nothing else:
-   * the request is accepted, the evidence is durable, and the rows appear when
-   * the store comes back and the object is drained.
+   * The acceptance boundary is the object store, so a ClickHouse outage costs
+   * query visibility and nothing else: the request is accepted, the evidence is
+   * durable, and the rows appear when the store comes back and the object is
+   * drained. A 5xx here would send an exporter into a retry loop over evidence
+   * Egma already holds.
    */
   it("accepts evidence while the trace store is unreachable, and lands it on recovery", async () => {
     await disconnectClickHouse();

--- a/apps/api/test/otlp-simulation-ingest.test.ts
+++ b/apps/api/test/otlp-simulation-ingest.test.ts
@@ -24,6 +24,7 @@ import {
   EXPORT_TRACE_SERVICE_RESPONSE,
 } from "../src/otlp/schema.ts";
 import { createApi, type TestApi } from "./support/api.ts";
+import { pendingObjectStore } from "../src/ingestion/object-store.ts";
 import { pendingSegments } from "./support/ingestion.ts";
 import {
   startObjectStorage,
@@ -596,21 +597,36 @@ function protobufBodyOf(fixtureJson: string): Buffer {
 
 describe.skipIf(!storage.available)("the same path in the other encoding", () => {
   /**
-   * **One immutable identity holds one account of one span.**
+   * The object the conflict case leaves behind. Retention is the point, so it
+   * is removed the way an operator removes one — deliberately, and only once
+   * what it proves has been proved.
+   */
+  let conflicting = "";
+
+  afterAll(async () => {
+    if (storage.available && conflicting !== "") {
+      await pendingObjectStore(ingestStore()).delete(conflicting);
+    }
+  });
+
+  /**
+   * **One immutable identity holds one account of one span, and the first
+   * account is the one that stands.**
    *
    * This case used to assert the opposite — that a second, different account of
    * a span already stored was kept beside the first, so a reader met two rows
-   * saying different things about one moment and had no rule for choosing. The
-   * identity rebuild settles it: a span's permanent identity is its customer,
-   * its project, its trace and its span id, and a replay under that identity
-   * never becomes a second visible span.
+   * saying different things about one moment and had no rule for choosing.
    *
-   * What the door does with the changed bytes is unchanged and deliberate: it
-   * accepts them, because a sender resending is ordinary and refusing at the
-   * door would be answering a storage question at a wire boundary. Everything
-   * this suite can see afterwards is one span and one turn.
+   * What happens now is three things at once, and all three matter. The door
+   * **accepts** the changed bytes, because a sender resending is ordinary and
+   * refusing at a wire boundary would be answering a storage question there.
+   * The drainer **refuses to write them**, because the stored evidence is
+   * already somebody's record of that moment. And the object is **retained**
+   * rather than deleted, because Egma promised those bytes were safe before it
+   * ever read them back — so a defect in Egma is not a reason to throw a
+   * customer's evidence away.
    */
-  it("leaves one visible span when changed protobuf evidence reuses span ids", async () => {
+  it("keeps the stored account and retains the object when protobuf evidence reuses span ids", async () => {
     const before = await countOf(
       `select count() as n from spans final where trace_id = '${VOICE_TRACE}'`,
     );
@@ -636,7 +652,7 @@ describe.skipIf(!storage.available)("the same path in the other encoding", () =>
       value: { stringValue: "retained" },
     });
 
-    const resent = await post(
+    const resent = await stage(
       protobufBodyOf(JSON.stringify(changed)),
       SERVICE_TOKEN,
       "application/x-protobuf",
@@ -649,6 +665,13 @@ describe.skipIf(!storage.available)("the same path in the other encoding", () =>
         { defaults: false },
       ),
     ).toEqual({});
+
+    // The drain writes nothing for this object and leaves it where it is.
+    expect(await api.drainEvidence()).toBe(0);
+    const retained = await pendingSegments(ingestStore());
+    expect(retained).toHaveLength(1);
+    conflicting = retained[0]?.key ?? "";
+    expect(conflicting).not.toBe("");
 
     expect(
       await countOf(
@@ -669,6 +692,14 @@ describe.skipIf(!storage.available)("the same path in the other encoding", () =>
           `where trace_id = '${VOICE_TRACE}' and span_id = 'bb20000000000002'`,
       ),
     ).toBe(1);
+
+    // The stored account is untouched: the attribute the resend added is
+    // nowhere in it.
+    const [stored] = await store().rows<{ payload: string }>(
+      "select payload from spans final " +
+        `where trace_id = '${VOICE_TRACE}' and span_id = 'bb20000000000002'`,
+    );
+    expect(stored?.payload).not.toContain("pipecat.changed");
   });
 
   it("lands a genuinely new protobuf flush, attributed exactly as the JSON ones", async () => {

--- a/apps/api/test/otlp-simulation-ingest.test.ts
+++ b/apps/api/test/otlp-simulation-ingest.test.ts
@@ -24,6 +24,11 @@ import {
   EXPORT_TRACE_SERVICE_RESPONSE,
 } from "../src/otlp/schema.ts";
 import { createApi, type TestApi } from "./support/api.ts";
+import { pendingSegments } from "./support/ingestion.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
 import {
   contextFor,
   mintKey,
@@ -49,7 +54,20 @@ import {
  * SQL to the ids the fixtures pin — the one edit no exported function offers,
  * made before anything references the row, so the golden bytes can post
  * unchanged against a database whose every other fact is genuine.
+ *
+ * The door answers on object-store durability and writes no row, so a post is
+ * followed by a drain wherever the claim is about what a reader sees. The one
+ * claim that is about the boundary itself — a batch naming two projects — reads
+ * the pending objects before anything drains them.
  */
+
+const storage: ObjectStorage = await startObjectStorage("otlp-simulation");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the simulation ingest suite — ${storage.why}\n\n`,
+  );
+}
 
 const contractRoot = fileURLToPath(
   new URL("../../../packages/simulation-contract", import.meta.url),
@@ -96,6 +114,17 @@ async function post(
   token: string | null = SERVICE_TOKEN,
   contentType = "application/json",
 ) {
+  const response = await stage(body, token, contentType);
+  await api.drainEvidence();
+  return response;
+}
+
+/** The same post, stopping where the door does: durable and not yet drained. */
+async function stage(
+  body: string | Buffer,
+  token: string | null = SERVICE_TOKEN,
+  contentType = "application/json",
+) {
   return api.app.inject({
     method: "POST",
     url: OTLP_TRACES_PATH,
@@ -105,6 +134,12 @@ async function post(
     },
     payload: body,
   });
+}
+
+/** The ingestion bucket this instance accepts into, for reading it back. */
+function ingestStore() {
+  if (!storage.available) throw new Error("this suite has no object store");
+  return storage.ingestStore;
 }
 
 /**
@@ -177,7 +212,11 @@ async function seedSimulationNamed(
 }
 
 beforeAll(async () => {
-  api = await createApi("otlp_simulation", { traceStore: true });
+  if (!storage.available) return;
+  api = await createApi("otlp_simulation", {
+    traceStore: true,
+    ingestStore: storage.ingestStore,
+  });
   acme = await signUp(api.app, "ada@acme.example", "Acme");
   globex = await signUp(api.app, "grace@globex.example", "Globex");
 
@@ -191,9 +230,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await api?.close();
+  if (storage.available) storage.stop();
 });
 
-describe("the contract's golden flushes, posted with the service token", () => {
+describe.skipIf(!storage.available)("the contract's golden flushes, posted with the service token", () => {
   it("land under the simulation's own customer and run, marked as simulation traffic from egma's runtime", async () => {
     const flush = await post(await fixture("valid", "chat-flush-1-turns.json"));
     expect(flush.statusCode, flush.body).toBe(200);
@@ -212,7 +252,7 @@ describe("the contract's golden flushes, posted with the service token", () => {
     }>(
       "select distinct organization_id, project_id, source, emitter, run_id, " +
         "agent_id, test_version_id, persona_version_id, environment " +
-        `from spans where trace_id = '${CHAT_TRACE}'`,
+        `from spans final where trace_id = '${CHAT_TRACE}'`,
     );
 
     expect(rows).toEqual([
@@ -237,7 +277,7 @@ describe("the contract's golden flushes, posted with the service token", () => {
       text: string;
       duration_ns: number;
     }>(
-      "select name, kind, text, duration_ns from spans " +
+      "select name, kind, text, duration_ns from spans final " +
         `where trace_id = '${CHAT_TRACE}' order by started_at, name`,
     );
 
@@ -268,7 +308,7 @@ describe("the contract's golden flushes, posted with the service token", () => {
     // own turn vocabulary.
     expect(
       await countOf(
-        `select count() as n from turns where trace_id = '${CHAT_TRACE}'`,
+        `select count() as n from turns final where trace_id = '${CHAT_TRACE}'`,
       ),
     ).toBe(2);
   });
@@ -296,7 +336,7 @@ describe("the contract's golden flushes, posted with the service token", () => {
     }
 
     const tools = await store().rows<{ tool_name: string; tool_arguments: string }>(
-      "select tool_name, tool_arguments from spans " +
+      "select tool_name, tool_arguments from spans final " +
         `where trace_id = '${CHAT_TRACE}' and kind = 'tool' order by started_at`,
     );
     expect(tools).toEqual([
@@ -311,13 +351,13 @@ describe("the contract's golden flushes, posted with the service token", () => {
     ]);
 
     const [root] = await store().rows<{ kind: string; parent_span_id: string }>(
-      `select kind, parent_span_id from spans where trace_id = '${CHAT_TRACE}' ` +
+      `select kind, parent_span_id from spans final where trace_id = '${CHAT_TRACE}' ` +
         "and name = 'simulation'",
     );
     expect(root).toEqual({ kind: "root", parent_span_id: "" });
 
     expect(
-      await countOf(`select count() as n from spans where trace_id = '${CHAT_TRACE}'`),
+      await countOf(`select count() as n from spans final where trace_id = '${CHAT_TRACE}'`),
     ).toBe(8);
   });
 
@@ -397,10 +437,10 @@ describe("the contract's golden flushes, posted with the service token", () => {
    */
   it("land nothing twice when every flush is sent again", async () => {
     const before = await countOf(
-      `select count() as n from spans where trace_id = '${CHAT_TRACE}'`,
+      `select count() as n from spans final where trace_id = '${CHAT_TRACE}'`,
     );
     const turnsBefore = await countOf(
-      `select count() as n from turns where trace_id = '${CHAT_TRACE}'`,
+      `select count() as n from turns final where trace_id = '${CHAT_TRACE}'`,
     );
     expect(before).toBe(8);
 
@@ -414,10 +454,10 @@ describe("the contract's golden flushes, posted with the service token", () => {
     }
 
     expect(
-      await countOf(`select count() as n from spans where trace_id = '${CHAT_TRACE}'`),
+      await countOf(`select count() as n from spans final where trace_id = '${CHAT_TRACE}'`),
     ).toBe(before);
     expect(
-      await countOf(`select count() as n from turns where trace_id = '${CHAT_TRACE}'`),
+      await countOf(`select count() as n from turns final where trace_id = '${CHAT_TRACE}'`),
     ).toBe(turnsBefore);
   });
 
@@ -432,7 +472,7 @@ describe("the contract's golden flushes, posted with the service token", () => {
       n: number;
     }>(
       "select organization_id, project_id, run_id, toUInt32(count()) as n " +
-        `from spans where trace_id = '${VOICE_TRACE}' ` +
+        `from spans final where trace_id = '${VOICE_TRACE}' ` +
         "group by organization_id, project_id, run_id",
     );
     expect(rows).toEqual([
@@ -447,7 +487,7 @@ describe("the contract's golden flushes, posted with the service token", () => {
     // The two turns genuinely overlap — the shape the vocabulary promises the
     // full-duplex persona — and both are stored as they were measured.
     const [overlap] = await store().rows<{ n: string }>(
-      "select count() as n from spans as human, spans as agent " +
+      "select count() as n from spans as human final, spans as agent final " +
         `where human.trace_id = '${VOICE_TRACE}' and agent.trace_id = '${VOICE_TRACE}' ` +
         "and human.kind = 'turn:human' and agent.kind = 'turn:agent' " +
         "and human.started_at < agent.started_at + intDivOrZero(agent.duration_ns, 1000) / 1000000 " +
@@ -476,7 +516,7 @@ describe("the contract's golden flushes, posted with the service token", () => {
       tool_result: string;
       payload: string;
     }>(
-      "select tool_name, tool_arguments, tool_result, payload from spans " +
+      "select tool_name, tool_arguments, tool_result, payload from spans final " +
         `where trace_id = '${MOCKED_TRACE}' and kind = 'tool' order by started_at`,
     );
 
@@ -554,13 +594,28 @@ function protobufBodyOf(fixtureJson: string): Buffer {
   );
 }
 
-describe("the same path in the other encoding", () => {
-  it("retains changed protobuf evidence that reuses span ids", async () => {
+describe.skipIf(!storage.available)("the same path in the other encoding", () => {
+  /**
+   * **One immutable identity holds one account of one span.**
+   *
+   * This case used to assert the opposite — that a second, different account of
+   * a span already stored was kept beside the first, so a reader met two rows
+   * saying different things about one moment and had no rule for choosing. The
+   * identity rebuild settles it: a span's permanent identity is its customer,
+   * its project, its trace and its span id, and a replay under that identity
+   * never becomes a second visible span.
+   *
+   * What the door does with the changed bytes is unchanged and deliberate: it
+   * accepts them, because a sender resending is ordinary and refusing at the
+   * door would be answering a storage question at a wire boundary. Everything
+   * this suite can see afterwards is one span and one turn.
+   */
+  it("leaves one visible span when changed protobuf evidence reuses span ids", async () => {
     const before = await countOf(
-      `select count() as n from spans where trace_id = '${VOICE_TRACE}'`,
+      `select count() as n from spans final where trace_id = '${VOICE_TRACE}'`,
     );
     const turnsBefore = await countOf(
-      `select count() as n from turns where trace_id = '${VOICE_TRACE}'`,
+      `select count() as n from turns final where trace_id = '${VOICE_TRACE}'`,
     );
     expect(before).toBe(4);
     expect(turnsBefore).toBe(2);
@@ -580,35 +635,7 @@ describe("the same path in the other encoding", () => {
       key: "pipecat.changed",
       value: { stringValue: "retained" },
     });
-    Object.assign(richSpan, {
-      traceState: "vendor=kept",
-      flags: 257,
-      droppedAttributesCount: 2,
-      droppedEventsCount: 3,
-      droppedLinksCount: 4,
-      events: [
-        {
-          timeUnixNano: "1785924902199999999",
-          name: "model-ready",
-          droppedAttributesCount: 1,
-          attributes: [
-            { key: "pipecat.event", value: { stringValue: "kept" } },
-          ],
-        },
-      ],
-      links: [
-        {
-          traceId: "31313131313131313131313131313131",
-          spanId: "3131313131313131",
-          traceState: "link=kept",
-          flags: 769,
-          droppedAttributesCount: 5,
-          attributes: [
-            { key: "pipecat.link", value: { stringValue: "kept" } },
-          ],
-        },
-      ],
-    });
+
     const resent = await post(
       protobufBodyOf(JSON.stringify(changed)),
       SERVICE_TOKEN,
@@ -625,62 +652,23 @@ describe("the same path in the other encoding", () => {
 
     expect(
       await countOf(
-        `select count() as n from spans where trace_id = '${VOICE_TRACE}'`,
+        `select count() as n from spans final where trace_id = '${VOICE_TRACE}'`,
       ),
-    ).toBe(before * 2);
-    // Changed rows reach the dependent view too. The reader does not collapse
-    // their reused span ids.
+    ).toBe(before);
+    // And the derived view holds one turn per identity too — a materialized
+    // view may process one replay more than once, and a reader must not see
+    // that.
     expect(
       await countOf(
-        `select count() as n from turns where trace_id = '${VOICE_TRACE}'`,
+        `select count() as n from turns final where trace_id = '${VOICE_TRACE}'`,
       ),
-    ).toBe(turnsBefore * 2);
-    const turnProjections = await store().rows<Record<string, unknown>>(
-      "select span_id, parent_span_id, toString(started_at) as started_at, " +
-        "duration_ns, kind, source, emitter, environment, connection_type, " +
-        "provider_call_id, run_id, agent_id, text_preview from turns " +
-        `where trace_id = '${VOICE_TRACE}' and span_id = 'bb20000000000002'`,
-    );
-    expect(turnProjections).toHaveLength(2);
-    expect(turnProjections[1]).toEqual(turnProjections[0]);
-
-    const [richRow] = await store().rows<{ payload: string }>(
-      "select payload from spans " +
-        `where trace_id = '${VOICE_TRACE}' and span_id = 'bb20000000000002' ` +
-        `and position(payload, '"pipecat.changed"') > 0`,
-    );
-    const raw = JSON.parse(richRow?.payload ?? "{}") as {
-      span?: Record<string, unknown>;
-    };
-    expect(raw.span).toMatchObject({
-      traceState: "vendor=kept",
-      flags: 257,
-      droppedAttributesCount: 2,
-      droppedEventsCount: 3,
-      droppedLinksCount: 4,
-      events: [
-        {
-          timeUnixNano: "1785924902199999999",
-          name: "model-ready",
-          droppedAttributesCount: 1,
-          attributes: [
-            { key: "pipecat.event", value: { stringValue: "kept" } },
-          ],
-        },
-      ],
-      links: [
-        {
-          traceId: "31313131313131313131313131313131",
-          spanId: "3131313131313131",
-          traceState: "link=kept",
-          flags: 769,
-          droppedAttributesCount: 5,
-          attributes: [
-            { key: "pipecat.link", value: { stringValue: "kept" } },
-          ],
-        },
-      ],
-    });
+    ).toBe(turnsBefore);
+    expect(
+      await countOf(
+        "select count() as n from turns final " +
+          `where trace_id = '${VOICE_TRACE}' and span_id = 'bb20000000000002'`,
+      ),
+    ).toBe(1);
   });
 
   it("lands a genuinely new protobuf flush, attributed exactly as the JSON ones", async () => {
@@ -724,7 +712,7 @@ describe("the same path in the other encoding", () => {
       status: string;
       payload: string;
     }>(
-      "select kind, duration_ns, run_id, source, status, payload from spans " +
+      "select kind, duration_ns, run_id, source, status, payload from spans final " +
         `where trace_id = '${VOICE_TRACE}' and span_id = 'bb20000000000006'`,
     );
     const [row] = rows;
@@ -745,9 +733,9 @@ describe("the same path in the other encoding", () => {
   });
 });
 
-describe("a resource that names no simulation, or one egma never conducted", () => {
+describe.skipIf(!storage.available)("a resource that names no simulation, or one egma never conducted", () => {
   it("is refused whole, with a body saying what to send", async () => {
-    const before = await countOf("select count() as n from spans");
+    const before = await countOf("select count() as n from spans final");
 
     const unnamed = await post(
       await fixture("invalid", "resource-naming-no-simulation.json"),
@@ -756,7 +744,7 @@ describe("a resource that names no simulation, or one egma never conducted", () 
     const refusal = unnamed.json() as { code: number; message: string };
     expect(refusal.message).toContain("egma.simulation_id");
 
-    expect(await countOf("select count() as n from spans")).toBe(before);
+    expect(await countOf("select count() as n from spans final")).toBe(before);
   });
 
   it("is refused by name when the simulation never existed, and stores nothing", async () => {
@@ -765,13 +753,13 @@ describe("a resource that names no simulation, or one egma never conducted", () 
       await fixture("valid", "chat-flush-1-turns.json")
     ).replaceAll(CHAT_SIMULATION, invented);
 
-    const before = await countOf("select count() as n from spans");
+    const before = await countOf("select count() as n from spans final");
     const refused = await post(body);
     expect(refused.statusCode).toBe(400);
     const refusal = refused.json() as { code: number; message: string };
     expect(refusal.message).toContain(invented);
 
-    expect(await countOf("select count() as n from spans")).toBe(before);
+    expect(await countOf("select count() as n from spans final")).toBe(before);
   });
 
   /**
@@ -796,7 +784,7 @@ describe("a resource that names no simulation, or one egma never conducted", () 
       await fixture("valid", "chat-flush-1-turns.json")
     ).replaceAll(CHAT_TRACE, VOICE_TRACE);
 
-    const before = await countOf("select count() as n from spans");
+    const before = await countOf("select count() as n from spans final");
     const refused = await post(body);
 
     expect(refused.statusCode, refused.body).toBe(400);
@@ -805,11 +793,11 @@ describe("a resource that names no simulation, or one egma never conducted", () 
     expect(refusal.message).toContain(VOICE_TRACE);
     expect(refusal.message).toContain(CHAT_TRACE);
 
-    expect(await countOf("select count() as n from spans")).toBe(before);
+    expect(await countOf("select count() as n from spans final")).toBe(before);
   });
 });
 
-describe("a payload that claims a tenant on the service path", () => {
+describe.skipIf(!storage.available)("a payload that claims a tenant on the service path", () => {
   it("is stored verbatim and decides nothing: the customer comes from the simulation row", async () => {
     const claimed = JSON.parse(
       await fixture("valid", "chat-flush-1-turns.json"),
@@ -841,7 +829,7 @@ describe("a payload that claims a tenant on the service path", () => {
       project_id: string;
       payload: string;
     }>(
-      "select organization_id, project_id, payload from spans " +
+      "select organization_id, project_id, payload from spans final " +
         `where trace_id = '${CHAT_TRACE}' and span_id = 'dd40000000000000'`,
     );
     expect(rows).toHaveLength(1);
@@ -852,7 +840,7 @@ describe("a payload that claims a tenant on the service path", () => {
   });
 });
 
-describe("a batch carrying two customers' evidence when the store refuses one of them", () => {
+describe.skipIf(!storage.available)("a batch carrying two customers' evidence", () => {
   /** One turn for each simulation, on span ids nothing else in this file mints. */
   function twoTenantBatch(): string {
     const turn = (
@@ -887,9 +875,8 @@ describe("a batch carrying two customers' evidence when the store refuses one of
       ],
     });
 
-    // The refusing tenant deliberately first: a door that stopped at the first
-    // refusal would never reach the second tenant at all, and this batch is
-    // shaped to catch exactly that.
+    // Globex's resource first, so that a door which stopped grouping at the
+    // first project would never reach Acme's at all.
     return JSON.stringify({
       resourceSpans: [
         turn(VOICE_SIMULATION, VOICE_TRACE, "ff60000000000001"),
@@ -899,79 +886,105 @@ describe("a batch carrying two customers' evidence when the store refuses one of
   }
 
   /**
-   * One customer's refused rows cost exactly that customer's spans — the
-   * other group still lands, and the answer counts as rejected only what was
-   * genuinely not stored. Nothing that landed is reported rejected: the
-   * sender's write-ahead log believes this count, and a landed span reported
-   * rejected would be evidence the sender stops owing.
+   * **A segment belongs to exactly one project, and the answer waits for all of
+   * them.**
+   *
+   * The trusted service batch is the only body that can carry two projects, and
+   * this is the one place the rule is visible: two projects may not share a
+   * durable object, so one request becomes two sealed segments — and the sender
+   * is not told the batch was accepted until every one of them is in the bucket.
+   * A per-group answer would report success while one project's evidence was
+   * still in a local log.
+   *
+   * No shipped client sends this. The simulator refuses a batch spanning more
+   * than one trace and delivers one reporter per simulation, so the body is
+   * built by hand here — the route's multi-project path is defensive, and a
+   * defence nothing exercises is a defence nobody knows is broken.
    */
-  it("lands the other customer's group, and counts only the refused one rejected", async () => {
-    await store().command(
-      "alter table spans add constraint refuses_globex check " +
-        `organization_id != '${globex.organizationId}'`,
+  it("seals one segment for each project and answers only when both are durable", async () => {
+    const response = await stage(twoTenantBatch());
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toEqual({});
+
+    // The request has been answered, so both projects' evidence is durable —
+    // in two objects, each naming one project and holding only its records.
+    const pending = await pendingSegments(ingestStore());
+    expect(pending).toHaveLength(2);
+
+    const byProject = new Map(
+      pending.map((segment) => [segment.header.project_id, segment]),
+    );
+    expect([...byProject.keys()].sort()).toEqual(
+      [acme.projectId, globex.projectId].sort(),
     );
 
-    try {
-      const response = await post(twoTenantBatch());
+    const acmeSegment = byProject.get(acme.projectId);
+    expect(acmeSegment?.header.organization_id).toBe(acme.organizationId);
+    expect(acmeSegment?.records.map((record) => record.span_id)).toEqual([
+      "ff60000000000002",
+    ]);
 
-      expect(response.statusCode, response.body).toBe(200);
-      expect(response.json()).toEqual({
-        partialSuccess: {
-          rejectedSpans: "1",
-          errorMessage: expect.stringContaining("the trace store refused"),
-        },
-      });
-    } finally {
-      await store().command("alter table spans drop constraint refuses_globex");
-    }
+    const globexSegment = byProject.get(globex.projectId);
+    expect(globexSegment?.header.organization_id).toBe(globex.organizationId);
+    expect(globexSegment?.records.map((record) => record.span_id)).toEqual([
+      "ff60000000000001",
+    ]);
 
-    // The tenant the store refused lost its span, and only it.
-    expect(
-      await countOf(
-        "select count() as n from spans where span_id = 'ff60000000000001'",
-      ),
-    ).toBe(0);
-    const landed = await store().rows<{ organization_id: string; text: string }>(
-      "select organization_id, text from spans where span_id = 'ff60000000000002'",
+    expect(await api.drainEvidence()).toBe(2);
+    const landed = await store().rows<{
+      organization_id: string;
+      span_id: string;
+      text: string;
+    }>(
+      "select organization_id, span_id, text from spans final " +
+        "where span_id in ('ff60000000000001', 'ff60000000000002') " +
+        "order by span_id",
     );
     expect(landed).toEqual([
       {
+        organization_id: globex.organizationId,
+        span_id: "ff60000000000001",
+        text: "Said while the store was fussy.",
+      },
+      {
         organization_id: acme.organizationId,
+        span_id: "ff60000000000002",
         text: "Said while the store was fussy.",
       },
     ]);
   });
 
   /**
-   * The other kind of store trouble stays the error it is: rows a minute of
-   * patience would land must reach the sender as a retry, never as a
-   * rejection its write-ahead log would believe forever. The resend is safe
-   * on the groups that landed before the fault within ClickHouse's recent
-   * exact-block window.
+   * **A trace store that is down is not an ingestion failure any more.**
+   *
+   * This used to be answered as a 500 an exporter would retry, because the door
+   * wrote ClickHouse before it answered. The acceptance boundary is the object
+   * store now, so a ClickHouse outage costs query visibility and nothing else:
+   * the request is accepted, the evidence is durable, and the rows appear when
+   * the store comes back and the object is drained.
    */
-  it("still answers a store that merely failed as an error the sender will retry", async () => {
+  it("accepts evidence while the trace store is unreachable, and lands it on recovery", async () => {
     await disconnectClickHouse();
+    let accepted;
     try {
-      const response = await post(twoTenantBatch());
-      expect(response.statusCode).toBe(500);
+      accepted = await stage(twoTenantBatch());
     } finally {
       connectClickHouse({ clickhouseUrl: store().url, maxOpenConnections: 4 });
     }
+    expect(accepted.statusCode, accepted.body).toBe(200);
+    expect(await pendingSegments(ingestStore())).toHaveLength(2);
 
-    // And the same document goes through whole once the store is back.
-    const retried = await post(twoTenantBatch());
-    expect(retried.statusCode, retried.body).toBe(200);
-    expect(retried.json()).toEqual({});
+    expect(await api.drainEvidence()).toBe(2);
     expect(
       await countOf(
-        "select count() as n from spans where span_id in " +
+        "select count() as n from spans final where span_id in " +
           "('ff60000000000001', 'ff60000000000002')",
       ),
     ).toBe(2);
   });
 });
 
-describe("the customer-key path, beside it", () => {
+describe.skipIf(!storage.available)("the customer-key path, beside it", () => {
   /**
    * The naming attribute belongs to the service path alone. A customer's
    * exporter is free to send it — nothing about a customer request is refused
@@ -1034,7 +1047,7 @@ describe("the customer-key path, beside it", () => {
       payload: string;
     }>(
       "select organization_id, project_id, source, emitter, run_id, kind, " +
-        `payload from spans where trace_id = '${traceId}'`,
+        `payload from spans final where trace_id = '${traceId}'`,
     );
 
     expect(rows).toHaveLength(1);
@@ -1067,7 +1080,7 @@ describe("the customer-key path, beside it", () => {
   });
 });
 
-describe("what the service path leaves alone", () => {
+describe.skipIf(!storage.available)("what the service path leaves alone", () => {
   /**
    * A simulation's grading work is minted by the transaction that lands it
    * terminal, so the door writes no queue row for simulation spans — one had

--- a/apps/api/test/recordings-routes.test.ts
+++ b/apps/api/test/recordings-routes.test.ts
@@ -1,9 +1,13 @@
 import { newId } from "@egma/ids";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 
 import { recordingPathFor } from "../src/routes/recordings.ts";
 import { RECORDING_LINK_SECONDS } from "../src/recordings/signed-link.ts";
 import { createApi, type TestApi } from "./support/api.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
 import {
   aConductedRun,
   fileTranscriptOf,
@@ -44,6 +48,10 @@ afterEach(async () => {
   await api?.close();
 });
 
+afterAll(() => {
+  if (storage.available) storage.stop();
+});
+
 function request(
   method: "GET",
   url: string,
@@ -69,6 +77,25 @@ const A_BROWSERS_STORE = {
 } as const;
 
 const A_REFERENCE = "sim_01JQ0A2B3C4D5E6F7G8H9J0K/dual-channel.wav";
+
+/**
+ * The one case here that files evidence at the door needs somewhere for that
+ * evidence to become durable — a transcript is read from rows, and rows come
+ * from a drained segment. Everything else in this file signs links against the
+ * fictional store above and needs no container at all.
+ */
+const storage: ObjectStorage = await startObjectStorage("recordings-routes");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the transcript-audio case — ${storage.why}\n\n`,
+  );
+}
+
+function running(): Extract<ObjectStorage, { available: true }> {
+  if (!storage.available) throw new Error("this suite has no object store");
+  return storage;
+}
 
 /** Somebody with a run of two voice conversations, one of which was recorded. */
 async function aCustomerWhoHasRecorded(
@@ -380,11 +407,12 @@ describe("what the run's own results say about audio", () => {
  * Both halves are asserted here, because a route that answered only the happy
  * one would put a player on a transcript that has nothing to play.
  */
-describe("what a transcript says about audio", () => {
+describe.skipIf(!storage.available)("what a transcript says about audio", () => {
   it("names the simulation it is, so one route serves both surfaces", async () => {
     api = await createApi("recording_transcript", {
       blob: A_BROWSERS_STORE,
       traceStore: true,
+      ingestStore: running().ingestStore,
     });
     const ada = await signUp(api.app, "ada@acme.example", "Acme");
     const who = await standingOf(api.app, ada.cookie, "a terminal");
@@ -392,13 +420,13 @@ describe("what a transcript says about audio", () => {
 
     const at = new Date("2026-08-11T09:00:00Z");
     const heard = await fileTranscriptOf(
-      api.app,
+      api,
       run.heard,
       { human: "I need to move my cleaning.", agent: "Of course — when to?" },
       at,
     );
     const silent = await fileTranscriptOf(
-      api.app,
+      api,
       run.silent,
       { human: "Hello?", agent: "" },
       at,

--- a/apps/api/test/retell-normalise.test.ts
+++ b/apps/api/test/retell-normalise.test.ts
@@ -426,7 +426,7 @@ describe("the spans a captured payload becomes", () => {
     );
   });
 
-  it("removes provider credentials before they enter any span payload", () => {
+  it("omits the two named transport fields before any span payload", () => {
     const accessToken = "SENTINEL-web-call-access-token";
     const authorization = "Bearer SENTINEL-customer-authorization";
     const normalised = normaliseRetellCall(
@@ -444,14 +444,45 @@ describe("the spans a captured payload becomes", () => {
     const stored = asBytes(normalised.spans);
     expect(stored).not.toContain(accessToken);
     expect(stored).not.toContain(authorization);
+    // Gone, with nothing written where they were. A marker is a value a
+    // customer can also send, so a reader meeting one could not tell who put
+    // it there.
+    expect(stored).not.toContain("REDACTED");
     const payload = JSON.parse(normalised.spans[0]?.payload ?? "{}") as Record<
       string,
       unknown
     >;
-    expect(payload["access_token"]).toBe("[REDACTED]");
+    expect(Object.keys(payload)).not.toContain("access_token");
     expect(payload["custom_sip_headers"]).toEqual({
-      Authorization: "[REDACTED]",
       "X-Customer-Route": "support",
+    });
+  });
+
+  it("keeps credential-looking customer evidence byte for byte", () => {
+    const transcript =
+      "Agent: what is the code? User: my password is hunter2, " +
+      "Authorization: Bearer not-a-credential-of-ours";
+    const normalised = normaliseRetellCall(
+      capturedCall({
+        transcript,
+        metadata: { secret: "customer-named-this", api_key: "customer-value" },
+        call_analysis: { custom_analysis_data: { authorization: "kept" } },
+      }),
+      FILED_INTO,
+      NOW,
+    );
+
+    const payload = JSON.parse(normalised.spans[0]?.payload ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(payload["transcript"]).toBe(transcript);
+    expect(payload["metadata"]).toEqual({
+      secret: "customer-named-this",
+      api_key: "customer-value",
+    });
+    expect(payload["call_analysis"]).toEqual({
+      custom_analysis_data: { authorization: "kept" },
     });
   });
 });

--- a/apps/api/test/retell-production-write.test.ts
+++ b/apps/api/test/retell-production-write.test.ts
@@ -135,10 +135,11 @@ describe("the shared Retell production writer", () => {
       platformAgentVersion: "7",
     });
     expect(recorded.claimed).not.toHaveProperty("connectionId");
-    expect(recorded.claimed?.payload).toContain('"access_token":"[REDACTED]"');
+    expect(recorded.claimed?.payload).not.toContain("access_token");
     expect(recorded.claimed?.payload).not.toContain(
       "provider-access-token-must-not-be-stored",
     );
+    expect(recorded.claimed?.payload).not.toContain("REDACTED");
     expect(recorded.appended).toBeGreaterThan(1);
     expect(recorded.grading).toBe(recorded.appended);
     expect(recorded.finished).toHaveLength(1);

--- a/apps/api/test/retell-production-write.test.ts
+++ b/apps/api/test/retell-production-write.test.ts
@@ -80,12 +80,9 @@ function writeStore(
     async finishProductionTrace(_auth, finished) {
       recorded.finished.push(finished.traceId);
     },
-    async recordRetellCallReceived() {
+    async recordProductionEvidenceReceived(_auth, input) {
       recorded.received += 1;
-    },
-    async recordRetellMonitoringReceived(_auth, input) {
-      recorded.received += 1;
-      recorded.replayedPlatformAgentIds.push(input.platformAgentId);
+      recorded.replayedPlatformAgentIds.push(input.platformAgentId ?? "");
     },
   };
 }

--- a/apps/api/test/retell-provider.test.ts
+++ b/apps/api/test/retell-provider.test.ts
@@ -77,9 +77,7 @@ describe("Retell production call reads", () => {
           agent_id: "agent_voice_1",
           call_status: "not_connected",
           call_type: "web_call",
-          access_token: "[REDACTED]",
           custom_sip_headers: {
-            Authorization: "[REDACTED]",
             "X-Customer-Route": "support",
           },
         },
@@ -183,9 +181,7 @@ describe("Retell production call reads", () => {
         call_type: "web_call",
         start_timestamp: 1_786_000_000_000,
         end_timestamp: 1_786_000_074_000,
-        access_token: "[REDACTED]",
         custom_sip_headers: {
-          "Proxy-Authorization": "[REDACTED]",
           "X-Customer-Route": "support",
         },
         transcript_with_tool_calls: [
@@ -193,6 +189,10 @@ describe("Retell production call reads", () => {
         ],
       },
     });
+    // Neither the listed item's token nor the hydrated document's reaches a
+    // caller, and nothing is written where they were.
+    expect(JSON.stringify(answer)).not.toContain("web-call-token");
+    expect(JSON.stringify(answer)).not.toContain("REDACTED");
   });
 
   it("separates a missing call from a malformed full document", async () => {

--- a/apps/api/test/run-results-lanes.test.ts
+++ b/apps/api/test/run-results-lanes.test.ts
@@ -512,6 +512,7 @@ function aSpan(traceId: string, over: Partial<NewSpan>): NewSpan {
     testVersionId: "",
     personaVersionId: "",
     payload: "{}",
+    endsTrace: false,
     ...over,
   };
 }

--- a/apps/api/test/simulation-evidence.test.ts
+++ b/apps/api/test/simulation-evidence.test.ts
@@ -629,18 +629,16 @@ describe.skipIf(!storage.available)("the conversation and its spans", () => {
    * **Simulation evidence goes through the same durable path, and is graded
    * once.**
    *
-   * Two guards used to stand between a simulation's spans and a second piece of
-   * grading work. The door's was one: the simulator branch deliberately never
-   * asked for the evidence-ready handoff. That guard is gone with the direct
-   * write — the door writes nothing at all now, and the drainer reports every
-   * segment it drains without knowing which conversation is whose.
+   * One rule stands between a simulation's spans and a second piece of grading
+   * work: a span whose source is not `production` is not reported through the
+   * evidence-ready boundary. The door writes nothing at all, and the drainer
+   * reports every segment it drains without knowing whose conversation is
+   * whose — so that per-span rule is the only guard there is.
    *
-   * What is left is the per-span rule, and it is the only thing standing there:
-   * a span whose source is not `production` is not the drainer's to report.
    * A simulation's grading work is minted by the transaction that lands it
    * terminal, so a second piece filed from telemetry would be one conversation
-   * judged twice — which is why the evidence going in **and** the evidence
-   * going through the drainer are both proved here rather than assumed.
+   * judged twice. That is why the evidence going in **and** the evidence going
+   * through the drainer are both proved here rather than assumed.
    */
   it("grades exactly once, however many segments its spans arrive in", async () => {
     const { who, run } = await aCustomerWhoHasRun("evidence_graded_once", {

--- a/apps/api/test/simulation-evidence.test.ts
+++ b/apps/api/test/simulation-evidence.test.ts
@@ -10,9 +10,13 @@ import {
   type NewVerdict,
 } from "@egma/db";
 import { traceIdOfSimulation } from "@egma/simulation-contract";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 
 import { createApi, type TestApi } from "./support/api.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
 import {
   aConductedRun,
   fileTranscriptOf,
@@ -43,10 +47,22 @@ import { colleagueOf, request as ask, signUp, type Answer } from "./support/trac
  * carries who judged it any more.
  */
 
+const storage: ObjectStorage = await startObjectStorage("simulation-evidence");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the simulation-evidence suite — ${storage.why}\n\n`,
+  );
+}
+
 let api: TestApi;
 
 afterEach(async () => {
   await api?.close();
+});
+
+afterAll(() => {
+  if (storage.available) storage.stop();
 });
 
 function request(
@@ -108,7 +124,12 @@ async function aCustomerWhoHasRun(
   label: string,
   options: { readonly withTraceEvidence?: boolean } = {},
 ): Promise<Conducted> {
-  api = await createApi(label, { traceStore: options.withTraceEvidence === true });
+  api = await createApi(label, {
+    traceStore: options.withTraceEvidence === true,
+    ...(options.withTraceEvidence === true && storage.available
+      ? { ingestStore: storage.ingestStore }
+      : {}),
+  });
   const ada = await signUp(api.app, "ada@acme.example", "Acme");
   const who = await standingOf(api.app, ada.cookie, "a terminal");
   const run = await aConductedRun(api.app, who, {
@@ -117,7 +138,7 @@ async function aCustomerWhoHasRun(
 
   if (options.withTraceEvidence === true) {
     await fileTranscriptOf(
-      api.app,
+      api,
       run.heard,
       {
         human: "I need to move Thursday's clean to next week.",
@@ -189,7 +210,7 @@ async function theJobOn(
   return { status: only.status, narrowedTo: only.regradeGraderId };
 }
 
-describe("one conversation's evidence, in one read", () => {
+describe.skipIf(!storage.available)("one conversation's evidence, in one read", () => {
   it("carries the pins, the identities, the plan, the judgement and the transcript together", async () => {
     const { who, run } = await aCustomerWhoHasRun("evidence_one_read", {
       withTraceEvidence: true,
@@ -321,7 +342,7 @@ describe("one conversation's evidence, in one read", () => {
   });
 });
 
-describe("judging one conversation again", () => {
+describe.skipIf(!storage.available)("judging one conversation again", () => {
   it("reopens its grading job, and says what the ask was narrowed to", async () => {
     const { who, run } = await aCustomerWhoHasRun("evidence_regrade");
     await finishGrading(who.auth);
@@ -593,7 +614,7 @@ describe("judging one conversation again", () => {
  * this is where that stops being a claim: the transcript above came back under
  * the id derived from the conversation, with nothing having stored a mapping.
  */
-describe("the conversation and its spans", () => {
+describe.skipIf(!storage.available)("the conversation and its spans", () => {
   it("files the transcript under the id derived from the simulation", async () => {
     const { who, run } = await aCustomerWhoHasRun("evidence_trace_identity", {
       withTraceEvidence: true,
@@ -602,5 +623,49 @@ describe("the conversation and its spans", () => {
     const read = await request("GET", `/v1/simulations/${run.heard}`, who.key);
     const transcript = read.body.transcript as { traceId: string };
     expect(transcript.traceId).toBe(traceIdOfSimulation(run.heard));
+  });
+
+  /**
+   * **Simulation evidence goes through the same durable path, and is graded
+   * once.**
+   *
+   * Two guards used to stand between a simulation's spans and a second piece of
+   * grading work. The door's was one: the simulator branch deliberately never
+   * asked for the evidence-ready handoff. That guard is gone with the direct
+   * write — the door writes nothing at all now, and the drainer reports every
+   * segment it drains without knowing which conversation is whose.
+   *
+   * What is left is the per-span rule, and it is the only thing standing there:
+   * a span whose source is not `production` is not the drainer's to report.
+   * A simulation's grading work is minted by the transaction that lands it
+   * terminal, so a second piece filed from telemetry would be one conversation
+   * judged twice — which is why the evidence going in **and** the evidence
+   * going through the drainer are both proved here rather than assumed.
+   */
+  it("grades exactly once, however many segments its spans arrive in", async () => {
+    const { who, run } = await aCustomerWhoHasRun("evidence_graded_once", {
+      withTraceEvidence: true,
+    });
+
+    // A second flush of the same conversation, drained on its own — which is
+    // the shape a simulator's ordered sender really produces.
+    await fileTranscriptOf(
+      api,
+      run.heard,
+      { human: "One more thing.", agent: "Of course." },
+      new Date(),
+    );
+
+    const jobs = await listGradingJobsForSimulation(who.auth, run.heard);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({ source: "simulation" });
+
+    // And nothing was filed against the trace those spans are stored under,
+    // which is where a second piece of work would have appeared.
+    const { rows } = await api.database.sql<{ count: string }>(
+      "select count(*) as count from grading_job where source = $1",
+      ["production"],
+    );
+    expect(rows[0]?.count).toBe("0");
   });
 });

--- a/apps/api/test/simulator-walk.test.ts
+++ b/apps/api/test/simulator-walk.test.ts
@@ -20,6 +20,10 @@ import { makeLog } from "../../grader/src/log.ts";
 import { startService, type Service } from "../../grader/src/service.ts";
 import { scriptedJudge } from "../../grader/test/support/scripted-judge.ts";
 import { startInstance, type Instance } from "./support/instance.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
 import { NEUTRAL_TRAITS } from "./support/traces.ts";
 
 /**
@@ -258,6 +262,22 @@ const THE_BEHAVIOR = "confirms the new time back before finishing";
  */
 const THE_PHRASE = "Wednesday afternoon";
 
+/**
+ * The walk needs somewhere for evidence to become durable, because the whole of
+ * what it watches runs through the real door: the simulator's span batches are
+ * answered on object-store durability, and its terminal report is sent behind
+ * them in order. An instance with no ingestion bucket answers those batches the
+ * way an unconfigured deployment does — retryably — and the simulation never
+ * reaches the report that ends it.
+ */
+const storage: ObjectStorage = await startObjectStorage("simulator-walk");
+
+if (!storage.available) {
+  process.stderr.write(
+    `\nskipping the shipped-simulator walk — ${storage.why}\n\n`,
+  );
+}
+
 let instance: Instance;
 let counterpart: RetellCounterpart;
 let simulator: ChildProcess | undefined;
@@ -437,15 +457,22 @@ type Sighting = {
 
 /**
  * Watch one simulation from queued to terminal, reading both stores as it
- * goes, and answer with everything seen — including one last look taken the
- * instant the row turned terminal.
+ * goes, and answer with everything seen — plus the conversation as it stands
+ * once the evidence behind it has been stored.
  *
- * The order inside the loop is the whole point. Spans are read *first* and
- * the row's status *second*, so a sighting that says terminal is saying the
- * spans beside it were already there before the transition was visible. Then
- * the terminal sighting is taken again, spans last, because what has to be
- * true is the strong direction: when the control plane records a terminal
- * transition, the evidence a verdict will cite is already stored.
+ * The order inside the loop is deliberate. Spans are read *first* and the row's
+ * status *second*, so a sighting is saying the spans beside it were already
+ * there before the transition it reports.
+ *
+ * **The terminal look waits, and that is the design rather than a slow test.**
+ * The two facts about a finished simulation are separate and arrive in either
+ * order: the lifecycle transition that ends it, and its evidence becoming
+ * query-visible. A span batch is answered when it is durable in the object
+ * store, which is a promise that it is safe rather than that it is readable —
+ * so a terminal row may be written while the last segment is still on its way
+ * into the trace store. What has to be true is that the conversation a verdict
+ * will cite does arrive, whole, and the reconciliation of the two arrivals
+ * belongs to the grading boundary rather than to either producer.
  */
 async function watchToTerminal(
   simulationId: string,
@@ -459,10 +486,17 @@ async function watchToTerminal(
     const status = String((await rowOf(simulationId)).status);
     seen.push({ status, spans });
     if (status === "completed" || status === "failed" || status === "canceled") {
-      return {
-        seen,
-        atTerminal: (await storedSpans(traceId)).map((span) => span.name),
-      };
+      // The root span is the last thing the simulator sends, so its arrival is
+      // what says the whole conversation is readable. Waited for rather than
+      // demanded in the same instant, and answered with whatever the last look
+      // saw either way, so a conversation that never lands fails on what is
+      // missing rather than on a timer.
+      let atTerminal = (await storedSpans(traceId)).map((span) => span.name);
+      while (!atTerminal.includes("simulation") && Date.now() <= deadline) {
+        await new Promise((resume) => setTimeout(resume, 25));
+        atTerminal = (await storedSpans(traceId)).map((span) => span.name);
+      }
+      return { seen, atTerminal };
     }
     if (Date.now() > deadline) {
       throw new Error(
@@ -506,6 +540,7 @@ beforeAll(async () => {
     web: false,
     traces: true,
     retellFetch: RETELL_CHAT_PREFLIGHT,
+    ...(storage.available ? { ingestStore: storage.ingestStore } : {}),
   });
 }, 120_000);
 
@@ -516,9 +551,10 @@ afterAll(async () => {
   await instance?.close();
   await counterpart?.stop();
   await rm(scratch, { recursive: true, force: true });
+  if (storage.available) storage.stop();
 });
 
-describe("the shipped simulator against the real API", () => {
+describe.skipIf(!storage.available)("the shipped simulator against the real API", () => {
   it(
     "walks queued → claimed → running → completed, and a refused key to an honest failed",
     { timeout: 90_000 },
@@ -732,8 +768,9 @@ describe("the shipped simulator against the real API", () => {
       // reader seeing it would mean the conversation was already over.
       expect(whileRunning[0]?.spans).not.toContain("simulation");
 
-      // The guarantee: at the moment the row went terminal, the whole
-      // conversation was already stored — root span and all.
+      // The guarantee: the whole conversation a verdict will cite is stored —
+      // root span and all — for a simulation the control plane has recorded as
+      // over.
       expect(watched.atTerminal).toContain("simulation");
 
       // The conversation that happened: completed, concluded by the persona,

--- a/apps/api/test/simulator-walk.test.ts
+++ b/apps/api/test/simulator-walk.test.ts
@@ -727,7 +727,10 @@ describe.skipIf(!storage.available)("the shipped simulator against the real API"
           capacity: 4,
           heartbeatSeconds: 1,
           leaseSeconds: 3_600,
-          sweepSeconds: 3_600,
+          // Short, because a claim declined for a conversation whose evidence
+          // is still being drained goes back to the queue and is taken up
+          // again by a sweep. A deployment's own default is thirty seconds.
+          sweepSeconds: 1,
           traceIdleSeconds: 3_600,
           logLevel: "ERROR",
         },

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -141,6 +141,19 @@ export type TestApiOptions = {
    */
   readonly ingestionFlushMilliseconds?: number;
   /**
+   * How long a request waits for object-store durability before it is answered
+   * retryably. Short here for the suites whose claim *is* the bound, so that
+   * proving it costs a second rather than the deployment's ten.
+   */
+  readonly ingestionRequestTimeoutMilliseconds?: number;
+  /**
+   * Where the local log lives, for the one case that needs two instances to
+   * share one: a stop and a start over staged evidence that outlived the
+   * process. A directory named here belongs to the caller and is left where it
+   * is on close.
+   */
+  readonly ingestionLogDirectory?: string;
+  /**
    * Somewhere to keep the log lines, for a test whose claim is about what is
    * not in them. Off by default: the suite runs silent, and a file that does
    * not read the log has no reason to collect one.
@@ -203,7 +216,8 @@ export async function createApi(
   const ingestionLogDirectory =
     options.ingestStore === undefined
       ? undefined
-      : mkdtempSync(path.join(tmpdir(), `egma-ingestion-${label}-`));
+      : (options.ingestionLogDirectory ??
+        mkdtempSync(path.join(tmpdir(), `egma-ingestion-${label}-`)));
 
   const base = testConfig({
     databaseUrl: database.url,
@@ -226,6 +240,12 @@ export async function createApi(
             store: options.ingestStore,
             logDirectory: ingestionLogDirectory,
             flushMilliseconds: options.ingestionFlushMilliseconds ?? 20,
+            ...(options.ingestionRequestTimeoutMilliseconds === undefined
+              ? {}
+              : {
+                  requestTimeoutMilliseconds:
+                    options.ingestionRequestTimeoutMilliseconds,
+                }),
           },
         };
 
@@ -282,7 +302,10 @@ export async function createApi(
       await app.close();
       await disconnect();
       await database.drop();
-      if (ingestionLogDirectory !== undefined) {
+      if (
+        ingestionLogDirectory !== undefined &&
+        options.ingestionLogDirectory === undefined
+      ) {
         rmSync(ingestionLogDirectory, { recursive: true, force: true });
       }
       if (traceStore !== undefined) {

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -57,12 +57,13 @@ export type TestApi = {
   /** Everything the email transport was handed, in order. */
   readonly mail: readonly Email[];
   /**
-   * Turn every pending object into rows, the way the drainer will.
+   * Turn every pending object into rows, the way the deployment does.
    *
    * The door answers on object-store durability and stops there, so a suite
    * whose claim is about what a reader sees calls this between posting and
-   * reading. It answers how many segments it drained, which is also how a test
-   * says "one project, one segment". Nothing to drain answers zero.
+   * reading. It answers how many objects the pass drained. On an instance that
+   * drains on its own, that count is whatever this pass happened to find — the
+   * evidence is what to assert on, not the number.
    */
   drainEvidence(): Promise<number>;
   close(): Promise<void>;
@@ -147,12 +148,28 @@ export type TestApiOptions = {
    */
   readonly ingestionRequestTimeoutMilliseconds?: number;
   /**
+   * What the local log will hold before it refuses. Tiny here for the one suite
+   * whose claim is the refusal, so that reaching a bound costs one request
+   * rather than half a gigabyte.
+   */
+  readonly ingestionLogMaxBytes?: number;
+  /**
    * Where the local log lives, for the one case that needs two instances to
    * share one: a stop and a start over staged evidence that outlived the
    * process. A directory named here belongs to the caller and is left where it
    * is on close.
    */
   readonly ingestionLogDirectory?: string;
+  /**
+   * Whether this instance runs the standing drainer. Off by default, so that a
+   * suite can look at a sealed segment before anything drains it — the state a
+   * deployment passes through in about the time one upload takes.
+   *
+   * On, the instance behaves as a deployment does: a durable segment is drained
+   * without anybody asking. `drainEvidence` then waits for a pass that started
+   * after the call, which is what a suite needs instead of a sleep.
+   */
+  readonly drainsPendingEvidence?: boolean;
   /**
    * Somewhere to keep the log lines, for a test whose claim is about what is
    * not in them. Off by default: the suite runs silent, and a file that does
@@ -246,6 +263,9 @@ export async function createApi(
                   requestTimeoutMilliseconds:
                     options.ingestionRequestTimeoutMilliseconds,
                 }),
+            ...(options.ingestionLogMaxBytes === undefined
+              ? {}
+              : { logMaxBytes: options.ingestionLogMaxBytes }),
           },
         };
 
@@ -264,8 +284,9 @@ export async function createApi(
   await seedPersonaLibrary();
   await seedGraderLibrary();
 
-  const { app, identity } = buildApi({
+  const { app, identity, drainer } = buildApi({
     config,
+    drainsPendingEvidence: options.drainsPendingEvidence ?? false,
     ...(options.defaultEmailSender === true ? {} : { emailSender }),
     ...(options.rateLimit === undefined ? {} : { rateLimit: options.rateLimit }),
     ...(options.logTo === undefined ? {} : { logTo: options.logTo }),
@@ -296,6 +317,10 @@ export async function createApi(
     mail,
     async drainEvidence() {
       if (options.ingestStore === undefined) return 0;
+      // The instance's own drainer where it has one, so a suite that proves the
+      // standing behaviour is waiting on the same object it is asserting about.
+      const standing = drainer();
+      if (standing !== undefined) return standing.drainNow();
       return drainPendingEvidence(options.ingestStore);
     },
     async close() {

--- a/apps/api/test/support/api.ts
+++ b/apps/api/test/support/api.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import {
   connect,
   connectClickHouse,
@@ -16,6 +20,8 @@ import type { Email, EmailSender } from "../../src/auth/email.ts";
 import type { RateLimit } from "../../src/http/rate-limit.ts";
 import { buildApi, type ServerOptions } from "../../src/server.ts";
 import type { Identity } from "../../src/auth/better-auth.ts";
+import type { IngestionStore } from "../../src/ingestion/object-store.ts";
+import { drainPendingEvidence } from "./ingestion.ts";
 import {
   createMigratedDatabase,
   TEST_ENCRYPTION_KEY,
@@ -50,6 +56,15 @@ export type TestApi = {
   readonly traceStore: MigratedTraceStore | undefined;
   /** Everything the email transport was handed, in order. */
   readonly mail: readonly Email[];
+  /**
+   * Turn every pending object into rows, the way the drainer will.
+   *
+   * The door answers on object-store durability and stops there, so a suite
+   * whose claim is about what a reader sees calls this between posting and
+   * reading. It answers how many segments it drained, which is also how a test
+   * says "one project, one segment". Nothing to drain answers zero.
+   */
+  drainEvidence(): Promise<number>;
   close(): Promise<void>;
 };
 
@@ -112,6 +127,20 @@ export type TestApiOptions = {
    */
   readonly traceStore?: boolean;
   /**
+   * The ingestion bucket this instance accepts evidence into, from
+   * `startObjectStorage`. Absent leaves the instance with nowhere to make
+   * evidence durable, which is what an unconfigured deployment is: the door
+   * answers `503` and nothing is staged.
+   */
+  readonly ingestStore?: IngestionStore;
+  /**
+   * How long the oldest staged record waits for company before its segment
+   * seals. Short here, because a suite posting thirty documents would otherwise
+   * spend fifteen seconds waiting out the deployment's own half-second — the
+   * timer's *behaviour* is proved where it is the claim.
+   */
+  readonly ingestionFlushMilliseconds?: number;
+  /**
    * Somewhere to keep the log lines, for a test whose claim is about what is
    * not in them. Off by default: the suite runs silent, and a file that does
    * not read the log has no reason to collect one.
@@ -168,7 +197,15 @@ export async function createApi(
     },
   };
 
-  const config = testConfig({
+  // One directory per instance, on the same terms as the database: a local log
+  // is a durable record, and two instances sharing one would each recover the
+  // other's staged evidence on the way up.
+  const ingestionLogDirectory =
+    options.ingestStore === undefined
+      ? undefined
+      : mkdtempSync(path.join(tmpdir(), `egma-ingestion-${label}-`));
+
+  const base = testConfig({
     databaseUrl: database.url,
     ...(traceStore === undefined ? {} : { clickhouseUrl: traceStore.url }),
     singleOrganization: options.singleOrganization ?? false,
@@ -179,6 +216,18 @@ export async function createApi(
       ? {}
       : { providerCredentials: options.providerCredentials }),
   });
+  const config: Config =
+    options.ingestStore === undefined || ingestionLogDirectory === undefined
+      ? base
+      : {
+          ...base,
+          ingestion: {
+            ...base.ingestion,
+            store: options.ingestStore,
+            logDirectory: ingestionLogDirectory,
+            flushMilliseconds: options.ingestionFlushMilliseconds ?? 20,
+          },
+        };
 
   // Through the deployment's own seeding door rather than written straight
   // into the table: what a test then reads back has been sealed and hinted the
@@ -225,10 +274,17 @@ export async function createApi(
     database,
     traceStore,
     mail,
+    async drainEvidence() {
+      if (options.ingestStore === undefined) return 0;
+      return drainPendingEvidence(options.ingestStore);
+    },
     async close() {
       await app.close();
       await disconnect();
       await database.drop();
+      if (ingestionLogDirectory !== undefined) {
+        rmSync(ingestionLogDirectory, { recursive: true, force: true });
+      }
       if (traceStore !== undefined) {
         await disconnectClickHouse();
         await traceStore.drop();

--- a/apps/api/test/support/ingestion.ts
+++ b/apps/api/test/support/ingestion.ts
@@ -1,7 +1,6 @@
 import { gunzipSync } from "node:zlib";
 
-import { appendSpans, type AuthContext } from "@egma/db";
-
+import { startDrainer } from "../../src/ingestion/drainer.ts";
 import {
   pendingObjectStore,
   type IngestionStore,
@@ -9,13 +8,9 @@ import {
 import {
   RECORD_FORMAT_VERSION,
   recordFrom,
-  spanFor,
   type IngestionRecord,
 } from "../../src/ingestion/record.ts";
-import {
-  segmentIdIn,
-  type SegmentHeader,
-} from "../../src/ingestion/segment.ts";
+import type { SegmentHeader } from "../../src/ingestion/segment.ts";
 
 /**
  * One normalized record, with evidence in it that a careless implementation
@@ -95,34 +90,30 @@ export async function pendingSegments(
 }
 
 /**
- * Every pending object turned into rows, and then removed — what the drainer
- * does, stood in for until the drainer itself exists.
+ * Every pending object drained, the way the deployment drains one.
  *
- * It is here rather than inside a test file because the door stops at
- * durability by design: a suite whose claim is about what a reader sees has to
- * carry evidence the rest of the way itself, and every one of them must do it
- * the same way or they would be proving different things. The scope comes from
- * the sealed object's own header, never from a key or from anything a caller
- * remembered, and the segment identity goes to the insert as its deduplication
- * token, which is the shape the real drainer keeps.
+ * The real drainer, driven for exactly one pass and then stopped — not a
+ * stand-in that repeats its steps. A suite whose claim is about what a reader
+ * sees has to carry evidence past the acceptance boundary somehow, and every
+ * one of them must do it the same way or they would be proving different
+ * things; doing it through the module the deployment runs is what stops this
+ * helper from quietly becoming a second implementation of the order that
+ * matters.
+ *
+ * A scan interval far beyond any suite's life, because the one pass is asked
+ * for here rather than waited for.
  */
 export async function drainPendingEvidence(
   store: IngestionStore,
 ): Promise<number> {
-  const bucket = pendingObjectStore(store);
-  const drained = await pendingSegments(store);
-  for (const segment of drained) {
-    const auth: AuthContext = {
-      userId: "",
-      organizationId: segment.header.organization_id,
-      projectId: segment.header.project_id,
-      role: "admin",
-      via: "engine",
-    };
-    await appendSpans(auth, segment.records.map(spanFor), {
-      segmentId: segmentIdIn(segment.key) ?? "",
-    });
-    await bucket.delete(segment.key);
+  const drainer = startDrainer({
+    store: pendingObjectStore(store),
+    log: { warn: () => undefined, error: () => undefined },
+    scanIntervalMilliseconds: 60 * 60_000,
+  });
+  try {
+    return await drainer.drainNow();
+  } finally {
+    await drainer.stop();
   }
-  return drained.length;
 }

--- a/apps/api/test/support/ingestion.ts
+++ b/apps/api/test/support/ingestion.ts
@@ -1,7 +1,21 @@
+import { gunzipSync } from "node:zlib";
+
+import { appendSpans, type AuthContext } from "@egma/db";
+
+import {
+  pendingObjectStore,
+  type IngestionStore,
+} from "../../src/ingestion/object-store.ts";
 import {
   RECORD_FORMAT_VERSION,
+  recordFrom,
+  spanFor,
   type IngestionRecord,
 } from "../../src/ingestion/record.ts";
+import {
+  segmentIdIn,
+  type SegmentHeader,
+} from "../../src/ingestion/segment.ts";
 
 /**
  * One normalized record, with evidence in it that a careless implementation
@@ -50,4 +64,65 @@ export function aRecord(
     ends_trace: false,
     ...overrides,
   };
+}
+
+/** One pending object, opened: its header line and the records under it. */
+export type PendingSegment = {
+  readonly key: string;
+  readonly header: SegmentHeader;
+  readonly records: readonly IngestionRecord[];
+};
+
+/** Every pending object in the bucket, opened and checked far enough to read. */
+export async function pendingSegments(
+  store: IngestionStore,
+): Promise<readonly PendingSegment[]> {
+  const bucket = pendingObjectStore(store);
+  const opened: PendingSegment[] = [];
+  for (const object of await bucket.list()) {
+    const lines = gunzipSync(Buffer.from(await bucket.read(object.key)))
+      .toString("utf8")
+      .split("\n")
+      .slice(0, -1);
+    const [header, ...records] = lines;
+    opened.push({
+      key: object.key,
+      header: JSON.parse(header ?? "{}") as SegmentHeader,
+      records: records.map((line) => recordFrom(JSON.parse(line))),
+    });
+  }
+  return opened;
+}
+
+/**
+ * Every pending object turned into rows, and then removed — the drainer's job,
+ * stood in for while the drainer itself is a later ticket's.
+ *
+ * It is here rather than inside a test file because the door stops at
+ * durability by design: a suite whose claim is about what a reader sees has to
+ * carry evidence the rest of the way itself, and every one of them must do it
+ * the same way or they would be proving different things. The scope comes from
+ * the sealed object's own header, never from a key or from anything a caller
+ * remembered, and the segment identity goes to the insert as its deduplication
+ * token, which is the shape the real drainer keeps.
+ */
+export async function drainPendingEvidence(
+  store: IngestionStore,
+): Promise<number> {
+  const bucket = pendingObjectStore(store);
+  const drained = await pendingSegments(store);
+  for (const segment of drained) {
+    const auth: AuthContext = {
+      userId: "",
+      organizationId: segment.header.organization_id,
+      projectId: segment.header.project_id,
+      role: "admin",
+      via: "engine",
+    };
+    await appendSpans(auth, segment.records.map(spanFor), {
+      segmentId: segmentIdIn(segment.key) ?? "",
+    });
+    await bucket.delete(segment.key);
+  }
+  return drained.length;
 }

--- a/apps/api/test/support/ingestion.ts
+++ b/apps/api/test/support/ingestion.ts
@@ -95,8 +95,8 @@ export async function pendingSegments(
 }
 
 /**
- * Every pending object turned into rows, and then removed — the drainer's job,
- * stood in for while the drainer itself is a later ticket's.
+ * Every pending object turned into rows, and then removed — what the drainer
+ * does, stood in for until the drainer itself exists.
  *
  * It is here rather than inside a test file because the door stops at
  * durability by design: a suite whose claim is about what a reader sees has to

--- a/apps/api/test/support/instance.ts
+++ b/apps/api/test/support/instance.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
@@ -14,6 +16,7 @@ import {
 import type { FastifyInstance } from "fastify";
 
 import { loadConfig, type Config } from "../../src/config.ts";
+import type { IngestionStore } from "../../src/ingestion/object-store.ts";
 import { buildApi, type ServerOptions } from "../../src/server.ts";
 import {
   holdWebOutputLock,
@@ -72,6 +75,12 @@ export type Instance = {
   readonly api: FastifyInstance;
   readonly database: MigratedDatabase;
   readonly traceStore: EmptyTraceStore;
+  /**
+   * Turn every pending object into rows, the way the deployment does. The door
+   * answers on object-store durability, so a flow whose claim is about what a
+   * page shows carries the evidence the rest of the way with this.
+   */
+  drainEvidence(): Promise<number>;
   close(): Promise<void>;
 };
 
@@ -106,6 +115,13 @@ export type InstanceOptions = {
    * one place is what keeps this arrangement from proving the wrong thing.
    */
   readonly blob?: Config["blob"];
+  /**
+   * The ingestion bucket evidence is accepted into, where the caller has a
+   * store running. Absent leaves this instance with nowhere to make evidence
+   * durable, which is what an unconfigured deployment is: the door answers
+   * `503` and nothing is staged.
+   */
+  readonly ingestStore?: IngestionStore;
   /** Deployment settings required by flows that exercise the phone adapter. */
   readonly platformSettings?: Config["platformSettings"];
   /**
@@ -200,25 +216,46 @@ export async function startInstance(
   const webPort = withPages ? await freePort() : apiPort;
   const origin = `http://127.0.0.1:${webPort}`;
 
-  const { app } = buildApi({
-    config: {
-      ...loadConfig({
-        DATABASE_URL: database.url,
-        CLICKHOUSE_URL: traceStore.url,
-        EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
-        EGMA_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
-        EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
-        EGMA_BASE_URL: origin,
-        EGMA_SINGLE_ORGANIZATION: "false",
-        // A self-host test deployment with one explicit key per provider
-        // account. They are nonsense and never reach a provider. Claim tests
-        // still exercise the real selection-to-credential path.
-        EGMA_OPENAI_API_KEY: "openai-key-held-by-this-test-instance",
-        EGMA_DEEPGRAM_API_KEY: "deepgram-key-held-by-this-test-instance",
-        EGMA_CARTESIA_API_KEY: "cartesia-key-held-by-this-test-instance",
-      }),
-      ...(options.blob === undefined ? {} : { blob: options.blob }),
-    },
+  // One directory per instance, on the same terms as the database: a local log
+  // is a durable record, and two instances sharing one would each recover the
+  // other's staged evidence on the way up.
+  const ingestionLogDirectory =
+    options.ingestStore === undefined
+      ? undefined
+      : mkdtempSync(path.join(tmpdir(), `egma-ingestion-${label}-`));
+
+  const base: Config = {
+    ...loadConfig({
+      DATABASE_URL: database.url,
+      CLICKHOUSE_URL: traceStore.url,
+      EGMA_AUTH_SECRET: "a-secret-only-this-test-uses",
+      EGMA_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
+      EGMA_SIMULATOR_SERVICE_TOKEN: "egma_st_held-by-this-test-suite-alone",
+      EGMA_BASE_URL: origin,
+      EGMA_SINGLE_ORGANIZATION: "false",
+      // A self-host test deployment with one explicit key per provider
+      // account. They are nonsense and never reach a provider. Claim tests
+      // still exercise the real selection-to-credential path.
+      EGMA_OPENAI_API_KEY: "openai-key-held-by-this-test-instance",
+      EGMA_DEEPGRAM_API_KEY: "deepgram-key-held-by-this-test-instance",
+      EGMA_CARTESIA_API_KEY: "cartesia-key-held-by-this-test-instance",
+    }),
+    ...(options.blob === undefined ? {} : { blob: options.blob }),
+  };
+
+  const { app, drainer } = buildApi({
+    config:
+      options.ingestStore === undefined || ingestionLogDirectory === undefined
+        ? base
+        : {
+            ...base,
+            ingestion: {
+              ...base.ingestion,
+              store: options.ingestStore,
+              logDirectory: ingestionLogDirectory,
+              flushMilliseconds: 20,
+            },
+          },
     ...(options.deviceAuthorizationInterval === undefined
       ? {}
       : { deviceAuthorizationInterval: options.deviceAuthorizationInterval }),
@@ -320,6 +357,9 @@ export async function startInstance(
     api: app,
     database,
     traceStore,
+    async drainEvidence() {
+      return (await drainer()?.drainNow()) ?? 0;
+    },
     async close() {
       // Waits for the development server to be gone before the output
       // directory is anybody else's. See `releaseAfter`.
@@ -329,6 +369,9 @@ export async function startInstance(
       await disconnectClickHouse();
       await database.drop();
       await traceStore.drop();
+      if (ingestionLogDirectory !== undefined) {
+        rmSync(ingestionLogDirectory, { recursive: true, force: true });
+      }
     },
   };
 }

--- a/apps/api/test/support/recordings.ts
+++ b/apps/api/test/support/recordings.ts
@@ -11,6 +11,26 @@ import type { FastifyInstance } from "fastify";
 import { expect } from "vitest";
 
 import { OTLP_TRACES_PATH } from "../../src/routes/traces.ts";
+import type { TestApi } from "./api.ts";
+
+/**
+ * A running Egma, however this tree spells it.
+ *
+ * Two arrangements answer for one: the in-process test API calls its Fastify
+ * instance `app`, and the listening browser instance calls it `api`. Asking for
+ * either rather than picking one keeps a helper both of them use from forcing a
+ * rename through a suite that has nothing to do with it.
+ */
+export type RunningEgma =
+  | Pick<TestApi, "app" | "drainEvidence">
+  | {
+      readonly api: FastifyInstance;
+      drainEvidence(): Promise<number>;
+    };
+
+function doorOf(egma: RunningEgma): FastifyInstance {
+  return "app" in egma ? egma.app : egma.api;
+}
 import { mintKey, NEUTRAL_TRAITS, request as ask } from "./traces.ts";
 
 /**
@@ -97,7 +117,7 @@ export type FiledTranscript = {
  * what proves a transcript and a run's results are looking at one conversation.
  */
 export async function fileTranscriptOf(
-  app: FastifyInstance,
+  egma: RunningEgma,
   simulationId: string,
   said: { readonly human: string; readonly agent: string },
   openedAt: Date,
@@ -130,7 +150,7 @@ export async function fileTranscriptOf(
         : [{ key: "egma.turn.text", value: { stringValue: text } }],
   });
 
-  const posted = await app.inject({
+  const posted = await doorOf(egma).inject({
     method: "POST",
     url: OTLP_TRACES_PATH,
     headers: {
@@ -167,6 +187,9 @@ export async function fileTranscriptOf(
     }),
   });
   expect(posted.statusCode, posted.body).toBe(200);
+  // The door answers on object-store durability; a transcript is read from
+  // rows, so the evidence is carried the rest of the way here.
+  await egma.drainEvidence();
 
   return {
     traceId: trace,

--- a/apps/api/test/support/traces.ts
+++ b/apps/api/test/support/traces.ts
@@ -4,7 +4,7 @@ import { expect } from "vitest";
 
 import { SIMULATION_ID_ATTRIBUTE } from "../../src/otlp/normalise.ts";
 import { OTLP_TRACES_PATH } from "../../src/routes/traces.ts";
-import { cookiesFrom } from "./api.ts";
+import { cookiesFrom, type TestApi } from "./api.ts";
 import { capturedRequests, type CapturedRequest } from "./fixture.ts";
 
 /**
@@ -176,14 +176,21 @@ export async function request(
 
 let captured: CapturedRequest[] | undefined;
 
-/** The captured LiveKit trace, read once and replayed byte for byte. */
+/**
+ * The captured LiveKit trace, read once and replayed byte for byte, then
+ * drained.
+ *
+ * The door stops at object-store durability, so a suite reading rows back has
+ * to carry the evidence the rest of the way. It takes the instance rather than
+ * its app for exactly that reason.
+ */
 export async function replayFixture(
-  app: FastifyInstance,
+  api: Pick<TestApi, "app" | "drainEvidence">,
   secret: string,
 ): Promise<void> {
   captured ??= await capturedRequests();
   for (const request of captured) {
-    const response = await app.inject({
+    const response = await api.app.inject({
       method: "POST",
       url: OTLP_TRACES_PATH,
       headers: {
@@ -194,6 +201,7 @@ export async function replayFixture(
     });
     expect(response.statusCode, request.file).toBe(200);
   }
+  await api.drainEvidence();
 }
 
 export type SyntheticTrace = {
@@ -293,18 +301,27 @@ export function syntheticExport(trace: SyntheticTrace): string {
   });
 }
 
+/**
+ * One export through the door, and then drained.
+ *
+ * It takes the instance rather than its app because the door answers on
+ * object-store durability and writes no row: a suite asking what a reader sees
+ * has to carry the evidence past that boundary, and every one of them must do
+ * it the same way.
+ */
 export async function ingest(
-  app: FastifyInstance,
+  api: Pick<TestApi, "app" | "drainEvidence">,
   secret: string,
   body: string,
 ): Promise<void> {
-  const response = await app.inject({
+  const response = await api.app.inject({
     method: "POST",
     url: OTLP_TRACES_PATH,
     headers: { "content-type": "application/json", authorization: `Bearer ${secret}` },
     payload: body,
   });
   expect(response.statusCode, response.body).toBe(200);
+  await api.drainEvidence();
 }
 
 /* ------------------------------------------------------------------ *

--- a/apps/api/test/trace-reads-contract.test.ts
+++ b/apps/api/test/trace-reads-contract.test.ts
@@ -15,6 +15,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { createApi, type TestApi } from "./support/api.ts";
 import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
+import {
   contextFor,
   ingest,
   listTracesAsSignedIn,
@@ -44,6 +48,12 @@ import {
  * right for the spine test and useless for asking whether page two follows page
  * one.
  */
+
+const storage: ObjectStorage = await startObjectStorage("trace-reads-contract");
+
+if (!storage.available) {
+  process.stderr.write(`\nskipping the trace-reads contract suite — ${storage.why}\n\n`);
+}
 
 let api: TestApi;
 let acme: Customer;
@@ -78,7 +88,11 @@ const PAGING_TRACES = [
 ] as const;
 
 beforeAll(async () => {
-  api = await createApi("trace_reads_contract", { traceStore: true });
+  if (!storage.available) return;
+  api = await createApi("trace_reads_contract", {
+    traceStore: true,
+    ingestStore: storage.ingestStore,
+  });
   acme = await signUp(api.app, "ada@acme.example", "Acme");
   globex = await signUp(api.app, "grace@globex.example", "Globex");
   acmeProjectSecret = await mintKey(
@@ -96,7 +110,7 @@ beforeAll(async () => {
 
   for (const trace of PAGING_TRACES) {
     await ingest(
-      api.app,
+      api,
       acmeProjectSecret,
       syntheticExport({
         traceId: trace.traceId,
@@ -109,6 +123,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await api?.close();
+  if (storage.available) storage.stop();
 });
 
 async function page(
@@ -120,7 +135,7 @@ async function page(
   return response.json() as ListedPage;
 }
 
-describe("a list request that does not say when", () => {
+describe.skipIf(!storage.available)("a list request that does not say when", () => {
   it("is refused, and told what to send", async () => {
     const response = await listTracesOverHttp(api.app, acme.secret, {});
     expect(response.statusCode).toBe(400);
@@ -221,7 +236,7 @@ describe("a list request that does not say when", () => {
  * window too wide to serve is the caller's decision to make, and only a refusal
  * lets them make it.
  */
-describe("a window wider than one request may ask for", () => {
+describe.skipIf(!storage.available)("a window wider than one request may ask for", () => {
   it("is refused rather than quietly narrowed", async () => {
     const response = await listTracesOverHttp(api.app, acme.secret, {
       from: "2026-01-01T00:00:00Z",
@@ -265,7 +280,7 @@ describe("a window wider than one request may ask for", () => {
   });
 });
 
-describe("walking every page of a list", () => {
+describe.skipIf(!storage.available)("walking every page of a list", () => {
   /**
    * The whole promise, in one walk: every trace once, in order, across
    * boundaries that fall in the middle of a shared minute.
@@ -382,7 +397,7 @@ describe("walking every page of a list", () => {
  * became `Number("")`, which is zero, which is refused. Neither is what the
  * caller asked, and neither said so.
  */
-describe("a parameter that arrived empty", () => {
+describe.skipIf(!storage.available)("a parameter that arrived empty", () => {
   it("is the whole organization, when it is the project", async () => {
     const answered = await page(acme.secret, {
       ...DAY,
@@ -418,7 +433,7 @@ describe("a parameter that arrived empty", () => {
  * organization leads the filing order, so the query never reached the rows and
  * there is nothing to leak the difference.
  */
-describe("another organization asking for a trace that is not theirs", () => {
+describe.skipIf(!storage.available)("another organization asking for a trace that is not theirs", () => {
   it("finds nothing in a list of the same window", async () => {
     const answered = await page(globex.secret, { ...DAY, pageSize: 200 });
     expect(answered.traces).toEqual([]);
@@ -447,7 +462,7 @@ describe("another organization asking for a trace that is not theirs", () => {
 
   it("still reads its own, so the refusal is about tenancy and not about the store", async () => {
     await ingest(
-      api.app,
+      api,
       globexProjectSecret,
       syntheticExport({
         traceId: "bb000000000000000000000000000001",
@@ -472,7 +487,7 @@ describe("another organization asking for a trace that is not theirs", () => {
  * reads that project and cannot be argued into another — and is told so out
  * loud rather than having its filter silently dropped.
  */
-describe("filtering a list to one project", () => {
+describe.skipIf(!storage.available)("filtering a list to one project", () => {
   const OUTBOUND_WINDOW = {
     from: "2026-07-01T00:00:00Z",
     to: "2026-07-02T00:00:00Z",
@@ -503,7 +518,7 @@ describe("filtering a list to one project", () => {
 
     // One trace in Outbound, and one in the project signup created.
     await ingest(
-      api.app,
+      api,
       outboundSecret,
       syntheticExport({
         traceId: "cc000000000000000000000000000001",
@@ -512,7 +527,7 @@ describe("filtering a list to one project", () => {
       }),
     );
     await ingest(
-      api.app,
+      api,
       acmeProjectSecret,
       syntheticExport({
         traceId: "cc000000000000000000000000000002",
@@ -731,7 +746,7 @@ describe("filtering a list to one project", () => {
  * a key scoped to that project rather than reusing the organization-wide one:
  * the question is whether the cookie reads, not which project it reads.
  */
-describe("a browser session rather than a key", () => {
+describe.skipIf(!storage.available)("a browser session rather than a key", () => {
   const SESSION_WINDOW = {
     from: "2026-09-01T00:00:00Z",
     to: "2026-09-02T00:00:00Z",
@@ -746,7 +761,7 @@ describe("a browser session rather than a key", () => {
       acme.projectId,
     );
     await ingest(
-      api.app,
+      api,
       homeSecret,
       syntheticExport({
         traceId: SESSION_TRACE,
@@ -820,7 +835,7 @@ describe("a browser session rather than a key", () => {
  * which is what separates a predicate inside the scan from a filter over a page
  * that has already been counted.
  */
-describe("narrowing a list to one kind of traffic", () => {
+describe.skipIf(!storage.available)("narrowing a list to one kind of traffic", () => {
   const MIXED = {
     from: "2026-10-01T00:00:00Z",
     to: "2026-10-02T00:00:00Z",
@@ -852,7 +867,7 @@ describe("narrowing a list to one kind of traffic", () => {
   beforeAll(async () => {
     for (const trace of PRODUCTION_TRACES) {
       await ingest(
-        api.app,
+        api,
         acmeProjectSecret,
         syntheticExport({
           traceId: trace.traceId,
@@ -912,7 +927,7 @@ describe("narrowing a list to one kind of traffic", () => {
       }
 
       await ingest(
-        api.app,
+        api,
         SERVICE_TOKEN,
         syntheticExport({
           traceId,
@@ -1069,7 +1084,7 @@ describe("narrowing a list to one kind of traffic", () => {
    */
   it("shows each organization only its own, whichever kind is asked for", async () => {
     await ingest(
-      api.app,
+      api,
       globexProjectSecret,
       syntheticExport({
         traceId: GLOBEX_TRACE,
@@ -1105,7 +1120,7 @@ describe("narrowing a list to one kind of traffic", () => {
   });
 });
 
-describe("a read with no usable credential", () => {
+describe.skipIf(!storage.available)("a read with no usable credential", () => {
   it("is refused before anything is looked up", async () => {
     for (const url of [
       `/v1/traces?from=${DAY.from}&to=${DAY.to}`,
@@ -1141,7 +1156,7 @@ describe("a read with no usable credential", () => {
  * A judgment egma wrote and then could not find is the exact false trust this
  * product exists to kill, so it is pinned here, at the read, through the routes.
  */
-describe("a production conversation egma judged", () => {
+describe.skipIf(!storage.available)("a production conversation egma judged", () => {
   const JUDGED_TRACE = "cc000000000000000000000000000001";
   const JUDGED_AT = "2026-06-01T11:00:00Z";
   const GRADER = newId("grd");
@@ -1149,7 +1164,7 @@ describe("a production conversation egma judged", () => {
 
   beforeAll(async () => {
     await ingest(
-      api.app,
+      api,
       acmeProjectSecret,
       syntheticExport({
         traceId: JUDGED_TRACE,

--- a/apps/api/test/trace-reads.test.ts
+++ b/apps/api/test/trace-reads.test.ts
@@ -1,12 +1,20 @@
 import {
   appendSpans,
+  connectClickHouse,
+  disconnectClickHouse,
   REPORTED_MEASUREMENTS_PAYLOAD_KEY,
   reportedMeasurementsPayload,
   type NewSpan,
 } from "@egma/db";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { OTLP_TRACES_PATH } from "../src/routes/traces.ts";
 import { createApi, type TestApi } from "./support/api.ts";
+import { pendingSegments } from "./support/ingestion.ts";
+import {
+  startObjectStorage,
+  type ObjectStorage,
+} from "./support/object-storage.ts";
 import { FIXTURE_PROVIDER_CALL_ID, FIXTURE_TRACE } from "./support/fixture.ts";
 import {
   contextFor,
@@ -16,6 +24,7 @@ import {
   readTraceOverHttp,
   replayFixture,
   signUp,
+  syntheticExport,
   type Customer,
   type DetailMeasure,
   type DetailSpan,
@@ -39,6 +48,18 @@ import {
  * and recovering — rather than the shape of the code that returns it.
  */
 
+const storage: ObjectStorage = await startObjectStorage("trace-reads");
+
+if (!storage.available) {
+  process.stderr.write(`\nskipping the trace-reads suite — ${storage.why}\n\n`);
+}
+
+/** The ingestion bucket this instance accepts into, for reading it back. */
+function ingestStore() {
+  if (!storage.available) throw new Error("this suite has no object store");
+  return storage.ingestStore;
+}
+
 let api: TestApi;
 let acme: Customer;
 
@@ -57,7 +78,11 @@ const WINDOW = {
 } as const;
 
 beforeAll(async () => {
-  api = await createApi("trace_reads", { traceStore: true });
+  if (!storage.available) return;
+  api = await createApi("trace_reads", {
+    traceStore: true,
+    ingestStore: storage.ingestStore,
+  });
   acme = await signUp(api.app, "ada@acme.example", "Acme");
   const telemetrySecret = await mintKey(
     api.app,
@@ -65,11 +90,12 @@ beforeAll(async () => {
     "Acme production telemetry",
     acme.projectId,
   );
-  await replayFixture(api.app, telemetrySecret);
+  await replayFixture(api, telemetrySecret);
 });
 
 afterAll(async () => {
   await api?.close();
+  if (storage.available) storage.stop();
 });
 
 async function listed(): Promise<ListedPage> {
@@ -88,7 +114,86 @@ async function transcript(): Promise<TraceDetailBody> {
   return response.json() as TraceDetailBody;
 }
 
-describe("the captured trace, found in a list", () => {
+/**
+ * **A ClickHouse outage costs query visibility and nothing else.**
+ *
+ * This is the release's whole point, read from the far end: evidence is
+ * accepted while the trace store is down, the request is answered as accepted
+ * because the object store took it, and when the store comes back the same
+ * evidence appears in every read a person makes — the list, the detail, the
+ * transcript, the measures — with the durable handoff written before the object
+ * is deleted. Nothing was retried by the sender and nothing was lost.
+ */
+describe.skipIf(!storage.available)(
+  "a conversation accepted while the trace store was down",
+  () => {
+    const traceId = "7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c";
+    const WHILE_DOWN = {
+      from: "2026-08-09T09:00:00Z",
+      to: "2026-08-09T10:00:00Z",
+    } as const;
+
+    it("appears whole in every read once the store is back, and only then is the object gone", async () => {
+      const store = api.traceStore;
+      if (store === undefined) throw new Error("this API has no trace store");
+      const secret = await mintKey(
+        api.app,
+        acme.cookie,
+        "an agent talking through an outage",
+        acme.projectId,
+      );
+
+      await disconnectClickHouse();
+      let accepted;
+      try {
+        accepted = await api.app.inject({
+          method: "POST",
+          url: OTLP_TRACES_PATH,
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${secret}`,
+          },
+          payload: syntheticExport({
+            traceId,
+            startedAt: new Date("2026-08-09T09:30:00Z"),
+            humanSaid: "Can you still hear me?",
+          }),
+        });
+      } finally {
+        connectClickHouse({ clickhouseUrl: store.url, maxOpenConnections: 4 });
+      }
+      // Accepted, because the object store took it. The sender owes nothing.
+      expect(accepted.statusCode, accepted.body).toBe(200);
+      expect(await pendingSegments(ingestStore())).toHaveLength(1);
+
+      await api.drainEvidence();
+
+      const page = (
+        await listTracesOverHttp(api.app, secret, WHILE_DOWN)
+      ).json() as ListedPage;
+      expect(page.traces.map((trace) => trace.traceId)).toEqual([traceId]);
+      expect(page.traces[0]?.turnCounts).toEqual({ human: 1, agent: 1 });
+
+      const detail = (
+        await readTraceOverHttp(api.app, secret, traceId, WHILE_DOWN)
+      ).json() as TraceDetailBody;
+      expect(
+        everySpan(detail.turns).map((span) => span.text).filter((text) => text !== ""),
+      ).toContain("Can you still hear me?");
+      expect(detail.measures.length).toBeGreaterThan(0);
+
+      // The evidence-ready handoff landed before the object did.
+      const { rows } = await api.database.sql<{ count: string }>(
+        "select count(*) as count from grading_job where trace_id = $1",
+        [traceId],
+      );
+      expect(rows[0]?.count).toBe("1");
+      expect(await pendingSegments(ingestStore())).toHaveLength(0);
+    });
+  },
+);
+
+describe.skipIf(!storage.available)("the captured trace, found in a list", () => {
   it("is one trace inside a window containing it, and the last page of one", async () => {
     const page = await listed();
     expect(page.traces).toHaveLength(1);
@@ -190,7 +295,7 @@ describe("the captured trace, found in a list", () => {
   });
 });
 
-describe("the captured trace, read as a transcript", () => {
+describe.skipIf(!storage.available)("the captured trace, read as a transcript", () => {
   it("is thirteen turns in the order they were taken", async () => {
     const detail = await transcript();
 
@@ -516,7 +621,7 @@ describe("the captured trace, read as a transcript", () => {
  * store, and putting them in the capture's own window would make every other
  * case in this file depend on the order the describes happen to run in.
  */
-describe("what one measure looks like on the wire", () => {
+describe.skipIf(!storage.available)("what one measure looks like on the wire", () => {
   const SIMULATED = "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a";
   const REPORTED = "1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b";
 

--- a/apps/api/test/trace-reads.test.ts
+++ b/apps/api/test/trace-reads.test.ts
@@ -558,6 +558,7 @@ describe("what one measure looks like on the wire", () => {
       testVersionId: "",
       personaVersionId: "",
       payload: "{}",
+      endsTrace: false,
       ...over,
     };
   }

--- a/apps/grader/src/conversation.ts
+++ b/apps/grader/src/conversation.ts
@@ -188,6 +188,38 @@ export function conversationOfSimulation(
   };
 }
 
+/**
+ * Whether this conversation's evidence is still on its way rather than absent.
+ *
+ * **The two are indistinguishable at a single read, and only one of them is a
+ * reason to wait.** A simulation's spans reach the trace store some time after
+ * the door accepted them — acceptance is a promise that evidence is safe, not
+ * that it is readable — while the transaction that lands the simulation
+ * terminal is what mints the work to judge it. So a conversation asked about
+ * the instant it ends can legitimately have nothing under it yet, and judging
+ * that would write a permanent verdict about a conversation egma is holding.
+ *
+ * Three things say waiting cannot help, and each is a fact rather than a guess:
+ *
+ * - **The simulator reported it did not complete.** No conversation happened
+ *   and no telemetry arriving later makes one.
+ * - **The reading overran the span limit.** What egma holds is whole and larger
+ *   than one reading returns; more of it arriving changes nothing.
+ * - **The trace is closed.** Its root span is the last thing the simulator
+ *   sends, so a trace holding one is a trace holding everything.
+ *
+ * Anything else is a conversation that completed and whose record is not all
+ * here yet, which is worth asking again about.
+ */
+export function evidenceIsStillArriving(
+  simulation: Simulation,
+  trace: TraceDetail | undefined,
+): boolean {
+  if (simulation.status !== "completed") return false;
+  if (trace === undefined) return true;
+  return !trace.truncated && !rootArrivedIn(trace);
+}
+
 /** A simulation that produced no conversation, in the simulator's own words. */
 function neverRan(simulation: Simulation): string {
   return `this simulation ended ${simulation.endingReason ?? "without running"}, so there was no conversation to judge.`;

--- a/apps/grader/src/grade.ts
+++ b/apps/grader/src/grade.ts
@@ -5,6 +5,7 @@ import {
   pinnedSimulationGraders,
   readTrace,
   MAXIMUM_WINDOW_MILLISECONDS,
+  MOST_GRADING_ATTEMPTS,
   type AuthContext,
   type ExecutableGrader,
   type GradingClaim,
@@ -22,6 +23,7 @@ import { traceIdOfSimulation } from "@egma/simulation-contract";
 
 import {
   conversationOfSimulation,
+  evidenceIsStillArriving,
   conversationOfTrace,
   type Conversation,
 } from "./conversation.ts";
@@ -260,11 +262,28 @@ async function theSimulation(claim: GradingClaim): Promise<Resolved> {
     );
   }
 
+  const trace = await theSimulationsTrace(claim.auth, simulation);
+
+  // **Ask again rather than answer now.** A conversation whose record is not
+  // all here yet would be judged as one egma could not read, and that verdict
+  // is permanent — so the claim is declined, the job goes back, and the next
+  // attempt looks again. The budget is what makes the waiting end: on the last
+  // attempt the answer below is written from whatever did arrive, so a
+  // conversation whose evidence never comes still gets the same list of checks
+  // a reader would have seen either way, and no job is abandoned for waiting.
+  if (
+    evidenceIsStillArriving(simulation, trace) &&
+    claim.attempts < MOST_GRADING_ATTEMPTS
+  ) {
+    throw new NotGradable(
+      `simulation ${simulation.id} is complete and egma does not hold all of ` +
+        `its conversation yet, so there is nothing to judge on attempt ` +
+        `${claim.attempts} of ${MOST_GRADING_ATTEMPTS}`,
+    );
+  }
+
   return {
-    conversation: conversationOfSimulation(
-      simulation,
-      await theSimulationsTrace(claim.auth, simulation),
-    ),
+    conversation: conversationOfSimulation(simulation, trace),
     graders: await (async () => {
       const pinned = await pinnedSimulationGraders(claim.auth, simulation.id);
       if (pinned === undefined) {

--- a/apps/grader/test/simulation-spans.test.ts
+++ b/apps/grader/test/simulation-spans.test.ts
@@ -1,4 +1,10 @@
-import { getSimulation, readTrace, readVerdicts } from "@egma/db";
+import {
+  getSimulation,
+  listGradingJobsForSimulation,
+  MOST_GRADING_ATTEMPTS,
+  readTrace,
+  readVerdicts,
+} from "@egma/db";
 import { traceIdOfSimulation } from "@egma/simulation-contract";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -6,7 +12,9 @@ import { conversationOfSimulation } from "../src/conversation.ts";
 import {
   aLatencyCopy,
   conductSimulation,
+  eventually,
   jobFor,
+  streamConversationLate,
   makeWorld,
   oneServiceAtATime,
   seedGrader,
@@ -421,6 +429,76 @@ describe("a simulation whose trace never closed", () => {
 
     expect(conversation.nothingToJudgeBecause).toContain("span limit");
     expect(conversation.transcript).toEqual([]);
+  });
+});
+
+/**
+ * **Evidence accepted and not yet readable is a reason to ask again, never a
+ * reason to answer.**
+ *
+ * A simulation's span batches are answered at the door when they are durable in
+ * the object store, and the transaction that lands the simulation terminal is
+ * what mints the work to judge it — so the work can be taken up before the
+ * evidence behind it has been drained into the trace store. A verdict written
+ * then would be permanent, and it would say egma could not read a conversation
+ * it was in the middle of storing.
+ */
+describe("a simulation whose evidence is still on its way", () => {
+  it("is asked again rather than judged, and judges the conversation once it lands", async () => {
+    const judge = await judgingWith([3]);
+    const testId = await seedTest(world, [THE_BEHAVIOR]);
+
+    // Landed terminal with nothing under it yet.
+    const conducted = await conductSimulation(world, { spans: null, testId });
+
+    // The claim is declined and the job goes back with an attempt spent and a
+    // sentence saying why. Nothing is written about the conversation.
+    const released = await eventually(
+      `the job for ${conducted.simulationId} to be handed back`,
+      async () => {
+        const [job] = await listGradingJobsForSimulation(
+          world.auth,
+          conducted.simulationId,
+        );
+        return job?.status === "pending" && job.attempts > 0 ? job : undefined;
+      },
+    );
+    expect(released.lastError).toContain(
+      "does not hold all of its conversation yet",
+    );
+    expect(
+      (await readVerdicts(world.auth, conducted.simulationId)).verdicts,
+    ).toEqual([]);
+    expect(judge.asked).toEqual([]);
+
+    // The drain finishes, and the next attempt judges what is now there.
+    await streamConversationLate(world, conducted.simulationId);
+    await jobFor(world, conducted, "graded");
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    expect(verdicts.length).toBeGreaterThan(0);
+    expect(verdicts.every((verdict) => verdict.verdict === "passed")).toBe(true);
+    expect(judge.asked.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * And the budget is what ends the waiting. A conversation whose evidence
+   * never arrives is answered on the last attempt out of what did — the same
+   * list of checks a reader would have seen either way — rather than left
+   * waiting or abandoned with nothing under it.
+   */
+  it("answers out of what arrived once the budget is spent", async () => {
+    await judgingWith();
+    const testId = await seedTest(world, [THE_BEHAVIOR]);
+    const conducted = await conductSimulation(world, { spans: null, testId });
+
+    const judged = await jobFor(world, conducted, "graded");
+    expect(judged.attempts).toBe(MOST_GRADING_ATTEMPTS);
+
+    const { verdicts } = await readVerdicts(world.auth, conducted.simulationId);
+    expect(verdicts.length).toBeGreaterThan(0);
+    expect(verdicts.every((verdict) => verdict.verdict === "errored")).toBe(true);
+    expect(verdicts[0]?.rationale).toContain("no record of this conversation");
   });
 });
 

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -953,7 +953,10 @@ export function testConfig(overrides: Partial<Config> = {}): Config {
     capacity: 4,
     heartbeatSeconds: 1,
     leaseSeconds: 3_600,
-    sweepSeconds: 3_600,
+    // Short, because a claim declined for a conversation egma does not hold all
+    // of yet goes back to the queue and is only taken up again by a sweep. A
+    // deployment's own default is thirty seconds; a suite's patience is not.
+    sweepSeconds: 1,
     // An hour, so a production trace judged inside a test's patience was judged
     // because its root span closed. The idle fallback's own test sets it low.
     traceIdleSeconds: 3_600,
@@ -1077,6 +1080,26 @@ export async function verdictsOn(
  * still claimable when the next case starts its own copy would be judged again,
  * by a judge scripted for something else.
  */
+/**
+ * The conversation's spans, arriving after the simulation already landed.
+ *
+ * The ordinary order is the other way round — a simulator streams while it
+ * conducts and lands terminal after — and this is the case that order does not
+ * cover: evidence accepted at the door, safe, and not yet readable when the
+ * work to judge it was minted.
+ */
+export async function streamConversationLate(
+  world: World,
+  simulationId: string,
+  streaming: StreamedConversation = aConversation(),
+): Promise<void> {
+  const simulation = await getSimulation(world.auth, simulationId);
+  if (simulation === undefined) {
+    throw new Error(`simulation ${simulationId} is not there`);
+  }
+  await streamConversation(world, simulation, streaming);
+}
+
 export async function jobFor(
   world: World,
   conversation:

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -597,6 +597,7 @@ function simulationSpan(
     testVersionId: simulation.testVersionId ?? "",
     personaVersionId: simulation.personaVersionId,
     payload: "{}",
+    endsTrace: false,
     ...over,
   };
 }
@@ -876,6 +877,7 @@ function productionSpan(traceId: string, over: Partial<NewSpan>): NewSpan {
     testVersionId: "",
     personaVersionId: "",
     payload: "{}",
+    endsTrace: false,
     ...over,
   };
 }

--- a/apps/grader/test/support/world.ts
+++ b/apps/grader/test/support/world.ts
@@ -792,6 +792,10 @@ export async function conductProductionTrace(
         parentSpanId: "",
         name: "agent_session",
         kind: "root",
+        // LiveKit's own session span, and the statement that carries the end
+        // fact: completion is the platform's word, never the absence of a
+        // parent.
+        endsTrace: true,
         durationNanoseconds: 20_000_000_000n,
         // The block rides here, under the egma-owned corner of a payload that
         // is otherwise the vendor's own document — written through the
@@ -826,8 +830,9 @@ async function exportFlush(world: World, spans: readonly NewSpan[]): Promise<voi
 }
 
 /**
- * One more flush of a conversation egma has already dealt with — a root span at
- * that, so it says as loudly as telemetry can that the conversation is over.
+ * One more flush of a conversation egma has already dealt with — carrying the
+ * platform's own end statement, so it says as loudly as telemetry can that the
+ * conversation is over.
  */
 export async function exportALateFlush(
   world: World,
@@ -839,6 +844,7 @@ export async function exportALateFlush(
       parentSpanId: "",
       name: "agent_session",
       kind: "root",
+      endsTrace: true,
       startedAtMicroseconds: BigInt(Date.now()) * 1_000n,
     }),
   ]);

--- a/packages/db/src/access/context.ts
+++ b/packages/db/src/access/context.ts
@@ -59,10 +59,13 @@ export type AuthContext = {
  * while `engine` may write grading results — and one shared service identity
  * would make either boundary wider than its work.
  *
- * `monitoring` is the third of them, for background production ingestion.
+ * `monitoring` is the third of them, for background production ingestion. Two
+ * things build one, and neither takes a customer identifier from a caller:
  * `claimDueRetellMonitoringAgent` builds one from the project-owned Monitoring
- * setup and selected Retell agent, never from a simulation connection and
- * never from a caller-supplied customer identifier.
+ * setup and selected Retell agent, and the ingestion drainer builds one from
+ * the organization and project sealed inside a pending object — a statement the
+ * segment's own checksum covers, and one the drainer holds against Postgres
+ * before it writes anything under it.
  *
  * It is its own word so that a context which came from claimed Monitoring work
  * says so wherever it is read, and so that it opens neither of the other two

--- a/packages/db/src/access/grading.ts
+++ b/packages/db/src/access/grading.ts
@@ -79,22 +79,24 @@ import { within } from "./within.ts";
  * ## And the other source, which nobody can wake for
  *
  * A production trace has no transaction to ride and no moment anybody owns. It
- * arrives as spans, so `recordProductionTraces` is called by the ingest door,
- * once per export, and writes the two facts completion is decided from: when
- * egma last heard about this trace, and whether the export carried its root
- * span. **That is a queue write and a notification and nothing else** — no
- * grader is resolved, no conversation is read, and no judgment is made anywhere
- * near a request path. What the API process must stay free of is judge work,
- * which would make an exporter's timeout depend on somebody's judge model; it
- * was never free of bookkeeping.
+ * arrives as spans, so `recordProductionTraces` is called by the drainer, once
+ * per drained segment and only after its rows are query-visible, and writes the
+ * two facts completion is decided from: when egma last heard about this trace,
+ * and whether the segment carried a span the platform said ends it. **That is a
+ * bookkeeping row and a notification and nothing else** — no grader is
+ * resolved, no conversation is read, and no judgment is made anywhere near it.
+ * Reporting before the evidence was readable would be worse than reporting
+ * late: a grader woken for a trace it cannot read would judge an empty one.
  *
  * The two ways such a trace completes are answered in two different places, and
  * they have to be:
  *
- * - **Its root span closed.** An exporter sends a span when the span ends, so a
- *   root arriving at the door *is* the conversation ending. The door stamps
- *   `root_closed_at` and raises the same notification a terminal transition
- *   does, so the wake-up is immediate and no interval is on the path.
+ * - **Its platform said it ended.** Each supported platform states that fact on
+ *   the one span that carries it, and the normalizer carries the statement
+ *   through to here. The drainer stamps `root_closed_at` and raises the same
+ *   notification a terminal transition does, so the wake-up is immediate and no
+ *   interval is on the path. A platform that states nothing produces no
+ *   completion here, and nothing infers one from the shape of a trace.
  * - **It went quiet.** An exporter that never closes a root would otherwise
  *   leave a conversation unjudged forever, and there is nothing to be woken by:
  *   the completing event is the *absence* of one. So this half is inherently a
@@ -418,11 +420,11 @@ type ProductionTraceActivity = {
 /**
  * A production trace becomes known, and — when its root closes — claimable work.
  *
- * Called by the ingest door with the very spans it just appended, after they are
- * stored and once per export. **It writes bookkeeping and raises a notification,
- * and does nothing else**: no grader is resolved, no conversation is read,
- * nothing is judged. Judging is the grader service's, and the request path stays
- * clear of it.
+ * Called by the drainer with the very spans it just wrote, after they are
+ * query-visible and once per segment. **It writes bookkeeping and raises a
+ * notification, and does nothing else**: no grader is resolved, no conversation
+ * is read, nothing is judged. Judging is the grader service's, and neither the
+ * request path nor the drainer holds anything open for it.
  *
  * It takes the spans rather than a summary of them so that **what completion
  * means is written down once**. A caller that computed "which trace, how wide,
@@ -431,11 +433,16 @@ type ProductionTraceActivity = {
  * would show up as conversations that were never judged, which is the failure
  * nobody notices.
  *
- * The row is written on the first export that carries any span of a trace and
- * updated by every export after it, which is why the whole thing is one upsert
+ * The row is written on the first segment that carries any span of a trace and
+ * updated by every segment after it, which is why the whole thing is one upsert
  * against the project-and-trace unique: an exporter flushes a conversation in
- * as many batches as it likes, in whatever order, and they all land on one row.
- * The project is part of that key because a trace id comes from the customer.
+ * as many batches as it likes, in whatever order, they are drained in whatever
+ * order they became durable, and they all land on one row. The project is part
+ * of that key because a trace id comes from the customer.
+ *
+ * **Replaying a segment repeats this harmlessly**, which is what makes the
+ * drainer's replay safe: the merge below is monotone in every column and the
+ * upsert touches nothing that has moved past `pending`.
  *
  * **A job already claimed or already graded is not touched**, which is the whole
  * of what late spans do. Telemetry that arrives after egma judged a trace does
@@ -450,7 +457,7 @@ type ProductionTraceActivity = {
  *
  * No permission is asked for, on the same terms as `appendSpans` beside it: what
  * may write telemetry is decided once, at the door, before a byte of the body is
- * read.
+ * read, and the scope this is called with is the one sealed into the segment.
  */
 export async function recordProductionTraces(
   auth: AuthContext,
@@ -515,28 +522,29 @@ export async function recordProductionTraces(
 }
 
 /**
- * The production conversations one export carried, gathered by trace.
+ * The production conversations one segment carried, gathered by trace.
  *
- * **A trace is over when its root span closes**, and an export can tell: an
- * OpenTelemetry exporter sends a span when the span *ends*, so the root — the
- * one span the whole conversation happened inside — arriving here is the
- * conversation having ended. The captured LiveKit trace does exactly that: a
- * hundred and thirty-three spans across fourteen flushes, and `agent_session`
- * comes alone in the last one.
+ * **A trace is over when the platform that ran it says so**, and each span
+ * carries that word: `endsTrace` is set by the normalizer that recognised the
+ * platform — LiveKit's own session span, Retell's reported end — and is `false`
+ * everywhere else, including on a platform this release does not support.
  *
- * A root is a span naming no parent, which is the recognition the whole store
- * already uses — `parent_span_id` is empty on a root, and the trace read files
- * such a span at the top. It has one consequence worth saying out loud: a span
- * whose parent id arrived malformed is normalised to no parent at all, so
- * telemetry a hand-written client mangled can complete a trace early. The
- * alternative is reading a framework's own word for its root out of the span
- * name, which would make completion mean something different for every provider
- * egma ever supports — and a trace completed early is judged on what arrived,
- * while a trace completed by nobody is judged by the idle window anyway.
+ * It used to be inferred instead, from any span arriving with no parent. That
+ * reads like the same fact and is not one. A parentless span is *a span whose
+ * parent did not arrive*: an exporter flush that lost its parent, and a span
+ * whose parent id came in malformed and was normalised to nothing at all, both
+ * produce one — and either would mark a conversation complete while the caller
+ * was still talking, which is a judgment written about half a call. The end is
+ * a fact only the platform holds, so it is carried from where the platform
+ * stated it rather than guessed from the shape of what arrived. Where no
+ * supported platform stated one, this reports no completion and invents
+ * nothing.
  *
  * Simulation traces are excluded rather than treated as production: their
- * grading job is created by the transaction that ends the simulation, so spans
- * arriving through this door must not create a second job.
+ * grading work is created by the transaction that ends the simulation, and this
+ * filter is what stops the same evidence creating a second piece of it. It is
+ * the only guard — the door that once skipped this call for the simulator path
+ * no longer writes anything at all — so every span is asked, not every segment.
  *
  * Nothing here decides whether a trace *should* be graded. It reports what
  * arrived; which graders apply, and whether this trace is their turn, are
@@ -553,13 +561,12 @@ function productionTracesIn(
   for (const span of spans) {
     if (span.source !== "production") continue;
 
-    const isRoot = span.parentSpanId === "";
     const found = seen.get(span.traceId);
     if (found === undefined) {
       seen.set(span.traceId, {
         first: span.startedAtMicroseconds,
         last: span.startedAtMicroseconds,
-        rootClosed: isRoot,
+        rootClosed: span.endsTrace,
       });
       continue;
     }
@@ -570,7 +577,7 @@ function productionTracesIn(
     if (span.startedAtMicroseconds > found.last) {
       found.last = span.startedAtMicroseconds;
     }
-    found.rootClosed ||= isRoot;
+    found.rootClosed ||= span.endsTrace;
   }
 
   return [...seen].map(([traceId, when]) => ({

--- a/packages/db/src/access/grading.ts
+++ b/packages/db/src/access/grading.ts
@@ -529,22 +529,21 @@ export async function recordProductionTraces(
  * platform — LiveKit's own session span, Retell's reported end — and is `false`
  * everywhere else, including on a platform this release does not support.
  *
- * It used to be inferred instead, from any span arriving with no parent. That
- * reads like the same fact and is not one. A parentless span is *a span whose
- * parent did not arrive*: an exporter flush that lost its parent, and a span
- * whose parent id came in malformed and was normalised to nothing at all, both
- * produce one — and either would mark a conversation complete while the caller
- * was still talking, which is a judgment written about half a call. The end is
- * a fact only the platform holds, so it is carried from where the platform
- * stated it rather than guessed from the shape of what arrived. Where no
- * supported platform stated one, this reports no completion and invents
- * nothing.
+ * **A span having no parent is not an ending**, and is never read as one here.
+ * A parentless span is a span whose parent did not arrive: an exporter flush
+ * that lost its parent produces one, and so does a span whose parent id came in
+ * malformed and was normalised to nothing at all. Either would mark a
+ * conversation complete while the caller was still talking, which is a judgment
+ * written about half a call. The end is a fact only the platform holds, so it
+ * is carried from where the platform stated it. Where no supported platform
+ * states one, this reports no completion and invents nothing.
  *
  * Simulation traces are excluded rather than treated as production: their
  * grading work is created by the transaction that ends the simulation, and this
  * filter is what stops the same evidence creating a second piece of it. It is
- * the only guard — the door that once skipped this call for the simulator path
- * no longer writes anything at all — so every span is asked, not every segment.
+ * the **only** guard, because the drainer reports every segment it drains
+ * without knowing whose conversation is whose — so the question is asked of
+ * every span rather than of a segment.
  *
  * Nothing here decides whether a trace *should* be graded. It reports what
  * arrived; which graders apply, and whether this trace is their turn, are

--- a/packages/db/src/access/grading.ts
+++ b/packages/db/src/access/grading.ts
@@ -167,7 +167,15 @@ const DEFAULT_LEASE_SECONDS = 120;
  * mid-judgment — and a fourth attempt at a conversation that has broken three
  * copies is a queue of one job growing forever.
  */
-const MOST_ATTEMPTS = 3;
+/**
+ * How many times one conversation is handed out before egma stops trying.
+ *
+ * Exported because the service that does the judging decides, on its own last
+ * attempt, to answer with what it can see rather than to decline again — and a
+ * bound named in two places is a bound that will one day disagree with itself,
+ * quietly, as a job abandoned where an answer was owed.
+ */
+export const MOST_GRADING_ATTEMPTS = 3;
 
 /**
  * How long a production trace has to be quiet before egma judges it without a
@@ -642,8 +650,8 @@ export type GradingClaimRequest = {
  * transaction said so, and sampling and idleness are both about traffic egma did
  * not cause.
  *
- * A job that has been claimed `MOST_ATTEMPTS` times and still is not finished is
- * `abandoned` here instead of handed out again. egma stops trying; it does not
+ * A job that has been claimed `MOST_GRADING_ATTEMPTS` times and still is not
+ * finished is `abandoned` here instead of handed out again. egma stops trying; it does not
  * say anything about the agent, which is why the word is not `failed`.
  *
  * **It takes no `AuthContext` and cannot be given one.** See the note at the top
@@ -713,7 +721,7 @@ export async function claimGradingJobs(
     // locked just above, in this same transaction, so nothing below reaches
     // further than that select already did.
     const exhausted = candidates
-      .filter((candidate) => candidate.attempts >= MOST_ATTEMPTS)
+      .filter((candidate) => candidate.attempts >= MOST_GRADING_ATTEMPTS)
       .map((candidate) => candidate.id);
     if (exhausted.length > 0) {
       await tx
@@ -726,7 +734,7 @@ export async function claimGradingJobs(
     }
 
     const takeable = candidates
-      .filter((candidate) => candidate.attempts < MOST_ATTEMPTS)
+      .filter((candidate) => candidate.attempts < MOST_GRADING_ATTEMPTS)
       .map((candidate) => candidate.id);
     if (takeable.length === 0) return [];
 

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -691,6 +691,7 @@ export {
   getGradingJobForTrace,
   listGradingJobsForSimulation,
   recordGradingHeartbeat,
+  MOST_GRADING_ATTEMPTS,
   recordProductionTraces,
   regrade,
   releaseGradingJob,

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -231,6 +231,7 @@ export {
 } from "./organizations.ts";
 
 export {
+  isProjectOfOrganization,
   listProjects,
   projectsOf,
   readProject,
@@ -399,6 +400,11 @@ export {
   type RetellMonitoringTarget,
   type SelectedRetellAgent,
 } from "./production-monitoring.ts";
+// The list beside the type, because a caller deciding whether a word names a
+// platform Monitoring keeps a setup for has to ask the shipped list rather than
+// write two names out again — the drainer does exactly that before it moves a
+// customer's last-received state.
+export { MONITORING_PLATFORMS } from "../schema/production.ts";
 export type {
   MonitoringHealthState,
   MonitoringPlatform,

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -70,11 +70,12 @@
  * unfiltered scan this boundary exists to make unreachable.
  *
  * `recordProductionTraces` sits beside `appendSpans` on that same path and is
- * the other half of what the ingest door does with an export. It is handed the
- * very same spans: the trace store gets the rows, and the grading queue gets one
- * row per conversation saying when egma last heard about it and whether its root
- * span closed. Taking the spans rather than a summary of them is what keeps
- * "when is a conversation over" written down once. It is a queue write and a
+ * the other half of what the drainer does with a segment. It is handed the very
+ * same spans, and only after they are query-visible: the trace store gets the
+ * rows, and the grader-owned boundary gets one row per conversation saying when
+ * egma last heard about it and whether a span the platform said ends it has
+ * arrived. Taking the spans rather than a summary of them is what keeps "when is
+ * a conversation over" written down once. It is a bookkeeping row and a
  * notification and never a judgment — grading happens in a service that holds no
  * request open.
  *
@@ -375,10 +376,8 @@ export {
   finishProductionTrace,
   finishRetellMonitoringScan,
   listMonitoringSetups,
-  recordLiveKitMonitoringReceived,
-  recordRetellCallReceived,
+  recordProductionEvidenceReceived,
   recordRetellIngestionFailure,
-  recordRetellMonitoringReceived,
   recoverRetellMonitoringSetup,
   releaseRetellMonitoringLease,
   releaseRetellIngestionFailureReplay,

--- a/packages/db/src/access/production-monitoring.ts
+++ b/packages/db/src/access/production-monitoring.ts
@@ -1206,53 +1206,69 @@ export async function releaseRetellMonitoringLease(
   });
 }
 
-export async function recordRetellCallReceived(
-  auth: AuthContext,
-  target: Pick<RetellMonitoringTarget, "setupId" | "monitoredAgentId">,
-  receivedAt: Date,
-): Promise<void> {
-  await db().transaction(async (tx) => {
-    await tx
-      .update(monitoringSetup)
-      .set({ lastReceivedAt: receivedAt, updatedAt: new Date() })
-      .where(
-        and(withinMonitoringProject(auth, monitoringSetup), eq(monitoringSetup.id, target.setupId)),
-      );
-    await tx
-      .update(retellMonitoredAgent)
-      .set({ lastCallReceivedAt: receivedAt, updatedAt: new Date() })
-      .where(
-        and(
-          withinMonitoringProject(auth, retellMonitoredAgent),
-          eq(retellMonitoredAgent.id, target.monitoredAgentId),
-          eq(retellMonitoredAgent.monitoringSetupId, target.setupId),
-        ),
-      );
-  });
-}
-
-/** Keep setup health truthful when a stale claim finishes after a restart. */
-export async function recordRetellMonitoringReceived(
+/**
+ * Move "last heard from" forward for one agent platform, and never backward.
+ *
+ * **One writer, because there was one fact and three writers.** A Retell call
+ * landing, a stale Retell claim finishing after a restart and a LiveKit export
+ * arriving were three functions saying the same sentence — *evidence for this
+ * platform reached the store at this instant* — and all three said it with a
+ * plain assignment. That was survivable while the writer was the door, because
+ * the door only ever wrote now. It is not survivable now: evidence becomes
+ * durable in one order and is drained in another, a replay carries the instant
+ * the evidence was *received* rather than the instant it is being replayed at,
+ * and an assignment would answer a customer's "last production conversation" by
+ * winding it back to a call from an hour ago.
+ *
+ * So the merge is monotone. `greatest` keeps whichever instant is later, and the
+ * `coalesce` is what makes the first write work at all — a column that has never
+ * been written is null, and `greatest(null, x)` is null in Postgres, so a setup
+ * that had never heard from anybody would stay that way forever.
+ *
+ * Batched by construction: the caller names a platform and, where the platform
+ * has selected agents, one of them — never a call. One drained segment carrying
+ * two hundred conversations of one agent is one statement here.
+ */
+export async function recordProductionEvidenceReceived(
   auth: AuthContext,
   input: {
-    readonly platformAgentId: string;
-    readonly receivedAt?: Date | undefined;
+    readonly agentPlatform: MonitoringPlatform;
+    /** The selected agent, where the platform has them. Retell does. */
+    readonly platformAgentId?: string | undefined;
+    readonly receivedAt: Date;
   },
 ): Promise<void> {
-  const receivedAt = input.receivedAt ?? new Date();
+  if (auth.projectId === undefined) return;
+  const { receivedAt } = input;
+  const monotone = (column: AnyPgColumn): SQL =>
+    sql`greatest(coalesce(${column}, ${receivedAt}), ${receivedAt})`;
+
   await db().transaction(async (tx) => {
     await tx
       .update(monitoringSetup)
-      .set({ lastReceivedAt: receivedAt, updatedAt: receivedAt })
+      .set({
+        lastReceivedAt: monotone(monitoringSetup.lastReceivedAt),
+        updatedAt: receivedAt,
+      })
       .where(
         and(
           withinMonitoringProject(auth, monitoringSetup),
-          eq(monitoringSetup.agentPlatform, "retell"),
+          eq(monitoringSetup.agentPlatform, input.agentPlatform),
         ),
       );
+
+    // Named agents only. A platform that has none — or a caller that did not
+    // name one — moves the setup's own state and nothing else, rather than
+    // every selected agent's.
+    if (input.platformAgentId === undefined || input.platformAgentId === "") {
+      return;
+    }
     await tx
       .update(retellMonitoredAgent)
-      .set({ lastCallReceivedAt: receivedAt, updatedAt: receivedAt })
+      .set({
+        lastCallReceivedAt: monotone(retellMonitoredAgent.lastCallReceivedAt),
+        updatedAt: receivedAt,
+      })
       .where(
         and(
           withinMonitoringProject(auth, retellMonitoredAgent),
@@ -1260,23 +1276,6 @@ export async function recordRetellMonitoringReceived(
         ),
       );
   });
-}
-
-/** Called after a valid LiveKit production export reaches the shared store. */
-export async function recordLiveKitMonitoringReceived(
-  auth: AuthContext,
-  receivedAt = new Date(),
-): Promise<void> {
-  if (auth.projectId === undefined) return;
-  await db()
-    .update(monitoringSetup)
-    .set({ lastReceivedAt: receivedAt, updatedAt: receivedAt })
-    .where(
-      and(
-        withinMonitoringProject(auth, monitoringSetup),
-        eq(monitoringSetup.agentPlatform, "livekit_agents"),
-      ),
-    );
 }
 
 /** A summary is already owned by a completed claim or a durable failure. */

--- a/packages/db/src/access/production-monitoring.ts
+++ b/packages/db/src/access/production-monitoring.ts
@@ -1209,21 +1209,21 @@ export async function releaseRetellMonitoringLease(
 /**
  * Move "last heard from" forward for one agent platform, and never backward.
  *
- * **One writer, because there was one fact and three writers.** A Retell call
- * landing, a stale Retell claim finishing after a restart and a LiveKit export
- * arriving were three functions saying the same sentence — *evidence for this
- * platform reached the store at this instant* — and all three said it with a
- * plain assignment. That was survivable while the writer was the door, because
- * the door only ever wrote now. It is not survivable now: evidence becomes
- * durable in one order and is drained in another, a replay carries the instant
- * the evidence was *received* rather than the instant it is being replayed at,
- * and an assignment would answer a customer's "last production conversation" by
- * winding it back to a call from an hour ago.
+ * **One writer, because there is one fact**: evidence for this platform reached
+ * the store at this instant. A Retell call landing, a Retell claim finishing
+ * after a restart and a LiveKit conversation arriving are the same sentence,
+ * and one sentence with three writers is three chances to say it differently.
  *
- * So the merge is monotone. `greatest` keeps whichever instant is later, and the
- * `coalesce` is what makes the first write work at all — a column that has never
- * been written is null, and `greatest(null, x)` is null in Postgres, so a setup
- * that had never heard from anybody would stay that way forever.
+ * **The merge is monotone, and it has to be.** Evidence becomes durable in one
+ * order and is drained in another, and the instant a caller passes is the one
+ * the evidence was *received* rather than the one it is being written at — so a
+ * replay or a historical import carries an older instant than the row already
+ * holds. A plain assignment would answer a customer's "last production
+ * conversation" by winding it back to a call from an hour ago. `greatest` keeps
+ * whichever instant is later, and the `coalesce` is what makes the first write
+ * work at all: a column that has never been written is null, and
+ * `greatest(null, x)` is null in Postgres, so a setup that had never heard from
+ * anybody would stay that way forever.
  *
  * Batched by construction: the caller names a platform and, where the platform
  * has selected agents, one of them — never a call. One drained segment carrying
@@ -1242,13 +1242,18 @@ export async function recordProductionEvidenceReceived(
   const { receivedAt } = input;
   const monotone = (column: AnyPgColumn): SQL =>
     sql`greatest(coalesce(${column}, ${receivedAt}), ${receivedAt})`;
+  // When the row was touched, which is a different fact from when the evidence
+  // was received: a replay or a historical import carries an old `receivedAt`
+  // and is happening now, and a row stamped with the older of the two would
+  // report that nothing has changed since.
+  const touchedAt = new Date();
 
   await db().transaction(async (tx) => {
     await tx
       .update(monitoringSetup)
       .set({
         lastReceivedAt: monotone(monitoringSetup.lastReceivedAt),
-        updatedAt: receivedAt,
+        updatedAt: touchedAt,
       })
       .where(
         and(
@@ -1267,7 +1272,7 @@ export async function recordProductionEvidenceReceived(
       .update(retellMonitoredAgent)
       .set({
         lastCallReceivedAt: monotone(retellMonitoredAgent.lastCallReceivedAt),
-        updatedAt: receivedAt,
+        updatedAt: touchedAt,
       })
       .where(
         and(

--- a/packages/db/src/access/spans.ts
+++ b/packages/db/src/access/spans.ts
@@ -116,10 +116,13 @@ export type NewSpan = {
   readonly testVersionId: string;
   readonly personaVersionId: string;
   /**
-   * Safe provider data for this span. Every platform adapter removes
-   * credentials and bearer-like values before this boundary. This field is
-   * never truncated, while child spans may hold a normalized
-   * provider-specific subset.
+   * The provider's own document for this span, as it arrived.
+   *
+   * Never shortened and never rewritten. A platform adapter omits the transport
+   * fields that are credentials by naming them exactly — Retell's top-level
+   * `access_token` and the six authentication headers inside its own
+   * `custom_sip_headers` map — and looks at nothing else on the way past. What
+   * a value happens to contain is evidence.
    */
   readonly payload: string;
   /**
@@ -131,10 +134,13 @@ export type NewSpan = {
    * parentless span is not an ending — an exporter flush whose parent never
    * arrived produces one too.
    *
-   * Optional while the doors still construct spans without it; absent is
-   * `false`, decided once at the insert boundary rather than at each reader.
+   * Required like every other field, and required *because* the honest value is
+   * so often `false`: an optional one would let a normalizer that has a real end
+   * fact to state forget to state it, and the trace would then go quiet with
+   * nothing anywhere saying why. Stating `false` is a sentence about the
+   * platform; leaving it out is a sentence about the code.
    */
-  readonly endsTrace?: boolean;
+  readonly endsTrace: boolean;
 };
 
 export type AppendedSpans = {
@@ -259,8 +265,7 @@ function asDateTime64(microseconds: bigint): string {
  *
  * Keys are sorted so that object literal order cannot move a hash, and the two
  * 64-bit counts are written as decimal rather than left to `JSON.stringify`,
- * which refuses a `bigint` outright. Absent `endsTrace` is `false` here, so a
- * writer that states it and one that has not learned to yet agree.
+ * which refuses a `bigint` outright.
  */
 function canonicalEvidence(span: NewSpan): string {
   const evidence: Record<string, string | boolean> = {
@@ -271,7 +276,7 @@ function canonicalEvidence(span: NewSpan): string {
     connection_kind: span.connectionKind,
     duration_nanoseconds: span.durationNanoseconds.toString(),
     emitter: span.emitter,
-    ends_trace: span.endsTrace ?? false,
+    ends_trace: span.endsTrace,
     environment: span.environment,
     kind: span.kind,
     name: span.name,

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -595,6 +595,16 @@ const READ_LIMITS = [
 const THE_MONITORED_PLATFORMS = ["MONITORING_PLATFORMS"];
 
 /**
+ * How many times one conversation is handed out before egma stops trying.
+ *
+ * Exported for the same reason the read limits are: the service that judges
+ * decides on its own last attempt to answer with what it can see rather than
+ * decline again, and a bound named in two places is a bound that will one day
+ * disagree with itself.
+ */
+const THE_GRADING_BUDGET = ["MOST_GRADING_ATTEMPTS"];
+
+/**
  * What a mock tool's answer may cost the exchange that carries it, and the two
  * pure functions that read one.
  *
@@ -723,6 +733,7 @@ describe("the data-access module's surface", () => {
         ...VALUES,
         ...READ_LIMITS,
         ...THE_MONITORED_PLATFORMS,
+        ...THE_GRADING_BUDGET,
         ...THE_FOLD,
         ...THE_MEASURES,
         ...THE_MOCKED_WORLD,

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -276,10 +276,11 @@ const CONTEXT_REQUIRING = [
   "readRunVerdicts",
   "readTrace",
   "readVerdicts",
-  "recordLiveKitMonitoringReceived",
-  "recordRetellCallReceived",
+  // One monotone writer for "evidence for this platform reached the store",
+  // where three plain assignments used to say the same thing — and could each
+  // wind a customer's Monitoring state backwards on a replay.
+  "recordProductionEvidenceReceived",
   "recordRetellIngestionFailure",
-  "recordRetellMonitoringReceived",
   "recordDeviceAuthorization",
   "recordGradingHeartbeat",
   "recordProductionTraces",

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -272,13 +272,17 @@ const CONTEXT_REQUIRING = [
   // test.
   "readAssertionShelf",
   "readAssertionWords",
+  // Asks one question and answers it about the acting customer: does this
+  // project belong to them. The drainer holds a scope it read out of a sealed
+  // object and must not write under a pair Postgres has never agreed to.
+  "isProjectOfOrganization",
   "readProject",
   "readRunVerdicts",
   "readTrace",
   "readVerdicts",
-  // One monotone writer for "evidence for this platform reached the store",
-  // where three plain assignments used to say the same thing — and could each
-  // wind a customer's Monitoring state backwards on a replay.
+  // The one writer for "evidence for this platform reached the store". Its
+  // merge is monotone, because the instant it is given comes from the evidence
+  // and a replay therefore carries an older one than the row already holds.
   "recordProductionEvidenceReceived",
   "recordRetellIngestionFailure",
   "recordDeviceAuthorization",
@@ -581,6 +585,16 @@ const READ_LIMITS = [
 ];
 
 /**
+ * The shipped list of agent platforms Monitoring keeps a setup for, beside the
+ * type spelled from it.
+ *
+ * Deciding whether a word names one is a question about that list, and a list
+ * written out a second time somewhere else is a list that will one day disagree
+ * with itself — quietly, as a platform whose bookkeeping stopped being written.
+ */
+const THE_MONITORED_PLATFORMS = ["MONITORING_PLATFORMS"];
+
+/**
  * What a mock tool's answer may cost the exchange that carries it, and the two
  * pure functions that read one.
  *
@@ -708,6 +722,7 @@ describe("the data-access module's surface", () => {
         ...PERMISSION,
         ...VALUES,
         ...READ_LIMITS,
+        ...THE_MONITORED_PLATFORMS,
         ...THE_FOLD,
         ...THE_MEASURES,
         ...THE_MOCKED_WORLD,

--- a/packages/db/test/grading-jobs.test.ts
+++ b/packages/db/test/grading-jobs.test.ts
@@ -228,6 +228,7 @@ function aSpan(over: Partial<NewSpan> & { readonly traceId: string }): NewSpan {
     testVersionId: "",
     personaVersionId: "",
     payload: "{}",
+    endsTrace: false,
     ...over,
   };
 }

--- a/packages/db/test/grading-jobs.test.ts
+++ b/packages/db/test/grading-jobs.test.ts
@@ -416,13 +416,13 @@ describe("a production trace at the door", () => {
   /**
    * **The platform's word, and only the platform's word.**
    *
-   * Completion used to be inferred from any span arriving with no parent, which
-   * reads like the same fact and is not one: a parentless span is a span whose
-   * parent did not arrive. An exporter flush that lost its parent produces one,
-   * and so does a span whose parent id came in malformed and was normalised to
-   * nothing at all — and either would have marked this conversation complete
-   * while the caller was still talking. A trace nobody states an end for stays
-   * open, and the idle sweep is what eventually picks it up.
+   * A parentless span reads like the same fact and is not one: it is a span
+   * whose parent did not arrive. An exporter flush that lost its parent
+   * produces one, and so does a span whose parent id came in malformed and was
+   * normalised to nothing at all — and either, read as an ending, would mark
+   * this conversation complete while the caller was still talking. A trace
+   * nobody states an end for stays open, and the idle sweep is what eventually
+   * picks it up.
    */
   it("is not completed by a span that merely arrived without a parent", async () => {
     const traceId = wireId(16);

--- a/packages/db/test/grading-jobs.test.ts
+++ b/packages/db/test/grading-jobs.test.ts
@@ -233,13 +233,30 @@ function aSpan(over: Partial<NewSpan> & { readonly traceId: string }): NewSpan {
   };
 }
 
-/** A root span: the one that names no parent, and so closes the conversation. */
+/**
+ * The span the platform stated ends the conversation — LiveKit's own session
+ * span, carrying `endsTrace` from the normalizer that recognised it.
+ *
+ * Having no parent is beside the point and is here only because that is what a
+ * session span looks like. `aParentlessSpan` below is the same shape without
+ * the statement, and it is what proves the two are different facts.
+ */
 function aRootSpan(traceId: string, startedAt = Date.now()): NewSpan {
   return aSpan({
     traceId,
     parentSpanId: "",
     name: "agent_session",
     kind: "root",
+    startedAtMicroseconds: BigInt(startedAt) * 1_000n,
+    endsTrace: true,
+  });
+}
+
+/** A span whose parent never arrived. It says nothing about the conversation. */
+function aParentlessSpan(traceId: string, startedAt = Date.now()): NewSpan {
+  return aSpan({
+    traceId,
+    parentSpanId: "",
     startedAtMicroseconds: BigInt(startedAt) * 1_000n,
   });
 }
@@ -333,9 +350,9 @@ describe("a terminal transition", () => {
 });
 
 /**
- * A production trace has no transaction to ride, so its job is written at the
- * door on the first export that mentions it and completed later — by the root
- * span arriving, or by nothing arriving at all for long enough.
+ * A production trace has no transaction to ride, so its bookkeeping row is
+ * written on the first segment that mentions it and completed later — by a span
+ * the platform said ends it, or by nothing arriving at all for long enough.
  */
 describe("a production trace at the door", () => {
   it("becomes known on the first export, and is not claimable while it is still happening", async () => {
@@ -394,6 +411,40 @@ describe("a production trace at the door", () => {
         [newId("gjb"), acme.organization, acme.project, traceId],
       ),
     ).rejects.toMatchObject({ code: POSTGRES_ERROR.uniqueViolation });
+  });
+
+  /**
+   * **The platform's word, and only the platform's word.**
+   *
+   * Completion used to be inferred from any span arriving with no parent, which
+   * reads like the same fact and is not one: a parentless span is a span whose
+   * parent did not arrive. An exporter flush that lost its parent produces one,
+   * and so does a span whose parent id came in malformed and was normalised to
+   * nothing at all — and either would have marked this conversation complete
+   * while the caller was still talking. A trace nobody states an end for stays
+   * open, and the idle sweep is what eventually picks it up.
+   */
+  it("is not completed by a span that merely arrived without a parent", async () => {
+    const traceId = wireId(16);
+    await recordProductionTraces(auth, [
+      aSpan({ traceId }),
+      aParentlessSpan(traceId),
+    ]);
+
+    expect((await theJobForTrace(traceId)).rootClosedAt).toBeNull();
+    expect(
+      (
+        await claimGradingJobs({
+          claimant: "grader-on-a-parentless-span",
+          capacity: 50,
+        })
+      ).some((claim) => claim.traceId === traceId),
+    ).toBe(false);
+
+    // And the platform saying so, on a span of exactly the same shape, does
+    // complete it.
+    await recordProductionTraces(auth, [aRootSpan(traceId)]);
+    expect((await theJobForTrace(traceId)).rootClosedAt).toBeInstanceOf(Date);
   });
 
   it("is claimable the moment its root span closes it", async () => {

--- a/packages/db/test/measures-from-spans.test.ts
+++ b/packages/db/test/measures-from-spans.test.ts
@@ -121,6 +121,7 @@ function span(overrides: Partial<NewSpan> = {}): NewSpan {
     testVersionId: "",
     personaVersionId: "",
     payload: "{}",
+    endsTrace: false,
     ...overrides,
   };
 }

--- a/packages/db/test/production-monitoring.test.ts
+++ b/packages/db/test/production-monitoring.test.ts
@@ -11,10 +11,8 @@ import {
   finishProductionTrace,
   listMonitoringSetups,
   NotPermittedError,
-  recordLiveKitMonitoringReceived,
-  recordRetellCallReceived,
+  recordProductionEvidenceReceived,
   recordRetellIngestionFailure,
-  recordRetellMonitoringReceived,
   recoverRetellMonitoringSetup,
   releaseRetellIngestionFailureReplay,
   releaseRetellMonitoringLease,
@@ -214,11 +212,15 @@ describe("Retell Monitoring setup", () => {
 
     const retellReceivedAt = new Date("2026-08-20T08:01:00.000Z");
     const liveKitReceivedAt = new Date("2026-08-20T08:02:00.000Z");
-    await recordRetellMonitoringReceived(acmeAuth, {
+    await recordProductionEvidenceReceived(acmeAuth, {
+      agentPlatform: "retell",
       platformAgentId: selected()[0].platformAgentId,
       receivedAt: retellReceivedAt,
     });
-    await recordLiveKitMonitoringReceived(acmeAuth, liveKitReceivedAt);
+    await recordProductionEvidenceReceived(acmeAuth, {
+      agentPlatform: "livekit_agents",
+      receivedAt: liveKitReceivedAt,
+    });
 
     const acmeSetups = await listMonitoringSetups(acmeAuth);
     expect(
@@ -554,31 +556,80 @@ describe("Retell Monitoring setup", () => {
     ).toBe(true);
   });
 
-  it("does not receive a Retell call through another setup id", async () => {
+  /**
+   * **A replay is not news.**
+   *
+   * Evidence becomes durable in one order and is drained in another, so an
+   * older segment can perfectly well be written after a newer one — a
+   * ClickHouse outage, a retained object repaired a day later, a restart that
+   * found a backlog. Each of those carries the instant its evidence was
+   * received rather than the instant it is being replayed at, and a plain
+   * assignment would answer a customer's "last production conversation" by
+   * winding it back to a call from an hour ago. The merge is `greatest`, so the
+   * later fact stands whichever order the two arrive in.
+   */
+  it("never winds a customer's last-received state backwards", async () => {
     const auth = at(acme, ada);
     await configureRetellMonitoring(auth, {
       apiKey: RETELL_KEY,
       agents: selected(),
       now: SETUP_TIME,
     });
-    const liveKit = await configureLiveKitMonitoring(auth);
-    const target = await claimDueRetellMonitoringAgent({ now: SETUP_TIME });
-    expect(target).toBeDefined();
-    if (target === undefined) return;
 
-    await recordRetellCallReceived(
-      target.auth,
-      {
-        setupId: liveKit.id,
-        monitoredAgentId: target.monitoredAgentId,
-      },
-      new Date(SETUP_TIME.getTime() + 1_000),
-    );
+    const newer = new Date("2026-08-20T09:00:00.000Z");
+    const older = new Date("2026-08-20T08:00:00.000Z");
+    for (const receivedAt of [newer, older]) {
+      await recordProductionEvidenceReceived(auth, {
+        agentPlatform: "retell",
+        platformAgentId: selected()[0].platformAgentId,
+        receivedAt,
+      });
+    }
 
-    const retell = (await listMonitoringSetups(auth)).find(
-      (setup) => setup.agentPlatform === "retell",
-    );
-    expect(retell?.agents[0]?.lastCallReceivedAt).toBeNull();
+    const [setup] = await listMonitoringSetups(auth);
+    expect(setup).toMatchObject({
+      lastReceivedAt: newer,
+      agents: [{ lastCallReceivedAt: newer }],
+    });
+
+    // And the same instant twice is a no-op rather than a step of any kind,
+    // which is what a rediscovered object does.
+    await recordProductionEvidenceReceived(auth, {
+      agentPlatform: "retell",
+      platformAgentId: selected()[0].platformAgentId,
+      receivedAt: newer,
+    });
+    expect((await listMonitoringSetups(auth))[0]).toMatchObject({
+      lastReceivedAt: newer,
+      agents: [{ lastCallReceivedAt: newer }],
+    });
+  });
+
+  it("moves only the named platform's setup, never the one beside it", async () => {
+    const auth = at(acme, ada);
+    await configureRetellMonitoring(auth, {
+      apiKey: RETELL_KEY,
+      agents: selected(),
+      now: SETUP_TIME,
+    });
+    await configureLiveKitMonitoring(auth);
+
+    const receivedAt = new Date(SETUP_TIME.getTime() + 1_000);
+    await recordProductionEvidenceReceived(auth, {
+      agentPlatform: "retell",
+      platformAgentId: selected()[0].platformAgentId,
+      receivedAt,
+    });
+
+    const setups = await listMonitoringSetups(auth);
+    expect(
+      setups.find((setup) => setup.agentPlatform === "retell"),
+    ).toMatchObject({ lastReceivedAt: receivedAt });
+    // A customer with both platforms configured has two independent facts, and
+    // one platform's evidence is not the other platform's news.
+    expect(
+      setups.find((setup) => setup.agentPlatform === "livekit_agents"),
+    ).toMatchObject({ lastReceivedAt: null });
   });
 
   it("stops an already leased agent when another agent sets the key-wide gate", async () => {
@@ -1411,7 +1462,8 @@ describe("Retell Monitoring setup", () => {
     });
     const replayedAt = new Date("2026-08-20T08:03:00.000Z");
 
-    await recordRetellMonitoringReceived(auth, {
+    await recordProductionEvidenceReceived(auth, {
+      agentPlatform: "retell",
       platformAgentId: selected()[0].platformAgentId,
       receivedAt: replayedAt,
     });

--- a/packages/db/test/span-identity.test.ts
+++ b/packages/db/test/span-identity.test.ts
@@ -96,6 +96,7 @@ function span(overrides: Partial<NewSpan> = {}): NewSpan {
     testVersionId: "",
     personaVersionId: "",
     payload: "{}",
+    endsTrace: false,
     ...overrides,
   };
 }

--- a/packages/db/test/spans.test.ts
+++ b/packages/db/test/spans.test.ts
@@ -93,6 +93,7 @@ function span(overrides: Partial<NewSpan> = {}): NewSpan {
     testVersionId: "",
     personaVersionId: "",
     payload: "{}",
+    endsTrace: false,
     ...overrides,
   };
 }

--- a/packages/db/test/trace-reads.test.ts
+++ b/packages/db/test/trace-reads.test.ts
@@ -107,6 +107,7 @@ function span(overrides: Partial<NewSpan> = {}): NewSpan {
     testVersionId: "",
     personaVersionId: "",
     payload: "{}",
+    endsTrace: false,
     ...overrides,
   };
 }

--- a/packages/retell/src/index.ts
+++ b/packages/retell/src/index.ts
@@ -5,10 +5,7 @@
  * number routing, and immediate number confirmation. The caller owns the
  * credential. This client never logs, stores, or returns it.
  */
-export {
-  RETELL_REDACTED,
-  safeRetellProviderData,
-} from "./provider-data.ts";
+export { safeRetellProviderData } from "./provider-data.ts";
 
 /** The one thing this client needs from the world, so tests can stand in. */
 export type Fetch = typeof fetch;

--- a/packages/retell/src/provider-data.ts
+++ b/packages/retell/src/provider-data.ts
@@ -1,83 +1,83 @@
-/** The visible value left where Retell supplied a credential. */
-export const RETELL_REDACTED = "[REDACTED]";
+/**
+ * Retell's own call document, with the two transport fields that are
+ * credentials taken out of it — and nothing else touched.
+ *
+ * **This is omission, not replacement, and it is exact-field rather than
+ * heuristic.** Two rules, both of them a rule about *where* a value sits rather
+ * than about what it looks like:
+ *
+ * 1. The top-level `access_token` field, which is how Retell hands back the
+ *    short-lived credential a web call was joined with.
+ * 2. Inside Retell's own `custom_sip_headers` map, the values of six exact
+ *    header names — `authorization`, `proxy-authorization`, `cookie`,
+ *    `set-cookie`, `api-key`, `x-api-key` — compared case-insensitively,
+ *    because HTTP header names are.
+ *
+ * Nothing else is looked at. Not a field whose name contains `token`, not a
+ * string that starts with `Bearer`, not a nested object anywhere at any depth.
+ * A transcript is evidence: a customer saying *my password is hunter2* on a
+ * recorded call is what a team is later going to argue about, and a scanner
+ * that rewrote it would have edited the one thing the product exists to show
+ * them. The same is true of a tool argument called `credential`, of a metadata
+ * field a customer named `secret`, and of a provider field Retell adds next
+ * month. **Preserved by default** is the rule; another omission is a versioned
+ * change to this contract with a round-trip test proving nothing else moved.
+ *
+ * And an omitted field is *gone*, with no marker written where it was. A marker
+ * is a value, values are evidence, and `"[REDACTED]"` is a string a customer
+ * can legitimately say — so a reader meeting one could never tell whether Egma
+ * put it there or the caller did.
+ */
 
-function normalKey(value: string): string {
-  return value.trim().toLowerCase().replaceAll(/[_\s]+/gu, "-");
-}
+/** The six exact names, lower-cased. HTTP header names are case-insensitive. */
+const AUTHENTICATION_HEADERS: ReadonlySet<string> = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "api-key",
+  "x-api-key",
+]);
 
-function isAccessToken(key: string): boolean {
-  return normalKey(key) === "access-token";
-}
+/** Retell's own name for the map a phone call's custom SIP headers arrive in. */
+const CUSTOM_SIP_HEADERS = "custom_sip_headers";
 
-/** A header name whose value can authorize a request or prove its sender. */
-function isAuthenticationHeader(key: string): boolean {
-  const name = normalKey(key);
-  if (
-    name === "authorization" ||
-    name === "proxy-authorization" ||
-    name === "cookie" ||
-    name === "set-cookie" ||
-    name === "api-key" ||
-    name === "x-api-key"
-  ) {
-    return true;
+/** The top-level field a web call's join credential arrives in. */
+const ACCESS_TOKEN = "access_token";
+
+/** The named map with the six names dropped out of it, or whatever it was. */
+function withoutAuthenticationHeaders(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
   }
-  return /(?:^|-)(?:auth|authorization|credential|password|secret|signature|token)(?:-|$)/u.test(
-    name,
-  );
-}
-
-function isHeaderCollection(key: string): boolean {
-  return /(?:^|-)(?:header|headers)(?:-|$)/u.test(normalKey(key));
-}
-
-function headerNameIn(row: Readonly<Record<string, unknown>>): string {
-  for (const key of ["name", "key", "header", "header_name"]) {
-    const value = row[key];
-    if (typeof value === "string" && value.trim() !== "") return value;
+  const held = value as Readonly<Record<string, unknown>>;
+  const kept: Record<string, unknown> = {};
+  for (const [name, header] of Object.entries(held)) {
+    if (AUTHENTICATION_HEADERS.has(name.toLowerCase())) continue;
+    kept[name] = header;
   }
-  return "";
-}
-
-function copied(value: unknown, insideHeaders: boolean): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => copied(entry, insideHeaders));
-  }
-  if (typeof value !== "object" || value === null) return value;
-
-  const row = value as Readonly<Record<string, unknown>>;
-  const namedHeader = insideHeaders ? headerNameIn(row) : "";
-  const redactEntryValue =
-    namedHeader !== "" && isAuthenticationHeader(namedHeader);
-  const safe: Record<string, unknown> = {};
-
-  for (const [key, held] of Object.entries(row)) {
-    const normalized = normalKey(key);
-    const isValue =
-      normalized === "value" ||
-      normalized === "values" ||
-      normalized === "header-value";
-    if (
-      isAccessToken(key) ||
-      (insideHeaders && isAuthenticationHeader(key)) ||
-      (redactEntryValue && isValue)
-    ) {
-      safe[key] = RETELL_REDACTED;
-      continue;
-    }
-    safe[key] = copied(held, insideHeaders || isHeaderCollection(key));
-  }
-
-  return safe;
+  return kept;
 }
 
 /**
- * Copy provider data after removing values that can grant access.
+ * One call document, ready to become evidence.
  *
- * Retell web calls can carry an `access_token`. Phone calls can carry custom
- * SIP headers, including authorization values. The marker stays in place so a
- * later reader can tell that Retell supplied a value and Egma removed it.
+ * Shallow on purpose: both rules name a position in Retell's own document, so
+ * there is nothing to recurse into and nothing further down that could match by
+ * accident. Values that stay are the same values — not copies rebuilt key by
+ * key — so what the provider sent is what is written down.
  */
 export function safeRetellProviderData<T>(value: T): T {
-  return copied(value, false) as T;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+
+  const held = value as Readonly<Record<string, unknown>>;
+  const kept: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(held)) {
+    if (key === ACCESS_TOKEN) continue;
+    kept[key] =
+      key === CUSTOM_SIP_HEADERS ? withoutAuthenticationHeaders(field) : field;
+  }
+  return kept as T;
 }

--- a/packages/retell/test/index.test.ts
+++ b/packages/retell/test/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  RETELL_REDACTED,
   listAgents,
   listNumbers,
   safeRetellProviderData,
@@ -192,39 +191,51 @@ describe("Retell phone-number discovery", () => {
 });
 
 describe("Retell provider data", () => {
-  it("removes access tokens and authentication header values", () => {
-    expect(
-      safeRetellProviderData({
-        call_id: "call_1",
-        access_token: "web-call-token",
-        llm_token_usage: { values: [42], average: 42 },
-        custom_sip_headers: {
-          Authorization: "Bearer customer-secret",
-          "X-Api-Key": "customer-api-key",
-          "X-Customer-Route": "support",
-        },
-        nested: {
-          headers: [
-            { name: "Proxy-Authorization", value: "Basic customer-secret" },
-            { name: "X-Customer-Region", value: "west" },
-          ],
-        },
-      }),
-    ).toEqual({
+  it("omits the access token and the named SIP authentication headers", () => {
+    const safe = safeRetellProviderData({
       call_id: "call_1",
-      access_token: RETELL_REDACTED,
-      llm_token_usage: { values: [42], average: 42 },
+      access_token: "web-call-token",
       custom_sip_headers: {
-        Authorization: RETELL_REDACTED,
-        "X-Api-Key": RETELL_REDACTED,
+        Authorization: "Bearer customer-secret",
+        "proxy-authorization": "Basic customer-secret",
+        Cookie: "session=customer",
+        "Set-Cookie": "session=customer",
+        "API-Key": "customer-api-key",
+        "X-Api-Key": "customer-api-key",
         "X-Customer-Route": "support",
       },
+    });
+
+    expect(safe).toEqual({
+      call_id: "call_1",
+      custom_sip_headers: { "X-Customer-Route": "support" },
+    });
+    // Absent, and nothing standing where they were: a marker is a value, and a
+    // value is evidence.
+    expect(Object.keys(safe)).not.toContain("access_token");
+    expect(JSON.stringify(safe)).not.toContain("REDACTED");
+  });
+
+  it("keeps every other field exactly, credential-looking ones included", () => {
+    const document = {
+      call_id: "call_1",
+      transcript: "My password is hunter2 and the token is Bearer abc.123",
+      llm_token_usage: { values: [42], average: 42 },
+      metadata: { secret: "customer-chose-this-name", api_key: "not-ours" },
+      // The six names matter only inside Retell's own named map. A customer's
+      // own header collection is customer data.
       nested: {
         headers: [
-          { name: "Proxy-Authorization", value: RETELL_REDACTED },
+          { name: "Proxy-Authorization", value: "Basic customer-secret" },
           { name: "X-Customer-Region", value: "west" },
         ],
+        access_token: "a field a customer named, not the one Retell mints",
       },
-    });
+      call_analysis: { custom_analysis_data: { authorization: "kept" } },
+    };
+
+    expect(JSON.stringify(safeRetellProviderData(document))).toBe(
+      JSON.stringify(document),
+    );
   });
 });


### PR DESCRIPTION
## What this changes

The trace door stops writing ClickHouse. `POST /v1/traces` now answers success only after the evidence is durable in the object store, and a single drainer moves it into ClickHouse afterwards. The public wire contract is unchanged (same URL, auth forms, content types, gzip, body limit, partial-success shape); the one new behavior is a retryable 503 when the object store is unreachable or the local log is at its bound — with the staged records retained, never discarded.

**Acceptance (`apps/api/src/ingestion/accept.ts`).** One module both OTLP branches call: normalize → append to the write-ahead log → group by project → seal immutable gzip segments → upload under `pending/` → answer. A multi-project service batch succeeds only when every project's segment is durable. Restart recovery re-stages what the previous process staged and did not finish, due immediately.

**Drain (`apps/api/src/ingestion/{drainer,verify,defects}.ts`).** One active drainer, fed by in-process wake-ups plus a full paginated scan at startup and on an interval. Each object is verified (identity, format version, checksum, record shape), its tenancy is bound into the checksum and held against Postgres before anything is written, then: complete ClickHouse segment write with a per-segment deduplication token → monotone Monitoring bookkeeping → the evidence-ready grading handoff → deletion. A failure at any step leaves the object pending; replays are safe end to end; corrupt, conflicting, or impossibly-scoped objects are retained under their key and reported once, never deleted, never written.

**Evidence preservation.** The recursive credential scrubber and its `[REDACTED]` marker are deleted everywhere. Payloads, transcripts, and attributes are stored byte-for-byte as they arrived. The only omissions are Retell's own transport credentials (top-level `access_token` and six named `custom_sip_headers` values), omitted with no marker. The README section on stored payloads now states exactly this.

**Completion.** Trace completion for grading is produced only from the platform's explicit end statement carried on the span (`endsTrace`), never inferred from a span having no parent. `NewSpan.endsTrace` is now required.

## Proof

- New `apps/api/test/ingestion-accept.test.ts`: durability-before-answer, sealed-object shape, byte-exact preservation of credential-looking values, nothing staged on refused auth or unreadable bodies, partial success staging only the valid remainder, oversize refusal by name and bound, a quiet store answering 503 then a restart landing the evidence exactly once, and an all-or-nothing multi-project batch where one refused upload keeps both projects' evidence.
- New `apps/api/test/ingestion-drain.test.ts`: crash-point rediscovery, failed deletion replayed harmlessly, ClickHouse-down retention then completion, handoff-only replay, re-sealed replay leaving one visible span, identity conflicts and corrupt objects retained, impossible tenant binding retained, multi-page recovery scans, both orders of the end fact, and local-log backpressure without discard.
- Focused suites across the touched surface: 400+ tests green; `pnpm lint` and `pnpm typecheck` clean on every commit.

The Retell polling path still writes directly and is reworked in the next PR on this integration branch, together with deployment roles and readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwXYSuY8x4PZUxvNNgZN8a

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwXYSuY8x4PZUxvNNgZN8a)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789971889&installation_model_id=431960&pr_number=182&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F182&signature=3d5ad87b7b1ec8a0e397c074ba4a64724ea834ef912606e564729c45a0d531aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves OTLP trace acceptance onto a durable object-store-backed write-ahead path and introduces asynchronous, replay-safe draining into ClickHouse.
- Stages normalized evidence locally, seals project-scoped segments, and answers success only after durable upload.
- Verifies pending segments before tenant-scoped ClickHouse writes, monitoring updates, grading handoff, and deletion.
- Preserves evidence payloads verbatim except for explicitly omitted Retell transport credentials.
- Requires explicit `endsTrace` metadata for production trace completion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the scope of this follow-up review.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/ingestion/accept.ts | Implements WAL-backed, project-scoped segment acceptance with durability-before-success, bounded retries, restart recovery, and retained backpressure failures. |
| apps/api/src/ingestion/drainer.ts | Implements verified, tenant-bound, replay-safe movement of pending segments into ClickHouse followed by monitoring, grading handoff, and deletion. |
| apps/api/src/ingestion/verify.ts | Validates pending segment identity, format, checksum, compression, scope, and record shape before side effects. |
| apps/api/src/routes/traces.ts | Routes both OTLP authentication branches through durable acceptance while preserving the existing public ingestion contract. |
| apps/api/src/server.ts | Wires acceptance and draining into API startup and shutdown; the previously discussed multi-process ownership boundary is explicitly deferred. |
| packages/db/src/access/spans.ts | Extends analytical persistence for segment-scoped replay and identity checking used by the drainer. |
| packages/db/src/access/grading.ts | Adds idempotent evidence-ready grading bookkeeping after trace evidence becomes query-visible. |
| apps/api/src/otlp/normalise.ts | Preserves normalized OTLP payload evidence verbatim and carries explicit trace-completion metadata. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Exporter
  participant API
  participant WAL as Local WAL
  participant ObjectStore as Pending Object Store
  participant Drainer
  participant Postgres
  participant ClickHouse
  participant Grader as Grading Handoff
  Exporter->>API: POST /v1/traces
  API->>WAL: Append normalized records
  WAL-->>API: Records staged
  API->>ObjectStore: Upload immutable project segment
  ObjectStore-->>API: Durable confirmation
  API-->>Exporter: Success
  Drainer->>ObjectStore: Scan or receive wake-up
  Drainer->>Drainer: Verify identity, checksum, and shape
  Drainer->>Postgres: Validate tenant binding
  Drainer->>ClickHouse: Probe identities and append segment
  Drainer->>Postgres: Update monitoring bookkeeping
  Drainer->>Grader: Mark evidence ready
  Drainer->>ObjectStore: Delete completed pending object
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(grader): ask again for a conversatio..."](https://github.com/egma-ai/egma/commit/8dd822ef5b50787b2796a8c067c8b50d1a5b9d85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55813332)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Egma API platform](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/api-platform.md)
- Knowledge Base — [Evaluation run lifecycle](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/evaluation-run-lifecycle.md)
- Knowledge Base — [Egma database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/db-persistence.md)
- Knowledge Base — [Retell integration boundary](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/retell-integration.md)
</details>


<!-- /greptile_comment -->