### PR TITLE
fix(web): the real-browser proof passes on the redesign (ui-refresh 10)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -218,6 +218,7 @@ rgba(122, 49, 23, 0.02) -130px 256px 115px 0
 - Every page has a title bar of its own, the same height as the wordmark bar, holding the page title alone. A purpose statement, where a form or settings page needs one, is the first quiet line of the page body; list screens carry none (read off the boards, 2026-08-23). Page actions are not in that bar.
 - A page below a section carries the trail into its record in that bar, and **the trail never repeats the title beside it**. A page passes the real trail, ending with the record's own name; the bar draws every step but the last, because the heading beside it is that last step. There is no separator after the step that is left. (Read off the boards, 2026-08-23.)
 - A page's actions sit in the toolbar row under the title bar, at the right, opposite whatever the page filters by.
+- The toolbar row is 52px, and the last 16px of it is the gap to whatever it stands over. The page body adds no gutter of its own under a toolbar row, so a list's panel begins 132px down the page: the 56px title bar, the 24px gutter, and the 52px row. A page whose header draws no toolbar row keeps the 24px gutter, because then nothing above it carries one. (Read off `71N-0` and `6ZM-0` on `6ZJ-0`, 2026-08-23; the application had been drawing the panel at 156.)
 - Page content is held to the page maximum and aligned to the left gutter, so the title in the bar and the first column under it are on one line.
 
 The measurements, all of them theme values:

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -907,7 +907,23 @@ describe("what a project recorded in production", () => {
           .getByRole("link", { name: "Simulation runs", exact: true })
           .count(),
       ).toBe(0);
-      expect(await sidebar.getByRole("link", { name: "Home" }).count()).toBe(0);
+      /*
+       * **There is a way home in this bar, and it is the wordmark.**
+       *
+       * This line used to say there was none, from the time the bar held six
+       * navigation rows and nothing else. The developer put the Egma wordmark
+       * at the top of the sidebar on 2026-08-23 — "our logo, not the
+       * organization's" — and it links to the product root, so the assertion is
+       * now about what that link is rather than that it is absent. What must
+       * stay absent is a *navigation row* called Home: the bar names areas, and
+       * a row pointing at the root would be a seventh area that is not one.
+       */
+      expect(
+        await sidebar.getByRole("link", { name: "Egma home", exact: true }).getAttribute("href"),
+      ).toBe("/");
+      expect(
+        await sidebar.getByRole("link", { name: "Home", exact: true }).count(),
+      ).toBe(0);
       expect(
         await sidebar.getByRole("link", { name: "Simulations" }).count(),
       ).toBe(0);
@@ -3496,8 +3512,19 @@ describe("the complete product, walked in order in a second project", () => {
                * whole of `NAVIGATION_GROUPS` — Agents, Graders, Tests,
                * Personas, Runs, Transcripts — and a row added or dropped
                * should be a decision somebody takes here on purpose.
+               *
+               * **Seven links, and the seventh is not a row.** The Egma
+               * wordmark at the top of the bar is a link to the product root
+               * (`/`), added on 2026-08-23 by the developer's ruling. It is
+               * separated out rather than counted in, so this stays a count of
+               * the navigation and the brand link stays named.
                */
-              expect(addresses.length).toBe(6);
+              const home = addresses.filter((one) => one === "/");
+              expect(home, addresses.join(", ")).toHaveLength(1);
+              expect(
+                addresses.filter((one) => one !== "/").length,
+                addresses.join(", "),
+              ).toBe(6);
               for (const address of addresses) {
                 expect(address, address).not.toContain("simulations");
               }
@@ -4259,6 +4286,14 @@ describe("the complete product, walked in order in a second project", () => {
         // No click first: a fresh document starts with the focus on nothing, so
         // the first Tab is the first focusable thing on the page. Clicking a
         // corner would make the answer depend on what is drawn there.
+        //
+        // **The wordmark is the first stop, and the switcher is the second.**
+        // The bar's topmost thing is the Egma wordmark in a bar of its own,
+        // linking to the product root (`DESIGN.md`, Shell; the developer's
+        // ruling of 2026-08-23). The topmost *control* is still the switcher,
+        // which is the line under it.
+        await walk.keyboard.press("Tab");
+        expect(await focused()).toBe("Egma home");
         await walk.keyboard.press("Tab");
         expect(await focused()).toMatch(/^Organization/u);
         await walk.keyboard.press("Tab");

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2220,13 +2220,28 @@ describe("pressing Use on a second grader while the first one's form is open", (
  * then switches off.
  */
 describe("changing a running grader and switching it off", () => {
-  /** One running copy's button, from the table rather than the mobile list. */
-  function on(named: string, button: string) {
-    return page
+  /**
+   * One running copy's act, reached the way a person reaches it.
+   *
+   * **Both acts are inside the row's ⋮ now** (ui-refresh 10): the trailing lane
+   * is the same 48px slot on every list in the product, and two buttons drawn
+   * in the cell had pushed this one out to 156px. So the act is opened rather
+   * than pressed — the ⋮ from the table rather than from the mobile list, then
+   * the item in the panel it opens, which the kit draws at the end of the page.
+   */
+  async function act(named: string, item: string): Promise<void> {
+    await page
       .locator("table")
       .getByRole("row")
       .filter({ hasText: named })
-      .getByRole("button", { name: button });
+      .getByRole("button", { name: `Actions for ${named}` })
+      .click();
+    await page.getByRole("menuitem", { name: item, exact: true }).click();
+  }
+
+  /** Whether a copy is still on the list at all. */
+  function rowFor(named: string) {
+    return page.locator("table").getByRole("row").filter({ hasText: named });
   }
 
   /** Every row of the table, the heading row included. */
@@ -2269,7 +2284,7 @@ describe("changing a running grader and switching it off", () => {
       // Blocking, as anything switched on is unless somebody said otherwise.
       await page.waitForSelector("text=Blocks");
 
-      await on("Latency", "Edit").click();
+      await act("Latency", "Edit");
       await page.waitForSelector("text=Edit Latency");
 
       // Filled in from the copy, which is the half a source scan cannot see:
@@ -2292,7 +2307,7 @@ describe("changing a running grader and switching it off", () => {
       // And opening it again shows the saved value rather than the old one —
       // which is the whole round trip: the browser wrote it, the API versioned
       // it, and the list handed it back.
-      await on("Latency", "Edit").click();
+      await act("Latency", "Edit");
       await page.waitForSelector("text=Edit Latency");
       expect(await page.locator(theEntrysNumber).inputValue()).toBe("1500");
     },
@@ -2305,7 +2320,7 @@ describe("changing a running grader and switching it off", () => {
       await page.goto(await gradersUrl("running"));
       await settlesAt(3);
 
-      await on("Latency", "Switch off").click();
+      await act("Latency", "Switch off");
 
       // The sentence that makes the button pressable: what stops is obvious,
       // and what stays is the thing somebody is actually worried about.
@@ -2320,7 +2335,7 @@ describe("changing a running grader and switching it off", () => {
       // project is created with is still there — only the one that was named
       // stopped judging.
       await settlesAt(2);
-      expect(await on("Latency", "Switch off").count()).toBe(0);
+      expect(await rowFor("Latency").count()).toBe(0);
       await page.waitForSelector("text=Expected behaviors");
     },
     SETTLE,

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -3821,6 +3821,8 @@ describe("the complete product, walked in order in a second project", () => {
         const cells: string[] = [];
         const rows: number[] = [];
         const lanes: number[] = [];
+        /** Where the toolbar strip ends and the panel under it begins. */
+        let strip = { ends: 0, panelBegins: 0 };
 
         for (const address of lists) {
           await walk.goto(address);
@@ -3829,11 +3831,44 @@ describe("the complete product, walked in order in a second project", () => {
           headings.push(Math.round(await heightOf(walk, "table thead tr")));
           cells.push(await cellStyle());
           rows.push(Math.round(await heightOf(walk, "table tbody tr")));
+          if (address === lists[0]) {
+            /*
+             * **The toolbar row carries the gap, and the panel starts on the
+             * pixel it ends on.** `71N-0` is a 52px strip — a 36px control with
+             * 16px under it — and `6ZM-0` begins at 132 from the top of the
+             * page, which is the title bar, the page gutter and that strip and
+             * nothing more. Read as a relationship rather than as 132, because
+             * 132 is three other numbers added up and this is the one of them
+             * that was wrong: the body was adding a second gutter under the
+             * strip and putting the panel at 156.
+             */
+            strip = await walk.evaluate(() => {
+              const find = (selector: string) =>
+                (
+                  Reflect.get(globalThis, "document") as {
+                    querySelector(one: string): {
+                      getBoundingClientRect(): {
+                        readonly top: number;
+                        readonly bottom: number;
+                      };
+                    } | null;
+                  }
+                ).querySelector(selector);
+              const toolbar = find('[data-slot="toolbar"]');
+              const panel = find('[data-slot="table-panel"]');
+              return {
+                ends: Math.round(toolbar?.getBoundingClientRect().bottom ?? -1),
+                panelBegins: Math.round(
+                  panel?.getBoundingClientRect().top ?? -2,
+                ),
+              };
+            });
+          }
           /*
-           * Only the lists that offer a row control have a lane. Two of the
-           * five do today; the rest gain one as their screens are rebuilt, and
-           * this measures whichever are there rather than demanding that every
-           * list grow a menu it has no use for.
+           * Only the lists that declare a trailing lane have one to measure.
+           * All five do now — the last two grew a row ⋮ in ui-refresh 10 — and
+           * this still measures whichever are there rather than demanding a
+           * lane of a list that has no row control to put in one.
            */
           const lane = walk.locator('table tbody td[data-action="true"]');
           if ((await lane.count()) > 0) {
@@ -3845,6 +3880,10 @@ describe("the complete product, walked in order in a second project", () => {
           }
         }
 
+        expect(
+          strip.panelBegins,
+          `the toolbar strip ends at ${String(strip.ends)}`,
+        ).toBe(strip.ends);
         expect(new Set(sidebars).size, sidebars.join(", ")).toBe(1);
         expect(new Set(headings).size, headings.join(", ")).toBe(1);
         expect(new Set(cells).size, cells.join(" | ")).toBe(1);

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2697,34 +2697,18 @@ describe("the complete product, walked in order in a second project", () => {
       const connected = await connectionResponse;
       expect(connected.status(), await connected.text()).toBe(201);
 
-      // The panel closes onto the list the new agent is now a row of, and the
-      // row's own name link is its address — read from the product rather than
-      // reconstructed from a database id.
-      await walk.waitForURL(new RegExp(`/projects/${second}/agents$`));
+      /*
+       * **The panel closes onto the agent it just made**, which is the record
+       * the person created rather than the list of everything that holds it.
+       * The address is read from the product — the browser is standing on it —
+       * rather than reconstructed from a database id.
+       */
+      await walk.waitForURL(
+        new RegExp(`/projects/${second}/agents/agt_[^/?#]+$`),
+      );
+      agentAddress = walk.url();
       await saysWithin(walk, "The Support line");
-      const named = walk
-        .getByRole("link", { name: "The Support line", exact: true })
-        .first();
-      await named.waitFor();
-      const agentHref = await named.getAttribute("href");
-      expect(
-        agentHref,
-        "the registered agent has a row that opens it",
-      ).toMatch(new RegExp(`^/projects/${second}/agents/agt_[^/]+$`));
-      agentAddress = new URL(agentHref ?? "/", origin).toString();
-
-      // And the way in is named on the row, as a link that opens it over the
-      // list rather than as four facts nobody can press.
       await saysWithin(walk, "Retell staging");
-      const connection = walk
-        .getByRole("link", { name: "Retell staging", exact: true })
-        .first();
-      await connection.waitFor();
-      const connectionHref = await connection.getAttribute("href");
-      expect(
-        connectionHref,
-        "the created connection opens from the row it is on",
-      ).toContain("sheet=connection");
 
       // The selected discovery candidate goes through the generic connection
       // write. The stored connection is only the public phone destination; the
@@ -2752,9 +2736,9 @@ describe("the complete product, walked in order in a second project", () => {
         credentials: null,
       });
       // The connection's own address still exists and still opens the same
-      // panel; the row's link is the query form of it.
-      connectionAddress = `${agentAddress}/connections/${stored.rows[0]?.id ?? ""}`;
-      expect(connectionHref).toContain(stored.rows[0]?.id ?? "");
+      // panel; the row's link, read off the list below, is the query form of it.
+      const storedConnectionId = stored.rows[0]?.id ?? "";
+      connectionAddress = `${agentAddress}/connections/${storedConnectionId}`;
       expect(JSON.stringify(stored.rows)).not.toContain(BROWSER_RETELL_KEY);
       expect(JSON.stringify(stored.rows)).not.toContain(BROWSER_RETELL_AGENT);
 
@@ -2767,7 +2751,6 @@ describe("the complete product, walked in order in a second project", () => {
        * checking them first would pass for the wrong reason — and go on
        * passing after the connections it is meant to guard stopped being drawn.
        */
-      await saysWithin(walk, "Retell staging");
       const agentPage = await walk.innerText("main");
       expect(agentPage).toContain("Connections");
       // The pull switch, which is the only stored monitoring choice in the
@@ -2786,6 +2769,28 @@ describe("the complete product, walked in order in a second project", () => {
        */
       await walk.goto(at("agents"));
       await saysWithin(walk, "The Support line");
+      // The row's own name link is the agent's address, and it is the same one
+      // the panel landed on.
+      const named = walk
+        .getByRole("link", { name: "The Support line", exact: true })
+        .first();
+      await named.waitFor();
+      expect(
+        new URL((await named.getAttribute("href")) ?? "/", origin).toString(),
+        "the registered agent has a row that opens it",
+      ).toBe(agentAddress);
+      // And the way in is named on the row, as a link that opens it over the
+      // list rather than as four facts nobody can press.
+      const connection = walk
+        .getByRole("link", { name: "Retell staging", exact: true })
+        .first();
+      await connection.waitFor();
+      const connectionHref = await connection.getAttribute("href");
+      expect(
+        connectionHref,
+        "the created connection opens from the row it is on",
+      ).toContain("sheet=connection");
+      expect(connectionHref).toContain(storedConnectionId);
       const row = walk
         .locator('table[aria-label="Agents in this project"] tbody tr')
         .first();

--- a/apps/web/app/new-project/page.tsx
+++ b/apps/web/app/new-project/page.tsx
@@ -80,6 +80,16 @@ function NewProject() {
   const [description, setDescription] = useState("");
   const [creating, setCreating] = useState(false);
   const [refused, setRefused] = useState<Refusal | null>(null);
+  /**
+   * Whether anybody has been in the name field yet.
+   *
+   * **A form that opens red is lying about what somebody did.** `DESIGN.md`
+   * asks every state to say what happened, and "A project needs a name" said
+   * before a page has been touched reports a mistake nobody has made. The
+   * sentence is true from the moment the field has been used and left empty,
+   * which is the moment it is about somebody's own work. (2026-08-23.)
+   */
+  const [nameTouched, setNameTouched] = useState(false);
 
   useUnsavedChanges((name !== "" || description !== "") && !creating, creating);
 
@@ -156,9 +166,12 @@ function NewProject() {
                 id="new-project-name"
                 value={name}
                 disabled={!mayAdminister}
-                aria-invalid={!named && refused !== null ? true : undefined}
+                aria-invalid={
+                  !named && (nameTouched || refused !== null) ? true : undefined
+                }
                 autoComplete="off"
                 spellCheck={false}
+                onBlur={() => setNameTouched(true)}
                 onChange={(event) => setName(event.target.value)}
               />
             </Field>
@@ -177,7 +190,9 @@ function NewProject() {
               />
             </Field>
 
-            {named ? null : <Problem>A project needs a name.</Problem>}
+            {named || !nameTouched ? null : (
+              <Problem>A project needs a name.</Problem>
+            )}
 
             <FormActions>
               <Button

--- a/apps/web/app/projects/[projectId]/agents/screen.tsx
+++ b/apps/web/app/projects/[projectId]/agents/screen.tsx
@@ -469,8 +469,33 @@ export function AgentsScreen({
           role={role}
           onClose={close}
           onConnected={(result) => {
+            /*
+             * **A create lands on the record it just made.**
+             *
+             * Registering an agent writes two things — the agent and the first
+             * way in to it — and the page that holds both is the agent's own:
+             * its identity, whether egma pulls its production calls, and its
+             * connections. Closing onto the list instead left somebody who had
+             * just made something looking at a list of everything, with the
+             * one row they wanted to see somewhere in it.
+             *
+             * It replaces rather than pushes, because the address behind is
+             * `…/agents/new` — the panel they just finished with. Back should
+             * be the list they opened it from, not the form opening again. The
+             * onboarding forward above keeps its push: that flow began on the
+             * agent's own page and the step behind it is a real one.
+             *
+             * Adding a connection to an agent that already existed is the
+             * other half of this panel and is not a create: that one closes
+             * onto the list it was opened over, which is where the row it
+             * changed is.
+             */
             if (sheet.onboarding === true) {
               router.push(projectPath(projectId, "agents", result.agentId));
+              return;
+            }
+            if (result.created) {
+              router.replace(projectPath(projectId, "agents", result.agentId));
               return;
             }
             router.replace(home);

--- a/apps/web/app/projects/[projectId]/graders/running/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/running/page.tsx
@@ -42,6 +42,12 @@ import {
 import { canAuthor } from "../../../../../lib/roles.ts";
 import { DataTable, type Column } from "../../../../../ui/data-table.tsx";
 import { Dialog } from "../../../../../ui/dialog.tsx";
+import { MenuDivider, MenuItem } from "../../../../../ui/menu.tsx";
+import {
+  DestructiveItem,
+  MenuReason,
+  RowMenu,
+} from "../../../../../ui/row-menu.tsx";
 import { useDraftNavigation } from "../../../../../ui/draft-navigation.tsx";
 import {
   Empty,
@@ -150,7 +156,16 @@ type Open =
   | { readonly act: "switch-off"; readonly copy: RunningGrader }
   | null;
 
-/** The stable relationship between a row's Edit button and its editor. */
+/**
+ * The stable relationship between a row and its editor.
+ *
+ * The editor is a region drawn beside the table and named after the copy it
+ * belongs to. The row's ⋮ carries no `aria-expanded` for it: a menu's
+ * `aria-expanded` is about the menu, and claiming it is about the editor would
+ * say the panel is inside the panel that opened it. What ties the two together
+ * is the focus move — the editor's heading takes it when it opens, and the
+ * row's ⋮ takes it back when it closes.
+ */
 function editorPanelId(copyId: string): string {
   return `grader-editor-${copyId}`;
 }
@@ -227,49 +242,66 @@ function columnsFor(
        * half is why this is here: the ellipsis comes from `overflow: hidden`
        * on the cell, and an outline is clipped by an ancestor's overflow, so a
        * control in an unmarked cell had the Ember focus ring cut off on every
-       * side. Other row controls were already marked; these were the same
-       * concept drawn two ways.
+       * side.
+       *
+       * **And the two acts are inside a ⋮ rather than beside it.** The lane is
+       * one 48px slot on every list in the product, which is what makes the
+       * menus line up in a straight column; two buttons drawn in the cell
+       * pushed this one out to 156px and bent the lane on the one screen that
+       * had them. (2026-08-23.)
        */
       action: true,
-      width: "200px",
       cell: (copy) => (
-        <>
-          <Button
-            type="button"
-            variant="secondary"
-            disabled={!mayAct || editorBusy}
-            {...(mayAct || whyNotEdit === undefined ? {} : { why: whyNotEdit })}
-            aria-expanded={open?.act === "edit" && open.copy.id === copy.id}
-            aria-controls={editorPanelId(copy.id)}
-            ref={(button) => {
-              if (button === null) editButtons.delete(copy.id);
-              else editButtons.set(copy.id, button);
-            }}
-            onClick={() => show({ act: "edit", copy })}
-          >
-            {EDIT.open}
-          </Button>{" "}
-          {/*
-            **The one destructive act on this row, as a text action in the
-            failure colour.** `DESIGN.md`: the control that opens a destructive
-            confirmation is text, and the filled failure-coloured button lives
-            inside the confirmation it opens. Two outlined buttons side by side
-            said that switching a grader off and editing it were the same size
-            of decision.
-          */}
-          <Button
-            type="button"
-            variant="ghost"
-            className="text-failure pointer-hover:text-failure"
-            disabled={!mayAct || editorBusy}
-            {...(mayAct || whyNotSwitchOff === undefined
-              ? {}
-              : { why: whyNotSwitchOff })}
-            onClick={() => show({ act: "switch-off", copy })}
-          >
-            {SWITCH_OFF.open}
-          </Button>
-        </>
+        <RowMenu
+          label={`Actions for ${graderDisplayName(copy.name)}`}
+          onTrigger={(button) => {
+            if (button === null) editButtons.delete(copy.id);
+            else editButtons.set(copy.id, button);
+          }}
+        >
+          {(close) => (
+            <>
+              <MenuItem
+                disabled={!mayAct || editorBusy}
+                onClick={() => {
+                  close();
+                  show({ act: "edit", copy });
+                }}
+              >
+                {EDIT.open}
+              </MenuItem>
+              {/*
+                **The one destructive act on this row, last and under a
+                divider.** `DESIGN.md`: the control that opens a destructive
+                confirmation is a text action in the failure colour, and the
+                filled failure-coloured button lives inside the confirmation it
+                opens.
+              */}
+              <MenuDivider />
+              <DestructiveItem
+                disabled={!mayAct || editorBusy}
+                onClick={() => {
+                  close();
+                  show({ act: "switch-off", copy });
+                }}
+              >
+                {SWITCH_OFF.open}
+              </DestructiveItem>
+              {/*
+                Why neither is theirs, drawn in the panel rather than hung off
+                a disabled control a keyboard cannot reach. Both sentences,
+                because they are two acts and a role may be refused each for a
+                reason of its own.
+              */}
+              {mayAct || whyNotEdit === undefined ? null : (
+                <MenuReason>{whyNotEdit}</MenuReason>
+              )}
+              {mayAct || whyNotSwitchOff === undefined ? null : (
+                <MenuReason>{whyNotSwitchOff}</MenuReason>
+              )}
+            </>
+          )}
+        </RowMenu>
       ),
     },
   ];
@@ -310,19 +342,31 @@ function RunningGraders({ projectId }: { readonly projectId: string }) {
 
   useUnsavedChanges(editorState.atRisk, editorState.busy);
 
-  // The panel appears beside the table on wide screens and before it on a
-  // narrow one. Put the reading position on its heading in either layout, so
-  // opening Edit never leaves a keyboard or screen reader back in the row.
+  /*
+   * The panel appears beside the table on wide screens and before it on a
+   * narrow one. Put the reading position on its heading in either layout, so
+   * opening Edit never leaves a keyboard or screen reader back in the row.
+   *
+   * **Twice, because the menu the press came from hands focus back one task
+   * later.** Edit is an item in the row's ⋮ now, and an anchored panel returns
+   * the keyboard to its own trigger when it closes — correctly, for a menu
+   * somebody finished with. Here the press opened something else, and the
+   * reading position belongs on that. The second call is after the panel has
+   * finished leaving, so it is the last word rather than a race with it.
+   */
   useEffect(() => {
     if (open?.act === "edit") {
-      editorHeading.current?.focus();
-      return;
+      const heading = editorHeading.current;
+      heading?.focus();
+      const settled = setTimeout(() => heading?.focus(), 0);
+      return () => clearTimeout(settled);
     }
 
     const copyId = returnFocusTo.current;
-    if (copyId === null) return;
+    if (copyId === null) return undefined;
     returnFocusTo.current = null;
     editButtons.current.get(copyId)?.focus();
+    return undefined;
   }, [open]);
 
   const mayAct = role !== null && canAuthor(role);

--- a/apps/web/app/projects/[projectId]/runs/page.tsx
+++ b/apps/web/app/projects/[projectId]/runs/page.tsx
@@ -34,6 +34,7 @@ import { Actions, TOOLBAR_FILTER } from "../../../../ui/section.tsx";
 import { Refused } from "../../../../ui/form.tsx";
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
+import { DestructiveItem, RowMenu } from "../../../../ui/row-menu.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
 import {
   ListInstant,
@@ -152,38 +153,41 @@ function columnsFor(
        * finished run in a healthy history.
        */
       action: true,
-      width: "100px",
       /*
        * Stopping a run without opening it.
        *
-       * **The button opens a row and does nothing else.** What it opens is one
+       * **The item opens a panel and does nothing else.** What it opens is one
        * panel drawn under the table, where the run name, consequences and retry
        * stay together at every viewport size instead of being squeezed into an
        * action cell.
        *
-       * A finished run has nothing to cancel, so it gets no control at all
-       * rather than a disabled one: a disabled control here would read as a
-       * broken feature on every row of a healthy history.
+       * **It is in the row's ⋮, like every other row control in the product.**
+       * A word drawn in the cell instead needed side padding the 48px lane has
+       * not got, and left the lane the wrong width on this screen: 100px where
+       * a run could be stopped, and nothing at all on a healthy history, where
+       * an empty cell let the column collapse to zero.
+       *
+       * A finished run has nothing to cancel, so it gets no menu at all rather
+       * than a menu holding one dead word: a disabled control here would read
+       * as a broken feature on every row of a healthy history. The lane stays
+       * open under it either way — that is the table's floor, not this cell's.
        */
       cell: (run) =>
         mayControl !== true || (run.status !== "pending" && run.status !== "running")
           ? ""
           : (
-              <Button
-                type="button"
-                variant="secondary"
-                /*
-                 * The trailing lane pays no side padding — it is sized for a
-                 * ⋮, and a control that carries a word instead would sit hard
-                 * against the panel's own edge. The margin is on the control
-                 * rather than the cell, and equal on both sides, so the lane
-                 * widens around it and the button stays centred in it.
-                 */
-                className="mx-4"
-                onClick={() => onCancel(run.id)}
-              >
-                Cancel
-              </Button>
+              <RowMenu label={`Actions for ${run.name ?? suiteLabel(run)}`}>
+                {(close) => (
+                  <DestructiveItem
+                    onClick={() => {
+                      close();
+                      onCancel(run.id);
+                    }}
+                  >
+                    Cancel run
+                  </DestructiveItem>
+                )}
+              </RowMenu>
             ),
     },
   ];

--- a/apps/web/app/projects/[projectId]/tests/page.tsx
+++ b/apps/web/app/projects/[projectId]/tests/page.tsx
@@ -75,9 +75,22 @@ function columnsFor({
       key: "name",
       header: "Name",
       primary: true,
+      /*
+       * **The row's name is plain text until a pointer is on it**, which is
+       * what the boards draw and what the Agents and Personas lists already
+       * do: only the secondary links in a row — a persona, a connection —
+       * carry an underline, because the row itself is the way in and the
+       * underline is what tells the two kinds apart. The shared table
+       * underlines every cell link, so this is said here rather than there.
+       */
       cell: (suite) => (
         <span className="flex min-w-0 items-baseline gap-2">
-          <Link href={suitePagePath(projectId, suite.id)}>{suite.name}</Link>
+          <Link
+            className="text-foreground no-underline pointer-hover:underline"
+            href={suitePagePath(projectId, suite.id)}
+          >
+            {suite.name}
+          </Link>
           {duplicateNames.has(suite.name) ? (
             <span className="flex-none font-mono text-xs text-muted-foreground">
               {shortSuiteId(suite.id)}

--- a/apps/web/app/projects/[projectId]/tests/page.tsx
+++ b/apps/web/app/projects/[projectId]/tests/page.tsx
@@ -36,11 +36,11 @@ import {
   useShellSession,
 } from "../../../../ui/shell.tsx";
 import {
-  ConfirmDialog,
   DestructiveItem,
   MenuReason,
   RowMenu,
-} from "./parts.tsx";
+} from "../../../../ui/row-menu.tsx";
+import { ConfirmDialog } from "./parts.tsx";
 import { CreateSuiteSheet, RenameSuiteSheet } from "./suite-sheets.tsx";
 
 /**

--- a/apps/web/app/projects/[projectId]/tests/parts.tsx
+++ b/apps/web/app/projects/[projectId]/tests/parts.tsx
@@ -7,54 +7,19 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Dialog } from "../../../../ui/dialog.tsx";
 import { Refused } from "../../../../ui/form.tsx";
-import { Menu, MenuItem } from "../../../../ui/menu.tsx";
+import { Menu } from "../../../../ui/menu.tsx";
 
 /**
- * The controls the Tests screens share: the ⋮ that opens a row's menu, the
- * one a page carries for itself, and the confirmation that names what is about
- * to go.
+ * The controls the Tests screens share: the ⋮ a page carries for itself, and
+ * the confirmation that names what is about to go.
  *
  * They are here rather than in the shared set because two screens use them and
- * both are this route's. If a third area grows the same pair, this is what
- * moves to `apps/web/ui/`.
+ * both are this route's — the promise this file made was that the pair moves to
+ * `apps/web/ui/` as soon as a third area grows it. Runs and Running graders did,
+ * so the row's own ⋮ and the two panel parts that go with it left on
+ * 2026-08-23 and are now `ui/row-menu.tsx`. What is left is the toolbar's ⋮,
+ * which no other area draws, and the confirmation these three screens share.
  */
-
-/**
- * The ⋮ at the end of a row.
- *
- * It draws no box. The lane it sits in is the table's — a fixed 48px slot on
- * every row, header included — so the menus line up in one column and a row
- * with no menu still holds the lane open. What the boards give this control is
- * the dots and nothing else (`8YA-0`, `A3H-0`).
- */
-export function RowMenu({
-  label,
-  children,
-}: {
-  readonly label: string;
-  readonly children: (close: () => void) => ReactNode;
-}) {
-  return (
-    <Menu
-      label={label}
-      placement="below-end"
-      triggerClassName={cn(
-        "inline-flex size-(--control-md) items-center justify-center",
-        "cursor-pointer rounded-button border border-transparent bg-transparent text-faint",
-        "transition-[color,background-color] duration-(--duration-hover) ease-out",
-        "pointer-coarse:size-(--tap-target)",
-        "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
-        "motion-reduce:transition-none",
-      )}
-      openClassName="bg-surface-soft text-foreground"
-      trigger={
-        <EllipsisVerticalIcon className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
-      }
-    >
-      {children}
-    </Menu>
-  );
-}
 
 /**
  * The ⋮ a page carries for itself, beside its other toolbar controls.
@@ -89,43 +54,6 @@ export function ToolbarMenu({
     >
       {children}
     </Menu>
-  );
-}
-
-/**
- * The one item in a menu that takes something away.
- *
- * It is the failure colour and it is last, under a divider. The press does not
- * delete anything: it opens the confirmation that names what would go.
- */
-export function DestructiveItem({
-  disabled,
-  onClick,
-  children,
-}: {
-  readonly disabled?: boolean;
-  readonly onClick: () => void;
-  readonly children: ReactNode;
-}) {
-  return (
-    <MenuItem disabled={disabled} onClick={onClick}>
-      <span className="text-failure">{children}</span>
-    </MenuItem>
-  );
-}
-
-/**
- * Why a menu offers nothing this person may press.
- *
- * A disabled item cannot take focus, so a `title` on it is a reason only a
- * pointer reaches. The sentence is drawn in the panel instead, where a keyboard
- * lands on it and a screen reader reads it with the items above.
- */
-export function MenuReason({ children }: { readonly children: ReactNode }) {
-  return (
-    <p className="m-0 max-w-[36ch] px-3 py-2 text-sm text-muted-foreground">
-      {children}
-    </p>
   );
 }
 

--- a/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
@@ -47,12 +47,11 @@ import {
   useShellSession,
 } from "../../../../ui/shell.tsx";
 import {
-  ConfirmDialog,
   DestructiveItem,
   MenuReason,
   RowMenu,
-  ToolbarMenu,
-} from "./parts.tsx";
+} from "../../../../ui/row-menu.tsx";
+import { ConfirmDialog, ToolbarMenu } from "./parts.tsx";
 import { RenameSuiteSheet } from "./suite-sheets.tsx";
 import { WriteTestSheet } from "./write-test-sheet.tsx";
 

--- a/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
@@ -238,8 +238,21 @@ export function SuiteScreen({
       header: "Name",
       primary: true,
       width: "480px",
+      /*
+       * **The row's name is plain text until a pointer is on it**, which is
+       * what the boards draw and what the Agents and Personas lists already
+       * do: only the secondary links in a row — a persona, a connection —
+       * carry an underline, because the row itself is the way in and the
+       * underline is what tells the two kinds apart. The shared table
+       * underlines every cell link, so this is said here rather than there.
+       */
       cell: (test) => (
-        <Link href={testPagePath(projectId, test.id)}>{test.name}</Link>
+        <Link
+          className="text-foreground no-underline pointer-hover:underline"
+          href={testPagePath(projectId, test.id)}
+        >
+          {test.name}
+        </Link>
       ),
     },
     {

--- a/apps/web/app/projects/[projectId]/tests/write-test-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/tests/write-test-sheet.tsx
@@ -70,6 +70,16 @@ export function WriteTestSheet({
   const [known, setKnown] = useState<ReadonlyMap<string, Named>>(new Map());
   const [saving, setSaving] = useState(false);
   const [refused, setRefused] = useState<Refusal | null>(null);
+  /**
+   * Whether the expected behaviors have been touched yet.
+   *
+   * **A panel that opens red is lying about what somebody did.** An empty draft
+   * genuinely cannot be written, and the sentence saying so is right — but it
+   * is a sentence about a person's own work, so it waits until there is some.
+   * The submit stays disabled from the first frame, which is where "not usable
+   * yet" is said without accusing anybody. (2026-08-23.)
+   */
+  const [behaviorsTouched, setBehaviorsTouched] = useState(false);
 
   const changed =
     name !== "" ||
@@ -87,9 +97,12 @@ export function WriteTestSheet({
     setDescription("");
     setDraft(EMPTY);
     setRefused(null);
+    setBehaviorsTouched(false);
   }, [open, suite.id]);
 
-  const behaviorProblem = whyBehaviorsRefuse(draft.behaviors);
+  const behaviorProblem = behaviorsTouched
+    ? whyBehaviorsRefuse(draft.behaviors)
+    : null;
   const usable =
     name.trim() !== "" &&
     draft.scenario.trim() !== "" &&
@@ -177,6 +190,7 @@ export function WriteTestSheet({
               disabled={!mayAuthor}
               problem={behaviorProblem}
               onChange={(next, named) => {
+                if (next.behaviors !== draft.behaviors) setBehaviorsTouched(true);
                 setDraft(next);
                 if (named !== undefined) setKnown(new Map(named));
               }}

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -751,9 +751,11 @@ describe("registering an agent", () => {
     for (const provider of ["prompt", "model", "tools"]) {
       expect(Object.keys(sent[0]?.body ?? {})).not.toContain(provider);
     }
-    // And the panel closes onto the list the new agent is now a row of.
+    // And the panel closes onto the agent it just made — the record with this
+    // agent's identity, its production-calls switch and its connections on it,
+    // rather than the list of everything with one new row somewhere in it.
     await waitFor(() =>
-      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents"),
+      expect(routed.replace).toHaveBeenCalledWith("/projects/prj_1/agents/agt_1"),
     );
   });
 

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -480,6 +480,32 @@ const SHELF = {
   body: { graderLibraryEntries: [BEHAVIORS, LATENCY], nextPageToken: null },
 } as const;
 
+/**
+ * One running copy's acts, reached the way somebody reaches them: through the
+ * ⋮ at the end of its row.
+ *
+ * **Both acts moved into that menu on 2026-08-23**, so that the trailing lane
+ * on this list is the same 48px slot every list in the product ends with. Two
+ * buttons drawn in the cell had pushed it out to 156px, which is the one place
+ * the lane went crooked. `index` is the row, in the order the answer lists the
+ * copies in.
+ */
+async function rowMenus(): Promise<HTMLElement[]> {
+  return screen.findAllByRole("button", { name: /^Actions for /u });
+}
+
+/** One row's menu, opened. */
+async function openRowMenu(index: number): Promise<HTMLElement> {
+  fireEvent.click((await rowMenus())[index]!);
+  return screen.findByRole("menu");
+}
+
+/** One row's act, opened and pressed. */
+async function press(index: number, act: string): Promise<void> {
+  const menu = await openRowMenu(index);
+  fireEvent.click(within(menu).getByRole("menuitem", { name: act }));
+}
+
 describe("the running graders of one project", () => {
   it("names its project in both reads, and says where each copy applies and whether it blocks", async () => {
     const { asked } = apiAnswers({
@@ -557,9 +583,8 @@ describe("the running graders of one project", () => {
     });
     render(<RunningGradersPage />);
 
-    const off = await screen.findAllByRole("button", { name: "Switch off" });
     // The table's rows are in answer order, so Latency's is the second.
-    fireEvent.click(off[1]!);
+    await press(1, "Switch off");
     fireEvent.click(screen.getByRole("button", { name: "Switch it off" }));
 
     expect((await screen.findByRole("status")).textContent).toContain(
@@ -592,9 +617,7 @@ describe("the running graders of one project", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click(
-      (await screen.findAllByRole("button", { name: "Switch off" }))[0]!,
-    );
+    await press(0, "Switch off");
 
     expect(screen.getByText(runningCopy.SWITCH_OFF.stops)).toBeTruthy();
     expect(screen.getByText(runningCopy.SWITCH_OFF.keeps)).toBeTruthy();
@@ -628,9 +651,7 @@ describe("the running graders of one project", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click(
-      (await screen.findAllByRole("button", { name: "Switch off" }))[0]!,
-    );
+    await press(0, "Switch off");
     expect(screen.getByText(runningCopy.SWITCH_OFF.theLastOne)).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch it off" }));
@@ -661,9 +682,7 @@ describe("the running graders of one project", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click(
-      (await screen.findAllByRole("button", { name: "Switch off" }))[0]!,
-    );
+    await press(0, "Switch off");
     fireEvent.click(screen.getByRole("button", { name: "Switch it off" }));
 
     expect(
@@ -685,19 +704,20 @@ describe("the running graders of one project", () => {
     });
     render(<RunningGradersPage />);
 
-    const off = (await screen.findAllByRole("button", {
-      name: "Switch off",
-    }))[0]!;
-    const edit = screen.getAllByRole("button", { name: "Edit" })[0]!;
+    // Both acts are offered in the row's menu and both are inert, with the
+    // reason for each written into the panel where a keyboard reaches it.
+    const menu = await openRowMenu(0);
+    const off = within(menu).getByRole("menuitem", { name: "Switch off" });
+    const edit = within(menu).getByRole("menuitem", { name: "Edit" });
 
     expect((off as HTMLButtonElement).disabled).toBe(true);
     expect((edit as HTMLButtonElement).disabled).toBe(true);
     expect(
-      screen.getAllByText(runningCopy.SWITCH_OFF.notYours("viewer")),
-    ).not.toHaveLength(0);
+      within(menu).getByText(runningCopy.SWITCH_OFF.notYours("viewer")),
+    ).toBeTruthy();
     expect(
-      screen.getAllByText(runningCopy.EDIT.notYours("viewer")),
-    ).not.toHaveLength(0);
+      within(menu).getByText(runningCopy.EDIT.notYours("viewer")),
+    ).toBeTruthy();
   });
 });
 
@@ -712,7 +732,7 @@ describe("the running graders of one project", () => {
  * update against Postgres.
  */
 describe("changing a running copy", () => {
-  it("connects each Edit button to the editor and moves focus to its heading", async () => {
+  it("connects each row's Edit to the editor and moves focus to its heading", async () => {
     apiAnswers({
       "GET /api/me": { status: 200, body: meWith("admin") },
       "GET /v1/graders": {
@@ -723,25 +743,28 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    const edits = await screen.findAllByRole("button", { name: "Edit" });
-    expect(edits[1]!.getAttribute("aria-expanded")).toBe("false");
-    expect(edits[1]!.getAttribute("aria-controls")).toBe(
-      "grader-editor-grd_2",
-    );
+    /*
+     * **The row's ⋮ is what the reading position comes back to**, and it is
+     * the whole of the relationship now that Edit is an item inside it. The ⋮
+     * carries no `aria-expanded` for the editor: a menu's `aria-expanded` is
+     * about the menu, and claiming it was about the editor would say the panel
+     * is inside the panel that opened it. The editor is named after the copy
+     * and takes the focus; closing it hands the focus back to the row.
+     */
+    const menus = await rowMenus();
+    expect(menus[1]!.getAttribute("aria-expanded")).toBe("false");
 
-    fireEvent.click(edits[1]!);
+    await press(1, "Edit");
 
     const editor = screen.getByRole("region", { name: "Edit Latency" });
     const heading = within(editor).getByRole("heading", {
       name: "Edit Latency",
     });
     expect(editor.id).toBe("grader-editor-grd_2");
-    expect(edits[1]!.getAttribute("aria-expanded")).toBe("true");
     expect(document.activeElement).toBe(heading);
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(document.activeElement).toBe(edits[1]);
-    expect(edits[1]!.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(menus[1]);
   });
 
   /**
@@ -763,7 +786,7 @@ describe("changing a running copy", () => {
     render(<RunningGradersPage />);
 
     // Latency's row is the second, and it is the one with values to fill in.
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[1]!);
+    await press(1, "Edit");
 
     expect((screen.getByLabelText("Bound") as HTMLInputElement).value).toBe(
       "2000",
@@ -804,11 +827,11 @@ describe("changing a running copy", () => {
     render(<RunningGradersPage />);
 
     // The copy whose assertions are each test's own sentences: it asks nothing.
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
     expect(screen.getByText(runningCopy.EDIT.asksNothing)).toBeTruthy();
 
     // And now the other one, without closing the first.
-    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[1]!);
+    await press(1, "Edit");
 
     expect(screen.getByText(runningCopy.EDIT.title("Latency"))).toBeTruthy();
     expect(screen.queryByText(runningCopy.EDIT.asksNothing)).toBeNull();
@@ -832,13 +855,12 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    const edits = await screen.findAllByRole("button", { name: "Edit" });
-    fireEvent.click(edits[0]!);
+    await press(0, "Edit");
     fireEvent.change(screen.getByLabelText("Name"), {
       target: { value: "Draft behavior grader" },
     });
 
-    fireEvent.click(edits[1]!);
+    await press(1, "Edit");
     expect(screen.getByRole("dialog").textContent).toContain(
       "Leave without saving?",
     );
@@ -874,7 +896,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
     fireEvent.change(screen.getByLabelText(runningCopy.EDIT.description), {
       target: { value: "Keep this draft" },
     });
@@ -939,8 +961,7 @@ describe("changing a running copy", () => {
     vi.stubGlobal("confirm", confirm);
     render(<RunningGradersPage />);
 
-    const edits = await screen.findAllByRole("button", { name: "Edit" });
-    fireEvent.click(edits[0]!);
+    await press(0, "Edit");
     fireEvent.change(screen.getByLabelText(runningCopy.EDIT.description), {
       target: { value: "Saving this note" },
     });
@@ -954,9 +975,18 @@ describe("changing a running copy", () => {
       (screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
-    expect(edits.every((edit) => (edit as HTMLButtonElement).disabled)).toBe(
-      true,
-    );
+    // Every row's acts are inert while the write is in flight, offered in the
+    // menu and refusing the press. The menu is closed again afterwards, so the
+    // navigation checks below run against the page rather than over a panel.
+    const busy = await openRowMenu(1);
+    for (const act of ["Edit", "Switch off"]) {
+      expect(
+        (within(busy).getByRole("menuitem", { name: act }) as HTMLButtonElement)
+          .disabled,
+        act,
+      ).toBe(true);
+    }
+    fireEvent.click((await rowMenus())[1]!);
 
     const leaving = new Event("beforeunload", { cancelable: true });
     window.dispatchEvent(leaving);
@@ -1007,7 +1037,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
     fireEvent.change(screen.getByLabelText("Bound"), {
       target: { value: "1200" },
     });
@@ -1047,7 +1077,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
     expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
       "Expected behaviors",
     );
@@ -1079,7 +1109,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
 
     expect(screen.getByText(runningCopy.EDIT.asksNothing)).toBeTruthy();
     expect(screen.queryByLabelText("Bound")).toBeNull();
@@ -1099,7 +1129,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
 
     const editor = screen.getByRole("region", {
       name: "Edit Expected behaviors",
@@ -1153,7 +1183,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
 
     // The panel names the copy, which is what the walk waits on before it
     // touches anything.
@@ -1195,7 +1225,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
     fireEvent.change(screen.getByLabelText(runningCopy.EDIT.sampleRate), {
       target: { value: "" },
     });
@@ -1225,7 +1255,7 @@ describe("changing a running copy", () => {
     });
     render(<RunningGradersPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]!);
+    await press(0, "Edit");
     fireEvent.change(screen.getByLabelText("Bound"), {
       target: { value: "1200" },
     });
@@ -1285,8 +1315,7 @@ describe("changing a running copy", () => {
 
     // The second row is the one with values to type into: a measure, a bound,
     // and a share of live traffic, because it applies to both.
-    const edits = await screen.findAllByRole("button", { name: "Edit" });
-    fireEvent.click(edits[1]!);
+    await press(1, "Edit");
     fireEvent.change(screen.getByLabelText("Bound"), {
       target: { value: "50" },
     });
@@ -1309,12 +1338,15 @@ describe("changing a running copy", () => {
       So the wait is on the control about to be pressed, rather than on
       something near it.
     */
+    const other = within(await openRowMenu(0)).getByRole("menuitem", {
+      name: "Edit",
+    });
     await waitFor(() => {
-      expect((edits[0] as HTMLButtonElement).disabled).toBe(false);
+      expect((other as HTMLButtonElement).disabled).toBe(false);
     });
 
     // Another row, over the top of a form that has been typed into and refused.
-    fireEvent.click(edits[0]!);
+    fireEvent.click(other);
     fireEvent.click(await screen.findByRole("button", { name: "Discard changes" }));
 
     const behaviors = screen.getByRole("region", {
@@ -1329,7 +1361,7 @@ describe("changing a running copy", () => {
 
     // And back, which is where the field would show the typed value if the
     // state were the page's rather than the open row's.
-    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[1]!);
+    await press(1, "Edit");
     expect((screen.getByLabelText("Bound") as HTMLInputElement).value).toBe(
       "2000",
     );

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -33,7 +33,9 @@ import { cn } from "@/lib/utils";
  * labels; rows at least 52px with a hairline between them and none after the
  * last; and a fixed 48px slot at the trailing edge that every row carries, so
  * the ⋮ menus line up in one lane down the table whether or not a given row
- * has one. Read off `6ZM-0`, `71F-0` and `710-0` on 2026-08-23.
+ * has one. Read off `6ZM-0`, `71F-0` and `710-0` on 2026-08-23. The lane is a
+ * floor as well as a width — see `floorOf`, which is what stopped a crowded
+ * table squeezing it.
  *
  * Paging is keyset, so "more" means *carry on from where that page stopped*
  * rather than *skip a number of rows*. The control is here rather than in each
@@ -147,6 +149,23 @@ export function DataTable<Row>({
     return column.width;
   }
   /**
+   * The one width that is a floor rather than a preference.
+   *
+   * **A declared width on a table is a request, and an over-constrained table
+   * refuses it.** The layout is `auto`, so when the columns' own minimums add
+   * up to more than the table has — which every list with a long name in it
+   * reaches — a browser takes the shortfall out of the columns that can give
+   * it, and the trailing lane gives most: its content is one 36px glyph, or on
+   * a row with no control, nothing at all. That is how the same 48px
+   * declaration measured 48 on Agents, 40 on Personas and 0 on Runs.
+   *
+   * `min-width` is what the lane cannot be argued out of. It is written beside
+   * the width, on the header cell alone and for the same reason.
+   */
+  function floorOf(column: Column<Row>): string | undefined {
+    return column.action === true ? "var(--table-action-width)" : undefined;
+  }
+  /**
    * Whether the narrow layout leaves this column out.
    *
    * The primary column can never be omitted: it is the row's name, and a
@@ -190,7 +209,7 @@ export function DataTable<Row>({
                   data-mobile-hidden={mobileHidden(column)}
                   key={column.key}
                   scope="col"
-                  style={{ width: widthOf(column) }}
+                  style={{ width: widthOf(column), minWidth: floorOf(column) }}
                 >
                   {column.action === true ? "" : column.header}
                   {column.action === true ? (

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -70,6 +70,15 @@ export type MenuProps = {
     | "right-end";
   /** `dialog` for a panel with a field in it; `menu` for commands alone. */
   readonly panelRole?: "menu" | "dialog";
+  /**
+   * The trigger element itself, handed to a page that has to reach it later.
+   *
+   * The panel puts focus back on its own trigger when it closes, so this is not
+   * for that. It is for a page whose *item* opens something else — the Running
+   * graders list opens an editor beside the table — and which has to put focus
+   * back on the row a person came from once that editor closes.
+   */
+  readonly onTrigger?: (button: HTMLButtonElement | null) => void;
   readonly panelClassName?: string;
   readonly children: (close: () => void) => ReactNode;
 };
@@ -132,6 +141,7 @@ export function Menu({
   placement = "below-start",
   panelRole = "menu",
   panelClassName,
+  onTrigger,
   children,
 }: MenuProps) {
   const [open, setOpen] = useState(false);
@@ -159,6 +169,22 @@ export function Menu({
    * has focus, and by then this has already put that back on the trigger.
    */
   const returnFocus = useCallback(() => triggerRef.current?.focus(), []);
+
+  /**
+   * Holding the trigger, and holding it **once**.
+   *
+   * The callback has to be the same function on every render or React detaches
+   * and re-attaches the ref each time, which churns the trigger through null on
+   * every keystroke somewhere else on the page. A caller's `onTrigger` is
+   * usually written inline at the call site, so it cannot be a dependency: it
+   * is kept in a ref and read when the element actually arrives.
+   */
+  const report = useRef(onTrigger);
+  report.current = onTrigger;
+  const holdTrigger = useCallback((button: HTMLButtonElement | null) => {
+    triggerRef.current = button;
+    report.current?.(button);
+  }, []);
 
   const close = useCallback(() => {
     returnFocus();
@@ -196,7 +222,7 @@ export function Menu({
             triggerClassName ?? MENU_ITEM,
             open ? (openClassName ?? "") : "",
           )}
-          ref={triggerRef}
+          ref={holdTrigger}
           aria-haspopup={panelRole}
           aria-label={label}
         >

--- a/apps/web/ui/row-menu.tsx
+++ b/apps/web/ui/row-menu.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { EllipsisVerticalIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { Menu, MenuItem } from "./menu.tsx";
+
+/**
+ * The ⋮ at the end of a row, and the things it offers.
+ *
+ * **It lives in the table's own trailing slot** — a fixed
+ * `--table-action-width` lane that every row carries whether or not it has a
+ * menu — so the triggers line up in one column down the table and a row with no
+ * menu still holds the lane open (`6ZM-0`, `8YA-0`, `A3H-0`). The lane belongs
+ * to `ui/data-table.tsx`; what is here is the control that stands in it.
+ *
+ * **It is shared rather than a route's, and the move is the one this pair asked
+ * for.** These lived in `app/projects/[projectId]/tests/parts.tsx` while the
+ * Tests screens were the only two drawing them, with a note saying they move
+ * here as soon as a third area grows the same pair. Runs and Running graders
+ * are the third and fourth: both had their acts drawn as buttons inside the
+ * cell, which bent the lane out of line — 0px on Runs, where a finished run
+ * offers nothing, and 156px on Running graders, where two buttons pushed it
+ * open. (2026-08-23.)
+ *
+ * **The control draws no box.** What the boards give it is the dots and
+ * nothing else; the hover fill is the only thing that answers a pointer.
+ */
+export function RowMenu({
+  label,
+  onTrigger,
+  children,
+}: {
+  /** What this menu is the menu of. Read out where the glyph says nothing. */
+  readonly label: string;
+  /** The ⋮ itself, for a row whose item opens something focus must come back from. */
+  readonly onTrigger?: (button: HTMLButtonElement | null) => void;
+  readonly children: (close: () => void) => ReactNode;
+}) {
+  return (
+    <Menu
+      label={label}
+      placement="below-end"
+      {...(onTrigger === undefined ? {} : { onTrigger })}
+      triggerClassName={cn(
+        "inline-flex size-(--control-md) items-center justify-center",
+        "cursor-pointer rounded-button border border-transparent bg-transparent text-faint",
+        "transition-[color,background-color] duration-(--duration-hover) ease-out",
+        "pointer-coarse:size-(--tap-target)",
+        "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
+        "motion-reduce:transition-none",
+      )}
+      openClassName="bg-surface-soft text-foreground"
+      trigger={
+        <EllipsisVerticalIcon className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
+      }
+    >
+      {children}
+    </Menu>
+  );
+}
+
+/**
+ * The one item in a menu that takes something away.
+ *
+ * It is the failure colour and it is last, under a divider. The press does not
+ * delete anything: it opens the confirmation that names what would go.
+ */
+export function DestructiveItem({
+  disabled,
+  onClick,
+  children,
+}: {
+  readonly disabled?: boolean;
+  readonly onClick: () => void;
+  readonly children: ReactNode;
+}) {
+  return (
+    <MenuItem disabled={disabled} onClick={onClick}>
+      <span className="text-failure">{children}</span>
+    </MenuItem>
+  );
+}
+
+/**
+ * Why a menu offers nothing this person may press.
+ *
+ * A disabled item cannot take focus, so a `title` on it is a reason only a
+ * pointer reaches. The sentence is drawn in the panel instead, where a keyboard
+ * lands on it and a screen reader reads it with the items above.
+ */
+export function MenuReason({ children }: { readonly children: ReactNode }) {
+  return (
+    <p className="m-0 max-w-[36ch] px-3 py-2 text-sm text-muted-foreground">
+      {children}
+    </p>
+  );
+}

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -825,7 +825,12 @@ export function PageHeader({
     label !== undefined;
 
   return (
-    <header className="contents" data-slot="page-header">
+    /*
+     * `peer`, so the body under this header can read whether a toolbar row was
+     * drawn. See `PageBody`: the toolbar row carries the gap to whatever comes
+     * next, and a body that added its own would double it.
+     */
+    <header className="peer contents" data-slot="page-header">
       <div
         data-slot="page-topbar"
         className={cn(
@@ -890,6 +895,15 @@ export function PageHeader({
  * and the inner block is where `--page-content-max` is spent. It is not
  * centred: see `ProductPage`.
  *
+ * **The top gutter goes when a toolbar row was drawn, because that row already
+ * carries it.** `71N-0` is a 52px strip — a 36px control with 16px under it —
+ * and `6ZM-0`, the table, starts at the pixel the strip ends on: 132 from the
+ * top of the page, which is the 56px title bar, the 24px gutter and the 52px
+ * strip and nothing else. A body that added a gutter of its own under that
+ * strip put the panel at 156. A page whose header drew no toolbar row keeps the
+ * 24px, because then there is nothing above to carry it. (Read off `6ZJ-0`,
+ * 2026-08-23.)
+ *
  * `flex-1 min-h-0` on the inner block is what lets a viewport page hand its
  * remaining height to whatever it holds. `SettingsLayout` asks for `h-full`,
  * and a percentage height needs a parent with a settled one.
@@ -899,7 +913,9 @@ export function PageBody({ children }: { readonly children: ReactNode }) {
     <div
       className={cn(
         "flex min-w-0 flex-col px-(--page-gutter) pt-(--page-gutter) pb-10",
+        "peer-has-[[data-slot=toolbar]]:pt-0",
         "max-[900px]:px-4 max-[900px]:pt-4 max-[900px]:pb-8",
+        "max-[900px]:peer-has-[[data-slot=toolbar]]:pt-0",
       )}
       data-slot="page-body"
     >


### PR DESCRIPTION
## What this is

The real-browser proof lane (`apps/api/test/browser.test.ts`, `npx vitest run --project browser`) had five failures on `integration/ui-refresh`. CI runs that lane only on a pull request into `main`, so this is the last gate before the final PR. Every failure is fixed here, plus three smaller things the proof turned up.

## Fixed

### 1. Every list's trailing lane is the 48px row-menu slot

Measured before: agents 48, tests 48, **personas 40, running graders 156, runs 0**.

Three separate faults with one cause and two symptoms:

- **The lane could be argued out of its width.** The table lays out `auto`, where a declared width is a preference. Every list whose columns' own minimums add up to more than the table has — which is every list with a long name in it — hands the shortfall to the columns that can give it, and the trailing lane gives the most. `ui/data-table.tsx` now writes `min-width: var(--table-action-width)` beside the width, on the header cell, which is what a browser cannot argue with. That alone is what took **personas** from 40 to 48.
- **Running graders drew two buttons in the cell** (`Edit`, `Switch off`), which pushed the lane out to 156. Both acts moved into the row's ⋮, keeping their names and their flows: Edit still opens the inline editor and moves the reading position to its heading; Switch off still opens the confirmation that names the grader.
- **Runs drew a `Cancel` button in the cell**, and a healthy history has no cancellable run at all — so the cell was empty and the column collapsed to 0. The act moved into the row's ⋮ as **Cancel run**, opening the same confirmation panel.

The ⋮ and the two panel parts that go with it moved out of `app/projects/[projectId]/tests/parts.tsx` into **`ui/row-menu.tsx`**, which is what that file's own note said to do once a third area grew the same pair. `ui/menu.tsx` gains one optional `onTrigger`, so a page whose menu item opens something else can put the reading position back on the row.

### 2. The sidebar's first stop is the wordmark

The Egma wordmark at the top of the sidebar is a link home (`Egma home` → `/`), by the developer's ruling of 2026-08-23. Three expectations still described the bar from before it: no link matching "Home", six links in the bar, and the switcher as the first Tab stop. They now say the new truth — the wordmark link first, the switcher second, and six *navigation* rows beside one brand link that is named rather than counted in.

### 3. Connecting an agent lands on the agent it made

`Connect an agent` writes the agent and its first connection in one request, then closed onto the list. It now goes to the agent's own page — the record the person just made, with its connections and its production-calls switch on it. It replaces rather than pushes, so Back is the list they opened the panel from. Adding a connection to an agent that already exists still closes onto the list, and the onboarding forward is unchanged.

### 4. The route inventory

Not a route: the seventh link in the sidebar is the wordmark's `/`. Covered by item 2 — the count is now six navigation rows plus one named brand link.

## Also fixed

### 5. A form says nothing is wrong until somebody has touched it

`/new-project` opened with "A project needs a name" already in the failure colour, and the write-a-test sheet opened with "A test needs at least one expected behavior". Both now wait: the project name until the field has been used and left empty, the behaviors until the draft has been typed in. The submit stays disabled from the first frame, which is where "not usable yet" is said without accusing anybody.

### 6. The table panel starts where the toolbar row ends

The boards: `71N-0` is a 52px toolbar strip — a 36px control with 16px under it — and `6ZM-0`, the table, starts on the pixel that strip ends on, 132 from the top of the page. The application put it at 156, because the page body added a second 24px gutter under a strip that already carried one. `PageBody` now drops its top gutter when the header drew a toolbar row, and keeps it when it did not. `DESIGN.md`'s Shell section records the relationship, and the proof asserts it as a relationship rather than as the number.

### 7. The tests lists draw a row's name as every other list does

The suites list and a suite's tests list underlined the name; the boards draw the name plain and underline only on hover, which is what Agents and Personas already do. Secondary links in a row — the personas on a test, the connections on an agent — keep their underline.

## Skipped

Nothing. Every item on the brief is in here.

## Lanes, verbatim

`npx vitest run --project fast --maxWorkers=2 apps/web/test/`

```
 Test Files  25 passed (25)
      Tests  570 passed (570)
```

`pnpm typecheck` — green (lint, `tsc -b`, `tsc -p tsconfig.tests.json`, `tsc --noEmit` in `apps/web`), no output but the build lines.

`pnpm --filter @egma/platform-api build && npx vitest run --project browser`

```
 Test Files  1 passed (1)
      Tests  58 passed (58)
   Duration  256.79s
```

The proof agent's run before this branch was 53 passed / 5 failed. The first run on this branch was 55 passed / 3 failed — the three left were the running-graders cases, whose helper still pressed a button in the row after the acts had moved into the ⋮; the helper moved with them and the second run is the one above. No failure was an environment artefact.

## One thing noticed and not done

There are now two row-⋮ implementations that look the same and are built on different primitives — `agents/row-menu.tsx` on the kit's `DropdownMenu`, `ui/row-menu.tsx` on the shared `ui/menu.tsx` — and the personas list builds a third trigger of its own. They differ in keyboard model, focus return and trigger size. Unifying them is a change of its own and is not in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790093249&installation_model_id=431960&pr_number=200&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F200&signature=af7dbcd30de1030a21489d8a58c597e83b9120e27c7d70126fd0441dab9b0a14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the redesigned web UI with its real-browser proof by standardizing table action lanes, moving grader and run actions into shared row menus, and correcting focus, navigation, validation timing, spacing, and link presentation.
- Adds a shared row-menu primitive and enforces the 48px action-column floor.
- Routes newly registered agents directly to their detail page.
- Defers empty-form validation messages until the relevant field has been touched.
- Removes duplicate spacing below toolbar rows and updates the corresponding design contract.
- Updates browser and component tests for sidebar navigation, row menus, agent routing, and layout behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified in the changed behavior.

The new routing, menu lifecycle, touched-state validation, table sizing, and toolbar spacing remain consistent with their callers and updated interaction contracts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/menu.tsx | Adds stable trigger-node reporting so callers can restore focus after a menu item opens another panel. |
| apps/web/ui/row-menu.tsx | Introduces the shared row-action menu, destructive item, and disabled-action explanation primitives. |
| apps/web/ui/data-table.tsx | Floors action columns at the shared 48px width so crowded tables cannot collapse the trailing lane. |
| apps/web/app/projects/[projectId]/graders/running/page.tsx | Moves edit and switch-off actions into row menus while preserving editor focus and confirmation flows. |
| apps/web/app/projects/[projectId]/runs/page.tsx | Moves cancellation into a row menu while retaining the existing confirmation behavior. |
| apps/web/app/projects/[projectId]/agents/screen.tsx | Routes a successful new-agent registration to the newly created agent detail page while preserving other connection flows. |
| apps/web/app/projects/[projectId]/tests/write-test-sheet.tsx | Defers expected-behavior validation until behavior content has actually been edited. |
| apps/web/ui/shell.tsx | Removes the page body's duplicate top gutter when the preceding header contains a toolbar. |
| apps/api/test/browser.test.ts | Updates real-browser assertions for the wordmark link, agent destination, row-menu actions, action-lane width, and toolbar-to-panel spacing. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Changed web interactions] --> B[Shared row menu]
  A --> C[Agent creation routing]
  A --> D[Touched-field validation]
  A --> E[Toolbar-aware spacing]
  B --> F[Consistent 48px action lane]
  C --> G[New agent detail page]
  D --> H[Errors shown after interaction]
  E --> I[Table begins after toolbar strip]
  F --> J[Updated browser and component proofs]
  G --> J
  H --> J
  I --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): a list&#39;s panel starts where it..."](https://github.com/egma-ai/egma/commit/bfb0405ddb9e0a9bcd1c36388597f41bc732117a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56026392)</sub>

<!-- /greptile_comment -->