### PR TITLE
perf(retell): read a page's outstanding calls together

### DIFF
--- a/apps/api/src/retell-production-ingestion.ts
+++ b/apps/api/src/retell-production-ingestion.ts
@@ -1101,7 +1101,7 @@ async function runTarget(
     };
 
   /** Answer one call's outcome where it ends the turn rather than the call. */
-  const stoppedBy = async (
+  const turnEndedBy = async (
     outcome: CallOutcome,
   ): Promise<RetellProductionIngestionResult | undefined> => {
     if (outcome.kind === "lease_lost") {
@@ -1136,6 +1136,15 @@ async function runTarget(
       leaseFinished = true;
       return completed("ingestion_unavailable");
     }
+    return undefined;
+  };
+
+  /** One call's whole answer: what ends the turn, and what only counts. */
+  const stoppedBy = async (
+    outcome: CallOutcome,
+  ): Promise<RetellProductionIngestionResult | undefined> => {
+    const stopped = await turnEndedBy(outcome);
+    if (stopped !== undefined) return stopped;
     if (outcome.kind === "dropped") counts.dropped += 1;
     if (outcome.kind === "scheduled") counts.settled += 1;
     return undefined;
@@ -1352,9 +1361,19 @@ async function runTarget(
           counts,
           turnBoundReached,
         );
+        // Page-mates finish together, so their retry rows and terminal drops
+        // are durable whatever answer stands beside them in listed order. The
+        // turn's own record must carry what the store already holds, which is
+        // why every answer is counted before any answer is allowed to end the
+        // turn.
+        for (const hydration of hydrations) {
+          if (hydration.status !== "fulfilled") continue;
+          if (hydration.value.kind === "dropped") counts.dropped += 1;
+          if (hydration.value.kind === "scheduled") counts.settled += 1;
+        }
         for (const hydration of hydrations) {
           if (hydration.status === "rejected") throw hydration.reason;
-          const stopped = await stoppedBy(hydration.value);
+          const stopped = await turnEndedBy(hydration.value);
           if (stopped !== undefined) return stopped;
         }
         // The turn ran out of time inside this page, so what follows must not

--- a/apps/api/src/retell-production-ingestion.ts
+++ b/apps/api/src/retell-production-ingestion.ts
@@ -64,7 +64,8 @@ import {
  *    trace store already holds, and which of them egma is already retrying or
  *    has recently dropped. Two statements for a hundred calls, never two per
  *    call.
- * 5. **Fetch and accept the remainder**, one hydration attempt each.
+ * 5. **Fetch and accept the remainder together**, one hydration attempt each
+ *    and at most `RETELL_HYDRATION_CONCURRENCY` of them open at once.
  * 6. **Advance only when every listed identity has an answer** — committed,
  *    durable in the object store, scheduled for a retry, or terminally dropped.
  *
@@ -124,6 +125,21 @@ const CALL_START_MARGIN_MILLISECONDS = 6 * 60 * 60 * 1_000;
 
 /** How many due retries one turn takes on, so a backlog cannot own the lease. */
 const RETRIES_PER_TURN = 25;
+
+/**
+ * How many of one page's calls egma hydrates at the same time.
+ *
+ * The ceiling is protective, not a throughput dial. A burst wide enough to make
+ * Retell refuse costs egma either way. A refusal that reads as this call's own
+ * spends one attempt of that call's bounded hydration budget — one initial
+ * attempt and at most three automatic retries — and a budget spent on refusals
+ * egma provoked ends where any exhausted budget ends: a terminal drop, and a
+ * conversation egma never imports. A refusal that reads as the account's pauses
+ * the whole selected agent until the provider says it may read again. Sixteen
+ * is narrow enough that a page cannot become that burst, and wide enough that a
+ * full page is a few waves rather than one sequential read per conversation.
+ */
+export const RETELL_HYDRATION_CONCURRENCY = 16;
 
 /**
  * How long an accepted-but-not-yet-visible identity is remembered.
@@ -898,6 +914,108 @@ async function handleCall(
   return { kind: "accepted" };
 }
 
+/** One listed call this page has not accounted for yet. */
+type OutstandingCall = {
+  readonly providerCallId: string;
+  readonly listedCall: RetellCall;
+  /** Whether this call already has a transient row. */
+  readonly held: boolean;
+};
+
+/** Whether one call's answer ends the turn rather than that call. */
+function endsTurn(outcome: CallOutcome): boolean {
+  return (
+    outcome.kind === "lease_lost" ||
+    outcome.kind === "provider_failure" ||
+    outcome.kind === "ingestion_unavailable"
+  );
+}
+
+/**
+ * Hydrate and accept a page's outstanding calls together, answering in listed
+ * order.
+ *
+ * At most `RETELL_HYDRATION_CONCURRENCY` hydrations are open at once, and each
+ * call keeps everything one at a time gave it: its own lease check, its own
+ * single attempt, and an answer that belongs to it alone — one call's failed
+ * hydration writes that call's retry row and leaves its page-mates to finish.
+ * Acceptances are deliberately not serialized: the door they go through already
+ * takes many senders at once, and acceptances that overlap share segment seals,
+ * which makes them fewer and fuller objects rather than a contended queue.
+ *
+ * The answer is shorter than `outstanding` where the turn bound stopped it
+ * short, and every call it did reach has finished before it answers: a turn
+ * about to yield its lease must have nothing of its own still writing.
+ */
+async function hydrateOutstanding(
+  target: RetellMonitoringTarget,
+  outstanding: readonly OutstandingCall[],
+  options: TurnOptions,
+  counts: TurnCounts,
+  boundReached: () => boolean,
+): Promise<readonly PromiseSettledResult<CallOutcome>[]> {
+  const settled: PromiseSettledResult<CallOutcome>[] = [];
+  let taken = 0;
+  // An answer that ends the turn — a lost lease, a failing setup, an object
+  // store that cannot take the evidence — stops this page being read further.
+  // What is already open finishes; nothing new is opened.
+  let stopping = false;
+
+  const hydrateOne = async (owed: OutstandingCall): Promise<CallOutcome> => {
+    const renewed = await options.store.renewRetellMonitoringLease(
+      target.auth,
+      target,
+      { now: options.clock() },
+    );
+    if (!renewed) return { kind: "lease_lost" };
+    return handleCall(
+      target,
+      owed.providerCallId,
+      () =>
+        withDeadline(
+          options.reach,
+          options.requestTimeoutMilliseconds,
+          (reach) =>
+            options.provider.hydrateRetellCall(
+              target.apiKey,
+              owed.listedCall,
+              reach,
+            ),
+        ),
+      options,
+      counts,
+      owed.held,
+    );
+  };
+
+  /** Take the next outstanding call, until there are none or the turn stops. */
+  const takeCalls = async (): Promise<void> => {
+    while (!stopping && !boundReached()) {
+      const index = taken;
+      if (index >= outstanding.length) return;
+      const owed = outstanding[index];
+      if (owed === undefined) return;
+      taken = index + 1;
+      try {
+        const outcome = await hydrateOne(owed);
+        settled[index] = { status: "fulfilled", value: outcome };
+        if (endsTurn(outcome)) stopping = true;
+      } catch (reason) {
+        settled[index] = { status: "rejected", reason };
+        stopping = true;
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(RETELL_HYDRATION_CONCURRENCY, outstanding.length) },
+      () => takeCalls(),
+    ),
+  );
+  return settled.slice(0, taken);
+}
+
 async function releaseAfterInternalFailure(
   store: RetellProductionIngestionStore,
   target: RetellMonitoringTarget,
@@ -1173,8 +1291,13 @@ async function runTarget(
           },
         );
 
+        // What this page still owes, decided in listed order before any of it
+        // is fetched. Nothing here reaches the provider or the store, so the
+        // two batched answers above settle every identity that is already
+        // accounted for and what is left is the page's outstanding work.
+        const outstanding: OutstandingCall[] = [];
+        const owing = new Set<string>();
         for (const [index, listedCall] of listed.calls.entries()) {
-          if (turnBoundReached()) return yieldBoundedTurn();
           const providerCallId = identities[index] ?? "";
           const traceId = traceIdFor(projectId, providerCallId);
           // Committed in the store, or accepted by this poller and not yet
@@ -1206,37 +1329,37 @@ async function runTarget(
             continue;
           }
 
-          const renewable = await options.store.renewRetellMonitoringLease(
-            target.auth,
-            target,
-            { now: options.clock() },
-          );
-          if (!renewable) {
-            leaseFinished = true;
-            return completed("lease_lost");
+          // One identity is read once a turn however often the page lists it.
+          // A second reading of one conversation under one immutable identity
+          // is the defect the memory above exists to keep out, and a page that
+          // repeats a row must not be the way it gets in.
+          if (owing.has(providerCallId)) {
+            counts.settled += 1;
+            continue;
           }
-          const stopped = await stoppedBy(
-            await handleCall(
-              target,
-              providerCallId,
-              () =>
-                withDeadline(
-                  options.reach,
-                  options.requestTimeoutMilliseconds,
-                  (reach) =>
-                    options.provider.hydrateRetellCall(
-                      target.apiKey,
-                      listedCall,
-                      reach,
-                    ),
-                ),
-              options,
-              counts,
-              held !== undefined,
-            ),
-          );
+          owing.add(providerCallId);
+          outstanding.push({
+            providerCallId,
+            listedCall,
+            held: held !== undefined,
+          });
+        }
+
+        const hydrations = await hydrateOutstanding(
+          target,
+          outstanding,
+          options,
+          counts,
+          turnBoundReached,
+        );
+        for (const hydration of hydrations) {
+          if (hydration.status === "rejected") throw hydration.reason;
+          const stopped = await stoppedBy(hydration.value);
           if (stopped !== undefined) return stopped;
         }
+        // The turn ran out of time inside this page, so what follows must not
+        // advance past the calls it never reached.
+        if (hydrations.length < outstanding.length) return yieldBoundedTurn();
       }
 
       if (!listed.hasMore) {

--- a/apps/api/test/retell-production-ingestion.test.ts
+++ b/apps/api/test/retell-production-ingestion.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { IngestionUnavailableError } from "../src/ingestion/accept.ts";
 import {
   acceptedIdentities,
+  RETELL_HYDRATION_CONCURRENCY,
   runRetellProductionIngestion,
   startRetellProductionIngestion,
   type RetellCommittedLookup,
@@ -266,6 +267,65 @@ function provider(
       return { kind: "call", call: hydrated(callId) };
     },
     ...changes,
+  };
+}
+
+/** One page of listed summaries, wide enough to say something about a wave. */
+function page(size: number, prefix: string): RetellCall[] {
+  return Array.from({ length: size }, (_unused, index) =>
+    summary(`${prefix}_${index}`),
+  );
+}
+
+/**
+ * Hydrations a test can hold open, so overlap is observed and never timed.
+ *
+ * Each call reports itself open and waits; the one that brings the count to
+ * `together` releases them all. A page read one call at a time never brings the
+ * count that high, so the escape timer is there to make that a plain assertion
+ * failure rather than a hung test.
+ */
+function heldHydrations(together: number) {
+  const started: string[] = [];
+  const finished: string[] = [];
+  let open = 0;
+  let mostOpen = 0;
+  let waves = 0;
+  let openWhenFirstFinished = 0;
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    started,
+    finished,
+    /** The most hydrations open at one instant. */
+    get mostOpen(): number {
+      return mostOpen;
+    },
+    /** How many times the count rose from none open: one per wave. */
+    get waves(): number {
+      return waves;
+    },
+    /** How many were still open when the first of them finished. */
+    get openWhenFirstFinished(): number {
+      return openWhenFirstFinished;
+    },
+    async hold(callId: string): Promise<void> {
+      if (open === 0) waves += 1;
+      open += 1;
+      started.push(callId);
+      mostOpen = Math.max(mostOpen, open);
+      if (open >= together) release();
+      await Promise.race([
+        released,
+        new Promise<void>((resolve) => setTimeout(resolve, 50)),
+      ]);
+      if (finished.length === 0) openWhenFirstFinished = open;
+      open -= 1;
+      finished.push(callId);
+    },
   };
 }
 
@@ -1126,11 +1186,11 @@ describe("Retell production ingestion", () => {
     expect(JSON.stringify(events)).not.toContain("different-private-agent-id");
   });
 
-  it("yields inside a large page without checkpointing past unprocessed calls", async () => {
+  it("reads a page's outstanding calls together rather than one at a time", async () => {
     const recorded = record();
-    const hydratedIds: string[] = [];
-    let advanced = 0;
-    const clock = () => new Date(BASE.getTime() + advanced);
+    const listed = page(8, "call_together");
+    const held = heldHydrations(listed.length);
+    const taken = acceptance();
     const { log } = logger();
 
     const result = await runRetellProductionIngestion({
@@ -1140,14 +1200,155 @@ describe("Retell production ingestion", () => {
         async listTerminalCalls() {
           return {
             kind: "calls",
-            calls: [summary("call_first"), summary("call_second")],
+            calls: listed,
+            hasMore: false,
+            paginationKey: null,
+          };
+        },
+        async hydrateRetellCall(_key, one) {
+          const callId = String(one["call_id"]);
+          await held.hold(callId);
+          return { kind: "call", call: hydrated(callId) };
+        },
+      }),
+      lookup: lookup({ windows: [], asked: [] }),
+      acceptance: taken.acceptance,
+      clock: () => BASE,
+    });
+
+    // Every call in the page was open at the same instant, and not one of them
+    // had finished by the time the last one started: one wave, not eight.
+    expect(held.started).toHaveLength(listed.length);
+    expect(held.mostOpen).toBe(listed.length);
+    expect(held.openWhenFirstFinished).toBe(listed.length);
+    expect(held.waves).toBe(1);
+    expect(result).toMatchObject({
+      accepted: listed.length,
+      settled: 0,
+      pages: 1,
+    });
+    expect(taken.recorded.traceIds).toHaveLength(listed.length);
+    expect(recorded.finishes).toHaveLength(1);
+  });
+
+  it("never opens more of a page at once than the hydration ceiling", async () => {
+    const recorded = record();
+    const listed = page(RETELL_HYDRATION_CONCURRENCY + 4, "call_wide");
+    const held = heldHydrations(RETELL_HYDRATION_CONCURRENCY);
+    const taken = acceptance();
+    const { log } = logger();
+
+    const result = await runRetellProductionIngestion({
+      log,
+      store: store(recorded),
+      provider: provider({
+        async listTerminalCalls() {
+          return {
+            kind: "calls",
+            calls: listed,
+            hasMore: false,
+            paginationKey: null,
+          };
+        },
+        async hydrateRetellCall(_key, one) {
+          const callId = String(one["call_id"]);
+          await held.hold(callId);
+          return { kind: "call", call: hydrated(callId) };
+        },
+      }),
+      lookup: lookup({ windows: [], asked: [] }),
+      acceptance: taken.acceptance,
+      clock: () => BASE,
+    });
+
+    // A page wider than the ceiling is still read in full, and the burst egma
+    // offers the provider never grows past the ceiling.
+    expect(held.mostOpen).toBe(RETELL_HYDRATION_CONCURRENCY);
+    expect(held.started).toHaveLength(listed.length);
+    expect(result).toMatchObject({ accepted: listed.length, settled: 0 });
+    expect(recorded.finishes).toHaveLength(1);
+  });
+
+  it("keeps one call's failed hydration off the page-mates open beside it", async () => {
+    const recorded = record();
+    const listed = [
+      summary("call_beside_one"),
+      summary("call_broken"),
+      summary("call_beside_two"),
+      summary("call_beside_three"),
+    ];
+    const held = heldHydrations(listed.length);
+    const taken = acceptance();
+    const { log } = logger();
+
+    const result = await runRetellProductionIngestion({
+      log,
+      store: store(recorded),
+      provider: provider({
+        async listTerminalCalls() {
+          return {
+            kind: "calls",
+            calls: listed,
+            hasMore: false,
+            paginationKey: null,
+          };
+        },
+        async hydrateRetellCall(_key, one) {
+          const callId = String(one["call_id"]);
+          await held.hold(callId);
+          return callId === "call_broken"
+            ? { kind: "not-found" }
+            : { kind: "call", call: hydrated(callId) };
+        },
+      }),
+      lookup: lookup({ windows: [], asked: [] }),
+      acceptance: taken.acceptance,
+      clock: () => BASE,
+    });
+
+    // All four were open together. The one that failed spent one attempt of its
+    // own budget and took a retry row; the other three landed.
+    expect(held.mostOpen).toBe(listed.length);
+    expect(result).toMatchObject({ accepted: 3, settled: 1, dropped: 0 });
+    expect(taken.recorded.traceIds).toEqual(
+      ["call_beside_one", "call_beside_two", "call_beside_three"].map((id) =>
+        traceIdFor(AUTH.projectId, id),
+      ),
+    );
+    expect(recorded.rows.get("call_broken")).toMatchObject({
+      attempts: 1,
+      errorKind: "provider_call_not_found",
+    });
+    expect(recorded.rows.get("call_broken")?.nextAttemptAt).not.toBeNull();
+    // Every listed identity has an answer, so the page advanced.
+    expect(recorded.finishes).toHaveLength(1);
+  });
+
+  it("yields inside a large page without checkpointing past unprocessed calls", async () => {
+    const recorded = record();
+    const hydratedIds: string[] = [];
+    let advanced = 0;
+    const clock = () => new Date(BASE.getTime() + advanced);
+    const { log } = logger();
+    // One call more than a single wave can hold, so the wall-time bound falls
+    // between the waves and leaves the page part-read.
+    const listed = page(RETELL_HYDRATION_CONCURRENCY + 1, "call_late");
+
+    const result = await runRetellProductionIngestion({
+      log,
+      store: store(recorded),
+      provider: provider({
+        async listTerminalCalls() {
+          return {
+            kind: "calls",
+            calls: listed,
             hasMore: true,
             paginationKey: "page-after-large-page",
           };
         },
-        async hydrateRetellCall(_key, listed) {
-          hydratedIds.push(String(listed["call_id"]));
-          return { kind: "call", call: hydrated(String(listed["call_id"])) };
+        async hydrateRetellCall(_key, one) {
+          hydratedIds.push(String(one["call_id"]));
+          return { kind: "call", call: hydrated(String(one["call_id"])) };
         },
       }),
       lookup: lookup({ windows: [], asked: [] }),
@@ -1161,7 +1362,10 @@ describe("Retell production ingestion", () => {
       maxTurnMilliseconds: 50,
     });
 
-    expect(hydratedIds).toEqual(["call_first"]);
+    expect(hydratedIds).toHaveLength(RETELL_HYDRATION_CONCURRENCY);
+    expect(hydratedIds).not.toContain(
+      `call_late_${RETELL_HYDRATION_CONCURRENCY}`,
+    );
     expect(recorded.checkpoints).toEqual([]);
     expect(recorded.yields).toHaveLength(1);
     expect(result.stoppedBecause).toBe("bounded_turn");

--- a/apps/api/test/retell-production-ingestion.test.ts
+++ b/apps/api/test/retell-production-ingestion.test.ts
@@ -1324,6 +1324,75 @@ describe("Retell production ingestion", () => {
     expect(recorded.finishes).toHaveLength(1);
   });
 
+  it("counts a page-mate's durable answer when another answer ends the turn", async () => {
+    const recorded = record();
+    // Listed first, so the settle order meets the turn-ending answer before
+    // the page-mate whose retry row is already in the store.
+    const listed = [
+      summary("call_pauses_agent"),
+      summary("call_beside_durable"),
+    ];
+    const held = heldHydrations(listed.length);
+    const taken = acceptance();
+    const { log } = logger();
+    const observed = metricRecorder();
+
+    const result = await runRetellProductionIngestion({
+      log,
+      metrics: observed.metrics,
+      store: store(recorded),
+      provider: provider({
+        async listTerminalCalls() {
+          return {
+            kind: "calls",
+            calls: listed,
+            hasMore: false,
+            paginationKey: null,
+          };
+        },
+        async hydrateRetellCall(_key, one) {
+          const callId = String(one["call_id"]);
+          await held.hold(callId);
+          return callId === "call_pauses_agent"
+            ? {
+                kind: "refused",
+                reason: "rate-limited",
+                status: 429,
+                retryAfterMilliseconds: 12_000,
+              }
+            : { kind: "not-found" };
+        },
+      }),
+      lookup: lookup({ windows: [], asked: [] }),
+      acceptance: taken.acceptance,
+      clock: () => BASE,
+    });
+
+    // Both were open together: the rate limit pauses the whole selected
+    // agent, and the page-mate's retry row was durable before the pause was
+    // acted on — so the turn's answer and its recorded metrics both carry the
+    // row the store holds.
+    expect(held.mostOpen).toBe(listed.length);
+    expect(recorded.rows.get("call_beside_durable")).toMatchObject({
+      attempts: 1,
+      errorKind: "provider_call_not_found",
+    });
+    expect(recorded.failures).toEqual([
+      { kind: "rate_limited", retryAt: new Date(BASE.getTime() + 12_000) },
+    ]);
+    expect(result).toMatchObject({
+      accepted: 0,
+      settled: 1,
+      dropped: 0,
+      stoppedBecause: "provider_failure",
+    });
+    expect(observed.recorded).toMatchObject({
+      turns: [
+        { outcome: "provider_failure", accepted: 0, settled: 1, dropped: 0 },
+      ],
+    });
+  });
+
   it("yields inside a large page without checkpointing past unprocessed calls", async () => {
     const recorded = record();
     const hydratedIds: string[] = [];

--- a/packages/db/src/access/production-monitoring.ts
+++ b/packages/db/src/access/production-monitoring.ts
@@ -1528,6 +1528,22 @@ export async function deleteRetellCallRetry(
 ): Promise<void> {
   const now = input.now ?? new Date();
   await db().transaction(async (tx) => {
+    // The agent row first, in the same order every writer of its state takes
+    // it. Two calls made durable at the same moment must not each see the
+    // other's row still standing and both leave the restore to the other;
+    // serialized here, whichever in-flight check runs last sees every
+    // sibling's committed delete, so an agent owing nothing cannot stay
+    // degraded.
+    await tx
+      .select({ id: retellMonitoredAgent.id })
+      .from(retellMonitoredAgent)
+      .where(
+        and(
+          withinMonitoringProject(auth, retellMonitoredAgent),
+          eq(retellMonitoredAgent.id, target.monitoredAgentId),
+        ),
+      )
+      .for("update");
     const deleted = await tx
       .delete(retellCallRetry)
       .where(

--- a/packages/db/test/production-monitoring.test.ts
+++ b/packages/db/test/production-monitoring.test.ts
@@ -983,6 +983,73 @@ describe("the bounded Retell call budget", () => {
     expect(await state()).toBe("active");
   });
 
+  it("restores a selected agent when two calls are made durable at the same moment", async () => {
+    const imported = await configured();
+    const state = async (): Promise<string | undefined> => {
+      const rows = await database.sql<{ state: string }>(
+        "select state from retell_monitored_agent",
+      );
+      return rows.rows[0]?.state;
+    };
+    await finishRetellMonitoringScan(imported.auth, imported, {
+      now: SETUP_TIME,
+    });
+    const target = await leased(new Date(SETUP_TIME.getTime() + 60_000));
+    for (const providerCallId of ["call_racing_a", "call_racing_b"]) {
+      await recordRetellCallAttempt(target.auth, target, {
+        providerCallId,
+        errorKind: "provider_call_refused",
+        retryBackoffMilliseconds: BACKOFF,
+        now: SETUP_TIME,
+      });
+    }
+    expect(await state()).toBe("degraded");
+
+    // A sibling deleter held open mid-transaction: it has taken the agent
+    // row, removed its own call, seen the other still in flight and left the
+    // restore to it — the moment two concurrent durable calls share. The
+    // delete under test must wait for this transaction rather than read past
+    // it, or both sides leave the restore to the other and the agent stays
+    // degraded owing nothing.
+    const sibling = await openSingleConnection(database.url);
+    try {
+      await sibling.sql("begin");
+      await sibling.sql(
+        "select id from retell_monitored_agent where id = $1 for update",
+        [target.monitoredAgentId],
+      );
+      await sibling.sql(
+        "delete from retell_call_retry where provider_call_id = $1",
+        ["call_racing_b"],
+      );
+      const inFlight = await sibling.sql(
+        "select id from retell_call_retry where next_attempt_at is not null",
+      );
+      expect(inFlight.rows).toHaveLength(1);
+
+      const deleting = deleteRetellCallRetry(target.auth, target, {
+        providerCallId: "call_racing_a",
+        now: SETUP_TIME,
+      });
+      // Long enough that a delete reading past the sibling would have
+      // finished inside the window; with the wait in place the length does
+      // not matter.
+      await new Promise<void>((wake) => {
+        setTimeout(wake, 100);
+      });
+      await sibling.sql("commit");
+      await deleting;
+    } finally {
+      await sibling.close();
+    }
+
+    const remaining = await database.sql<{ count: string }>(
+      "select count(*)::text as count from retell_call_retry",
+    );
+    expect(remaining.rows[0]?.count).toBe("0");
+    expect(await state()).toBe("active");
+  });
+
   it("clears the one budget two selected agents share for a call they both meet", async () => {
     // Two selected agents in one project, so a provider call that turns out to
     // belong to one of them is a `platform_agent_mismatch` the other can also


### PR DESCRIPTION
## What this changes

Importing or polling a Retell agent reads calls in two steps: one listing request returns a page of call summaries, then each call the platform does not yet hold is fetched in full and accepted. Until now the second step ran one call at a time, so a page of ~30 calls spent ~20 s almost entirely waiting on sequential round-trips (~730 ms each, measured against the live provider).

A poll turn now processes a page in two passes:

1. **Settle first, with no network.** Walk the page in listed order and decide which calls it still owes. Already-committed identities, expiring drop markers, and calls the turn has no remaining budget for settle without a fetch. Within one page an identity is now taken at most once, so a duplicated row in a provider listing cannot become two concurrent readings of one conversation.
2. **Fetch the outstanding calls together**, at most `RETELL_HYDRATION_CONCURRENCY` (16) in flight, accepting each result as it lands. Results are then settled in listed order, so everything per call is unchanged: lease renewal, retry rows, drop markers, page advance, and the reconcile at the turn boundary. An object-store refusal is still not a hydration failure.

Expected effect: a ~30-call page drops from ~20 s to ~2 s, and a two-agent 30-day import that took ~2¼ minutes should finish in roughly 15 s.

## Why the ceiling is 16

- The per-call time is nearly all network wait, so wall time falls almost linearly with concurrency at this scale: 16 turns a 30-call page into two waves.
- Overshooting the provider's rate limit is benign but not free. A 429 pauses the whole agent's poll and spends no call's retry budget, so unbounded concurrency can make an import *slower*. A non-429 refusal does spend one of a call's bounded fetch attempts, and a modest burst keeps that risk small.
- At most 16 full call transcripts are in flight inside the same process that serves live ingestion.

The ceiling is one exported constant, and the tests enforce whatever value it holds.

## Proof

35 tests pass, 3 of them new: a page's outstanding calls really are fetched in one wave; never more than the ceiling is open at once; one call's failure leaves the calls beside it untouched. The new tests were checked for teeth by setting the ceiling to 1 and watching them fail. One pre-existing test ("yields inside a large page without checkpointing past unprocessed calls") was reshaped because it asserted the one-at-a-time order itself; its intent — a turn that runs out of budget stops without checkpointing past unread calls — is preserved and still proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwXYSuY8x4PZUxvNNgZN8a

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwXYSuY8x4PZUxvNNgZN8a)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790021463&installation_model_id=431960&pr_number=190&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F190&signature=1c1c26da1fdee8c0c9b1cc8c3c86d53dee5561d25ecdfb74f57410f48ab9a7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Retell polling to hydrate each page’s outstanding calls concurrently under a fixed ceiling while preserving ordered settlement and bounded-turn behavior. It also serializes retry cleanup so concurrent successful calls reliably restore an agent’s monitoring state.

- Collects unaccounted calls before hydration and deduplicates repeated provider identities within a page.
- Runs up to 16 hydrations concurrently and waits for opened work to finish before settling outcomes.
- Accounts for durable sibling retry and drop outcomes before honoring a turn-ending result.
- Locks the monitored-agent row before deleting retry state and deciding whether to restore the agent to active.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/src/retell-production-ingestion.ts | Adds bounded concurrent page hydration, identity deduplication, and two-pass outcome settlement; the previously reported sibling-accounting issue is resolved. |
| packages/db/src/access/production-monitoring.ts | Serializes retry deletion and active-state restoration with a monitored-agent row lock, resolving the previously reported concurrent-cleanup race. |
| apps/api/test/retell-production-ingestion.test.ts | Adds coverage for concurrent hydration, the concurrency ceiling, isolated call failures, terminal sibling accounting, and bounded turns. |
| packages/db/test/production-monitoring.test.ts | Adds a real-database concurrency regression test proving that simultaneous retry cleanup restores the agent to active. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Poller
  participant Provider
  participant Store
  Poller->>Store: Read committed identities and retry markers
  Poller->>Poller: Build deduplicated outstanding page
  par Up to 16 calls
    Poller->>Store: Renew monitoring lease
    Poller->>Provider: Hydrate call
    Poller->>Store: Accept call or record retry/drop
  end
  Poller->>Poller: Count all durable per-call outcomes
  Poller->>Poller: Process turn-ending outcomes in listed order
  Poller->>Store: Advance page or yield without checkpointing
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(retell): count and restore what page..."](https://github.com/egma-ai/egma/commit/ef8241fdb7bec191910f7d121c093ec3ef2549e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55898887)</sub>

**Context used:**

- Knowledge Base — [Egma API platform](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/api-platform.md)
- Knowledge Base — [Egma database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/db-persistence.md)

<!-- /greptile_comment -->