### PR TITLE
fix(web): integration polish — the shared defects the route tickets found (ui-refresh 09)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -216,6 +216,7 @@ rgba(122, 49, 23, 0.02) -130px 256px 115px 0
 - The active item uses Ember Wash and a small Ember mark on its leading edge. Its icon follows the row's text colour; the mark is the brand signal and there is only one.
 - The account control stays at the bottom.
 - Every page has a title bar of its own, the same height as the wordmark bar, with the page title and its purpose statement in it. Page actions are not in that bar.
+- A page below a section carries the trail into its record in that bar, and **the trail never repeats the title beside it**. A page passes the real trail, ending with the record's own name; the bar draws every step but the last, because the heading beside it is that last step. There is no separator after the step that is left. (Read off the boards, 2026-08-23.)
 - A page's actions sit in the toolbar row under the title bar, at the right, opposite whatever the page filters by.
 - Page content is held to the page maximum and aligned to the left gutter, so the title in the bar and the first column under it are on one line.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -274,6 +274,7 @@ The measurements, all of them theme values:
 - Selected or active rows use Ember Wash plus a non-color state mark.
 - Mobile may restyle the same DOM as rows. It must not duplicate interactive content.
 - Empty, loading, failed, and filtered-empty are separate states.
+- A list's date column is the absolute short date — `Aug 16, 2026` — in tabular numerals, with the exact instant kept on the element. A relative age belongs in a sentence ("started just now", "last received 2 min ago") and never in a column: a column of ages cannot be scanned, and two rows a minute apart read the same for the whole of the first hour. One column names a moment rather than a day, and it keeps its precision in the same shape. (Read off `6ZJ-0`, `8TQ-0` and `8P4-0`, 2026-08-23.)
 
 ### Side sheets
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -275,6 +275,7 @@ The measurements, all of them theme values:
 - Selected or active rows use Ember Wash plus a non-color state mark.
 - Mobile may restyle the same DOM as rows. It must not duplicate interactive content.
 - Empty, loading, failed, and filtered-empty are separate states.
+- The empty state is a solid Pure Paper card inside one hairline, with 40px of padding, a 16px weight-500 title, one 14px supporting sentence, and the page's action under them as the wash button. It is a fact about the project rather than about egma, so it sits on the page like anything else. Loading, failed, and not-available are interruptions and stay set apart from it. (Read off `AN8-0`, 2026-08-23.)
 - A list's date column is the absolute short date — `Aug 16, 2026` — in tabular numerals, with the exact instant kept on the element. A relative age belongs in a sentence ("started just now", "last received 2 min ago") and never in a column: a column of ages cannot be scanned, and two rows a minute apart read the same for the whole of the first hour. One column names a moment rather than a day, and it keeps its precision in the same shape. (Read off `6ZJ-0`, `8TQ-0` and `8P4-0`, 2026-08-23.)
 
 ### Side sheets

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2,7 +2,7 @@ import { newId } from "@egma/ids";
 import type { Browser, Page, Request, Route } from "playwright-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { asSecond } from "../../web/lib/instants.ts";
+import { asListInstant, asSecond } from "../../web/lib/instants.ts";
 import { openBrowser } from "./support/browser.ts";
 import {
   capturedRequests,
@@ -1140,7 +1140,17 @@ describe("what a project recorded in production", () => {
 
       // The facts the list endpoint returns, as columns.
       const started = page.locator("tbody time").first();
-      expect(await started.innerText()).toBe("2 hours ago");
+      /*
+       * **A list's date column is an absolute short date, never a changing
+       * age.** The boards print `Aug 16, 2026` in every list column that holds
+       * a time, and a column of ages cannot be scanned — two exchanges a
+       * minute apart read the same for the whole of the first hour. This
+       * column names the exchange itself, so it keeps the precision it has
+       * always had and takes that shape (ui-refresh ticket 09, item a).
+       */
+      expect(await started.innerText()).toBe(
+        asListInstant(FIXTURE_TRACE.started_at, "second"),
+      );
       expect(await started.getAttribute("title")).toBe(
         asSecond(FIXTURE_TRACE.started_at),
       );

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
@@ -20,7 +20,7 @@ import {
   type ListedAgent,
   type ListedConnection,
 } from "../../../../../lib/agents.ts";
-import { asDay } from "../../../../../lib/instants.ts";
+import { asListInstant } from "../../../../../lib/instants.ts";
 import { roleOf } from "../../../../../lib/me.ts";
 import { startMonitoringPath } from "../../../../../lib/monitoring.ts";
 import { platformAnswer, platformClient } from "../../../../../lib/platform-client.ts";
@@ -33,6 +33,7 @@ import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
 import { Dialog } from "../../../../../ui/dialog.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../../ui/page-state.tsx";
 import {
+  ListInstant,
   RelativeInstant,
   useMinuteClock,
 } from "../../../../../ui/relative-time.tsx";
@@ -148,7 +149,7 @@ function connectionColumns({
       key: "created",
       header: "Created",
       hideOnMobile: true,
-      cell: (one) => asDay(one.createdAt),
+      cell: (one) => <ListInstant instant={one.createdAt} />,
     },
     {
       key: "menu",
@@ -338,7 +339,7 @@ function AgentDetailView({
          * sentence the connection panel ends with, in the same words.
          */}
         <p className="mt-0 mb-6 text-sm text-faint">
-          {`Created ${asDay(agent.createdAt)} · Last changed ${asDay(agent.updatedAt)}`}
+          {`Created ${asListInstant(agent.createdAt)} · Last changed ${asListInstant(agent.updatedAt)}`}
         </p>
         <ProductionCalls
           projectId={projectId}

--- a/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/agents/[agentId]/page.tsx
@@ -286,9 +286,15 @@ function AgentDetailView({
        */}
       <PageHeader
         title={agent.name}
+        /*
+          The real trail: Agents, then this agent. `PageHeader` takes the last
+          step off, because the heading beside it is that step. Before that
+          rule this page named the *kind* here — "Agents / Agent   Ada" — to
+          keep the record's own name out of the bar twice.
+        */
         breadcrumbs={[
           { label: "Agents", href: agents },
-          { label: "Agent" },
+          { label: agent.name },
         ]}
         action={
           role === null ? undefined : (

--- a/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
@@ -26,7 +26,7 @@ import {
   type ConnectionOption,
   type ConnectionOptionCatalog,
 } from "@/lib/connection-options.ts";
-import { asDay } from "@/lib/instants.ts";
+import { asListInstant } from "@/lib/instants.ts";
 import { platformAnswer, platformClient } from "@/lib/platform-client.ts";
 import { agentPlatformLabel } from "@/lib/transcripts.ts";
 import { Field, Help, Problem } from "@/ui/form.tsx";
@@ -603,7 +603,7 @@ function ReadConnection({
         </pre>
       </div>
       <p className="m-0 text-sm text-faint">
-        {`Created ${asDay(connection.createdAt)} · Updated ${asDay(connection.updatedAt)}`}
+        {`Created ${asListInstant(connection.createdAt)} · Updated ${asListInstant(connection.updatedAt)}`}
       </p>
     </>
   );

--- a/apps/web/app/projects/[projectId]/agents/screen.tsx
+++ b/apps/web/app/projects/[projectId]/agents/screen.tsx
@@ -13,13 +13,13 @@ import {
   type AgentPage,
   type ListedAgentWithConnections,
 } from "@/lib/agents.ts";
-import { asDay } from "@/lib/instants.ts";
 import { firstProjectOf, roleOf } from "@/lib/me.ts";
 import { platformAnswer, platformClient } from "@/lib/platform-client.ts";
 import { projectLanding, projectPath } from "@/lib/project-context.ts";
 import { canAuthor } from "@/lib/roles.ts";
 import { DataTable, type Column } from "@/ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "@/ui/page-state.tsx";
+import { ListInstant } from "@/ui/relative-time.tsx";
 import { useProjectRead } from "@/ui/resource.ts";
 import { SearchField } from "@/ui/section.tsx";
 import { PageBody, PageHeader, ProductPage, useShellSession } from "@/ui/shell.tsx";
@@ -263,7 +263,7 @@ export function AgentsScreen({
         key: "created",
         header: "Created",
         hideOnMobile: true,
-        cell: (agent) => asDay(agent.createdAt),
+        cell: (agent) => <ListInstant instant={agent.createdAt} />,
       },
       {
         key: "menu",

--- a/apps/web/app/projects/[projectId]/graders/running/loading.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/loading.tsx
@@ -4,7 +4,6 @@ import { useParams } from "next/navigation";
 
 import { RUNNING } from "../../../../../lib/grader-running-copy.ts";
 import { GRADERS_SECTION } from "../../../../../lib/graders.ts";
-import { GRADER_VIEW_LABELS } from "../../../../../lib/presentation.ts";
 import { projectPath } from "../../../../../lib/project-context.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
@@ -31,7 +30,7 @@ export default function RunningGradersLoading() {
         title={RUNNING.title}
         breadcrumbs={[
           { label: "Graders", href: projectPath(projectId, GRADERS_SECTION) },
-          { label: GRADER_VIEW_LABELS.running },
+          { label: RUNNING.title },
         ]}
       >
         <Loading what={RUNNING.loading} />

--- a/apps/web/app/projects/[projectId]/graders/running/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/page.tsx
@@ -34,10 +34,7 @@ import {
   platformAnswer,
   platformClient,
 } from "../../../../../lib/platform-client.ts";
-import {
-  graderDisplayName,
-  GRADER_VIEW_LABELS,
-} from "../../../../../lib/presentation.ts";
+import { graderDisplayName } from "../../../../../lib/presentation.ts";
 import {
   projectLanding,
   projectPath,
@@ -487,12 +484,19 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
       {/* The trail and the title, and the strip under them. See the library. */}
       <PageHeader
         title={RUNNING.title}
+        /*
+          The trail ends with this screen's own name, and `PageHeader` takes
+          that step off. What is left is the section; the title beside it says
+          what the screen holds. Before that rule the bar read "Graders /
+          Running   Running graders" — the word "Running" twice, once as a tab
+          label and once inside the title.
+        */
         breadcrumbs={[
           {
             label: "Graders",
             href: projectPath(projectId, GRADERS_SECTION),
           },
-          { label: GRADER_VIEW_LABELS.running },
+          { label: RUNNING.title },
         ]}
       />
       <PageBody>

--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/page.tsx
@@ -48,8 +48,7 @@ import { Select } from "@/components/ui/select";
 import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading } from "../../../../../ui/page-state.tsx";
 import {
-  RelativeInstant,
-  useMinuteClock,
+  ListInstant,
 } from "../../../../../ui/relative-time.tsx";
 import { useProjectRead } from "../../../../../ui/resource.ts";
 import { TOOLBAR_FILTER } from "../../../../../ui/section.tsx";
@@ -127,7 +126,6 @@ export default function MonitoringTranscriptsPage() {
 }
 
 function Transcripts({ projectId }: { readonly projectId: string }) {
-  const now = useMinuteClock();
   /**
    * Which window this page is on, read out of the address.
    *
@@ -546,7 +544,7 @@ function Transcripts({ projectId }: { readonly projectId: string }) {
             )}
             <DataTable
               label={LIST.tableLabel}
-              columns={columnsFor(projectId, now)}
+              columns={columnsFor(projectId)}
               rows={shownRows}
               keyOf={(row) => row.traceId}
               stretchPrimaryLink
@@ -605,17 +603,13 @@ function Nothing() {
  * endpoint under it requires both, and this row already knows the answers, so
  * nobody has to.
  */
-function columnsFor(projectId: string, now: number): readonly Column<Listed>[] {
+function columnsFor(projectId: string): readonly Column<Listed>[] {
   const order: readonly (readonly [string, (row: Listed) => ReactNode])[] = [
     [
       COLUMNS.started,
       (row) => (
         <Link href={transcriptPath(projectId, row)}>
-          <RelativeInstant
-            instant={row.startedAt}
-            now={now}
-            precision="second"
-          />
+          <ListInstant instant={row.startedAt} precision="second" />
         </Link>
       ),
     ],

--- a/apps/web/app/projects/[projectId]/personas/archive-dialog.tsx
+++ b/apps/web/app/projects/[projectId]/personas/archive-dialog.tsx
@@ -6,7 +6,6 @@ import { getPersonaUsage, listPersonas } from "@egma/platform-api/client";
 
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import type { Refusal } from "../../../../lib/api.ts";
 import {
   ownerSaid,
@@ -149,14 +148,6 @@ export function ArchiveDialog({
     <Dialog title={`Archive ${persona.name}?`} onClose={onClose}>
       {(dismiss) => (
         <>
-          {/*
-           * The hairline the boards draw under a confirmation's title
-           * (`BJZ-0`). It is here rather than on the shared `DialogHeader`
-           * because a route ticket does not restyle a shared component; the
-           * wish is recorded on the ticket instead.
-           */}
-          <Separator />
-
           <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
             They leave the list your team authors from. Every version stays
             where it is, and every run that used one stays readable. Restore is

--- a/apps/web/app/projects/[projectId]/personas/personas-screen.tsx
+++ b/apps/web/app/projects/[projectId]/personas/personas-screen.tsx
@@ -44,8 +44,7 @@ import {
 } from "../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
 import {
-  RelativeInstant,
-  useMinuteClock,
+  ListInstant,
 } from "../../../../ui/relative-time.tsx";
 import { SearchField } from "../../../../ui/section.tsx";
 import {
@@ -117,7 +116,6 @@ export function PersonasScreen({
 }) {
   const { me } = useShellSession();
   const router = useRouter();
-  const now = useMinuteClock();
   // Null until the session read answers. A page that guessed would tell an
   // admin their role cannot do something it can, on every load.
   const role = me === null ? null : roleOf(me);
@@ -538,9 +536,7 @@ export function PersonasScreen({
         key: "updated",
         header: "Updated",
         width: "130px",
-        cell: (persona) => (
-          <RelativeInstant instant={persona.updatedAt} now={now} />
-        ),
+        cell: (persona) => <ListInstant instant={persona.updatedAt} />,
       },
       {
         key: "actions",

--- a/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/[runId]/page.tsx
@@ -498,13 +498,14 @@ function RunDetailView({
         eyebrow="Simulation runs"
         title={displayTitle}
         /*
-         * The trail names the section and the kind of record; the title beside
-         * it names *this* record. Ending the trail with the run's own name put
-         * the same words twice in one 56px bar, a comma apart.
+         * The real trail: Runs, then this run. `PageHeader` takes the last
+         * step off, because the heading beside it is that step. Before that
+         * rule this page named the *kind* here — "Runs / Run   Pre-release
+         * check" — to keep the run's own name out of the bar twice.
          */
         breadcrumbs={[
           { label: "Runs", href: projectPath(projectId, "runs") },
-          { label: "Run" },
+          { label: displayTitle },
         ]}
         action={
           !mayControl || !active ? undefined : (

--- a/apps/web/app/projects/[projectId]/runs/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/page.tsx
@@ -36,8 +36,7 @@ import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
 import {
-  RelativeInstant,
-  useMinuteClock,
+  ListInstant,
 } from "../../../../ui/relative-time.tsx";
 import {
   RunStatus,
@@ -85,7 +84,6 @@ function columnsFor(
   /** Null while the session read has not answered, so no control is drawn. */
   mayControl: boolean | null,
   onCancel: (runId: string) => void,
-  now: number,
 ): readonly Column<RunRow>[] {
   return [
     {
@@ -114,9 +112,7 @@ function columnsFor(
       key: "started",
       header: "Started",
       width: "130px",
-      cell: (run) => (
-        <RelativeInstant instant={run.createdAt} now={now} />
-      ),
+      cell: (run) => <ListInstant instant={run.createdAt} />,
     },
     {
       key: "status",
@@ -207,7 +203,6 @@ function Runs({ projectId }: { readonly projectId: string }) {
   /** The earliest day to show, as somebody typed it and as it was asked for. */
   const [typedSince, setTypedSince] = useState("");
   const [since, setSince] = useState("");
-  const now = useMinuteClock();
 
   const asked = JSON.stringify({ agent, connection, status, verdict, since });
   const { answer, reload } = useProjectRead<RunHistoryPage>(
@@ -507,7 +502,6 @@ function Runs({ projectId }: { readonly projectId: string }) {
             projectId,
             role === null ? null : mayStart,
             openCancel,
-            now,
           )}
           rows={items}
           keyOf={(run) => run.id}

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -35,8 +35,7 @@ import {
 } from "../../../../../ui/form.tsx";
 import { Empty, Failure, Loading } from "../../../../../ui/page-state.tsx";
 import {
-  RelativeInstant,
-  useMinuteClock,
+  ListInstant,
 } from "../../../../../ui/relative-time.tsx";
 import { Section } from "../../../../../ui/section.tsx";
 import { SettingsLayout } from "../../../../../ui/settings-nav.tsx";
@@ -179,7 +178,6 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
   const { me } = useShellSession();
   const role = me === null ? null : roleOf(me);
   const projects: readonly Project[] = me?.projects ?? [];
-  const now = useMinuteClock();
 
   const { answer, reload } = useOrganizationRead<ApiKeyList>(() =>
     platformAnswer(listApiKeys({ client: platformClient })),
@@ -269,11 +267,11 @@ function ApiKeys({ projectId }: { readonly projectId: string }) {
         key: "used",
         header: "Last used",
         cell: (key) =>
-          key.lastUsedAt === null
-            ? "Never"
-            : (
-                <RelativeInstant instant={key.lastUsedAt} now={now} />
-              ),
+          key.lastUsedAt === null ? (
+            "Never"
+          ) : (
+            <ListInstant instant={key.lastUsedAt} />
+          ),
       },
       {
         key: "actions",

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -121,19 +121,6 @@ const ROW_ACTIONS = [
 /** The same lane, for a row that offers one control and no reason. */
 const ROW_ACTION = "flex items-center justify-end gap-2 px-4";
 
-/**
- * A control inside a row, at the row's height.
- *
- * A form control is 44px and a row is 52, so a `Select` at its natural size
- * makes every row of this table 60px tall and stands a head above the buttons
- * beside it. 36px is the dense control the toolbar and the navigation row
- * already use, and it is what leaves the row at the 52px the boards draw. The
- * 44px coarse-pointer target is not traded away for it: `pointer-coarse` puts
- * it straight back, the same trade `Button` and the sidebar row make.
- */
-const ROW_CONTROL =
-  "w-auto min-h-(--control-md) pointer-coarse:min-h-(--tap-target) text-sm";
-
 export default function PeopleSettingsPage() {
   const { projectId } = useParams<{ projectId: string }>();
   return (
@@ -348,7 +335,14 @@ function PeopleSettings({ projectId }: { readonly projectId: string }) {
       cell: (member) =>
         mayManage ? (
           <Select
-            className={ROW_CONTROL}
+            /*
+              The row's height, and the table's type step. The 36px is
+              `Select`'s own `default` now rather than a class list this page
+              kept: a form control is 44px, a control inside a 52px row is 36,
+              and the coarse-pointer target comes back in the primitive.
+            */
+            size="default"
+            className="w-auto text-sm"
             id={`role-${member.userId}`}
             aria-label={`${member.email} role`}
             value={member.role}

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -43,8 +43,7 @@ import {
 } from "../../../../../ui/form.tsx";
 import { Empty, Failure, Loading } from "../../../../../ui/page-state.tsx";
 import {
-  RelativeInstant,
-  useMinuteClock,
+  ListInstant,
 } from "../../../../../ui/relative-time.tsx";
 import { Section } from "../../../../../ui/section.tsx";
 import {
@@ -562,7 +561,6 @@ function Invitations({
   readonly onRefused: (refusal: Refusal | null) => void;
   readonly onBusy: (busy: boolean) => void;
 }) {
-  const now = useMinuteClock();
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<string>("viewer");
   const [link, setLink] = useState<string | null>(null);
@@ -642,10 +640,7 @@ function Invitations({
     {
       key: "expiry",
       header: "Expiry",
-      mono: true,
-      cell: (invitation) => (
-        <RelativeInstant instant={invitation.expiresAt} now={now} />
-      ),
+      cell: (invitation) => <ListInstant instant={invitation.expiresAt} />,
     },
     {
       key: "actions",

--- a/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/[testId]/loading.tsx
@@ -3,7 +3,6 @@
 import { useParams } from "next/navigation";
 
 import { projectPath } from "../../../../../lib/project-context.ts";
-import { trailInto } from "../../../../../lib/test-suites.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
@@ -26,10 +25,10 @@ export default function TestLoading() {
     <div data-slot="route-loading">
       <ProductStatePage
         title="Test"
-        breadcrumbs={trailInto({
-          label: "Tests",
-          href: projectPath(projectId, "tests"),
-        })}
+        breadcrumbs={[
+          { label: "Tests", href: projectPath(projectId, "tests") },
+          { label: "Test" },
+        ]}
       >
         <Loading what="this test" />
       </ProductStatePage>

--- a/apps/web/app/projects/[projectId]/tests/[testId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/tests/[testId]/page.tsx
@@ -22,7 +22,6 @@ import { canAuthor } from "../../../../../lib/roles.ts";
 import {
   suitePagePath,
   testsPagePath,
-  trailInto,
   type TestSuite,
 } from "../../../../../lib/test-suites.ts";
 import {
@@ -366,15 +365,21 @@ function TestDetail({
     );
   }
 
-  const basicBreadcrumbs = trailInto({
-    label: "Tests",
-    href: testsPagePath(projectId),
-  });
+  /*
+    The trail into this test. It ends with whatever this page is currently
+    calling itself, because that is the page — `PageHeader` takes the last step
+    off and draws it as the heading beside the rest.
+  */
+  const trailTo = (name: string) =>
+    [
+      { label: "Tests", href: testsPagePath(projectId) },
+      { label: name },
+    ] as const;
 
   if (answer === null || answer.status === "signed-out") {
     return (
       <ProductPage>
-        <PageHeader title="Test" breadcrumbs={basicBreadcrumbs} />
+        <PageHeader title="Test" breadcrumbs={trailTo("Test")} />
         <PageBody><Loading what="this test" /></PageBody>
       </ProductPage>
     );
@@ -382,7 +387,7 @@ function TestDetail({
   if (answer.status === "missing") {
     return (
       <ProductPage>
-        <PageHeader title="Test" breadcrumbs={basicBreadcrumbs} />
+        <PageHeader title="Test" breadcrumbs={trailTo("Test")} />
         <PageBody><NotFound message={answer.refusal.message} /></PageBody>
       </ProductPage>
     );
@@ -390,7 +395,7 @@ function TestDetail({
   if (answer.status === "failed") {
     return (
       <ProductPage>
-        <PageHeader title="Test" breadcrumbs={basicBreadcrumbs} />
+        <PageHeader title="Test" breadcrumbs={trailTo("Test")} />
         <PageBody><Failure message={answer.refusal.message} onRetry={reload} /></PageBody>
       </ProductPage>
     );
@@ -398,7 +403,10 @@ function TestDetail({
   if (test === null || editing === null || suite === null || suite.status === "signed-out") {
     return (
       <ProductPage>
-        <PageHeader title={answer.value.name} breadcrumbs={basicBreadcrumbs} />
+        <PageHeader
+          title={answer.value.name}
+          breadcrumbs={trailTo(answer.value.name)}
+        />
         <PageBody><Loading what="this test's suite" /></PageBody>
       </ProductPage>
     );
@@ -406,7 +414,7 @@ function TestDetail({
   if (suite.status === "missing") {
     return (
       <ProductPage>
-        <PageHeader title={test.name} breadcrumbs={basicBreadcrumbs} />
+        <PageHeader title={test.name} breadcrumbs={trailTo(test.name)} />
         <PageBody><NotFound message={suite.refusal.message} /></PageBody>
       </ProductPage>
     );
@@ -414,7 +422,7 @@ function TestDetail({
   if (suite.status === "failed") {
     return (
       <ProductPage>
-        <PageHeader title={test.name} breadcrumbs={basicBreadcrumbs} />
+        <PageHeader title={test.name} breadcrumbs={trailTo(test.name)} />
         <PageBody><Failure message={suite.refusal.message} onRetry={reloadSuite} /></PageBody>
       </ProductPage>
     );
@@ -430,13 +438,14 @@ function TestDetail({
     <ProductPage>
       <PageHeader
         title={test.name}
-        breadcrumbs={trailInto(
+        breadcrumbs={[
           { label: "Tests", href: testsPagePath(projectId) },
           {
             label: suite.value.name,
             href: suitePagePath(projectId, suite.value.id),
           },
-        )}
+          { label: test.name },
+        ]}
         toolbar={
           <p className="m-0 text-sm text-muted-foreground">
             changed <RelativeInstant instant={test.updatedAt} now={now} /> ·{" "}

--- a/apps/web/app/projects/[projectId]/tests/editor.tsx
+++ b/apps/web/app/projects/[projectId]/tests/editor.tsx
@@ -996,7 +996,7 @@ export function SaveAction({
            */
           className={
             disabled || !changed
-              ? "border-border bg-surface text-faint disabled:opacity-100 pointer-hover:bg-surface pointer-hover:text-faint"
+              ? "border-border bg-surface text-faint disabled:opacity-100"
               : undefined
           }
           {...(why === undefined ? {} : { why })}

--- a/apps/web/app/projects/[projectId]/tests/editor.tsx
+++ b/apps/web/app/projects/[projectId]/tests/editor.tsx
@@ -155,15 +155,16 @@ function AddRow({
         "inline-flex w-fit min-h-(--control-md) items-center gap-1 px-0",
         "cursor-pointer rounded-button border-0 bg-transparent",
         /*
-         * `text-primary` is the Ember-ink key: the theme maps
-         * `--color-primary` onto `--action`, and there is no `--color-action`
-         * for a `text-action` to read. A class that reads nothing draws the
-         * inherited colour, which is how this arrived as ordinary body text.
+         * The product's own word for the Ember ink. It drew as ordinary body
+         * text until ticket 09, because the theme published this family only
+         * under shadcn's name — `--color-primary` — and a class naming a key
+         * the theme does not have compiles to nothing and inherits. Both words
+         * read one declaration now; this is the one `DESIGN.md` uses.
          */
-        "text-sm text-primary",
+        "text-sm text-action",
         "transition-[color] duration-(--duration-hover) ease-out",
         "pointer-coarse:min-h-(--tap-target)",
-        "pointer-hover:not-disabled:text-primary-hover",
+        "pointer-hover:not-disabled:text-action-hover",
         "disabled:cursor-not-allowed disabled:opacity-55",
         "motion-reduce:transition-none",
       )}

--- a/apps/web/app/projects/[projectId]/tests/new/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/new/loading.tsx
@@ -3,7 +3,6 @@
 import { useParams } from "next/navigation";
 
 import { projectPath } from "../../../../../lib/project-context.ts";
-import { trailInto } from "../../../../../lib/test-suites.ts";
 import { Loading } from "../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../ui/shell.tsx";
 
@@ -26,10 +25,10 @@ export default function NewTestLoading() {
     <div data-slot="route-loading">
       <ProductStatePage
         title="Test suite"
-        breadcrumbs={trailInto({
-          label: "Tests",
-          href: projectPath(projectId, "tests"),
-        })}
+        breadcrumbs={[
+          { label: "Tests", href: projectPath(projectId, "tests") },
+          { label: "Test suite" },
+        ]}
       >
         <Loading what="the test form" />
       </ProductStatePage>

--- a/apps/web/app/projects/[projectId]/tests/page.tsx
+++ b/apps/web/app/projects/[projectId]/tests/page.tsx
@@ -25,7 +25,7 @@ import {
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
 import { MenuDivider, MenuItem } from "../../../../ui/menu.tsx";
-import { RelativeInstant, useMinuteClock } from "../../../../ui/relative-time.tsx";
+import { ListInstant } from "../../../../ui/relative-time.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
 import { SearchField } from "../../../../ui/section.tsx";
 import {
@@ -63,12 +63,10 @@ export default function TestsPage() {
 
 function columnsFor({
   projectId,
-  now,
   duplicateNames,
   menuFor,
 }: {
   readonly projectId: string;
-  readonly now: number;
   readonly duplicateNames: ReadonlySet<string>;
   readonly menuFor: (suite: TestSuite) => ReactNode;
 }): readonly Column<TestSuite>[] {
@@ -102,7 +100,7 @@ function columnsFor({
       key: "changed",
       header: "Changed",
       width: "200px",
-      cell: (suite) => <RelativeInstant instant={suite.updatedAt} now={now} />,
+      cell: (suite) => <ListInstant instant={suite.updatedAt} />,
     },
     {
       key: "menu",
@@ -118,7 +116,6 @@ function Suites({ projectId }: { readonly projectId: string }) {
   const { me } = useShellSession();
   const role = me === null ? null : roleOf(me);
   const mayAuthor = role !== null && canAuthor(role);
-  const now = useMinuteClock();
   const { answer, reload } = useProjectRead<TestSuitePage>(
     (projectId) =>
       platformAnswer(
@@ -332,7 +329,7 @@ function Suites({ projectId }: { readonly projectId: string }) {
       <>
         <DataTable
           label="Test suites in this project"
-          columns={columnsFor({ projectId, now, duplicateNames, menuFor })}
+          columns={columnsFor({ projectId, duplicateNames, menuFor })}
           rows={items}
           keyOf={(suite) => suite.id}
           stretchPrimaryLink

--- a/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
@@ -25,7 +25,6 @@ import {
   runSuitePath,
   suitePagePath,
   testsPagePath,
-  trailInto,
   type TestSuite,
 } from "../../../../lib/test-suites.ts";
 import {
@@ -434,7 +433,10 @@ export function SuiteScreen({
     <ProductPage>
       <PageHeader
         title={title}
-        breadcrumbs={trailInto({ label: "Tests", href: testsPagePath(projectId) })}
+        breadcrumbs={[
+          { label: "Tests", href: testsPagePath(projectId) },
+          { label: title },
+        ]}
         toolbar={
           <SearchField
             aria-label="Search tests"

--- a/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
@@ -38,7 +38,7 @@ import {
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { MenuDivider, MenuItem } from "../../../../ui/menu.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
-import { RelativeInstant, useMinuteClock } from "../../../../ui/relative-time.tsx";
+import { ListInstant } from "../../../../ui/relative-time.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
 import { SearchField } from "../../../../ui/section.tsx";
 import {
@@ -80,7 +80,6 @@ export function SuiteScreen({
   const { me } = useShellSession();
   const role = me === null ? null : roleOf(me);
   const mayAuthor = role !== null && canAuthor(role);
-  const now = useMinuteClock();
   const { answer: suite, reload: reloadSuite } = useProjectRead<TestSuite>(
     (projectId) =>
       platformAnswer(
@@ -282,7 +281,7 @@ export function SuiteScreen({
     {
       key: "changed",
       header: "Changed",
-      cell: (test) => <RelativeInstant instant={test.updatedAt} now={now} />,
+      cell: (test) => <ListInstant instant={test.updatedAt} />,
     },
     {
       key: "menu",

--- a/apps/web/app/projects/[projectId]/tests/suites/[suiteId]/loading.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suites/[suiteId]/loading.tsx
@@ -3,7 +3,6 @@
 import { useParams } from "next/navigation";
 
 import { projectPath } from "../../../../../../lib/project-context.ts";
-import { trailInto } from "../../../../../../lib/test-suites.ts";
 import { Loading } from "../../../../../../ui/page-state.tsx";
 import { ProductStatePage } from "../../../../../../ui/shell.tsx";
 
@@ -15,10 +14,10 @@ export default function TestSuiteLoading() {
     <div data-slot="route-loading">
       <ProductStatePage
         title="Test suite"
-        breadcrumbs={trailInto({
-          label: "Tests",
-          href: projectPath(projectId, "tests"),
-        })}
+        breadcrumbs={[
+          { label: "Tests", href: projectPath(projectId, "tests") },
+          { label: "Test suite" },
+        ]}
       >
         <Loading what="this test suite" />
       </ProductStatePage>

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -44,6 +44,14 @@ const buttonVariants = cva(
     // 140ms on every Tab step — motion on keyboard navigation, which
     // `DESIGN.md` forbids outright.
     "transition-[color,background-color,border-color] duration-(--duration-hover) ease-out",
+    /*
+     * **A control that cannot be pressed does not answer a pointer.** Every
+     * variant's hover state is behind `not-disabled:`, because the wash
+     * primary's was not: a disabled Save repainted as an available one the
+     * moment somebody's pointer rested on it, which is the opposite of what a
+     * disabled control is for. `active:` needs no guard — a browser does not
+     * fire it on a disabled element.
+     */
     "disabled:cursor-not-allowed disabled:opacity-55",
     "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   ],
@@ -59,7 +67,8 @@ const buttonVariants = cva(
          */
         default: [
           "border border-border bg-primary-wash text-primary",
-          "pointer-hover:bg-primary-wash-hover pointer-hover:text-primary-hover",
+          "pointer-hover:not-disabled:bg-primary-wash-hover",
+          "pointer-hover:not-disabled:text-primary-hover",
           "active:bg-primary-wash-pressed active:text-primary-pressed",
         ],
         /*
@@ -75,20 +84,28 @@ const buttonVariants = cva(
          */
         secondary: [
           "border border-border-strong bg-transparent text-foreground",
-          "pointer-hover:border-foreground pointer-hover:bg-surface-soft",
+          "pointer-hover:not-disabled:border-foreground",
+          "pointer-hover:not-disabled:bg-surface-soft",
         ],
         outline: [
           "border border-border-strong bg-transparent text-foreground",
-          "pointer-hover:border-foreground pointer-hover:bg-surface-soft",
+          "pointer-hover:not-disabled:border-foreground",
+          "pointer-hover:not-disabled:bg-surface-soft",
         ],
         /* Quiet action: text only. */
-        ghost:
-          "border border-transparent bg-transparent text-foreground pointer-hover:bg-surface-soft",
-        link: "border border-transparent bg-transparent text-foreground underline-offset-4 pointer-hover:underline",
+        ghost: [
+          "border border-transparent bg-transparent text-foreground",
+          "pointer-hover:not-disabled:bg-surface-soft",
+        ],
+        link: [
+          "border border-transparent bg-transparent text-foreground underline-offset-4",
+          "pointer-hover:not-disabled:underline",
+        ],
         /* Destructive: the failure colour, and never the brand colour. */
         destructive: [
           "border border-destructive bg-destructive text-destructive-foreground",
-          "pointer-hover:bg-destructive-hover pointer-hover:border-destructive-hover",
+          "pointer-hover:not-disabled:bg-destructive-hover",
+          "pointer-hover:not-disabled:border-destructive-hover",
           "active:bg-destructive-pressed active:border-destructive-pressed",
         ],
       },

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -114,11 +114,27 @@ function DialogContent({
   );
 }
 
+/**
+ * The head of a dialog, and the hairline the boards draw under it.
+ *
+ * `BK0-0` measures 16px of padding under the title and a 1px `--border` rule
+ * across the panel's inner width — the same on `BEM-0`, `BMT-0` and `C8F-0`.
+ * Nothing here drew it, and no caller could add it (`ui/dialog.tsx` takes no
+ * class for its head), so one screen reached for a `Separator` as the panel's
+ * first child instead. It belongs on the head, once.
+ *
+ * A column rather than the board's row: the close control is placed by
+ * `DialogContent`, against the panel, so that a head with two lines in it does
+ * not move the ✕ down the corner.
+ */
 function DialogHeader({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn(
+        "flex flex-col gap-2 border-b border-border pb-4",
+        className,
+      )}
       {...props}
     />
   );

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -37,10 +37,11 @@ import { cn } from "@/lib/utils";
  * also a filter above a list and a control inside a row, and those are 36px —
  * so the height became a prop instead of something each caller wrote for
  * itself. The roster row had a 44px select standing a head above the two 36px
- * buttons beside it and made every row of that table 60px tall; two more
- * screen kept another copy of the same class list for its toolbar controls —
- * that one stays, because it is shared with `Input`, which cannot take a
- * `size` prop: `size` is already a native attribute on a text input.
+ * buttons beside it, which made every row of that table 60px tall.
+ *
+ * Two other screens keep a class list of their own for their toolbar filters,
+ * and that one stays: it is shared with `Input`, and a text input cannot take
+ * a `size` prop — `size` is already a native attribute there.
  *
  * The coarse-pointer minimum is not traded away for the smaller steps:
  * `pointer-coarse` puts the 44px target straight back, which is the trade

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -1,3 +1,4 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import type { ComponentProps } from "react";
 
 import { useFieldHint } from "@/ui/field-hint.ts";
@@ -29,19 +30,58 @@ import { cn } from "@/lib/utils";
  * server owns is a list that is wrong the day the server grows an entry, and
  * silently: the form would keep offering yesterday's choices and refusing
  * today's.
+ *
+ * **The three sizes are `Button`'s, and `default` is not the default here.** A
+ * select is mostly a form field, so `lg` (44px, the form control) is what a
+ * caller gets for saying nothing and every form is unchanged. But a select is
+ * also a filter above a list and a control inside a row, and those are 36px —
+ * so the height became a prop instead of something each caller wrote for
+ * itself. The roster row had a 44px select standing a head above the two 36px
+ * buttons beside it and made every row of that table 60px tall; two more
+ * screen kept another copy of the same class list for its toolbar controls —
+ * that one stays, because it is shared with `Input`, which cannot take a
+ * `size` prop: `size` is already a native attribute on a text input.
+ *
+ * The coarse-pointer minimum is not traded away for the smaller steps:
+ * `pointer-coarse` puts the 44px target straight back, which is the trade
+ * `Button` and the sidebar row already make — and which the copied class lists
+ * were not making at all.
  */
-function Select({ className, ...props }: ComponentProps<"select">) {
+const selectVariants = cva(
+  [
+    "w-full rounded-input border border-input bg-surface px-3",
+    "text-base text-foreground",
+    "disabled:cursor-not-allowed disabled:opacity-60",
+    /* "Pointer targets are at least 44px on coarse pointers." */
+    "pointer-coarse:min-h-(--tap-target)",
+  ],
+  {
+    variants: {
+      size: {
+        /* Denser still, for a control inside a row rather than above a list. */
+        sm: "min-h-(--control-sm)",
+        /* 36px: the toolbar control, and the one a table row holds. */
+        default: "min-h-(--control-md)",
+        /* 44px: the form control, which is what a field or a sheet holds. */
+        lg: "min-h-(--control-lg)",
+      },
+    },
+    defaultVariants: { size: "lg" },
+  },
+);
+
+function Select({
+  className,
+  size,
+  ...props
+}: Omit<ComponentProps<"select">, "size"> &
+  VariantProps<typeof selectVariants>) {
   const hint = useFieldHint();
 
   return (
     <select
       data-slot="select"
-      className={cn(
-        "w-full min-h-(--control-lg) rounded-input border border-input bg-surface px-3",
-        "text-base text-foreground",
-        "disabled:cursor-not-allowed disabled:opacity-60",
-        className,
-      )}
+      className={cn(selectVariants({ size }), className)}
       {...props}
       /* After the spread, so a caller passing nothing cannot erase the hint. */
       aria-describedby={props["aria-describedby"] ?? hint}
@@ -49,4 +89,4 @@ function Select({ className, ...props }: ComponentProps<"select">) {
   );
 }
 
-export { Select };
+export { Select, selectVariants };

--- a/apps/web/components/ui/tabs.tsx
+++ b/apps/web/components/ui/tabs.tsx
@@ -49,8 +49,9 @@ function Tabs({
  *   the current one raised out of it on Ember Wash. It is for a small closed
  *   set that belongs inside a row of other controls.
  * - `line` is the rail: the choices sit on a hairline and the current one is
- *   marked on it. It is for the top of a page or a panel, where the strip is
- *   what a whole region is switched by.
+ *   marked on it — the mark alone, with no fill behind the label. It is for the
+ *   top of a page or a panel, where the strip is what a whole region is
+ *   switched by.
  *
  * The track's 8px input radius holds 6px button radii on 4px of padding, which
  * is the nesting the eye reads as one control rather than two.
@@ -93,10 +94,11 @@ function TabsList({
 /**
  * One choice in the strip.
  *
- * The current one is Ember Wash **and** a mark that survives a greyscale
- * screenshot: the rail's 2px Ember rule under the `line` tab, and the raised
- * bordered plate around the `default` one. `DESIGN.md`: "State is not
- * communicated by colour alone."
+ * The current one always carries a mark that survives a greyscale screenshot:
+ * the rail's 2px Ember rule under the `line` tab, and the raised bordered plate
+ * around the `default` one. `DESIGN.md`: "State is not communicated by colour
+ * alone." Only the segmented plate is filled with Ember Wash — a rail tab is
+ * its mark, which is what `2B1-0` draws.
  *
  * There is no `focus-visible` rule here on purpose. `globals.css` draws the
  * product's Ember focus ring for everything a keyboard reaches, `[role="tab"]`
@@ -141,12 +143,29 @@ function TabsTrigger({
           "pointer-hover:data-[state=inactive]:bg-surface-soft",
           "pointer-hover:text-foreground",
           "disabled:cursor-not-allowed disabled:opacity-55",
-          "data-[state=active]:bg-selected data-[state=active]:text-foreground",
+          /*
+           * The current tab's label darkens in both shapes. The *fill* does
+           * not: see the two variant blocks below.
+           */
+          "data-[state=active]:text-foreground",
           "[&_svg]:pointer-events-none [&_svg]:shrink-0",
           "[&_svg:not([class*='size-'])]:size-4",
         ],
         [
-          /* The segmented plate: raised out of the track on a narrow Ember edge. */
+          /*
+           * The segmented plate: raised out of the track on Ember Wash behind
+           * a narrow Ember edge. **The wash is the plate's, not every tab's.**
+           * It was written unscoped, so the rail tab drew it as well — a block
+           * of wash that stops at the label's box, under a rail whose own mark
+           * is the 2px Ember rule. `2B1-0` draws the mark and nothing else, and
+           * on a dark surface the extra fill read as a second control.
+           *
+           * Scoped here rather than undone in the `line` block, for the reason
+           * the shared table learned the same week: two `background-color`
+           * rules of equal weight under one selector are decided by whichever
+           * Tailwind emits last, and that is not a decision.
+           */
+          "group-data-[variant=default]/tabs-list:data-[state=active]:bg-selected",
           "group-data-[variant=default]/tabs-list:data-[state=active]:border-brand",
         ],
         [

--- a/apps/web/lib/instants.ts
+++ b/apps/web/lib/instants.ts
@@ -48,6 +48,35 @@ function formatterFor(
 }
 
 /**
+ * The boards' short absolute form, cached the same way as the ISO one above.
+ *
+ * `en-US` rather than `en-CA`: the month name and the comma are what make
+ * "Aug 16, 2026" the date the boards draw, and the ISO formatter beside it
+ * stays exactly as it was for evidence and for the elements' titles.
+ */
+function listFormatterFor(precision: InstantPrecision): Intl.DateTimeFormat {
+  const key = `list:${precision}`;
+  const cached = FORMATTERS.get(key);
+  if (cached !== undefined) return cached;
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    ...(precision === "day"
+      ? {}
+      : {
+          hour: "2-digit",
+          minute: "2-digit",
+          ...(precision === "second" ? { second: "2-digit" } : {}),
+          hourCycle: "h23",
+        }),
+  });
+  FORMATTERS.set(key, formatter);
+  return formatter;
+}
+
+/**
  * One formatter for every visible absolute instant.
  *
  * Product callers omit `timeZone`, which lets the browser use the viewer's
@@ -74,9 +103,34 @@ export function formatViewerInstant(
   return `${day} ${clock} ${part("timeZoneName")}`.trimEnd();
 }
 
-/** The local day something happened: what a list column has room for. */
-export function asDay(instant: string): string {
-  return formatViewerInstant(instant, "day");
+/**
+ * The one absolute form a list column carries: `Aug 16, 2026`.
+ *
+ * **A list's date column is an absolute short date, and never a relative age.**
+ * The boards print `Aug 16, 2026` in every list column that holds a time
+ * (`6ZJ-0`, `8TQ-0`, `8P4-0`), and the product printed two other things: an ISO
+ * day on the agents list and a changing age on personas, suites, tests, runs,
+ * transcripts, keys and invitations. A column of ages is a column that cannot
+ * be scanned — every row says "a moment ago" until it says "2 days ago" — and
+ * two rows a minute apart are indistinguishable by the time anybody reads them.
+ * Relative time stays where it is a fact inside a sentence: "started just now",
+ * "last received 2 min ago".
+ *
+ * `precision` is here because one column names a *moment* rather than a day:
+ * the transcript list's leading column is the exchange's own identity and has
+ * always been to the second. It keeps that precision and takes this shape, so
+ * there is still one absolute form in the product rather than two.
+ *
+ * The exact instant is not lost. `ListInstant` keeps the RFC 3339 value on the
+ * element and the viewer-local moment with its zone in the title.
+ */
+export function asListInstant(
+  instant: string,
+  precision: InstantPrecision = "day",
+): string {
+  const at = Date.parse(instant);
+  if (Number.isNaN(at)) return instant;
+  return listFormatterFor(precision).format(new Date(at));
 }
 
 /** The local moment to the minute: what detail and history views need. */

--- a/apps/web/lib/test-suites.ts
+++ b/apps/web/lib/test-suites.ts
@@ -52,31 +52,3 @@ export function matchesSearch(name: string, search: string): boolean {
   const wanted = search.trim().toLocaleLowerCase();
   return wanted === "" || name.toLocaleLowerCase().includes(wanted);
 }
-
-/**
- * The trail into a record, for a page whose `<h1>` is that record's own name.
- *
- * `PageHeader` draws the trail and the page title side by side in one 56px bar,
- * so a trail that ended with the record would say its name twice — "Tests /
- * Default   Default" — which is not what `9VT-0` and `B9M-0` draw. They draw
- * one line, and its last step is the heading. So the trail carries the
- * ancestors and stops, and the `<h1>` beside it is the current page: one name,
- * in the element that means "this page", with the separator still between it
- * and its parent.
- *
- * **This belongs in the shell rather than here**, and it is written here only
- * because `apps/web/ui/` is another ticket's during this effort. The one-line
- * fix is for `PageHeader` to stop drawing the trail's last step; when that
- * lands, every caller of this can pass its own trail again and this goes.
- */
-export function trailInto(
-  ...ancestors: readonly { readonly label: string; readonly href: string }[]
-): readonly [
-  { readonly label: string; readonly href: string },
-  ...{ readonly label: string; readonly href: string }[],
-  { readonly label: string; readonly href?: never },
-] {
-  const [first, ...rest] = ancestors;
-  if (first === undefined) throw new Error("a trail needs at least one parent");
-  return [first, ...rest, { label: "" }];
-}

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -538,8 +538,12 @@ describe("reading an agent's reach from the list", () => {
     // agent's own column is null until Start monitoring binds it, and this
     // agent has a live Retell connection.
     expect(screen.getByText("Retell")).toBeDefined();
-    // And when it joined egma.
-    expect(screen.getByText("2026-08-15")).toBeDefined();
+    /*
+     * And when it joined egma, as the boards write a date in a list column:
+     * the absolute short date, not the ISO day this printed before ticket 09
+     * gave every list one formatter (`asListInstant`).
+     */
+    expect(screen.getByText("Aug 15, 2026")).toBeDefined();
 
     expect(screen.queryByText("Not checked")).toBeNull();
     expect(screen.queryByText("Checked")).toBeNull();

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -509,8 +509,18 @@ describe("the running graders of one project", () => {
         .getByRole("link", { name: "Graders" })
         .getAttribute("href"),
     ).toBe("/projects/prj_1/graders");
-    expect(within(breadcrumb).getByText("Running").getAttribute("aria-current"))
-      .toBe("page");
+    /*
+     * **And nothing after it.** A trail's last step is the page it is on, and
+     * `PageHeader` draws the trail and the heading in one 56px bar — so the
+     * shell takes that step off and the heading beside it is what says where
+     * somebody is (ui-refresh ticket 09, item c). Before the rule this bar
+     * read "Graders / Running   Running graders".
+     */
+    expect(within(breadcrumb).queryByText(runningCopy.RUNNING.title)).toBeNull();
+    expect(within(breadcrumb).queryByText("Running")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: runningCopy.RUNNING.title }),
+    ).toBeTruthy();
 
     // What `required` decides, rather than the flag's own value.
     expect(screen.getAllByText("Blocks")).not.toHaveLength(0);

--- a/apps/web/test/monitoring.test.tsx
+++ b/apps/web/test/monitoring.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import MonitoringTranscriptsPage from "../app/projects/[projectId]/monitoring/transcripts/page.tsx";
+import { asListInstant } from "../lib/instants.ts";
 import type { Me } from "../lib/me.ts";
 import { COLUMNS, LIST, QUIET } from "../lib/transcript-copy.ts";
 import type { Facts, Listed } from "../lib/transcripts.ts";
@@ -348,7 +349,15 @@ describe("what the Monitoring list shows", () => {
     const table = await screen.findByRole("table", { name: LIST.tableLabel });
     const link = within(table).getAllByRole("link")[0];
     const href = link?.getAttribute("href") ?? "";
-    const started = within(link as HTMLAnchorElement).getByText("5 minutes ago");
+    /*
+     * The exchange's own moment, absolute and to the second. A list column is
+     * an absolute short date (ticket 09, item a): a column of ages cannot be
+     * scanned, and two exchanges a minute apart read the same for the whole of
+     * the first hour. The precision this column has always had is kept.
+     */
+    const started = within(link as HTMLAnchorElement).getByText(
+      asListInstant(startedAt, "second"),
+    );
 
     expect(started.closest("time")?.dateTime).toBe(startedAt);
     expect(started.closest("time")?.title).toMatch(

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -59,6 +59,23 @@ export type Column<Row> = {
   readonly mono?: boolean;
   /** A row control. It stays at the trailing edge in both table layouts. */
   readonly action?: boolean;
+  /**
+   * How wide this column is, when the boards say.
+   *
+   * **It is a real width, not a hint, and that was worth measuring.** The table
+   * lays out `auto`, where a declared width is only a preference — but every
+   * cell's content is clipped to one line, so a column's own minimum is its
+   * padding and nothing pushes back. A browser then gives the widths that were
+   * asked for and hands the slack to the columns that asked for none.
+   *
+   * Measured at 1440 on 2026-08-23, against `6ZM-0` and `8XV-0`: the agents
+   * list lands 260 / 160 / 360 with Created taking the 338 left over, and
+   * personas lands 260 / 140 / 110 / 90 / 130 with Description taking the
+   * slack. Both are the boards, to the pixel. So `table-fixed` is not needed,
+   * and a list that wants the boards' proportions only has to say them.
+   *
+   * A row control's slot is not a caller's to set: see `widthOf`.
+   */
   readonly width?: string;
 };
 

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -129,8 +129,17 @@ export function DataTable<Row>({
     if (column.action === true) return "var(--table-action-width)";
     return column.width;
   }
+  /**
+   * Whether the narrow layout leaves this column out.
+   *
+   * The primary column can never be omitted: it is the row's name, and a
+   * stacked row without one is a row nobody can read.
+   */
+  function hiddenWhenStacked(column: Column<Row>): boolean {
+    return column !== primary && column.hideOnMobile === true;
+  }
   function mobileHidden(column: Column<Row>): "true" | undefined {
-    return column !== primary && column.hideOnMobile === true ? "true" : undefined;
+    return hiddenWhenStacked(column) ? "true" : undefined;
   }
 
   return (
@@ -158,9 +167,7 @@ export function DataTable<Row>({
                      * ⋮, which is where a person's eye starts down it.
                      */
                     "data-[action=true]:px-0",
-                    column.hideOnMobile === true &&
-                      column !== primary &&
-                      "max-[900px]:hidden",
+                    hiddenWhenStacked(column) && "stacked:hidden",
                   )}
                   data-action={column.action === true ? "true" : undefined}
                   data-mobile-hidden={mobileHidden(column)}
@@ -196,8 +203,30 @@ export function DataTable<Row>({
                     className={cn(
                       "h-(--row-min-height) text-muted-foreground",
                       "data-[action=true]:px-0 data-[action=true]:text-center",
-                      "stacked:flex stacked:h-auto stacked:min-h-0 stacked:items-baseline",
-                      "stacked:justify-between stacked:gap-3 stacked:border-0 stacked:p-0",
+                      /*
+                       * **A column the narrow layout omits takes the stacked
+                       * layout's `display` and nothing else.** Writing the two
+                       * as separate rules — `stacked:flex` for every cell and
+                       * `max-[900px]:hidden` for this one — put two `display`
+                       * declarations of equal weight under one query, and the
+                       * one Tailwind happened to emit last won. It was `flex`,
+                       * so `hideOnMobile` hid nothing on a phone: the personas
+                       * list still drew Description and Version, and the
+                       * agents list still drew Created.
+                       *
+                       * There is no rule to outrank now, and the second half
+                       * is the same fix: the omission follows `stacked`, so a
+                       * table that stacks because its own container is narrow
+                       * omits the same columns a phone does. `hideOnMobile`
+                       * has always meant "the narrow layout may leave this
+                       * out", and `stacked` is what "narrow layout" means.
+                       */
+                      hiddenWhenStacked(column)
+                        ? "stacked:hidden"
+                        : [
+                            "stacked:flex stacked:h-auto stacked:min-h-0 stacked:items-baseline",
+                            "stacked:justify-between stacked:gap-3 stacked:border-0 stacked:p-0",
+                          ],
                       column === primary
                         ? "stacked:mb-1"
                         : column.action === true
@@ -225,9 +254,6 @@ export function DataTable<Row>({
                         "@max-[60rem]/data-table:justify-end",
                         "@max-[60rem]/data-table:has-[[data-slot=cell]:empty]:hidden",
                       ],
-                      column.hideOnMobile === true &&
-                        column !== primary &&
-                        "max-[900px]:hidden",
                     )}
                     data-action={column.action === true ? "true" : undefined}
                     data-label={column.header}

--- a/apps/web/ui/dialog.tsx
+++ b/apps/web/ui/dialog.tsx
@@ -97,11 +97,18 @@ const PANEL_WIDE = {
   sheet: "w-[min(var(--sheet-width-wide),100vw)]",
 } as const;
 
-/** A sheet's head is a fixed bar over a body that scrolls under it. */
+/**
+ * A sheet's head is a fixed bar over a body that scrolls under it.
+ *
+ * The hairline is not here any more: `DialogHeader` carries it for every kind,
+ * because the boards draw one under a confirmation's title too. What is left is
+ * the sheet's own bar — it does not shrink, and its padding is even rather than
+ * the dialog head's "under the title only".
+ */
 const HEAD_SHAPE = {
   dialog: "",
   drawer: "",
-  sheet: "flex-none border-b border-border p-5",
+  sheet: "flex-none p-5",
 } as const;
 
 /**

--- a/apps/web/ui/page-navigation.tsx
+++ b/apps/web/ui/page-navigation.tsx
@@ -21,6 +21,40 @@ export type PageNavigationItems = readonly [
   CurrentNavigationItem,
 ];
 
+/** One step of a trail, whichever kind it is. */
+export type PageNavigationItem = ParentNavigationItem | CurrentNavigationItem;
+
+/** A trail with at least one step left in it. */
+export type DrawnTrail = readonly [PageNavigationItem, ...PageNavigationItem[]];
+
+/**
+ * The trail a page draws, with the page's own name taken off the end.
+ *
+ * **A trail never repeats the title beside it.** `PageHeader` draws the trail
+ * and the `<h1>` side by side in one 56px bar, and a trail's last step *is* the
+ * current page — so every record page in the product read its own name twice,
+ * a slash apart: "Tests / Default   Default". Two tickets worked around it
+ * locally, one by ending the trail with an empty step (which left a dangling
+ * "/" wherever the bar wrapped) and one by putting the kind of record there
+ * instead of the record ("Runs / Run   Pre-release check").
+ *
+ * So the rule is here, once: a page passes its real trail, ending with its own
+ * name, and this takes that step off. The separator goes with it, because the
+ * step it belonged to is gone. What is left says which section the record is
+ * in, and the heading beside it says which record.
+ */
+export function trailWithoutTitle(
+  items: PageNavigationItems | undefined,
+  title: string,
+): DrawnTrail | undefined {
+  if (items === undefined) return undefined;
+  if (items[items.length - 1]?.label !== title) return items;
+
+  const [first, ...rest] = items.slice(0, -1);
+  /* A trail that was only the page's own name has nothing left to draw. */
+  return first === undefined ? undefined : [first, ...rest];
+}
+
 /**
  * The one navigation model for a page below a product section.
  *
@@ -45,11 +79,7 @@ export type PageNavigationItems = readonly [
  * pointer target — and carries no motion, which is what `DESIGN.md` asks of a
  * navigation row. Rewriting it would have been churn with a diff attached.
  */
-export function PageNavigation({
-  items,
-}: {
-  readonly items: PageNavigationItems;
-}) {
+export function PageNavigation({ items }: { readonly items: DrawnTrail }) {
   return (
     <nav
       className="mb-3 min-w-0"

--- a/apps/web/ui/page-navigation.tsx
+++ b/apps/web/ui/page-navigation.tsx
@@ -82,7 +82,16 @@ export function trailWithoutTitle(
 export function PageNavigation({ items }: { readonly items: DrawnTrail }) {
   return (
     <nav
-      className="mb-3 min-w-0"
+      /*
+       * **The room under the trail is for the width where it wraps.** In the
+       * 56px bar the trail and the heading are one centred row, and a bottom
+       * margin there lifts the trail off the heading's line by half of it —
+       * which nobody could see while the trail ended with the page's own name
+       * and ran the width of the bar. Under 900px the bar becomes the page's
+       * first lines and the trail takes a line of its own, which is where the
+       * 12px belongs.
+       */
+      className="mb-0 min-w-0 max-[900px]:mb-3"
       data-slot="page-navigation"
       aria-label="Breadcrumb"
     >

--- a/apps/web/ui/page-state.tsx
+++ b/apps/web/ui/page-state.tsx
@@ -52,7 +52,11 @@ function PageState({
         "flex flex-col items-start gap-3 text-left",
         "rounded-card border border-border bg-surface px-8 py-10",
         "max-[900px]:px-5 max-[900px]:py-8",
-        /* Quiet is an outline around an absence: nothing is raised off the page. */
+        /*
+         * Quiet is an outline around an absence that is about to be filled:
+         * nothing is raised off the page. `Loading` is its only caller — an
+         * empty list is not an absence egma caused, and it draws its own card.
+         */
         tone === "quiet" && "border-dashed bg-transparent",
       )}
       role={tone === "bad" ? "alert" : "status"}
@@ -110,7 +114,26 @@ export function Loading({ what }: { readonly what: string }) {
   );
 }
 
-/** There is nothing here, and that is a fact about the project, not a fault. */
+/**
+ * There is nothing here, and that is a fact about the project, not a fault.
+ *
+ * **It is drawn here rather than through `PageState`, and the reason is what
+ * the four states are about.** Loading, failed and not-available are about
+ * *egma* — a wait, a refusal, an address that leads nowhere. They interrupt,
+ * so they are set apart from the page. An empty list is about the *project*:
+ * it is the ordinary first day of a list nobody has written to yet, it belongs
+ * on the page, and it is the one state that offers an action.
+ *
+ * `AN8-0` (page `B-0`) draws exactly that and it is what this matches, value
+ * for value: a solid `--surface` card inside one `--border` hairline with no
+ * corner, 40px of padding, a 16px weight-500 title over one 14px sentence at
+ * the board's measure, and the primary action under them as the wash button.
+ * The dashed outline and 24px heading it wore before said "something has gone
+ * wrong here", which is the one thing an empty list has not done.
+ *
+ * The gap inside the head block is the board's 6px rounded to the 4px grid,
+ * the same rounding ticket 01 made for the sheet's padding.
+ */
 export function Empty({
   title,
   lead,
@@ -120,7 +143,28 @@ export function Empty({
   readonly lead?: ReactNode;
   readonly action?: ReactNode;
 }) {
-  return <PageState tone="quiet" title={title} lead={lead} action={action} />;
+  return (
+    <section
+      data-slot="page-state"
+      data-tone="empty"
+      className={cn(
+        "flex w-full flex-col items-start gap-4 text-left",
+        "rounded-card border border-border bg-surface p-10",
+        "max-[900px]:p-5",
+      )}
+      role="status"
+    >
+      <div className="flex flex-col gap-1">
+        <h2 className="m-0 text-base font-medium">{title}</h2>
+        {lead === undefined ? null : (
+          <p className="m-0 max-w-(--state-lead-width) text-sm text-muted-foreground">
+            {lead}
+          </p>
+        )}
+      </div>
+      {action}
+    </section>
+  );
 }
 
 /**

--- a/apps/web/ui/relative-time.tsx
+++ b/apps/web/ui/relative-time.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import {
+  asListInstant,
   formatViewerInstant,
   relativeViewerInstant,
   type InstantPrecision,
@@ -49,6 +50,38 @@ export function RelativeInstant({
       suppressHydrationWarning
     >
       {relativeViewerInstant(instant, now)}
+    </time>
+  );
+}
+
+/**
+ * A settled date in a list column: the boards' `Aug 16, 2026`.
+ *
+ * **This is the element every list's date column uses, and `RelativeInstant`
+ * is not.** The two are one decision written twice — see `asListInstant` for
+ * why a column of ages cannot be scanned — and they share everything else: the
+ * RFC 3339 value stays on the element, the exact viewer-local moment with its
+ * zone stays in the title, and the figures are tabular so a column of dates is
+ * one column rather than a ragged edge.
+ *
+ * There is no page clock, because a settled date does not change. That is the
+ * whole difference in the signature.
+ */
+export function ListInstant({
+  instant,
+  precision = "day",
+}: {
+  readonly instant: string;
+  readonly precision?: InstantPrecision;
+}) {
+  return (
+    <time
+      className="tabular-nums"
+      dateTime={instant}
+      title={formatViewerInstant(instant, precision)}
+      suppressHydrationWarning
+    >
+      {asListInstant(instant, precision)}
     </time>
   );
 }

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -52,6 +52,7 @@ import { DraftNavigationProvider } from "./draft-navigation.tsx";
 import { MENU_ITEM, Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
 import {
   PageNavigation,
+  trailWithoutTitle,
   type PageNavigationItems,
 } from "./page-navigation.tsx";
 import { ProjectSelector } from "./project-selector.tsx";
@@ -765,6 +766,13 @@ export function ProductPage({
  * purpose statement `DESIGN.md` asks for, kept where somebody reads it rather
  * than squeezed into a 56px strip beside the title it explains.
  *
+ * **A trail never repeats the title beside it.** A page passes the real trail
+ * into its record, ending with the record's own name, and this header takes
+ * that last step off before drawing it — because the `<h1>` beside it is that
+ * step. Without the rule every record page read its own name twice in one bar
+ * ("Tests / Default   Default"), and the two workarounds for it left either a
+ * dangling separator or the kind of record where its name belonged.
+ *
  * `eyebrow` moved out of the bar with it, and is drawn in the same quiet
  * block. **It is not decoration on every page**: the transcript screen puts the
  * trace's source and environment there — "production / default" — which is a
@@ -804,6 +812,12 @@ export function PageHeader({
    * twice is the thing this suppression has always been for.
    */
   const label = breadcrumbs === undefined ? eyebrow : undefined;
+  /*
+   * The trail, with this page's own name taken off the end. See
+   * `trailWithoutTitle`: the trail and the heading sit in one 56px bar, so a
+   * trail that ended with the page said its name twice.
+   */
+  const trail = trailWithoutTitle(breadcrumbs, title);
   const hasBlock =
     toolbar !== undefined ||
     action !== undefined ||
@@ -827,9 +841,7 @@ export function PageHeader({
           "max-[900px]:border-b-0 max-[900px]:px-4 max-[900px]:pt-4",
         )}
       >
-        {breadcrumbs === undefined ? null : (
-          <PageNavigation items={breadcrumbs} />
-        )}
+        {trail === undefined ? null : <PageNavigation items={trail} />}
         {/* A heading carries no size of its own; the class is the size. */}
         <h1 className="m-0 min-w-0 truncate text-base font-medium">{title}</h1>
       </div>

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -327,6 +327,8 @@
    */
   --access-panel-width: 440px;
   --dialog-width: 480px;
+  /* One sentence under an empty state's title, held to the board's measure. */
+  --state-lead-width: 520px;
   --search-width: 300px;
   --chip-height: 22px;
   --menu-width: 210px;

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -580,6 +580,29 @@
   --color-primary-wash-hover: var(--action-wash-hover);
   --color-primary-wash-pressed: var(--action-wash-pressed);
 
+  /*
+   * The same seven declarations under the product's own word.
+   *
+   * **`primary` is shadcn's name for this and `action` is egma's, and a class
+   * that names a key the theme does not publish fails in silence.** `DESIGN.md`
+   * and the spec both say `--action`; the theme published only `--color-primary`,
+   * so `text-action` compiled to nothing at all, drew the inherited body colour,
+   * and looked exactly like somebody's decision. That is how "+ Add a behavior"
+   * shipped as ordinary text until a screenshot caught it.
+   *
+   * Both words now read one declaration. `primary` stays because a component
+   * pasted from the registry arrives asking for it; `action` is what the rest
+   * of the product writes. The two feedback fills are aliased as well, on
+   * purpose: publishing `action-wash` but not `action-wash-hover` would put
+   * the same silent hole back one name along.
+   */
+  --color-action: var(--action);
+  --color-action-hover: var(--action-hover);
+  --color-action-pressed: var(--action-pressed);
+  --color-action-wash: var(--action-wash);
+  --color-action-wash-hover: var(--action-wash-hover);
+  --color-action-wash-pressed: var(--action-wash-pressed);
+
   /* Destructive, which is the failure colour and never the brand colour. */
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-text);


### PR DESCRIPTION
Six route tickets built in parallel on ticket 01's base. Each found the same handful of shared defects and, being forbidden to edit shared files, worked around them locally. This fixes each one at the source, removes the workaround it names, and re-proves the screens it touched.

## The merge product, before any edit

On `dba8deec`: `pnpm typecheck` green, and `npx vitest run --project fast --maxWorkers=2 apps/web/test/` → **25 files, 570 tests, all passing**. The seven pull requests merged cleanly in text *and* in meaning; nothing had to be fixed before the list started.

## The list

**(a) List dates — fixed.** Every list's date column is the boards' `Aug 16, 2026`. The product printed two other things: an ISO day on the agents list, and a changing age on personas, suites, tests, runs, transcripts, keys and invitations. A column of ages cannot be scanned, and two rows a minute apart read the same for the whole of the first hour. `asListInstant` in `lib/instants.ts` is the one helper and `ListInstant` in `ui/relative-time.tsx` is the element that spends it — RFC 3339 on the element, the exact viewer-local moment with its zone in the title, tabular figures. `asDay` had no caller left and went. Relative time stays where it is a fact in a sentence ("changed just now · 1 persona"). Three expectations moved with it, including the browser walk's transcripts row.

*The transcript list keeps its precision.* Its leading column is the exchange's own identity and has always been to the second; it takes the boards' shape at that precision, so the product has one absolute form rather than two.

**(b) `hideOnMobile` — fixed.** `stacked:flex` on every cell and `max-[900px]:hidden` on this one were two `display` declarations of equal weight under one query, and Tailwind's emission order decided. `flex` won. A cell the narrow layout omits now takes `stacked:hidden` and none of the stacked layout's other declarations, so there is nothing left to outrank — and the omission moved onto the `stacked` variant, so a table that stacks because its own container is narrow omits the same columns a phone does.

**(c) The title bar said a record's name twice — fixed.** `trailWithoutTitle` in `ui/page-navigation.tsx` takes the trail's last step off when it equals the title, and the separator goes with it. Three workarounds went: `lib/test-suites.ts`'s `trailInto()` (deleted; five callers pass their own trails again), the agent page's `{ label: "Agent" }`, and the run page's and running-graders page's kind words. The transcript and simulation pages needed no edit — they already passed real names. One expectation moved (`graders-pages.test.tsx`). A fourth thing the proof found: the trail carried a 12px bottom margin into a centred 56px row and sat 6px above the heading; it now belongs only to the width where the bar wraps.

**(d) `text-action` mapped to nothing — fixed.** The theme published this family only under shadcn's `primary`, so `text-action` named a key that does not exist, compiled to no rule, and drew the inherited body colour. Six aliases added — including the two wash feedback steps, because publishing `action-wash` and not `action-wash-hover` puts the same silent hole back one name along. The one control written for the missing word now takes it: measured `rgb(194, 65, 12)` against `--action` `#c2410c`.

**(e) Wash hover while disabled — fixed.** Guarded with `not-disabled:` — and not only the wash: `secondary`, `outline`, `ghost`, `link` and `destructive` all repainted the same way. The test page's local `pointer-hover:bg-surface pointer-hover:text-faint` half goes; its *unchanged look* stays, which is a different decision.

**(f) Empty state — fixed.** `AN8-0`'s card, value for value. `Empty` is drawn directly in `page-state.tsx` rather than through `PageState`: loading, failed and not-available are about egma and interrupt, so they stay set apart; an empty list is about the project, belongs on the page, and is the only one of the four that offers an action. `quiet` now has one caller and says so.

**(g) Select height in rows — fixed.** `Select` takes `Button`'s three sizes; the default stays `lg` (44), so every form is untouched. `ROW_CONTROL` in `settings/people/page.tsx` is gone. `TOOLBAR_FILTER` stays: it is shared with `Input`, and a text input cannot take a `size` prop — `size` is already a native attribute there.

**(h) Confirm dialog header hairline — fixed.** On `DialogHeader`, once. The persona archive confirmation's `Separator` workaround goes, and the sheet's head stops declaring the same border a second time.

**(i) `line` tabs drew a wash — fixed.** The wash is scoped to the segmented plate. Scoped rather than undone in the `line` block, for the same reason as (b). The graders strip is its own hand-drawn component and was already right; the two now match.

**(j) Platform column width — fixed, and it needed no code.** `Column.width` was already declared on both lists; what was unknown was whether it *lands* under `table-layout: auto`. Measured at 1440: agents lands **260 / 160 / 360 / 338 / 48** and personas lands **260 / 140 / 110 / (slack) / 90 / 130 / 48** — both the boards to the pixel, because every cell clips to one line so nothing pushes back on the declared width. `table-fixed` is not needed; ticket 04's G6 is answered and the finding is written on the prop.

## Measured, not argued

```
agents table         Name=260 Platform=160 Connections=360 Created=338 Actions=48
personas table       Name=260 Type=140 Language=110 Description=388 Version=90 Updated=130 ⋮=48
agents at 375        Created=none, Created=none, Created=none
personas at 375      Description=none Version=none  (×2 rows)
list dates           "Aug 23, 2026"  title "2026-08-23"   ·  invitations "Aug 30, 2026"
transcripts date     "Aug 23, 2026, 05:11:39"  title "2026-08-23 05:11:39 PDT"
empty card           bg #ffffff · solid 1px --border · radius 0 · padding 40 · gap 16 · title 16px/500
dialog head          border-bottom solid 1px --border · padding-bottom 16px
roster row           controls [36,36,36] · row 53px
line tab (current)   background rgba(0,0,0,0) · ::after #ff5229 · label #1f1f1f
action ink           "+ Add a behavior" rgb(194,65,12) = --action #c2410c
wash hover rule      .pointer-hover\:not-disabled\:bg-primary-wash-hover:hover:not(:disabled)
disabled wash button "Send invitation" rgb(255,245,242) → hover → rgb(255,245,242)  (unchanged)
```

Every title bar, at 1440 and 375, trail then heading:

```
agents        (no trail)                                    Agents
agent         Agents                                        Front desk
test          Tests / Insurance questions                   Asks what the excess is
empty suite   Tests                                         After-hours
run           Runs                                          Pre-release check
simulation    Runs / Pre-release check / Simulation 01      Asks what the excess is
transcript    Monitoring                                    Transcript
graders       Graders                                       Running graders
```

No duplicate anywhere, and no dangling separator at either width.

## Gates

- `npx vitest run --project fast --maxWorkers=2 apps/web/test/` → **25 files, 570 tests, all passing**.
- `pnpm typecheck` → green end to end (contract check, lint, `tsc -b`, the tests project, the web app).
- `DESIGN.md` updated for (a), (c) and (f).

## Screenshots

38 files, in `.proofs/ui-09/` and the session scratchpad's `proofs/ui-09/`:

`agents-{1440-light,1440-dark,375-light}`, `agents-empty-1440-{light,dark}`, `agent-{1440-light,1440-dark,375-light}`, `personas-{1440-light,1440-dark,375-light}`, `suites-1440-light`, `suite-empty-1440-{light,dark}`, `test-{1440-light,1440-dark,375-light}`, `delete-test-dialog-1440-{light,dark}`, `runs-1440-light`, `run-{1440-light,1440-dark,375-light}`, `simulation-{1440-light,1440-dark,375-light}`, `transcripts-1440-light`, `transcript-{1440-light,1440-dark,375-light}`, `graders-running-{1440-light,1440-dark,375-light}`, `settings-people-1440-{light,dark}`, `settings-people-invitations-1440-light`, `settings-people-invitations-1440-light-hovered`, `settings-keys-1440-light`.

The seed is a real one: agents with connections through `registerAgent`, a forked persona, two suites and two tests, a run and its simulations through `createRun`, an adopted grader, two colleagues and an outstanding invitation, and one production trace posted at the OTLP door against an isolated MinIO container.

## Left for whoever picks it up

- The runs list's trailing lane measures 109px rather than the theme's 48, because it holds a labelled `Cancel` rather than a ⋮ (ticket 06's finding 2, still open). A `DataTable` action column that can be a labelled control is the general fix.
- The graders tab strip is a hand-drawn `<nav>` of links, not `TabsList variant="line"`. Both now draw the same thing; one component would be better than two that agree.
- `DESIGN.md`'s Shell bullet still says the title bar holds "the page title and its purpose statement". Ticket 01 round 1 moved the purpose statement out of that bar. Worth a one-line correction in ticket 08.
- A `text-*`/`bg-*` class naming a key the theme does not publish still fails in silence. (d) closed the one instance; a lint rule would close the class of them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790086749&installation_model_id=431960&pr_number=199&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F199&signature=039f76a768ed375dfd16ac9d89ebeca6ea231c645a92cc731e4dda07f45c1694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates UI fixes discovered across several route implementations into shared components and removes route-level workarounds.

- Standardizes list timestamps as absolute viewer-local dates while retaining exact instants in semantic `<time>` elements.
- Corrects responsive table column hiding, breadcrumb/title deduplication, disabled hover states, tab styling, dialog headers, empty states, theme action aliases, and dense select sizing.
- Updates affected routes, tests, and design guidance to use the shared behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defect identified in the changed behavior.

The shared date, responsive-table, navigation, control-state, dialog, tab, and empty-state changes remain compatible with their current callers and preserve the relevant rendering and interaction contracts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/lib/instants.ts | Adds the shared absolute list-date formatter while preserving existing exact and relative timestamp helpers. |
| apps/web/ui/relative-time.tsx | Adds the semantic `ListInstant` component and retains exact viewer-local timestamp metadata. |
| apps/web/ui/data-table.tsx | Aligns omitted columns with both viewport- and container-triggered stacked layouts without leaving competing display rules. |
| apps/web/ui/page-navigation.tsx | Removes a breadcrumb’s final item when it duplicates the adjacent page title and adjusts wrapped spacing. |
| apps/web/components/ui/button.tsx | Prevents disabled button variants from applying pointer-hover visual feedback. |
| apps/web/components/ui/select.tsx | Introduces shared visual sizes while keeping the form-oriented 44px size as the default. |
| apps/web/ui/page-state.tsx | Gives empty-list states a dedicated card presentation while retaining distinct loading and failure states. |
| apps/web/ui/tailwind-theme.css | Publishes action-color aliases and the empty-state measure through shared theme tokens. |
| apps/web/components/ui/dialog.tsx | Centralizes the dialog-header hairline so route-specific separators are unnecessary. |
| apps/web/components/ui/tabs.tsx | Restricts active wash styling to segmented tabs so line tabs use only their rail indicator. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): the trail sits on the heading&#39;..."](https://github.com/egma-ai/egma/commit/f91469657f753eb8dc401da70c72318721453cb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56013633)</sub>

**Context used:**

- Knowledge Base — [Egma web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->