### PR TITLE
feat(web): the Paper look — theme, primitives, shell (ui-refresh 01)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -67,7 +67,7 @@ Rules:
 - Keep the canonical geometry, proportions, and black-and-white treatment.
 - Do not recolor, stretch, rotate, outline, shadow, or animate the logo.
 - The signed-in sidebar starts with the Egma wordmark, in a 56px bar with a hairline under it. It links to the product root. (Developer decision, 2026-08-23: "our logo, not the organization's". This replaces the earlier rule that kept the full logo out of the signed-in sidebar, which asked for exactly this approval.)
-- Dark theme inverts the wordmark. Black line art printed white is the same mark, not a recolor.
+- 2026-08-23: the sidebar wordmark follows the access pages' existing dark-theme treatment (the black line art is printed white by inversion).
 - The organization is the eyebrow above the project name, under the wordmark bar. The project is the line that opens the switcher.
 - Auth, onboarding, and public brand surfaces may use the full logo.
 - Product icons and status symbols must not imitate the logo.
@@ -117,7 +117,7 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 
 ### Dark theme
 
-- Dark theme uses neutral dark surfaces and the same Ember focus and action family.
+- Dark theme uses neutral dark surfaces and the same Ember focus and action family, lightened where a dark surface needs it. The primary action's text is Ember pulled towards paper rather than Deep Ember: Deep Ember on the dark Ember Wash is 2.69:1 and fails AA, and the lighter step is 5.26:1. (Developer decision, 2026-08-23.)
 - Dense evidence may use a dark contained surface in either theme.
 - Every shared component must support light and dark themes.
 - Verify text, borders, focus, status, overlays, and disabled states in both themes.
@@ -278,7 +278,8 @@ The measurements, all of them theme values:
 ### Side sheets
 
 - One record is created, read, and edited in a side sheet anchored to the right edge: agents, connections, personas, and tests. The list stays on screen behind it. (Developer decision, 2026-08-23.)
-- A side sheet is 440px wide, full height, on Pure Paper behind a hairline on its left edge, over a scrim.
+- **There are two side sheets, and they are two behaviours.** The **modal** sheet is the create, read, and edit surface named above: it is 440px, sits over a scrim, and makes the page behind it inert. The **wide reading** sheet is the evidence surface — a transcript beside its grader results, a persona's version history — it is 640px, has no scrim, and deliberately leaves the page beside it usable, because that page is what the evidence is being read against. Both widths are theme values. (Developer decision, 2026-08-23.)
+- A side sheet is full height, on Pure Paper behind a hairline on its left edge.
 - Its head is the record's name at the lead step with a close beside it, over a hairline. Its body is the fields and scrolls. Its footer is pinned to the bottom: the answer and the way out at the left, the one destructive action at the right.
 - It travels from the edge it is attached to, on the drawer's durations, and fades in place under reduced motion.
 - It traps focus, makes the page behind it inert, closes with Escape, and restores the exact opener.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,6 +6,8 @@ The orange-red palette and the Egma logo are locked. Change them only with expli
 
 The styling architecture changed on 2026-08-19 with that approval. **Styling architecture** below is the current truth.
 
+The product's shape changed on 2026-08-23 with that approval, from the Paper file "Egma — Design system and product UI". Five rules moved, and each is marked where it is written: **one radius, and it is 0px**; the **Egma wordmark returns to the signed-in sidebar**; the **primary action is the wash button**, not a Deep Ember block; **`system-ui` leads the font stack**; and the **side sheet** is where one record is created, read and edited. The palette did not move. The logo's own treatment rules did not move.
+
 ## Product context
 
 - **What this is:** The product interface for teams that test voice agents and decide whether they trust them in production.
@@ -64,7 +66,9 @@ Rules:
 
 - Keep the canonical geometry, proportions, and black-and-white treatment.
 - Do not recolor, stretch, rotate, outline, shadow, or animate the logo.
-- The signed-in sidebar starts with the organization and project switcher. It does not repeat the full Egma logo.
+- The signed-in sidebar starts with the Egma wordmark, in a 56px bar with a hairline under it. It links to the product root. (Developer decision, 2026-08-23: "our logo, not the organization's". This replaces the earlier rule that kept the full logo out of the signed-in sidebar, which asked for exactly this approval.)
+- Dark theme inverts the wordmark. Black line art printed white is the same mark, not a recolor.
+- The organization is the eyebrow above the project name, under the wordmark bar. The project is the line that opens the switcher.
 - Auth, onboarding, and public brand surfaces may use the full logo.
 - Product icons and status symbols must not imitate the logo.
 
@@ -80,10 +84,10 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 | Carbon | `#000000` | Maximum contrast and rare dark application surfaces |
 | Graphite | `#3c3c3c` | Secondary text and stronger neutral states |
 | Ember | `#ff5229` | Brand accent, focus, active marks, and directional icons |
-| Deep Ember | `#c2410c` | Primary filled actions with white text |
-| Ember Hover | `#a93609` | Pointer hover on primary filled actions |
-| Ember Pressed | `#872b09` | Pointer press on primary filled actions |
-| Ember Wash | `#fff5f2` | Selected, current, open, cited, and active-attention surfaces |
+| Deep Ember | `#c2410c` | The primary action's text, on Ember Wash |
+| Ember Hover | `#a93609` | Pointer hover on the primary action's text |
+| Ember Pressed | `#872b09` | Pointer press on the primary action's text |
+| Ember Wash | `#fff5f2` | The primary action's fill; selected, current, open, cited, and active-attention surfaces |
 
 ### Color rules
 
@@ -91,8 +95,8 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 - Ordinary borders use a neutral mix of Graphite and Pure Paper.
 - Quiet hover, read-only, progress, and supporting surfaces use a neutral Graphite-and-Paper mix.
 - Ember is the main brand signal. Use it for focus, icons, marks, and narrow active edges.
-- Deep Ember is the primary filled action. Its white-text contrast is above 5:1.
-- Ember Wash is for selected, current, open, cited, or active-attention states.
+- Deep Ember is the primary action's text on Ember Wash. Its contrast on that fill is above 7:1. (Developer decision, 2026-08-23: the filled Deep Ember button with white text is retired.)
+- Ember Wash is the primary action's fill, and the surface for selected, current, open, cited, or active-attention states.
 - Carbon is for maximum contrast and dark evidence surfaces.
 - Body text uses Midnight Ink or Graphite.
 - Shadows use restrained orange-brown.
@@ -120,10 +124,13 @@ Egma uses neutral paper surfaces and one orange-red brand family. Routine produc
 
 ## Typography
 
-Use Arial, Helvetica, and the system sans-serif fallback. Product text uses weight 400. Weight 500 is reserved for compact labels, important values, and page, section, state, or dialog titles that need stronger hierarchy.
+Use `system-ui` first, then Helvetica, Arial, and the system sans-serif fallback. Product text uses weight 400. Weight 500 is reserved for compact labels, important values, and page, section, state, or dialog titles that need stronger hierarchy.
+
+`system-ui` leads because the design boards are rendered in it: Arial first would not draw the product that was approved. (Developer decision, 2026-08-23.)
 
 | Role | Size | Line height | Letter spacing |
 | --- | ---: | ---: | ---: |
+| Micro label | 12px | 1.5 | 0.08em |
 | Caption and table text | 14px | 1.43 | -0.35px |
 | UI body | 16px | 1.5 | -0.4px |
 | Lead body | 24px | 1.33 | -0.6px |
@@ -136,6 +143,7 @@ Use Arial, Helvetica, and the system sans-serif fallback. Product text uses weig
 Rules:
 
 - Hierarchy comes from size, space, and restrained use of weight 500.
+- The micro label is for the two letter-spaced uppercase labels the sidebar carries — the organization over the project name, and the role under the account's email. Nothing else uses it. The scale still starts at 14px. (Developer decision, 2026-08-23.)
 - Do not use weights 600 or 700.
 - Product tables, forms, and navigation use the 14px and 16px steps.
 - Headings carry no size of their own. Every heading takes its size from a class, because the browser's own heading sizes are not on this scale.
@@ -160,21 +168,34 @@ Allowed spacing values are `4, 8, 12, 16, 20, 24, 32, 40, 48, 64, 72, 80, 100px`
 
 | Element | Radius |
 | --- | ---: |
-| Button | 6px |
-| Input | 8px |
-| Card, menu, dialog | 12px |
-| Tag, chip, filter | 9999px |
+| Every component | 0px |
 
-Use each radius for its named component type. Do not apply one large radius to every component.
+One radius, and it is none: buttons, inputs, panels, tables, sheets, menus, dialogs, chips, badges. Sharp corners are the product's shape. (Developer decision, 2026-08-23. This replaces the four-step table that named a radius per component type.)
+
+Two round shapes remain, and neither is a component corner:
+
+- The account avatar is a circle. It is an avatar.
+- A radio button is a circle. The shape is what tells it apart from a checkbox in every operating system, and taking it away would make one control claim to be another.
+
+The four radius names stay in the theme — `--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-pill` — because component class lists read them and the name says which component asked. All four are `0px`.
 
 ## Elevation
 
 Most structure comes from contrast and borders.
 
-- Menus and dialogs use the shared short orange-brown shadow.
+- Menus, side sheets, and dialogs use one shared orange-brown shadow: the two-layer stack below. There is no separate shorter menu shadow; the boards draw all three raised surfaces the same way. (Read off the boards, 2026-08-23.)
 - Large showcase panels may use the full orange-brown shadow stack.
-- Tables, sidebars, inputs, and ordinary cards do not float.
+- Tables, sidebars, topbars, inputs, search boxes, and ordinary cards do not float. They carry a hairline and nothing else.
 - Do not use cool gray shadows.
+
+The shared shadow, worn by every menu, sheet, and dialog:
+
+```css
+rgba(122, 49, 23, 0.12) -8px 16px 39px 0,
+rgba(122, 49, 23, 0.1) -33px 64px 72px 0
+```
+
+The full stack, for a showcase panel:
 
 ```css
 rgba(122, 49, 23, 0.12) -8px 16px 39px 0,
@@ -189,27 +210,47 @@ rgba(122, 49, 23, 0.02) -130px 256px 115px 0
 
 - Neutral Paper is the application canvas.
 - The sidebar is a quiet paper region separated by a neutral hairline.
-- The organization and project switcher is the topmost sidebar control.
-- The full Egma logo is absent from the signed-in sidebar.
+- The Egma wordmark is the topmost thing in the sidebar, in a bar of its own.
+- The organization and project switcher is the topmost sidebar *control*, under that bar.
 - Navigation uses text and small line icons.
-- The active item uses Ember Wash and a small Ember mark.
+- The active item uses Ember Wash and a small Ember mark on its leading edge. Its icon follows the row's text colour; the mark is the brand signal and there is only one.
 - The account control stays at the bottom.
+- Every page has a title bar of its own, the same height as the wordmark bar, with the page title and its purpose statement in it. Page actions are not in that bar.
+- A page's actions sit in the toolbar row under the title bar, at the right, opposite whatever the page filters by.
+- Page content is held to the page maximum and aligned to the left gutter, so the title in the bar and the first column under it are on one line.
+
+The measurements, all of them theme values:
+
+| Part | Value |
+| --- | ---: |
+| Sidebar width | 224px |
+| Sidebar wordmark bar | 56px |
+| Page title bar | 56px |
+| Sidebar gutter, page gutter | 16px, 24px |
+| Navigation row, toolbar control | 36px |
+| Form control, touch target | 44px |
+| Table header row | 40px |
+| Table body row, minimum | 52px |
+| Table row-menu slot | 48px |
+| Toolbar row | 52px |
+| Side sheet | 440px |
 
 ### Organization and project switcher
 
-- Show organization as the primary line and project as the secondary line.
+- Show the organization as the eyebrow and the project as the primary line. The project is what a person changes; the organization is the one thing they cannot. (Developer decision, 2026-08-23.)
 - Support search, keyboard use, Escape, focus return, and unsaved-work protection.
 - Open the menu from its trigger with an origin-aware transition.
 - Do not add fake teams, sample projects, or a second navigation model.
 
 ### Buttons and links
 
-- Primary: Deep Ember fill, white text, and 6px radius.
-- Primary hover and press use the darker Ember steps.
+- Primary: Ember Wash fill, Deep Ember text, a one-pixel neutral hairline, no corner. 36px in a toolbar, 44px in a form. (Developer decision, 2026-08-23. The Deep Ember block with white text is retired; no variant draws it.)
+- Primary hover and press take one more step of Ember into the fill and the darker Ember steps in the text. The hairline does not move, so the control never looks like it changed size.
 - Secondary: transparent with a one-pixel Midnight Ink border.
 - Quiet action: text only, with an optional small Ember arrow.
-- Destructive actions require confirmation and say what will happen.
+- Destructive actions require confirmation and say what will happen. The action that opens the confirmation is a text action in the failure colour, kept at the far end of a footer from the normal save. The button inside the confirmation is a filled failure-colour button.
 - Pointer press feedback uses a subtle scale. Keyboard activation is immediate.
+- A link inside a table cell is underlined in the text colour and turns Ember under a pointer.
 
 ### Forms and Settings
 
@@ -225,12 +266,22 @@ rgba(122, 49, 23, 0.02) -130px 256px 115px 0
 ### Tables and lists
 
 - Use one semantic table tree on desktop and mobile.
+- A table is a Pure Paper panel inside one neutral hairline, with its corners clipped.
 - Table text starts at 14px.
-- Neutral hairlines separate rows.
-- Headers are quiet, regular-weight labels.
+- Neutral hairlines separate rows. There is no hairline after the last row.
+- Headers are quiet, regular-weight labels in a 40px row. A body row is at least 52px.
+- Every row ends with the same fixed slot for its row menu, whether or not it has one, so the menus line up in one lane down the table.
 - Selected or active rows use Ember Wash plus a non-color state mark.
 - Mobile may restyle the same DOM as rows. It must not duplicate interactive content.
 - Empty, loading, failed, and filtered-empty are separate states.
+
+### Side sheets
+
+- One record is created, read, and edited in a side sheet anchored to the right edge: agents, connections, personas, and tests. The list stays on screen behind it. (Developer decision, 2026-08-23.)
+- A side sheet is 440px wide, full height, on Pure Paper behind a hairline on its left edge, over a scrim.
+- Its head is the record's name at the lead step with a close beside it, over a hairline. Its body is the fields and scrolls. Its footer is pinned to the bottom: the answer and the way out at the left, the one destructive action at the right.
+- It travels from the edge it is attached to, on the drawer's durations, and fades in place under reduced motion.
+- It traps focus, makes the page behind it inert, closes with Escape, and restores the exact opener.
 
 ### Menus, popovers, and dialogs
 

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -3735,6 +3735,7 @@ describe("the complete product, walked in order in a second project", () => {
         const headings: number[] = [];
         const cells: string[] = [];
         const rows: number[] = [];
+        const lanes: number[] = [];
 
         for (const address of lists) {
           await walk.goto(address);
@@ -3743,6 +3744,20 @@ describe("the complete product, walked in order in a second project", () => {
           headings.push(Math.round(await heightOf(walk, "table thead tr")));
           cells.push(await cellStyle());
           rows.push(Math.round(await heightOf(walk, "table tbody tr")));
+          /*
+           * Only the lists that offer a row control have a lane. Two of the
+           * five do today; the rest gain one as their screens are rebuilt, and
+           * this measures whichever are there rather than demanding that every
+           * list grow a menu it has no use for.
+           */
+          const lane = walk.locator('table tbody td[data-action="true"]');
+          if ((await lane.count()) > 0) {
+            lanes.push(
+              Math.round(
+                await widthOf(walk, 'table tbody td[data-action="true"]'),
+              ),
+            );
+          }
         }
 
         expect(new Set(sidebars).size, sidebars.join(", ")).toBe(1);
@@ -3787,6 +3802,11 @@ describe("the complete product, walked in order in a second project", () => {
               read.getPropertyValue("--row-min-height"),
               10,
             ),
+            header: Number.parseInt(read.getPropertyValue("--row-height"), 10),
+            lane: Number.parseInt(
+              read.getPropertyValue("--table-action-width"),
+              10,
+            ),
             control: Number.parseInt(read.getPropertyValue("--control-lg"), 10),
           };
         });
@@ -3794,6 +3814,15 @@ describe("the complete product, walked in order in a second project", () => {
         // The shell's width is the token's own, rather than five pages
         // happening to agree on a hand-typed number.
         expect(sidebars[0]).toBe(tokens.sidebar);
+        // The header row holds no controls, so it is an equality rather than a
+        // floor — and it is the token's own number, not five pages agreeing.
+        expect(headings[0], headings.join(", ")).toBe(tokens.header);
+        // The trailing lane a row control stands in, on every list that has
+        // one. A page that drew its own action column would put its control
+        // somewhere else down the table.
+        expect(lanes.length, "no list offered a row control").toBeGreaterThan(0);
+        expect(new Set(lanes).size, lanes.join(", ")).toBe(1);
+        expect(lanes[0], lanes.join(", ")).toBe(tokens.lane);
         // No list sinks below the row token, and none rises above it by more
         // than one control — which is the whole of what a row may hold.
         expect(Math.min(...rows), rows.join(", ")).toBeGreaterThanOrEqual(

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -3753,11 +3753,16 @@ describe("the complete product, walked in order in a second project", () => {
          * **A row is measured as a floor rather than as an equality**, and the
          * distinction is the honest one.
          *
-         * `--row-height` is a `height` on a table cell, which a browser treats
-         * as a minimum: a row carrying controls can be taller than a row
+         * `--row-min-height` is a `height` on a table cell, which a browser
+         * treats as a minimum: a row carrying controls can be taller than a row
          * carrying a sentence, on the same table, from the same definition. A
          * test demanding one number would be a test demanding that no list ever
          * hold a button.
+         *
+         * It is the *body* row's token. `--row-height` is the header's, and
+         * the header is held to an equality above because it holds no
+         * controls. The two parted company on 2026-08-23, when the boards gave
+         * a 40px header row and a 52px body row.
          *
          * What a copied implementation would break is the three above — the
          * shell, the heading row that holds no controls, and the cell's own
@@ -3778,7 +3783,10 @@ describe("the complete product, walked in order in a second project", () => {
               read.getPropertyValue("--sidebar-width"),
               10,
             ),
-            row: Number.parseInt(read.getPropertyValue("--row-height"), 10),
+            row: Number.parseInt(
+              read.getPropertyValue("--row-min-height"),
+              10,
+            ),
             control: Number.parseInt(read.getPropertyValue("--control-lg"), 10),
           };
         });
@@ -3863,7 +3871,7 @@ describe("the complete product, walked in order in a second project", () => {
             sidebar: Math.round(await widthOf(walk, "aside")),
             row: Math.round(await heightOf(walk, "table tbody tr")),
             sidebarToken: await pixelToken(walk, "--sidebar-width"),
-            rowToken: await pixelToken(walk, "--row-height"),
+            rowToken: await pixelToken(walk, "--row-min-height"),
           };
           const nextSidebar = before.sidebarToken + 36;
           // A table row may already sit above its token because a control plus
@@ -3878,7 +3886,7 @@ describe("the complete product, walked in order in a second project", () => {
           );
           const putBackRow = await retuned(
             walk,
-            "--row-height",
+            "--row-min-height",
             `${nextRow}px`,
           );
 
@@ -3936,7 +3944,7 @@ describe("the complete product, walked in order in a second project", () => {
 
         const tokens = {
           sidebar: await pixelToken(walk, "--sidebar-width"),
-          row: await pixelToken(walk, "--row-height"),
+          row: await pixelToken(walk, "--row-min-height"),
           control: await pixelToken(walk, "--control-lg"),
         };
 

--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -50,6 +50,17 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select } from "@/components/ui/select";
+import {
+  Sheet,
+  SheetBody,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Toaster } from "@/components/ui/sonner";
@@ -557,11 +568,65 @@ export function DesignSystemProof() {
                       </DialogFooter>
                     </DialogContent>
                   </BaseDialog>
+
+                  <Sheet>
+                    <SheetTrigger asChild>
+                      <BaseButton type="button">Open connection</BaseButton>
+                    </SheetTrigger>
+                    <SheetContent aria-describedby={undefined}>
+                      <SheetHeader>
+                        <SheetTitle>phone</SheetTitle>
+                        <SheetDescription>
+                          Retell · production
+                        </SheetDescription>
+                      </SheetHeader>
+                      <SheetBody>
+                        <Field label="Name" htmlFor="proof-sheet-name">
+                          <Input
+                            id="proof-sheet-name"
+                            value="phone"
+                            autoComplete="off"
+                            spellCheck={false}
+                            onChange={() => undefined}
+                          />
+                        </Field>
+                        <Field label="Phone number" htmlFor="proof-sheet-number">
+                          <Input
+                            id="proof-sheet-number"
+                            value="+1 415 555 0134"
+                            autoComplete="off"
+                            spellCheck={false}
+                            onChange={() => undefined}
+                          />
+                        </Field>
+                        <p className="m-0 text-sm text-faint">
+                          Created Aug 16, 2026 · Updated Aug 20, 2026
+                        </p>
+                      </SheetBody>
+                      <SheetFooter
+                        destructive={
+                          <BaseButton type="button" variant="ghost" className="text-failure">
+                            Delete
+                          </BaseButton>
+                        }
+                      >
+                        <BaseButton type="button" size="lg">
+                          Save connection
+                        </BaseButton>
+                        <SheetClose asChild>
+                          <BaseButton type="button" size="lg" variant="secondary">
+                            Cancel
+                          </BaseButton>
+                        </SheetClose>
+                      </SheetFooter>
+                    </SheetContent>
+                  </Sheet>
                 </div>
                 <p className="m-0 text-sm text-muted-foreground">
                   The menu and the popover grow from the control that opened
-                  them; the dialog stays centred. Every duration is a DESIGN.md
-                  motion token and every one is under 300ms.
+                  them; the dialog stays centred; the side sheet comes in from
+                  the right edge it is anchored to. Every duration is a
+                  DESIGN.md motion token and every one is under 300ms.
                 </p>
               </div>
             </div>
@@ -1102,8 +1167,60 @@ export function DesignSystemProof() {
         </article>
 
         <article className={cn(PANEL_WIDE)}>
-          <p className={KICKER}>Responsive and motion checks</p>
+          <p className={KICKER}>Responsive, theme and motion checks</p>
           <div className="grid grid-cols-2 gap-6 max-[760px]:grid-cols-1 max-[760px]:gap-4">
+            {/*
+              * **The dark theme, beside the light one rather than instead of
+              * it.** Every shared component has to support both, and the way
+              * that rule is broken is never on purpose — it is a colour written
+              * where a token belonged, and it only shows when the two are held
+              * against each other. The account menu's switch still flips the
+              * whole document; this frame is what makes a difference visible
+              * without leaving the page.
+              *
+              * `data-theme` on a `<div>` works because `tailwind-theme.css`
+              * binds the dark values to the attribute as well as to `:root`.
+              */}
+            <section
+              className={cn(PREVIEW, "col-span-2 max-[760px]:col-span-1")}
+              aria-label="Dark theme component preview"
+              data-preview="dark"
+              data-theme="dark"
+            >
+              <header className={cn(PREVIEW_HEAD)}>
+                <strong className="font-medium">Dark theme preview</strong>
+                <span className="text-muted-foreground">
+                  The same components on the dark tokens
+                </span>
+              </header>
+              <div className="flex flex-col gap-4 bg-background p-4">
+                <div className="flex flex-wrap items-center gap-3">
+                  <BaseButton type="button">Connect an agent</BaseButton>
+                  <BaseButton type="button" variant="secondary">
+                    Edit
+                  </BaseButton>
+                  <BaseButton type="button" variant="destructive">
+                    Archive
+                  </BaseButton>
+                  <BaseBadge variant="success">Passed</BaseBadge>
+                  <BaseBadge shape="count">+3</BaseBadge>
+                </div>
+                <Input
+                  aria-label="Search agents by name in the dark preview"
+                  placeholder="Search by name"
+                  value=""
+                  autoComplete="off"
+                  onChange={() => undefined}
+                />
+                <DataTable
+                  label="Proof agents in dark theme"
+                  columns={COLUMNS}
+                  rows={AGENTS.slice(0, 2)}
+                  keyOf={(agent) => agent.id}
+                />
+              </div>
+            </section>
+
             <section
               className={PREVIEW}
               aria-label="Narrow 360 pixel component preview"

--- a/apps/web/app/design-system/proof.tsx
+++ b/apps/web/app/design-system/proof.tsx
@@ -92,7 +92,7 @@ import { NumberField } from "../../ui/number-field.tsx";
 import { Empty, Failure, Loading } from "../../ui/page-state.tsx";
 import { ProjectSelector } from "../../ui/project-selector.tsx";
 import { RunProgress, VerdictBadge } from "../../ui/run-status.tsx";
-import { Actions, Section, Toolbar } from "../../ui/section.tsx";
+import { Actions, SearchField, Section, Toolbar } from "../../ui/section.tsx";
 import { SettingsNav } from "../../ui/settings-nav.tsx";
 import { AppShell, ProductPage } from "../../ui/shell.tsx";
 
@@ -231,6 +231,40 @@ const COLUMNS: readonly Column<ProofAgent>[] = [
     ),
   },
   { key: "id", header: "Identifier", mono: true, cell: (agent) => agent.id },
+  /*
+   * The row menu's lane.
+   *
+   * `action: true` is what makes the cell a fixed `--table-action-width` slot
+   * at the trailing edge, on every row and in the header, so the ⋮ marks line
+   * up in one column down the table instead of each floating to the right of
+   * whatever text came before it. It is drawn here because a lane that only
+   * exists on product screens is a lane nothing holds to the boards.
+   */
+  {
+    key: "menu",
+    header: "Actions",
+    action: true,
+    cell: (agent) => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <BaseButton
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Actions for ${agent.name}`}
+          >
+            <EllipsisIcon />
+          </BaseButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem>Open</DropdownMenuItem>
+          <DropdownMenuItem>Edit</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive">Archive</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+  },
 ];
 
 const TRANSCRIPT: EvidenceTranscript = {
@@ -1205,7 +1239,8 @@ export function DesignSystemProof() {
                   <BaseBadge variant="success">Passed</BaseBadge>
                   <BaseBadge shape="count">+3</BaseBadge>
                 </div>
-                <Input
+                <SearchField
+                  id="proof-dark-search"
                   aria-label="Search agents by name in the dark preview"
                   placeholder="Search by name"
                   value=""
@@ -1329,6 +1364,22 @@ export function DesignSystemProof() {
               <BaseButton type="button">Register agent</BaseButton>
             </Actions>
           </div>
+          {/*
+            * The list toolbar, at the shape every list page has: the 300×36
+            * search box on the left, the one action hard right.
+            */}
+          <Toolbar
+            action={<BaseButton type="button">Connect an agent</BaseButton>}
+          >
+            <SearchField
+              id="proof-agent-search"
+              aria-label="Search proof agents by name"
+              placeholder="Search by name"
+              value=""
+              autoComplete="off"
+              onChange={() => undefined}
+            />
+          </Toolbar>
           <DataTable label="Proof agents" columns={COLUMNS} rows={AGENTS} keyOf={(agent) => agent.id} />
         </article>
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -31,7 +31,8 @@
   color-scheme: light;
 }
 
-:root[data-theme="dark"] {
+:root[data-theme="dark"],
+[data-theme="dark"] {
   color-scheme: dark;
 }
 
@@ -94,13 +95,13 @@
 /*
  * Inside a menu the ring turns inward.
  *
- * The panel holds its items on 8px of padding and scrolls, so a ring drawn 3px
+ * The panel holds its items on 4px of padding and scrolls, so a ring drawn 3px
  * *outside* a full-width item is clipped on both sides and reads as two stripes
  * rather than a rectangle. A negative offset puts the whole ring on the item.
  *
  * This is a design call rather than a fact, and it is called out in the pull
  * request for the developer to overrule: -2px, so the ring sits just inside the
- * item's own 6px radius without touching the text.
+ * item's own edge without touching the text.
  */
 :is([role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"], [role="option"]):focus-visible { outline-offset: -2px; }
 

--- a/apps/web/app/projects/[projectId]/personas/[personaId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/personas/[personaId]/page.tsx
@@ -636,6 +636,7 @@ function PersonaDetail({
         {historyOpen ? (
           <Dialog
             kind="sheet"
+            size="wide"
             title="Version history"
             returnFocusTo={historyButton.current}
             onClose={() => setHistoryOpen(false)}

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The chip, at the 9999px tag radius.
+ * The chip, square like everything else.
  *
  * The variant names are the meanings rather than shadcn's `default`,
  * `secondary` and `destructive`. A chip in this product usually carries a
@@ -23,8 +23,7 @@ import { cn } from "@/lib/utils";
 const badgeVariants = cva(
   [
     "inline-flex w-fit shrink-0 items-center justify-center gap-2 whitespace-nowrap",
-    "min-h-(--control-sm) rounded-chip border px-3",
-    "text-sm tracking-(--tracking-label) uppercase",
+    "rounded-chip border text-sm",
     "[&>svg]:pointer-events-none [&>svg]:size-3",
   ],
   {
@@ -35,9 +34,25 @@ const badgeVariants = cva(
         warning: "border-warning-border text-warning",
         failure: "border-failure-border text-failure",
       },
+      /*
+       * Two shapes, and the second one is a chip that holds a number.
+       *
+       * `verdict` is the chip this product has always drawn: a word in
+       * letter-spaced capitals, at the dense control height. `count` is the
+       * overflow chip the boards put at the end of a cell that ran out of room
+       * (`719-0`) — "+3", 22px tall on the quiet neutral surface, in ordinary
+       * sentence case because it is a number and capitals would say nothing.
+       * It is deliberately not a variant of the colour axis above: a count
+       * carries no verdict, and the colours there all do.
+       */
+      shape: {
+        verdict: "min-h-(--control-sm) px-3 tracking-(--tracking-label) uppercase",
+        count: "h-[22px] min-w-7 bg-surface-soft px-2",
+      },
     },
     defaultVariants: {
       variant: "neutral",
+      shape: "verdict",
     },
   },
 );
@@ -45,6 +60,7 @@ const badgeVariants = cva(
 function Badge({
   className,
   variant,
+  shape,
   asChild = false,
   ...props
 }: ComponentProps<"span"> &
@@ -56,7 +72,8 @@ function Badge({
   return (
     <Component
       data-slot="badge"
-      className={cn(badgeVariants({ variant }), className)}
+      data-shape={shape ?? "verdict"}
+      className={cn(badgeVariants({ variant, shape }), className)}
       {...props}
     />
   );

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -47,7 +47,7 @@ const badgeVariants = cva(
        */
       shape: {
         verdict: "min-h-(--control-sm) px-3 tracking-(--tracking-label) uppercase",
-        count: "h-[22px] min-w-7 bg-surface-soft px-2",
+        count: "h-(--chip-height) min-w-7 bg-surface-soft px-2",
       },
     },
     defaultVariants: {
@@ -72,7 +72,6 @@ function Badge({
   return (
     <Component
       data-slot="badge"
-      data-shape={shape ?? "verdict"}
       className={cn(badgeVariants({ variant, shape }), className)}
       {...props}
     />

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -9,26 +9,36 @@ import { cn } from "@/lib/utils";
  *
  * The variant names are shadcn's, so a component pasted from the registry
  * arrives already dressed. What each name *draws* is egma's: `default` is the
- * Deep Ember primary, `secondary` and `outline` are both the one outlined kind
+ * wash primary, `secondary` and `outline` are both the one outlined kind
  * `DESIGN.md` describes, and `ghost` and `link` are both the quiet action.
  * shadcn's own `secondary` — a filled grey button — is a look this product does
  * not have, so no name produces it.
  *
- * **When migrating:** the CSS Modules `Button` defaults to the outlined kind and
- * takes `weight="strong"` for the filled one. This one defaults to the filled
- * one, because that is what `variant="default"` means everywhere shadcn is
- * used. A migrated quiet button therefore has to say `variant="secondary"` out
- * loud; a migration that drops the prop turns a quiet button primary.
+ * **`default` is the wash button, and it replaced a Deep Ember block.** The
+ * boards draw the one action a page offers as Ember Wash behind Deep Ember
+ * text on a neutral hairline (`71O-0` on the agents board, `7DC-0` in the side
+ * sheet's footer), 36px tall with 16px of side padding. The developer ruled on
+ * 2026-08-23 that this *is* the primary action and retired the filled one, so
+ * no variant name produces a Deep Ember block any more. Hover and press move
+ * both halves one step: the fill takes a little more Ember, the ink takes the
+ * darker Ember steps `DESIGN.md` already named for a primary's feedback.
+ *
+ * **Sizes are 32 / 36 / 44, and 36 is the default.** The board's toolbar
+ * control is 36px and its form control is 44px, so `default` is the toolbar's
+ * and `lg` is the one a sheet or a dialog footer wears. A 36px button is under
+ * the 44px `DESIGN.md` asks of a coarse pointer, so the base puts that back on
+ * every touch screen — the same trade the sidebar row already makes.
  *
  * Every value here is a theme key, and every theme key reads one of egma's
- * own declarations in `tailwind-theme.css`. The result is the same 44px,
- * 6px-radius, weight-500 button the CSS Modules `Button` drew, which is what
- * made replacing it a restyle rather than a redesign.
+ * own declarations in `tailwind-theme.css`. Nothing here holds a colour, a
+ * size, a radius or a duration of its own.
  */
 const buttonVariants = cva(
   [
     "inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap",
     "rounded-button text-sm font-medium no-underline",
+    /* "Pointer targets are at least 44px on coarse pointers." */
+    "pointer-coarse:min-h-(--tap-target)",
     // Named properties, never `all`, and never `outline-color`. Tailwind's
     // `transition-colors` includes it, which fades the focus ring in over
     // 140ms on every Tab step — motion on keyboard navigation, which
@@ -40,11 +50,17 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        /* Primary: Deep Ember fill, white text. */
+        /*
+         * Primary: Ember Wash behind Deep Ember, on the ordinary neutral
+         * hairline — the button the boards draw. The border stays `--border`
+         * through every state: what answers a press is the fill and the ink,
+         * and a hairline that moved as well would make the control look like
+         * it changed size.
+         */
         default: [
-          "border border-primary bg-primary text-primary-foreground",
-          "pointer-hover:bg-primary-hover pointer-hover:border-primary-hover",
-          "active:bg-primary-pressed active:border-primary-pressed",
+          "border border-border bg-primary-wash text-primary",
+          "pointer-hover:bg-primary-wash-hover pointer-hover:text-primary-hover",
+          "active:bg-primary-wash-pressed active:text-primary-pressed",
         ],
         /*
          * Secondary: transparent with a one-pixel Midnight Ink border.
@@ -77,12 +93,14 @@ const buttonVariants = cva(
         ],
       },
       size: {
-        /* 44px, which is also the coarse-pointer target `DESIGN.md` asks for. */
-        default: "min-h-(--control-lg) px-4",
-        /* Dense toolbars, where the row is the target rather than the control. */
+        /* 36px and 16px of side padding: the toolbar control the boards draw. */
+        default: "min-h-(--control-md) px-4",
+        /* Denser still, for a control inside a row rather than above a list. */
         sm: "min-h-(--control-sm) px-3",
+        /* 44px: the form control, which is what a sheet or a dialog footer holds. */
         lg: "min-h-(--control-lg) px-5",
-        icon: "min-h-(--control-lg) w-(--control-lg) px-0",
+        /* A square, sized to the toolbar control it stands beside. */
+        icon: "min-h-(--control-md) w-(--control-md) px-0",
       },
     },
     defaultVariants: {

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -81,7 +81,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2",
-          "flex w-[min(480px,calc(100vw-var(--space-8)))] flex-col gap-5",
+          "flex w-[min(var(--dialog-width),calc(100vw-var(--space-8)))] flex-col gap-5",
           "rounded-card border border-border bg-surface p-6 text-foreground shadow-modal",
           className,
         )}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -7,7 +7,15 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The centered modal layer.
+ * The centered modal layer, drawn the way the confirm boards draw it.
+ *
+ * 480px wide, 24px of padding, a 20px column gap, the shared orange-brown
+ * shadow over a neutral hairline and no corner at all — read off `BEM-0` and
+ * `BMT-0` with `get_computed_styles` on 2026-08-23. The header is a title with
+ * a close beside it over a hairline; the footer is the answer and the way out,
+ * in that order, at the left. The boards put 28px of padding on the panel and
+ * this is 24: 28px is off `DESIGN.md`'s 4px spacing list, and the ticket rounds
+ * it to the step that is on it.
  *
  * Radix supplies what `DESIGN.md` requires of a dialog and a hand-written one
  * keeps getting wrong: focus is trapped, the page behind it is inert, Escape
@@ -73,8 +81,8 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2",
-          "flex w-[min(420px,calc(100vw-40px))] flex-col gap-5",
-          "rounded-card border border-border bg-surface p-5 text-foreground shadow-modal",
+          "flex w-[min(480px,calc(100vw-var(--space-8)))] flex-col gap-5",
+          "rounded-card border border-border bg-surface p-6 text-foreground shadow-modal",
           className,
         )}
         {...props}
@@ -84,7 +92,7 @@ function DialogContent({
           <DialogPrimitive.Close
             data-slot="dialog-close"
             className={cn(
-              "absolute top-4 right-4 inline-flex size-8 cursor-pointer items-center justify-center",
+              "absolute top-6 right-6 inline-flex size-8 cursor-pointer items-center justify-center",
               "rounded-button border border-transparent text-muted-foreground",
               /* "Pointer targets are at least 44px on coarse pointers." */
               "pointer-coarse:size-(--tap-target)",
@@ -120,13 +128,27 @@ function DialogFooter({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-footer"
-      className={cn("flex flex-wrap justify-end gap-3", className)}
+      /*
+       * The answer leads and the way out follows it, both at the left edge —
+       * which is what `BEM-0` draws and the reverse of shadcn's default. A
+       * destructive footer also carries a third thing at the right end; that
+       * is the caller's, and `justify-between` on the caller's own class list
+       * is what puts it there.
+       */
+      className={cn("flex flex-wrap items-center gap-3", className)}
       {...props}
     />
   );
 }
 
-/* Weight 500, which `DESIGN.md` reserves for titles that need the hierarchy. */
+/*
+ * The lead step, at weight 400.
+ *
+ * The boards write a dialog's question at 24px in the ordinary weight rather
+ * than at 16px in weight 500: the size is the hierarchy, which is what
+ * `DESIGN.md` asks for first ("hierarchy comes from size, space, and
+ * restrained use of weight 500").
+ */
 function DialogTitle({
   className,
   ...props
@@ -134,7 +156,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("m-0 pr-8 text-base font-medium", className)}
+      className={cn("m-0 pr-8 text-lg", className)}
       {...props}
     />
   );

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -7,7 +7,7 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * The menu, on Pure Paper with the short orange-brown shadow.
+ * The menu, on Pure Paper with the shared orange-brown shadow.
  *
  * Two things here are `DESIGN.md` rather than shadcn. The highlighted item — the
  * one under the pointer or the arrow keys — uses the quiet neutral mix, because
@@ -17,8 +17,9 @@ import { cn } from "@/lib/utils";
  * alone. shadcn spends one colour on both and would have said "hovered" and
  * "chosen" the same way.
  *
- * Items are 44px so a coarse pointer can hit them, and take the 6px button
- * radius inside the 12px menu.
+ * Items are 36px, which is what the boards draw (`9AH-0`), and 44px wherever
+ * the pointer is coarse — the same trade every dense control in this product
+ * makes. The panel holds them on 4px of padding.
  *
  * The transitions name their properties. `transition-colors` would include
  * `outline-color`, and an item reached with the arrow keys would then fade its
@@ -88,7 +89,8 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex min-h-(--control-lg) cursor-pointer items-center gap-2 rounded-button px-3",
+        "relative flex min-h-(--control-md) cursor-pointer items-center gap-2 rounded-button px-3",
+        "pointer-coarse:min-h-(--tap-target)",
         "text-sm outline-none select-none",
         "transition-[color,background-color] duration-(--duration-hover) ease-out",
         "data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
@@ -118,7 +120,8 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       checked={checked}
       className={cn(
-        "relative flex min-h-(--control-lg) cursor-pointer items-center gap-2 rounded-button py-2 pr-3 pl-8",
+        "relative flex min-h-(--control-md) cursor-pointer items-center gap-2 rounded-button py-2 pr-3 pl-8",
+        "pointer-coarse:min-h-(--tap-target)",
         "text-sm outline-none select-none",
         "transition-[color,background-color] duration-(--duration-hover) ease-out",
         "data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
@@ -201,7 +204,8 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex min-h-(--control-lg) cursor-pointer items-center gap-2 rounded-button px-3",
+        "flex min-h-(--control-md) cursor-pointer items-center gap-2 rounded-button px-3",
+        "pointer-coarse:min-h-(--tap-target)",
         "text-sm outline-none select-none",
         "transition-[color,background-color] duration-(--duration-hover) ease-out",
         "data-[highlighted]:bg-accent data-[state=open]:bg-accent",

--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -72,10 +72,12 @@ function Progress({
          * "Quiet hover, read-only, progress, and supporting surfaces use a
          * neutral Graphite-and-Paper mix." That mix is `--surface-soft`.
          *
-         * The chip radius, because a track is a pill and `DESIGN.md` names the
-         * pill for "tag, chip, filter" — the nearest named type, and the rule
-         * it is guarding against is one big radius on everything rather than a
-         * pill on something pill-shaped.
+         * The track is square, like every other component: the 2026-08-23
+         * ruling collapsed the radius table to one line and a progress bar is
+         * a component rather than a shape. The paragraph below about a round
+         * cap is kept because the mechanism it argues for is still the right
+         * one — a `translateX` inside a clipping track survives a cap of any
+         * radius, including none.
          */
         "relative h-2 w-full overflow-hidden rounded-chip bg-surface-soft",
         className,

--- a/apps/web/components/ui/radio-group.tsx
+++ b/apps/web/components/ui/radio-group.tsx
@@ -74,9 +74,17 @@ const radioItemVariants = cva(
          * radio. The target grows on a pseudo-element so nothing moves around
          * it, and a mouse sees no change at all.
          */
+        /*
+         * **The one place a circle survived the 0px ruling, with the avatar.**
+         * A radio button is round the way an avatar is round: the shape is
+         * what tells it apart from a checkbox, in every operating system a
+         * person has ever used. So it says `rounded-full`, which is Tailwind's
+         * own and not one of egma's four component radii. Called out in the
+         * pull request for the developer to overrule.
+         */
         dot: [
           "relative grid size-[18px] place-items-center",
-          "rounded-chip border border-input bg-surface",
+          "rounded-full border border-input bg-surface",
           "pointer-coarse:before:absolute pointer-coarse:before:top-1/2 pointer-coarse:before:left-1/2",
           "pointer-coarse:before:size-(--tap-target) pointer-coarse:before:-translate-x-1/2",
           "pointer-coarse:before:-translate-y-1/2 pointer-coarse:before:content-['']",
@@ -88,7 +96,7 @@ const radioItemVariants = cva(
            * sits on the strip rather than over its edge.
            */
           "inline-flex h-[calc(var(--control-md)-6px)] items-center px-4",
-          "rounded-[calc(var(--radius-sm)-1px)] border-0 bg-transparent",
+          "border-0 bg-transparent",
           "text-sm whitespace-nowrap text-muted-foreground",
           /* A real target on a coarse pointer, without growing what a mouse gets. */
           "pointer-coarse:min-h-(--tap-target)",
@@ -125,7 +133,7 @@ function RadioGroupItem({
         <RadioGroupPrimitive.Indicator
           data-slot="radio-group-indicator"
           /* Ember, which `DESIGN.md` names for focus, icons, marks and edges. */
-          className="size-2 rounded-chip bg-brand"
+          className="size-2 rounded-full bg-brand"
         />
       )}
     </RadioGroupPrimitive.Item>

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import type { ComponentProps, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The panel that comes in from the right to create, read or edit one thing.
+ *
+ * **This is the surface the boards choose over a page.** `77F-0` opens a
+ * connection in it, `7E0-0` creates an agent in it, and the personas and tests
+ * boards do the same with their own records — so a person stays on the list
+ * they were reading while they work on one row of it. `DESIGN.md` records that
+ * choice for agents, connections, personas and tests.
+ *
+ * Read off `7CD-0` with `get_computed_styles` on 2026-08-23: anchored to the
+ * right edge, 440px wide, full height, Pure Paper behind a neutral hairline on
+ * its left edge, the shared orange-brown shadow, a 20px column gap, and no
+ * corner. The boards put 28px of padding on it; that is off `DESIGN.md`'s 4px
+ * spacing list, so this is the 24px step that is on it — the same rounding the
+ * confirm dialog makes.
+ *
+ * **It is the same Radix dialog the centred one is, and that is the point.**
+ * Focus is trapped, the page behind is inert, Escape closes it and the exact
+ * control that opened it is focused again afterwards. A hand-rolled drawer
+ * loses every one of those quietly. What differs from `dialog.tsx` is where the
+ * panel sits and how it arrives, and nothing else.
+ *
+ * **The motion is not here.** `tailwind-theme.css` keys the entrance, the exit
+ * and the reduced-motion form of both on `data-slot` and Radix's `data-state`,
+ * exactly as it does for the dialog, the popover and the drawer. The sheet
+ * travels from its own edge on the drawer's tokens — 280ms in, 220ms out —
+ * because that is the movement `DESIGN.md` gives an edge-attached surface, and
+ * under reduced motion it stays put and fades.
+ *
+ * **`ui/dialog.tsx` also has a `sheet` kind, and the two are not the same
+ * thing.** That one is a wide reading surface that deliberately leaves the page
+ * behind it usable — the transcript beside its grader results. This one is a
+ * modal form. Both are kept, and a caller choosing between them is choosing
+ * whether the page behind stays reachable.
+ */
+
+function Sheet(props: ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger(props: ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose(props: ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal(props: ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn("fixed inset-0 z-30 bg-scrim", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * The panel.
+ *
+ * `inset-y-0 right-0` puts it against the edge with no centring shift to be
+ * cancelled, so the entrance can be written on `translate` alone. The width is
+ * capped at the viewport so a 390px phone gets the whole screen rather than a
+ * panel with 50px of scrim beside it.
+ */
+function SheetContent({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed inset-y-0 right-0 z-30 flex w-[min(440px,100vw)] flex-col gap-5",
+          "border-l border-border bg-surface p-6 text-foreground shadow-modal",
+          "outline-none",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+/**
+ * The title, and the way out beside it.
+ *
+ * The close is drawn here rather than positioned over the panel's corner,
+ * because that is what the board draws — one row, the title at the left and the
+ * ✕ at the right, over the hairline that separates the head from the fields. An
+ * absolutely placed close would have to be told the panel's padding, and would
+ * be wrong the day the padding moves.
+ *
+ * It is a 44px target on every pointer. A close is the control somebody reaches
+ * for when they have decided they are finished, and it is the one control in
+ * the panel that has nothing beside it to catch a near miss.
+ */
+function SheetHeader({
+  className,
+  children,
+  closeLabel = "Close",
+  showCloseButton = true,
+  ...props
+}: ComponentProps<"div"> & {
+  readonly closeLabel?: string;
+  readonly showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn(
+        "flex flex-none items-start justify-between gap-3",
+        "border-b border-border pb-4",
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex min-w-0 flex-col gap-1">{children}</div>
+      {showCloseButton ? (
+        <SheetClose
+          className={cn(
+            "-mt-1 -mr-1 inline-flex size-(--control-lg) flex-none cursor-pointer",
+            "items-center justify-center rounded-button border border-transparent",
+            "text-muted-foreground",
+            /* Named, so the focus ring is not among them. See `button.tsx`. */
+            "transition-[color,background-color] duration-(--duration-hover) ease-out",
+            "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
+          )}
+        >
+          <XIcon className="size-4" />
+          <span className="sr-only">{closeLabel}</span>
+        </SheetClose>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The lead step at weight 400, which is the size the boards write a sheet's
+ * subject at. See `dialog.tsx` for why the size carries the hierarchy here
+ * rather than the weight.
+ */
+function SheetTitle({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("m-0 min-w-0 text-lg [overflow-wrap:anywhere]", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("m-0 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * The fields.
+ *
+ * It is the part that scrolls, and it has to be: a sheet is a fixed-height
+ * column and the footer below it is the answer. Without `min-h-0` a flex child
+ * refuses to shrink below its content, and what would leave the screen is the
+ * submit button.
+ */
+function SheetBody({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-body"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * The bottom of the sheet: what this panel is for, the way out of it, and —
+ * at the far end — the one destructive thing it offers.
+ *
+ * The split is the board's (`7DA-0`): submit and cancel together at the left,
+ * Delete alone at the right in the failure colour. Putting the destructive
+ * action at the other end of the row is what stops it being pressed by
+ * somebody aiming for Cancel, and `DESIGN.md` asks for it to be kept apart from
+ * the normal save. It is a text action rather than a filled one, because the
+ * confirmation it opens is where the filled destructive button lives.
+ */
+function SheetFooter({
+  className,
+  children,
+  destructive,
+  ...props
+}: ComponentProps<"div"> & { readonly destructive?: ReactNode }) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn(
+        "mt-auto flex flex-none flex-wrap items-center justify-between gap-3",
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+      {destructive === undefined ? null : (
+        <div className="flex items-center">{destructive}</div>
+      )}
+    </div>
+  );
+}
+
+export {
+  Sheet,
+  SheetBody,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -154,15 +154,25 @@ function SheetOverlay({
 function SheetContent({
   className,
   children,
+  size = "default",
   ...props
-}: ComponentProps<typeof DialogPrimitive.Content>) {
+}: ComponentProps<typeof DialogPrimitive.Content> & {
+  /**
+   * How much room the panel needs. `default` is the boards' 440px form panel;
+   * `wide` is the 640px reading panel, for a surface whose content is evidence
+   * rather than fields. Both widths are theme values.
+   */
+  readonly size?: "default" | "wide";
+}) {
   return (
     <SheetPortal>
       <SheetOverlay />
       <DialogPrimitive.Content
         data-slot="sheet-content"
+        data-size={size}
         className={cn(
           "fixed inset-y-0 right-0 z-30 flex w-[min(var(--sheet-width),100vw)] flex-col gap-5",
+          size === "wide" && "w-[min(var(--sheet-width-wide),100vw)]",
           "border-l border-border bg-surface p-6 text-foreground shadow-modal",
           "outline-none",
           className,

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -104,12 +104,19 @@ function SheetClose(props: ComponentProps<typeof DialogPrimitive.Close>) {
 }
 
 /**
- * The portal, aimed at the page's own host.
+ * The portal, aimed at the page's own host — **and at `<body>` when there is
+ * none.**
  *
- * `container` is left off entirely when there is no host, rather than passed as
- * `null`: Radix reads an explicit `null` as "no container" and falls back to
- * `body`, which is what we want, but saying nothing is what keeps that a
- * fallback rather than a second code path.
+ * The fallback is not a nicety. A component test renders one screen with no
+ * shell around it, so no `SheetHost` is mounted and no container exists; a
+ * portal that insisted on one would mount nothing at all, and every page test
+ * that opens a sheet would fail to find a single control inside it. Radix's own
+ * default for `container` is `document.body`, and `undefined` is how you ask
+ * for it, so the fallback is the library's rather than a second code path
+ * written here.
+ *
+ * A caller may still pass its own `container`; the spread is after this, so it
+ * wins.
  */
 function SheetPortal(props: ComponentProps<typeof DialogPrimitive.Portal>) {
   const root = useContext(SheetRootContext);
@@ -117,7 +124,7 @@ function SheetPortal(props: ComponentProps<typeof DialogPrimitive.Portal>) {
   return (
     <DialogPrimitive.Portal
       data-slot="sheet-portal"
-      {...(root === null ? {} : { container: root })}
+      container={root ?? undefined}
       {...props}
     />
   );

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -2,7 +2,13 @@
 
 import { XIcon } from "lucide-react";
 import { Dialog as DialogPrimitive } from "radix-ui";
-import type { ComponentProps, ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -40,7 +46,50 @@ import { cn } from "@/lib/utils";
  * behind it usable — the transcript beside its grader results. This one is a
  * modal form. Both are kept, and a caller choosing between them is choosing
  * whether the page behind stays reachable.
+ *
+ * **The panel is portaled inside `<main>`, not to `<body>`, and that is a
+ * decision with a test behind it.** The browser walk reads whole screens as
+ * `page.innerText("main")`, and the create, edit and read flows for agents,
+ * connections, personas and tests are all moving into this panel. A panel
+ * portaled to `body` is outside `main`, so every one of those reads would come
+ * back without the thing the person is actually looking at — and the
+ * expectation would be quietly false rather than loudly broken.
+ *
+ * `SheetHost` is what makes that possible: `ui/shell.tsx` renders one at the
+ * end of every product page, and this file's portal aims at it. The panel is
+ * still `position: fixed`, so the scrim covers the whole viewport including
+ * the sidebar, which is outside `main` — the DOM position changes what a text
+ * read finds, not where anything is drawn. With no host in the tree (a
+ * component test rendering a sheet on its own) Radix falls back to `body`,
+ * which is the behaviour that was there before.
  */
+
+/**
+ * Where a sheet's panel is put, published by the product page that owns it.
+ *
+ * It is state rather than a ref because a portal target has to exist *before*
+ * the portal renders into it, and a ref does not tell React that it now does.
+ * The callback ref below sets state, the host renders a second time, and the
+ * value the context carries on that pass is a real element.
+ */
+const SheetRootContext = createContext<HTMLElement | null>(null);
+
+/**
+ * One product page's sheet container, drawn last inside its `<main>`.
+ *
+ * It draws nothing: no size, no padding, nothing that could take a line of the
+ * page's own layout. What it is, is an address.
+ */
+function SheetHost({ children }: { readonly children: ReactNode }) {
+  const [root, setRoot] = useState<HTMLElement | null>(null);
+
+  return (
+    <SheetRootContext.Provider value={root}>
+      {children}
+      <div data-slot="sheet-root" ref={setRoot} />
+    </SheetRootContext.Provider>
+  );
+}
 
 function Sheet(props: ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="sheet" {...props} />;
@@ -54,8 +103,24 @@ function SheetClose(props: ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
+/**
+ * The portal, aimed at the page's own host.
+ *
+ * `container` is left off entirely when there is no host, rather than passed as
+ * `null`: Radix reads an explicit `null` as "no container" and falls back to
+ * `body`, which is what we want, but saying nothing is what keeps that a
+ * fallback rather than a second code path.
+ */
 function SheetPortal(props: ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />;
+  const root = useContext(SheetRootContext);
+
+  return (
+    <DialogPrimitive.Portal
+      data-slot="sheet-portal"
+      {...(root === null ? {} : { container: root })}
+      {...props}
+    />
+  );
 }
 
 function SheetOverlay({
@@ -90,7 +155,7 @@ function SheetContent({
       <DialogPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "fixed inset-y-0 right-0 z-30 flex w-[min(440px,100vw)] flex-col gap-5",
+          "fixed inset-y-0 right-0 z-30 flex w-[min(var(--sheet-width),100vw)] flex-col gap-5",
           "border-l border-border bg-surface p-6 text-foreground shadow-modal",
           "outline-none",
           className,
@@ -250,6 +315,7 @@ export {
   SheetDescription,
   SheetFooter,
   SheetHeader,
+  SheetHost,
   SheetOverlay,
   SheetPortal,
   SheetTitle,

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -72,6 +72,34 @@ function SidebarProvider({
 }
 
 /**
+ * The bar the Egma wordmark stands in, at the very top.
+ *
+ * **The wordmark is here because the developer put it here**, on 2026-08-23,
+ * looking at the boards: "our logo, not the organization's". `DESIGN.md` used
+ * to say the signed-in sidebar does not repeat the full logo and asked for
+ * explicit approval to change that; the instruction *is* the approval, and
+ * `DESIGN.md` records it as such.
+ *
+ * 56px tall over a hairline, which is exactly the topbar beside it (`73A-0`
+ * and `71V-0` are both 56). The two bars line up across the whole application
+ * because they read the same two theme values, not because somebody matched
+ * them once.
+ */
+function SidebarBrand({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-brand"
+      className={cn(
+        "flex h-(--sidebar-header-height) w-full min-w-0 flex-none items-center",
+        "border-b border-border px-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
  * The topmost slot, which holds the organization and project switcher.
  *
  * `min-w-0` is the load-bearing part: the switcher names an organization and a
@@ -198,7 +226,12 @@ function SidebarGroupLabel({ className, ...props }: ComponentProps<"h2">) {
       data-slot="sidebar-group-label"
       id={labelId ?? undefined}
       className={cn(
-        "mt-0 mb-1 px-3 text-sm text-faint tracking-(--tracking-label) uppercase",
+        /*
+         * `my-0`: the group's own 4px gap is the space under the label, and a
+         * margin of the label's as well made it 8. The boards put the label
+         * one gap above its first row like every other pair in the column.
+         */
+        "my-0 px-3 text-sm text-faint tracking-(--tracking-label) uppercase",
         className,
       )}
       {...props}
@@ -292,7 +325,13 @@ function SidebarMenuButton({
         "pointer-hover:data-[active=false]:bg-surface-soft pointer-hover:data-[active=false]:text-foreground",
         "data-[active=true]:bg-selected data-[active=true]:text-foreground",
         "data-[active=true]:before:bg-brand",
-        "data-[active=true]:[&_svg]:text-brand",
+        /*
+         * The icon follows the row's own colour rather than turning Ember. The
+         * boards draw the lit row's symbol in ink beside ink text (`72T-0`),
+         * and they are right to: the Ember mark on the left edge is already
+         * the brand signal, and a second one inside the row makes the two
+         * compete for the same job.
+         */
         className,
       )}
       onClick={(event: MouseEvent<HTMLButtonElement>) => {
@@ -305,6 +344,7 @@ function SidebarMenuButton({
 }
 
 export {
+  SidebarBrand,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -1,0 +1,136 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The table, as the parts the boards draw it from.
+ *
+ * Read off `6ZM-0`, `71F-0` and `710-0` with `get_computed_styles` on
+ * 2026-08-23: a Pure Paper panel inside one neutral hairline with the corners
+ * clipped and no corner radius; a 40px header row of quiet 14px labels over a
+ * hairline; body rows at least 52px tall with 8px of vertical padding, 16px of
+ * side padding and a hairline between them; and a 48px slot at the trailing
+ * edge that every row carries whether or not it holds a menu.
+ *
+ * **`TablePanel` is separate from `Table`, which is where this leaves the
+ * registry.** shadcn's `Table` renders its own scrolling wrapper around the
+ * `<table>`. This product's table is a *panel* — the border and the surface
+ * belong to the frame, not to the element — and the same frame has to carry the
+ * container query that makes a narrow table stack. Welding the two together
+ * would mean `ui/data-table.tsx` reaching inside a primitive to add a class to
+ * a `<div>` it cannot name.
+ *
+ * Nothing here holds a colour, a size or a radius of its own. The last column's
+ * width is `--table-action-width`, declared in `tailwind-theme.css` beside the
+ * row heights it lines up with.
+ */
+
+/** The bordered surface a table is drawn on. */
+function TablePanel({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="table-panel"
+      className={cn(
+        "overflow-x-auto rounded-card border border-border bg-surface",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function Table({ className, ...props }: ComponentProps<"table">) {
+  return (
+    <table
+      data-slot="table"
+      className={cn("w-full border-collapse text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function TableHeader({ className, ...props }: ComponentProps<"thead">) {
+  return <thead data-slot="table-header" className={cn(className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: ComponentProps<"tbody">) {
+  return <tbody data-slot="table-body" className={cn(className)} {...props} />;
+}
+
+function TableFooter({ className, ...props }: ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn("border-t border-border", className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: ComponentProps<"tr">) {
+  return <tr data-slot="table-row" className={cn(className)} {...props} />;
+}
+
+/**
+ * A column's name: quiet, regular weight, and the same 14px the rows are at.
+ *
+ * `DESIGN.md`: "Headers are quiet, regular-weight labels." The height is fixed
+ * rather than a minimum, because a header holds one word and has nothing to
+ * grow for.
+ */
+function TableHead({ className, ...props }: ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-(--row-height) border-b border-border px-(--row-padding-x)",
+        "text-left font-normal whitespace-nowrap text-faint",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * One fact in one row.
+ *
+ * The height is a minimum. A cell holding two connection links and an overflow
+ * chip is taller than one holding a date, and a fixed height would either clip
+ * it or make every row as tall as the tallest thing any row could hold.
+ */
+function TableCell({ className, ...props }: ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "border-t border-border align-middle",
+        "px-(--row-padding-x) py-(--row-padding-y)",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TablePanel,
+  TableRow,
+};

--- a/apps/web/components/ui/tabs.tsx
+++ b/apps/web/components/ui/tabs.tsx
@@ -182,8 +182,6 @@ function TabsTrigger({
            * with every tab below it.
            */
           "group-data-[orientation=horizontal]/tabs:group-data-[variant=line]/tabs-list:first:pl-0",
-          "group-data-[orientation=horizontal]/tabs:group-data-[variant=line]/tabs-list:rounded-b-none",
-          "group-data-[orientation=vertical]/tabs:group-data-[variant=line]/tabs-list:rounded-r-none",
           /*
            * The mark, drawn for the current tab and colourless for the rest.
            *

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -1619,7 +1619,18 @@ describe("the role the shell shows", () => {
     expect(sessionReads).toHaveLength(2);
   });
 
-  it("starts the signed-in sidebar with project context, not a repeated logo", () => {
+  /**
+   * The bar starts with the Egma wordmark, and the project context is under it.
+   *
+   * **This assertion was the other way round until 2026-08-23.** `DESIGN.md`
+   * kept the full logo out of the signed-in sidebar and asked for explicit
+   * approval to change that rule; the developer gave it, looking at the Paper
+   * boards — "our logo, not the organization's" — and `DESIGN.md` records the
+   * decision with its date. The organization did not disappear with the change:
+   * it moved into the eyebrow above the project name, which is what the second
+   * half of this case holds.
+   */
+  it("starts the signed-in sidebar with the Egma wordmark, then project context", () => {
     render(
       <AppShell initialMe={meWith("admin")}>
         <p>page</p>
@@ -1627,9 +1638,16 @@ describe("the role the shell shows", () => {
     );
 
     const sidebar = screen.getByRole("complementary");
+    const wordmark = within(sidebar).getByRole("img", { name: /egma/i });
+    expect(wordmark.getAttribute("src")).toBe("/brand/egma-wordmark.svg");
+    expect(
+      within(sidebar).getByRole("link", { name: "Egma home" }).getAttribute("href"),
+    ).toBe("/");
+
     const firstControl = sidebar.querySelector("button");
     expect(firstControl?.getAttribute("aria-label")).toMatch(/^Organization Acme/);
-    expect(within(sidebar).queryByRole("img", { name: /egma/i })).toBeNull();
+    /* The organization is the eyebrow now; the project is the line you press. */
+    expect(within(sidebar).getByText("Acme")).toBeTruthy();
   });
 
   it("keeps navigation icons decorative and every label visible", () => {

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -460,6 +460,40 @@ describe("nested page navigation", () => {
     expect(screen.getAllByText("Runs")).toHaveLength(1);
     expect(screen.getByRole("heading", { name: "Nightly smoke" })).toBeTruthy();
   });
+
+  /**
+   * The other half of the rule above, and it needs its own case.
+   *
+   * A page with no trail still says which section it is in, and on one screen
+   * that label is a *fact* rather than a repetition: the transcript page puts
+   * the trace's source and environment in it — "production / default" — and
+   * states it nowhere else. Sixty-four call sites pass this prop, so a version
+   * of `PageHeader` that accepted it and quietly drew nothing would take a
+   * line off every one of them and break no test at all. This is that test.
+   *
+   * It is not in the title bar. The bar holds the page title alone, which is
+   * what `71V-0` draws; the label and the purpose statement are the quiet
+   * block under it.
+   */
+  it("draws the eyebrow when a page offers no trail, outside the title bar", () => {
+    render(
+      <PageHeader
+        eyebrow="production / default"
+        title="Nightly smoke"
+        lead="What this run was for."
+      />,
+    );
+
+    const label = screen.getByText("production / default");
+    expect(label).toBeTruthy();
+    expect(label.closest('[data-slot="page-topbar"]')).toBeNull();
+    expect(label.closest('[data-slot="page-toolbar"]')).not.toBeNull();
+
+    const title = screen.getByRole("heading", { name: "Nightly smoke" });
+    expect(title.closest('[data-slot="page-topbar"]')).not.toBeNull();
+    /* One header holds both, which is how a page finds its own controls. */
+    expect(title.closest("header")).toBe(label.closest("header"));
+  });
 });
 
 /* ------------------------------------------------------------------------ */

--- a/apps/web/test/design-system.test.tsx
+++ b/apps/web/test/design-system.test.tsx
@@ -131,13 +131,21 @@ describe("the development design proof", () => {
     /*
      * These are class assertions rather than colour assertions because jsdom
      * loads no stylesheet. What they guard is the mapping: the primary action
-     * asks for the theme's `primary`, and `tailwind-theme.css` is what makes
-     * `primary` mean Deep Ember. The colours themselves are proved in a real
-     * browser, by reading the computed value back off the element.
+     * asks for the theme's `primary-wash` fill and `primary` ink, and
+     * `tailwind-theme.css` is what makes those mean Ember Wash and Deep Ember.
+     * The colours themselves are proved in a real browser, by reading the
+     * computed value back off the element.
+     *
+     * **The primary is the wash button as of 2026-08-23.** It used to be a
+     * Deep Ember block with white text; the developer retired that looking at
+     * the Paper boards, so a filled fill here would be the old rule coming
+     * back rather than a passing test.
      */
     const start = screen.getByRole("button", { name: "Start run" });
     expect(start.getAttribute("data-slot")).toBe("button");
-    expect(start.className).toContain("bg-primary");
+    expect(start.className).toContain("bg-primary-wash");
+    expect(start.className).toContain("text-primary");
+    expect(start.className).not.toContain("text-primary-foreground");
     expect(start.className).toContain("rounded-button");
 
     /* The secondary action is the outlined kind, never a filled grey one. */
@@ -154,17 +162,63 @@ describe("the development design proof", () => {
       .getAllByText("Passed")
       .filter((node) => node.getAttribute("data-slot") === "badge");
     /*
-     * Two of them and one component: the chip block on the base panel, and the
-     * same chip beside a verdict in the project-context panel. That second one
-     * was the CSS Modules chip until the mop-up, so every match is read rather
-     * than only the first.
+     * Three of them and one component: the chip block on the base panel, the
+     * same chip beside a verdict in the project-context panel, and the same
+     * chip again inside the dark-theme frame. The second was the CSS Modules
+     * chip until the mop-up and the third is what proves the component carries
+     * both themes, so every match is read rather than only the first.
      */
-    expect(chips).toHaveLength(2);
+    expect(chips).toHaveLength(3);
     for (const chip of chips) {
       expect(chip.className).toContain("border-success-border");
       expect(chip.className).not.toContain("brand");
       expect(chip.className).not.toContain("primary");
     }
+  });
+
+  /**
+   * The side sheet: the surface the boards create, read and edit one record in.
+   *
+   * It is asserted on the slot its motion is keyed to, exactly as the dialog
+   * below is, and on the three things a form panel has to have — a title, a
+   * body to fill in, and a footer with the answer and the way out.
+   */
+  it("opens the side sheet on the slot its motion is keyed to", () => {
+    render(<DesignSystemProof />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open connection" }));
+
+    const sheet = screen.getByRole("dialog", { name: "phone" });
+    expect(sheet.getAttribute("data-slot")).toBe("sheet-content");
+    expect(within(sheet).getByLabelText("Phone number")).toBeTruthy();
+    expect(within(sheet).getByRole("button", { name: "Save connection" })).toBeTruthy();
+    expect(within(sheet).getByRole("button", { name: "Delete" })).toBeTruthy();
+
+    fireEvent.click(within(sheet).getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog", { name: "phone" })).toBeNull();
+  });
+
+  /**
+   * Both themes, on one page, at the same time.
+   *
+   * `DESIGN.md`: "Every shared component must support light and dark themes."
+   * The frame carries `data-theme="dark"`, which is the attribute the theme
+   * binds its dark values to, so what is inside it is drawn on the dark tokens
+   * while the page around it stays light.
+   */
+  it("draws the shared components on the dark tokens beside the light ones", () => {
+    render(<DesignSystemProof />);
+
+    const dark = screen.getByRole("region", {
+      name: "Dark theme component preview",
+    });
+    expect(dark.getAttribute("data-theme")).toBe("dark");
+    expect(
+      within(dark).getByRole("button", { name: "Connect an agent" }).className,
+    ).toContain("bg-primary-wash");
+    expect(
+      within(dark).getByRole("table", { name: "Proof agents in dark theme" }),
+    ).toBeTruthy();
   });
 
   it("opens the base dialog on the slot its motion is keyed to", () => {

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -381,7 +381,18 @@ describe("the grader library, in one project", () => {
     const cell = used.closest("td");
     expect(cell).not.toBeNull();
     expect(cell?.dataset.action).toBe("true");
-    expect(cell?.className).toContain("data-[action=true]:text-right");
+    /*
+     * **The trailing edge is a fixed lane now, not an alignment.** The Paper
+     * boards give every row the same 48px slot at its end — present whether or
+     * not that row has a control in it — so the controls line up in one column
+     * down the table instead of each floating to the right of whatever text
+     * came before it. `--table-action-width` is the lane and the cell centres
+     * its control in it, so the class that says so is `text-center` rather
+     * than the `text-right` this used to read. What the case is about has not
+     * moved: the row's control is at the row's trailing edge.
+     */
+    expect(cell?.className).toContain("data-[action=true]:text-center");
+    expect(cell?.className).toContain("data-[action=true]:px-0");
   });
 
   it("shows a refused Use without clearing the form", async () => {

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -344,12 +344,18 @@ describe("the grouped sidebar", () => {
   });
 
   /**
-   * The switcher stays topmost and the account control stays at the bottom.
-   * Both keep the implementations they shipped with; what this asserts is that
-   * the groups landed *between* them rather than around them — which is also
-   * the order a keyboard walks the bar in.
+   * The wordmark leads the bar, the switcher follows it, and the account
+   * control stays at the bottom. What this asserts is that the groups landed
+   * *between* them rather than around them — which is also the order a
+   * keyboard walks the bar in.
+   *
+   * **The wordmark is first, and that is the 2026-08-23 ruling.** The
+   * developer put the Egma logo back at the top of the signed-in sidebar
+   * — "our logo, not the organization's" — so the first thing a keyboard
+   * reaches in the bar is a link home, and the organization moved into the
+   * eyebrow above the project name where the switcher now stands.
    */
-  it("keeps the switcher above the groups and the account control below them", () => {
+  it("leads with the wordmark, then the switcher, and ends with the account", () => {
     drawShell();
 
     const bar = sidebarNavigation().closest("aside");
@@ -361,12 +367,15 @@ describe("the grouped sidebar", () => {
     const at = (node: HTMLElement | null) =>
       node === null ? -1 : order.indexOf(node);
 
+    const wordmark = within(bar!).getByRole("link", { name: "Egma home" });
     const switcher = within(bar!).getByRole("button", { name: /^Organization Acme/ });
     const account = within(bar!).getByRole("button", { name: /account menu$/ });
     const agents = within(bar!).getByRole("link", { name: "Agents" });
     const transcripts = within(bar!).getByRole("link", { name: "Transcripts" });
 
-    expect(at(switcher)).toBe(0);
+    expect(at(wordmark)).toBe(0);
+    expect(wordmark.getAttribute("href")).toBe("/");
+    expect(at(switcher)).toBe(1);
     expect(at(switcher)).toBeLessThan(at(agents));
     expect(at(agents)).toBeLessThan(at(transcripts));
     expect(at(transcripts)).toBeLessThan(at(account));

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -3,6 +3,15 @@
 import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TablePanel,
+  TableRow,
+} from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
 /**
@@ -18,6 +27,13 @@ import { cn } from "@/lib/utils";
  * **A row is a line of reading, not a card.** The height is a token, cells do
  * not wrap, and the vertical padding is deliberately small: a list of forty
  * agents should be a list of forty agents rather than four screens of scroll.
+ *
+ * **The frame is the kit's `Table`, and the numbers are the boards'.** A Pure
+ * Paper panel inside one hairline with no corner; a 40px header of quiet
+ * labels; rows at least 52px with a hairline between them and none after the
+ * last; and a fixed 48px slot at the trailing edge that every row carries, so
+ * the ⋮ menus line up in one lane down the table whether or not a given row
+ * has one. Read off `6ZM-0`, `71F-0` and `710-0` on 2026-08-23.
  *
  * Paging is keyset, so "more" means *carry on from where that page stopped*
  * rather than *skip a number of rows*. The control is here rather than in each
@@ -97,36 +113,51 @@ export function DataTable<Row>({
 }) {
   const primary = columns.find((column) => column.primary) ?? columns[0];
   const pageLabel = pagination?.pageLabel(pagination.page);
+  /**
+   * How wide a column is, and the one width this component decides for itself.
+   *
+   * A row control's slot is the theme's, not the caller's: it is what makes
+   * the trailing lane straight, and a page choosing its own would bend it. A
+   * caller may still say `width` on any other column.
+   *
+   * It is written on the header cell alone. A column width set there governs
+   * the whole column, and a width on the body cells as well would survive into
+   * the stacked layout — where the cells are no longer a table and a 48px
+   * "column" is a 48px box with a menu falling out of it.
+   */
+  function widthOf(column: Column<Row>): string | undefined {
+    if (column.action === true) return "var(--table-action-width)";
+    return column.width;
+  }
   function mobileHidden(column: Column<Row>): "true" | undefined {
     return column !== primary && column.hideOnMobile === true ? "true" : undefined;
   }
 
   return (
     <div className={stackWhenConstrained ? "@container/data-table" : undefined}>
-      <div
+      <TablePanel
         className={cn(
-          "overflow-x-auto rounded-card border border-border bg-surface",
           /* Stacked rows are not a scrolling region; they are the page. */
           "stacked:overflow-visible",
         )}
       >
-        <table
-          className="w-full border-collapse stacked:block"
-          aria-label={label}
-        >
+        <Table className="stacked:block" aria-label={label}>
           {/*
            * The headers are read out in both layouts and drawn in one. Stacked
            * rows carry their own label on each cell, so a visible header row
            * would be the same word twice.
            */}
-          <thead className="stacked:sr-only">
-            <tr>
+          <TableHeader className="stacked:sr-only">
+            <TableRow>
               {columns.map((column) => (
-                <th
+                <TableHead
                   className={cn(
-                    "border-b border-border px-(--row-padding-x) py-2",
-                    "text-left text-sm font-normal tracking-normal whitespace-nowrap text-faint",
-                    "data-[action=true]:text-right",
+                    /*
+                     * The trailing slot is empty in the header and still
+                     * present: it is what holds the lane open above the first
+                     * ⋮, which is where a person's eye starts down it.
+                     */
+                    "data-[action=true]:px-0",
                     column.hideOnMobile === true &&
                       column !== primary &&
                       "max-[900px]:hidden",
@@ -135,16 +166,19 @@ export function DataTable<Row>({
                   data-mobile-hidden={mobileHidden(column)}
                   key={column.key}
                   scope="col"
-                  style={{ width: column.width }}
+                  style={{ width: widthOf(column) }}
                 >
-                  {column.header}
-                </th>
+                  {column.action === true ? "" : column.header}
+                  {column.action === true ? (
+                    <span className="sr-only">{column.header}</span>
+                  ) : null}
+                </TableHead>
               ))}
-            </tr>
-          </thead>
-          <tbody className="stacked:block">
+            </TableRow>
+          </TableHeader>
+          <TableBody className="stacked:block">
             {rows.map((row) => (
-              <tr
+              <TableRow
                 className={cn(
                   "[&:first-child>td]:border-t-0",
                   "stacked:flex stacked:flex-col stacked:gap-1",
@@ -158,11 +192,10 @@ export function DataTable<Row>({
                 key={keyOf(row)}
               >
                 {columns.map((column) => (
-                  <td
+                  <TableCell
                     className={cn(
-                      "h-(--row-height) border-t border-border align-middle",
-                      "px-(--row-padding-x) py-(--row-padding-y) text-sm text-muted-foreground",
-                      "data-[action=true]:text-right",
+                      "h-(--row-min-height) text-muted-foreground",
+                      "data-[action=true]:px-0 data-[action=true]:text-center",
                       "stacked:flex stacked:h-auto stacked:min-h-0 stacked:items-baseline",
                       "stacked:justify-between stacked:gap-3 stacked:border-0 stacked:p-0",
                       column === primary
@@ -194,7 +227,13 @@ export function DataTable<Row>({
                     <span
                       className={cn(
                         "block overflow-hidden text-ellipsis whitespace-nowrap",
-                        column === primary && "font-medium text-foreground",
+                        /*
+                         * The name of the row, at the ordinary weight. The
+                         * boards write it in the same 400 as the facts beside
+                         * it and let the underline and the column position say
+                         * which one names the row.
+                         */
+                        column === primary && "text-foreground",
                         column.mono === true && "font-mono text-sm",
                         /*
                          * The action cell's own shape, read off the cell it
@@ -204,7 +243,7 @@ export function DataTable<Row>({
                          * the trailing edge — not a label beside whatever does.
                          */
                         "in-data-[action=true]:flex in-data-[action=true]:items-center",
-                        "in-data-[action=true]:justify-end",
+                        "in-data-[action=true]:justify-center",
                         "in-data-[action=true]:overflow-visible in-data-[action=true]:text-clip",
                         column !== primary &&
                           "stacked:min-w-0 stacked:max-w-[70%] stacked:text-right",
@@ -214,13 +253,13 @@ export function DataTable<Row>({
                     >
                       {column.cell(row)}
                     </span>
-                  </td>
+                  </TableCell>
                 ))}
-              </tr>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
-      </div>
+          </TableBody>
+        </Table>
+      </TablePanel>
 
       {more === undefined ? null : (
         <div className="mt-4 flex items-center justify-between gap-4 text-xs text-muted-foreground">

--- a/apps/web/ui/dialog.tsx
+++ b/apps/web/ui/dialog.tsx
@@ -66,14 +66,16 @@ const PANEL_SHAPE = {
     "overflow-y-auto border-y-0 border-l-0",
   ],
   /*
-   * **One side sheet look, at one width.** This is the same panel
-   * `components/ui/sheet.tsx` draws — right-anchored, `--sheet-width` wide,
-   * Pure Paper behind a hairline on its left edge, no corner — and the width
-   * is the theme's rather than a second number here. The two components are
-   * still two: this one is a *reading* surface that deliberately leaves the
-   * page beside it usable, and that one is a modal form portaled inside
-   * `<main>`. They differ in what they do and no longer in what they look
-   * like.
+   * **One side sheet look, in two sizes.** This is the same panel
+   * `components/ui/sheet.tsx` draws — right-anchored, Pure Paper behind a
+   * hairline on its left edge, no corner, the same travel — and both widths
+   * are the theme's rather than numbers written here.
+   *
+   * The two components are still two, and the difference is behaviour: this
+   * one is a *reading* surface that deliberately leaves the page beside it
+   * usable, and that one is a modal form portaled inside `<main>`.
+   * `size="wide"` is for the reading surface, where the content is a
+   * transcript rather than a form and 440px is not enough of a page.
    */
   sheet: [
     "top-0 right-0 left-auto h-full max-h-none",
@@ -84,25 +86,15 @@ const PANEL_SHAPE = {
 } as const;
 
 /**
- * The travel of each edge kind — and there is none left to write here.
+ * The wider panel, for a surface that is read rather than filled in.
  *
- * Both movements are in `tailwind-theme.css` now, keyed on `data-kind`, as
- * animations of their own at the drawer's tokens. An animation rather than a
- * transition, because Radix removes a panel on `animationend`: whatever is
- * animating is what holds the panel on screen while it leaves, and a
- * transition racing the centred dialog's `scale` is what used to cut the sheet
- * off at its own edge.
- *
- * The sheet used to travel on a transition at the *dialog's* tokens, with a
- * `@starting-style` to give the entrance somewhere to come from and four more
- * rules to give reduced motion a form. It shares the drawer's rule now, so it
- * shares the drawer's reduced-motion form as well: nothing travels, and the
- * opacity says a surface arrived and left.
+ * Only the sheet has one. A dialog is a question and a drawer is a list of
+ * places to go; neither gets bigger by holding more.
  */
-const PANEL_TRAVEL = {
+const PANEL_WIDE = {
   dialog: "",
   drawer: "",
-  sheet: "",
+  sheet: "w-[min(var(--sheet-width-wide),100vw)]",
 } as const;
 
 /** A sheet's head is a fixed bar over a body that scrolls under it. */
@@ -164,12 +156,18 @@ const TAKES_THE_SCREEN = { dialog: true, drawer: true, sheet: false } as const;
 
 export function Dialog({
   kind = "dialog",
+  size = "default",
   title,
   onClose,
   returnFocusTo,
   children,
 }: {
   readonly kind?: "dialog" | "drawer" | "sheet";
+  /**
+   * How much room the surface needs. `wide` is the reading sheet — evidence
+   * beside a page — and does nothing to the other two kinds.
+   */
+  readonly size?: "default" | "wide";
   readonly title: string;
   readonly onClose: () => void;
   /** A known trigger to restore when the surface closes. */
@@ -250,7 +248,7 @@ export function Dialog({
       }}
     >
       <DialogContent
-        className={cn(PANEL_SHAPE[kind], PANEL_TRAVEL[kind])}
+        className={cn(PANEL_SHAPE[kind], size === "wide" && PANEL_WIDE[kind])}
         data-kind={kind}
         /*
          * Every caller writes its own body, and most bodies are not one

--- a/apps/web/ui/dialog.tsx
+++ b/apps/web/ui/dialog.tsx
@@ -63,46 +63,46 @@ const PANEL_SHAPE = {
   drawer: [
     "top-0 left-0 h-full max-h-none",
     "w-[min(340px,calc(100vw-var(--space-7)))] translate-x-0 translate-y-0",
-    "overflow-y-auto rounded-[0_var(--radius-lg)_var(--radius-lg)_0]",
-    "border-y-0 border-l-0",
+    "overflow-y-auto border-y-0 border-l-0",
   ],
+  /*
+   * **One side sheet look, at one width.** This is the same panel
+   * `components/ui/sheet.tsx` draws — right-anchored, `--sheet-width` wide,
+   * Pure Paper behind a hairline on its left edge, no corner — and the width
+   * is the theme's rather than a second number here. The two components are
+   * still two: this one is a *reading* surface that deliberately leaves the
+   * page beside it usable, and that one is a modal form portaled inside
+   * `<main>`. They differ in what they do and no longer in what they look
+   * like.
+   */
   sheet: [
     "top-0 right-0 left-auto h-full max-h-none",
-    "w-[min(640px,100vw)] translate-x-0 translate-y-0",
-    "gap-0 overflow-hidden rounded-none border-y-0 border-r-0 p-0",
+    "w-[min(var(--sheet-width),100vw)] translate-x-0 translate-y-0",
+    "gap-0 overflow-hidden border-y-0 border-r-0 p-0",
     "max-[40rem]:w-full max-[40rem]:border-l-0",
   ],
 } as const;
 
 /**
- * The travel of the sheet, which is the one edge kind the theme does not move.
+ * The travel of each edge kind — and there is none left to write here.
  *
- * The drawer's movement is in `tailwind-theme.css`, keyed on `data-kind`, as an
- * animation of its own at the drawer's own tokens — an animation, because Radix
- * removes a panel on `animationend` and so whatever is animating is what holds
- * the panel on screen while it leaves. A sheet has no token pair of its own, so
- * it travels on a transition at the dialog's two, which the theme's `scale`
- * animation is exactly as long as. `@starting-style` is what makes the entrance
- * a movement: without it a panel that mounts already open has nowhere to travel
- * from.
+ * Both movements are in `tailwind-theme.css` now, keyed on `data-kind`, as
+ * animations of their own at the drawer's tokens. An animation rather than a
+ * transition, because Radix removes a panel on `animationend`: whatever is
+ * animating is what holds the panel on screen while it leaves, and a
+ * transition racing the centred dialog's `scale` is what used to cut the sheet
+ * off at its own edge.
  *
- * **Reduced motion removes the travel from both ends, not just the entrance.**
- * Dropping the transition alone left the exit teleporting: the closed position
- * still applied, so the panel jumped off the edge in one frame with nothing
- * left to say it had gone. So the closed position is put back where the open
- * one is, and the opacity the theme still runs is what says a surface left.
+ * The sheet used to travel on a transition at the *dialog's* tokens, with a
+ * `@starting-style` to give the entrance somewhere to come from and four more
+ * rules to give reduced motion a form. It shares the drawer's rule now, so it
+ * shares the drawer's reduced-motion form as well: nothing travels, and the
+ * opacity says a surface arrived and left.
  */
 const PANEL_TRAVEL = {
   dialog: "",
   drawer: "",
-  sheet: [
-    "transition-[translate] duration-(--duration-dialog-in) ease-out",
-    "starting:translate-x-full",
-    "data-[state=closed]:translate-x-full",
-    "data-[state=closed]:duration-(--duration-dialog-out)",
-    "motion-reduce:transition-none",
-    "motion-reduce:data-[state=closed]:translate-x-0!",
-  ],
+  sheet: "",
 } as const;
 
 /** A sheet's head is a fixed bar over a body that scrolls under it. */

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -210,7 +210,8 @@ export function Menu({
              * visible margin round a list of four words.
              */
             "w-max p-1",
-            "min-w-[min(240px,calc(100vw-var(--space-8)))]",
+            /* 210px, which is what the boards draw a row menu at (`9AH-0`). */
+            "min-w-[min(var(--menu-width),calc(100vw-var(--space-8)))]",
             "max-w-[min(320px,calc(100vw-var(--space-8)))]",
             /*
              * A panel keeps a gap off the edge it was pushed against, and
@@ -286,7 +287,7 @@ export function MenuItem({
 
 export function MenuLabel({ children }: { readonly children: ReactNode }) {
   return (
-    <p className="m-0 px-3 pt-2 pb-1 text-2xs tracking-(--tracking-label) text-faint uppercase">
+    <p className="m-0 px-3 pt-2 pb-1 text-xs tracking-(--tracking-label) text-faint uppercase">
       {children}
     </p>
   );

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -204,7 +204,12 @@ export function Menu({
         </PopoverTrigger>
         <PopoverContent
           className={cn(
-            "w-max p-2",
+            /*
+             * 4px of padding, which is what the boards give a row menu
+             * (`9AH-0`): the items are 36px and they are the panel. Eight put a
+             * visible margin round a list of four words.
+             */
+            "w-max p-1",
             "min-w-[min(240px,calc(100vw-var(--space-8)))]",
             "max-w-[min(320px,calc(100vw-var(--space-8)))]",
             /*
@@ -281,12 +286,12 @@ export function MenuItem({
 
 export function MenuLabel({ children }: { readonly children: ReactNode }) {
   return (
-    <p className="m-0 px-3 pt-2 pb-1 text-xs tracking-(--tracking-label) text-faint uppercase">
+    <p className="m-0 px-3 pt-2 pb-1 text-2xs tracking-(--tracking-label) text-faint uppercase">
       {children}
     </p>
   );
 }
 
 export function MenuDivider() {
-  return <div className="my-2 h-px bg-border" role="separator" />;
+  return <div className="my-1 h-px bg-border" role="separator" />;
 }

--- a/apps/web/ui/project-selector.tsx
+++ b/apps/web/ui/project-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { ChevronDownIcon, ChevronsUpDownIcon } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 
@@ -34,62 +34,44 @@ import { Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
  */
 
 /**
- * The trigger, which is a card in the sidebar and a compact control on a phone.
+ * The trigger: two lines, no card, and no mark.
  *
- * **The card is what the developer asked for after seeing the bar beside a
- * competitor's.** It carries four things and they answer four questions in one
- * glance: a square mark with the organization's initial (*which* organization,
- * before any word is read), a quiet eyebrow naming what the primary line is,
- * the organization name, and the project under it. The chevron points the way
- * the menu opens.
+ * **The card went when the wordmark arrived.** It used to carry a square with
+ * the organization's initial, a quiet "ORGANIZATION" eyebrow, the organization
+ * name and the project under it — four things, because the top of the bar had
+ * to answer *which Egma is this* on its own. It does not any more: the
+ * wordmark bar above says the product, so this block says the two things left,
+ * and the boards draw them as plain type on the sidebar's own surface
+ * (`734-0`).
  *
- * **The Egma mark is deliberately not the avatar.** `DESIGN.md` keeps the full
- * logo out of the signed-in sidebar, and a logo here would say *Egma* to a
- * person asking *which of my organizations am I in*. The initial answers the
- * question that is actually being asked.
+ * The **organization is the eyebrow** now and the **project is the primary
+ * line** — the developer's ruling of 2026-08-23, and the right way round: the
+ * project is what a person changes and the organization is the one thing they
+ * cannot. 12px for the eyebrow and 14px for the name, both read off the board.
  *
  * **This is a restyle of the trigger and nothing else.** Search, the keyboard
  * path, Escape, focus return, the unsaved-work guard and the origin-aware open
- * are the menu's, and none of them is touched below.
+ * are the menu's, and none of them is touched below. Its accessible name still
+ * names both, so nothing that reaches this control by name has moved.
  *
- * The compact form is the mobile top bar's, and it stays two lines. A card with
- * a mark and an eyebrow is a block, and the top bar is a 44px row shared with a
- * drawer button and a page title. The width it is held to used to be a rule in
- * the shell's stylesheet reaching in by class name. It is here now, on the one
- * prop that asks for it, because a shared component's own size should not
- * depend on which page happened to put it somewhere.
+ * The compact form is the mobile top bar's, where the control shares a 56px row
+ * with a drawer button and the account, so it stays held to a width of its own.
  */
 const TRIGGER = [
-  "grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center",
-  "gap-x-3 gap-y-1",
-  "min-h-[calc(var(--control-lg)+var(--space-5))] p-3",
-  "rounded-card border border-border bg-surface text-left",
+  "flex w-full min-w-0 flex-col items-stretch gap-1.5",
+  "border-0 bg-transparent p-0 text-left",
   "cursor-pointer transition-transform duration-(--duration-press) ease-out",
-  "pointer-coarse:min-h-(--tap-target)",
-  "pointer-hover:border-border-strong pointer-hover:bg-surface-soft",
   "[&:active:not(:focus-visible)]:scale-97",
   "motion-reduce:transition-none",
   "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
 ];
 
 const TRIGGER_COMPACT = [
-  "grid-cols-[minmax(0,1fr)_auto] gap-x-2 gap-y-0",
+  "flex-row items-center gap-2",
   "min-h-(--control-lg) max-w-[220px] rounded-input px-3 py-1",
+  "border border-border bg-surface",
+  "pointer-hover:border-border-strong pointer-hover:bg-surface-soft",
   "max-[900px]:min-w-0 max-[900px]:max-w-[min(220px,56vw)]",
-];
-
-/**
- * The square mark, which carries one letter and never a logo.
- *
- * It is neutral rather than Ember. Ember is this product's signal for focus,
- * for the current row and for a state that wants attention, and an avatar that
- * is always on would spend it on something that is never news. The open trigger
- * still turns, because the menu hands it `border-brand bg-selected`.
- */
-const MARK = [
-  "grid size-9 flex-none place-items-center",
-  "rounded-button border border-border bg-surface-soft",
-  "text-base leading-(--line-tight) font-medium text-foreground",
 ];
 
 export function ProjectSelector({
@@ -131,16 +113,6 @@ export function ProjectSelector({
   const projectName =
     current?.name ?? (projectId === null ? "No project" : "Unknown project");
 
-  /**
-   * The letter in the square, and a dash where there is no name to take one
-   * from. A membership with no organization would otherwise wear the N of
-   * "No organization" and look like an organization whose name starts with N.
-   */
-  const initial =
-    organization === undefined
-      ? "\u2013"
-      : organization.name.trim().slice(0, 1).toUpperCase() || "\u2013";
-
   function choose(project: Project, close: () => void): void {
     if (project.id === projectId) {
       close();
@@ -163,61 +135,49 @@ export function ProjectSelector({
     <Menu
       label={`Organization ${organizationName}, project ${projectName}. Choose a project`}
       triggerClassName={cn(TRIGGER, compact && TRIGGER_COMPACT)}
-      openClassName="border-brand bg-selected"
+      openClassName="[&_[data-slot=project-name]]:text-brand"
       placement={compact ? "below-start" : "right-start"}
       // A panel with a field to type in, so a dialog rather than a menu.
       panelRole="dialog"
       trigger={
         <>
           {/*
-           * The eyebrow takes the whole first row rather than sitting in the
-           * text column beside the mark, and it is measurement rather than
-           * taste: the docked bar is a 224px column, which leaves the text
-           * column 89px once the mark, the chevron and two gaps are out of it,
-           * and the word needs 119px. Across the card it has 167px. A fixed
-           * word that ellipses is a label saying it does not fit.
+           * The organization, quiet and above. It is not a choice — one person
+           * belongs to one organization in this version — so it is a label
+           * rather than something with a control on it.
            */}
           {compact ? null : (
-            <span className="col-span-3 block text-sm leading-(--line-tight) whitespace-nowrap text-faint uppercase tracking-(--tracking-label)">
-              Organization
-            </span>
-          )}
-          {compact ? null : (
-            <span className={cn(MARK)} aria-hidden="true">
-              {initial}
-            </span>
-          )}
-          <span className="min-w-0">
-            {/*
-             * Every line is one line, whatever the name. The tight line height
-             * is the 1.0 step rather than body text's 1.5, because these are
-             * labels stacked and not a paragraph.
-             */}
-            <span className="block overflow-hidden text-base leading-(--line-tight) font-medium text-ellipsis whitespace-nowrap text-foreground">
+            <span className="block overflow-hidden text-2xs leading-(--line-normal) text-ellipsis whitespace-nowrap text-faint">
               {organizationName}
             </span>
-            <span className="mt-1 block overflow-hidden text-sm leading-(--line-tight) font-normal text-ellipsis whitespace-nowrap text-muted-foreground">
+          )}
+          <span className="flex min-w-0 items-center justify-between gap-2">
+            <span
+              className="block overflow-hidden text-sm text-ellipsis whitespace-nowrap text-foreground"
+              data-slot="project-name"
+            >
               {projectName}
             </span>
+            {/*
+             * The chevron says the line under it can be changed. Down out of
+             * the top bar on a phone, where the panel drops; the two-way arrow
+             * in the docked bar, which is what the board draws and what a
+             * switcher wears everywhere else.
+             */}
+            {compact ? (
+              <ChevronDownIcon
+                className="block size-3 flex-none text-faint"
+                aria-hidden="true"
+                strokeWidth={1.75}
+              />
+            ) : (
+              <ChevronsUpDownIcon
+                className="block size-3 flex-none text-faint"
+                aria-hidden="true"
+                strokeWidth={1.75}
+              />
+            )}
           </span>
-          {/*
-           * The chevron points where the menu goes: right out of the bar on a
-           * wide screen, down out of the top bar on a narrow one. Same control,
-           * and it never promises a direction the panel does not take.
-           */}
-          {compact ? (
-            <ChevronDownIcon
-              className="block size-4 flex-none text-muted-foreground"
-              aria-hidden="true"
-              strokeWidth={1.75}
-            />
-          ) : (
-            <ChevronRightIcon
-              className="block size-4 flex-none text-muted-foreground"
-              aria-hidden="true"
-              strokeWidth={1.75}
-            />
-          )}
         </>
       }
     >

--- a/apps/web/ui/section.tsx
+++ b/apps/web/ui/section.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { SearchIcon } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
 
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 /**
@@ -87,13 +89,57 @@ export function Toolbar({
   readonly action?: ReactNode;
 }) {
   return (
-    <div className="mb-4 flex items-center justify-between gap-3 max-[900px]:flex-wrap">
+    /*
+     * 52px: a 36px control with the boards' 16px under it (`71N-0`). The gap
+     * is 20px because that is the gap the board leaves between the filters and
+     * the action, and the whole strip is held to the page's content maximum so
+     * the action lands over the last column of the table below it.
+     */
+    <div
+      data-slot="toolbar"
+      className={cn(
+        "flex w-full max-w-(--page-content-max) items-center justify-between gap-5 pb-4",
+        "max-[900px]:flex-wrap",
+      )}
+    >
       <div className="flex min-w-0 flex-wrap items-center gap-3">{children}</div>
       {action === undefined ? null : (
         <div className="flex flex-none flex-wrap items-center justify-end gap-3">
           {action}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * The search box every list is filtered with: 300 by 36, with a magnifier.
+ *
+ * **One box, one size, on every list page.** `71Q-0` is 300px wide and 36px
+ * tall with 12px of side padding and an 8px gap to the icon, and it is that on
+ * the agents board, the personas board and the tests board alike — which is the
+ * point of drawing it once here. A page that reached for a bare `Input` got a
+ * 44px form control that ran to whatever width was left.
+ *
+ * The icon is decoration: the field carries its own `aria-label`, and a
+ * magnifier read out as "search" beside a field already called "Search agents
+ * by name" is the word twice.
+ *
+ * `TOOLBAR_SEARCH` below is the same shape as a class list, for the pages that
+ * have not moved onto this component yet.
+ */
+export function SearchField({
+  className,
+  ...props
+}: ComponentProps<typeof Input>) {
+  return (
+    <div className={cn("relative flex-none", className)} data-slot="search-field">
+      <SearchIcon
+        className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-faint"
+        aria-hidden="true"
+        strokeWidth={1.75}
+      />
+      <Input type="search" className={cn(TOOLBAR_SEARCH, "pl-9")} {...props} />
     </div>
   );
 }
@@ -117,10 +163,15 @@ export function Toolbar({
  * which wins the main axis back from `width`: the box grows into whatever the
  * filters leave and stops at its maximum.
  */
-export const TOOLBAR_SEARCH = "min-w-[180px] w-full max-w-[380px] flex-1";
+export const TOOLBAR_SEARCH = [
+  "w-[300px] max-w-full min-h-(--control-md) text-sm",
+  /* One column on a phone, where 300px is most of the screen. */
+  "max-[900px]:w-full",
+].join(" ");
 
 /** A filter that chooses one value, held narrower than the search beside it. */
-export const TOOLBAR_FILTER = "w-auto max-w-[240px] min-w-[160px]";
+export const TOOLBAR_FILTER =
+  "w-auto max-w-[240px] min-w-[160px] min-h-(--control-md) text-sm";
 
 /** A group of controls that act on the thing the page is about. */
 export function Actions({ children }: { readonly children: ReactNode }) {

--- a/apps/web/ui/section.tsx
+++ b/apps/web/ui/section.tsx
@@ -164,7 +164,7 @@ export function SearchField({
  * filters leave and stops at its maximum.
  */
 export const TOOLBAR_SEARCH = [
-  "w-[300px] max-w-full min-h-(--control-md) text-sm",
+  "w-(--search-width) max-w-full min-h-(--control-md) text-sm",
   /* One column on a phone, where 300px is most of the screen. */
   "max-[900px]:w-full",
 ].join(" ");

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -23,8 +23,10 @@ import {
 } from "react";
 
 import { Badge } from "@/components/ui/badge";
+import { SheetHost } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import {
+  SidebarBrand,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
@@ -53,6 +55,7 @@ import {
   type PageNavigationItems,
 } from "./page-navigation.tsx";
 import { ProjectSelector } from "./project-selector.tsx";
+import { Toolbar } from "./section.tsx";
 import { settingsPath } from "./settings-nav.tsx";
 import { useTheme } from "./theme.tsx";
 
@@ -251,7 +254,14 @@ function Navigation({
 
   return (
     <SidebarProvider onNavigate={onNavigate}>
-      <SidebarContent asChild>
+      {/*
+       * The 16px gutter is the bar's, and it is on every block in the column
+       * rather than on the column itself. The wordmark bar's hairline has to
+       * run the full 224px, so the `<aside>` can carry no side padding — and
+       * the rows are 192px wide with their Ember mark exactly on the gutter,
+       * which is what the boards draw (`725-0`, `72Z-0`).
+       */}
+      <SidebarContent className="px-4" asChild>
         <nav aria-label="Product navigation">
           {groups.map((group) => (
             <SidebarGroup key={group.id} labelled={group.label !== null}>
@@ -342,7 +352,7 @@ function AccountMenu({
       label={`Account ${standing}. Open the account menu`}
       triggerClassName={cn(
         "grid w-full min-w-0 items-center gap-3",
-        "grid-cols-[var(--control-md)_minmax(0,1fr)] min-h-(--control-lg) p-2",
+        "grid-cols-[var(--control-md)_minmax(0,1fr)] min-h-(--control-lg) px-2 py-1",
         "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
         "transition-transform duration-(--duration-press) ease-out",
         "pointer-coarse:min-h-(--tap-target)",
@@ -372,7 +382,8 @@ function AccountMenu({
                 {standing}
               </span>
               {role === null ? null : (
-                <span className="block text-xs tracking-(--tracking-label) text-faint uppercase">
+                /* 12px: the micro label the boards give the role line (`720-0`). */
+                <span className="block text-2xs tracking-(--tracking-label) text-faint uppercase">
                   {canAuthor(role) ? role : VIEW_ONLY}
                 </span>
               )}
@@ -562,14 +573,38 @@ function ShellFrame({
        */}
       <aside
         className={cn(
-          "sticky top-0 z-20 flex h-svh flex-col gap-5 overflow-visible p-4",
+          "sticky top-0 z-20 flex h-svh flex-col gap-5 overflow-visible pb-4",
           "border-r border-border bg-surface",
           "max-[900px]:hidden",
         )}
       >
-        <SidebarHeader>{selector(false)}</SidebarHeader>
+        {/*
+         * The wordmark, and a link home.
+         *
+         * `[[data-theme=dark]_&]:invert` is the whole of the dark-theme
+         * treatment: the asset is black line art on nothing, so inverting it
+         * gives white line art on nothing. `DESIGN.md` forbids recolouring the
+         * logo and this does not recolour it — it is the same two-value mark,
+         * the way a black wordmark is printed white on a dark page.
+         */}
+        <SidebarBrand>
+          <Link
+            className="inline-flex items-center rounded-button no-underline"
+            href="/"
+            aria-label="Egma home"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              className="h-6 w-auto [[data-theme=dark]_&]:invert"
+              src="/brand/egma-wordmark.svg"
+              alt="Egma"
+              height={24}
+            />
+          </Link>
+        </SidebarBrand>
+        <SidebarHeader className="px-4">{selector(false)}</SidebarHeader>
         {shown === null ? null : <Navigation projectId={shown} pathname={pathname} />}
-        <SidebarFooter>
+        <SidebarFooter className="px-4">
           {role !== null && !canAuthor(role) ? (
             <Badge title="Your role can read, not author">{VIEW_ONLY}</Badge>
           ) : null}
@@ -586,7 +621,7 @@ function ShellFrame({
       <div className="flex min-w-0 flex-col bg-background">
         <header
           className={cn(
-            "sticky top-0 z-10 hidden h-(--topbar-height) items-center gap-3 px-4",
+            "sticky top-0 z-20 hidden h-(--topbar-height) items-center gap-3 px-4",
             "border-b border-border backdrop-blur-[12px]",
             /*
              * Nearly the raised surface, so what scrolls under the bar is felt
@@ -649,12 +684,28 @@ function ShellFrame({
 }
 
 /**
- * The page itself.
+ * The page itself: a 56px title bar, then the page's own toolbar, then its
+ * content, all inside 24px gutters.
+ *
+ * **The board's page is not centred and this one stopped being centred with
+ * it.** `6ZL-0` starts at the left gutter and runs to the right one. The
+ * maximum survives — a settings form on a 2560px monitor is still held to a
+ * readable width — but it is applied to the content rather than to the page,
+ * and without `mx-auto`, so the title in the bar and the first cell of the
+ * table under it are always on the same vertical line. Centring the page put
+ * them 8px apart at 1440.
  *
  * `wide` is for a page whose subject is wide by nature — a transcript beside
  * the timing of what happened during it, a run beside its simulations. It is a
  * different maximum and not a different layout, so a page asks for room rather
- * than styling itself.
+ * than styling itself. It is published as `--page-content-max` because the two
+ * blocks that read it, `PageHeader` and `PageBody`, are this component's
+ * siblings' children rather than its own props.
+ *
+ * **The sheet host is drawn last, inside `<main>`.** Every create, edit and
+ * read panel in the product is portaled into it, so the browser walk's
+ * `page.innerText("main")` reads what a person is actually looking at.
+ * `components/ui/sheet.tsx` records the whole argument.
  */
 export function ProductPage({
   wide = false,
@@ -669,106 +720,149 @@ export function ProductPage({
   return (
     <main
       className={cn(
-        "mx-auto w-full max-w-(--page-max) px-(--page-gutter) py-10",
-        "max-[900px]:px-4 max-[900px]:pt-5 max-[900px]:pb-8",
-        wide && "max-w-(--page-max-wide)",
+        "flex w-full min-w-0 flex-col",
+        "[--page-content-max:var(--page-max)]",
+        wide && "[--page-content-max:var(--page-max-wide)]",
         viewport && [
-          "flex h-svh min-h-0 flex-col overflow-hidden",
+          "h-svh min-h-0 overflow-hidden",
           "max-[900px]:h-[calc(100svh-var(--topbar-height))]",
           /*
            * Settings is a set of views rather than a long document: the page
            * title stays put and the body owns the remaining height. The rule
            * is on the page because only the page knows it was asked for a
-           * viewport.
+           * viewport. The bottom gutter goes with it — the body scrolls now,
+           * and its own last group already ends the page.
            */
           "[&>[data-slot=page-body]]:min-h-0",
           "[&>[data-slot=page-body]]:flex-1",
           "[&>[data-slot=page-body]]:overflow-hidden",
+          "[&>[data-slot=page-body]]:pb-0",
         ],
       )}
     >
-      {children}
+      <SheetHost>{children}</SheetHost>
     </main>
   );
 }
 
+/**
+ * The title bar, and the strip of controls under it.
+ *
+ * **The title moved into a bar of its own**, 56px tall over a hairline with
+ * 24px of side padding, which is `71V-0`. It is where a person looks to answer
+ * "what am I on", so it stays put while the page scrolls under it and it is
+ * the same 56px as the wordmark bar across the divider from it.
+ *
+ * **The page's actions are not in that bar.** They sit in the toolbar row
+ * below it, hard right, opposite whatever the page filters by — which is the
+ * one shape every list in the product now has (`71N-0`). `toolbar` is the left
+ * half of that row and is new; `action` is the right half and is the prop
+ * every page already passes.
+ *
+ * `lead` rides in the bar beside the title, quiet and truncated. `DESIGN.md`
+ * asks a page for "one clear page title and a short purpose statement", and
+ * the bar is where the two belong together — the boards leave the right two
+ * thirds of it empty. It shrinks first and the title never does, because a
+ * title that truncated to make room for its own explanation would have the
+ * hierarchy backwards.
+ *
+ * `eyebrow` is drawn as the first step of the trail rather than as a label
+ * over the title: on a 56px bar there is one line, and "Settings / Project"
+ * says in that line what two stacked lines used to. A page that supplies real
+ * `breadcrumbs` draws those instead, because they are the same trail with
+ * addresses on it.
+ */
 export function PageHeader({
   eyebrow,
   title,
   lead,
   action,
+  toolbar,
   breadcrumbs,
 }: {
   readonly eyebrow?: string;
   readonly title: string;
   readonly lead?: ReactNode;
   readonly action?: ReactNode;
+  /** What this page filters or searches by, at the left of the toolbar row. */
+  readonly toolbar?: ReactNode;
   /** Parent links and the current page, in that order. */
   readonly breadcrumbs?: PageNavigationItems;
 }) {
   return (
     <>
-      {breadcrumbs === undefined ? null : (
-        <PageNavigation items={breadcrumbs} />
-      )}
-      {/*
-       * **Both halves wrap**, and they have to. A run can offer long action
-       * labels such as Cancel run and Retry, and on a phone they once sat on
-       * one unbreakable line inside a 390px screen, which pushed the whole
-       * document sideways: every page then scrolled horizontally, including
-       * the parts that fit perfectly.
-       *
-       * Not behind the breakpoint: a header runs out of room when its own
-       * contents are wider than it, which is a narrow window rather than a
-       * phone, and a page with one control has nothing to wrap at any width.
-       */}
       <header
+        data-slot="page-topbar"
         className={cn(
-          "flex flex-wrap items-start justify-between gap-5",
-          "border-b border-border pb-4",
-          "max-[900px]:flex-col",
+          "sticky top-0 z-10 flex min-w-0 flex-none items-center gap-3",
+          "h-(--topbar-height) border-b border-border bg-background",
+          "px-(--page-gutter)",
+          /*
+           * Under the one layout breakpoint the page has a top bar of its own
+           * already — the drawer button, the switcher and the account control
+           * — so this stops being a bar and becomes the page's first line.
+           */
+          "max-[900px]:static max-[900px]:h-auto max-[900px]:flex-wrap",
+          "max-[900px]:border-b-0 max-[900px]:px-4 max-[900px]:pt-4",
         )}
       >
-        <div>
-          {eyebrow === undefined || breadcrumbs !== undefined ? null : (
-            <p className="mt-0 mb-1 text-xs tracking-(--tracking-label) text-faint uppercase">
-              {eyebrow}
+        {breadcrumbs === undefined ? (
+          eyebrow === undefined ? null : (
+            <p className="m-0 flex flex-none items-center gap-3 text-base text-faint">
+              <span>{eyebrow}</span>
+              <span aria-hidden="true">/</span>
             </p>
-          )}
-          {/* A heading carries no size of its own; the class is the size. */}
-          <h1 className="m-0 text-xl font-medium">{title}</h1>
-          {lead === undefined ? null : (
-            <p className="mt-2 mb-0 max-w-[62ch] text-base leading-(--line-normal) text-muted-foreground">
-              {lead}
-            </p>
-          )}
-        </div>
-        {action === undefined ? null : (
-          /*
-           * `flex-initial` — grow 0, **shrink 1**. Refusing to grow is right;
-           * a strip of controls should not stretch across a wide page. Refusing
-           * to shrink made this box as wide as its contents laid out on one
-           * line, whatever the screen was, and a box already at its preferred
-           * width has nothing to wrap — so the wrap above did nothing until
-           * this changed with it.
-           *
-           * `min-w-0` for the reason one flex item in three needs it: `auto`
-           * floors a flex item at its content, and the sentence saying why a
-           * control is unavailable is a whole sentence.
-           */
-          <div className="flex min-w-0 flex-initial flex-wrap items-center gap-3">
-            {action}
-          </div>
+          )
+        ) : (
+          <PageNavigation items={breadcrumbs} />
+        )}
+        {/* A heading carries no size of its own; the class is the size. */}
+        <h1 className="m-0 min-w-0 truncate text-base font-medium">{title}</h1>
+        {lead === undefined ? null : (
+          <p className="m-0 min-w-0 flex-1 truncate text-sm text-muted-foreground">
+            {lead}
+          </p>
         )}
       </header>
+
+      {toolbar === undefined && action === undefined ? null : (
+        <div
+          data-slot="page-toolbar"
+          className={cn(
+            "flex-none px-(--page-gutter) pt-(--page-gutter)",
+            "max-[900px]:px-4 max-[900px]:pt-4",
+          )}
+        >
+          <Toolbar action={action}>{toolbar}</Toolbar>
+        </div>
+      )}
     </>
   );
 }
 
+/**
+ * The page's content, under the bar and the toolbar.
+ *
+ * The gutters are the board's — 24px at the sides, 24px above and 40px below —
+ * and the inner block is where `--page-content-max` is spent. It is not
+ * centred: see `ProductPage`.
+ *
+ * `flex-1 min-h-0` on the inner block is what lets a viewport page hand its
+ * remaining height to whatever it holds. `SettingsLayout` asks for `h-full`,
+ * and a percentage height needs a parent with a settled one.
+ */
 export function PageBody({ children }: { readonly children: ReactNode }) {
   return (
-    <div className="mt-5" data-slot="page-body">
-      {children}
+    <div
+      className={cn(
+        "flex min-w-0 flex-col px-(--page-gutter) pt-(--page-gutter) pb-10",
+        "max-[900px]:px-4 max-[900px]:pt-4 max-[900px]:pb-8",
+      )}
+      data-slot="page-body"
+    >
+      <div className="flex w-full max-w-(--page-content-max) min-h-0 flex-1 flex-col">
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -760,18 +760,26 @@ export function ProductPage({
  * half of that row and is new; `action` is the right half and is the prop
  * every page already passes.
  *
- * `lead` rides in the bar beside the title, quiet and truncated. `DESIGN.md`
- * asks a page for "one clear page title and a short purpose statement", and
- * the bar is where the two belong together — the boards leave the right two
- * thirds of it empty. It shrinks first and the title never does, because a
- * title that truncated to make room for its own explanation would have the
- * hierarchy backwards.
+ * **The bar holds the page title and nothing else**, which is what `71V-0`
+ * draws. `lead` is a quiet line at the top of the page's own block — the
+ * purpose statement `DESIGN.md` asks for, kept where somebody reads it rather
+ * than squeezed into a 56px strip beside the title it explains.
  *
- * `eyebrow` is drawn as the first step of the trail rather than as a label
- * over the title: on a 56px bar there is one line, and "Settings / Project"
- * says in that line what two stacked lines used to. A page that supplies real
- * `breadcrumbs` draws those instead, because they are the same trail with
- * addresses on it.
+ * `eyebrow` moved out of the bar with it, and is drawn in the same quiet
+ * block. **It is not decoration on every page**: the transcript screen puts the
+ * trace's source and environment there — "production / default" — which is a
+ * fact about the record and the only place the page states it. On a list page
+ * it says "Project" over a page whose project the sidebar already names twice,
+ * which is noise; delete the prop when you next touch such a page, and the
+ * label goes with it. Real `breadcrumbs` still draw in the bar, as the trail
+ * into the record being read.
+ *
+ * **One `<header>` wraps both rows, and it is `display: contents`.** A page
+ * that walks up from its own title to find its own controls — the persona page
+ * does exactly that, and a test holds it to it — has to find one element
+ * holding both. A header that generates no box gives them that ancestor while
+ * the two rows still lay out as children of `<main>`, so the bar goes on
+ * sticking to the top of the page rather than to the header.
  */
 export function PageHeader({
   eyebrow,
@@ -790,9 +798,21 @@ export function PageHeader({
   /** Parent links and the current page, in that order. */
   readonly breadcrumbs?: PageNavigationItems;
 }) {
+  /*
+   * A page that draws a real trail does not also draw the label above it: the
+   * breadcrumb already says which section this record is in, and saying it
+   * twice is the thing this suppression has always been for.
+   */
+  const label = breadcrumbs === undefined ? eyebrow : undefined;
+  const hasBlock =
+    toolbar !== undefined ||
+    action !== undefined ||
+    lead !== undefined ||
+    label !== undefined;
+
   return (
-    <>
-      <header
+    <header className="contents" data-slot="page-header">
+      <div
         data-slot="page-topbar"
         className={cn(
           "sticky top-0 z-10 flex min-w-0 flex-none items-center gap-3",
@@ -807,48 +827,47 @@ export function PageHeader({
           "max-[900px]:border-b-0 max-[900px]:px-4 max-[900px]:pt-4",
         )}
       >
-        {breadcrumbs === undefined ? (
-          eyebrow === undefined ? null : (
-            <p className="m-0 flex flex-none items-center gap-3 text-base text-faint">
-              <span>{eyebrow}</span>
-              <span aria-hidden="true">/</span>
-            </p>
-          )
-        ) : (
+        {breadcrumbs === undefined ? null : (
           <PageNavigation items={breadcrumbs} />
         )}
         {/* A heading carries no size of its own; the class is the size. */}
         <h1 className="m-0 min-w-0 truncate text-base font-medium">{title}</h1>
-        {lead === undefined ? null : (
-          <p
-            className={cn(
-              "m-0 min-w-0 flex-1 truncate text-sm text-muted-foreground",
-              /*
-               * On a phone the bar is a stack rather than a line, so the
-               * purpose statement takes its own row and says all of itself.
-               * Truncating it there would leave a sentence that stops.
-               */
-              "max-[900px]:basis-full max-[900px]:overflow-visible",
-              "max-[900px]:text-clip max-[900px]:whitespace-normal",
-            )}
-          >
-            {lead}
-          </p>
-        )}
-      </header>
+      </div>
 
-      {toolbar === undefined && action === undefined ? null : (
+      {hasBlock ? (
         <div
           data-slot="page-toolbar"
           className={cn(
-            "flex-none px-(--page-gutter) pt-(--page-gutter)",
+            "flex flex-none flex-col px-(--page-gutter) pt-(--page-gutter)",
             "max-[900px]:px-4 max-[900px]:pt-4",
           )}
         >
-          <Toolbar action={action}>{toolbar}</Toolbar>
+          {label === undefined ? null : (
+            <p
+              className={cn(
+                "m-0 text-xs tracking-(--tracking-label) text-faint uppercase",
+                lead === undefined ? "" : "mb-1",
+              )}
+            >
+              {label}
+            </p>
+          )}
+          {lead === undefined ? null : (
+            <p className="m-0 w-full max-w-[92ch] text-sm text-muted-foreground">
+              {lead}
+            </p>
+          )}
+          {(lead !== undefined || label !== undefined) &&
+          (toolbar !== undefined || action !== undefined) ? (
+            /* The gap to the toolbar row, when the block holds both. */
+            <div className="h-4" aria-hidden="true" />
+          ) : null}
+          {toolbar === undefined && action === undefined ? null : (
+            <Toolbar action={action}>{toolbar}</Toolbar>
+          )}
         </div>
-      )}
-    </>
+      ) : null}
+    </header>
   );
 }
 

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -820,7 +820,18 @@ export function PageHeader({
         {/* A heading carries no size of its own; the class is the size. */}
         <h1 className="m-0 min-w-0 truncate text-base font-medium">{title}</h1>
         {lead === undefined ? null : (
-          <p className="m-0 min-w-0 flex-1 truncate text-sm text-muted-foreground">
+          <p
+            className={cn(
+              "m-0 min-w-0 flex-1 truncate text-sm text-muted-foreground",
+              /*
+               * On a phone the bar is a stack rather than a line, so the
+               * purpose statement takes its own row and says all of itself.
+               * Truncating it there would leave a sentence that stops.
+               */
+              "max-[900px]:basis-full max-[900px]:overflow-visible",
+              "max-[900px]:text-clip max-[900px]:whitespace-normal",
+            )}
+          >
             {lead}
           </p>
         )}

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -438,7 +438,8 @@ function ThemeItem() {
       >
         <span
           className={cn(
-            "absolute top-0.5 left-0.5 block size-[9px] rounded-full bg-muted-foreground",
+            /* Square, like everything else: a switch is a component. */
+            "absolute top-0.5 left-0.5 block size-[9px] bg-muted-foreground",
             "transition-transform duration-(--duration-press) ease-out",
             "group-aria-checked/theme:translate-x-[11px] group-aria-checked/theme:bg-background",
             /* Keyboard activation is immediate: the thumb is already there. */

--- a/apps/web/ui/simulation-evidence.tsx
+++ b/apps/web/ui/simulation-evidence.tsx
@@ -1207,6 +1207,7 @@ function SimulationEvidencePanel({
       {evidenceOpen ? (
         <Dialog
           kind="sheet"
+          size="wide"
           title="Transcript and audio"
           onClose={() => onEvidenceChange(false)}
         >

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -302,6 +302,18 @@
    */
   --table-action-width: 48px;
 
+  /*
+   * How wide a side sheet is — the one the boards draw, and the reading
+   * surface `ui/dialog.tsx` opens beside a page.
+   *
+   * They were 440 and 640 and there is no reason for a product to have two
+   * side sheets of two widths: a person meets both and sees one control that
+   * cannot make up its mind. `77F-0` says 440, so 440 is the width, and it is
+   * one declaration so that widening the reading surface later is one edit
+   * rather than a hunt through two components.
+   */
+  --sheet-width: 440px;
+
   /* Product shell measurements. */
   --sidebar-width: 224px;
   --sidebar-header-height: 56px;
@@ -955,11 +967,13 @@
     animation: egma-fade-out var(--duration-drawer-out) var(--ease-drawer);
   }
 
-  [data-slot="sheet-content"][data-state="open"] {
+  [data-slot="sheet-content"][data-state="open"],
+  [data-slot="dialog-content"][data-kind="sheet"][data-state="open"] {
     animation: egma-sheet-in var(--duration-drawer-in) var(--ease-drawer);
   }
 
-  [data-slot="sheet-content"][data-state="closed"] {
+  [data-slot="sheet-content"][data-state="closed"],
+  [data-slot="dialog-content"][data-kind="sheet"][data-state="closed"] {
     animation: egma-sheet-out var(--duration-drawer-out) var(--ease-drawer);
   }
 
@@ -1041,6 +1055,41 @@
   [data-preview="reduced-motion"]
     [data-slot="tooltip-content"][data-input="pointer"][data-state="closed"] {
     animation: egma-fade-out var(--duration-hover) linear;
+  }
+
+  /*
+   * A link inside a table cell.
+   *
+   * The boards underline it in the text colour and turn it Ember under the
+   * pointer (`71C-0`): an underline is what says "this is a link" without
+   * spending the brand colour on every row of a list, and the colour arrives
+   * when somebody is actually pointing at one. It is here rather than in
+   * `ui/data-table.tsx` because the cell's contents are written by the page —
+   * the component never sees the link — and because every list in the product
+   * has to answer this the same way.
+   *
+   * Underline offset and thickness are the board's. Both are properties of the
+   * text rather than values a component chose, and neither has a token because
+   * `DESIGN.md` names no scale for them.
+   */
+  [data-slot="table-cell"] a {
+    color: inherit;
+    text-decoration-line: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+    transition: color var(--duration-hover) var(--ease-out);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    [data-slot="table-cell"] a:hover {
+      color: var(--accent);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-slot="table-cell"] a {
+      transition: none;
+    }
   }
 
   /*
@@ -1128,6 +1177,7 @@
     [data-slot="dialog-content"][data-state="open"],
     [data-slot="dialog-content"][data-kind="drawer"][data-state="open"],
     [data-slot="dialog-overlay"][data-state="open"],
+    [data-slot="dialog-content"][data-kind="sheet"][data-state="open"],
     [data-slot="sheet-content"][data-state="open"],
     [data-slot="sheet-overlay"][data-state="open"] {
       animation: egma-fade-in var(--duration-hover) linear;
@@ -1139,6 +1189,7 @@
     [data-slot="dialog-content"][data-state="closed"],
     [data-slot="dialog-content"][data-kind="drawer"][data-state="closed"],
     [data-slot="dialog-overlay"][data-state="closed"],
+    [data-slot="dialog-content"][data-kind="sheet"][data-state="closed"],
     [data-slot="sheet-content"][data-state="closed"],
     [data-slot="sheet-overlay"][data-state="closed"] {
       animation: egma-fade-out var(--duration-hover) linear;

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -347,8 +347,19 @@
     rgb(122 49 23 / 0.02) -130px 256px 115px 0;
 }
 
-/* Dark theme semantic overrides. */
-:root[data-theme="dark"] {
+/*
+ * Dark theme semantic overrides.
+ *
+ * **Two selectors, and the second one is what makes the proof page honest.**
+ * The document carries `data-theme` on `<html>`, which is what the theme
+ * script writes and what every real page reads. `/design-system` also has to
+ * draw the dark theme *beside* the light one, in a frame, so a person can hold
+ * the two against each other without reloading — and a rule bound to `:root`
+ * alone cannot dress a `<div>`. The attribute means the same thing in both
+ * places: everything inside me is dark.
+ */
+:root[data-theme="dark"],
+[data-theme="dark"] {
   --background: #151514;
   --surface: #1b1b1a;
   --surface-soft: #222220;

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -1071,14 +1071,19 @@
   /*
    * A page that drew its own toolbar row does not pay the top gutter twice.
    *
-   * `PageHeader` opens the block under the title bar when a page hands it an
-   * action or a filter, and `PageBody` opens one when the page did not — so
-   * whichever comes first carries the 24px, and the second one starts where
-   * the first left off. It is a sibling rule because that is the question:
-   * *is there already a block above me*, which no class on either element can
-   * answer about the other.
+   * `PageHeader` opens the block under the title bar when a page hands it a
+   * purpose statement, an action or a filter, and `PageBody` opens one when
+   * the page did not — so whichever comes first carries the 24px, and the
+   * second one starts where the first left off. It is a sibling rule because
+   * that is the question: *is there already a block above me*, which no class
+   * on either element can answer about the other.
+   *
+   * The header between them is `display: contents`, which changes what is
+   * drawn and not what is a sibling of what — so the match is on the header
+   * that holds a toolbar rather than on the toolbar itself.
    */
-  [data-slot="page-toolbar"] + [data-slot="page-body"] {
+  [data-slot="page-header"]:has([data-slot="page-toolbar"])
+    + [data-slot="page-body"] {
     padding-top: 0;
   }
 

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -1069,6 +1069,20 @@
   }
 
   /*
+   * A page that drew its own toolbar row does not pay the top gutter twice.
+   *
+   * `PageHeader` opens the block under the title bar when a page hands it an
+   * action or a filter, and `PageBody` opens one when the page did not — so
+   * whichever comes first carries the 24px, and the second one starts where
+   * the first left off. It is a sibling rule because that is the question:
+   * *is there already a block above me*, which no class on either element can
+   * answer about the other.
+   */
+  [data-slot="page-toolbar"] + [data-slot="page-body"] {
+    padding-top: 0;
+  }
+
+  /*
    * A link inside a table cell.
    *
    * The boards underline it in the text colour and turn it Ember under the

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -303,16 +303,25 @@
   --table-action-width: 48px;
 
   /*
-   * How wide a side sheet is — the one the boards draw, and the reading
-   * surface `ui/dialog.tsx` opens beside a page.
+   * How wide each surface is. Every one of these lived in a class list as a
+   * bare number until 2026-08-23; a size is a design value like a colour is,
+   * and `DESIGN.md` says a component holds neither.
    *
-   * They were 440 and 640 and there is no reason for a product to have two
-   * side sheets of two widths: a person meets both and sees one control that
-   * cannot make up its mind. `77F-0` says 440, so 440 is the width, and it is
-   * one declaration so that widening the reading surface later is one edit
-   * rather than a hunt through two components.
+   * **Two side sheets, two widths, and they are two things.** `--sheet-width`
+   * is the modal panel the boards draw one record in (`77F-0`): create, read
+   * and edit, over a scrim, with the page behind it inert.
+   * `--sheet-width-wide` is the *reading* surface `ui/dialog.tsx` opens beside
+   * a page that stays usable — a transcript against its grader results, a
+   * persona's version history. Collapsing the second into the first took 200px
+   * off a transcript to make a number match, which is a worse product for a
+   * tidier theme.
    */
   --sheet-width: 440px;
+  --sheet-width-wide: 640px;
+  --dialog-width: 480px;
+  --search-width: 300px;
+  --chip-height: 22px;
+  --menu-width: 210px;
 
   /* Product shell measurements. */
   --sidebar-width: 224px;
@@ -363,7 +372,14 @@
   --background: #151514;
   --surface: #1b1b1a;
   --surface-soft: #222220;
-  --surface-active: color-mix(in srgb, var(--color-ember) 16%, var(--surface));
+  /*
+   * The designer's own dark wash, read from the Paper file's tokens
+   * (`--color-dark-surface-active`). It was a `color-mix` of Ember into the
+   * surface, which landed within one hex step of this — so the value barely
+   * moved, and taking it from the file rather than deriving it is what stops
+   * the two drifting the next time either side is tuned.
+   */
+  --surface-active: #43241c;
   --foreground: #f2f2ed;
   --muted: #a3a39b;
   --faint: #82827b;
@@ -371,10 +387,28 @@
   --border-strong: #4a4a44;
   --focus: var(--color-ember);
   --accent: var(--color-ember);
-  --action: var(--color-ember-deep);
-  --action-hover: var(--color-ember-hover);
-  --action-pressed: var(--color-ember-pressed);
-  --action-text: var(--color-paper);
+  /*
+   * The primary action's ink, lightened for the dark wash it sits on.
+   *
+   * **Deep Ember on the dark wash is 2.69:1, which fails AA and fails even the
+   * 3:1 a non-text control gets.** That was true before this theme change as
+   * well — the wash was already Ember-on-dark and the ink was already
+   * `#c2410c` — so this is a fault being fixed rather than one being created.
+   * Ember alone is 4.3:1, still short. Ember pulled 20% towards paper is
+   * `#ff7554` at **5.26:1**, which passes AA for the 14px label a button
+   * carries, and it is the same colour family the light theme uses.
+   *
+   * Hover and press move *further* towards paper, which is "further from the
+   * surface it sits on" — the same direction, in dark, that the light theme's
+   * darker steps take. `--destructive` above already works this way.
+   *
+   * `DESIGN.md`: "Dark theme uses lighter status values that keep the same
+   * meanings." This is that rule applied to the action family.
+   */
+  --action: color-mix(in srgb, var(--color-ember) 80%, var(--color-paper));
+  --action-hover: color-mix(in srgb, var(--color-ember) 62%, var(--color-paper));
+  --action-pressed: color-mix(in srgb, var(--color-ember) 46%, var(--color-paper));
+  --action-text: var(--color-midnight);
   --good: #55bd8c;
   --warn: #d69a38;
   --bad: #e27373;

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -37,15 +37,19 @@
  *
  *    | Name | Tailwind's | egma's |
  *    | --- | --- | --- |
- *    | `--radius-sm` | `0.25rem` | `6px` |
- *    | `--radius-md` | `0.375rem` | `8px` |
- *    | `--radius-lg` | `0.5rem` | `12px` |
+ *    | `--radius-sm` | `0.25rem` | `0px` |
+ *    | `--radius-md` | `0.375rem` | `0px` |
+ *    | `--radius-lg` | `0.5rem` | `0px` |
  *    | `--ease-out` | `cubic-bezier(0, 0, 0.2, 1)` | `cubic-bezier(0.23, 1, 0.32, 1)` |
  *    | `--ease-in-out` | `cubic-bezier(0.4, 0, 0.2, 1)` | `cubic-bezier(0.77, 0, 0.175, 1)` |
  *
  *    This is load-bearing rather than incidental: moving these declarations
  *    into `@theme` would put them in that layer and hand all five names back
- *    to Tailwind — every radius in the product and two of its easings.
+ *    to Tailwind — every radius in the product and two of its easings. The
+ *    three radii all read `0px` now, and that makes the trick *more*
+ *    load-bearing rather than less: hand them back and every component in the
+ *    product grows a corner again, quietly, in a commit that touched no
+ *    component.
  *
  * A key may not reference its own name. `@theme inline { --text-sm:
  * var(--text-sm) }` compiles, but it emits a circular declaration that only
@@ -115,6 +119,24 @@
   --action-hover: var(--color-ember-hover);
   --action-pressed: var(--color-ember-pressed);
   --action-text: var(--color-paper);
+
+  /*
+   * The primary action's fill, and its two feedback steps.
+   *
+   * The boards draw the primary button as Ember Wash behind Deep Ember text on
+   * a neutral hairline (`71O-0`), not as a Deep Ember block with white text.
+   * The developer ruled that the wash button *is* the primary action on
+   * 2026-08-23 and retired the filled one. `--action` is still the ink, so the
+   * text steps above are the text's; these three are the fill's.
+   *
+   * Derived rather than fixed, so one declaration follows both themes: each
+   * step pulls a little more Ember into whatever `--surface-active` is in
+   * force. Light theme starts at `#fff5f2` and warms; dark theme starts at
+   * Ember-on-dark and warms the same way.
+   */
+  --action-wash: var(--surface-active);
+  --action-wash-hover: color-mix(in srgb, var(--color-ember) 8%, var(--surface-active));
+  --action-wash-pressed: color-mix(in srgb, var(--color-ember) 16%, var(--surface-active));
   --destructive: #b44444;
   --destructive-hover: #963636;
   --destructive-pressed: #7e2d2d;
@@ -163,15 +185,49 @@
   --space-12: 80px;
   --space-13: 100px;
 
-  /* Component shape. */
-  --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-  --radius-pill: 9999px;
+  /*
+   * Component shape: one radius, and it is none.
+   *
+   * The four names stay because forty class lists read them — `rounded-button`
+   * on a button, `rounded-card` on a panel — and because a name says which
+   * component asked. What changed is every value. The developer ruled it on
+   * 2026-08-23 looking at the Paper boards: "0px radius, sharp corners, on
+   * every component". `DESIGN.md`'s per-component radius table collapsed to
+   * one line in the same change.
+   *
+   * **A round *shape* is not a component corner and is not drawn from here.**
+   * An avatar is a circle and a radio button is a circle; both say
+   * `rounded-full`, which is Tailwind's own and untouched by this block. That
+   * is the whole exception, and it is written down so the next person does not
+   * read a circular avatar as a radius that escaped.
+   */
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-pill: 0px;
 
-  /* Accepted Arial type scale. */
-  --sans: Arial, Helvetica, sans-serif;
+  /*
+   * The accepted type scale.
+   *
+   * **`system-ui` leads, and the reason is the boards.** Paper renders its
+   * artboards in `system-ui`, so a product drawn in Arial first would not look
+   * like the thing that was approved — on a Mac the two are a different face,
+   * not a different hinting. Helvetica and Arial stay behind it, so a machine
+   * with no `system-ui` lands exactly where this product used to. Developer
+   * decision, 2026-08-23. Weights are still 400 and 500 and nothing else.
+   */
+  --sans: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
   --mono: var(--egma-mono), "IBM Plex Mono", ui-monospace, monospace;
+  /*
+   * 12px, and it is one thing rather than a step of the scale.
+   *
+   * `DESIGN.md`'s scale starts at 14px and still does: this is the letter-
+   * spaced uppercase micro-label the boards draw twice — the organization
+   * eyebrow over the project name, and the role under the account's email —
+   * and nothing else may reach for it. It is named `micro` rather than given a
+   * number so that it cannot be mistaken for the bottom of the scale.
+   */
+  --text-micro: 12px;
   --text-caption: 14px;
   --text-body: 16px;
   --text-lead: 24px;
@@ -194,7 +250,7 @@
   --tracking-display: -2.05px;
 
   /* Compact type aliases used by shared components. */
-  --text-2xs: var(--text-caption);
+  --text-2xs: var(--text-micro);
   --text-xs: var(--text-caption);
   --text-sm: var(--text-caption);
   --text-md: var(--text-body);
@@ -224,23 +280,54 @@
   --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
   --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
 
-  /* A list row is one line of reading. */
+  /*
+   * A list row is one line of reading, and a header row is shorter than one.
+   *
+   * The boards separate the two: the header is a fixed 40px of quiet labels,
+   * and a body row is *at least* 52px — a minimum rather than a height,
+   * because a cell holding two connection links and an overflow chip has to be
+   * allowed to be taller than one holding a date.
+   */
   --row-height: 40px;
+  --row-min-height: 52px;
   --row-padding-y: var(--space-2);
   --row-padding-x: var(--space-4);
 
+  /*
+   * The trailing slot every row ends with, whether or not it holds a ⋮ menu.
+   *
+   * It is a fixed width rather than a cell that shrinks to its content,
+   * because the vertical lane it makes is what a person's eye follows down the
+   * table. A row with no menu keeps the empty slot for the same reason.
+   */
+  --table-action-width: 48px;
+
   /* Product shell measurements. */
   --sidebar-width: 224px;
-  --topbar-height: 48px;
+  --sidebar-header-height: 56px;
+  --topbar-height: 56px;
   --page-gutter: var(--space-6);
   --page-max: 1200px;
   --page-max-wide: 1440px;
 
-  /* Orange-brown elevation is reserved for menus, dialogs, and showcase panels. */
-  --shadow-menu: 0 12px 32px rgb(122 49 23 / 0.14);
+  /*
+   * Orange-brown elevation, reserved for what is raised off the page.
+   *
+   * **There used to be two recipes and the boards draw one.** The row menu
+   * (`9AH-0`), the side sheet (`77F-0`) and the confirm dialog (`BEM-0`) were
+   * read with `get_computed_styles` on 2026-08-23 and all three carry the same
+   * two-layer stack — the short menu shadow is not on any of them. So
+   * `--shadow-menu` reads the same declaration rather than holding a second
+   * value that nothing draws. The name stays because `shadow-popover` reads
+   * it and because a menu is still what asks.
+   *
+   * Everything the boards give a hairline and no shadow — the table panel, the
+   * sidebar, the topbar, inputs, the search box — keeps the hairline alone.
+   */
   --shadow-dialog:
     rgb(122 49 23 / 0.12) -8px 16px 39px 0,
     rgb(122 49 23 / 0.1) -33px 64px 72px 0;
+  --shadow-menu: var(--shadow-dialog);
   --shadow-showcase:
     rgb(122 49 23 / 0.12) -8px 16px 39px 0,
     rgb(122 49 23 / 0.1) -33px 64px 72px 0,
@@ -410,11 +497,23 @@
   --color-selected: var(--surface-active);
   --color-selected-foreground: var(--foreground);
 
-  /* The primary filled action: Deep Ember with white text, and its two steps. */
+  /*
+   * The primary action.
+   *
+   * `--color-primary` and its two steps are the *ink* — Deep Ember, and the
+   * two darker Ember steps under pointer feedback. `--color-primary-wash` and
+   * its two are the *fill* the boards put behind that ink. `-foreground` is
+   * kept pointing at white for the one thing that still fills with Deep Ember
+   * (nothing in the product today; a pasted shadcn component tomorrow), so a
+   * component that reaches for it lands somewhere legible rather than nowhere.
+   */
   --color-primary: var(--action);
   --color-primary-foreground: var(--action-text);
   --color-primary-hover: var(--action-hover);
   --color-primary-pressed: var(--action-pressed);
+  --color-primary-wash: var(--action-wash);
+  --color-primary-wash-hover: var(--action-wash-hover);
+  --color-primary-wash-pressed: var(--action-wash-pressed);
 
   /* Destructive, which is the failure colour and never the brand colour. */
   --color-destructive: var(--destructive);
@@ -483,6 +582,9 @@
    * the 16px UI body. Line height and letter spacing travel with each step,
    * which is what keeps a heading from arriving with body tracking.
    */
+  --text-2xs: var(--text-micro);
+  --text-2xs--line-height: var(--line-caption);
+  --text-2xs--letter-spacing: 0px;
   --text-xs: var(--text-caption);
   --text-xs--line-height: var(--line-caption);
   --text-xs--letter-spacing: var(--tracking-caption);
@@ -649,6 +751,30 @@
 @keyframes egma-drawer-out {
   from { translate: 0 0; }
   to { translate: -100% 0; }
+}
+
+/*
+ * The side sheet, which comes in from the right edge and fades with it.
+ *
+ * `DESIGN.md` gives an edge-attached surface one behaviour — "translate from
+ * its attached edge" — and one pair of tokens, the drawer's. A sheet is that
+ * surface on the other edge, so it takes the same movement and the same
+ * durations. The opacity travels with it because a sheet lands over a scrim
+ * rather than over the bare page, and a panel that only slid would look like it
+ * had always been there, just off screen.
+ *
+ * `translate` and nothing else, for the reason the drawer's keyframes give: the
+ * panel's resting position is whatever its class list says, and an animation
+ * that wrote `transform` would replace it.
+ */
+@keyframes egma-sheet-in {
+  from { opacity: 0; translate: 100% 0; }
+  to { opacity: 1; translate: 0 0; }
+}
+
+@keyframes egma-sheet-out {
+  from { opacity: 1; translate: 0 0; }
+  to { opacity: 0; translate: 100% 0; }
 }
 
 @layer components {
@@ -820,6 +946,23 @@
     animation: egma-drawer-out var(--duration-drawer-out) var(--ease-drawer);
   }
 
+  /* The side sheet, on the drawer's tokens. See the keyframes above. */
+  [data-slot="sheet-overlay"][data-state="open"] {
+    animation: egma-fade-in var(--duration-drawer-in) var(--ease-drawer);
+  }
+
+  [data-slot="sheet-overlay"][data-state="closed"] {
+    animation: egma-fade-out var(--duration-drawer-out) var(--ease-drawer);
+  }
+
+  [data-slot="sheet-content"][data-state="open"] {
+    animation: egma-sheet-in var(--duration-drawer-in) var(--ease-drawer);
+  }
+
+  [data-slot="sheet-content"][data-state="closed"] {
+    animation: egma-sheet-out var(--duration-drawer-out) var(--ease-drawer);
+  }
+
   /*
    * The tooltip.
    *
@@ -984,7 +1127,9 @@
     [data-slot="dropdown-menu-sub-content"][data-state="open"],
     [data-slot="dialog-content"][data-state="open"],
     [data-slot="dialog-content"][data-kind="drawer"][data-state="open"],
-    [data-slot="dialog-overlay"][data-state="open"] {
+    [data-slot="dialog-overlay"][data-state="open"],
+    [data-slot="sheet-content"][data-state="open"],
+    [data-slot="sheet-overlay"][data-state="open"] {
       animation: egma-fade-in var(--duration-hover) linear;
     }
 
@@ -993,7 +1138,9 @@
     [data-slot="dropdown-menu-sub-content"][data-state="closed"],
     [data-slot="dialog-content"][data-state="closed"],
     [data-slot="dialog-content"][data-kind="drawer"][data-state="closed"],
-    [data-slot="dialog-overlay"][data-state="closed"] {
+    [data-slot="dialog-overlay"][data-state="closed"],
+    [data-slot="sheet-content"][data-state="closed"],
+    [data-slot="sheet-overlay"][data-state="closed"] {
       animation: egma-fade-out var(--duration-hover) linear;
     }
 


### PR DESCRIPTION
Ticket 01 of the **ui-refresh** effort: the shared base — theme values, shadcn primitives, shared components, the signed-in shell — now draws the look of the Paper boards on page `A-0` (agents), `C-0` (personas) and `B-0` (tests & suites). Every number was read with the Paper MCP (`get_computed_styles` / `get_jsx`, file `01M0G2QX6CJWZ27QBSNT7SVT1H`), never off a screenshot. The developer's four rulings of 2026-08-23 override the boards where they disagree: **0px radius on every component**, the **Egma wordmark in the sidebar**, the **wash primary button**, and **`system-ui` first**.

Tickets 02–07 build their screens on this. No route page was edited.

---

## Theme — `apps/web/ui/tailwind-theme.css`

- `--radius-sm` / `-md` / `-lg` / `-pill` → **`0px`**. The four names stay, because component class lists read them and the name says which component asked. The unlayered-`:root` trick that makes egma's value beat Tailwind's is now *more* load-bearing, and the header comment says so.
- `--sans` → **`system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif`**. Paper renders `system-ui`; Arial first would not draw what was approved.
- `--topbar-height: 56px`; new `--sidebar-header-height: 56px`, `--row-min-height: 52px`, `--table-action-width: 48px`, `--sheet-width: 440px`, `--text-micro: 12px` (reachable only as `text-2xs`).
- New derived fills for the wash primary: `--action-wash` / `-hover` / `-pressed`, each pulling one more step of Ember into `--surface-active`, so one declaration follows both themes. Exposed as `--color-primary-wash*`.
- **The shadow answer:** the row menu (`9AH-0`), the side sheet (`77F-0`) and the confirm dialog (`BEM-0`) all carry the *same* two-layer orange-brown stack, which is the existing `--shadow-dialog`. `--shadow-menu` now reads it rather than holding a second value nothing draws. Table panel, sidebar, topbar, inputs and search keep a hairline and no shadow.
- Dark values are bound to `[data-theme="dark"]` as well as `:root[data-theme="dark"]`, so `/design-system` can draw a dark frame beside the light page.
- New keyframes and rules for the side sheet, on the drawer's tokens (280ms in / 220ms out), with a reduced-motion form. A new cell-link rule (underlined in the text colour, Ember under a fine pointer) and a sibling rule so a page never pays the 24px top gutter twice.

## Primitives — `apps/web/components/ui/*`

- **`button.tsx`** — `default` is the **wash primary**: Ember Wash fill, Deep Ember text, a neutral hairline, no corner. Hover and press move the fill and the ink one step each; the hairline never moves. The Deep Ember block with white text is retired and no variant produces it. Sizes are **32 / 36 / 44** with `default` at 36 (the toolbar control) and `lg` at 44 (the form control); the base puts the 44px target back on every coarse pointer.
- **`sheet.tsx` (new)** — the right-anchored side sheet from `77F-0` / `7E0-0`. `Sheet`, `SheetContent`, `SheetHeader`, `SheetTitle`, `SheetDescription`, `SheetBody`, `SheetFooter`, `SheetClose`, `SheetTrigger`, `SheetOverlay`, `SheetHost`. Same Radix dialog as the centred one, so focus trap / inert page / Escape / opener restore all hold.
- **`table.tsx` (new)** — `TablePanel`, `Table`, `TableHeader`, `TableBody`, `TableRow`, `TableHead`, `TableCell`, `TableFooter`, `TableCaption`, at the boards' numbers. `TablePanel` is separate from `Table` (the registry welds them) because the border, the surface and the stacking container query belong to the frame.
- **`dialog.tsx`** — 480px, 24px padding, hairline, no corner, title at the lead step in weight 400, footer left-aligned (the answer, then the way out), close aligned to the padding.
- **`badge.tsx`** — a `shape` axis: `verdict` (what it always drew) and `count`, the overflow chip from `719-0` — 22px, quiet neutral surface, sentence case.
- **`dropdown-menu.tsx`** — items 36px (the board's), 44px on a coarse pointer.
- **`radio-group.tsx`**, **`progress.tsx`**, **`tabs.tsx`**, **`sidebar.tsx`** — square, with the two round shapes called out below. `sidebar.tsx` gained `SidebarBrand` for the wordmark bar and stopped turning the lit row's icon Ember (the 2px Ember mark is already the signal).

## Shell — `apps/web/ui/*`

- **Sidebar** (`71X-0`): 224px, `--surface`, right hairline, 20px column gap, 16px bottom padding, 16px gutter on every block so the wordmark bar's hairline runs the full width and the rows are 192px with their Ember mark on the gutter. Wordmark bar 56px with a bottom hairline, the wordmark as a link to `/`, inverted in dark. Project block: **organization as the eyebrow (12px), project as the primary line (14px) with a two-way chevron** — no card, no initial square. Navigation groups and rows unchanged in behaviour. Account: 36px circular initial, 14px email, 12px letter-spaced role.
- **Topbar** (`71V-0`): new, 56px, 24px side padding, bottom hairline, page title at 16px weight 500, sticky. **The bar holds the title and nothing else**, which is what the board draws. The purpose statement (`lead`) and `eyebrow` sit in a quiet block at the top of the page's own content — `eyebrow` because one page uses it for a fact rather than a label (the transcript screen states the trace's source and environment there, and nowhere else); on a list page it says "Project" and route tickets should delete the prop. A page that supplies real `breadcrumbs` draws those in the bar and no eyebrow, as before.
- **One `<header>` wraps the bar and the toolbar block**, at `display: contents`. A page that walks up from its own title to find its own controls — the persona screen does exactly that — needs one ancestor holding both; a header that generates no box gives them that while the two rows still lay out as children of `<main>`, so the bar goes on sticking to the page.
- **Page** (`6ZK-0`, `71N-0`): 24px gutters, 24px above, 40px below; a 52px toolbar row (filters left, the page's action hard right). **`PageHeader` gained a `toolbar` prop; nothing was renamed** — `PageHeader`, `PageBody`, `ProductPage`, `ProductStatePage`, `DataTable`, `Menu`, `Dialog`, `Field` all keep their signatures.
- The page is now **left-aligned rather than centred**. `--page-max` survives and is applied to the content without `mx-auto`, so the title in the bar and the first cell under it are always on one line; centring put them 8px apart at 1440.
- `Toolbar` in `section.tsx` is the 52px row; new **`SearchField`** gives the board's 300×36 box with a magnifier, and `TOOLBAR_SEARCH` already puts existing call sites on that size.
- Mobile (<900px) top bar and drawer, reduced-motion forms, keyboard and focus behaviour all unchanged in kind and verified in the browser.

## `DESIGN.md`

Dated 2026-08-23 as developer decisions: the wordmark in the sidebar (Brand + Shell), the single 0px radius (the per-component table collapses to one line, with the avatar and the radio named as the two round *shapes*), the wash primary and the new secondary/destructive drawings, `system-ui` first, the 12px micro label, the shell measurement table (224 / 56 / 56 / 36 / 40 / 52 / 48 / 440), a new **Side sheets** section, and the one-shadow answer. **The locked-palette sentence and every logo treatment rule stay.** The one brand rule that changed is the rule whose own text asked for exactly this approval.

## Tests

Owned and updated: `components.test.tsx` (the sidebar starts with the wordmark, then project context), `sidebar-groups.test.tsx` (the wordmark leads the bar, then the switcher), `design-system.test.tsx` (the wash primary; two new cases — the side sheet opens on the slot its motion is keyed to, and the shared components draw on the dark tokens beside the light ones).

```
npx vitest run --project fast \
  apps/web/test/components.test.tsx apps/web/test/design-system.test.tsx \
  apps/web/test/sidebar-groups.test.tsx apps/web/test/project-shell.test.ts \
  apps/web/test/menu-placement.test.tsx apps/web/test/brand-assets.test.ts \
  apps/web/test/data-table-row-link.test.tsx apps/web/test/feedback.test.tsx \
  apps/web/test/number-field.test.tsx apps/web/test/pages.test.ts
→ 10 files, 207 tests, all passing

pnpm typecheck  → green (lint + every package + web)
```

`graders-pages.test.tsx` was updated too: the trailing action cell is a fixed 48px lane centred on its control (`data-[action=true]:text-center` / `px-0`) rather than a right-aligned cell, which is what makes the ⋮ menus line up in one column down the table. What the case is about — the row's control at the row's trailing edge — has not moved.

**One expectation outside `apps/web` was updated, deliberately.** `apps/api/test/browser.test.ts` measured table body rows against `--row-height`; the boards split the header (40px, still `--row-height`) from the body (52px, the new `--row-min-height`), so the three places that measure or retune a *body* row name the new token. Only that describe block was touched — **route tickets should not touch it again.**

## Screenshots

Saved outside git, in the worktree's `.proofs/ui-01/` and in the coordinator's scratchpad `…/scratchpad/proofs/ui-01/`:

| File | What it shows |
| --- | --- |
| `agents-1440-light.png` | The agents list, signed in, 1440×900, light |
| `agents-1440-dark.png` | The same, dark |
| `agents-390-light.png` | The mobile shell and the stacked table at 390 |
| `agents-390-drawer.png` | The mobile navigation drawer |
| `design-system-sheet-light.png` | `/design-system` with the new side sheet open |
| `design-system-sheet-dark.png` | The same, dark |

Next's development overlay parks a black badge over the account control in the bottom-left corner; the proof script hides it, so what the screenshots show there is the product's own avatar — a light `--surface-soft` circle with a hairline and a dark initial, which is `722-0`.

## Left undone, and for whom

- **The agents list has no ⋮ slot and no Platform/Created columns yet.** Its page declares two columns and no row menu; the slot itself is built and enforced by `ui/data-table.tsx` (a fixed 48px lane on every row, header included). **Ticket 03.**
- **The agents search box is a bare `Input`**, so it has the board's 300×36 but no magnifier. Swap it for `SearchField`. **Ticket 03.**
- **Every list page still passes `eyebrow="Project"`**, which the topbar draws as "Project / Agents"; the boards say just "Agents". Delete the prop when you touch a page — `PageHeader` still accepts it. **Route tickets.**
- **`ui/dialog.tsx`'s `kind="sheet"` lost 200px** (640 → `--sheet-width`, 440) so there is one side sheet look. It is still a *different component* from `components/ui/sheet.tsx` — non-modal, for reading beside a live page — and the two now differ only in behaviour. If a transcript reads badly at 440, the fix is one declaration in the theme.
- **Two round shapes survive the 0px ruling** and both are called out for the developer to overrule: the account avatar, and the radio button (its shape is what tells it apart from a checkbox).
- **No route page was edited** and nothing broke at a call site, so there was no minimal fix to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refreshes the shared web presentation layer around the Paper design, adding square theme geometry, updated shell measurements, wash-style actions, table primitives, and a modal side sheet.
- Reworks shared theme tokens, typography, dimensions, shadows, and responsive motion.
- Updates the signed-in sidebar, page title bar, toolbar layout, tables, dialogs, menus, and controls.
- Adds reusable sheet and table primitives with corresponding design-system and component coverage.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because Runs and Monitoring still place actions and filters in separate stacked toolbar rows.

PageHeader independently renders an action toolbar while both affected pages retain their filter toolbars inside PageBody, so the previously reported split-control layout remains.

**Files Needing Attention:** apps/web/ui/shell.tsx; apps/web/app/projects/[projectId]/runs/page.tsx; apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/tailwind-theme.css | Centralizes the refreshed Paper theme values, dimensions, fills, shadows, and motion rules. |
| apps/web/ui/shell.tsx | Rebuilds the signed-in sidebar and shared page shell around the new title-bar and toolbar structure. |
| apps/web/components/ui/sheet.tsx | Introduces the Radix-backed modal side-sheet primitive and its structured regions. |
| apps/web/components/ui/table.tsx | Adds semantic table primitives and the separately styled table panel. |
| apps/web/ui/data-table.tsx | Adopts the table primitives and standardizes the trailing action lane. |
| apps/web/components/ui/button.tsx | Changes the primary button to the wash treatment and updates shared control sizes. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Shell[Signed-in shell] --> Sidebar[Sidebar and project context]
  Shell --> Page[ProductPage]
  Page --> Header[PageHeader and title bar]
  Header --> Controls[Toolbar controls]
  Page --> Body[PageBody]
  Body --> Tables[Table panels and data tables]
  Page --> SheetHost[SheetHost]
  SheetHost --> Sheet[Modal side sheet]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): two side sheets at two widths,..."](https://github.com/egma-ai/egma/commit/f690810052372928efb9510c246ed1286f853871) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55991799)</sub>

<!-- /greptile_comment -->