### PR TITLE
feat(web): runs, simulations, transcripts, monitoring and graders by the recipe (ui-refresh 06)

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -1119,10 +1119,19 @@ describe("what a project recorded in production", () => {
       await page.waitForSelector("table");
       const shown = await page.innerText("main");
 
-      // The heading is the product's word for this area, and the page says what
-      // it holds before a single row is read.
+      // The heading is the product's word for this area.
+      //
+      // **And it is the whole of what stands above the list now.** The boards
+      // draw a list screen as a title bar, one strip of controls and the table
+      // (`71V-0`, `71N-0`) — no label over the title and no purpose sentence
+      // under it. The sidebar already says which section this is and which
+      // project it belongs to, and the table says what it holds; the sentence
+      // that used to sit here is kept for the screens that ask somebody to
+      // fill something in. Updated with the ui-refresh restyle of this screen.
       expect(shown).toContain("Monitoring");
-      expect(shown).toContain("What your agents did in production, newest first.");
+      expect(shown).not.toContain(
+        "What your agents did in production, newest first.",
+      );
 
       // The window control is on the default nobody chose, and the capture is
       // inside it — the browser's clock is pinned to the evening of the day the

--- a/apps/web/app/projects/[projectId]/graders/loading.tsx
+++ b/apps/web/app/projects/[projectId]/graders/loading.tsx
@@ -17,7 +17,7 @@ import { ProductStatePage } from "../../../../ui/shell.tsx";
 export default function GradersLoading() {
   return (
     <div data-slot="route-loading">
-      <ProductStatePage eyebrow="Project" title={LIBRARY.title}>
+      <ProductStatePage title={LIBRARY.title}>
         <Loading what={LIBRARY.loading} />
       </ProductStatePage>
     </div>

--- a/apps/web/app/projects/[projectId]/graders/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/page.tsx
@@ -41,6 +41,7 @@ import {
   ProductPage,
   useShellSession,
 } from "../../../../ui/shell.tsx";
+import { Notice } from "../../../ui.tsx";
 import { GraderTabs, VIEW_CONTENT } from "./tabs.tsx";
 import { UseForm } from "./use-form.tsx";
 
@@ -255,7 +256,7 @@ function GraderLibrary({ projectId }: { readonly projectId: string }) {
             points at the screen where it now appears.
           */}
           {started === null ? null : (
-            <p role="status">
+            <Notice tone="success">
               {USE.started(started)}{" "}
               <Link
                 href={projectPath(
@@ -266,7 +267,7 @@ function GraderLibrary({ projectId }: { readonly projectId: string }) {
               >
                 {USE.seeRunning}
               </Link>
-            </p>
+            </Notice>
           )}
 
           {/*

--- a/apps/web/app/projects/[projectId]/graders/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/page.tsx
@@ -239,7 +239,13 @@ function GraderLibrary({ projectId }: { readonly projectId: string }) {
 
   return (
     <ProductPage wide>
-      <PageHeader eyebrow="Project" title={LIBRARY.title} lead={LIBRARY.lead} />
+      {/*
+        The title, and then the strip. A list screen carries no label over its
+        title and no purpose sentence under it (`71V-0`): the sidebar already
+        says which section and which project this is, and the tab strip under
+        the bar says which of the section's two screens this is.
+      */}
+      <PageHeader title={LIBRARY.title} />
       <PageBody>
         <GraderTabs projectId={projectId} active="library" />
         <div className={VIEW_CONTENT}>

--- a/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
@@ -362,7 +362,11 @@ export function EditForm({
         </Field>
       </fieldset>
 
+      {/* The answer leads and the way out follows it, which is `7DA-0`. */}
       <FormActions>
+        <Button type="submit" busy={busy}>
+          {busy ? EDIT.submitting : EDIT.submit}
+        </Button>
         <Button
           type="button"
           variant="secondary"
@@ -370,9 +374,6 @@ export function EditForm({
           disabled={busy}
         >
           {EDIT.cancel}
-        </Button>
-        <Button type="submit" busy={busy}>
-          {busy ? EDIT.submitting : EDIT.submit}
         </Button>
       </FormActions>
     </Form>
@@ -444,10 +445,11 @@ export function SwitchOffPanel({
       {theLastOne ? <p>{SWITCH_OFF.theLastOne}</p> : null}
       {refused === null ? null : <Refused message={refused.message} />}
 
+      {/*
+        Inside the confirmation, the destructive act is the filled failure
+        button — the one place in the product that draws one.
+      */}
       <Actions>
-        <Button type="button" variant="secondary" onClick={onCancel}>
-          {SWITCH_OFF.cancel}
-        </Button>
         <Button
           type="button"
           variant="destructive"
@@ -455,6 +457,9 @@ export function SwitchOffPanel({
           onClick={() => void switchOff()}
         >
           {busy ? SWITCH_OFF.confirming : SWITCH_OFF.confirm}
+        </Button>
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          {SWITCH_OFF.cancel}
         </Button>
       </Actions>
     </>

--- a/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
@@ -37,14 +37,6 @@ import { Actions } from "../../../../../ui/section.tsx";
 import { EntryFields } from "../use-form.tsx";
 
 /**
- * One group of the edit form, and the word that names it.
- *
- * A `fieldset` because that is what a named group of controls is, and because
- * `disabled` on one makes every control inside it inert in one place while a
- * write is in flight. The hairline between groups is on the group rather than
- * between them, so a group added later is spaced without anybody remembering.
- */
-/**
  * One group of the editor.
  *
  * **The hairline is on the wrapper and the fieldset carries none**, which is a

--- a/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/edit-form.tsx
@@ -44,9 +44,19 @@ import { EntryFields } from "../use-form.tsx";
  * write is in flight. The hairline between groups is on the group rather than
  * between them, so a group added later is spaced without anybody remembering.
  */
-const FORM_GROUP =
-  "m-0 grid min-w-0 gap-5 px-0 pb-0 pt-5 first:pt-0 " +
-  "border-t border-border first:border-t-0";
+/**
+ * One group of the editor.
+ *
+ * **The hairline is on the wrapper and the fieldset carries none**, which is a
+ * fix rather than a preference: a `<legend>` sits *on* its fieldset's top
+ * border and the browser removes the border behind it, so a rule drawn on the
+ * fieldset started to the right of the group's name and never to the left of
+ * it. The fieldset stays, because `disabled` on it is what makes every control
+ * in the group inert while a save is in flight.
+ */
+const FORM_GROUP_FRAME = "min-w-0 border-t border-border pt-5";
+
+const FORM_GROUP = "m-0 grid min-w-0 gap-5 border-0 p-0";
 
 const FORM_GROUP_TITLE = "m-0 mb-4 p-0 text-base font-medium text-foreground";
 
@@ -249,118 +259,126 @@ export function EditForm({
       <Help>{EDIT.lead}</Help>
       {refused === null ? null : <Refused message={refused.message} />}
 
-      <fieldset className={FORM_GROUP} disabled={busy}>
-        <legend className={FORM_GROUP_TITLE}>{EDIT.groups.general}</legend>
-        <Field label={EDIT.name} hint={EDIT.nameMeans} htmlFor="edit-name">
-          <Input
-            id="edit-name"
-            value={name}
-            autoComplete="off"
-            spellCheck={false}
-            onChange={(event) => setName(event.target.value)}
-          />
-        </Field>
+      <div className={FORM_GROUP_FRAME}>
+        <fieldset className={FORM_GROUP} disabled={busy}>
+          <legend className={FORM_GROUP_TITLE}>{EDIT.groups.general}</legend>
+          <Field label={EDIT.name} hint={EDIT.nameMeans} htmlFor="edit-name">
+            <Input
+              id="edit-name"
+              value={name}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </Field>
 
-        <Field
-          label={EDIT.description}
-          hint={EDIT.descriptionMeans}
-          htmlFor="edit-description"
-        >
-          <Input
-            id="edit-description"
-            value={description}
-            autoComplete="off"
-            spellCheck={false}
-            onChange={(event) => setDescription(event.target.value)}
-          />
-        </Field>
-      </fieldset>
-
-      <fieldset className={FORM_GROUP} disabled={busy}>
-        <legend className={FORM_GROUP_TITLE}>{EDIT.groups.logic}</legend>
-        {/*
-          The entry's own questions, rendered by the component the Use form
-          renders them with — one declaration, one reading of it.
-        */}
-        <EntryFields
-          params={params}
-          filled={filled}
-          onFilled={(parameter, value) =>
-            setFilled((was) => ({ ...was, [parameter]: value }))
-          }
-          named="edit"
-          sentence={EDIT.asksNothing}
-        />
-      </fieldset>
-
-      <fieldset className={FORM_GROUP} disabled={busy}>
-        <legend className={FORM_GROUP_TITLE}>
-          {EDIT.groups.applicability}
-        </legend>
-        <Field label={EDIT.scope} hint={EDIT.scopeMeans} htmlFor="edit-scope">
-          <Select
-            id="edit-scope"
-            value={scope}
-            onChange={(event) => setScope(event.target.value)}
+          <Field
+            label={EDIT.description}
+            hint={EDIT.descriptionMeans}
+            htmlFor="edit-description"
           >
-            {Object.entries(SCOPES).map(([stored, said]) => (
-              <option key={stored} value={stored}>
-                {said}
-              </option>
-            ))}
-          </Select>
-        </Field>
+            <Input
+              id="edit-description"
+              value={description}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(event) => setDescription(event.target.value)}
+            />
+          </Field>
+        </fieldset>
+      </div>
 
-        {/*
-          The share of live traffic, on the shared numeric field.
-
-          **The bounds are now on the control rather than only in the
-          sentence.** `sampleRateMeans` says "a whole percentage from 0 to 100",
-          which is a claim a text box told to look numeric would happily take
-          900 against; `min`, `max` and `step` are the browser's own validation
-          and its own arrow-key stepping, so the sentence and the box agree. The
-          sentence stays as it is, because its second half — that a change
-          reaches future live traffic only — is the part a bound cannot say.
-
-          An empty box is still left out of the write rather than sent as
-          nought. That rule is in `save` below, and it is where it has to be:
-          `Number("")` is `0`, and `0` is a perfectly good share of live
-          traffic.
-        */}
-        {scope === "production" || scope === "both" ? (
-          <NumberField
-            id="edit-sample-rate"
-            label={EDIT.sampleRate}
-            hint={EDIT.sampleRateMeans}
-            value={sampleRate}
-            unit="%"
-            min={0}
-            max={100}
-            step={1}
-            onChange={setSampleRate}
+      <div className={FORM_GROUP_FRAME}>
+        <fieldset className={FORM_GROUP} disabled={busy}>
+          <legend className={FORM_GROUP_TITLE}>{EDIT.groups.logic}</legend>
+          {/*
+            The entry's own questions, rendered by the component the Use form
+            renders them with — one declaration, one reading of it.
+          */}
+          <EntryFields
+            params={params}
+            filled={filled}
+            onFilled={(parameter, value) =>
+              setFilled((was) => ({ ...was, [parameter]: value }))
+            }
+            named="edit"
+            sentence={EDIT.asksNothing}
           />
-        ) : null}
-      </fieldset>
+        </fieldset>
+      </div>
 
-      <fieldset className={FORM_GROUP} disabled={busy}>
-        <legend className={FORM_GROUP_TITLE}>{EDIT.groups.impact}</legend>
-        {/*
-          Both readings of `required` are spelled out beside the control, and
-          both carry the same warning: no verdict is rewritten, and every run
-          already read is counted again the next time somebody opens it.
-        */}
-        <Field
-          label={EDIT.required}
-          hint={required ? EDIT.requiredOn : EDIT.requiredOff}
-          htmlFor="edit-required"
-        >
-          <Checkbox
-            id="edit-required"
-            checked={required}
-            onChange={(event) => setRequired(event.target.checked)}
-          />
-        </Field>
-      </fieldset>
+      <div className={FORM_GROUP_FRAME}>
+        <fieldset className={FORM_GROUP} disabled={busy}>
+          <legend className={FORM_GROUP_TITLE}>
+            {EDIT.groups.applicability}
+          </legend>
+          <Field label={EDIT.scope} hint={EDIT.scopeMeans} htmlFor="edit-scope">
+            <Select
+              id="edit-scope"
+              value={scope}
+              onChange={(event) => setScope(event.target.value)}
+            >
+              {Object.entries(SCOPES).map(([stored, said]) => (
+                <option key={stored} value={stored}>
+                  {said}
+                </option>
+              ))}
+            </Select>
+          </Field>
+
+          {/*
+            The share of live traffic, on the shared numeric field.
+
+            **The bounds are now on the control rather than only in the
+            sentence.** `sampleRateMeans` says "a whole percentage from 0 to 100",
+            which is a claim a text box told to look numeric would happily take
+            900 against; `min`, `max` and `step` are the browser's own validation
+            and its own arrow-key stepping, so the sentence and the box agree. The
+            sentence stays as it is, because its second half — that a change
+            reaches future live traffic only — is the part a bound cannot say.
+
+            An empty box is still left out of the write rather than sent as
+            nought. That rule is in `save` below, and it is where it has to be:
+            `Number("")` is `0`, and `0` is a perfectly good share of live
+            traffic.
+          */}
+          {scope === "production" || scope === "both" ? (
+            <NumberField
+              id="edit-sample-rate"
+              label={EDIT.sampleRate}
+              hint={EDIT.sampleRateMeans}
+              value={sampleRate}
+              unit="%"
+              min={0}
+              max={100}
+              step={1}
+              onChange={setSampleRate}
+            />
+          ) : null}
+        </fieldset>
+      </div>
+
+      <div className={FORM_GROUP_FRAME}>
+        <fieldset className={FORM_GROUP} disabled={busy}>
+          <legend className={FORM_GROUP_TITLE}>{EDIT.groups.impact}</legend>
+          {/*
+            Both readings of `required` are spelled out beside the control, and
+            both carry the same warning: no verdict is rewritten, and every run
+            already read is counted again the next time somebody opens it.
+          */}
+          <Field
+            label={EDIT.required}
+            hint={required ? EDIT.requiredOn : EDIT.requiredOff}
+            htmlFor="edit-required"
+          >
+            <Checkbox
+              id="edit-required"
+              checked={required}
+              onChange={(event) => setRequired(event.target.checked)}
+            />
+          </Field>
+        </fieldset>
+      </div>
 
       {/* The answer leads and the way out follows it, which is `7DA-0`. */}
       <FormActions>

--- a/apps/web/app/projects/[projectId]/graders/running/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/page.tsx
@@ -534,11 +534,14 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
           {/*
             One column while nothing is open, two while an editor is.
 
-            The 230px shell leaves about 1170px of work area at a 1400px
-            viewport, and below that the five-column table and the 440px editor
-            are both cramped — so the editor goes above the list rather than
-            beside it. The width that decides is the whole product frame rather
-            than a phone.
+            **Measured rather than estimated, after a 1440 screenshot.** Five
+            columns, two of which are fixed at 170 and 130, plus a row that
+            carries two labelled controls, need about 900px before anything is
+            clipped; the editor is 440 and the gap is 24. With the 224px
+            sidebar and the page's own gutters that is roughly 1640px of
+            window. Below it the editor goes above the list, where both get the
+            full width. The earlier number left the two controls half off the
+            panel at 1440, which is the width this product is designed at.
           */}
           <div
             className={
@@ -546,7 +549,7 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
               "data-[editing=true]:grid data-[editing=true]:items-start " +
               "data-[editing=true]:gap-6 " +
               "data-[editing=true]:grid-cols-[minmax(0,1fr)_minmax(360px,440px)] " +
-              "max-[1400px]:data-[editing=true]:grid-cols-[minmax(0,1fr)]"
+              "max-[1640px]:data-[editing=true]:grid-cols-[minmax(0,1fr)]"
             }
             data-editing={open?.act === "edit" ? "true" : "false"}
           >
@@ -563,10 +566,10 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
                 className={
                   "sticky top-6 col-start-2 row-start-1 min-w-0 " +
                   "border-l border-border pl-6 " +
-                  "max-[1400px]:static max-[1400px]:col-start-1 " +
-                  "max-[1400px]:row-auto max-[1400px]:border-l-0 " +
-                  "max-[1400px]:border-b max-[1400px]:pt-0 max-[1400px]:pr-0 " +
-                  "max-[1400px]:pb-5 max-[1400px]:pl-0"
+                  "max-[1640px]:static max-[1640px]:col-start-1 " +
+                  "max-[1640px]:row-auto max-[1640px]:border-l-0 " +
+                  "max-[1640px]:border-b max-[1640px]:pt-0 max-[1640px]:pr-0 " +
+                  "max-[1640px]:pb-5 max-[1640px]:pl-0"
                 }
                 aria-labelledby={`${editorPanelId(open.copy.id)}-title`}
               >
@@ -598,7 +601,7 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
               className={
                 "min-w-0 in-data-[editing=true]:col-start-1 " +
                 "in-data-[editing=true]:row-start-1 " +
-                "max-[1400px]:in-data-[editing=true]:row-auto"
+                "max-[1640px]:in-data-[editing=true]:row-auto"
               }
             >
               {body()}

--- a/apps/web/app/projects/[projectId]/graders/running/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/page.tsx
@@ -251,9 +251,18 @@ function columnsFor(
           >
             {EDIT.open}
           </Button>{" "}
+          {/*
+            **The one destructive act on this row, as a text action in the
+            failure colour.** `DESIGN.md`: the control that opens a destructive
+            confirmation is text, and the filled failure-coloured button lives
+            inside the confirmation it opens. Two outlined buttons side by side
+            said that switching a grader off and editing it were the same size
+            of decision.
+          */}
           <Button
             type="button"
-            variant="secondary"
+            variant="ghost"
+            className="text-failure pointer-hover:text-failure"
             disabled={!mayAct || editorBusy}
             {...(mayAct || whyNotSwitchOff === undefined
               ? {}
@@ -474,10 +483,9 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
 
   return (
     <ProductPage wide>
+      {/* The trail and the title, and the strip under them. See the library. */}
       <PageHeader
-        eyebrow="Project"
         title={RUNNING.title}
-        lead={RUNNING.lead}
         breadcrumbs={[
           {
             label: "Graders",

--- a/apps/web/app/projects/[projectId]/graders/running/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/page.tsx
@@ -61,6 +61,7 @@ import {
   ProductPage,
   useShellSession,
 } from "../../../../../ui/shell.tsx";
+import { Notice } from "../../../../ui.tsx";
 import { GraderTabs, VIEW_CONTENT } from "../tabs.tsx";
 import { EditForm, SwitchOffPanel } from "./edit-form.tsx";
 
@@ -528,7 +529,7 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
             somebody has after saving a tighter bound or switching a grader off is
             always about the runs they have already read.
           */}
-          {said === null ? null : <p role="status">{said}</p>}
+          {said === null ? null : <Notice tone="success">{said}</Notice>}
 
           {/*
             One column while nothing is open, two while an editor is.

--- a/apps/web/app/projects/[projectId]/graders/use-form.tsx
+++ b/apps/web/app/projects/[projectId]/graders/use-form.tsx
@@ -259,12 +259,13 @@ export function UseForm({
         />
       </Field>
 
+      {/* The answer leads and the way out follows it, which is `7DA-0`. */}
       <FormActions>
-        <Button type="button" variant="secondary" onClick={onCancel}>
-          {USE.cancel}
-        </Button>
         <Button type="submit" disabled={busy}>
           {busy ? USE.submitting : USE.submit}
+        </Button>
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          {USE.cancel}
         </Button>
       </FormActions>
     </Form>

--- a/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
@@ -176,9 +176,14 @@ function StartMonitoring({ projectId }: { readonly projectId: string }) {
     <PageHeader
       title={COPY.title}
       lead={COPY.lead}
+      /*
+        The trail names the section and where in it this page sits; the title
+        beside it says the same thing at full length. Ending the trail with the
+        page's own title put the same three words twice in one 56px bar.
+      */
       breadcrumbs={[
         { label: COPY.eyebrow, href: monitoring },
-        { label: COPY.title },
+        { label: "Start" },
       ]}
     />
   );

--- a/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/start/page.tsx
@@ -174,7 +174,6 @@ function StartMonitoring({ projectId }: { readonly projectId: string }) {
   const monitoring = projectPath(projectId, "monitoring");
   const header = (
     <PageHeader
-      eyebrow={COPY.eyebrow}
       title={COPY.title}
       lead={COPY.lead}
       breadcrumbs={[

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -418,31 +418,39 @@ export default function TranscriptPage({
             { label: LIST.title, href: transcriptsPath(projectId) },
             { label: DETAIL.title },
           ]}
+          /*
+            One line of facts about this exchange, ending with its state.
+            **The chip is here rather than in the page's action slot**: an
+            action slot draws a 52px strip of its own, and a chip alone at the
+            far right of an otherwise empty strip is a gap with a badge in it.
+            A transcript offers no action, so the strip has nothing else to
+            hold.
+          */
           lead={
-            <>
+            <span className="inline-flex flex-wrap items-center gap-x-2 gap-y-1">
               <span>
                 {detail.trace.source} / {detail.trace.environment}
               </span>
-              {" · "}
+              <span aria-hidden="true">·</span>
               <RelativeInstant instant={openedAt} now={now} precision="second" />
-              {" · "}
-              {howLong(detail.trace.durationNs)}
-            </>
-          }
-          action={
-            <Badge variant={errored > 0 ? "failure" : "success"}>
-              {/*
-                The dot the hand-drawn chip carried as `::before`, kept. It is
-                `bg-current` and the same circle either way, so it separates
-                nothing on its own — `Recorded` and `1 error` are what say which
-                state this is. It is the chip's mark, not its meaning.
-              */}
-              <span
-                aria-hidden="true"
-                className="size-1.5 shrink-0 rounded-chip bg-current"
-              />
-              {errored === 0 ? DETAIL.recorded : DETAIL.errors(errored)}
-            </Badge>
+              <span aria-hidden="true">·</span>
+              <span className="tabular-nums">
+                {howLong(detail.trace.durationNs)}
+              </span>
+              <Badge variant={errored > 0 ? "failure" : "success"}>
+                {/*
+                  The dot the hand-drawn chip carried as `::before`, kept. It is
+                  `bg-current` and the same circle either way, so it separates
+                  nothing on its own — `Recorded` and `1 error` are what say which
+                  state this is. It is the chip's mark, not its meaning.
+                */}
+                <span
+                  aria-hidden="true"
+                  className="size-1.5 shrink-0 rounded-chip bg-current"
+                />
+                {errored === 0 ? DETAIL.recorded : DETAIL.errors(errored)}
+              </Badge>
+            </span>
           }
         />
 

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -55,7 +55,6 @@ import { SPEAKERS } from "../../../../../../ui/evidence.tsx";
 import { shownScore } from "../../../../../../ui/run-status.tsx";
 import { JudgmentCard } from "../../../../../judgment-card.tsx";
 import { RecordingPlayer } from "../../../../../recording-player.tsx";
-import { PageNavigation } from "../../../../../../ui/page-navigation.tsx";
 import { Loading } from "../../../../../../ui/page-state.tsx";
 import {
   RelativeInstant,
@@ -65,6 +64,7 @@ import {
   AppShell,
   LinkLine,
   Notice,
+  PageBody,
   PageHeader,
   ProductPage,
   ProductStatePage,
@@ -85,12 +85,24 @@ import {
  * four rules out of five would look right.
  * ------------------------------------------------------------------------ */
 
-/** The word above one fact: the compact uppercase caption, in the mono face. */
+/**
+ * The word above one fact: the compact uppercase caption, in the mono face.
+ *
+ * `--faint` is the recipe's one quiet-label colour, and it is the colour a
+ * table's column heading takes two blocks further down this same page. Two
+ * greys for one job is what makes a screen look assembled rather than drawn.
+ */
 const FACT_LABEL =
-  "font-mono text-sm tracking-(--tracking-label) text-muted-foreground uppercase";
+  "font-mono text-sm tracking-(--tracking-label) text-faint uppercase";
 
-/** The figure under it, which is a value rather than a heading. */
-const FACT_VALUE = "text-sm font-normal [overflow-wrap:anywhere]";
+/**
+ * The figure under it, which is a value rather than a heading.
+ *
+ * "Metrics, dates, durations, and scores use tabular numerals." Every one of
+ * these strips is a row of figures somebody reads across, and a proportional
+ * face puts each of them at its own width.
+ */
+const FACT_VALUE = "text-sm font-normal tabular-nums [overflow-wrap:anywhere]";
 
 /**
  * One fact inside a strip: a label over a figure, with the hairline that
@@ -380,12 +392,6 @@ export default function TranscriptPage({
   return (
     <AppShell>
       <ProductPage wide>
-        <PageNavigation
-          items={[
-            { label: LIST.title, href: transcriptsPath(projectId) },
-            { label: DETAIL.title },
-          ]}
-        />
         {/*
           The product's own page header, rather than one this page drew for
           itself. It used to carry a heading that grew to 56px — type
@@ -393,12 +399,31 @@ export default function TranscriptPage({
           settled transcript did not even match its own loading state, which
           has always been drawn by the shared header underneath
           `ProductStatePage`.
+
+          **The trail moved into the title bar with it.** It used to be drawn
+          above the bar as a sibling of `<main>`, where it had none of the
+          page's gutters and sat over the bar rather than in it; `breadcrumbs`
+          is where the shared header keeps a trail, and it is what every other
+          record page in this product hands it.
+
+          Where the trace came from goes into the lead, because a page with a
+          real trail draws no label above its title — and this is the only
+          place the page states which source and which environment this
+          exchange belongs to. It is a fact about the record, the same kind as
+          the two beside it.
         */}
         <PageHeader
-          eyebrow={`${detail.trace.source} / ${detail.trace.environment}`}
           title={DETAIL.title}
+          breadcrumbs={[
+            { label: LIST.title, href: transcriptsPath(projectId) },
+            { label: DETAIL.title },
+          ]}
           lead={
             <>
+              <span>
+                {detail.trace.source} / {detail.trace.environment}
+              </span>
+              {" · "}
               <RelativeInstant instant={openedAt} now={now} precision="second" />
               {" · "}
               {howLong(detail.trace.durationNs)}
@@ -421,6 +446,7 @@ export default function TranscriptPage({
           }
         />
 
+        <PageBody>
         <Summary facts={detail.trace} />
         <Measures measured={detail.measures ?? []} />
         {detail.outcome ? (
@@ -570,6 +596,7 @@ export default function TranscriptPage({
           </section>
           <Inspector selected={selected} facts={detail.trace} openedAt={openedAt} />
         </div>
+        </PageBody>
       </ProductPage>
     </AppShell>
   );

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/loading.tsx
@@ -13,12 +13,13 @@ import { ProductStatePage } from "../../../../../ui/shell.tsx";
  * Its header is the page's own down to its shape — the same eyebrow or the
  * same crumbs, never one standing in for the other — so nothing is redrawn a
  * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
+ * reasoning every one of these shares. The list screen carries no label above
+ * its title now, so neither does this.
  */
 export default function TranscriptsLoading() {
   return (
     <div data-slot="route-loading">
-      <ProductStatePage eyebrow={LIST.eyebrow} title={LIST.title}>
+      <ProductStatePage title={LIST.title}>
         <Loading what={LIST.loadingWhat} />
       </ProductStatePage>
     </div>

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
@@ -52,7 +52,7 @@ import {
   useMinuteClock,
 } from "../../../../../ui/relative-time.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
-import { Toolbar, TOOLBAR_FILTER } from "../../../../../ui/section.tsx";
+import { TOOLBAR_FILTER } from "../../../../../ui/section.tsx";
 import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { useOrganizationRead } from "../../../../../ui/settings-read.ts";
 import {
@@ -450,12 +450,40 @@ function Transcripts({ projectId }: { readonly projectId: string }) {
           ),
         });
 
+  /*
+   * The window is a filter, so it sits where every list page in this product
+   * keeps its filters: the left of the one strip under the title bar, opposite
+   * the one action. A person moving between Runs and Monitoring should not
+   * have to look in two places for the same kind of control.
+   */
+  const filters = (
+    <Select
+      id="window"
+      className={TOOLBAR_FILTER}
+      value={choice ?? DEFAULT_WINDOW}
+      aria-label={LIST.window}
+      onChange={(event) => choose(event.target.value as WindowChoice)}
+    >
+      {WINDOWS.map((one) => (
+        <option key={one.id} value={one.id}>
+          {one.label}
+        </option>
+      ))}
+    </Select>
+  );
+
   return (
     <ProductPage wide>
+      {/*
+        The title, the filter and the action, and nothing else above the list.
+        The boards draw no label and no purpose sentence over a list screen
+        (`71V-0`, `71N-0`): the sidebar already says which section this is and
+        which project it belongs to, and the table under it says what it holds.
+        The purpose sentence stays where a form needs one.
+      */}
       <PageHeader
-        eyebrow={LIST.eyebrow}
         title={LIST.title}
-        lead={LIST.lead}
+        toolbar={filters}
         action={
           <Button asChild>
             <Link href={startMonitoringPath(projectId)}>{LIST.startMonitoring}</Link>
@@ -463,27 +491,6 @@ function Transcripts({ projectId }: { readonly projectId: string }) {
         }
       />
       <PageBody>
-        {/*
-          The window is a filter, so it sits where every list page in this
-          product now keeps its filters: the left of the strip above the list.
-          A person moving between Runs and Monitoring should not have to look
-          in two places for the same kind of control.
-        */}
-        <Toolbar>
-          <Select
-            id="window"
-            className={TOOLBAR_FILTER}
-            value={choice ?? DEFAULT_WINDOW}
-            aria-label={LIST.window}
-            onChange={(event) => choose(event.target.value as WindowChoice)}
-          >
-            {WINDOWS.map((one) => (
-              <option key={one.id} value={one.id}>
-                {one.label}
-              </option>
-            ))}
-          </Select>
-        </Toolbar>
         {state.status === "failed" ? (
           <Failure
             message={state.why}

--- a/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
@@ -497,9 +497,14 @@ function RunDetailView({
       <PageHeader
         eyebrow="Simulation runs"
         title={displayTitle}
+        /*
+         * The trail names the section and the kind of record; the title beside
+         * it names *this* record. Ending the trail with the run's own name put
+         * the same words twice in one 56px bar, a comma apart.
+         */
         breadcrumbs={[
           { label: "Runs", href: projectPath(projectId, "runs") },
-          { label: displayTitle },
+          { label: "Run" },
         ]}
         action={
           !mayControl || !active ? undefined : (

--- a/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
@@ -44,6 +44,7 @@ import {
 } from "../../../../../ui/relative-time.tsx";
 import {
   GradingState,
+  RunProgress,
   RunStatus,
   SimulationStatus,
   VerdictBadge,
@@ -471,6 +472,26 @@ function RunDetailView({
 
   const active = status === "pending" || status === "running";
 
+  /**
+   * How many of this run's simulations have landed — **a floor, never a
+   * guess.**
+   *
+   * `finishedCount` is what the run said when it was last read, and the run is
+   * only re-read when the feed says it is done. So a bar drawn from that alone
+   * would sit still for the whole of a live run. The feed, meanwhile, names
+   * every simulation that has reached a terminal state since the read, and each
+   * of those is finished by definition.
+   *
+   * The larger of the two is therefore true of both moments and can only move
+   * forwards: it never claims a simulation nobody has finished, and the final
+   * read settles it exactly. `RunProgress` clamps its own share, so an overlap
+   * between the two cannot push the bar past its end.
+   */
+  const landed = [...moved.values()].filter((one) =>
+    ["completed", "failed", "canceled"].includes(one.status),
+  ).length;
+  const finished = Math.max(read.finishedCount, landed);
+
   return (
     <ProductPage wide>
       <PageHeader
@@ -535,7 +556,9 @@ function RunDetailView({
             <div className={FACT}>
               <dt>Grading</dt>
               <dd>
-                {read.gradedCount} of {read.gradableCount} judged
+                <span className="tabular-nums">
+                  {read.gradedCount} of {read.gradableCount} judged
+                </span>
               </dd>
             </div>
             <div className={FACT}>
@@ -590,6 +613,26 @@ function RunDetailView({
         </section>
 
         <Section title="Simulations">
+          {/*
+            How far the machinery has got, over the conversations it got there
+            through. **The bar measures simulations and says so**: judging
+            settles at a different moment, and one bar over both would have to
+            decide which half a half-full bar meant. Grading has its own figure
+            in the summary above.
+          */}
+          {read.expectedSimulationCount === 0 ? null : (
+            <div className="flex min-w-0 items-center gap-4">
+              <div className="min-w-0 flex-1">
+                <RunProgress
+                  finished={finished}
+                  expected={read.expectedSimulationCount}
+                />
+              </div>
+              <span className="flex-none font-mono text-sm text-faint tabular-nums">
+                {finished} of {read.expectedSimulationCount} finished
+              </span>
+            </div>
+          )}
           {simulationPage === null || simulationPage.status === "signed-out" ? (
             <Loading what="this run's simulations" />
           ) : simulationPage.status !== "ready" ? (

--- a/apps/web/app/projects/[projectId]/runs/new/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/new/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   createRun,
   getAgent,
@@ -12,6 +12,7 @@ import {
 } from "@egma/platform-api/client";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import {
@@ -42,7 +43,6 @@ import {
 } from "../../../../../ui/form.tsx";
 import { Empty, Failure, Loading } from "../../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
-import { Section } from "../../../../../ui/section.tsx";
 import { useUnsavedChanges } from "../../../../../ui/settings-read.ts";
 import {
   AppShell,
@@ -55,6 +55,44 @@ import {
 function connectionLabel(connection: ListedConnection): string {
   const environment = connection.environment === null ? "" : ` · ${connection.environment}`;
   return `${connection.name} · ${connection.productLabel} · ${connection.modality}${environment}`;
+}
+
+/**
+ * One group of the builder: a legend, the sentence under it, and its fields.
+ *
+ * **A fieldset rather than the page-level `Section`.** The four groups are
+ * parts of one form on one surface, not four blocks of a page: `Section`
+ * carries a 24px title and 32px of its own room above it, which on a form
+ * inside a card reads as four separate forms 52px apart. This is the shape the
+ * grader editor already draws its four groups in — a hairline between, a 16px
+ * legend — so the two forms in this product read as one.
+ */
+function Group({
+  title,
+  lead,
+  children,
+}: {
+  readonly title: string;
+  readonly lead?: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    /*
+     * **The hairline is on the wrapper and the fieldset carries none.** A
+     * `<legend>` sits on its fieldset's top border and the browser drops the
+     * border behind it, so a rule drawn on the fieldset would start to the
+     * right of the group's name and never to the left of it.
+     */
+    <div className="min-w-0 not-first:border-t not-first:border-border not-first:pt-5">
+      <fieldset className={cn("m-0 grid min-w-0 gap-4 border-0 p-0")}>
+        <legend className="m-0 mb-1 p-0 text-base font-medium text-foreground">
+          {title}
+        </legend>
+        {lead === undefined ? null : <Help>{lead}</Help>}
+        {children}
+      </fieldset>
+    </div>
+  );
 }
 
 function newRunIntentKey(): string {
@@ -390,7 +428,10 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
               }
             />
           ) : (
-            <Section title="Test suite" lead="Egma runs the full suite. Individual tests cannot be picked here.">
+            <Group
+              title="Test suite"
+              lead="Egma runs the full suite. Individual tests cannot be picked here."
+            >
               <Field label="Test suite" htmlFor="run-suite">
                 <Select
                   id="run-suite"
@@ -430,10 +471,10 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
                   {loadingSuites ? "Loading…" : "Load more suites"}
                 </Button>
               )}
-            </Section>
+            </Group>
           )}
 
-          <Section title="Agent" lead="Choose the agent under test.">
+          <Group title="Agent" lead="Choose the agent under test.">
             {agents.length === 0 ? (
               <Empty title="This project has no active agent" />
             ) : (
@@ -465,9 +506,9 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
                 )}
               </>
             )}
-          </Section>
+          </Group>
 
-          <Section title="Connection" lead="Choose how Egma reaches this agent.">
+          <Group title="Connection" lead="Choose how Egma reaches this agent.">
             {agentId === "" ? (
               <p className="m-0 text-sm text-muted-foreground">Choose an agent first.</p>
             ) : agentDetail === null ? (
@@ -495,9 +536,9 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
             ) : agentDetail.status === "signed-out" ? null : (
               <Failure message={agentDetail.refusal.message} />
             )}
-          </Section>
+          </Group>
 
-          <Section title="Run details">
+          <Group title="Run details">
             <Field label="Run name (optional)" htmlFor="run-name">
               <Input
                 id="run-name"
@@ -512,7 +553,7 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
               />
             </Field>
             <Help>Leave this blank and Egma will use the test suite name.</Help>
-          </Section>
+          </Group>
 
           {moreRefused === null ? null : <Refused message={moreRefused.message} />}
           {refused === null ? null : <Refused message={refused.message} />}

--- a/apps/web/app/projects/[projectId]/runs/new/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/new/page.tsx
@@ -33,10 +33,16 @@ import {
   type TestSuitePage,
 } from "../../../../../lib/test-suites.ts";
 import type { TestPage } from "../../../../../lib/tests.ts";
-import { Field, Help, Refused } from "../../../../../ui/form.tsx";
+import {
+  Field,
+  Form,
+  FormActions,
+  Help,
+  Refused,
+} from "../../../../../ui/form.tsx";
 import { Empty, Failure, Loading } from "../../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
-import { Actions, Section } from "../../../../../ui/section.tsx";
+import { Section } from "../../../../../ui/section.tsx";
 import { useUnsavedChanges } from "../../../../../ui/settings-read.ts";
 import {
   AppShell,
@@ -85,6 +91,8 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
   );
 
   const [suiteId, setSuiteId] = useState("");
+  /** The suite the address asked for, until the loaded list confirms it. */
+  const [wantedSuite, setWantedSuite] = useState("");
   const [agentId, setAgentId] = useState("");
   const [connectionId, setConnectionId] = useState("");
   const [name, setName] = useState("");
@@ -128,9 +136,21 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
     setRefused(null);
   }
 
+  /**
+   * The two records this page can be opened *about*, read out of the address.
+   *
+   * A suite page's "Run suite" and an agent page's "Run this agent" both land
+   * here, and both name what they came from. Neither is trusted: the value is
+   * matched against what this project can actually see, further down, and a
+   * parameter naming something else simply selects nothing — which is how the
+   * agent parameter has always behaved and is the only safe reading of an
+   * identifier somebody can type into a URL bar.
+   */
   useEffect(() => {
     showing.current = projectId;
-    const selected = new URLSearchParams(window.location.search).get("agent")?.trim() ?? "";
+    const address = new URLSearchParams(window.location.search);
+    const selected = address.get("agent")?.trim() ?? "";
+    setWantedSuite(address.get("suite")?.trim() ?? "");
     setSuiteId("");
     setAgentId(selected);
     setConnectionId("");
@@ -149,6 +169,28 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
       setSuiteCursor(suitePage.value.nextPageToken);
     }
   }, [suitePage]);
+
+  /**
+   * The suite the address asked for, selected once this project has confirmed
+   * it exists — and never otherwise.
+   *
+   * The check is against the suites already loaded rather than a read of its
+   * own, so an identifier belonging to another project, or to nothing, leaves
+   * the field on "Choose a test suite" instead of putting a name on screen
+   * that the person cannot open. A suite that has not been paged to yet is
+   * picked up the moment "Load more suites" brings it in, because the ask is
+   * held until it is answered.
+   */
+  useEffect(() => {
+    if (wantedSuite === "" || suitePage?.status !== "ready") return;
+    const known = [...suitePage.value.testSuites, ...moreSuites].some(
+      (suite) => suite.id === wantedSuite,
+    );
+    if (!known) return;
+    setSuiteId(wantedSuite);
+    setWantedSuite("");
+    setIdempotencyKey(newRunIntentKey());
+  }, [wantedSuite, suitePage, moreSuites]);
 
   useEffect(() => {
     if (agentPage?.status === "ready") {
@@ -326,14 +368,17 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
           { label: "New run" },
         ]}
         lead="Run every current test in one suite against one agent and one connection."
-        action={
-          <Button asChild variant="secondary">
-            <Link href={`/projects/${encodeURIComponent(projectId)}/runs`}>Cancel</Link>
-          </Button>
-        }
       />
       <PageBody>
-        <div className="flex flex-col gap-8">
+        {/*
+          **One form on one Pure Paper surface**, which is what `DESIGN.md`
+          asks of a page that groups fields — and what the shared `Form`
+          already draws, first group flush with its top edge. The page used to
+          stack four bare sections straight onto the canvas, each paying its
+          own top margin over a wrapper's gap, so the groups sat 64px apart on
+          no surface at all.
+        */}
+        <Form onSubmit={() => void start()}>
           {suites.length === 0 ? (
             <Empty
               title="This project has no test suite"
@@ -471,18 +516,28 @@ function RunBuilder({ projectId }: { readonly projectId: string }) {
 
           {moreRefused === null ? null : <Refused message={moreRefused.message} />}
           {refused === null ? null : <Refused message={refused.message} />}
-          <Actions>
+          {/*
+            The answer and the way out, together at the leading edge — the
+            footer shape `7DA-0` draws on every panel in this product. `Start
+            run` is the wash primary and a real submit, so the return key in
+            the name field starts the run rather than doing nothing.
+          */}
+          <FormActions>
             <Button
-              type="button"
+              type="submit"
               disabled={!mayStart || !ready}
               busy={starting}
               why={whyNot}
-              onClick={() => void start()}
             >
               {starting ? "Starting…" : "Start run"}
             </Button>
-          </Actions>
-        </div>
+            <Button asChild variant="secondary">
+              <Link href={`/projects/${encodeURIComponent(projectId)}/runs`}>
+                Cancel
+              </Link>
+            </Button>
+          </FormActions>
+        </Form>
       </PageBody>
     </ProductPage>
   );

--- a/apps/web/app/projects/[projectId]/runs/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/page.tsx
@@ -30,11 +30,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
-import {
-  Actions,
-  Toolbar,
-  TOOLBAR_FILTER,
-} from "../../../../ui/section.tsx";
+import { Actions, TOOLBAR_FILTER } from "../../../../ui/section.tsx";
 import { Refused } from "../../../../ui/form.tsx";
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
@@ -605,102 +601,109 @@ function Runs({ projectId }: { readonly projectId: string }) {
     }
   }
 
+  /**
+   * What this list is narrowed by, in the order somebody narrows.
+   *
+   * It is handed to the page header rather than drawn in the body, because the
+   * recipe gives every list in this product one strip under the title bar: the
+   * filters at the left and the one action at the right (`71N-0`). Drawing them
+   * in the body put the action on one row and the filters on the row under it,
+   * which is two strips doing one job.
+   */
+  const filters = (
+    <>
+      <Select
+        id="runs-agent"
+        className={TOOLBAR_FILTER}
+        value={agent}
+        aria-label="Show only runs against one agent"
+        onChange={(event) => setAgent(event.target.value)}
+      >
+        <option value="">Any agent</option>
+        {agentRows.map((one) => (
+          <option key={one.id} value={one.id}>
+            {one.name}
+          </option>
+        ))}
+      </Select>
+      <Select
+        id="runs-connection"
+        className={TOOLBAR_FILTER}
+        value={connection}
+        aria-label="Show only runs over one connection"
+        onChange={(event) => setConnection(event.target.value)}
+      >
+        <option value="">Any connection</option>
+        {[...connections].map(([id, label]) => (
+          <option key={id} value={id}>
+            {label}
+          </option>
+        ))}
+      </Select>
+      <Select
+        id="runs-status"
+        className={TOOLBAR_FILTER}
+        value={status}
+        aria-label="Show only runs whose machinery is in one state"
+        onChange={(event) =>
+          setStatus(event.target.value as "" | RunStatusWord)
+        }
+      >
+        <option value="">Any run state</option>
+        {RUN_STATUS_WORDS.map((one) => (
+          <option key={one} value={one}>
+            {one}
+          </option>
+        ))}
+      </Select>
+      <Select
+        id="runs-verdict"
+        className={TOOLBAR_FILTER}
+        value={verdict}
+        aria-label="Show only runs with one verdict"
+        onChange={(event) =>
+          setVerdict(event.target.value as "" | VerdictWord)
+        }
+      >
+        <option value="">Any verdict</option>
+        {VERDICT_WORDS.map((one) => (
+          <option key={one} value={one}>
+            {one}
+          </option>
+        ))}
+      </Select>
+      {/*
+        The field carries its own name rather than a visible label, the
+        same way the four filters beside it do. `autoComplete` is said out
+        loud because the control set this replaces defaulted it to `off`,
+        and a browser offering to remember a date filter is a menu over
+        the toolbar every time somebody focuses it.
+      */}
+      <Input
+        id="runs-since"
+        className={TOOLBAR_FILTER}
+        type="text"
+        value={typedSince}
+        aria-label="Show only runs started on or after a day"
+        placeholder="YYYY-MM-DD"
+        autoComplete="off"
+        spellCheck={false}
+        onChange={(event) => setTypedSince(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") setSince(typedSince);
+          if (event.key === "Escape") {
+            setTypedSince("");
+            setSince("");
+          }
+        }}
+      />
+    </>
+  );
+
   return (
     <ProductPage>
-      <PageHeader
-        title="Simulation runs"
-        action={plan()}
-      />
-      <PageBody>
-        <Toolbar>
-          <Select
-            id="runs-agent"
-            className={TOOLBAR_FILTER}
-            value={agent}
-            aria-label="Show only runs against one agent"
-            onChange={(event) => setAgent(event.target.value)}
-          >
-            <option value="">Any agent</option>
-            {agentRows.map((one) => (
-              <option key={one.id} value={one.id}>
-                {one.name}
-              </option>
-            ))}
-          </Select>
-          <Select
-            id="runs-connection"
-            className={TOOLBAR_FILTER}
-            value={connection}
-            aria-label="Show only runs over one connection"
-            onChange={(event) => setConnection(event.target.value)}
-          >
-            <option value="">Any connection</option>
-            {[...connections].map(([id, label]) => (
-              <option key={id} value={id}>
-                {label}
-              </option>
-            ))}
-          </Select>
-          <Select
-            id="runs-status"
-            className={TOOLBAR_FILTER}
-            value={status}
-            aria-label="Show only runs whose machinery is in one state"
-            onChange={(event) =>
-              setStatus(event.target.value as "" | RunStatusWord)
-            }
-          >
-            <option value="">Any run state</option>
-            {RUN_STATUS_WORDS.map((one) => (
-              <option key={one} value={one}>
-                {one}
-              </option>
-            ))}
-          </Select>
-          <Select
-            id="runs-verdict"
-            className={TOOLBAR_FILTER}
-            value={verdict}
-            aria-label="Show only runs with one verdict"
-            onChange={(event) =>
-              setVerdict(event.target.value as "" | VerdictWord)
-            }
-          >
-            <option value="">Any verdict</option>
-            {VERDICT_WORDS.map((one) => (
-              <option key={one} value={one}>
-                {one}
-              </option>
-            ))}
-          </Select>
-          {/*
-            The field carries its own name rather than a visible label, the
-            same way the four filters beside it do. `autoComplete` is said out
-            loud because the control set this replaces defaulted it to `off`,
-            and a browser offering to remember a date filter is a menu over
-            the toolbar every time somebody focuses it.
-          */}
-          <Input
-            id="runs-since"
-            className={TOOLBAR_FILTER}
-            type="text"
-            value={typedSince}
-            aria-label="Show only runs started on or after a day"
-            placeholder="YYYY-MM-DD"
-            autoComplete="off"
-            spellCheck={false}
-            onChange={(event) => setTypedSince(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") setSince(typedSince);
-              if (event.key === "Escape") {
-                setTypedSince("");
-                setSince("");
-              }
-            }}
-          />
-        </Toolbar>
-        {body()}
-      </PageBody>
+      <PageHeader title="Simulation runs" toolbar={filters} action={plan()} />
+      <PageBody>{body()}</PageBody>
     </ProductPage>
   );
 }

--- a/apps/web/app/projects/[projectId]/runs/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/page.tsx
@@ -176,6 +176,14 @@ function columnsFor(
               <Button
                 type="button"
                 variant="secondary"
+                /*
+                 * The trailing lane pays no side padding — it is sized for a
+                 * ⋮, and a control that carries a word instead would sit hard
+                 * against the panel's own edge. The margin is on the control
+                 * rather than the cell, and equal on both sides, so the lane
+                 * widens around it and the button stays centred in it.
+                 */
+                className="mx-4"
                 onClick={() => onCancel(run.id)}
               >
                 Cancel

--- a/apps/web/lib/grader-library-copy.ts
+++ b/apps/web/lib/grader-library-copy.ts
@@ -31,7 +31,14 @@
 
 export const LIBRARY = {
   title: "Graders",
-  lead: "Choose a grader to use in this project.",
+  /*
+   * **There was a `lead` here and the screen stopped drawing it.** The boards
+   * put a title bar, one strip of controls and the table over a list screen and
+   * nothing else, so the purpose sentence had nowhere left to be — and the rule
+   * this file states about itself says a word nobody renders is deleted rather
+   * than kept. A purpose statement is still what a form gets; a list is
+   * explained by the table under it.
+   */
   /** What the page says it is waiting for, never merely that it is waiting. */
   loading: "the grader library",
   /**

--- a/apps/web/lib/grader-running-copy.ts
+++ b/apps/web/lib/grader-running-copy.ts
@@ -27,7 +27,7 @@
 
 export const RUNNING = {
   title: "Graders",
-  lead: "The graders judging this project now.",
+  /* See `LIBRARY` for why a list screen keeps no purpose sentence. */
   /** What the page says it is waiting for, never merely that it is waiting. */
   loading: "running graders",
   /**

--- a/apps/web/lib/grader-running-copy.ts
+++ b/apps/web/lib/grader-running-copy.ts
@@ -26,7 +26,13 @@
  */
 
 export const RUNNING = {
-  title: "Graders",
+  /*
+   * **Not "Graders", which is the first crumb of this page's own trail.** The
+   * title bar draws the trail and then the title, so a page titled with the
+   * word its trail opens with reads "Graders / Running   Graders". The trail
+   * says which section and where in it; the title says what this screen holds.
+   */
+  title: "Running graders",
   /* See `LIBRARY` for why a list screen keeps no purpose sentence. */
   /** What the page says it is waiting for, never merely that it is waiting. */
   loading: "running graders",

--- a/apps/web/lib/transcript-copy.ts
+++ b/apps/web/lib/transcript-copy.ts
@@ -22,7 +22,6 @@
 
 /** The list page. */
 export const LIST = {
-  eyebrow: "Project",
   /**
    * The heading, and deliberately not the navigation label: the sidebar reads
    * its words from `lib/navigation.ts`, which is where a navigation item is
@@ -30,7 +29,6 @@ export const LIST = {
    * many, and this is the one the page renders.
    */
   title: "Monitoring",
-  lead: "What your agents did in production, newest first.",
   /** What the table is called where somebody hears it rather than sees it. */
   tableLabel: "Production transcripts in this project",
   loadingWhat: "this project's production transcripts",

--- a/apps/web/ui/evidence.tsx
+++ b/apps/web/ui/evidence.tsx
@@ -151,10 +151,6 @@ export function Transcript({
     );
   }
 
-  const spoken = howLong(
-    transcript.turns.reduce((total, turn) => total + turn.durationNs, 0),
-  );
-
   return (
     <div
       className="flex flex-col overflow-hidden rounded-card border border-border bg-surface"
@@ -176,7 +172,7 @@ export function Transcript({
         <span className="font-mono text-sm text-faint tabular-nums">
           {transcript.turns.length} turn{transcript.turns.length === 1 ? "" : "s"}
           {" · "}
-          {spoken}
+          {howLong(transcript.durationNs)}
         </span>
       </div>
       {transcript.turns.map((turn, at) => {
@@ -512,35 +508,50 @@ export function Measures({
   }
 
   return (
-    <dl
-      className={cn(
-        "m-0 grid grid-cols-[repeat(auto-fit,minmax(148px,1fr))] overflow-hidden",
-        /*
-         * The hairline between two measures is the grid gap showing the
-         * background through it, so a row of them needs no border of its own
-         * and no rule about which edge is doubled.
-         */
-        "gap-px rounded-card border border-border bg-border",
-      )}
+    <div
+      className="flex min-w-0 flex-col overflow-hidden rounded-card border border-border bg-surface"
       data-slot="measures"
     >
-      {entries.map(([name, value]) => {
-        const how = MEASURES[name];
-        return (
-          <div
-            className="flex min-w-0 flex-col gap-1 bg-surface p-5"
-            key={name}
-          >
-            <dt className="text-sm text-muted-foreground">
-              {how?.label ?? name.replaceAll("_", " ")}
-            </dt>
-            <dd className="m-0 font-mono text-base text-foreground tabular-nums">
-              {how === undefined ? String(value) : how.shown(value)}
-            </dd>
-          </div>
-        );
-      })}
-    </dl>
+      <div
+        className={cn(
+          "flex min-h-(--row-height) flex-none items-center justify-between gap-3",
+          "border-b border-border bg-surface-soft px-5 py-2",
+        )}
+      >
+        <strong className="text-sm font-medium text-foreground">Measures</strong>
+        <span className="font-mono text-sm text-faint tabular-nums">
+          {entries.length} captured
+        </span>
+      </div>
+      {/*
+       * **A label at the leading edge and a figure in a fixed slot at the
+       * other**, which is what `1E8-0` asks for in as many words: "Value
+       * columns use a stable mono slot, so scans do not jump." A grid of cards
+       * put every figure at a different left edge, so reading four measures
+       * meant finding four of them.
+       */}
+      <dl className="m-0 flex min-w-0 flex-col">
+        {entries.map(([name, value]) => {
+          const how = MEASURES[name];
+          return (
+            <div
+              className={cn(
+                "flex min-w-0 items-baseline justify-between gap-4 px-5 py-2.5",
+                "not-first:border-t not-first:border-t-border",
+              )}
+              key={name}
+            >
+              <dt className="min-w-0 text-sm text-muted-foreground">
+                {how?.label ?? name.replaceAll("_", " ")}
+              </dt>
+              <dd className="m-0 w-[12ch] flex-none text-end font-mono text-sm text-foreground tabular-nums">
+                {how === undefined ? String(value) : how.shown(value)}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+    </div>
   );
 }
 
@@ -587,9 +598,33 @@ export function MockToolEvidence({
 
   return (
     <div
-      className="flex flex-col gap-4 rounded-card border border-border bg-surface p-5"
+      className="flex min-w-0 flex-col overflow-hidden rounded-card border border-border bg-surface"
       data-slot="mock-tools"
     >
+      {/* The head `1EZ-0` draws: what this record is, and whether it matched. */}
+      <div
+        className={cn(
+          "flex min-h-(--row-height) flex-none items-center justify-between gap-3",
+          "border-b border-border bg-surface-soft px-5 py-2",
+        )}
+      >
+        <strong className="text-sm font-medium text-foreground">Mock tools</strong>
+        <span
+          className={cn(
+            "text-sm",
+            coverage !== null && coverage.uncovered.length === 0
+              ? "text-success"
+              : "text-faint",
+          )}
+        >
+          {coverage === null
+            ? "Nothing was asked"
+            : coverage.uncovered.length === 0
+              ? "Matched"
+              : `${String(coverage.uncovered.length)} ran for real`}
+        </span>
+      </div>
+      <div className="flex flex-col gap-4 p-5">
       {frozen.length === 0 ? null : (
         <div className="flex flex-wrap items-baseline gap-2">
           <strong className="me-2 text-sm font-medium text-foreground">
@@ -610,7 +645,11 @@ export function MockToolEvidence({
         </Help>
       ) : (
         <>
-          <div className="flex flex-wrap items-baseline gap-2">
+          {/*
+           * The good half of the record, on the quiet wash behind a narrow
+           * success edge — a state colour, never the brand one.
+           */}
+          <div className="flex flex-wrap items-baseline gap-2 border-s-[3px] border-s-success bg-surface-soft px-3 py-2">
             <strong className="me-2 text-sm font-medium text-foreground">
               Answered by Egma
             </strong>
@@ -648,6 +687,7 @@ export function MockToolEvidence({
           </Help>
         </>
       )}
+      </div>
     </div>
   );
 }
@@ -716,12 +756,17 @@ export function VerdictEvidence({
         {speaking.rationale}
       </p>
       {cited.length === 0 ? null : (
-        <p className={cn(CITED)}>
+        /*
+         * The citation, on the wash `DESIGN.md` reserves for "cited" and behind
+         * the one narrow Ember edge this surface is allowed. It is decoration
+         * pointing at the words, never a verdict — the chip above says that.
+         */
+        <p className={cn(CITED, "border-s-[3px] border-s-brand bg-selected px-3 py-2")}>
           Cites {cited.map((turn, at) => (
             <span key={turn}>
               {at === 0 ? "" : ", "}
               <a
-                className="text-foreground underline-offset-3"
+                className="text-foreground decoration-brand underline-offset-3"
                 href={`#transcript-turn-${String(turn)}`}
               >
                 turn {turn}

--- a/apps/web/ui/evidence.tsx
+++ b/apps/web/ui/evidence.tsx
@@ -151,11 +151,34 @@ export function Transcript({
     );
   }
 
+  const spoken = howLong(
+    transcript.turns.reduce((total, turn) => total + turn.durationNs, 0),
+  );
+
   return (
     <div
       className="flex flex-col overflow-hidden rounded-card border border-border bg-surface"
       data-slot="transcript"
     >
+      {/*
+       * The head the board draws over a transcript (`WU-0`): what this panel
+       * is at the leading edge, and how much of it there is at the other. The
+       * count and the clock are the mono tabular pair every figure in this
+       * product wears, so two transcripts side by side line up.
+       */}
+      <div
+        className={cn(
+          "flex min-h-(--row-height) flex-none items-center justify-between gap-3",
+          "border-b border-border bg-surface-soft px-5 py-2",
+        )}
+      >
+        <strong className="text-sm font-medium text-foreground">Transcript</strong>
+        <span className="font-mono text-sm text-faint tabular-nums">
+          {transcript.turns.length} turn{transcript.turns.length === 1 ? "" : "s"}
+          {" · "}
+          {spoken}
+        </span>
+      </div>
       {transcript.turns.map((turn, at) => {
         const inside = everyStep(turn.spans);
         const failed = inside.some((step) => step.status === "error");
@@ -169,7 +192,8 @@ export function Transcript({
               /* The leading edge is always there and usually invisible, so a
                  cited turn colours it rather than moving the text along. */
               "border-s-[3px] border-s-transparent",
-              "not-first:border-t not-first:border-t-border",
+              /* The head above supplies the first line, so every turn takes one. */
+              "border-t border-t-border",
               /* A verdict points here. */
               cited && "border-s-brand bg-selected",
               /* Somebody followed a `Cites turn 3` link to this turn. The

--- a/apps/web/ui/relative-time.tsx
+++ b/apps/web/ui/relative-time.tsx
@@ -37,6 +37,13 @@ export function RelativeInstant({
 }) {
   return (
     <time
+      /*
+       * "Metrics, dates, durations, and scores use tabular numerals."
+       * An age is a figure, and a column of them is what somebody scans: a
+       * proportional face puts "2 minutes ago" and "9 minutes ago" at two
+       * widths, so the eye has to read each row instead of seeing the column.
+       */
+      className="tabular-nums"
       dateTime={instant}
       title={formatViewerInstant(instant, precision)}
       suppressHydrationWarning

--- a/apps/web/ui/run-status.tsx
+++ b/apps/web/ui/run-status.tsx
@@ -469,7 +469,13 @@ function Fact({
 }) {
   return (
     <div className="flex min-w-0 flex-col gap-2 px-5 py-4">
-      <span className="text-sm text-muted-foreground">{label}</span>
+      {/*
+       * The quiet label the boards write over every fact: 14px in `--faint`,
+       * the same step and the same colour as a table's own column headings, so
+       * a strip of facts and the table under it read as one product rather
+       * than two densities.
+       */}
+      <span className="text-sm text-faint">{label}</span>
       <span className="flex min-w-0 items-center gap-2 text-sm text-foreground">
         {children}
       </span>

--- a/apps/web/ui/simulation-evidence.tsx
+++ b/apps/web/ui/simulation-evidence.tsx
@@ -117,9 +117,15 @@ export function SimulationEvidenceSummary({
 }) {
   const turns = turnsOf(evidence);
   return (
+    /*
+     * **The container is the wrapper, not the strip.** An element cannot be
+     * its own query container, so `@container` and `grid-cols-3` on one
+     * `<section>` left the query measuring nothing: the three facts stayed in
+     * three columns however little room the strip had.
+     */
+    <div className="@container/summary min-w-0">
     <section
       className={cn(
-        "@container/summary",
         "grid min-w-0 grid-cols-3 overflow-hidden rounded-card border border-border",
         /*
          * **Its own width decides, not the window's.** The reading sheet opens
@@ -149,6 +155,7 @@ export function SimulationEvidenceSummary({
         </strong>
       </div>
     </section>
+    </div>
   );
 }
 
@@ -1162,35 +1169,7 @@ function SimulationEvidencePanel({
   }
 
   return (
-    <section
-      className={cn(
-        REVIEW,
-        /*
-         * **The sheet is docked beside this page, so the page steps aside for
-         * it.** That is what a non-modal reading surface promises — the test
-         * covering this panel says it in as many words: "a panel docked beside
-         * this page rather than a layer over it, so the grader results stay
-         * reachable while the transcript is open". The panel is `position:
-         * fixed` against the viewport's right edge, which means nothing under
-         * it moves on its own: at 1440 the transcript covered the judge
-         * findings it is evidence *for*, and a reader had to close the
-         * transcript to read the finding that cited it.
-         *
-         * The room is the sheet's own width from the theme plus one gutter,
-         * and only where there is room to give: below 1100px the sheet is
-         * most of the screen and reading it *is* the mode, so the page stays
-         * where it is and the sheet covers it.
-         *
-         * It is not animated. `DESIGN.md` asks motion to run on `transform`
-         * and `opacity`, and this is padding — a layout property, on a panel
-         * holding a whole review. The sheet's own entrance already explains
-         * where the room went.
-         */
-        evidenceOpen &&
-          "min-[1100px]:pe-[calc(var(--sheet-width-wide)+var(--page-gutter))]",
-      )}
-      aria-label="Simulation evidence"
-    >
+    <section className={REVIEW} aria-label="Simulation evidence">
       <section
         className={cn(
           "flex min-h-full min-w-0 flex-col overflow-hidden",
@@ -1332,7 +1311,41 @@ export function SimulationEvidenceReview({
   useEffect(() => setEvidenceOpen(true), [evidence.id]);
 
   return (
-    <div className={REVIEW}>
+    <div
+      className={cn(
+        REVIEW,
+        /*
+         * **The sheet is docked beside this page, so the page steps aside for
+         * it.** That is what a non-modal reading surface promises — the test
+         * covering this panel says it in as many words: "a panel docked beside
+         * this page rather than a layer over it, so the grader results stay
+         * reachable while the transcript is open". The panel is `position:
+         * fixed` against the viewport's right edge, so nothing under it moves
+         * on its own: at 1440 the transcript covered the judge findings it is
+         * evidence *for*, and a reader had to close the transcript to read the
+         * finding that cited it.
+         *
+         * **The room is reserved here, on the block that holds both halves**,
+         * and not on the review panel alone. The summary strip is that panel's
+         * sibling, so padding the panel left the strip running on under the
+         * sheet — Duration cut in half and Total turns gone — while the panel
+         * beside it sat clear of it. One ancestor pays, and every child is
+         * inside what is left.
+         *
+         * The room is the sheet's own width from the theme plus one gutter,
+         * and only where there is room to give: below 1100px the sheet is
+         * most of the screen and reading it *is* the mode, so the page stays
+         * where it is and the sheet covers it.
+         *
+         * It is not animated. `DESIGN.md` asks motion to run on `transform`
+         * and `opacity`, and this is padding — a layout property, on a block
+         * holding a whole review. The sheet's own entrance already explains
+         * where the room went.
+         */
+        evidenceOpen &&
+          "min-[1100px]:pe-[calc(var(--sheet-width-wide)+var(--page-gutter))]",
+      )}
+    >
       <SimulationEvidenceSummary evidence={evidence} />
       <SimulationEvidencePanel
         evidence={evidence}

--- a/apps/web/ui/simulation-evidence.tsx
+++ b/apps/web/ui/simulation-evidence.tsx
@@ -84,8 +84,15 @@ const SUMMARY_CELL = "flex min-w-0 items-center justify-between gap-3 px-5 py-3"
 const SUMMARY_CELL_NEXT =
   "border-border border-s max-[40rem]:border-s-0 max-[40rem]:border-t";
 
-/** Metrics and counts read straight in the mono face. */
-const SUMMARY_VALUE = "font-mono text-base font-normal text-foreground";
+/**
+ * Metrics and counts read straight in the mono face, on tabular figures.
+ *
+ * `WV-0` writes the three summary values in mono; `DESIGN.md` asks every
+ * metric, date, duration and score for tabular numerals. Both together are
+ * what stops "1m 04s" and "11m 40s" sitting at two widths in one strip.
+ */
+const SUMMARY_VALUE =
+  "font-mono text-base font-normal text-foreground tabular-nums";
 
 /**
  * The name of one fact, quiet, beside its value.
@@ -941,13 +948,19 @@ function graderSummary(
   return parts.join(" · ");
 }
 
-/** The quiet mono kicker over a title: what kind of thing this block is. */
+/**
+ * The quiet mono kicker over a title: what kind of thing this block is.
+ *
+ * `--faint` rather than `--muted-foreground`, which is the recipe's one quiet
+ * label colour: the same step a table's column heading takes, so a kicker over
+ * a panel and a heading over a column are the same weight of voice.
+ */
 const PANE_KIND =
-  "mb-1 block font-mono text-sm tracking-(--tracking-label) text-muted-foreground uppercase";
+  "mb-1 block font-mono text-sm tracking-(--tracking-label) text-faint uppercase";
 
 /** The name over each half of the expected-against-found comparison. */
 const COMPARISON_LABEL =
-  "m-0 mb-2 font-mono text-sm font-normal tracking-(--tracking-label) text-muted-foreground uppercase";
+  "m-0 mb-2 font-mono text-sm font-normal tracking-(--tracking-label) text-faint uppercase";
 
 /** Sentences inside a check. Judge findings run long, so they break anywhere. */
 const ASSERTION_TEXT = "m-0 min-w-0 text-sm wrap-anywhere text-foreground";
@@ -1002,7 +1015,7 @@ function GraderGroup({
                    * the two have to read as one line.
                    */
                   "[&>span]:font-mono [&>span]:text-sm",
-                  "[&>span]:text-muted-foreground [&>span]:uppercase",
+                  "[&>span]:text-faint [&>span]:uppercase [&>span]:tabular-nums",
                 )}
               >
                 <span>Check {String(at + 1).padStart(2, "0")}</span>

--- a/apps/web/ui/simulation-evidence.tsx
+++ b/apps/web/ui/simulation-evidence.tsx
@@ -81,8 +81,10 @@ const SUMMARY_CELL = "flex min-w-0 items-center justify-between gap-3 px-5 py-3"
  * The line between two facts. It runs beside them while the three sit in a row,
  * and above them once a narrow screen stacks the row into a column.
  */
-const SUMMARY_CELL_NEXT =
-  "border-border border-s max-[40rem]:border-s-0 max-[40rem]:border-t";
+const SUMMARY_CELL_NEXT = cn(
+  "border-border border-s",
+  "@max-[40rem]/summary:border-s-0 @max-[40rem]/summary:border-t",
+);
 
 /**
  * Metrics and counts read straight in the mono face, on tabular figures.
@@ -117,8 +119,16 @@ export function SimulationEvidenceSummary({
   return (
     <section
       className={cn(
+        "@container/summary",
         "grid min-w-0 grid-cols-3 overflow-hidden rounded-card border border-border",
-        "bg-surface max-[40rem]:grid-cols-1",
+        /*
+         * **Its own width decides, not the window's.** The reading sheet opens
+         * over the right half of this page by default, so at 1440 these three
+         * facts share about 520px — while a viewport rule was still calling it
+         * a wide screen and holding them in three 170px columns. A container
+         * query asks the strip how much room *it* has.
+         */
+        "bg-surface @max-[40rem]/summary:grid-cols-1",
       )}
       aria-label="Simulation summary"
     >
@@ -999,7 +1009,7 @@ function GraderGroup({
             : "This grader returned no assertions."}
         </p>
       ) : (
-        <div className="flex min-w-0 flex-col gap-4 bg-background p-5 max-[40rem]:p-4">
+        <div className="@container/checks flex min-w-0 flex-col gap-4 bg-background p-5 max-[40rem]:p-4">
           {grader.assertions.map((assertion, at) => (
             <article
               className="min-w-0 overflow-hidden rounded-input border border-border bg-surface"
@@ -1021,7 +1031,14 @@ function GraderGroup({
                 <span>Check {String(at + 1).padStart(2, "0")}</span>
                 <VerdictBadge verdict={assertion.verdict} compact />
               </header>
-              <div className="grid min-w-0 grid-cols-2 max-[40rem]:grid-cols-1">
+              {/*
+                Expected beside found while the card has room for both, and one
+                under the other when it does not. The card's own width decides:
+                with the reading sheet open this column is about 520px wide on
+                a 1440 screen, and two 250px halves is not two halves anybody
+                can read a judge's finding in.
+              */}
+              <div className="grid min-w-0 grid-cols-2 @max-[44rem]/checks:grid-cols-1">
                 <section className="min-w-0 p-4">
                   <h4 className={COMPARISON_LABEL}>Expected behavior</h4>
                   <p className={ASSERTION_TEXT}>{assertion.expected}</p>
@@ -1030,7 +1047,7 @@ function GraderGroup({
                  * The two halves are divided by a line: beside them while they
                  * sit side by side, and above the second once they stack.
                  */}
-                <section className="min-w-0 border-border border-s bg-surface-soft p-4 max-[40rem]:border-s-0 max-[40rem]:border-t">
+                <section className="min-w-0 border-border border-s bg-surface-soft p-4 @max-[44rem]/checks:border-s-0 @max-[44rem]/checks:border-t">
                   <h4 className={COMPARISON_LABEL}>Judge finding</h4>
                   <p className={ASSERTION_TEXT}>
                     {assertion.finding ??
@@ -1145,7 +1162,35 @@ function SimulationEvidencePanel({
   }
 
   return (
-    <section className={REVIEW} aria-label="Simulation evidence">
+    <section
+      className={cn(
+        REVIEW,
+        /*
+         * **The sheet is docked beside this page, so the page steps aside for
+         * it.** That is what a non-modal reading surface promises — the test
+         * covering this panel says it in as many words: "a panel docked beside
+         * this page rather than a layer over it, so the grader results stay
+         * reachable while the transcript is open". The panel is `position:
+         * fixed` against the viewport's right edge, which means nothing under
+         * it moves on its own: at 1440 the transcript covered the judge
+         * findings it is evidence *for*, and a reader had to close the
+         * transcript to read the finding that cited it.
+         *
+         * The room is the sheet's own width from the theme plus one gutter,
+         * and only where there is room to give: below 1100px the sheet is
+         * most of the screen and reading it *is* the mode, so the page stays
+         * where it is and the sheet covers it.
+         *
+         * It is not animated. `DESIGN.md` asks motion to run on `transform`
+         * and `opacity`, and this is padding — a layout property, on a panel
+         * holding a whole review. The sheet's own entrance already explains
+         * where the room went.
+         */
+        evidenceOpen &&
+          "min-[1100px]:pe-[calc(var(--sheet-width-wide)+var(--page-gutter))]",
+      )}
+      aria-label="Simulation evidence"
+    >
       <section
         className={cn(
           "flex min-h-full min-w-0 flex-col overflow-hidden",


### PR DESCRIPTION
Ticket: `egma-planning/.scratch/ui-refresh/issues/06-runs-simulations-monitoring-graders.md`.
Base: `integration/ui-refresh` at **e5346550** (ticket 01's PR #192, which contains f6908100).

Eleven screens — the ones that carry the product's evidence — on the recipe.

## What the work turned out to be

These screens were already on Tailwind and the shadcn base, and every radius they draw is a theme token ticket 01 had already moved to 0px. A grep for a hard-coded radius or colour across all of `runs/**`, `monitoring/**`, `graders/**`, `app/runs/**`, `judgment-card.tsx`, `recording-player.tsx` and my four `ui/*` files came back empty. So this is not a repaint. It is four things: the recipe's **one strip under the title bar**, the **quiet label colour and tabular figures** the boards give every kicker and every figure, the **facts the boards add**, and the **page gutters one screen was not paying at all**.

## Per screen

| Screen | What changed |
| --- | --- |
| `runs/page.tsx` | The five filters move into the header's own strip, opposite `Create a run` — one row under the title bar instead of two. The row's `Cancel` keeps equal margins so it stops sitting on the panel's edge. |
| `runs/new` | The four groups move onto the shared form's Pure Paper surface and become `fieldset`/`legend` groups (the grader editor's shape) instead of four page-level `Section`s 52px apart. The answer and the way out are together in the footer, and `Start run` is a real submit. **Reads `?suite=`** for ticket 05's "Run suite" link, matched against the suites the page has loaded. |
| `runs/[runId]` | **Draws `RunProgress`**, which has been in the product unused since it was written, with `N of M finished` beside it. The trail names the kind and the heading names the record. Grading's figure is tabular. |
| `runs/[runId]/simulations/[simulationId]` | Wiring only; the review is `ui/simulation-evidence.tsx`. |
| `app/runs/[runId]` | Untouched — three states, already right. |
| `monitoring/transcripts` | Drops the label over its title and the sentence under it; the window filter moves into the strip, opposite `Start monitoring`. |
| `monitoring/transcripts/[transcriptId]` | **Was drawing its whole body straight into `<main>`** — no `PageBody`, so no gutters at all — and its trail above the sticky bar rather than in it. Both are the shared header's and body's now, which is what all four of its own state branches already used. Source and environment move into the lead; the `Recorded` chip goes with them rather than sitting alone in a 52px strip. Kickers to `--faint`, figures to tabular. |
| `monitoring/start` | The trail stops repeating the title. |
| `graders` + `graders/running` | Both drop the label and the purpose sentence. `Switch off` becomes the destructive **text** action `DESIGN.md` asks for, with the filled failure button kept inside the confirmation. Every footer puts the answer first. The two status lines move into the shared `Notice`. The editor stands beside the table only above 1640px — measured, after a 1440 shot showed it cutting two row controls in half. |
| `ui/evidence.tsx` | `WU-0`. The measures panel becomes the board's own argument — a label at the leading edge, a figure in a stable mono slot — rather than a grid of cards at four different left edges. Mock-tool evidence grows the board's head with "Matched" beside it. A verdict's citation moves onto the wash `DESIGN.md` reserves for cited work. |
| `ui/simulation-evidence.tsx` | `WV-0`. Kickers to `--faint`, summary values tabular, check numbers tabular. |
| `ui/run-status.tsx`, `ui/relative-time.tsx` | Quiet labels, and a relative instant reads in tabular numerals wherever a column of them is scanned. |

## Screenshots

`.proofs/ui-06/` in the worktree and the session scratchpad's `proofs/ui-06/`. Nineteen screens, light and dark at 1440: `runs-list`, `runs-list-empty`, `runs-new`, `run-detail-running`, `run-detail-finished`, `simulation-evidence` (sheet open), `simulation-evidence-pending`, `transcripts-list`, `transcripts-list-quiet`, `transcript-detail-transcript`, `-timeline`, `-execution`, `monitoring-start`, `graders-library`, `graders-running`, `graders-running-editing`; and `runs-list`, `transcripts-list`, `transcript-detail-transcript` again at 375.

They are of real rows. A throwaway script boots the real API and the real pages against the isolated stores, seeds a project through the API, and moves its simulations with the same data-access functions a simulator calls — no simulator and no grader run in a proof instance, so verdicts are written through the same store the grading service writes to rather than invented in the page.

**Six things the screenshots found that reading the code did not**, all fixed before this opened: the doubled record name in the title bar; a row control sitting on the panel's edge; the grader editor clipping two controls at 1440; a `<legend>` punching a hole in every group rule; the `Recorded` chip alone in an empty strip; and the evidence strips asking the window how much room they had while the reading sheet covered half of it — container queries now, so each strip asks itself.

## Browser expectations updated

One, in the monitoring block of `apps/api/test/browser.test.ts`: the list's purpose sentence is gone, so the block asserts its absence with the reason on it. Nothing else in that file moved. `browser-lane.test.ts` untouched.

## Shared files

**None added and none edited.** Everything is inside the ticket's own files, plus its four `ui/*` files (`evidence.tsx`, `simulation-evidence.tsx`, `run-status.tsx`, `relative-time.tsx`) and its `lib/*` copy modules. `ui/dialog.tsx`, `ui/shell.tsx`, `ui/data-table.tsx`, `app/ui.tsx` and everything under `components/ui/` are untouched.

## Left for somebody else

- **The title bar says a record's name twice.** `PageHeader` draws the trail and then the `<h1>`, and a trail's last item is the current page. This hits every record page in the product, so it is `ui/shell.tsx`'s. Worked around where a page can pick a different last crumb; the transcript page cannot, because a test pins its `<h1>` to "Transcript".
- **`ui/data-table.tsx` sizes every `action` column to the 48px menu lane and gives it no side padding.** Right for a ⋮, wrong for a labelled control. Fixed locally with margins on the control; if 03–05 hit the same thing the fix belongs in the shared table.
- **Two API gaps, both in the run builder** (contract wins, as the ticket ruled): no operation answers a pre-flight plan before a run exists, and `createRun` takes no test-id list, so the board's test picker cannot be built. The section lead says so out loud instead.
- The 52px waveform lane and the 200ms progress transition are still off `DESIGN.md`'s scales, still flagged in the code.
- The reading sheet is 640px again after ticket 01's round 2. It was covering the judge findings it is evidence *for*, because it is `position: fixed` and nothing under it moved; the review pays its width as room now, which is what that surface's own test says it promises. Below 1100px the sheet is most of the screen and reading it is the mode.

## Gate

`pnpm typecheck` green (the whole of it: skills check, contract generate check, lint, `tsc -b` across the packages, the tests project, and the web app). `npx vitest run --project fast --maxWorkers=2 apps/web/test/` → **26 files, 564 tests, all passing** (the whole web suite, not only the owned files).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790081330&installation_model_id=431960&pr_number=196&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F196&signature=93af2c8b3d89cc435493c37f427a2fd8b2dcf0342e00d1494b845c7f0b07fc61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes eleven evidence-focused web screens while preserving their existing product contracts.
- Consolidates run, transcript, monitoring, and grader controls into shared header, body, form, notice, and navigation patterns.
- Adds suite preselection to the run builder and live simulation progress to run details.
- Refines evidence panels, responsive layouts, typography, destructive actions, and accessibility-oriented form structure.
- Updates the monitoring browser expectation to match the revised list-page copy.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/runs/new/page.tsx | Reorganizes the builder into a semantic shared form, supports suite URL preselection, and makes run creation a native submit action. |
| apps/web/app/projects/[projectId]/runs/[runId]/page.tsx | Adds simulation progress derived from the latest read and terminal feed updates while refining record-header presentation. |
| apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx | Moves transcript content into the shared page body and consolidates provenance, timing, and status in the shared header. |
| apps/web/app/projects/[projectId]/graders/running/edit-form.tsx | Restructures fieldset borders and action ordering while retaining existing grader update and deletion behavior. |
| apps/web/app/projects/[projectId]/graders/running/page.tsx | Updates grader actions, status notices, and responsive editor layout without changing the underlying project-scoped operations. |
| apps/web/ui/evidence.tsx | Redesigns transcript, measure, mock-tool, and citation presentation around stable evidence-panel layouts. |
| apps/web/ui/simulation-evidence.tsx | Introduces container-responsive evidence summaries and consistent quiet-label and tabular-number styling. |
| apps/api/test/browser.test.ts | Updates the monitoring browser assertion to verify removal of the former purpose sentence. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Run builder] --> B[Create simulation run]
  B --> C[Run detail and progress]
  C --> D[Simulation evidence]
  E[Production monitoring] --> F[Transcript list]
  F --> G[Transcript evidence]
  H[Grader library] --> I[Running graders]
  I --> C
  I --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): the whole review steps aside f..."](https://github.com/egma-ai/egma/commit/c898a6964e6873555ac5ce69918ad2ddfcfd7e49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56004564)</sub>

<!-- /greptile_comment -->