### PR TITLE
feat(web): settings, organization, people, keys and the entry pages by the recipe (ui-refresh 07)

### DIFF
--- a/apps/web/app/members/page.tsx
+++ b/apps/web/app/members/page.tsx
@@ -8,6 +8,7 @@ import { firstProjectOf, type Me } from "../../lib/me.ts";
 import { NEW_PROJECT_PATH } from "../../lib/settings.ts";
 import { Button } from "@/components/ui/button";
 
+import { Actions } from "../../ui/section.tsx";
 import { settingsPath } from "../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../ui/shell.tsx";
 
@@ -80,13 +81,16 @@ export default function MembersPage() {
           : answer.refusal.message
       }
     >
-      <Button
-        type="button"
-        variant="secondary"
-        onClick={() => setAttempt((one) => one + 1)}
-      >
-        Try again
-      </Button>
+      {/* Wrapped, so the control is the width of its own label. See `app/page.tsx`. */}
+      <Actions>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => setAttempt((one) => one + 1)}
+        >
+          Try again
+        </Button>
+      </Actions>
     </ProductStatePage>
   );
 }

--- a/apps/web/app/new-project/page.tsx
+++ b/apps/web/app/new-project/page.tsx
@@ -12,7 +12,6 @@ import type { Refusal } from "../../lib/api.ts";
 import { roleOf } from "../../lib/me.ts";
 import { platformAnswer, platformClient } from "../../lib/platform-client.ts";
 import { projectLanding } from "../../lib/project-context.ts";
-import { Section } from "../../ui/section.tsx";
 import {
   Field,
   Form,
@@ -118,13 +117,20 @@ function NewProject() {
 
   return (
     <ProductPage>
+      {/*
+        * No label over the title. This address is reached from the project
+        * selector rather than from Settings, so an eyebrow reading "Settings"
+        * put the page in a section it is not in — and there is no trail here
+        * for it to be the first step of. The title bar names the page and the
+        * line under it says what a project is.
+        */}
       <PageHeader
-        eyebrow="Settings"
         title="New project"
         lead="A project holds its own agents, tests, personas, graders and runs. Everybody in the organization can work in every one of them."
       />
       <PageBody>
-        <Section title="Name it">
+        {/* One form, and the title bar has already named it. */}
+        <div className="flex flex-col gap-4">
           {/*
             * Said before the form rather than instead of it. A viewer or a
             * member sees exactly this page with the controls disabled, so the
@@ -187,7 +193,7 @@ function NewProject() {
               </Button>
             </FormActions>
           </Form>
-        </Section>
+        </div>
       </PageBody>
     </ProductPage>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -9,6 +9,7 @@ import { readJson, type Answer } from "../lib/api.ts";
 import { firstProjectOf, roleOf, type Me } from "../lib/me.ts";
 import { projectLanding } from "../lib/project-context.ts";
 import { NEW_PROJECT_PATH } from "../lib/settings.ts";
+import { Actions } from "../ui/section.tsx";
 import { ProductStatePage } from "../ui/shell.tsx";
 
 /**
@@ -83,6 +84,13 @@ export default function RootPage() {
         lead="Agents, tests, personas, graders and runs all live in a project. Making one is the first step, and it takes a name."
       >
         {/*
+          * The control is wrapped, and a screenshot is what asked for it.
+          * `ProductStatePage` puts whatever it is given straight into the
+          * page body, which is a column — so a lone button stretched to the
+          * full width of the page and stopped looking like a button at all.
+          * `Actions` is the shared group a page's controls stand in.
+          */}
+        {/*
           * A way forward rather than a dead end. Signup provisions a project, so
           * an organization reaching this state is rare — and the person looking
           * at it is standing in front of a product shell with nothing in it,
@@ -97,19 +105,21 @@ export default function RootPage() {
           * which carries the reason where a keyboard and a screen reader can
           * reach it.
           */}
-        {role === "admin" ? (
-          <Button asChild>
-            <Link href={NEW_PROJECT_PATH}>Create the first project</Link>
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            disabled
-            why={`Your ${role} role cannot create a project. Ask an organization admin to make the first one.`}
-          >
-            Create the first project
-          </Button>
-        )}
+        <Actions>
+          {role === "admin" ? (
+            <Button asChild>
+              <Link href={NEW_PROJECT_PATH}>Create the first project</Link>
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              disabled
+              why={`Your ${role} role cannot create a project. Ask an organization admin to make the first one.`}
+            >
+              Create the first project
+            </Button>
+          )}
+        </Actions>
       </ProductStatePage>
     );
   }
@@ -119,13 +129,15 @@ export default function RootPage() {
       title="Egma could not be reached."
       lead={answer.refusal.message}
     >
-      <Button
-        type="button"
-        variant="secondary"
-        onClick={() => setAttempt((one) => one + 1)}
-      >
-        Try again
-      </Button>
+      <Actions>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => setAttempt((one) => one + 1)}
+        >
+          Try again
+        </Button>
+      </Actions>
     </ProductStatePage>
   );
 }

--- a/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/loading.tsx
@@ -1,9 +1,4 @@
-"use client";
-
-import { useParams } from "next/navigation";
-
 import { Loading } from "../../../../../ui/page-state.tsx";
-import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
@@ -12,23 +7,15 @@ import { ProductStatePage } from "../../../../../ui/shell.tsx";
  *
  * Its own boundary, so moving between settings views stays instant.
  *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the title bar carries the
+ * page's name and nothing else, and the settings rail beside the page is the
+ * trail into it — so nothing is redrawn a second way when the page arrives.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
  */
 export default function KeysSettingsLoading() {
-  const { projectId } = useParams<{ projectId: string }>();
-
   return (
     <div data-slot="route-loading">
-      <ProductStatePage
-        title="API keys"
-        breadcrumbs={[
-          { label: "Settings", href: settingsPath(projectId) },
-          { label: "API keys" },
-        ]}
-      >
+      <ProductStatePage title="API keys">
         <Loading what="your keys" />
       </ProductStatePage>
     </div>

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { EyeOffIcon } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { createApiKey, listApiKeys, revokeApiKey } from "@egma/platform-api/client";
@@ -17,6 +18,8 @@ import {
   type MintedApiKey,
 } from "../../../../../lib/settings.ts";
 import { Button } from "@/components/ui/button";
+import { Card, CardFooter } from "@/components/ui/card";
+import { DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 
@@ -84,6 +87,19 @@ export default function ApiKeysSettingsPage() {
 const WHOLE_ORGANIZATION = "";
 
 /**
+ * The lane a row's own controls stand in.
+ *
+ * The shared table draws the trailing cell as the boards do — a fixed 48px slot
+ * with no side padding, so that every ⋮ in the product lines up in one column
+ * down the table (`78X-0`). A cell holding a named button rather than a ⋮ is
+ * wider than the slot and grows it, and with no padding of its own the button
+ * then sits against the panel's own hairline. This puts the row's padding back
+ * inside the cell, where the width is the caller's problem rather than the
+ * table's.
+ */
+const ROW_ACTIONS = "flex items-center justify-end gap-2 px-4";
+
+/**
  * The only copy of a newly minted secret.
  *
  * This component sits above the key-list read rather than inside it. A refresh
@@ -114,21 +130,51 @@ function ApiKeyReceipt({
   }
 
   return (
-    <Section title="Copy your new key">
-      <p role="status">
-        <strong>Here is your key. Copy it now.</strong> Egma will not show it
-        again, and cannot: only its hash was kept. <code>{keyValue.secret}</code>
-      </p>
-      <Button type="button" onClick={() => void copy()}>
-        Copy key
-      </Button>{" "}
-      <Button type="button" variant="secondary" onClick={onDismiss}>
-        Dismiss
-      </Button>
-      {copyState === "copied" ? <Help>Copied.</Help> : null}
-      {copyState === "failed" ? (
-        <Refused message="Egma could not copy the key. Select it above and copy it before you dismiss this message." />
-      ) : null}
+    <Section
+      title="Copy your new key"
+      /*
+       * That this is the only time, said beside the heading rather than only
+       * inside the paragraph under it — which is what `2BN-0` draws. The word
+       * carries the meaning and the icon carries it again for anybody reading
+       * without colour: "state is not communicated by colour alone".
+       */
+      action={
+        <span className="inline-flex items-center gap-2 text-sm text-(--bad)">
+          <EyeOffIcon aria-hidden="true" className="size-4" strokeWidth={1.75} />
+          Shown once
+        </span>
+      }
+    >
+      <Card className="gap-4">
+        <div className="flex flex-col gap-3">
+          <p className="m-0 max-w-[72ch] text-sm text-muted-foreground" role="status">
+            <strong className="font-medium text-foreground">
+              Here is your key. Copy it now.
+            </strong>{" "}
+            Egma will not show it again, and cannot: only its hash was kept.
+          </p>
+          {/*
+           * The secret on its own contained surface, in the mono face, wrapped
+           * rather than clipped (`7D6-0`). A key that ran off the edge of its
+           * line would be a key somebody copied half of.
+           */}
+          <code className="block rounded-input border border-border bg-surface-soft p-3 font-mono text-sm break-all text-foreground">
+            {keyValue.secret}
+          </code>
+        </div>
+        <CardFooter>
+          <Button type="button" onClick={() => void copy()}>
+            Copy key
+          </Button>
+          <Button type="button" variant="secondary" onClick={onDismiss}>
+            Dismiss
+          </Button>
+        </CardFooter>
+        {copyState === "copied" ? <Help>Copied.</Help> : null}
+        {copyState === "failed" ? (
+          <Refused message="Egma could not copy the key. Select it above and copy it before you dismiss this message." />
+        ) : null}
+      </Card>
     </Section>
   );
 }
@@ -249,14 +295,16 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
          */
         action: true,
         cell: (key) => (
-          <Button
-            type="button"
-            variant="secondary"
-            disabled={busy}
-            onClick={() => setConfirmingRevoke(key)}
-          >
-            Revoke
-          </Button>
+          <div className={ROW_ACTIONS}>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={busy}
+              onClick={() => setConfirmingRevoke(key)}
+            >
+              Revoke
+            </Button>
+          </div>
         ),
       },
     ];
@@ -285,7 +333,6 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
   return (
     <ProductPage viewport>
       <PageHeader
-        eyebrow="Settings"
         title="API keys"
         breadcrumbs={[
           { label: "Settings", href: settingsPath(projectId) },
@@ -417,25 +464,35 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
         >
           {(dismiss) => (
             <>
-              <p>
+              <p className="m-0 max-w-[62ch] text-sm text-muted-foreground">
                 {confirmingRevoke.name ?? "This key"} will stop working on its next
                 request. This action cannot be undone.
               </p>
-              <Button type="button" variant="secondary" onClick={dismiss}>
-                Cancel
-              </Button>{" "}
-              <Button
-                type="button"
-                variant="destructive"
-                disabled={busy}
-                onClick={() => {
-                  const key = confirmingRevoke;
-                  setConfirmingRevoke(null);
-                  void revoke(key);
-                }}
-              >
-                Revoke key
-              </Button>
+              {/*
+               * The answer leads and the way out follows it, both at the left
+               * edge, which is what `BK9-0` draws. Without the footer the two
+               * were flex children of the panel's own column and each ran the
+               * full width of it, stacked — two blocks where the board has one
+               * row.
+               */}
+              <DialogFooter>
+                <Button
+                  type="button"
+                  size="lg"
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={() => {
+                    const key = confirmingRevoke;
+                    setConfirmingRevoke(null);
+                    void revoke(key);
+                  }}
+                >
+                  Revoke key
+                </Button>
+                <Button type="button" size="lg" variant="secondary" onClick={dismiss}>
+                  Cancel
+                </Button>
+              </DialogFooter>
             </>
           )}
         </Dialog>

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -39,10 +39,7 @@ import {
   useMinuteClock,
 } from "../../../../../ui/relative-time.tsx";
 import { Section } from "../../../../../ui/section.tsx";
-import {
-  SettingsLayout,
-  settingsPath,
-} from "../../../../../ui/settings-nav.tsx";
+import { SettingsLayout } from "../../../../../ui/settings-nav.tsx";
 import {
   useOrganizationRead,
   useUnsavedChanges,

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -130,29 +130,28 @@ function ApiKeyReceipt({
   }
 
   return (
-    <Section
-      title="Copy your new key"
-      /*
-       * That this is the only time, said beside the heading rather than only
-       * inside the paragraph under it — which is what `2BN-0` draws. The word
-       * carries the meaning and the icon carries it again for anybody reading
-       * without colour: "state is not communicated by colour alone".
-       */
-      action={
-        <span className="inline-flex items-center gap-2 text-sm text-(--bad)">
-          <EyeOffIcon aria-hidden="true" className="size-4" strokeWidth={1.75} />
-          Shown once
-        </span>
-      }
-    >
+    <Section title="Copy your new key">
       <Card className="gap-4">
         <div className="flex flex-col gap-3">
-          <p className="m-0 max-w-[72ch] text-sm text-muted-foreground" role="status">
-            <strong className="font-medium text-foreground">
-              Here is your key. Copy it now.
-            </strong>{" "}
-            Egma will not show it again, and cannot: only its hash was kept.
-          </p>
+          <div className="flex items-start justify-between gap-4">
+            <p className="m-0 max-w-[72ch] text-sm text-muted-foreground" role="status">
+              <strong className="font-medium text-foreground">
+                Here is your key. Copy it now.
+              </strong>{" "}
+              Egma will not show it again, and cannot: only its hash was kept.
+            </p>
+            {/*
+             * That this is the only time, said at the head of the panel rather
+             * than only inside the sentence — which is what `2BO-0` draws. The
+             * word carries the meaning and the icon carries it again for
+             * anybody reading without colour: "state is not communicated by
+             * colour alone".
+             */}
+            <span className="inline-flex flex-none items-center gap-2 text-sm text-(--bad)">
+              <EyeOffIcon aria-hidden="true" className="size-4" strokeWidth={1.75} />
+              Shown once
+            </span>
+          </div>
           {/*
            * The secret on its own contained surface, in the mono face, wrapped
            * rather than clipped (`7D6-0`). A key that ran off the edge of its
@@ -334,10 +333,6 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
     <ProductPage viewport>
       <PageHeader
         title="API keys"
-        breadcrumbs={[
-          { label: "Settings", href: settingsPath(projectId) },
-          { label: "API keys" },
-        ]}
         lead="What a terminal or a script authenticates to Egma with."
       />
       <PageBody>

--- a/apps/web/app/projects/[projectId]/settings/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/loading.tsx
@@ -5,23 +5,20 @@ import { ProductStatePage } from "../../../../ui/shell.tsx";
  * What the router draws between the press and
  * `/projects/:projectId/settings` arriving.
  *
- * An eyebrow and no crumbs, which is what this one page in Settings shows —
- * the three below it carry crumbs and say so themselves.
- *
  * Settings also draws a second navigation column of its own, which arrives
  * with the page rather than with this, so the card moves once on arrival.
  * Drawing that column here would mean giving a fallback the settings
  * navigation's own state for the sake of one shift.
  *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the title bar carries the
+ * page's name and nothing else, the way every settings page's does — so
+ * nothing is redrawn a second way when the page arrives. `agents/loading.tsx`
+ * carries the reasoning every one of these shares.
  */
 export default function SettingsLoading() {
   return (
     <div data-slot="route-loading">
-      <ProductStatePage eyebrow="Settings" title="Project">
+      <ProductStatePage title="Project">
         <Loading what="this project" />
       </ProductStatePage>
     </div>

--- a/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/loading.tsx
@@ -1,9 +1,4 @@
-"use client";
-
-import { useParams } from "next/navigation";
-
 import { Loading } from "../../../../../ui/page-state.tsx";
-import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
@@ -12,23 +7,15 @@ import { ProductStatePage } from "../../../../../ui/shell.tsx";
  *
  * Its own boundary, so moving between settings views stays instant.
  *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the title bar carries the
+ * page's name and nothing else, and the settings rail beside the page is the
+ * trail into it — so nothing is redrawn a second way when the page arrives.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
  */
 export default function OrganizationSettingsLoading() {
-  const { projectId } = useParams<{ projectId: string }>();
-
   return (
     <div data-slot="route-loading">
-      <ProductStatePage
-        title="Organization"
-        breadcrumbs={[
-          { label: "Settings", href: settingsPath(projectId) },
-          { label: "Organization" },
-        ]}
-      >
+      <ProductStatePage title="Organization">
         <Loading what="this organization" />
       </ProductStatePage>
     </div>

--- a/apps/web/app/projects/[projectId]/settings/organization/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getOrganization, updateOrganization } from "@egma/platform-api/client";
 
 import type { Refusal } from "../../../../../lib/api.ts";
@@ -56,8 +56,6 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
   const settled = answer?.status === "ready" ? answer.value : null;
   const mayAdminister = settled?.mayManageOrganization === true;
 
-  /* The field's hint, named so the input can point at it. */
-  const nameHint = useId();
   const [name, setName] = useState("");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -125,8 +123,7 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
     return (
       <ProductPage viewport>
         <PageHeader
-          eyebrow="Settings"
-          title="Organization"
+            title="Organization"
           breadcrumbs={[
             { label: "Settings", href: settingsPath(projectId) },
             { label: "Organization" },
@@ -145,8 +142,7 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
     return (
       <ProductPage viewport>
         <PageHeader
-          eyebrow="Settings"
-          title="Organization"
+            title="Organization"
           breadcrumbs={[
             { label: "Settings", href: settingsPath(projectId) },
             { label: "Organization" },
@@ -171,7 +167,6 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
   return (
     <ProductPage viewport>
       <PageHeader
-        eyebrow="Settings"
         title="Organization"
         breadcrumbs={[
           { label: "Settings", href: settingsPath(projectId) },
@@ -185,7 +180,20 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
             {refused === null ? null : <Refused message={refused.message} />}
 
             <Form onSubmit={() => void save()}>
-              <Field label="Name" htmlFor="organization-name">
+              {/*
+                * The hint is the field's own rather than a paragraph written
+                * beside it. `Field` draws the sentence and hands its id to
+                * whatever control it wraps through context, so the
+                * `aria-describedby` cannot be dropped by an edit here and the
+                * space under the input is the 8px every other field in the
+                * product gets. The words and the wiring did not move; a second
+                * copy of a shared component's job did.
+                */}
+              <Field
+                label="Name"
+                htmlFor="organization-name"
+                hint="What Egma calls your organization. Changing it breaks no link and no invitation."
+              >
                 <Input
                   id="organization-name"
                   value={name}
@@ -193,17 +201,12 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
                   spellCheck={false}
                   disabled={!mayAdminister}
                   aria-invalid={named ? undefined : true}
-                  aria-describedby={nameHint}
                   onChange={(event) => {
                     editVersion.current += 1;
                     setName(event.target.value);
                     setSaved(false);
                   }}
                 />
-                <p className="m-0 text-sm leading-(--line-normal) text-faint" id={nameHint}>
-                  What Egma calls your organization. Changing it breaks no link
-                  and no invitation.
-                </p>
               </Field>
 
               {named ? null : <Problem>An organization needs a name.</Problem>}

--- a/apps/web/app/projects/[projectId]/settings/organization/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/page.tsx
@@ -20,7 +20,6 @@ import {
   Refused,
 } from "../../../../../ui/form.tsx";
 import { Failure, Loading } from "../../../../../ui/page-state.tsx";
-import { Section } from "../../../../../ui/section.tsx";
 import {
   SettingsLayout,
   settingsPath,
@@ -124,10 +123,6 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
       <ProductPage viewport>
         <PageHeader
             title="Organization"
-          breadcrumbs={[
-            { label: "Settings", href: settingsPath(projectId) },
-            { label: "Organization" },
-          ]}
         />
         <PageBody>
           <SettingsLayout projectId={projectId} current="organization">
@@ -143,10 +138,6 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
       <ProductPage viewport>
         <PageHeader
             title="Organization"
-          breadcrumbs={[
-            { label: "Settings", href: settingsPath(projectId) },
-            { label: "Organization" },
-          ]}
         />
         <PageBody>
           <SettingsLayout projectId={projectId} current="organization">
@@ -168,15 +159,12 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
     <ProductPage viewport>
       <PageHeader
         title="Organization"
-        breadcrumbs={[
-          { label: "Settings", href: settingsPath(projectId) },
-          { label: "Organization" },
-        ]}
         lead="The customer every project below belongs to."
       />
       <PageBody>
         <SettingsLayout projectId={projectId} current="organization">
-          <Section title="Details">
+          {/* One form, and the title bar has already named the page. */}
+          <div className="flex flex-col gap-4">
             {refused === null ? null : <Refused message={refused.message} />}
 
             <Form onSubmit={() => void save()}>
@@ -223,7 +211,7 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
                 </Button>
               </FormActions>
             </Form>
-          </Section>
+          </div>
         </SettingsLayout>
       </PageBody>
     </ProductPage>

--- a/apps/web/app/projects/[projectId]/settings/organization/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/organization/page.tsx
@@ -20,10 +20,7 @@ import {
   Refused,
 } from "../../../../../ui/form.tsx";
 import { Failure, Loading } from "../../../../../ui/page-state.tsx";
-import {
-  SettingsLayout,
-  settingsPath,
-} from "../../../../../ui/settings-nav.tsx";
+import { SettingsLayout } from "../../../../../ui/settings-nav.tsx";
 import {
   useOrganizationRead,
   useUnsavedChanges,
@@ -121,9 +118,7 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
   if (answer === null) {
     return (
       <ProductPage viewport>
-        <PageHeader
-            title="Organization"
-        />
+        <PageHeader title="Organization" />
         <PageBody>
           <SettingsLayout projectId={projectId} current="organization">
             <Loading what="this organization" />
@@ -136,9 +131,7 @@ function OrganizationSettingsBody({ projectId }: { readonly projectId: string })
   if (answer.status !== "ready") {
     return (
       <ProductPage viewport>
-        <PageHeader
-            title="Organization"
-        />
+        <PageHeader title="Organization" />
         <PageBody>
           <SettingsLayout projectId={projectId} current="organization">
             <Failure

--- a/apps/web/app/projects/[projectId]/settings/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/page.tsx
@@ -21,7 +21,6 @@ import {
   Refused,
 } from "../../../../ui/form.tsx";
 import { Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
-import { Section } from "../../../../ui/section.tsx";
 import { SettingsLayout } from "../../../../ui/settings-nav.tsx";
 import {
   useOrganizationRead,
@@ -200,7 +199,7 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
   if (answer === null) {
     return (
       <ProductPage viewport>
-        <PageHeader eyebrow="Settings" title="Project" />
+        <PageHeader title="Project" />
         <PageBody>
           <SettingsLayout projectId={projectId} current="project">
             <Loading what="this project" />
@@ -213,7 +212,7 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
   if (answer.status !== "ready") {
     return (
       <ProductPage viewport>
-        <PageHeader eyebrow="Settings" title="Project" />
+        <PageHeader title="Project" />
         <PageBody>
           <SettingsLayout projectId={projectId} current="project">
             {answer.status === "missing" ? (
@@ -237,13 +236,22 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
   return (
     <ProductPage viewport>
       <PageHeader
-        eyebrow="Settings"
         title="Project"
         lead="What this product area is called, and what it is for."
       />
       <PageBody>
         <SettingsLayout projectId={projectId} current="project">
-          <Section title="Details">
+          {/*
+            * No section heading over a page that holds one form.
+            *
+            * The title bar says "Project", the line under it says what the
+            * page is for, and the rail says which settings these are. A
+            * "Details" heading over the only thing on the screen was the
+            * largest type on it — larger than the page's own title — and said
+            * less than anything else. A page that grows a second group gets
+            * `Section` back, and then the heading is doing work.
+            */}
+          <div className="flex flex-col gap-4">
             {refused === null ? null : (
               <Refused
                 message={refused.message}
@@ -314,7 +322,7 @@ function ProjectSettingsBody({ projectId }: { readonly projectId: string }) {
                 </Button>
               </FormActions>
             </Form>
-          </Section>
+          </div>
         </SettingsLayout>
       </PageBody>
     </ProductPage>

--- a/apps/web/app/projects/[projectId]/settings/people/loading.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/loading.tsx
@@ -1,35 +1,24 @@
-"use client";
-
-import { useParams } from "next/navigation";
-
 import { Loading } from "../../../../../ui/page-state.tsx";
-import { settingsPath } from "../../../../../ui/settings-nav.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
 /**
  * What the router draws between the press and
  * `/projects/:projectId/settings/people` arriving.
  *
+ * Its own boundary, so moving between settings views stays instant.
+ *
  * People and invitations are two reads on one page; this names the first,
  * which is the one that decides whether the page can be drawn at all.
  *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
+ * Its header is the page's own down to its shape — the title bar carries the
+ * page's name and nothing else, and the settings rail beside the page is the
+ * trail into it — so nothing is redrawn a second way when the page arrives.
+ * `agents/loading.tsx` carries the reasoning every one of these shares.
  */
 export default function PeopleSettingsLoading() {
-  const { projectId } = useParams<{ projectId: string }>();
-
   return (
     <div data-slot="route-loading">
-      <ProductStatePage
-        title="People"
-        breadcrumbs={[
-          { label: "Settings", href: settingsPath(projectId) },
-          { label: "People" },
-        ]}
-      >
+      <ProductStatePage title="People">
         <Loading what="this organization's people" />
       </ProductStatePage>
     </div>

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -104,10 +104,20 @@ type Tab = "people" | "invitations";
  * and the sentence is placed on a second row spanning both — so the buttons sit
  * side by side whether or not there is a reason under them. The reading order
  * does not move, which is what `aria-describedby` follows.
+ *
+ * `w-0 min-w-full` on the sentence is the second half of that, and the first
+ * screenshot is what found it: an item spanning two `max-content` tracks hands
+ * its own width to them, so a 600px sentence made two 300px buttons. A width of
+ * zero is what the tracks are measured against; the minimum is a percentage,
+ * which is indefinite while they are being measured and resolves to the whole
+ * pair afterwards. The sentence also has to be told it may wrap: the shared
+ * cell keeps every other fact on one line, and a row control's cell inherits
+ * that.
  */
 const ROW_ACTIONS = [
   "grid grid-cols-[max-content_max-content] items-center gap-2 px-4",
   "[&>span]:col-span-2 [&>span]:row-start-2 [&>span]:text-left",
+  "[&>span]:w-0 [&>span]:min-w-full [&>span]:whitespace-normal",
 ].join(" ");
 
 /** The same lane, for a row that offers one control and no reason. */

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -25,6 +25,8 @@ import {
 } from "../../../../../lib/settings.ts";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 
@@ -81,6 +83,40 @@ import {
  */
 
 type Tab = "people" | "invitations";
+
+/**
+ * The lane a row's own controls stand in.
+ *
+ * The shared table draws the trailing cell as the boards do — a fixed 48px slot
+ * with no side padding, so every ⋮ in the product lines up in one column down
+ * the table (`78X-0`). This row keeps named buttons rather than a ⋮ (the
+ * browser walk measures three controls in it), so the cell is wider than the
+ * slot and needs the row's own padding back inside it, or the last button sits
+ * against the panel's hairline.
+ *
+ * **The reason under a disabled control is given its own line.** `Button`
+ * writes `why` as a `<span>` beside the control it explains, so with two
+ * buttons in one cell the sentence would otherwise land between them. `order`
+ * moves it visually and leaves the reading order alone, which is what
+ * `aria-describedby` follows.
+ */
+const ROW_ACTIONS = [
+  "flex flex-wrap items-center justify-end gap-2 px-4",
+  "[&>span]:order-last [&>span]:basis-full [&>span]:text-left",
+].join(" ");
+
+/**
+ * A control inside a row, at the row's height.
+ *
+ * A form control is 44px and a row is 52, so a `Select` at its natural size
+ * makes every row of this table 60px tall and stands a head above the buttons
+ * beside it. 36px is the dense control the toolbar and the navigation row
+ * already use, and it is what leaves the row at the 52px the boards draw. The
+ * 44px coarse-pointer target is not traded away for it: `pointer-coarse` puts
+ * it straight back, the same trade `Button` and the sidebar row make.
+ */
+const ROW_CONTROL =
+  "w-auto min-h-(--control-md) pointer-coarse:min-h-(--tap-target) text-sm";
 
 export default function PeopleSettingsPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -252,8 +288,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
     return (
       <ProductPage viewport>
         <PageHeader
-          eyebrow="Settings"
-          title="People"
+            title="People"
           breadcrumbs={[
             { label: "Settings", href: settingsPath(projectId) },
             { label: "People" },
@@ -272,8 +307,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
     return (
       <ProductPage viewport>
         <PageHeader
-          eyebrow="Settings"
-          title="People"
+            title="People"
           breadcrumbs={[
             { label: "Settings", href: settingsPath(projectId) },
             { label: "People" },
@@ -310,6 +344,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
       cell: (member) =>
         mayManage ? (
           <Select
+            className={ROW_CONTROL}
             id={`role-${member.userId}`}
             aria-label={`${member.email} role`}
             value={member.role}
@@ -358,7 +393,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
        */
       action: true,
       cell: (member) => (
-        <>
+        <div className={ROW_ACTIONS}>
           <Button
             type="button"
             variant="secondary"
@@ -368,7 +403,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
             onClick={() => setConfirming({ action: "deactivate", member })}
           >
             Deactivate
-          </Button>{" "}
+          </Button>
           <Button
             type="button"
             variant="secondary"
@@ -377,7 +412,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
           >
             Remove
           </Button>
-        </>
+        </div>
       ),
     },
   ];
@@ -385,7 +420,6 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
   return (
     <ProductPage viewport>
       <PageHeader
-        eyebrow="Settings"
         title="People"
         breadcrumbs={[
           { label: "Settings", href: settingsPath(projectId) },
@@ -459,27 +493,31 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
         >
           {(dismiss) => (
             <>
-              <p>
+              <p className="m-0 max-w-[62ch] text-sm text-muted-foreground">
                 {confirming.member.email}{" "}
                 {confirming.action === "remove"
                   ? "will lose membership in this organization. Everything they authored stays where it is, with their name on it."
                   : "will no longer be able to use this organization, and every key they minted stops working on the next request."}
               </p>
-              <Button type="button" variant="secondary" onClick={dismiss}>
-                Cancel
-              </Button>{" "}
-              <Button
-                type="button"
-                variant="destructive"
-                disabled={busy}
-                onClick={() => {
-                  const chosen = confirming;
-                  setConfirming(null);
-                  void act(chosen.action, chosen.member);
-                }}
-              >
-                {confirming.action === "remove" ? "Remove" : "Deactivate"}
-              </Button>
+              {/* The answer leads and the way out follows it (`BK9-0`). */}
+              <DialogFooter>
+                <Button
+                  type="button"
+                  size="lg"
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={() => {
+                    const chosen = confirming;
+                    setConfirming(null);
+                    void act(chosen.action, chosen.member);
+                  }}
+                >
+                  {confirming.action === "remove" ? "Remove" : "Deactivate"}
+                </Button>
+                <Button type="button" size="lg" variant="secondary" onClick={dismiss}>
+                  Cancel
+                </Button>
+              </DialogFooter>
             </>
           )}
         </Dialog>
@@ -612,14 +650,16 @@ function Invitations({
       // cannot be waited on, so the one thing left to do about it is here.
       cell: (invitation) =>
         standingOf(invitation) === "expired" ? (
-          <Button
-            type="button"
-            variant="secondary"
-            disabled={busy}
-            onClick={() => void send(invitation.email, invitation.role)}
-          >
-            Send again
-          </Button>
+          <div className={ROW_ACTIONS}>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={busy}
+              onClick={() => void send(invitation.email, invitation.role)}
+            >
+              Send again
+            </Button>
+          </div>
         ) : null,
     },
   ];
@@ -635,11 +675,26 @@ function Invitations({
         lead="If no mail transport is configured, Egma gives you a one-time link to send yourself."
       >
         {note === null ? null : <Help>{note}</Help>}
+        {/*
+         * The link, on the same contained surface a new API key gets, and
+         * still plain text inside `main`. It is the whole promise of this page
+         * on an install with no mail transport: the person who created the
+         * invitation is the one who has to deliver it, so it has to be
+         * readable and selectable rather than tucked into a sentence and
+         * clipped by the width of one.
+         */}
         {link === null ? null : (
-          <p>
-            <strong>Here is the link.</strong> It works once, for the person named
-            above. {link}
-          </p>
+          <Card className="gap-3">
+            <p className="m-0 max-w-[72ch] text-sm text-muted-foreground">
+              <strong className="font-medium text-foreground">
+                Here is the link.
+              </strong>{" "}
+              It works once, for the person named above.
+            </p>
+            <code className="block rounded-input border border-border bg-surface-soft p-3 font-mono text-sm break-all text-foreground">
+              {link}
+            </code>
+          </Card>
         )}
 
         <Form onSubmit={() => void invite()}>

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -50,7 +50,6 @@ import { Section } from "../../../../../ui/section.tsx";
 import {
   SettingsLayout,
   SettingsTabs,
-  settingsPath,
 } from "../../../../../ui/settings-nav.tsx";
 import {
   currentDraftState,
@@ -305,9 +304,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
   if (answer === null) {
     return (
       <ProductPage viewport>
-        <PageHeader
-            title="People"
-        />
+        <PageHeader title="People" />
         <PageBody>
           <SettingsLayout projectId={projectId} current="people">
             <Loading what="this organization's people" />
@@ -320,9 +317,7 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
   if (answer.status !== "ready") {
     return (
       <ProductPage viewport>
-        <PageHeader
-            title="People"
-        />
+        <PageHeader title="People" />
         <PageBody>
           <SettingsLayout projectId={projectId} current="people">
             <Failure

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -94,16 +94,24 @@ type Tab = "people" | "invitations";
  * slot and needs the row's own padding back inside it, or the last button sits
  * against the panel's hairline.
  *
- * **The reason under a disabled control is given its own line.** `Button`
- * writes `why` as a `<span>` beside the control it explains, so with two
- * buttons in one cell the sentence would otherwise land between them. `order`
- * moves it visually and leaves the reading order alone, which is what
- * `aria-describedby` follows.
+ * **It is a grid, and a browser is what said so.** `Button` writes `why` as a
+ * `<span>` beside the control it explains, so a cell holding two of them holds
+ * button, sentence, button — and wrapping that in a flex row put the sentence
+ * between the two buttons. Letting the row wrap fixed the sentence and broke
+ * the buttons instead: a wrapping flex box is only as wide as its widest child,
+ * so the table shrank the column to one button and stacked the other under it.
+ * Two `max-content` columns give the cell a minimum the table has to honour,
+ * and the sentence is placed on a second row spanning both — so the buttons sit
+ * side by side whether or not there is a reason under them. The reading order
+ * does not move, which is what `aria-describedby` follows.
  */
 const ROW_ACTIONS = [
-  "flex flex-wrap items-center justify-end gap-2 px-4",
-  "[&>span]:order-last [&>span]:basis-full [&>span]:text-left",
+  "grid grid-cols-[max-content_max-content] items-center gap-2 px-4",
+  "[&>span]:col-span-2 [&>span]:row-start-2 [&>span]:text-left",
 ].join(" ");
+
+/** The same lane, for a row that offers one control and no reason. */
+const ROW_ACTION = "flex items-center justify-end gap-2 px-4";
 
 /**
  * A control inside a row, at the row's height.
@@ -289,10 +297,6 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
       <ProductPage viewport>
         <PageHeader
             title="People"
-          breadcrumbs={[
-            { label: "Settings", href: settingsPath(projectId) },
-            { label: "People" },
-          ]}
         />
         <PageBody>
           <SettingsLayout projectId={projectId} current="people">
@@ -308,10 +312,6 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
       <ProductPage viewport>
         <PageHeader
             title="People"
-          breadcrumbs={[
-            { label: "Settings", href: settingsPath(projectId) },
-            { label: "People" },
-          ]}
         />
         <PageBody>
           <SettingsLayout projectId={projectId} current="people">
@@ -421,10 +421,6 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
     <ProductPage viewport>
       <PageHeader
         title="People"
-        breadcrumbs={[
-          { label: "Settings", href: settingsPath(projectId) },
-          { label: "People" },
-        ]}
         lead="Everybody in this organization, and what each of them may do."
       />
       <PageBody>
@@ -450,18 +446,23 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
               role={mayManage ? "tabpanel" : undefined}
               aria-labelledby={mayManage ? "people-view-people-tab" : undefined}
             >
-              <Section title="People">
-                {members.length === 0 ? (
-                  <Empty title="Nobody is here yet." />
-                ) : (
-                  <DataTable
-                    label="Members"
-                    columns={columns}
-                    rows={members}
-                    keyOf={(member) => member.userId}
-                  />
-                )}
-              </Section>
+              {/*
+                * No heading over this table. The tab above it says "People",
+                * the title bar says "People", and a third one in the largest
+                * type on the page said it a third time. The Invitations panel
+                * keeps its two headings, because it holds two different things
+                * and the headings are what tell them apart.
+                */}
+              {members.length === 0 ? (
+                <Empty title="Nobody is here yet." />
+              ) : (
+                <DataTable
+                  label="Members"
+                  columns={columns}
+                  rows={members}
+                  keyOf={(member) => member.userId}
+                />
+              )}
             </div>
           ) : (
             <div
@@ -650,7 +651,7 @@ function Invitations({
       // cannot be waited on, so the one thing left to do about it is here.
       cell: (invitation) =>
         standingOf(invitation) === "expired" ? (
-          <div className={ROW_ACTIONS}>
+          <div className={ROW_ACTION}>
             <Button
               type="button"
               variant="secondary"

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -181,7 +181,7 @@ export function SettingsNav({
           className={cn(
             "flex flex-col gap-1",
             "max-[900px]:grid max-[900px]:grid-cols-[repeat(auto-fit,minmax(112px,1fr))]",
-            "max-[640px]:grid-cols-2",
+            "max-[640px]:grid-cols-1",
           )}
         >
           {items.map((item) => (

--- a/apps/web/ui/settings-nav.tsx
+++ b/apps/web/ui/settings-nav.tsx
@@ -73,10 +73,17 @@ export function settingsPath(
  * The current one is Ember Wash plus a narrow Ember mark down its leading edge,
  * because state is never colour alone — the mark is the half of it somebody
  * reading in greyscale still gets.
+ *
+ * **It is the sidebar's row, down to the last value** — 36px on a fine pointer
+ * and 44px on a coarse one, 12px of side padding, the 14px step, and the 2px
+ * mark inset 8px from either end (`72Y-0`, `72Z-0`). Settings navigation is
+ * navigation: a rail that drew its rows at a different height beside the bar
+ * that drew them at the board's would read as a second product, and a person
+ * moving between the two would feel the change without being able to name it.
  */
 const NAV_ITEM = [
-  "relative flex w-full min-h-(--control-lg) items-center px-3",
-  "rounded-button text-base whitespace-nowrap text-muted-foreground no-underline",
+  "relative flex w-full min-h-(--control-md) items-center px-3",
+  "rounded-button text-sm whitespace-nowrap text-muted-foreground no-underline",
   /*
    * **Colour, and nothing that moves.** `DESIGN.md`: "Navigation row — support
    * routine navigation — colour feedback only." These rows used to answer a
@@ -116,7 +123,7 @@ const NAV_ITEM_QUIET = [
 
 const NAV_ITEM_CURRENT = [
   "bg-selected text-foreground",
-  "before:absolute before:top-3 before:bottom-3 before:left-0 before:w-0.5",
+  "before:absolute before:inset-y-2 before:left-0 before:w-0.5",
   "before:rounded-chip before:bg-brand before:content-['']",
 ];
 
@@ -133,19 +140,20 @@ export function SettingsNav({
     return (
       <div
         className={cn(
-          "flex min-w-0 flex-col gap-2",
+          "flex min-w-0 flex-col gap-1",
           /*
            * The second group is separated from the first — by a line above it
            * in a column, and by a line beside it once the two sit side by side.
            */
-          "not-first:border-t not-first:border-border not-first:pt-5",
-          "max-[900px]:flex-none",
+          "not-first:mt-1 not-first:border-t not-first:border-border not-first:pt-3",
+          "max-[900px]:flex-none max-[900px]:not-first:mt-0",
           "max-[900px]:not-first:border-t-0 max-[900px]:not-first:border-l",
           "max-[900px]:not-first:border-border max-[900px]:not-first:pt-0",
-          "max-[900px]:not-first:pl-6",
+          "max-[900px]:not-first:pl-4",
           "max-[640px]:w-full",
-          "max-[640px]:not-first:border-t max-[640px]:not-first:border-l-0",
-          "max-[640px]:not-first:pt-4 max-[640px]:not-first:pl-0",
+          "max-[640px]:not-first:mt-1 max-[640px]:not-first:border-t",
+          "max-[640px]:not-first:border-l-0",
+          "max-[640px]:not-first:pt-3 max-[640px]:not-first:pl-0",
         )}
         role="group"
         aria-labelledby={labelId}
@@ -161,7 +169,10 @@ export function SettingsNav({
          * somebody would eventually believe it.
          */}
         <p
-          className="m-0 px-2 text-xs tracking-(--tracking-label) text-faint uppercase"
+          className={cn(
+            "m-0 flex h-5 items-center px-3",
+            "text-sm tracking-(--tracking-label) text-faint uppercase",
+          )}
           id={labelId}
         >
           {label}
@@ -194,18 +205,24 @@ export function SettingsNav({
   return (
     <nav
       className={cn(
-        "flex flex-col items-stretch gap-5 border-r border-border pr-5",
         /*
-         * Narrow, the navigation stops being a column beside the page and
+         * **A rail, and a rail is a panel.** The scene board draws the settings
+         * navigation as a bordered Pure Paper card beside the page (`2AO-0`)
+         * rather than as a column hanging off a divider, which is what this
+         * was: a hairline on the right and nothing else made the links read as
+         * part of the page's own left margin. The card says they are a place
+         * you are in. No corner and no shadow — a rail does not float.
+         */
+        "flex flex-col items-stretch gap-2",
+        "rounded-card border border-border bg-surface p-2",
+        /*
+         * Narrow, the same card stops being a column beside the page and
          * becomes a card above it — two scopes side by side, still labelled,
          * still not a second horizontal scroll area.
          */
-        "max-[900px]:static max-[900px]:grid max-[900px]:overflow-visible",
-        "max-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)] max-[900px]:items-start",
-        "max-[900px]:gap-5 max-[900px]:rounded-card max-[900px]:border",
-        "max-[900px]:border-border max-[900px]:bg-surface max-[900px]:p-3",
-        "max-[640px]:grid-cols-[minmax(0,1fr)] max-[640px]:gap-4",
-        "max-[640px]:overflow-x-visible",
+        "max-[900px]:grid max-[900px]:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)]",
+        "max-[900px]:items-start max-[900px]:gap-4 max-[900px]:p-3",
+        "max-[640px]:grid-cols-[minmax(0,1fr)] max-[640px]:gap-2",
       )}
       aria-label="Settings"
     >
@@ -282,10 +299,11 @@ export function SettingsTabs<Value extends string>({
  * The stable frame every Settings state uses.
  *
  * Settings navigation is local to this area, so it stays beside the page on a
- * wide screen instead of becoming a large card above every form. On a narrow
- * screen the same links wrap into a compact grid without creating a second
- * horizontal scroll area. Loading and failure states use this frame too,
- * which stops the page from moving when its data arrives.
+ * wide screen instead of running across the top of every form. On a narrow
+ * screen the same card moves above the page and its links wrap into a compact
+ * grid, without creating a second horizontal scroll area. Loading and failure
+ * states use this frame too, which stops the page from moving when its data
+ * arrives.
  *
  * The rules for `section`, `region` and `tabpanel` reach into whatever the page
  * puts here, because the page supplies its own states and this frame is what
@@ -303,7 +321,12 @@ export function SettingsLayout({
   return (
     <div
       className={cn(
-        "grid h-full min-h-0 items-start gap-10",
+        /*
+         * 24px between the rail and the page, which is the page's own gutter:
+         * the rail is a panel now, and the 40px it used to be was the space a
+         * bare column of links needed to stop reading as part of the form.
+         */
+        "grid h-full min-h-0 items-start gap-6",
         "grid-cols-[minmax(176px,220px)_minmax(0,1fr)]",
         "max-[900px]:grid-cols-[minmax(0,1fr)]",
         "max-[900px]:grid-rows-[auto_minmax(0,1fr)] max-[900px]:gap-5",


### PR DESCRIPTION
Ticket: `egma-planning/.scratch/ui-refresh/issues/07-settings-organization-people-entry.md` (recipe, no boards — reference `2AH-0` on Paper page `7-0`).

Every page here was already built from the shared primitives, so ticket 01's theme dressed most of them for free. What is in this pull request is the part a rendered page had to say: the settings rail, four things that were genuinely broken on screen, and the copy a page was saying twice.

## Per screen

**`ui/settings-nav.tsx` — the rail.** The scene board draws settings navigation as a bordered Pure Paper card beside the page (`2AO-0`), not a column of links hanging off a hairline — which is what it was, and it read as part of the page's own left margin. Its rows are now the sidebar's row **value for value**: `--control-md` on a fine pointer and `--tap-target` on a coarse one, 12px of side padding, the 14px step, and the 2px Ember mark at `inset-y-2`. A rail beside the bar that drew the same thing at a different height is a seam a person can feel. Group labels are 14px/0.08em/`--faint` at `px-3` (`72R-0`), which also lines them up with the rows under them. Layout gap 40 → 24. Two labelled groups and the 900/640 collapse are unchanged, and the rail is still the layout's first child.

**`settings/page.tsx`, `settings/organization/page.tsx` — the forms.** The organization hint became the field's own (`Field hint=`), so the `aria-describedby` is wired by the shared component rather than by hand; same words, same wiring, one copy. Both lost the "Details" heading over the only form on the page — 24px type, larger than the page's own title, saying less than anything else on the screen.

**`settings/keys/page.tsx` — the receipt.** `2BN-0`: a panel with the sentence, an `EyeOffIcon` + "Shown once" in `var(--bad)` opposite it, and the secret in a mono block on `--surface-soft` that wraps rather than clipping. Then Copy key (wash primary) and Dismiss (secondary). It was a bare paragraph with the key run into the middle of a sentence and two buttons floating after it. The revoke dialog got a footer.

**`settings/people/page.tsx` — the roster.** Three fixes, below. The invitation link moved onto the same contained panel the new key gets — it is the whole promise of this page on an install with no mail transport and it was being clipped by the width of the sentence it was written into. Still plain text inside `main`. Both confirm dialogs got a footer. The tab panel lost its "People" heading, which was the third "People" on the page.

**`new-project/page.tsx`, `app/page.tsx`, `app/members/page.tsx`, six `loading.tsx`.** Behaviour frozen; header shapes matched to the pages they stand in for.

## Four things only a screenshot could say

1. **The roster row's three controls were no longer one height.** Ticket 01 moved the shared button's `default` size from 44 to the boards' 36; `Select` is still the 44px form control. So the row held a 44px select beside two 36px buttons, stood 60px tall, and broke `apps/api/test/browser.test.ts:406-416`, which holds that row to *three controls, all one height*. The select now takes `--control-md`, with `pointer-coarse` putting the 44px target straight back. **Measured in a browser after the fix: `[36,36,36]`, row height 52.5** — the board's 52px. *Every other list in the product that puts a `Select` in a row has the same fault; tickets 03 and 06 should measure their own.*
2. **The trail and the page title were the same word twice.** `PageHeader` draws real `breadcrumbs` inside the 56px title bar immediately before the `h1`, and `PageNavigationItems` requires the last crumb to be the current page — so `/settings/people` read "Settings / People **People**". The three crumbed settings pages dropped the trail: the settings rail *is* the trail (always on screen, names the section, links every sibling, marks the current page), and its "Project" row is the exact address the "Settings" crumb pointed at. All four settings pages now wear one header, and their loading files with them. **This is a shell finding rather than a settings one** — every other crumbed page says its own name twice in that bar. Flagged for ticket 08 rather than fixed here.
3. **A lone control on an entry page ran the full width of the page.** `ProductStatePage` hands its children straight to `PageBody`, which is a column, so "Create the first project" and both "Try again" buttons stretched and stopped reading as buttons. They stand in the shared `Actions` group now.
4. **The trailing action cell fights any content that is not a ⋮.** It is 48px, `padding-inline: 0`, centred and `white-space: nowrap`, so a named button sits on the panel's hairline, and two buttons plus a `why` sentence cannot be a flex row at all: wrapping makes the cell's minimum one button wide (the table then stacks them), and not wrapping puts the sentence between the two buttons. The roster's lane is a two-track grid with the sentence on a second row, clamped `w-0 min-w-full` so it does not hand its own width to the button tracks. Reasoned out in the file.

## Browser expectations

**None changed.** The "adding a colleague…" describe shared with ticket 02 was not touched: `#invite-email`, `#invite-role`, the visible "Here is the link" text and the URL readable from `main`'s innerText all still read the same. The three-controls-one-height measurement was re-proved in a browser rather than edited.

## Shared files

**None added, none edited.** `ui/settings-nav.tsx` is this ticket's own file. Gaps found in ticket 01's primitives, recorded in the ticket rather than patched here:

- `ui/dialog.tsx` gives `kind="dialog"` no hairline under its header; `BK0-0` has one. No caller can add it — `Dialog` takes no class.
- `TabsList variant="line"`'s current tab draws Ember Wash **and** the 2px mark; `2B1-0` draws the mark alone, and on a dark surface the wash reads as a block that stops at the label's box. Left alone: the only other caller is `/design-system`.
- The action cell has no way to say "this lane holds a named control, not a ⋮" (finding 4). Every route ticket putting a button in a row is writing the same wrapper.

## Proof

`.proofs/ui-07/` (and the session scratchpad), 1440×900 at 2×, light and dark for each: `settings-project`, `settings-project-refused`, `settings-organization`, `settings-people`, `settings-people-refused`, `settings-people-remove-dialog`, `settings-people-invitations`, `settings-people-invitation-link`, `settings-keys` (receipt up, Your keys, Other members' keys), `settings-keys-receipt`, `settings-keys-revoke-dialog`, `new-project`, `entry-no-project`, `members-redirect` — plus `settings-people-375` and `settings-keys-375` where the rail collapses twice.

No route can produce the no-project entrance (nothing deletes a project), so the real session answer is served back to the browser with its projects removed; what is photographed is the real page reading it.

## Gates

- `npx vitest run --project fast --maxWorkers=2 apps/web/test/settings.test.tsx` → **54 passed**
- `pnpm typecheck` → **green** (skills check, contract check, lint, every package, the tests project, and the web app)

## Left for somebody else

- The crumb-and-title stutter on every other crumbed page (finding 2) — ticket 08 or ticket 01.
- New project still gates on `roleOf(me) === "admin"` rather than a server permission; the contract carries none on a read this page makes (ticket §5.9).
- The rail's own ⋮ menus were not added anywhere (ticket §3, "none added" — a coordinator decision, not a default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790082630&installation_model_id=431960&pr_number=198&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F198&signature=3d7a6861116e68c51f9e7ac02b946a8909750e89c4dc2b3d148a4fda6dbb6abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refreshes settings and entry-page presentation without changing API behavior.
- Restyles the settings navigation as a responsive, grouped rail and simplifies duplicated page headers.
- Adds contained one-time API-key and invitation-link receipts, consistent dialog footers, and padded table action lanes.
- Aligns roster controls and entry-page actions with shared control sizing and layout primitives.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/settings-nav.tsx | Converts settings navigation into a responsive card rail while preserving grouped links and current-page semantics. |
| apps/web/app/projects/[projectId]/settings/people/page.tsx | Aligns roster controls, restructures row actions, contains invitation links, and adopts shared dialog footers. |
| apps/web/app/projects/[projectId]/settings/keys/page.tsx | Introduces a wrapping one-time-key receipt, padded revoke actions, and shared destructive-dialog layout. |
| apps/web/app/projects/[projectId]/settings/organization/page.tsx | Moves organization guidance into the shared Field hint and removes redundant page structure. |
| apps/web/app/new-project/page.tsx | Simplifies the single-form page hierarchy while retaining project-creation behavior and authorization presentation. |

<sub>Reviews (2): Last reviewed commit: ["fix(web): the settings rail stacks on a ..."](https://github.com/egma-ai/egma/commit/b9d845264812e15ea6472c5ed37ece6869bbbdfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56006640)</sub>

**Context used:**

- Knowledge Base — [Egma web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->