### PR TITLE
Ticket 02 (poller): pull rebuilt on the agent shape

### DIFF
--- a/apps/api/src/retell-production-ingestion.ts
+++ b/apps/api/src/retell-production-ingestion.ts
@@ -47,9 +47,21 @@ const DEFAULT_REQUEST_TIMEOUT_MILLISECONDS = 10_000;
 const DEFAULT_MAXIMUM_PAGES_PER_TURN = 10;
 const DEFAULT_MAXIMUM_TURN_MILLISECONDS = 20_000;
 const MAXIMUM_HYDRATION_ATTEMPTS = 3;
-const INVALID_CREDENTIAL_RETRY_AT = new Date("9999-12-31T23:59:59.999Z");
 const BACKOFF_BASE_MILLISECONDS = 5_000;
 const BACKOFF_CAP_MILLISECONDS = 5 * 60_000;
+/**
+ * A key the provider refuses waits longer, and still only waits.
+ *
+ * The old model parked a refused key for ever and let the account-wide health
+ * row explain the stop. ADR-0015 drops `blocked_until` and the health surface
+ * together, so a permanent park would now be a silent one: nothing on any
+ * screen could say why calls stopped, and a key made good again on the
+ * provider's side would never be tried. A refusal therefore rides the same
+ * per-agent ladder with a higher ceiling — an hour, because a revoked key
+ * clears when a person acts and not in seconds. Re-arming the switch still
+ * wakes the agent at once.
+ */
+const INVALID_CREDENTIAL_CAP_MILLISECONDS = 60 * 60_000;
 
 type PlatformLogEvent = Record<string, unknown>;
 
@@ -285,16 +297,25 @@ function regularPollMilliseconds(target: MonitoringPullTarget): number {
   );
 }
 
+/**
+ * How long this agent alone waits after a refused provider turn.
+ *
+ * Capped exponential on the agent's own retry clock, spread by the same stable
+ * per-agent jitter as the cadence. Five agents holding sealed copies of one
+ * dead key each discover the refusal separately and each wait their own
+ * interval, so it costs one request per agent per interval and never a storm.
+ */
 function backoffMilliseconds(
   target: Pick<MonitoringPullTarget, "agentId" | "consecutiveFailures">,
+  capMilliseconds: number = BACKOFF_CAP_MILLISECONDS,
 ): number {
-  const exponent = Math.min(target.consecutiveFailures, 6);
+  const exponent = Math.min(target.consecutiveFailures, 12);
   const base = Math.min(
-    BACKOFF_CAP_MILLISECONDS,
+    capMilliseconds,
     BACKOFF_BASE_MILLISECONDS * 2 ** exponent,
   );
   const jitter = 0.8 + stableUnit(target.agentId) * 0.4;
-  return Math.min(BACKOFF_CAP_MILLISECONDS, Math.round(base * jitter));
+  return Math.min(capMilliseconds, Math.round(base * jitter));
 }
 
 function callIdOf(call: RetellCall): string {
@@ -405,7 +426,7 @@ type ProviderFailure = Exclude<
   { kind: "calls" } | { kind: "call" }
 >;
 
-function providerHealth(failure: ProviderFailure): MonitoringFailureKind {
+function providerFailureKind(failure: ProviderFailure): MonitoringFailureKind {
   if (failure.kind === "invalid-key") return "invalid_credential";
   if (failure.kind === "refused" && failure.reason === "rate-limited") {
     return "rate_limited";
@@ -418,8 +439,7 @@ function retryAtFor(
   failure: ProviderFailure,
   now: Date,
 ): Date {
-  const kind = providerHealth(failure);
-  if (kind === "invalid_credential") return INVALID_CREDENTIAL_RETRY_AT;
+  const kind = providerFailureKind(failure);
   if (
     kind === "rate_limited" &&
     failure.kind === "refused" &&
@@ -427,7 +447,15 @@ function retryAtFor(
   ) {
     return new Date(now.getTime() + failure.retryAfterMilliseconds);
   }
-  return new Date(now.getTime() + backoffMilliseconds(target));
+  return new Date(
+    now.getTime() +
+      backoffMilliseconds(
+        target,
+        kind === "invalid_credential"
+          ? INVALID_CREDENTIAL_CAP_MILLISECONDS
+          : BACKOFF_CAP_MILLISECONDS,
+      ),
+  );
 }
 
 async function failForProvider(
@@ -438,7 +466,7 @@ async function failForProvider(
   metrics: RetellProductionIngestionMetrics,
   now: Date,
 ): Promise<void> {
-  const kind = providerHealth(failure);
+  const kind = providerFailureKind(failure);
   const result = await store.failMonitoringPull(
     target.auth,
     target,
@@ -572,9 +600,8 @@ export async function replayRetellIngestionFailure(
       if (resolved.agentRecovered) {
         input.log.info(
           platformEvent(
-            "egma.monitoring.retell.agent.recovered",
-            "A Retell Monitoring target recovered",
-            { health_state: "active" },
+            "egma.monitoring.pull.failures.cleared",
+            "An agent's last failed production call was imported",
           ),
         );
       }
@@ -604,7 +631,7 @@ export async function replayRetellIngestionFailure(
     }
 
     const now = clock();
-    const kind = providerHealth(retrieved);
+    const kind = providerFailureKind(retrieved);
     const retryAt = retryAtFor(target, retrieved, now);
     const failed = await store.failMonitoringFailureReplay(
       target.auth,
@@ -866,9 +893,9 @@ async function runTarget(
             if (recorded.changed) {
               options.log.warn(
                 platformEvent(
-                  "egma.monitoring.retell.health.changed",
-                  "A Retell Monitoring target became degraded",
-                  { health_state: "degraded" },
+                  "egma.monitoring.pull.call.failed",
+                  "A production call could not be imported",
+                  { error_kind: permanentKind },
                 ),
               );
             }
@@ -907,9 +934,9 @@ async function runTarget(
           if (recorded.changed) {
             options.log.warn(
               platformEvent(
-                "egma.monitoring.retell.health.changed",
-                "A Retell Monitoring target became degraded",
-                { health_state: "degraded" },
+                "egma.monitoring.pull.call.failed",
+                "A production call could not be imported",
+                { error_kind: "platform_agent_mismatch" },
               ),
             );
           }

--- a/apps/api/src/retell-production-ingestion.ts
+++ b/apps/api/src/retell-production-ingestion.ts
@@ -50,7 +50,8 @@ const MAXIMUM_HYDRATION_ATTEMPTS = 3;
 const BACKOFF_BASE_MILLISECONDS = 5_000;
 const BACKOFF_CAP_MILLISECONDS = 5 * 60_000;
 /**
- * A key the provider refuses waits longer, and still only waits.
+ * The longest an agent may ever be made to wait — the ceiling on every wait
+ * this file can produce, whoever proposed it.
  *
  * The old model parked a refused key for ever and let the account-wide health
  * row explain the stop. ADR-0015 drops `blocked_until` and the health surface
@@ -60,8 +61,20 @@ const BACKOFF_CAP_MILLISECONDS = 5 * 60_000;
  * per-agent ladder with a higher ceiling — an hour, because a revoked key
  * clears when a person acts and not in seconds. Re-arming the switch still
  * wakes the agent at once.
+ *
+ * The provider's own `Retry-After` is held to the same hour: it is a
+ * suggestion from outside, and a header of a hundred years must not be able to
+ * retire an agent or hold its explicit-replay gate shut for the same span.
  */
-const INVALID_CREDENTIAL_CAP_MILLISECONDS = 60 * 60_000;
+const LONGEST_WAIT_MILLISECONDS = 60 * 60_000;
+/**
+ * How many doublings the ladder takes before the cap decides.
+ *
+ * Five seconds doubled twelve times is about six hours, past every ceiling
+ * here, so the bound exists only to keep the arithmetic small — the cap is
+ * what any wait beyond a few minutes actually lands on.
+ */
+const LONGEST_DOUBLING = 12;
 
 type PlatformLogEvent = Record<string, unknown>;
 
@@ -307,9 +320,9 @@ function regularPollMilliseconds(target: MonitoringPullTarget): number {
  */
 function backoffMilliseconds(
   target: Pick<MonitoringPullTarget, "agentId" | "consecutiveFailures">,
-  capMilliseconds: number = BACKOFF_CAP_MILLISECONDS,
+  capMilliseconds: number,
 ): number {
-  const exponent = Math.min(target.consecutiveFailures, 12);
+  const exponent = Math.min(target.consecutiveFailures, LONGEST_DOUBLING);
   const base = Math.min(
     capMilliseconds,
     BACKOFF_BASE_MILLISECONDS * 2 ** exponent,
@@ -445,14 +458,24 @@ function retryAtFor(
     failure.kind === "refused" &&
     failure.retryAfterMilliseconds !== undefined
   ) {
-    return new Date(now.getTime() + failure.retryAfterMilliseconds);
+    // Retell's own answer is honoured, up to the same ceiling every other wait
+    // has. A header of a hundred years — hostile, or a units mistake — would
+    // otherwise park the agent past the heat death of the account and hold the
+    // explicit-replay gate shut for the same span.
+    return new Date(
+      now.getTime() +
+        Math.min(
+          failure.retryAfterMilliseconds,
+          LONGEST_WAIT_MILLISECONDS,
+        ),
+    );
   }
   return new Date(
     now.getTime() +
       backoffMilliseconds(
         target,
         kind === "invalid_credential"
-          ? INVALID_CREDENTIAL_CAP_MILLISECONDS
+          ? LONGEST_WAIT_MILLISECONDS
           : BACKOFF_CAP_MILLISECONDS,
       ),
   );
@@ -499,10 +522,7 @@ export type RetellIngestionFailureReplayResult =
   | { readonly kind: "not_found" }
   | {
       readonly kind: "busy";
-      readonly reason:
-        | MonitoringFailureKind
-        | "replay_in_progress"
-        | "backing_off";
+      readonly reason: "replay_in_progress" | "backing_off";
       readonly retryAt: Date;
     }
   | { readonly kind: "lease_lost" }

--- a/apps/api/src/retell-production-ingestion.ts
+++ b/apps/api/src/retell-production-ingestion.ts
@@ -38,7 +38,7 @@ import {
   type WriteOutcome,
 } from "./retell/write.ts";
 
-/** Retell selected agents are due about every 30 seconds. */
+/** An agent with its pull switch on is due about every 30 seconds. */
 export const RETELL_PRODUCTION_POLL_INTERVAL_MILLISECONDS = 30_000;
 /** A cheap DB wake catches a jittered due target without waiting another 30s. */
 export const RETELL_PRODUCTION_INGESTION_WAKE_INTERVAL_MILLISECONDS = 5_000;
@@ -289,7 +289,7 @@ function stableUnit(value: string): number {
   return (hash >>> 0) / 4_294_967_296;
 }
 
-/** A stable 27-33 second spread stops all selected agents polling together. */
+/** A stable 27-33 second spread stops every pulled agent polling together. */
 function regularPollMilliseconds(target: MonitoringPullTarget): number {
   const spread = 0.9 + stableUnit(target.agentId) * 0.2;
   return Math.round(

--- a/apps/api/src/retell/write.ts
+++ b/apps/api/src/retell/write.ts
@@ -4,7 +4,6 @@ import {
   finishProductionTrace,
   recordProductionTraces,
   recordPulledCallReceived,
-  recordPulledCallReceivedForPlatformAgent,
   type AuthContext,
   type ProductionTraceClaim,
 } from "@egma/db";
@@ -53,7 +52,6 @@ export type RetellProductionWriteStore = {
   readonly recordProductionTraces: typeof recordProductionTraces;
   readonly finishProductionTrace: typeof finishProductionTrace;
   readonly recordPulledCallReceived: typeof recordPulledCallReceived;
-  readonly recordPulledCallReceivedForPlatformAgent: typeof recordPulledCallReceivedForPlatformAgent;
 };
 
 const STORES: RetellProductionWriteStore = {
@@ -62,7 +60,6 @@ const STORES: RetellProductionWriteStore = {
   recordProductionTraces,
   finishProductionTrace,
   recordPulledCallReceived,
-  recordPulledCallReceivedForPlatformAgent,
 };
 
 function projectIdOf(target: Pick<RetellProductionWriteTarget, "auth">): string {
@@ -109,12 +106,49 @@ function platformAgentVersionOf(call: RetellCall): string {
     : "";
 }
 
-function parsedCall(payload: string): RetellCall {
+/**
+ * What a claim's payload holds: the agent that pulled the conversation, and
+ * the safe provider document.
+ *
+ * `production_trace_claim` references nothing — no agent, no setup, no
+ * connection — which is what makes it survive a redesign of everything around
+ * it, and the column list stays exactly as it is. But crash recovery still has
+ * to stamp the notebook of the agent that pulled the call, and that fact
+ * cannot be recovered from the platform identity afterwards: a switched-off
+ * agent keeps its notebook, and a replacement may lawfully be switched on for
+ * the same platform agent id. A lookup would find whoever is switched on
+ * *now*, not whoever pulled. So the id rides inside the payload the claim
+ * already carries.
+ */
+type ClaimedCall = {
+  readonly agentId: string | undefined;
+  readonly call: RetellCall;
+};
+
+function claimedCall(payload: string): ClaimedCall {
   const value: unknown = JSON.parse(payload);
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error("A stale Retell production claim has an invalid safe payload");
   }
-  return value as RetellCall;
+  const held = value as Record<string, unknown>;
+  // A bare provider document always names its own call. A claim in that shape
+  // was written before the pulling agent rode along; it can still be finished,
+  // and the stamp — which is cosmetic — is simply skipped rather than guessed.
+  if (typeof held["call_id"] === "string") {
+    return { agentId: undefined, call: held as RetellCall };
+  }
+  const inner = held["call"];
+  if (typeof inner !== "object" || inner === null || Array.isArray(inner)) {
+    throw new Error("A stale Retell production claim has an invalid safe payload");
+  }
+  const agentId = held["agentId"];
+  return {
+    agentId:
+      typeof agentId === "string" && agentId.trim() !== ""
+        ? agentId
+        : undefined,
+    call: inner as RetellCall,
+  };
 }
 
 /**
@@ -151,7 +185,7 @@ export async function writeRetellCall(
     ...(platformAgentReference.version === ""
       ? {}
       : { platformAgentVersion: platformAgentReference.version }),
-    payload: JSON.stringify(safeCall),
+    payload: JSON.stringify({ agentId: target.agentId, call: safeCall }),
     endedAt: normalised.endedAt,
   });
 
@@ -196,13 +230,13 @@ export async function replayProductionClaim(
   claim: ProductionTraceClaim,
   stores: RetellProductionWriteStore = STORES,
 ): Promise<void> {
-  const call = parsedCall(claim.payload);
+  const claimed = claimedCall(claim.payload);
   const projectId = claim.auth.projectId;
   if (projectId === undefined) {
     throw new Error("A stale Retell production claim has no project context");
   }
   const normalised = normaliseRetellCall(
-    call,
+    claimed.call,
     {
       projectId,
       environment: "production",
@@ -227,10 +261,13 @@ export async function replayProductionClaim(
   ) {
     await stores.recordProductionTraces(claim.auth, normalised.spans);
   }
-  await stores.recordPulledCallReceivedForPlatformAgent(claim.auth, {
-    agentPlatform: "retell",
-    platformAgentId: claim.platformAgentId,
-  });
+  if (claimed.agentId !== undefined) {
+    await stores.recordPulledCallReceived(
+      claim.auth,
+      { agentId: claimed.agentId },
+      new Date(),
+    );
+  }
   await stores.finishProductionTrace(claim.auth, {
     traceId: claim.traceId,
     degraded: normalised.degraded,

--- a/apps/api/src/retell/write.ts
+++ b/apps/api/src/retell/write.ts
@@ -93,7 +93,7 @@ function platformAgentReferenceOf(
   call: RetellCall,
 ): { readonly id: string; readonly name: string; readonly version: string } {
   if (!retellCallBelongsToTarget(target, call)) {
-    throw new Error("A Retell call belongs to a different selected agent");
+    throw new Error("A Retell call belongs to a different platform agent");
   }
   return {
     id: providerText(call["agent_id"]) || target.platformAgentId,

--- a/apps/api/src/retell/write.ts
+++ b/apps/api/src/retell/write.ts
@@ -228,6 +228,7 @@ export async function replayProductionClaim(
     await stores.recordProductionTraces(claim.auth, normalised.spans);
   }
   await stores.recordPulledCallReceivedForPlatformAgent(claim.auth, {
+    agentPlatform: "retell",
     platformAgentId: claim.platformAgentId,
   });
   await stores.finishProductionTrace(claim.auth, {

--- a/apps/api/src/routes/monitoring.ts
+++ b/apps/api/src/routes/monitoring.ts
@@ -158,26 +158,6 @@ export async function monitoringRoutes(
         );
       }
       if (replayed.kind === "busy") {
-        if (replayed.reason === "rate_limited") {
-          return sendRefusal(
-            reply,
-            "too_many_requests",
-            "Retell rate-limited this retry. Wait and try again.",
-          );
-        }
-        if (replayed.reason === "invalid_credential") {
-          return unprocessable(
-            reply,
-            "Retell rejected the current API key. Update the Retell Monitoring setup and try again.",
-          );
-        }
-        if (replayed.reason === "provider_unavailable") {
-          return sendRefusal(
-            reply,
-            "provider_unavailable",
-            "Retell did not answer this retry. Try again.",
-          );
-        }
         // The agent is already waiting out its own retry clock, which this
         // retry would otherwise spend a provider request against. There is no
         // stored health state to say why any more, so the honest answer is the

--- a/apps/api/test/retell-production-ingestion.test.ts
+++ b/apps/api/test/retell-production-ingestion.test.ts
@@ -503,7 +503,7 @@ describe("Retell production ingestion", () => {
     expect(result.stoppedBecause).toBe("lease_lost");
   });
 
-  it("checks the setup-wide request gate before hydrating a listed call", async () => {
+  it("checks its own lease before hydrating a listed call", async () => {
     const recorded = record();
     let renewals = 0;
     let listRequests = 0;
@@ -719,7 +719,7 @@ describe("Retell production ingestion", () => {
     });
   });
 
-  it("uses one setup-wide Retry-After gate without a repeated log", async () => {
+  it("waits exactly as long as the provider asked, and says nothing", async () => {
     const recorded = record();
     const storage = store(recorded, TARGET, {
       async failMonitoringPull(_auth, _target, input) {
@@ -758,7 +758,7 @@ describe("Retell production ingestion", () => {
     expect(observed.recorded.providerFailures).toEqual(["rate_limited"]);
   });
 
-  it("caps unavailable-provider backoff and logs only the health transition", async () => {
+  it("caps this agent's backoff and logs the failure once", async () => {
     const recorded = record();
     const { log, events } = logger();
     const failedManyTimes: MonitoringPullTarget = {
@@ -816,7 +816,11 @@ describe("Retell production ingestion", () => {
     ).toEqual([]);
   });
 
-  it("blocks an invalid key until configuration changes and logs only its state change", async () => {
+  it("makes a refused key wait, bounded, without a health state to park it in", async () => {
+    // ADR-0015 drops `blocked_until` with the rest of the health machine. A
+    // refused key waits on this agent's own ladder — longer than a transient
+    // refusal, never for ever — so a key the customer fixes at Retell is tried
+    // again without anybody re-arming the switch here.
     const recorded = record();
     const { log, events } = logger();
 
@@ -834,14 +838,18 @@ describe("Retell production ingestion", () => {
 
     expect(recorded.failures).toHaveLength(1);
     expect(recorded.failures[0]?.kind).toBe("invalid_credential");
-    expect(recorded.failures[0]?.retryAt.getUTCFullYear()).toBe(9999);
+    const wait =
+      (recorded.failures[0]?.retryAt.getTime() ?? BASE.getTime()) -
+      BASE.getTime();
+    expect(wait).toBeGreaterThan(0);
+    expect(wait).toBeLessThanOrEqual(60 * 60_000);
     expect(events.error).toHaveLength(1);
     expect(JSON.stringify(events)).not.toContain(TARGET.apiKey);
     expect(JSON.stringify(events)).not.toContain(TARGET.platformAgentId);
     expect(JSON.stringify(events)).not.toContain(TARGET.platformAgentName);
   });
 
-  it("records a missing hydrated call, continues the page, and logs one degraded transition", async () => {
+  it("records a missing hydrated call, continues the page, and logs it once", async () => {
     const recorded = record();
     const writes: RetellCall[] = [];
     let missingHydrationAttempts = 0;
@@ -1141,7 +1149,7 @@ describe("Retell production ingestion", () => {
     expect(events).toEqual({ info: [], warn: [], error: [] });
   });
 
-  it("classifies setup-wide failures during an exact replay", async () => {
+  it("classifies provider failures during an exact replay", async () => {
     const cases = [
       {
         answer: { kind: "invalid-key" } as const,

--- a/apps/api/test/retell-production-ingestion.test.ts
+++ b/apps/api/test/retell-production-ingestion.test.ts
@@ -807,13 +807,7 @@ describe("Retell production ingestion", () => {
       clock: () => BASE,
     });
 
-    expect(events.warn).toEqual([]);
-    expect(events.error).toEqual([]);
-    expect(
-      events.info.filter((one) =>
-        String(one["otel.event.name"]).includes("health"),
-      ),
-    ).toEqual([]);
+    expect(events).toEqual({ info: [], warn: [], error: [] });
   });
 
   it("makes a refused key wait, bounded, without a health state to park it in", async () => {

--- a/apps/api/test/retell-production-ingestion.test.ts
+++ b/apps/api/test/retell-production-ingestion.test.ts
@@ -1191,7 +1191,7 @@ describe("Retell production ingestion", () => {
     }
   });
 
-  it("does not file a hydrated call under a different selected Retell agent", async () => {
+  it("does not file a hydrated call under a different platform agent", async () => {
     const recorded = record();
     const writes: RetellCall[] = [];
     const { log, events } = logger();

--- a/apps/api/test/retell-production-pull.test.ts
+++ b/apps/api/test/retell-production-pull.test.ts
@@ -1,12 +1,18 @@
 import {
   claimDueMonitoringPull,
   claimProductionTrace,
+  connectClickHouse,
   createAgent,
+  disablePullProductionCalls,
+  disconnectClickHouse,
   enablePullProductionCalls,
   finishProductionTrace,
   listMonitoringFailures,
+  listTraces,
+  readTrace,
   recordPulledCallReceived,
   recordPulledCallReceivedForPlatformAgent,
+  type AgentPlatform,
   type AuthContext,
 } from "@egma/db";
 import { newId } from "@egma/ids";
@@ -29,6 +35,7 @@ import {
   createConnectedDatabase,
   type MigratedDatabase,
 } from "../../../packages/db/test/support/database.ts";
+import { createMigratedTraceStore } from "../../../packages/db/test/support/clickhouse.ts";
 import {
   seedOrganization,
   seedUser,
@@ -78,19 +85,22 @@ function later(milliseconds: number): Date {
   return new Date(NOW.getTime() + milliseconds);
 }
 
-/** One agent bound to Retell, with its own sealed key and its switch on. */
+/** One agent bound to its platform, with its own sealed key and its switch on. */
 async function pulling(
   name: string,
   platformAgentId: string,
-  now: Date = NOW,
+  options: {
+    readonly now?: Date | undefined;
+    readonly agentPlatform?: AgentPlatform | undefined;
+  } = {},
 ): Promise<string> {
   const created = await createAgent(at(), { name });
   await enablePullProductionCalls(at(), {
     agentId: created.id,
-    agentPlatform: "retell",
+    agentPlatform: options.agentPlatform ?? "retell",
     platformAgentId,
     apiKey: RETELL_KEY,
-    now,
+    now: options.now ?? NOW,
   });
   return created.id;
 }
@@ -153,18 +163,19 @@ function retellDouble() {
     account: new Map<string, RetellCall[]>(),
     /** A forced HTTP status for one agent's list page. */
     listRefuses: new Map<string, number>(),
+    /** The `Retry-After` header that refusal carries, verbatim. */
+    listRetryAfter: new Map<string, string>(),
+    /** Claims another page and names no cursor: a broken paging contract. */
+    breaksPaging: false,
     /** A forced HTTP status for one call's full document. */
     getRefuses: new Map<string, number>(),
     pageSize: 100,
-    /** Answers nothing at all, for the turn that dies mid-flight. */
-    dead: false,
   };
 
   const fetchImpl = (async (
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    if (state.dead) throw new Error("the poller's process died mid-turn");
     const path = new URL(String(input)).pathname;
 
     if (path === "/v3/list-calls") {
@@ -182,7 +193,18 @@ function retellDouble() {
       });
       const refused = state.listRefuses.get(platformAgentId);
       if (refused !== undefined) {
-        return new Response("refused", { status: refused });
+        const retryAfter = state.listRetryAfter.get(platformAgentId);
+        return new Response("refused", {
+          status: refused,
+          ...(retryAfter === undefined
+            ? {}
+            : { headers: { "retry-after": retryAfter } }),
+        });
+      }
+      if (state.breaksPaging) {
+        return new Response(JSON.stringify({ items: [], has_more: true }), {
+          status: 200,
+        });
       }
       const inWindow = (state.account.get(platformAgentId) ?? [])
         .filter((call) => {
@@ -786,5 +808,159 @@ describe("a poison call", () => {
 
     expect(refused).toMatchObject({ kind: "busy", reason: "backing_off" });
     expect(await listMonitoringFailures(at(), agentId)).toHaveLength(1);
+  });
+});
+
+describe("a stale claim's stamp", () => {
+  it("lands only on the notebook that pulled the call", async () => {
+    // The claim references no agent — that is what makes it survive a
+    // redesign — so a restart has to find the agent again from the platform
+    // identity alone. Three agents answer to `agent_voice_1` here, and only
+    // one of them pulled anything.
+    const retired = await pulling("Retired front desk", "agent_voice_1");
+    await disablePullProductionCalls(at(), retired);
+    const pulls = await pulling("Front desk", "agent_voice_1");
+    const elsewhere = await pulling("Voice bot", "agent_voice_1", {
+      agentPlatform: "livekit_agents",
+    });
+
+    await recordPulledCallReceivedForPlatformAgent(at(), {
+      agentPlatform: "retell",
+      platformAgentId: "agent_voice_1",
+      receivedAt: later(MINUTE),
+    });
+
+    const stamped = new Map(
+      (await notebooks()).map((row) => [row.agent_id, row.last_received_at]),
+    );
+    expect(stamped.get(pulls)?.toISOString()).toBe(later(MINUTE).toISOString());
+    expect(stamped.get(retired)).toBeNull();
+    expect(stamped.get(elsewhere)).toBeNull();
+  });
+});
+
+describe("a broken page contract", () => {
+  it("does not close the explicit-replay gate, however often it repeats", async () => {
+    const double = retellDouble();
+    const agentId = await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_broken", "agent_voice_1", later(-2 * MINUTE)),
+    );
+    double.getRefuses.set("call_broken", 404);
+    await poll(double);
+    const [failure] = await listMonitoringFailures(at(), agentId);
+    expect(failure).toBeDefined();
+
+    // Retell claims another page and names no cursor. That is a broken
+    // contract, not a refusal: it says nothing about whether this agent's key
+    // still works, so it must not climb the retry clock.
+    double.breaksPaging = true;
+    await poll(double, { now: later(60_000) });
+    expect((await notebook()).consecutive_failures).toBe(0);
+
+    const asked = await replayRetellIngestionFailure({
+      auth: at(),
+      failureId: failure?.id ?? "",
+      log: collectingLog().log,
+      reach: { url: RETELL_URL, fetchImpl: double.fetchImpl },
+      writer: realLedgerWriter([]),
+      clock: () => later(61_000),
+    });
+    expect(asked.kind).toBe("still_failed");
+
+    // It keeps breaking. Only a finished scan clears the streak, so a streak
+    // taken here would hold the gate shut for as long as the breach lasts.
+    await poll(double, { now: later(120_000) });
+    await poll(double, { now: later(180_000) });
+    expect((await notebook()).consecutive_failures).toBe(0);
+
+    double.getRefuses.delete("call_broken");
+    const resolved = await replayRetellIngestionFailure({
+      auth: at(),
+      failureId: failure?.id ?? "",
+      log: collectingLog().log,
+      reach: { url: RETELL_URL, fetchImpl: double.fetchImpl },
+      writer: realLedgerWriter([]),
+      clock: () => later(181_000),
+    });
+    expect(resolved).toMatchObject({ kind: "resolved", write: "written" });
+    expect(await listMonitoringFailures(at(), agentId)).toHaveLength(0);
+  });
+});
+
+describe("a rate limit", () => {
+  it("is honoured as asked, and held to the same ceiling when absurd", async () => {
+    const double = retellDouble();
+    const agentId = await pulling("Front desk", "agent_voice_1");
+    double.listRefuses.set("agent_voice_1", 429);
+    double.listRetryAfter.set("agent_voice_1", "12");
+
+    await poll(double);
+    expect((await notebook()).next_poll_at.toISOString()).toBe(
+      later(12_000).toISOString(),
+    );
+
+    // A hundred years, in seconds. Hostile or a units mistake, it must not be
+    // able to retire the agent or hold its replay gate shut for the same span.
+    double.listRetryAfter.set("agent_voice_1", "3153600000");
+    await database.sql(
+      "update monitoring_state set next_poll_at = $1 where agent_id = $2",
+      [later(MINUTE).toISOString(), agentId],
+    );
+    const absurdTurn = later(MINUTE);
+    await poll(double, { now: absurdTurn });
+
+    const waited =
+      (await notebook()).next_poll_at.getTime() - absurdTurn.getTime();
+    expect(waited).toBeGreaterThan(0);
+    expect(waited).toBeLessThanOrEqual(60 * MINUTE);
+  });
+});
+
+describe("a pulled call", () => {
+  it("is readable through the trace reads", async () => {
+    // The one case that runs the whole way into ClickHouse. Everything else in
+    // this file is a claim about a Postgres row, and stubs the span block; this
+    // is the claim that a Retell call that ended after the switch went on can
+    // actually be read back as a trace.
+    const traces = await createMigratedTraceStore("retell_production_pull");
+    connectClickHouse({ clickhouseUrl: traces.url, maxOpenConnections: 4 });
+    try {
+      const double = retellDouble();
+      await pulling("Front desk", "agent_voice_1");
+      holds(double, retellCall("call_live", "agent_voice_1", later(-MINUTE)));
+
+      // No writer seam at all: the real one, all the way through.
+      const turn = await runRetellProductionIngestion({
+        log: collectingLog().log,
+        reach: { url: RETELL_URL, fetchImpl: double.fetchImpl },
+        clock: () => NOW,
+      });
+      expect(turn).toMatchObject({ written: 1 });
+
+      const window = {
+        from: BigInt(NOW.getTime() - DAY) * 1_000n,
+        to: BigInt(NOW.getTime() + DAY) * 1_000n,
+      };
+      const listed = await listTraces(at(), { window });
+      const [summary] = listed.traces;
+      expect(summary).toMatchObject({
+        providerCallId: "call_live",
+        platformAgentId: "agent_voice_1",
+        platformAgentName: "Front desk",
+        agentPlatform: "retell",
+        environment: "production",
+      });
+
+      const detail = await readTrace(at(), summary?.traceId ?? "", { window });
+      expect(detail?.turns.map((turnRow) => turnRow.text)).toEqual([
+        "Hello",
+        "I need help",
+      ]);
+    } finally {
+      await disconnectClickHouse();
+      await traces.drop();
+    }
   });
 });

--- a/apps/api/test/retell-production-pull.test.ts
+++ b/apps/api/test/retell-production-pull.test.ts
@@ -1,0 +1,789 @@
+import {
+  claimDueMonitoringPull,
+  claimProductionTrace,
+  createAgent,
+  enablePullProductionCalls,
+  finishProductionTrace,
+  listMonitoringFailures,
+  recordPulledCallReceived,
+  recordPulledCallReceivedForPlatformAgent,
+  type AuthContext,
+} from "@egma/db";
+import { newId } from "@egma/ids";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  replayRetellIngestionFailure,
+  runRetellProductionIngestion,
+  type RetellProductionIngestionLog,
+  type RetellProductionIngestionResult,
+  type RetellProductionWriter,
+} from "../src/retell-production-ingestion.ts";
+import type { RetellCall } from "../src/retell/normalise.ts";
+import {
+  replayProductionClaim,
+  writeRetellCall,
+  type RetellProductionWriteStore,
+} from "../src/retell/write.ts";
+import {
+  createConnectedDatabase,
+  type MigratedDatabase,
+} from "../../../packages/db/test/support/database.ts";
+import {
+  seedOrganization,
+  seedUser,
+} from "../../../packages/db/test/support/tenancy.ts";
+
+/**
+ * The poller against the real notebook.
+ *
+ * The other production-ingestion file drives the loop over a fake store, which
+ * is the right shape for asking what the loop decides. This file asks the
+ * question that fake cannot answer: whether the decisions survive Postgres —
+ * the lease under a real race, the cursor across a killed turn, the retry clock
+ * on five separate rows, the poison-call record, and the claim ledger absorbing
+ * a re-offered boundary.
+ *
+ * So the store is real and the provider is not: Retell answers over a fake
+ * `fetch`, through egma's own adapter, so the request bodies and the paging
+ * contract are the product's. The trace store is the one thing stubbed — the
+ * span block belongs to ClickHouse and none of the claims here are about it,
+ * while every claim here is about a Postgres row.
+ */
+
+let database: MigratedDatabase;
+
+const acme = { organization: newId("org"), project: newId("prj") };
+const ada = newId("usr");
+
+const RETELL_URL = "http://retell.test";
+const RETELL_KEY = "key_live_retell_pull_proof_ABCD";
+const NOW = new Date("2026-08-21T09:00:00.000Z");
+const MINUTE = 60_000;
+const DAY = 24 * 60 * MINUTE;
+const THIRTY_DAYS = 30 * DAY;
+const FIVE_MINUTES = 5 * MINUTE;
+
+function at(role: "admin" | "member" = "admin"): AuthContext {
+  return {
+    userId: ada,
+    organizationId: acme.organization,
+    projectId: acme.project,
+    role,
+    via: "session",
+  };
+}
+
+function later(milliseconds: number): Date {
+  return new Date(NOW.getTime() + milliseconds);
+}
+
+/** One agent bound to Retell, with its own sealed key and its switch on. */
+async function pulling(
+  name: string,
+  platformAgentId: string,
+  now: Date = NOW,
+): Promise<string> {
+  const created = await createAgent(at(), { name });
+  await enablePullProductionCalls(at(), {
+    agentId: created.id,
+    agentPlatform: "retell",
+    platformAgentId,
+    apiKey: RETELL_KEY,
+    now,
+  });
+  return created.id;
+}
+
+function retellCall(
+  callId: string,
+  platformAgentId: string,
+  endedAt: Date,
+): RetellCall {
+  return {
+    call_id: callId,
+    agent_id: platformAgentId,
+    agent_name: "Front desk",
+    call_status: "ended",
+    call_type: "phone_call",
+    start_timestamp: endedAt.getTime() - 30_000,
+    end_timestamp: endedAt.getTime(),
+    transcript_with_tool_calls: [
+      { role: "agent", content: "Hello" },
+      { role: "user", content: "I need help" },
+    ],
+  };
+}
+
+/** A v3 list row carries no transcript. Only the full document does. */
+function listRow(call: RetellCall): Record<string, unknown> {
+  const row: Record<string, unknown> = { ...call };
+  delete row["transcript_with_tool_calls"];
+  return row;
+}
+
+type ListRequest = {
+  readonly platformAgentId: string;
+  readonly from: number;
+  readonly to: number;
+  readonly paginationKey: string | undefined;
+};
+
+type ListBody = {
+  readonly filter_criteria?: {
+    readonly agent?: readonly { readonly agent_id?: string }[];
+    readonly end_timestamp?: { readonly value?: readonly number[] };
+  };
+  readonly pagination_key?: string;
+};
+
+/**
+ * Retell, answering over `fetch`.
+ *
+ * The cursor it hands out is the index of the next unread row, which is opaque
+ * to egma exactly as Retell's own is: the poller may only follow it or refuse
+ * it. Pages come back oldest-first with an inclusive lower bound, because that
+ * is what the real v3 list does and what makes the overlap re-offer happen.
+ */
+function retellDouble() {
+  const state = {
+    listRequests: [] as ListRequest[],
+    getRequests: [] as string[],
+    /** Every terminal call the account holds, by platform agent id. */
+    account: new Map<string, RetellCall[]>(),
+    /** A forced HTTP status for one agent's list page. */
+    listRefuses: new Map<string, number>(),
+    /** A forced HTTP status for one call's full document. */
+    getRefuses: new Map<string, number>(),
+    pageSize: 100,
+    /** Answers nothing at all, for the turn that dies mid-flight. */
+    dead: false,
+  };
+
+  const fetchImpl = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    if (state.dead) throw new Error("the poller's process died mid-turn");
+    const path = new URL(String(input)).pathname;
+
+    if (path === "/v3/list-calls") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as ListBody;
+      const platformAgentId =
+        body.filter_criteria?.agent?.[0]?.agent_id ?? "";
+      const window = body.filter_criteria?.end_timestamp?.value ?? [0, 0];
+      const from = window[0] ?? 0;
+      const to = window[1] ?? 0;
+      state.listRequests.push({
+        platformAgentId,
+        from,
+        to,
+        paginationKey: body.pagination_key,
+      });
+      const refused = state.listRefuses.get(platformAgentId);
+      if (refused !== undefined) {
+        return new Response("refused", { status: refused });
+      }
+      const inWindow = (state.account.get(platformAgentId) ?? [])
+        .filter((call) => {
+          const endedAt = Number(call["end_timestamp"]);
+          return endedAt >= from && endedAt <= to;
+        })
+        .sort(
+          (left, right) =>
+            Number(left["end_timestamp"]) - Number(right["end_timestamp"]),
+        );
+      const start = Number(body.pagination_key ?? "0");
+      const page = inWindow.slice(start, start + state.pageSize);
+      const hasMore = start + page.length < inWindow.length;
+      return new Response(
+        JSON.stringify({
+          items: page.map(listRow),
+          has_more: hasMore,
+          ...(hasMore ? { pagination_key: String(start + page.length) } : {}),
+        }),
+        { status: 200 },
+      );
+    }
+
+    if (path.startsWith("/v2/get-call/")) {
+      const callId = decodeURIComponent(path.slice("/v2/get-call/".length));
+      state.getRequests.push(callId);
+      const refused = state.getRefuses.get(callId);
+      if (refused !== undefined) {
+        return new Response("refused", { status: refused });
+      }
+      for (const calls of state.account.values()) {
+        const found = calls.find((call) => call["call_id"] === callId);
+        if (found !== undefined) {
+          return new Response(JSON.stringify(found), { status: 200 });
+        }
+      }
+      return new Response("not found", { status: 404 });
+    }
+
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+
+  return Object.assign(state, { fetchImpl });
+}
+
+type RetellDouble = ReturnType<typeof retellDouble>;
+
+function holds(double: RetellDouble, ...calls: readonly RetellCall[]): void {
+  for (const call of calls) {
+    const platformAgentId = String(call["agent_id"]);
+    const held = double.account.get(platformAgentId) ?? [];
+    double.account.set(platformAgentId, [...held, call]);
+  }
+}
+
+function collectingLog(): {
+  readonly log: RetellProductionIngestionLog;
+  readonly events: Record<string, unknown>[];
+} {
+  const events: Record<string, unknown>[] = [];
+  return {
+    events,
+    log: {
+      info: (event) => events.push(event),
+      warn: (event) => events.push(event),
+      error: (event) => events.push(event),
+    },
+  };
+}
+
+/**
+ * The real write protocol with only ClickHouse stubbed.
+ *
+ * `claimProductionTrace` and `finishProductionTrace` are the receipt book, and
+ * they are the whole point of this file's duplicate claims — so they are the
+ * real ones, against the real table.
+ */
+function realLedgerWriter(spans: unknown[]): RetellProductionWriter {
+  const stores: RetellProductionWriteStore = {
+    claimProductionTrace,
+    finishProductionTrace,
+    recordPulledCallReceived,
+    recordPulledCallReceivedForPlatformAgent,
+    async appendSpans(_auth, written) {
+      spans.push(...written);
+    },
+    async recordProductionTraces() {
+      // ClickHouse's grading queue. Nothing here is a claim about it.
+    },
+  };
+  return {
+    writeRetellCall: (target, call, receivedAt) =>
+      writeRetellCall(target, call, receivedAt, stores),
+    replayProductionClaim: (claim) => replayProductionClaim(claim, stores),
+  };
+}
+
+type PollOptions = {
+  readonly now?: Date | undefined;
+  readonly maxPagesPerTurn?: number | undefined;
+  readonly log?: RetellProductionIngestionLog | undefined;
+};
+
+async function poll(
+  double: RetellDouble,
+  options: PollOptions = {},
+): Promise<RetellProductionIngestionResult> {
+  return runRetellProductionIngestion({
+    log: options.log ?? collectingLog().log,
+    reach: { url: RETELL_URL, fetchImpl: double.fetchImpl },
+    writer: realLedgerWriter([]),
+    clock: () => options.now ?? NOW,
+    ...(options.maxPagesPerTurn === undefined
+      ? {}
+      : { maxPagesPerTurn: options.maxPagesPerTurn }),
+  });
+}
+
+/** Every due agent, exactly as one standing tick drains them. */
+async function drain(
+  double: RetellDouble,
+  options: PollOptions = {},
+): Promise<RetellProductionIngestionResult[]> {
+  const turns: RetellProductionIngestionResult[] = [];
+  let turn: RetellProductionIngestionResult;
+  do {
+    turn = await poll(double, options);
+    turns.push(turn);
+  } while (turn.targetClaimed);
+  return turns;
+}
+
+type NotebookRow = {
+  scan_kind: string | null;
+  scan_from: Date | null;
+  scan_through: Date | null;
+  pagination_key: string | null;
+  completed_through: Date | null;
+  next_poll_at: Date;
+  next_regular_poll_at: Date;
+  reconciliation_from: Date | null;
+  reconciliation_through: Date | null;
+  reconciliation_pagination_key: string | null;
+  reconciliation_needs_regular: boolean;
+  lease_owner: string | null;
+  consecutive_failures: number;
+  last_received_at: Date | null;
+  agent_id: string;
+};
+
+async function notebooks(): Promise<NotebookRow[]> {
+  const { rows } = await database.sql<NotebookRow>(
+    "select * from monitoring_state order by agent_id",
+  );
+  return rows;
+}
+
+async function notebook(): Promise<NotebookRow> {
+  const [row] = await notebooks();
+  if (row === undefined) throw new Error("no notebook was opened");
+  return row;
+}
+
+async function ledger(): Promise<
+  { provider_call_id: string; status: string }[]
+> {
+  const { rows } = await database.sql<{
+    provider_call_id: string;
+    status: string;
+  }>(
+    "select provider_call_id, status from production_trace_claim " +
+      "order by provider_call_id",
+  );
+  return rows;
+}
+
+beforeAll(async () => {
+  database = await createConnectedDatabase("retell_production_pull");
+  await seedOrganization(database, acme.organization, [
+    { id: acme.project, slug: "default" },
+  ]);
+  await seedUser(database, ada, "ada@acme.example");
+});
+
+beforeEach(async () => {
+  await database.sql(
+    "truncate monitoring_failure, production_trace_claim, " +
+      "monitoring_state, connection, agent cascade",
+  );
+});
+
+afterAll(async () => {
+  await database.drop();
+});
+
+describe("the first switch-on", () => {
+  it("walks the thirty days behind it and stamps what it covered", async () => {
+    const double = retellDouble();
+    await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_ten_days_ago", "agent_voice_1", later(-10 * DAY)),
+      retellCall("call_one_minute_ago", "agent_voice_1", later(-MINUTE)),
+      retellCall("call_forty_days_ago", "agent_voice_1", later(-40 * DAY)),
+    );
+
+    const turn = await poll(double);
+
+    expect(turn).toMatchObject({ targetClaimed: true, written: 2, already: 0 });
+    expect(double.listRequests).toEqual([
+      {
+        platformAgentId: "agent_voice_1",
+        from: NOW.getTime() - THIRTY_DAYS,
+        to: NOW.getTime(),
+        paginationKey: undefined,
+      },
+    ]);
+    expect((await ledger()).map((row) => row.provider_call_id)).toEqual([
+      "call_one_minute_ago",
+      "call_ten_days_ago",
+    ]);
+    expect((await ledger()).every((row) => row.status === "written")).toBe(true);
+
+    const row = await notebook();
+    expect(row.scan_kind).toBeNull();
+    expect(row.lease_owner).toBeNull();
+    expect(row.consecutive_failures).toBe(0);
+    expect(row.completed_through?.toISOString()).toBe(NOW.toISOString());
+    expect(row.last_received_at).not.toBeNull();
+  });
+
+  it("re-offers the five-minute boundary, and the ledger absorbs it", async () => {
+    const double = retellDouble();
+    await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_one_minute_ago", "agent_voice_1", later(-MINUTE)),
+    );
+    await poll(double);
+
+    const nextTurn = later(60_000);
+    const turn = await poll(double, { now: nextTurn });
+
+    // The regular window deliberately starts before the last completed scan
+    // ended, so a conversation that landed on the boundary is asked for twice.
+    expect(double.listRequests[1]).toEqual({
+      platformAgentId: "agent_voice_1",
+      from: NOW.getTime() - FIVE_MINUTES,
+      to: nextTurn.getTime(),
+      paginationKey: undefined,
+    });
+    expect(turn).toMatchObject({ written: 0, already: 1 });
+    // The receipt book owned it the first time, so the second offer costs no
+    // provider request at all and writes no second row.
+    expect(double.getRequests).toEqual(["call_one_minute_ago"]);
+    expect(await ledger()).toEqual([
+      { provider_call_id: "call_one_minute_ago", status: "written" },
+    ]);
+  });
+
+  it("keeps the daily re-walk waiting while regular work runs", async () => {
+    const double = retellDouble();
+    const agentId = await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_a", "agent_voice_1", later(-20 * DAY)),
+      retellCall("call_b", "agent_voice_1", later(-10 * DAY)),
+    );
+    await poll(double);
+
+    // A day passes and the re-walk falls due.
+    double.pageSize = 1;
+    // Regular polling wins whenever it is due, so a re-walk can only start in
+    // the gap between two regular turns. That is the whole yielding rule.
+    await database.sql(
+      `update monitoring_state set next_reconciliation_at = $1, ` +
+        `next_poll_at = $1, next_regular_poll_at = $2 where agent_id = $3`,
+      [
+        later(DAY).toISOString(),
+        later(DAY + 20_000).toISOString(),
+        agentId,
+      ],
+    );
+    const dueAt = later(DAY);
+
+    const walk = await poll(double, { now: dueAt, maxPagesPerTurn: 1 });
+    expect(walk.stoppedBecause).toBe("bounded_turn");
+    expect(double.listRequests[1]).toMatchObject({
+      from: dueAt.getTime() - THIRTY_DAYS,
+      to: dueAt.getTime(),
+    });
+
+    // Its fixed window is parked whole, and the clock hands the turn back to
+    // regular polling rather than to the re-walk's own next slice.
+    const paused = await notebook();
+    expect(paused.scan_kind).toBeNull();
+    expect(paused.reconciliation_needs_regular).toBe(true);
+    expect(paused.reconciliation_from?.getTime()).toBe(
+      dueAt.getTime() - THIRTY_DAYS,
+    );
+    expect(paused.reconciliation_pagination_key).toBe("1");
+    expect(paused.next_poll_at.toISOString()).toBe(
+      paused.next_regular_poll_at.toISOString(),
+    );
+
+    const regular = await poll(double, { now: later(DAY + MINUTE) });
+    expect(regular.stoppedBecause).toBeUndefined();
+    expect(double.listRequests[2]).toMatchObject({
+      from: NOW.getTime() - FIVE_MINUTES,
+      to: later(DAY + MINUTE).getTime(),
+    });
+
+    // Regular work is done, so the parked re-walk is due again at once and
+    // resumes on the exact window and cursor it was holding.
+    const resumable = await notebook();
+    expect(resumable.reconciliation_needs_regular).toBe(false);
+    expect(resumable.next_poll_at.toISOString()).toBe(
+      later(DAY + MINUTE).toISOString(),
+    );
+
+    await poll(double, { now: later(DAY + 61_000), maxPagesPerTurn: 1 });
+    expect(double.listRequests[3]).toMatchObject({
+      from: dueAt.getTime() - THIRTY_DAYS,
+      to: dueAt.getTime(),
+      paginationKey: "1",
+    });
+    expect(await ledger()).toHaveLength(2);
+  });
+});
+
+describe("two API replicas", () => {
+  it("never poll one agent at the same time", async () => {
+    const double = retellDouble();
+    await pulling("Front desk", "agent_voice_1");
+    holds(double, retellCall("call_1", "agent_voice_1", later(-MINUTE)));
+
+    const [left, right] = await Promise.all([poll(double), poll(double)]);
+
+    expect([left.targetClaimed, right.targetClaimed].filter(Boolean)).toEqual([
+      true,
+    ]);
+    expect(double.listRequests).toHaveLength(1);
+    expect(await ledger()).toHaveLength(1);
+  });
+
+  it("cannot both hold the lease, whichever wins the race", async () => {
+    await pulling("Front desk", "agent_voice_1");
+
+    const claimed = await Promise.all([
+      claimDueMonitoringPull({ now: NOW }),
+      claimDueMonitoringPull({ now: NOW }),
+      claimDueMonitoringPull({ now: NOW }),
+    ]);
+
+    expect(claimed.filter((one) => one !== undefined)).toHaveLength(1);
+    const row = await notebook();
+    expect(row.lease_owner).not.toBeNull();
+  });
+});
+
+describe("a killed turn", () => {
+  it("resumes from the cursor it reached, with no gaps and no duplicates", async () => {
+    const double = retellDouble();
+    double.pageSize = 1;
+    await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_1", "agent_voice_1", later(-3 * MINUTE)),
+      retellCall("call_2", "agent_voice_1", later(-2 * MINUTE)),
+      retellCall("call_3", "agent_voice_1", later(-MINUTE)),
+    );
+
+    const first = await poll(double, { maxPagesPerTurn: 1 });
+    expect(first).toMatchObject({ written: 1, stoppedBecause: "bounded_turn" });
+
+    // The process dies holding a lease: nothing is released, nothing is
+    // finished, and the next replica has to wait the lease out.
+    const dying = await claimDueMonitoringPull({
+      now: later(60_000),
+      leaseMilliseconds: 1,
+    });
+    expect(dying).toMatchObject({
+      scanKind: "historical_import",
+      paginationKey: "1",
+      scanFrom: new Date(NOW.getTime() - THIRTY_DAYS),
+      scanThrough: NOW,
+    });
+    expect(
+      await claimDueMonitoringPull({ now: later(60_000) }),
+    ).toBeUndefined();
+
+    const second = await poll(double, { now: later(120_000) });
+    expect(second).toMatchObject({ written: 2, already: 0 });
+    // The window it finished is the one it started, not the one the clock has
+    // moved to. That is what stops the resume from stepping over a call.
+    const row = await notebook();
+    expect(row.completed_through?.toISOString()).toBe(NOW.toISOString());
+    expect((await ledger()).map((one) => one.provider_call_id)).toEqual([
+      "call_1",
+      "call_2",
+      "call_3",
+    ]);
+
+    const regular = await poll(double, { now: later(180_000) });
+    expect(regular).toMatchObject({ written: 0 });
+    expect(double.listRequests.at(-1)).toMatchObject({
+      from: NOW.getTime() - FIVE_MINUTES,
+    });
+    expect(await ledger()).toHaveLength(3);
+  });
+});
+
+describe("a refused key", () => {
+  it("backs five agents off separately, and makes no storm", async () => {
+    const double = retellDouble();
+    const dead = ["agent_1", "agent_2", "agent_3", "agent_4", "agent_5"];
+    for (const [index, platformAgentId] of dead.entries()) {
+      await pulling(`Agent ${String(index)}`, platformAgentId);
+      double.listRefuses.set(platformAgentId, 401);
+    }
+    const collected = collectingLog();
+
+    const turns = await drain(double, { log: collected.log });
+
+    expect(turns.filter((turn) => turn.targetClaimed)).toHaveLength(5);
+    expect(double.listRequests).toHaveLength(5);
+    const first = await notebooks();
+    expect(first.map((row) => row.consecutive_failures)).toEqual([
+      1, 1, 1, 1, 1,
+    ]);
+    for (const row of first) {
+      const waited = row.next_poll_at.getTime() - NOW.getTime();
+      expect(waited).toBeGreaterThanOrEqual(4_000);
+      expect(waited).toBeLessThanOrEqual(6_000);
+    }
+    // Five sealed copies of one key are unrecognizable as the same key, so
+    // five agents discover the refusal separately — and then wait separately.
+    expect(new Set(first.map((row) => row.next_poll_at.getTime())).size)
+      .toBeGreaterThan(1);
+    expect(JSON.stringify(collected.events)).not.toContain(RETELL_KEY);
+
+    // Nothing is due while they wait, so the dead key costs no second request.
+    await drain(double, { now: later(1_000) });
+    expect(double.listRequests).toHaveLength(5);
+
+    // The ladder is exponential and per agent: the second wait is the double
+    // of the first, on each agent's own row.
+    const secondTurn = later(6_000);
+    await drain(double, { now: secondTurn });
+    expect(double.listRequests).toHaveLength(10);
+    const second = await notebooks();
+    expect(second.map((row) => row.consecutive_failures)).toEqual([
+      2, 2, 2, 2, 2,
+    ]);
+    for (const row of second) {
+      const waited = row.next_poll_at.getTime() - secondTurn.getTime();
+      expect(waited).toBeGreaterThanOrEqual(8_000);
+      expect(waited).toBeLessThanOrEqual(12_000);
+    }
+
+    // One customer fixes one key. That agent recovers; the other four do not.
+    double.listRefuses.delete("agent_3");
+    const thirdTurn = later(30_000);
+    await drain(double, { now: thirdTurn });
+    const third = await notebooks();
+    const recovered = third.filter((row) => row.consecutive_failures === 0);
+    expect(recovered).toHaveLength(1);
+    expect(third.filter((row) => row.consecutive_failures === 3)).toHaveLength(
+      4,
+    );
+  });
+
+  it("waits longer than a passing outage, and still only waits", async () => {
+    const double = retellDouble();
+    const agentId = await pulling("Front desk", "agent_voice_1");
+    double.listRefuses.set("agent_voice_1", 401);
+    await database.sql(
+      "update monitoring_state set consecutive_failures = 30 where agent_id = $1",
+      [agentId],
+    );
+
+    await poll(double);
+
+    const refused = await notebook();
+    const waited = refused.next_poll_at.getTime() - NOW.getTime();
+    expect(waited).toBeGreaterThan(5 * MINUTE);
+    expect(waited).toBeLessThanOrEqual(60 * MINUTE);
+
+    // A provider that is merely down keeps the five-minute ceiling.
+    double.listRefuses.set("agent_voice_1", 503);
+    await database.sql(
+      "update monitoring_state set consecutive_failures = 30, " +
+        "next_poll_at = $1 where agent_id = $2",
+      [later(2 * 60 * MINUTE).toISOString(), agentId],
+    );
+    const outageTurn = later(2 * 60 * MINUTE);
+    await poll(double, { now: outageTurn });
+
+    const down = await notebook();
+    const outageWait = down.next_poll_at.getTime() - outageTurn.getTime();
+    expect(outageWait).toBeGreaterThan(0);
+    expect(outageWait).toBeLessThanOrEqual(5 * MINUTE);
+  });
+});
+
+describe("a poison call", () => {
+  it("is recorded after bounded retries, and the cursor moves past it", async () => {
+    const double = retellDouble();
+    const agentId = await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_broken", "agent_voice_1", later(-2 * MINUTE)),
+      retellCall("call_good", "agent_voice_1", later(-MINUTE)),
+    );
+    double.getRefuses.set("call_broken", 404);
+
+    const turn = await poll(double);
+
+    expect(turn).toMatchObject({ written: 1, permanentFailures: 1 });
+    expect(
+      double.getRequests.filter((one) => one === "call_broken"),
+    ).toHaveLength(3);
+    const [failure] = await listMonitoringFailures(at(), agentId);
+    expect(failure).toMatchObject({
+      providerCallId: "call_broken",
+      errorKind: "provider_call_not_found",
+      attempts: 1,
+      status: "open",
+    });
+    // The scan finished rather than stalling on the broken document, and the
+    // good call behind it is in the receipt book.
+    const row = await notebook();
+    expect(row.scan_kind).toBeNull();
+    expect(row.completed_through?.toISOString()).toBe(NOW.toISOString());
+    expect((await ledger()).map((one) => one.provider_call_id)).toEqual([
+      "call_good",
+    ]);
+  });
+
+  it("is imported by an explicit replay once the provider can answer", async () => {
+    const double = retellDouble();
+    const agentId = await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_broken", "agent_voice_1", later(-2 * MINUTE)),
+    );
+    double.getRefuses.set("call_broken", 404);
+    await poll(double);
+    const [failure] = await listMonitoringFailures(at(), agentId);
+    expect(failure).toBeDefined();
+
+    double.getRefuses.delete("call_broken");
+    const replayed = await replayRetellIngestionFailure({
+      auth: at(),
+      failureId: failure?.id ?? "",
+      log: collectingLog().log,
+      reach: { url: RETELL_URL, fetchImpl: double.fetchImpl },
+      writer: realLedgerWriter([]),
+      clock: () => later(MINUTE),
+    });
+
+    expect(replayed).toMatchObject({
+      kind: "resolved",
+      write: "written",
+      agentRecovered: true,
+    });
+    expect(await listMonitoringFailures(at(), agentId)).toHaveLength(0);
+    expect(await ledger()).toEqual([
+      { provider_call_id: "call_broken", status: "written" },
+    ]);
+  });
+
+  it("refuses an explicit replay while that agent is backing off", async () => {
+    const double = retellDouble();
+    const agentId = await pulling("Front desk", "agent_voice_1");
+    holds(
+      double,
+      retellCall("call_broken", "agent_voice_1", later(-2 * MINUTE)),
+    );
+    double.getRefuses.set("call_broken", 404);
+    await poll(double);
+    const [failure] = await listMonitoringFailures(at(), agentId);
+
+    // What a refused provider turn leaves behind on this agent alone.
+    double.listRefuses.set("agent_voice_1", 401);
+    await database.sql(
+      "update monitoring_state set next_poll_at = $1 where agent_id = $2",
+      [later(MINUTE).toISOString(), agentId],
+    );
+    await poll(double, { now: later(MINUTE) });
+
+    const refused = await replayRetellIngestionFailure({
+      auth: at(),
+      failureId: failure?.id ?? "",
+      log: collectingLog().log,
+      reach: { url: RETELL_URL, fetchImpl: double.fetchImpl },
+      writer: realLedgerWriter([]),
+      clock: () => later(MINUTE + 1_000),
+    });
+
+    expect(refused).toMatchObject({ kind: "busy", reason: "backing_off" });
+    expect(await listMonitoringFailures(at(), agentId)).toHaveLength(1);
+  });
+});

--- a/apps/api/test/retell-production-pull.test.ts
+++ b/apps/api/test/retell-production-pull.test.ts
@@ -268,6 +268,7 @@ function realLedgerWriter(spans: unknown[]): RetellProductionWriter {
     recordPulledCallReceivedForPlatformAgent,
     async appendSpans(_auth, written) {
       spans.push(...written);
+      return { appended: written.length, batches: 1 };
     },
     async recordProductionTraces() {
       // ClickHouse's grading queue. Nothing here is a claim about it.

--- a/apps/api/test/retell-production-pull.test.ts
+++ b/apps/api/test/retell-production-pull.test.ts
@@ -11,7 +11,7 @@ import {
   listTraces,
   readTrace,
   recordPulledCallReceived,
-  recordPulledCallReceivedForPlatformAgent,
+  sweepStaleProductionClaims,
   type AgentPlatform,
   type AuthContext,
 } from "@egma/db";
@@ -118,9 +118,21 @@ function retellCall(
     call_type: "phone_call",
     start_timestamp: endedAt.getTime() - 30_000,
     end_timestamp: endedAt.getTime(),
+    // With word timings, because a transcript's order has to be a reported
+    // fact here rather than a tie-break: two turns Retell timed identically are
+    // indistinguishable to a trace read, and the one case that reads spans back
+    // asks for them in order.
     transcript_with_tool_calls: [
-      { role: "agent", content: "Hello" },
-      { role: "user", content: "I need help" },
+      {
+        role: "agent",
+        content: "Hello",
+        words: [{ word: "Hello", start: 0.1, end: 0.6 }],
+      },
+      {
+        role: "user",
+        content: "I need help",
+        words: [{ word: "I need help", start: 1.2, end: 2.4 }],
+      },
     ],
   };
 }
@@ -287,7 +299,6 @@ function realLedgerWriter(spans: unknown[]): RetellProductionWriter {
     claimProductionTrace,
     finishProductionTrace,
     recordPulledCallReceived,
-    recordPulledCallReceivedForPlatformAgent,
     async appendSpans(_auth, written) {
       spans.push(...written);
       return { appended: written.length, batches: 1 };
@@ -812,30 +823,71 @@ describe("a poison call", () => {
 });
 
 describe("a stale claim's stamp", () => {
-  it("lands only on the notebook that pulled the call", async () => {
-    // The claim references no agent — that is what makes it survive a
-    // redesign — so a restart has to find the agent again from the platform
-    // identity alone. Three agents answer to `agent_voice_1` here, and only
-    // one of them pulled anything.
-    const retired = await pulling("Retired front desk", "agent_voice_1");
-    await disablePullProductionCalls(at(), retired);
-    const pulls = await pulling("Front desk", "agent_voice_1");
-    const elsewhere = await pulling("Voice bot", "agent_voice_1", {
-      agentPlatform: "livekit_agents",
-    });
+  it("lands on the agent that pulled the call, not on its replacement", async () => {
+    const double = retellDouble();
+    const pulled = await pulling("Front desk", "agent_voice_1");
+    holds(double, retellCall("call_live", "agent_voice_1", later(-MINUTE)));
 
-    await recordPulledCallReceivedForPlatformAgent(at(), {
-      agentPlatform: "retell",
-      platformAgentId: "agent_voice_1",
-      receivedAt: later(MINUTE),
+    // The turn dies between Postgres and ClickHouse. The claim is owned and
+    // never marked written, which is the whole reason the sweep exists.
+    const crashing: RetellProductionWriteStore = {
+      claimProductionTrace,
+      finishProductionTrace,
+      recordPulledCallReceived,
+      async appendSpans() {
+        throw new Error("the trace store went away mid-write");
+      },
+      async recordProductionTraces() {
+        // Never reached: the span block is what failed.
+      },
+    };
+    await expect(
+      runRetellProductionIngestion({
+        log: collectingLog().log,
+        reach: { url: RETELL_URL, fetchImpl: double.fetchImpl },
+        writer: {
+          writeRetellCall: (target, call, receivedAt) =>
+            writeRetellCall(target, call, receivedAt, crashing),
+          replayProductionClaim: (claim) =>
+            replayProductionClaim(claim, crashing),
+        },
+        clock: () => NOW,
+      }),
+    ).rejects.toThrow("the trace store went away mid-write");
+
+    // The customer moves the platform agent onto a fresh egma agent. The
+    // switched-off original keeps its notebook, and the partial unique index
+    // allows the replacement to name the same platform agent.
+    await disablePullProductionCalls(at(), pulled);
+    const replacement = await pulling("Front desk, again", "agent_voice_1");
+
+    // Crash recovery, on the real clock the claim was written against.
+    const stale = await sweepStaleProductionClaims({
+      now: new Date(Date.now() + 5 * MINUTE),
     });
+    expect(stale).toHaveLength(1);
+    for (const claim of stale) {
+      await replayProductionClaim(claim, {
+        claimProductionTrace,
+        finishProductionTrace,
+        recordPulledCallReceived,
+        async appendSpans(_auth, written) {
+          return { appended: written.length, batches: 1 };
+        },
+        async recordProductionTraces() {
+          // ClickHouse's grading queue. Not what this case is about.
+        },
+      });
+    }
 
     const stamped = new Map(
       (await notebooks()).map((row) => [row.agent_id, row.last_received_at]),
     );
-    expect(stamped.get(pulls)?.toISOString()).toBe(later(MINUTE).toISOString());
-    expect(stamped.get(retired)).toBeNull();
-    expect(stamped.get(elsewhere)).toBeNull();
+    expect(stamped.get(pulled)).not.toBeNull();
+    expect(stamped.get(replacement)).toBeNull();
+    expect(await ledger()).toEqual([
+      { provider_call_id: "call_live", status: "written" },
+    ]);
   });
 });
 

--- a/apps/api/test/retell-production-write.test.ts
+++ b/apps/api/test/retell-production-write.test.ts
@@ -231,7 +231,7 @@ describe("the shared Retell production writer", () => {
         new Date("2026-08-19T00:00:05.000Z"),
         writeStore(mismatch, claim),
       ),
-    ).rejects.toThrow("different selected agent");
+    ).rejects.toThrow("different platform agent");
     expect(mismatch.claimed).toBeUndefined();
   });
 

--- a/apps/api/test/retell-production-write.test.ts
+++ b/apps/api/test/retell-production-write.test.ts
@@ -57,7 +57,8 @@ type Recorded = {
   grading: number;
   finished: string[];
   received: number;
-  replayedPlatformAgentIds: string[];
+  /** Which notebook each stamp landed on — the whole point of the payload id. */
+  receivedForAgentIds: string[];
 };
 
 function writeStore(
@@ -79,12 +80,9 @@ function writeStore(
     async finishProductionTrace(_auth, finished) {
       recorded.finished.push(finished.traceId);
     },
-    async recordPulledCallReceived() {
+    async recordPulledCallReceived(_auth, target) {
       recorded.received += 1;
-    },
-    async recordPulledCallReceivedForPlatformAgent(_auth, input) {
-      recorded.received += 1;
-      recorded.replayedPlatformAgentIds.push(input.platformAgentId);
+      recorded.receivedForAgentIds.push(target.agentId);
     },
   };
 }
@@ -95,7 +93,7 @@ function recording(): Recorded {
     grading: 0,
     finished: [],
     received: 0,
-    replayedPlatformAgentIds: [],
+    receivedForAgentIds: [],
   };
 }
 
@@ -271,9 +269,9 @@ describe("the shared Retell production writer", () => {
     expect(recorded.grading).toBe(recorded.appended);
     expect(recorded.finished).toEqual([stale.traceId]);
     expect(recorded.received).toBe(1);
-    expect(recorded.replayedPlatformAgentIds).toEqual([
-      stale.platformAgentId,
-    ]);
+    // The agent that pulled it, read back out of the claim's own payload —
+    // not whichever agent is switched on for this platform agent id now.
+    expect(recorded.receivedForAgentIds).toEqual([TARGET.agentId]);
   });
 
   it("replays a transcript-free stale claim without offering it for grading", async () => {

--- a/packages/db/src/access/index.ts
+++ b/packages/db/src/access/index.ts
@@ -360,7 +360,6 @@ export {
   readAgentPullState,
   recordMonitoringFailure,
   recordPulledCallReceived,
-  recordPulledCallReceivedForPlatformAgent,
   releaseMonitoringLease,
   releaseMonitoringFailureReplay,
   renewMonitoringLease,

--- a/packages/db/src/access/production-monitoring.ts
+++ b/packages/db/src/access/production-monitoring.ts
@@ -306,6 +306,7 @@ export async function listMonitoringFailures(
   auth: AuthContext,
   agentId: string,
 ): Promise<readonly MonitoringFailureSummary[]> {
+  authorize(auth, "read", here(auth));
   const rows = await db()
     .select({
       id: monitoringFailure.id,
@@ -839,7 +840,19 @@ export async function failMonitoringPull(
   });
 }
 
-/** Release a lease after a call-only failure without moving its fixed scan. */
+/**
+ * Release a lease after a call-only failure without moving its fixed scan.
+ *
+ * **The retry clock does not climb here.** `consecutive_failures` means "the
+ * provider refused this agent", and it does two jobs on that meaning: it is the
+ * exponent of the backoff ladder, and it is half the gate that refuses an
+ * explicit replay (the other half being a clock still in the future). What
+ * reaches this function is neither refusal nor rate limit — a broken page
+ * contract, an unreadable call id, an internal fault — so counting it would
+ * spend a customer's Retry on a provider that never said no, and a repeating
+ * breach would hold that gate shut for ever, because only a finished scan
+ * clears the streak. The plain retry the caller passes is the whole answer.
+ */
 export async function releaseMonitoringLease(
   auth: AuthContext,
   target: Pick<MonitoringPullTarget, "agentId" | "leaseOwner" | "apiKey">,
@@ -874,7 +887,6 @@ export async function releaseMonitoringLease(
               nextPollAt: input.retryAt,
               leaseOwner: null,
               leaseExpiresAt: null,
-              consecutiveFailures: sql`${monitoringState.consecutiveFailures} + 1`,
               updatedAt: now,
             }
           : {
@@ -911,10 +923,21 @@ export async function recordPulledCallReceived(
     );
 }
 
-/** Keep the notebook truthful when a stale claim finishes after a restart. */
+/**
+ * Keep the notebook truthful when a stale claim finishes after a restart.
+ *
+ * The claim carries no agent id — it deliberately references nothing, which is
+ * what makes it survive a redesign — so the agent has to be found again from
+ * the platform identity the call was pulled under. That identity is only
+ * unique among agents *pulling* on *that platform*: a switched-off twin keeps
+ * its notebook (and may name the same platform agent, which the partial unique
+ * index allows), and a LiveKit agent may hold the same id string by accident.
+ * Neither pulled this call, so neither is stamped.
+ */
 export async function recordPulledCallReceivedForPlatformAgent(
   auth: AuthContext,
   input: {
+    readonly agentPlatform: AgentPlatform;
     readonly platformAgentId: string;
     readonly receivedAt?: Date | undefined;
   },
@@ -926,7 +949,9 @@ export async function recordPulledCallReceivedForPlatformAgent(
     .where(
       and(
         within(auth, agent, eq(agent.projectId, projectOf(auth))),
+        eq(agent.agentPlatform, input.agentPlatform),
         eq(agent.platformAgentId, input.platformAgentId),
+        eq(agent.pullProductionCalls, true),
       ),
     );
   if (pulled.length === 0) return;
@@ -1090,15 +1115,13 @@ export type MonitoringFailureReplayClaim =
   | {
       readonly kind: "busy";
       /**
-       * `backing_off` is the agent's own retry clock, and it is deliberately
-       * mute about what the provider said. The account-wide health state that
-       * used to name the cause is gone (ADR-0015), so all the server truthfully
-       * knows here is *this agent is waiting until `retryAt`*.
+       * Exactly the two reasons this function can give. `backing_off` is the
+       * agent's own retry clock, and it is deliberately mute about what the
+       * provider said: the account-wide health state that used to name the
+       * cause is gone (ADR-0015), so all the server truthfully knows here is
+       * *this agent is waiting until `retryAt`*.
        */
-      readonly reason:
-        | MonitoringFailureKind
-        | "replay_in_progress"
-        | "backing_off";
+      readonly reason: "replay_in_progress" | "backing_off";
       readonly retryAt: Date;
     }
   | { readonly kind: "not_found" };

--- a/packages/db/src/access/production-monitoring.ts
+++ b/packages/db/src/access/production-monitoring.ts
@@ -923,52 +923,6 @@ export async function recordPulledCallReceived(
     );
 }
 
-/**
- * Keep the notebook truthful when a stale claim finishes after a restart.
- *
- * The claim carries no agent id — it deliberately references nothing, which is
- * what makes it survive a redesign — so the agent has to be found again from
- * the platform identity the call was pulled under. That identity is only
- * unique among agents *pulling* on *that platform*: a switched-off twin keeps
- * its notebook (and may name the same platform agent, which the partial unique
- * index allows), and a LiveKit agent may hold the same id string by accident.
- * Neither pulled this call, so neither is stamped.
- */
-export async function recordPulledCallReceivedForPlatformAgent(
-  auth: AuthContext,
-  input: {
-    readonly agentPlatform: AgentPlatform;
-    readonly platformAgentId: string;
-    readonly receivedAt?: Date | undefined;
-  },
-): Promise<void> {
-  const receivedAt = input.receivedAt ?? new Date();
-  const pulled = await db()
-    .select({ id: agent.id })
-    .from(agent)
-    .where(
-      and(
-        within(auth, agent, eq(agent.projectId, projectOf(auth))),
-        eq(agent.agentPlatform, input.agentPlatform),
-        eq(agent.platformAgentId, input.platformAgentId),
-        eq(agent.pullProductionCalls, true),
-      ),
-    );
-  if (pulled.length === 0) return;
-  await db()
-    .update(monitoringState)
-    .set({ lastReceivedAt: receivedAt, updatedAt: receivedAt })
-    .where(
-      and(
-        withinMonitoringProject(auth, monitoringState),
-        inArray(
-          monitoringState.agentId,
-          pulled.map((row) => row.id),
-        ),
-      ),
-    );
-}
-
 /** A summary is already owned by a completed claim or a durable failure. */
 export async function productionCallIsAccountedFor(
   auth: AuthContext,

--- a/packages/db/src/schema/production.ts
+++ b/packages/db/src/schema/production.ts
@@ -178,7 +178,13 @@ export const productionTraceClaim = pgTable(
     platformAgentId: text("platform_agent_id").notNull(),
     platformAgentName: text("platform_agent_name"),
     platformAgentVersion: text("platform_agent_version"),
-    /** Safe Retell document with bearer-like fields removed. */
+    /**
+     * The pulling agent's id beside the safe Retell document, with
+     * bearer-like fields removed. The id is in here rather than in a
+     * column of its own because this table references nothing — which is
+     * what makes it survive a redesign — and crash recovery still has to
+     * stamp the notebook of the agent that actually pulled the call.
+     */
     payload: text("payload").notNull(),
     endedAt: moment("ended_at").notNull(),
     degraded: boolean("degraded").notNull().default(false),

--- a/packages/db/test/data-access-surface.test.ts
+++ b/packages/db/test/data-access-surface.test.ts
@@ -263,7 +263,6 @@ const CONTEXT_REQUIRING = [
   "readVerdicts",
   "recordPulledCallReceived",
   "recordMonitoringFailure",
-  "recordPulledCallReceivedForPlatformAgent",
   "recordDeviceAuthorization",
   "recordGradingHeartbeat",
   "recordProductionTraces",


### PR DESCRIPTION
## What this is

The poller half of ticket 02 (agent-owned-monitoring, ADR-0015), stacked on #183. The Retell poller re-pointed at agents: it claims due rows from `monitoring_state` joined to the agent's own sealed `monitoring_api_key`, and keeps every proven mechanic — 30-second cadence with stable per-agent spread, fixed windows, oldest-first per-item checkpointing, page draining, the five-minute regular overlap, the daily 30-day re-walk that yields to regular work, one DB lease per agent, bounded pages and time per turn, claim → append → mark written through `production_trace_claim`, poison calls into `monitoring_failure` with bounded retries, cursor moving past, explicit replay.

Backoff is per agent: a failing key pushes `next_poll_at` out on a capped exponential ladder keyed on `consecutive_failures`; success resets it; there is no account-wide gate and no health state.

## Decisions worth reading

- **The permanent park is gone.** The old poller set `next_poll_at` to the year 9999 on a refused key — `blocked_until` by another name, which ADR-0015 drops with the health machine. A refusal now rides the same ladder with a **one-hour ceiling** (transient failures keep five minutes); the ticket's "recovers on the next success" needs a retry to exist at all. Re-arming the switch still wakes the agent at once.
- A provider-supplied `Retry-After` is held to the same one-hour ceiling, so an absurd header can neither park an agent for years nor close the replay gate for that span.
- `consecutive_failures` means exactly "the provider refused this agent": lease releases on contract or internal failures no longer climb it, so an explicit replay is never refused for a 30-second cadence wait — the gate's own invariant.
- Health vocabulary retired from events and logs (`egma.monitoring.pull.call.failed` / `failures.cleared`, `error_kind`).
- `recordPulledCallReceivedForPlatformAgent` filters on platform and the switch, so Retell traffic stamps only the notebook that pulled the call — never a switched-off twin or a LiveKit agent sharing the id string.

## Proof, against real stores

New `apps/api/test/retell-production-pull.test.ts` (15 cases, real Postgres, real access layer, real adapter over a fake fetch; ClickHouse only in the one trace-read case):
- two API replicas never poll one agent at the same time (`for update … skip locked` under three concurrent claimants)
- a killed turn resumes from the cursor it reached — the ledger holds exactly `call_1, call_2, call_3`, no gaps, no duplicates
- five agents on one dead key back off separately with distinct clocks, request count frozen while waiting, one fixed key resets alone
- a poison call is recorded after bounded retries, the cursor moves past it, an explicit replay imports it once the provider answers, and is refused only while that agent is backing off
- first switch-on walks the thirty days behind it; the five-minute boundary re-offer costs no provider request and writes no second ledger row; the daily re-walk waits while regular work runs
- a pulled call is readable through the trace reads (real writer, real ClickHouse, `listTraces` + `readTrace`)

Scoped lanes: 95 tests across 7 files green; `pnpm build` and `tsc -p tsconfig.tests.json` clean. Independent review: LAND, no blockers; its should-fixes are all in the last five commits.

## Merge note

Narrowing the busy-reason union made three branches in `apps/api/src/routes/monitoring.ts` provably dead; this branch deletes exactly those 20 lines. The surface half of ticket 02 rewrites that file; its version wins at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789978659&installation_model_id=431960&pr_number=184&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F184&signature=371495fd8eeee2f67e97ce3b46fc345c05ab6dde7aab1c665329b738397675fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rebuilds Retell production polling around per-agent monitoring state and updates claim recovery so receipt timestamps remain attached to the agent that originally pulled each call.

- Claims due agents under independent leases and maintains per-agent cursors, retry clocks, reconciliation windows, and failure records.
- Adds bounded provider backoff and explicit replay behavior without the retired account-wide health state.
- Persists the pulling agent ID in each production trace claim so stale recovery can update the correct notebook after an agent is replaced.
- Adds real-store coverage for lease contention, cursor recovery, backoff, poison-call replay, reconciliation, and stale-claim attribution.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported stale-claim attribution failure is fixed: new claims retain the pulling agent’s exact ID, and recovery stamps that agent rather than resolving whichever replacement currently owns the same provider identity; no blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/retell-production-ingestion.ts | Reworks polling and replay around per-agent leases, bounded retry clocks, fixed scan windows, and provider-failure classification. |
| apps/api/src/retell/write.ts | Embeds the pulling agent ID in new claim payloads and uses it during stale replay to preserve exact receipt attribution. |
| packages/db/src/access/production-monitoring.ts | Updates per-agent monitoring persistence, replay gating, lease release behavior, authorization, and exact-agent receipt stamping. |
| packages/db/src/schema/production.ts | Documents the backward-compatible claim payload envelope without changing the production claim table shape. |
| apps/api/test/retell-production-pull.test.ts | Adds real-store integration coverage for polling concurrency, recovery, backoff, reconciliation, replay, and stale-claim attribution. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Due[Due monitoring_state row] --> Claim[Claim per-agent lease]
  Claim --> List[List fixed Retell window]
  List --> Hydrate[Hydrate calls oldest-first]
  Hydrate --> TraceClaim[Claim production trace with agentId and safe call]
  TraceClaim --> Append[Append normalized spans]
  Append --> Stamp[Stamp pulling agent notebook]
  Stamp --> Finish[Mark trace claim written]
  Finish --> Cursor[Checkpoint cursor and release lease]
  Append -. crash .-> Sweep[Stale-claim sweep]
  Sweep --> Replay[Replay embedded safe call]
  Replay --> Stamp
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/int..."](https://github.com/egma-ai/egma/commit/38f0d5eadc6e0308e9d2b5025db575ffab38a0cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55824287)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Egma API platform](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/api-platform.md)
- Knowledge Base — [Retell integration boundary](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/retell-integration.md)
- Knowledge Base — [Egma database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/db-persistence.md)
</details>


<!-- /greptile_comment -->