### PR TITLE
fix(web): the agents list is the one agent screen — the name is plain text

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2769,16 +2769,37 @@ describe("the complete product, walked in order in a second project", () => {
        */
       await walk.goto(at("agents"));
       await saysWithin(walk, "The Support line");
-      // The row's own name link is the agent's address, and it is the same one
-      // the panel landed on.
+      /*
+       * **The row names the agent as plain text, and its ⋮ is the way in.**
+       * This list is the one agent screen (`6ZJ-0`), so the name is a name
+       * rather than a link, and the underline on this row belongs to the
+       * connections alone. Open agent still carries the address the panel
+       * landed on.
+       */
       const named = walk
-        .getByRole("link", { name: "The Support line", exact: true })
+        .locator('table[aria-label="Agents in this project"] tbody tr')
+        .filter({ hasText: "The Support line" })
         .first();
       await named.waitFor();
       expect(
-        new URL((await named.getAttribute("href")) ?? "/", origin).toString(),
-        "the registered agent has a row that opens it",
+        await named
+          .getByRole("link", { name: "The Support line", exact: true })
+          .count(),
+        "the agent's name is not a link",
+      ).toBe(0);
+      await named
+        .getByRole("button", { name: "Actions for The Support line" })
+        .click();
+      const openAgent = walk.getByRole("menuitem", {
+        name: "Open agent",
+        exact: true,
+      });
+      await openAgent.waitFor();
+      expect(
+        new URL((await openAgent.getAttribute("href")) ?? "/", origin).toString(),
+        "the registered agent has a row whose menu opens it",
       ).toBe(agentAddress);
+      await walk.keyboard.press("Escape");
       // And the way in is named on the row, as a link that opens it over the
       // list rather than as four facts nobody can press.
       const connection = walk
@@ -4359,10 +4380,12 @@ describe("the complete product, walked in order in a second project", () => {
      * The case above stops at the sidebar, and stopping there is what left the
      * word *tables* in this criterion covered by nothing: a list whose rows
      * could not be reached by Tab would have passed every keyboard case in this
-     * file. A row's name is a link, so the promise is the ordinary one — Tab
-     * gets there, Enter follows it — and it has to hold past the page's own
-     * controls, one of which is a radio group whose whole design is that it
-     * costs a single Tab stop rather than one per option.
+     * file. A row's name is plain text now — the agents list is the one agent
+     * screen — so the row's own control is its ⋮, and the promise is the
+     * ordinary one: Tab gets to it, Enter opens it, Enter follows the way in
+     * it offers. It has to hold past the page's own controls, one of which is
+     * a radio group whose whole design is that it costs a single Tab stop
+     * rather than one per option.
      *
      * The presses are bounded and the trail is reported. "Press Tab until
      * something happens" with no bound is a test that hangs where it should
@@ -4378,15 +4401,17 @@ describe("the complete product, walked in order in a second project", () => {
 
         const trail: string[] = [];
         let reached = false;
-        for (let press = 0; press < 20 && !reached; press += 1) {
+        // The row's ⋮ sits after the connection links in the same row, so the
+        // bound allows for those stops as well as the page's own controls.
+        for (let press = 0; press < 30 && !reached; press += 1) {
           await walk.keyboard.press("Tab");
           const name = await focused();
           trail.push(name === "" ? "(nothing)" : name);
-          reached = name === "The Support line";
+          reached = name === "Actions for The Support line";
         }
         expect(reached, `the focus went ${trail.join(" → ")}`).toBe(true);
 
-        // It is the row's own link in the table, rather than a heading or a
+        // It is the row's own control in the table, rather than a heading or a
         // control that happens to carry the same words.
         expect(
           await walk.evaluate(() => {
@@ -4408,6 +4433,13 @@ describe("the complete product, walked in order in a second project", () => {
         expect(trail.filter((name) => name === "Active")).toEqual([]);
         expect(trail.filter((name) => name === "Archived")).toEqual([]);
 
+        // Enter opens the row's menu on its first item, and Enter again
+        // follows it to the agent this row is a row for.
+        await walk.keyboard.press("Enter");
+        await walk
+          .getByRole("menuitem", { name: "Open agent", exact: true })
+          .waitFor();
+        expect(await focused()).toBe("Open agent");
         await walk.keyboard.press("Enter");
         await walk.waitForURL(agentAddress);
         await saysWithin(walk, "The Support line");

--- a/apps/web/app/projects/[projectId]/agents/connection-facts.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connection-facts.tsx
@@ -77,17 +77,21 @@ export function ConnectionsOnRow({
 
   return (
     /*
-     * 20px between the links and 8px between rows of them, which is `6ZJ-0`.
-     * It wraps rather than clipping: a narrow window and the stacked mobile
-     * layout both give this cell less than the 360px the board measures, and a
-     * name cut in half is a name nobody can tell from its neighbour.
+     * 20px between the links, which is `6ZJ-0`, and one line however long the
+     * names are. **The cell never wraps.** A second line here makes one row
+     * taller than the rows above and below it, and a column of ragged rows is
+     * what makes a dense list hard to scan — the same reason the chip counts
+     * instead of listing. A long name is cut with an ellipsis and carries its
+     * full text in a tooltip, and the connection sheet behind the link says
+     * the whole name again.
      */
-    <span className="flex min-w-0 flex-wrap items-center gap-x-5 gap-y-2 whitespace-normal">
+    <span className="flex min-w-0 flex-nowrap items-center gap-x-5 whitespace-nowrap">
       {shown.map((one) => (
         <Link
-          className="w-fit flex-none text-foreground"
+          className="min-w-0 truncate text-foreground"
           href={hrefOf(one)}
           key={one.id}
+          title={one.name}
         >
           {one.name}
         </Link>
@@ -107,7 +111,7 @@ export function ConnectionsOnRow({
            * surface, and an underline inside that border reads as a second,
            * broken link rather than as one control.
            */}
-          <Link className="no-underline" href={agentHref}>
+          <Link className="flex-none no-underline" href={agentHref}>
             <span aria-hidden="true">{`+${String(overflow)}`}</span>
             <span className="sr-only">{`${String(overflow)} more connections`}</span>
           </Link>

--- a/apps/web/app/projects/[projectId]/agents/screen.tsx
+++ b/apps/web/app/projects/[projectId]/agents/screen.tsx
@@ -212,22 +212,19 @@ export function AgentsScreen({
         primary: true,
         width: "260px",
         /*
-         * **The agent's name is plain text until a pointer is on it**, which
-         * is what `6ZJ-0` draws: only the connections are underlined, because
-         * the row itself is the way into the agent and the underline is what
-         * tells the two apart. The shared table underlines every cell link, so
-         * this is said here rather than there — the connection links in the
-         * next column keep it, and so do the connection names on the agent
-         * page.
+         * **The agent's name is plain text and nothing else**, which is what
+         * `6ZJ-0` draws. This list is the one agent screen: everything a
+         * person came here to read is already on the row, so the name names
+         * the agent rather than promising a second page behind it. Only the
+         * connections in the next column are links, and now the underline
+         * means one thing on this row — press this and a connection opens.
+         *
+         * **The agent page is still reached**, from the row's actions menu
+         * (Open agent) and from the connect flow, which lands on it. Both are
+         * deliberate steps rather than a whole-name target a pointer finds by
+         * accident.
          */
-        cell: (agent) => (
-          <Link
-            className="text-foreground no-underline pointer-hover:underline"
-            href={projectPath(projectId, "agents", agent.id)}
-          >
-            {agent.name}
-          </Link>
-        ),
+        cell: (agent) => agent.name,
       },
       {
         /*
@@ -394,7 +391,6 @@ export function AgentsScreen({
           columns={columns()}
           rows={items}
           keyOf={(agent) => agent.id}
-          stretchPrimaryLink
           {...(cursor === null
             ? {}
             : {


### PR DESCRIPTION
**What changed**

- `apps/web/app/projects/[projectId]/agents/screen.tsx` — the agent's name in the list is plain text. No link, no hover underline, and the table no longer stretches a primary link across the row (there is no primary link now). The row's ⋮ keeps every way in: Open agent, Connect, Archive agent. The connect flow still lands on the agent page.
- `apps/web/app/projects/[projectId]/agents/connection-facts.tsx` — the Connections cell never wraps to a second line. It was `flex-wrap` + `whitespace-normal`, so one long connection name made one row taller than its neighbours. It is one line now: `flex-nowrap`, a long name is cut with an ellipsis and carries its full text in a `title`, and the square `+N` chip keeps its place with `flex-none`. The two-then-chip cap was already there and is unchanged.

**Why**

The developer's morning ask: the agents list is the one agent screen, exactly as Paper board `6ZJ-0`. The name names the agent; only the connections are links, so an underline on this row means one thing — press it and a connection opens. Consistent row heights was the earlier decision on the same board.

**Tests**

- `apps/web/test/agents-pages.test.tsx` — 37 passed, unchanged. It reads the name with `findAllByText`, so nothing there became false.
- `apps/api/test/browser.test.ts` — two agents-lane expectations updated: the walk that asserted the name link's href now asserts the name is *not* a link and reads the address off the row's ⋮ (Open agent); the keyboard walk now Tabs to the row's ⋮ and follows Open agent with Enter. CI's browser lane proves both on this PR.
- `pnpm typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790191449&installation_model_id=431960&pr_number=202&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F202&signature=78e44c78268c03744a0ec30c69e60d446eac1d0a42674d11ebfd4dad45698cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes agent names non-interactive in the agents list while retaining agent navigation in each row’s actions menu. It also keeps connection names on one line with ellipsis and updates browser coverage for the revised pointer and keyboard flows.
- Replaces each agent-name link with plain text and removes stretched primary-link behavior.
- Keeps “Open agent,” “Connect,” and “Archive agent” in the row actions menu.
- Prevents connection cells from wrapping while preserving the overflow-count chip.
- Updates browser tests to verify menu-based agent navigation and keyboard access.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking issue was identified.

The actions menu remains reachable across table layouts, plain-text primary cells are supported by the shared table, and the connection layout preserves link access while constraining long labels.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/agents/screen.tsx | Replaces linked agent names with plain text and relies on the consistently available row actions menu for agent navigation. |
| apps/web/app/projects/[projectId]/agents/connection-facts.tsx | Changes connection links to a single-line truncating flex layout and prevents the overflow chip from shrinking. |
| apps/api/test/browser.test.ts | Updates end-to-end assertions and keyboard navigation to cover opening an agent through its row menu. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): the agents list is the one age..."](https://github.com/egma-ai/egma/commit/c2fc49bee334c4a5658e65d1ab740a3148a51c51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56373042)</sub>

<!-- /greptile_comment -->