### PR TITLE
Update sidebar organization and project context

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@ The orange-red palette and the Egma logo are locked. Change them only with expli
 
 The styling architecture changed on 2026-08-19 with that approval. **Styling architecture** below is the current truth.
 
-The product's shape changed on 2026-08-23 with that approval, from the Paper file "Egma — Design system and product UI". Five rules moved, and each is marked where it is written: **one radius, and it is 0px**; the **Egma wordmark returns to the signed-in sidebar**; the **primary action is the wash button**, not a Deep Ember block; **`system-ui` leads the font stack**; and the **side sheet** is where one record is created, read and edited. The palette did not move. The logo's own treatment rules did not move.
+The product's shape changed on 2026-08-23 with that approval, from the Paper file "Egma — Design system and product UI". Five rules moved, and each is marked where it is written: **one radius, and it is 0px**; Egma identity returned to the signed-in sidebar; the **primary action is the wash button**, not a Deep Ember block; **`system-ui` leads the font stack**; and the **side sheet** is where one record is created, read and edited. On 2026-08-24, the approved Paper refinement replaced the full sidebar wordmark with the Egma mark beside organization context and made the account avatar square. The palette and the logo's own treatment rules did not move.
 
 ## Product context
 
@@ -60,15 +60,17 @@ Rules:
 Canonical assets:
 
 - `apps/web/public/brand/egma-mark.svg`
+- `apps/web/public/brand/egma-mark-light.svg`
+- `apps/web/public/brand/egma-mark-dark.svg`
 - `apps/web/public/brand/egma-wordmark.svg`
 
 Rules:
 
 - Keep the canonical geometry, proportions, and black-and-white treatment.
 - Do not recolor, stretch, rotate, outline, shadow, or animate the logo.
-- The signed-in sidebar starts with the Egma wordmark, in a 56px bar with a hairline under it. It links to the product root. (Developer decision, 2026-08-23: "our logo, not the organization's". This replaces the earlier rule that kept the full logo out of the signed-in sidebar, which asked for exactly this approval.)
-- 2026-08-23: the sidebar wordmark follows the access pages' existing dark-theme treatment (the black line art is printed white by inversion).
-- The organization is the eyebrow above the project name, under the wordmark bar. The project is the line that opens the switcher.
+- The signed-in sidebar starts with the Egma loop mark beside the current organization, its `Free` plan chip and paired arrows, in a 56px bar with a hairline under it. Use the square light/dark mark asset, not the full wordmark. (Developer decision, 2026-08-24, from the approved Paper refinement.)
+- The sidebar mark follows the access pages' existing dark-theme treatment: black line art is printed white by inversion.
+- Project context is a separate control under the organization bar. It always shows the word `Project`, the current project name and paired arrows.
 - Auth, onboarding, and public brand surfaces may use the full logo.
 - Product icons and status symbols must not imitate the logo.
 
@@ -172,10 +174,9 @@ Allowed spacing values are `4, 8, 12, 16, 20, 24, 32, 40, 48, 64, 72, 80, 100px`
 
 One radius, and it is none: buttons, inputs, panels, tables, sheets, menus, dialogs, chips, badges. Sharp corners are the product's shape. (Developer decision, 2026-08-23. This replaces the four-step table that named a radius per component type.)
 
-Two round shapes remain, and neither is a component corner:
+The account avatar is square for every role. (Developer decision, 2026-08-24.)
 
-- The account avatar is a circle. It is an avatar.
-- A radio button is a circle. The shape is what tells it apart from a checkbox in every operating system, and taking it away would make one control claim to be another.
+One round shape remains, and it is not a component corner: a radio button is a circle. The shape is what tells it apart from a checkbox in every operating system, and taking it away would make one control claim to be another.
 
 The four radius names stay in the theme — `--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-pill` — because component class lists read them and the name says which component asked. All four are `0px`.
 
@@ -210,8 +211,8 @@ rgba(122, 49, 23, 0.02) -130px 256px 115px 0
 
 - Neutral Paper is the application canvas.
 - The sidebar is a quiet paper region separated by a neutral hairline.
-- The Egma wordmark is the topmost thing in the sidebar, in a bar of its own.
-- The organization and project switcher is the topmost sidebar *control*, under that bar.
+- The organization control is the topmost thing in the sidebar. It holds the Egma mark, organization name, current plan and paired arrows in a bar of its own.
+- The project selector is a separate control under the organization bar and keeps the word `Project` visible.
 - Navigation uses text and small line icons.
 - The active item uses Ember Wash and a small Ember mark on its leading edge. Its icon follows the row's text colour; the mark is the brand signal and there is only one.
 - The account control stays at the bottom.
@@ -226,7 +227,7 @@ The measurements, all of them theme values:
 | Part | Value |
 | --- | ---: |
 | Sidebar width | 224px |
-| Sidebar wordmark bar | 56px |
+| Sidebar organization bar | 56px |
 | Page title bar | 56px |
 | Sidebar gutter, page gutter | 16px, 24px |
 | Navigation row, toolbar control | 36px |
@@ -237,11 +238,13 @@ The measurements, all of them theme values:
 | Toolbar row | 52px |
 | Side sheet | 440px |
 
-### Organization and project switcher
+### Organization and project controls
 
-- Show the organization as the eyebrow and the project as the primary line. The project is what a person changes; the organization is the one thing they cannot. (Developer decision, 2026-08-23.)
-- Support search, keyboard use, Escape, focus return, and unsaved-work protection.
-- Open the menu from its trigger with an origin-aware transition.
+- Keep organization and project as two clear controls. The organization bar shows the Egma mark, organization name, the fixed `Free` release-plan chip and paired arrows. The project control below shows the explicit `Project` label, project name and paired arrows. (Developer decision, 2026-08-24.)
+- The organization menu is informational in the current one-organization model. It shows the organization name, `Free Plan`, and the person's real `Admin`, `Member`, or `Viewer` role. It does not offer organization switching or Organization settings yet.
+- `Free` is fixed release copy because billing data does not exist in the session yet. Show it only after a real organization has loaded; do not make a plan claim while loading or when the organization is absent.
+- The project selector continues to support search, keyboard use, Escape, focus return, URL-based selection, and unsaved-work protection.
+- Open each menu from its trigger with an origin-aware transition.
 - Do not add fake teams, sample projects, or a second navigation model.
 
 ### Buttons and links

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -806,11 +806,16 @@ describe("what a project recorded in production", () => {
       const account = sidebar.locator('button[aria-label^="Account"]');
       await account.waitFor({ state: "visible" });
 
-      // Where you are, without having to open anything: the organization and
-      // the project, on one compact control that is there with one project.
+      // Where you are, without having to open anything: organization and
+      // project are two clear controls, both present with one project.
+      const organization = sidebar.locator(
+        'button[aria-label^="Open organization menu for"]',
+      );
+      await organization.waitFor({ state: "visible" });
+      await expect.poll(() => organization.innerText()).toMatch(/acme/i);
       const selector = sidebar.locator('button[aria-label^="Organization"]');
       await selector.waitFor({ state: "visible" });
-      await expect.poll(() => selector.innerText()).toMatch(/acme/i);
+      await expect.poll(() => selector.innerText()).toMatch(/project/i);
 
       // From here on, changing the page must not replace or empty the shell.
       // The old page-owned shell stayed in one document but still remounted,
@@ -907,20 +912,6 @@ describe("what a project recorded in production", () => {
           .getByRole("link", { name: "Simulation runs", exact: true })
           .count(),
       ).toBe(0);
-      /*
-       * **There is a way home in this bar, and it is the wordmark.**
-       *
-       * This line used to say there was none, from the time the bar held six
-       * navigation rows and nothing else. The developer put the Egma wordmark
-       * at the top of the sidebar on 2026-08-23 — "our logo, not the
-       * organization's" — and it links to the product root, so the assertion is
-       * now about what that link is rather than that it is absent. What must
-       * stay absent is a *navigation row* called Home: the bar names areas, and
-       * a row pointing at the root would be a seventh area that is not one.
-       */
-      expect(
-        await sidebar.getByRole("link", { name: "Egma home", exact: true }).getAttribute("href"),
-      ).toBe("/");
       expect(
         await sidebar.getByRole("link", { name: "Home", exact: true }).count(),
       ).toBe(0);
@@ -3538,19 +3529,9 @@ describe("the complete product, walked in order in a second project", () => {
                * whole of `NAVIGATION_GROUPS` — Agents, Graders, Tests,
                * Personas, Runs, Transcripts — and a row added or dropped
                * should be a decision somebody takes here on purpose.
-               *
-               * **Seven links, and the seventh is not a row.** The Egma
-               * wordmark at the top of the bar is a link to the product root
-               * (`/`), added on 2026-08-23 by the developer's ruling. It is
-               * separated out rather than counted in, so this stays a count of
-               * the navigation and the brand link stays named.
                */
-              const home = addresses.filter((one) => one === "/");
-              expect(home, addresses.join(", ")).toHaveLength(1);
-              expect(
-                addresses.filter((one) => one !== "/").length,
-                addresses.join(", "),
-              ).toBe(6);
+              expect(addresses, addresses.join(", ")).toHaveLength(6);
+              expect(addresses, addresses.join(", ")).not.toContain("/");
               for (const address of addresses) {
                 expect(address, address).not.toContain("simulations");
               }
@@ -4352,13 +4333,9 @@ describe("the complete product, walked in order in a second project", () => {
         // the first Tab is the first focusable thing on the page. Clicking a
         // corner would make the answer depend on what is drawn there.
         //
-        // **The wordmark is the first stop, and the switcher is the second.**
-        // The bar's topmost thing is the Egma wordmark in a bar of its own,
-        // linking to the product root (`DESIGN.md`, Shell; the developer's
-        // ruling of 2026-08-23). The topmost *control* is still the switcher,
-        // which is the line under it.
+        // Organization is the first control and Project is the second.
         await walk.keyboard.press("Tab");
-        expect(await focused()).toBe("Egma home");
+        expect(await focused()).toMatch(/^Open organization menu for/u);
         await walk.keyboard.press("Tab");
         expect(await focused()).toMatch(/^Organization/u);
         await walk.keyboard.press("Tab");

--- a/apps/web/components/ui/radio-group.tsx
+++ b/apps/web/components/ui/radio-group.tsx
@@ -75,12 +75,11 @@ const radioItemVariants = cva(
          * it, and a mouse sees no change at all.
          */
         /*
-         * **The one place a circle survived the 0px ruling, with the avatar.**
-         * A radio button is round the way an avatar is round: the shape is
-         * what tells it apart from a checkbox, in every operating system a
-         * person has ever used. So it says `rounded-full`, which is Tailwind's
-         * own and not one of egma's four component radii. Called out in the
-         * pull request for the developer to overrule.
+         * **The one place a circle survives the 0px ruling.** A radio button's
+         * shape tells it apart from a checkbox in every operating system a
+         * person has used. So it says `rounded-full`, which is Tailwind's own
+         * and not one of egma's four component radii. Account avatars are
+         * square; this functional control remains the only exception.
          */
         dot: [
           "relative grid size-[18px] place-items-center",

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -72,13 +72,10 @@ function SidebarProvider({
 }
 
 /**
- * The bar the Egma wordmark stands in, at the very top.
+ * The organization bar at the very top of the signed-in sidebar.
  *
- * **The wordmark is here because the developer put it here**, on 2026-08-23,
- * looking at the boards: "our logo, not the organization's". `DESIGN.md` used
- * to say the signed-in sidebar does not repeat the full logo and asked for
- * explicit approval to change that; the instruction *is* the approval, and
- * `DESIGN.md` records it as such.
+ * The approved Paper refinement puts the Egma mark, organization name, plan
+ * and arrows in this row. The project is a separate control below it.
  *
  * 56px tall over a hairline, which is exactly the topbar beside it (`73A-0`
  * and `71V-0` are both 56). The two bars line up across the whole application
@@ -100,11 +97,10 @@ function SidebarBrand({ className, ...props }: ComponentProps<"div">) {
 }
 
 /**
- * The topmost slot, which holds the organization and project switcher.
+ * The slot under the organization bar, which holds the project switcher.
  *
- * `min-w-0` is the load-bearing part: the switcher names an organization and a
- * project, and a long name in a 224px column has to be allowed to shrink rather
- * than push the bar wider than the grid column it is in.
+ * `min-w-0` is the load-bearing part: a long project name in a 224px column has
+ * to shrink rather than push the bar wider than the grid column it is in.
  */
 function SidebarHeader({ className, ...props }: ComponentProps<"div">) {
   return (

--- a/apps/web/test/brand-assets.test.ts
+++ b/apps/web/test/brand-assets.test.ts
@@ -12,8 +12,7 @@
  * A brand-asset migration exposed this gap: source could keep naming a deleted
  * image while component tests stayed green. This file is the guard that would
  * have reported the missing file. The public authentication Brand gives the
- * scan a real asset to hold; the signed-in shell intentionally starts with
- * project context and has no logo.
+ * scan a real asset to hold; the signed-in shell also uses the compact mark.
  *
  * It reads the source rather than a list, so an asset added tomorrow is
  * covered the day it is written, and it deliberately says nothing about which
@@ -96,7 +95,7 @@ describe("what the application asks the browser to fetch", () => {
 
   it("finds the brand asset the public authentication Brand draws", () => {
     // A guard that matches nothing passes for ever. The public Brand is where
-    // the logo belongs; the signed-in shell starts with project context.
+    // the full logo belongs; the signed-in shell uses the compact mark.
     const authentication = readFileSync(path.join(WEB, "app", "ui.tsx"), "utf8");
     expect(authentication).toContain("export function Brand()");
     const marks = [...authentication.matchAll(ASSET)]

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -222,7 +222,7 @@ describe("the organization and project selector", () => {
     );
 
     const trigger = screen.getByRole("button", { name: /^Organization Acme/ });
-    expect(trigger.textContent).toContain("Acme");
+    expect(trigger.textContent).toContain("Project");
     expect(trigger.textContent).toContain("Default");
 
     fireEvent.click(trigger);
@@ -1669,18 +1669,7 @@ describe("the role the shell shows", () => {
     expect(sessionReads).toHaveLength(2);
   });
 
-  /**
-   * The bar starts with the Egma wordmark, and the project context is under it.
-   *
-   * **This assertion was the other way round until 2026-08-23.** `DESIGN.md`
-   * kept the full logo out of the signed-in sidebar and asked for explicit
-   * approval to change that rule; the developer gave it, looking at the Paper
-   * boards — "our logo, not the organization's" — and `DESIGN.md` records the
-   * decision with its date. The organization did not disappear with the change:
-   * it moved into the eyebrow above the project name, which is what the second
-   * half of this case holds.
-   */
-  it("starts the signed-in sidebar with the Egma wordmark, then project context", () => {
+  it("keeps organization and project as two clear sidebar controls", () => {
     render(
       <AppShell initialMe={meWith("admin")}>
         <p>page</p>
@@ -1688,17 +1677,52 @@ describe("the role the shell shows", () => {
     );
 
     const sidebar = screen.getByRole("complementary");
-    const wordmark = within(sidebar).getByRole("img", { name: /egma/i });
-    expect(wordmark.getAttribute("src")).toBe("/brand/egma-wordmark.svg");
-    expect(
-      within(sidebar).getByRole("link", { name: "Egma home" }).getAttribute("href"),
-    ).toBe("/");
+    const organization = within(sidebar).getByRole("button", {
+      name: "Open organization menu for Acme",
+    });
+    expect(organization.querySelector("img")?.getAttribute("src")).toBe(
+      "/brand/egma-mark-light.svg",
+    );
+    expect(organization.textContent).toContain("Acme");
+    expect(organization.textContent).toContain("Free");
+    expect(organization.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
 
-    const firstControl = sidebar.querySelector("button");
-    expect(firstControl?.getAttribute("aria-label")).toMatch(/^Organization Acme/);
-    /* The organization is the eyebrow now; the project is the line you press. */
-    expect(within(sidebar).getByText("Acme")).toBeTruthy();
+    const project = within(sidebar).getByRole("button", {
+      name: /^Organization Acme, project Default/u,
+    });
+    expect(project.textContent).toContain("Project");
+    expect(project.textContent).toContain("Default");
+    expect(project.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+
+    fireEvent.click(organization);
+    const summary = within(
+      screen.getByRole("dialog", { name: "Open organization menu for Acme" }),
+    );
+    expect(summary.getByText("Free Plan")).toBeTruthy();
+    expect(summary.getByText("Admin")).toBeTruthy();
+    expect(summary.queryByText("Organization settings")).toBeNull();
   });
+
+  it.each(["admin", "member", "viewer"] as const)(
+    "keeps the bottom account avatar square for a %s",
+    (role) => {
+      render(
+        <AppShell initialMe={meWith(role)}>
+          <p>page</p>
+        </AppShell>,
+      );
+
+      const account = within(screen.getByRole("complementary")).getByRole(
+        "button",
+        { name: /^Account /u },
+      );
+      const avatar = account.querySelector('[data-slot="account-avatar"]');
+      expect(avatar?.classList.contains("rounded-none")).toBe(true);
+      expect(avatar?.classList.contains("rounded-full")).toBe(false);
+    },
+  );
 
   it("keeps navigation icons decorative and every label visible", () => {
     render(

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -343,19 +343,8 @@ describe("the grouped sidebar", () => {
     expect(screen.queryByRole("dialog", { name: "Navigation" })).toBeNull();
   });
 
-  /**
-   * The wordmark leads the bar, the switcher follows it, and the account
-   * control stays at the bottom. What this asserts is that the groups landed
-   * *between* them rather than around them — which is also the order a
-   * keyboard walks the bar in.
-   *
-   * **The wordmark is first, and that is the 2026-08-23 ruling.** The
-   * developer put the Egma logo back at the top of the signed-in sidebar
-   * — "our logo, not the organization's" — so the first thing a keyboard
-   * reaches in the bar is a link home, and the organization moved into the
-   * eyebrow above the project name where the switcher now stands.
-   */
-  it("leads with the wordmark, then the switcher, and ends with the account", () => {
+  /** Organization, then project, then the navigation and bottom account. */
+  it("leads with organization and project, and ends with the account", () => {
     drawShell();
 
     const bar = sidebarNavigation().closest("aside");
@@ -367,14 +356,15 @@ describe("the grouped sidebar", () => {
     const at = (node: HTMLElement | null) =>
       node === null ? -1 : order.indexOf(node);
 
-    const wordmark = within(bar!).getByRole("link", { name: "Egma home" });
+    const organization = within(bar!).getByRole("button", {
+      name: "Open organization menu for Acme",
+    });
     const switcher = within(bar!).getByRole("button", { name: /^Organization Acme/ });
     const account = within(bar!).getByRole("button", { name: /account menu$/ });
     const agents = within(bar!).getByRole("link", { name: "Agents" });
     const transcripts = within(bar!).getByRole("link", { name: "Transcripts" });
 
-    expect(at(wordmark)).toBe(0);
-    expect(wordmark.getAttribute("href")).toBe("/");
+    expect(at(organization)).toBe(0);
     expect(at(switcher)).toBe(1);
     expect(at(switcher)).toBeLessThan(at(agents));
     expect(at(agents)).toBeLessThan(at(transcripts));

--- a/apps/web/ui/project-selector.tsx
+++ b/apps/web/ui/project-selector.tsx
@@ -14,7 +14,7 @@ import { useDraftNavigation } from "./draft-navigation.tsx";
 import { Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
 
 /**
- * Where you are working: the organization, and the project inside it.
+ * The project where you are working.
  *
  * **It is on screen even when there is one project.** An earlier rule hid a
  * level with one thing in it as clutter. It is not clutter — it is the answer
@@ -28,26 +28,18 @@ import { Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
  * work because they always did — they restore an address, and an address is the
  * whole of the state.
  *
- * The organization is shown and is not a choice: one person belongs to one
- * organization in this version, and offering a menu of one would suggest
- * otherwise.
+ * Organization identity now has its own control in the shell. It is still
+ * passed here because the chooser names the organization whose projects it
+ * lists, but it is no longer repeated in this trigger.
  */
 
 /**
- * The trigger: two lines, no card, and no mark.
+ * The trigger: an explicit label over the current project.
  *
- * **The card went when the wordmark arrived.** It used to carry a square with
- * the organization's initial, a quiet "ORGANIZATION" eyebrow, the organization
- * name and the project under it — four things, because the top of the bar had
- * to answer *which Egma is this* on its own. It does not any more: the
- * wordmark bar above says the product, so this block says the two things left,
- * and the boards draw them as plain type on the sidebar's own surface
- * (`734-0`).
- *
- * The **organization is the eyebrow** now and the **project is the primary
- * line** — the developer's ruling of 2026-08-23, and the right way round: the
- * project is what a person changes and the organization is the one thing they
- * cannot. 12px for the eyebrow and 14px for the name, both read off the board.
+ * The word **Project** stays visible even when there is only one. Organization
+ * and project are different scopes, so a quiet label is the small amount of
+ * copy that prevents the current project's name from being mistaken for an
+ * organization. The organization sits in the bar above it.
  *
  * **This is a restyle of the trigger and nothing else.** Search, the keyboard
  * path, Escape, focus return, the unsaved-work guard and the origin-aware open
@@ -141,14 +133,10 @@ export function ProjectSelector({
       panelRole="dialog"
       trigger={
         <>
-          {/*
-           * The organization, quiet and above. It is not a choice — one person
-           * belongs to one organization in this version — so it is a label
-           * rather than something with a control on it.
-           */}
+          {/* The mobile row has no room for a second line. */}
           {compact ? null : (
             <span className="block overflow-hidden text-2xs leading-(--line-normal) text-ellipsis whitespace-nowrap text-faint">
-              {organizationName}
+              Project
             </span>
           )}
           <span className="flex min-w-0 items-center justify-between gap-2">

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -3,6 +3,7 @@
 import {
   BotIcon,
   ClipboardCheckIcon,
+  ChevronsUpDownIcon,
   MessageSquareTextIcon,
   PlayIcon,
   ScaleIcon,
@@ -39,7 +40,13 @@ import {
 } from "@/components/ui/sidebar";
 
 import { readJson } from "../lib/api.ts";
-import { organizationOf, roleOf, type Me, type Project } from "../lib/me.ts";
+import {
+  organizationOf,
+  roleOf,
+  type Me,
+  type Organization,
+  type Project,
+} from "../lib/me.ts";
 import {
   activeSectionIn,
   navigationFor,
@@ -257,7 +264,7 @@ function Navigation({
     <SidebarProvider onNavigate={onNavigate}>
       {/*
        * The 16px gutter is the bar's, and it is on every block in the column
-       * rather than on the column itself. The wordmark bar's hairline has to
+       * rather than on the column itself. The organization bar's hairline has to
        * run the full 224px, so the `<aside>` can carry no side padding — and
        * the rows are 192px wide with their Ember mark exactly on the gutter,
        * which is what the boards draw (`725-0`, `72Z-0`).
@@ -286,6 +293,128 @@ function Navigation({
         </nav>
       </SidebarContent>
     </SidebarProvider>
+  );
+}
+
+/*
+ * Billing is not part of `/api/me` yet. Every organization in this release is
+ * on the same plan, so this stays explicit UI copy instead of pretending the
+ * session contains subscription data. Do not show it without a real
+ * organization; a loading or failed session has made no plan claim.
+ */
+const CURRENT_PLAN = { badge: "Free", name: "Free Plan" } as const;
+
+const ROLE_LABEL: Record<Role, string> = {
+  admin: "Admin",
+  member: "Member",
+  viewer: "Viewer",
+};
+
+/**
+ * The organization identity at the top of the signed-in sidebar.
+ *
+ * There is one organization per session today, so this panel gives context and
+ * does not offer a false switcher. The paired arrows still open a useful
+ * surface: organization name, current plan and the person's real membership
+ * role. Organization settings stay out until that product level exists.
+ */
+function OrganizationMenu({
+  organization,
+  role,
+  settled,
+}: {
+  readonly organization: Organization | undefined;
+  readonly role: Role | null;
+  readonly settled: boolean;
+}) {
+  const mark = (
+    /* eslint-disable-next-line @next/next/no-img-element */
+    <img
+      className="size-7 flex-none [[data-theme=dark]_&]:invert"
+      src="/brand/egma-mark-light.svg"
+      alt="Egma"
+      width={28}
+      height={28}
+    />
+  );
+
+  if (organization === undefined) {
+    return (
+      <div
+        className="flex min-h-(--control-lg) w-full min-w-0 items-center gap-2"
+        data-slot="organization-status"
+      >
+        {mark}
+        <span className="min-w-0 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-muted-foreground">
+          {settled ? "No organization" : "Checking your session…"}
+        </span>
+      </div>
+    );
+  }
+
+  const initial = organization.name.trim().slice(0, 1).toUpperCase() || "E";
+
+  return (
+    <Menu
+      label={`Open organization menu for ${organization.name}`}
+      triggerClassName={cn(
+        "flex min-h-(--control-lg) w-full min-w-0 items-center gap-2 p-0",
+        "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
+        "transition-transform duration-(--duration-press) ease-out",
+        "pointer-hover:border-border pointer-hover:bg-surface-soft",
+        "[&:active:not(:focus-visible)]:scale-97",
+        "motion-reduce:transition-none",
+        "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
+      )}
+      openClassName="border-border bg-surface-soft"
+      placement="below-start"
+      panelRole="dialog"
+      panelClassName="w-[280px] p-3"
+      trigger={
+        <>
+          {mark}
+          <span
+            className="min-w-0 flex-1 overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground"
+            data-slot="organization-name"
+          >
+            {organization.name}
+          </span>
+          <Badge className="text-xs" shape="count" data-slot="organization-plan">
+            {CURRENT_PLAN.badge}
+          </Badge>
+          <ChevronsUpDownIcon
+            className="size-3 flex-none text-faint"
+            aria-hidden="true"
+            strokeWidth={1.75}
+          />
+        </>
+      }
+    >
+      {() => (
+        <div className="flex min-w-0 items-center gap-3 p-2" data-slot="organization-summary">
+          <span
+            className="grid size-10 flex-none place-items-center rounded-none border border-border bg-surface-soft text-sm text-muted-foreground"
+            aria-hidden="true"
+          >
+            {initial}
+          </span>
+          <span className="min-w-0">
+            <span className="block overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground">
+              {organization.name}
+            </span>
+            <span className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+              <span>{CURRENT_PLAN.name}</span>
+              {role === null ? null : (
+                <>
+                  <span className="h-3 w-px bg-border" aria-hidden="true" />
+                  <span>{ROLE_LABEL[role]}</span>
+                </>
+              )}
+            </span>
+          </span>
+        </div>
+      )}
+    </Menu>
   );
 }
 
@@ -370,9 +499,10 @@ function AccountMenu({
           <span
             className={cn(
               "grid size-(--control-md) flex-none place-items-center",
-              "rounded-full border border-border bg-surface-soft text-sm",
+              "rounded-none border border-border bg-surface-soft text-sm",
               compact && "size-(--tap-target)",
             )}
+            data-slot="account-avatar"
             aria-hidden="true"
           >
             {initial}
@@ -580,29 +710,13 @@ function ShellFrame({
           "max-[900px]:hidden",
         )}
       >
-        {/*
-         * The wordmark, and a link home.
-         *
-         * `[[data-theme=dark]_&]:invert` is the whole of the dark-theme
-         * treatment: the asset is black line art on nothing, so inverting it
-         * gives white line art on nothing. `DESIGN.md` forbids recolouring the
-         * logo and this does not recolour it — it is the same two-value mark,
-         * the way a black wordmark is printed white on a dark page.
-         */}
-        <SidebarBrand>
-          <Link
-            className="inline-flex items-center rounded-button no-underline"
-            href="/"
-            aria-label="Egma home"
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              className="h-6 w-auto [[data-theme=dark]_&]:invert"
-              src="/brand/egma-wordmark.svg"
-              alt="Egma"
-              height={24}
-            />
-          </Link>
+        {/* Organization context owns the top bar; project context stays below. */}
+        <SidebarBrand className="[&>[data-slot=menu]]:min-w-0 [&>[data-slot=menu]]:flex-1">
+          <OrganizationMenu
+            organization={organization}
+            role={role}
+            settled={session.settled}
+          />
         </SidebarBrand>
         <SidebarHeader className="px-4">{selector(false)}</SidebarHeader>
         {shown === null ? null : <Navigation projectId={shown} pathname={pathname} />}
@@ -753,7 +867,7 @@ export function ProductPage({
  * **The title moved into a bar of its own**, 56px tall over a hairline with
  * 24px of side padding, which is `71V-0`. It is where a person looks to answer
  * "what am I on", so it stays put while the page scrolls under it and it is
- * the same 56px as the wordmark bar across the divider from it.
+ * the same 56px as the organization bar across the divider from it.
  *
  * **The page's actions are not in that bar.** They sit in the toolbar row
  * below it, hard right, opposite whatever the page filters by — which is the

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -196,10 +196,8 @@
    * one line in the same change.
    *
    * **A round *shape* is not a component corner and is not drawn from here.**
-   * An avatar is a circle and a radio button is a circle; both say
-   * `rounded-full`, which is Tailwind's own and untouched by this block. That
-   * is the whole exception, and it is written down so the next person does not
-   * read a circular avatar as a radius that escaped.
+   * A radio button stays circular because its shape distinguishes it from a
+   * checkbox. The account avatar is square with every other component.
    */
   --radius-sm: 0px;
   --radius-md: 0px;


### PR DESCRIPTION
## Summary

- replace the sidebar wordmark with the Egma mark, organization name, Free plan chip, and organization details menu
- keep Project as a separate, explicit switcher with paired arrows
- make the bottom account avatar square for every role
- keep Organization settings out until organization-level settings exist

## Checks

- pnpm --filter @egma/platform-api build
- pnpm --filter @egma/web typecheck

The focused test command was not run because the local database service was not active. CI will run the full suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790205523&installation_model_id=431960&pr_number=205&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F205&signature=72da4f600fbea985e67ef5173e4868e612ce1f5af52f05add648a07c55da370a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reorganizes the signed-in sidebar around separate organization and project controls.
- Replaces the linked Egma wordmark with an organization details menu containing the compact mark, organization name, fixed Free plan label, and membership role.
- Restyles the project selector to retain an explicit Project label.
- Makes account avatars square and updates design documentation and UI/browser tests accordingly.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defects identified.

The new organization and project controls preserve their existing session and project context, while the removed home link and square avatars are explicitly documented product decisions covered by updated tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/shell.tsx | Adds the organization context menu, removes the wordmark home link, and makes account avatars square without introducing an actionable defect. |
| apps/web/ui/project-selector.tsx | Changes the desktop selector eyebrow from the organization name to an explicit Project label while preserving project-selection behavior. |
| apps/api/test/browser.test.ts | Updates end-to-end expectations for the new organization/project control order and intentional removal of the root brand link. |
| apps/web/test/components.test.tsx | Adds coverage for organization details, role presentation, compact mark usage, and square avatars across all roles. |
| DESIGN.md | Records the approved sidebar organization, compact brand mark, fixed plan copy, and square-avatar design decisions. |

<sub>Reviews (1): Last reviewed commit: ["Update sidebar organization and project ..."](https://github.com/egma-ai/egma/commit/e6e1fffab2b61483375c427f98ccdbff0c60adac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56454976)</sub>

<!-- /greptile_comment -->