### PR TITLE
Simplify the project selector

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -145,7 +145,7 @@ Use `system-ui` first, then Helvetica, Arial, and the system sans-serif fallback
 Rules:
 
 - Hierarchy comes from size, space, and restrained use of weight 500.
-- The micro label is for the two letter-spaced uppercase labels the sidebar carries — the organization over the project name, and the role under the account's email. Nothing else uses it. The scale still starts at 14px. (Developer decision, 2026-08-23.)
+- The micro label is for the two letter-spaced uppercase labels the sidebar carries — `Project` over the project name, and the role under the account's email. Nothing else uses it. The scale still starts at 14px.
 - Do not use weights 600 or 700.
 - Product tables, forms, and navigation use the 14px and 16px steps.
 - Headings carry no size of their own. Every heading takes its size from a class, because the browser's own heading sizes are not on this scale.
@@ -243,7 +243,7 @@ The measurements, all of them theme values:
 - Keep organization and project as two clear controls. The organization bar shows the Egma mark, organization name, the fixed `Free` release-plan chip and paired arrows. The project control below shows the explicit `Project` label, project name and paired arrows. (Developer decision, 2026-08-24.)
 - The organization menu is informational in the current one-organization model. It shows the organization name, `Free Plan`, and the person's real `Admin`, `Member`, or `Viewer` role. It does not offer organization switching or Organization settings yet.
 - `Free` is fixed release copy because billing data does not exist in the session yet. Show it only after a real organization has loaded; do not make a plan claim while loading or when the organization is absent.
-- The project selector continues to support search, keyboard use, Escape, focus return, URL-based selection, and unsaved-work protection.
+- The project selector is a direct list with no search field. It keeps the project name neutral when open and continues to support keyboard use, Escape, focus return, URL-based selection, and unsaved-work protection. (Developer decision, 2026-08-24.)
 - Open each menu from its trigger with an origin-aware transition.
 - Do not add fake teams, sample projects, or a second navigation model.
 

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -985,13 +985,13 @@ describe("what a project recorded in production", () => {
       // returning to the current project must keep the same settled context.
       await selector.click();
       await page
-        .getByRole("dialog")
+        .getByRole("menu")
         .getByText("New project", { exact: true })
         .click();
       await page.waitForURL(new RegExp(`/new-project$`));
       await selector.click();
       await page
-        .getByRole("dialog")
+        .getByRole("menu")
         .locator("button[data-menu-item]")
         .first()
         .click();

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2500,8 +2500,9 @@ describe("the complete product, walked in order in a second project", () => {
       await expect.poll(() => selectorOf(walk).innerText()).toContain("Default");
 
       await selectorOf(walk).click();
-      await walk.fill("#project-search", "Supp");
-      await walk.keyboard.press("Enter");
+      await walk
+        .getByRole("menuitem", { name: "Support", exact: true })
+        .click();
 
       await walk.waitForURL(`${origin}/projects/${second}/agents`);
       await expect.poll(() => selectorOf(walk).innerText()).toContain("Support");
@@ -3570,8 +3571,9 @@ describe("the complete product, walked in order in a second project", () => {
          * screen — so Back has to undo it.
          */
         await selectorOf(walk).click();
-        await walk.fill("#project-search", "Default");
-        await walk.keyboard.press("Enter");
+        await walk
+          .getByRole("menuitem", { name: "Default", exact: true })
+          .click();
         await walk.waitForURL(`${origin}/projects/${first}/tests`);
 
         await walk.goBack();

--- a/apps/web/lib/me.ts
+++ b/apps/web/lib/me.ts
@@ -68,24 +68,3 @@ export function roleOf(me: Me): Role {
 export function firstProjectOf(me: Me): Project | undefined {
   return me.projects[0];
 }
-
-/**
- * The projects a typed query leaves. Name and slug both, because a person who
- * knows a project by the word in its address should not have to know its
- * display name to find it.
- *
- * Order is never rearranged by relevance: the list is in stable creation order
- * and a menu whose items move under the keyboard is a menu that mis-selects.
- */
-export function projectsMatching(
-  projects: readonly Project[],
-  query: string,
-): readonly Project[] {
-  const wanted = query.trim().toLowerCase();
-  if (wanted === "") return projects;
-  return projects.filter(
-    (project) =>
-      project.name.toLowerCase().includes(wanted) ||
-      project.slug.toLowerCase().includes(wanted),
-  );
-}

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -227,7 +227,7 @@ describe("the organization and project selector", () => {
 
     fireEvent.click(trigger);
     expect(
-      within(screen.getByRole("dialog")).queryByText(/project in this organization/i),
+      within(screen.getByRole("menu")).queryByText(/project in this organization/i),
     ).toBeNull();
   });
 
@@ -243,8 +243,8 @@ describe("the organization and project selector", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /^Organization Acme/ }));
     expect(
-      within(screen.getByRole("dialog"))
-        .getByRole("link", { name: "New project" })
+      within(screen.getByRole("menu"))
+        .getByRole("menuitem", { name: "New project" })
         .getAttribute("href"),
     ).toBe("/new-project");
   });
@@ -284,31 +284,9 @@ describe("the organization and project selector", () => {
     expect(trigger.textContent).not.toContain("Default");
     // And the way into one is never lost: every project is still offered.
     fireEvent.click(trigger);
-    const panel = within(screen.getByRole("dialog"));
+    const panel = within(screen.getByRole("menu"));
     expect(panel.getByText("Default")).toBeTruthy();
     expect(panel.getByText("Outbound")).toBeTruthy();
-  });
-
-  /**
-   * Typing filters, and Enter takes what is left. This is the whole of the
-   * keyboard path a person uses to change project, and it never touches a
-   * pointer.
-   */
-  it("is driven from the keyboard: open, type, Enter", () => {
-    open();
-
-    const search = screen.getByRole("textbox", { name: "Search projects" });
-    expect(document.activeElement).toBe(search);
-
-    // Scoped to the panel: the trigger still says which project is open, and
-    // filtering is about the list of ones you could move to.
-    const panel = within(screen.getByRole("dialog"));
-    fireEvent.change(search, { target: { value: "outb" } });
-    expect(panel.queryByText("Default")).toBeNull();
-    expect(panel.getByText("Outbound")).toBeDefined();
-
-    fireEvent.keyDown(search, { key: "Enter" });
-    expect(routed.push).toHaveBeenCalledWith("/projects/prj_2/agents");
   });
 
   /**
@@ -317,7 +295,7 @@ describe("the organization and project selector", () => {
    */
   it("leaves the change in the history, so Back undoes it", () => {
     open();
-    fireEvent.click(within(screen.getByRole("dialog")).getByText("Outbound"));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("Outbound"));
 
     expect(routed.push).toHaveBeenCalledTimes(1);
     expect(routed.push).toHaveBeenCalledWith("/projects/prj_2/agents");
@@ -325,19 +303,17 @@ describe("the organization and project selector", () => {
 
   it("goes nowhere when the project chosen is the one already open", () => {
     open();
-    fireEvent.click(within(screen.getByRole("dialog")).getByText("Default"));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("Default"));
     expect(routed.push).not.toHaveBeenCalled();
   });
 
   it("closes on Escape, with focus back on the control that opened it", () => {
     const trigger = open();
-    expect(screen.getByRole("dialog")).toBeDefined();
+    const panel = screen.getByRole("menu");
 
-    fireEvent.keyDown(screen.getByRole("textbox", { name: "Search projects" }), {
-      key: "Escape",
-    });
+    fireEvent.keyDown(panel, { key: "Escape" });
 
-    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByRole("menu")).toBeNull();
     expect(document.activeElement).toBe(trigger);
   });
 
@@ -351,15 +327,13 @@ describe("the organization and project selector", () => {
    */
   it("marks the panel closed and leaves on the animation, not on the press", () => {
     const trigger = open();
-    const panel = screen.getByRole("dialog");
+    const panel = screen.getByRole("menu");
     expect(panel.dataset.slot).toBe("popover-content");
     expect(panel.dataset.state).toBe("open");
 
-    fireEvent.keyDown(screen.getByRole("textbox", { name: "Search projects" }), {
-      key: "Escape",
-    });
+    fireEvent.keyDown(panel, { key: "Escape" });
 
-    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByRole("menu")).toBeNull();
     expect(trigger.getAttribute("data-state")).toBe("closed");
   });
 
@@ -374,7 +348,7 @@ describe("the organization and project selector", () => {
     const trigger = screen.getByRole("button", { name: /^Organization Acme/ });
     fireEvent.pointerDown(trigger);
     fireEvent.click(trigger);
-    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(screen.getByRole("menu")).toBeDefined();
 
     // Two things about a press outside, and both are the panel's own rule.
     // It starts listening on the task after it opened, so the press that
@@ -385,47 +359,25 @@ describe("the organization and project selector", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
     fireEvent.pointerDown(document.body);
-    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(screen.getByRole("menu")).toBeDefined();
     fireEvent.click(document.body);
 
-    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByRole("menu")).toBeNull();
     // A press elsewhere is a way of leaving, so the keyboard is not dragged
     // back to the control somebody has just moved away from.
     expect(document.activeElement).not.toBe(trigger);
   });
 
-  /**
-   * Home and End belong to the caret while somebody is typing in the search
-   * field. Stealing them for the list means the ends of the text cannot be
-   * reached, which is a worse trade than the one it buys.
-   */
-  it("leaves Home and End to the caret while the search field has focus", () => {
-    open();
+  it("opens a direct project menu without search or orange trigger text", () => {
+    const trigger = open();
+    const panel = screen.getByRole("menu");
 
-    const search = screen.getByRole("textbox", { name: "Search projects" });
-    fireEvent.change(search, { target: { value: "outbound" } });
-    const field = search as HTMLInputElement;
-    field.setSelectionRange(8, 8);
-
-    const home = fireEvent.keyDown(search, { key: "Home" });
-
-    // Not prevented, so the browser still moves the caret.
-    expect(home).toBe(true);
-    expect(document.activeElement).toBe(search);
-  });
-
-  /**
-   * A panel holding a text field is a dialog, not a menu: `role="menu"`
-   * promises a list of commands and no screen reader's menu mode expects a
-   * textbox inside one.
-   */
-  it("is a dialog rather than a menu, because it has something to type in", () => {
-    open();
-
-    const panel = screen.getByRole("dialog");
-    expect(within(panel).getAllByRole("textbox")).toHaveLength(1);
-    expect(screen.queryByRole("menu")).toBeNull();
-    expect(screen.queryAllByRole("menuitem")).toHaveLength(0);
+    expect(within(panel).queryByRole("textbox")).toBeNull();
+    expect(within(panel).getByRole("menuitem", { name: /Default/u })).toBeTruthy();
+    expect(within(panel).getByRole("menuitem", { name: "Outbound" })).toBeTruthy();
+    const projectName = trigger.querySelector('[data-slot="project-name"]');
+    expect(projectName?.classList.contains("text-foreground")).toBe(true);
+    expect(projectName?.classList.contains("text-brand")).toBe(false);
   });
 });
 
@@ -1526,7 +1478,7 @@ describe("the shared draft navigation guard", () => {
     if (projectSelector === undefined) throw new Error("project selector missing");
     fireEvent.click(projectSelector);
     fireEvent.click(
-      within(screen.getByRole("dialog")).getByText("Outbound"),
+      within(screen.getByRole("menu")).getByText("Outbound"),
     );
     expect(routed.push).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog", { name: "Leave without saving?" }))
@@ -1966,7 +1918,7 @@ describe("the run address a terminal prints, stuck", () => {
     for (const one of triggers) expect(one.textContent).toContain("No project");
 
     fireEvent.click(triggers[0] as HTMLElement);
-    const panel = within(screen.getByRole("dialog"));
+    const panel = within(screen.getByRole("menu"));
     fireEvent.click(panel.getByText("Outbound"));
 
     // `inProject`, reached from an address with no project in it: there is no

--- a/apps/web/test/project-shell.test.ts
+++ b/apps/web/test/project-shell.test.ts
@@ -6,7 +6,6 @@ import { answerFor, PROJECT_OUTSIDE_ORGANIZATION, unreachable } from "../lib/api
 import {
   firstProjectOf,
   organizationOf,
-  projectsMatching,
   roleOf,
   type Me,
 } from "../lib/me.ts";
@@ -326,34 +325,6 @@ describe("the organization and project control", () => {
   it("has an organization to name, and the projects to choose between", () => {
     expect(organizationOf(ADA)?.name).toBe("Acme");
     expect(firstProjectOf(ADA)?.id).toBe("prj_1");
-  });
-
-  /**
-   * One project is still a place somebody is working, so the control still has
-   * something to say — and the list it opens is that one project rather than
-   * nothing.
-   */
-  it("still has one project to show when there is only one", () => {
-    const alone = { ...ADA, projects: ADA.projects.slice(0, 1) };
-    expect(projectsMatching(alone.projects, "")).toHaveLength(1);
-  });
-
-  it("finds a project by its name or by the word in its address", () => {
-    expect(projectsMatching(ADA.projects, "out").map((one) => one.id)).toEqual([
-      "prj_2",
-    ]);
-    expect(projectsMatching(ADA.projects, "DEFAULT").map((one) => one.id)).toEqual([
-      "prj_1",
-    ]);
-    expect(projectsMatching(ADA.projects, "  ")).toEqual(ADA.projects);
-    expect(projectsMatching(ADA.projects, "zzz")).toEqual([]);
-  });
-
-  it("never reorders the list under the keyboard", () => {
-    expect(projectsMatching(ADA.projects, "").map((one) => one.id)).toEqual([
-      "prj_1",
-      "prj_2",
-    ]);
   });
 });
 

--- a/apps/web/test/settings.test.tsx
+++ b/apps/web/test/settings.test.tsx
@@ -503,7 +503,7 @@ describe("project settings", () => {
       name: /^Organization Acme, project Default\./,
     });
     fireEvent.click(selectors[0]!);
-    const outbound = screen.getByRole("button", { name: "Outbound" });
+    const outbound = screen.getByRole("menuitem", { name: "Outbound" });
     fireEvent.click(outbound);
     expect(routed.push).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog", { name: "Leave without saving?" }))
@@ -512,7 +512,7 @@ describe("project settings", () => {
     expect(document.activeElement).toBe(selectors[0]);
 
     fireEvent.click(selectors[0]!);
-    fireEvent.click(screen.getByRole("button", { name: "Outbound" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Outbound" }));
     fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
     expect(routed.push).toHaveBeenCalledWith("/projects/prj_2/settings");
     expect(confirm).not.toHaveBeenCalled();

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -734,7 +734,7 @@ describe("the suite-first Tests route", () => {
     })[0];
     if (projectSelector === undefined) throw new Error("project selector missing");
     fireEvent.click(projectSelector);
-    fireEvent.click(within(screen.getByRole("dialog")).getByText("Outbound"));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("Outbound"));
 
     expect(routed.push).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog", { name: "Leave without saving?" })).toBeTruthy();

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -14,9 +14,8 @@ import { cn } from "@/lib/utils";
  * A button that opens a small panel, and everything that has to be true of one
  * before somebody without a pointer can use it.
  *
- * There are three of these in the product — the organization and project
- * selector, the account menu, and the test editor's choosers — and there will
- * be more. Writing the behaviour once is what stops the second one being the
+ * The organization and project controls, account menu, and editor choosers all
+ * use this behavior. Writing it once is what stops a later control being the
  * first one with the keyboard left out.
  *
  * **The panel is the kit's anchored surface.** `components/ui/popover.tsx` is
@@ -30,7 +29,7 @@ import { cn } from "@/lib/utils";
  * **The list of items is still this file's, and that is the reason for
  * `Popover` rather than the kit's `DropdownMenu`.** A dropdown menu keeps its
  * own register of items: only what it was handed as an item takes the arrow
- * keys, and it reads every printable key as a jump to a matching item. Two
+ * keys, and it reads every printable key as a jump to a matching item. Some
  * panels here hold a field to type in, which that would take the keys away
  * from, and the account menu's dark-theme switch is a `role="switch"` rather
  * than an item, which that would leave reachable by pointer alone. So the
@@ -40,8 +39,7 @@ import { cn } from "@/lib/utils";
  * - **The arrow keys move between items**, Home and End reach the ends, and
  *   opening moves focus into the panel.
  * - An item marked `data-menu-focus-first` takes focus when the panel opens.
- *   The selector's search field uses it, which is what makes typing to filter
- *   work without anybody reaching for the field first.
+ *   This lets a panel with a field put the keyboard there before its rows.
  *
  * **A panel holding a text field is not a `menu`.** `role="menu"` promises a
  * list of commands, and neither ARIA nor a screen reader's menu mode expects a

--- a/apps/web/ui/project-selector.tsx
+++ b/apps/web/ui/project-selector.tsx
@@ -2,12 +2,10 @@
 
 import { ChevronDownIcon, ChevronsUpDownIcon } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
 
-import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
-import { projectsMatching, type Organization, type Project } from "../lib/me.ts";
+import { type Organization, type Project } from "../lib/me.ts";
 import { inProject } from "../lib/project-context.ts";
 import { NEW_PROJECT_PATH } from "../lib/settings.ts";
 import { useDraftNavigation } from "./draft-navigation.tsx";
@@ -41,10 +39,10 @@ import { Menu, MenuDivider, MenuItem, MenuLabel } from "./menu.tsx";
  * copy that prevents the current project's name from being mistaken for an
  * organization. The organization sits in the bar above it.
  *
- * **This is a restyle of the trigger and nothing else.** Search, the keyboard
- * path, Escape, focus return, the unsaved-work guard and the origin-aware open
- * are the menu's, and none of them is touched below. Its accessible name still
- * names both, so nothing that reaches this control by name has moved.
+ * The project name stays neutral while the menu is open. Opening a chooser is
+ * not a brand state, and changing its text colour made the current context look
+ * like an action. The menu is a direct list: no search field stands between a
+ * person and the projects they can choose.
  *
  * The compact form is the mobile top bar's, where the control shares a 56px row
  * with a drawer button and the account, so it stays held to a width of its own.
@@ -84,10 +82,8 @@ export function ProjectSelector({
 }) {
   const draftNavigation = useDraftNavigation();
   const pathname = usePathname();
-  const [query, setQuery] = useState("");
 
   const current = projects.find((project) => project.id === projectId);
-  const shown = projectsMatching(projects, query);
   const organizationName = organization?.name ?? "No organization";
 
   /**
@@ -108,7 +104,6 @@ export function ProjectSelector({
   function choose(project: Project, close: () => void): void {
     if (project.id === projectId) {
       close();
-      setQuery("");
       return;
     }
     /*
@@ -119,7 +114,6 @@ export function ProjectSelector({
      * navigation untouched.
      */
     close();
-    setQuery("");
     draftNavigation.push(inProject(pathname, project.id), null);
   }
 
@@ -127,10 +121,7 @@ export function ProjectSelector({
     <Menu
       label={`Organization ${organizationName}, project ${projectName}. Choose a project`}
       triggerClassName={cn(TRIGGER, compact && TRIGGER_COMPACT)}
-      openClassName="[&_[data-slot=project-name]]:text-brand"
       placement={compact ? "below-start" : "right-start"}
-      // A panel with a field to type in, so a dialog rather than a menu.
-      panelRole="dialog"
       trigger={
         <>
           {/* The mobile row has no room for a second line. */}
@@ -172,36 +163,15 @@ export function ProjectSelector({
       {(close) => (
         <>
           <MenuLabel>{organizationName}</MenuLabel>
-          {projects.length > 1 ? (
-            <div className="px-1 pt-1 pb-2">
-              <Input
-                id="project-search"
-                aria-label="Search projects"
-                placeholder="Search projects"
-                value={query}
-                autoComplete="off"
-                spellCheck={false}
-                /* The field an opening menu puts focus in. */
-                data-menu-focus-first=""
-                onChange={(event) => setQuery(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter") return;
-                  const only = shown[0];
-                  if (only !== undefined) choose(only, close);
-                }}
-              />
-            </div>
-          ) : null}
           <div className="max-h-60 overflow-y-auto">
-            {shown.length === 0 ? (
+            {projects.length === 0 ? (
               <p className="m-0 p-3 text-sm text-muted-foreground">
-                No project matches that.
+                No projects available.
               </p>
             ) : (
-              shown.map((project) => (
+              projects.map((project) => (
                 <MenuItem
                   key={project.id}
-                  role="none"
                   selected={project.id === projectId}
                   onClick={() => choose(project, close)}
                 >
@@ -218,14 +188,7 @@ export function ProjectSelector({
           {mayCreateProject ? (
             <>
               <MenuDivider />
-              <MenuItem
-                href={NEW_PROJECT_PATH}
-                role="none"
-                onClick={() => {
-                  close();
-                  setQuery("");
-                }}
-              >
+              <MenuItem href={NEW_PROJECT_PATH} onClick={close}>
                 New project
               </MenuItem>
             </>


### PR DESCRIPTION
## Summary

- keep the project name neutral when the selector opens
- remove project search and its focused input treatment
- present projects as a direct accessible menu
- remove the unused project-filtering code

## Checks

- pnpm --filter @egma/platform-api build
- pnpm --filter @egma/web typecheck

Full tests are left to PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790208146&installation_model_id=431960&pr_number=206&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F206&signature=3c4a248f4b638a9e2235cd6c9f5f11c5b55e9fff54cc98c43357fefeaee84daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR simplifies project selection by replacing the searchable dialog with a direct accessible menu while retaining URL-based selection and draft-navigation protection.
- Removes project filtering state, utilities, and associated tests.
- Presents available projects and project creation as menu items.
- Updates browser and component tests for the new menu semantics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/project-selector.tsx | Replaces the searchable project dialog with a direct menu and preserves project-ID navigation and unsaved-work handling. |
| apps/web/ui/menu.tsx | Updates shared menu documentation without materially changing runtime behavior. |
| apps/web/lib/me.ts | Removes the now-unused project filtering helper. |
| apps/web/test/components.test.tsx | Updates selector assertions for menu semantics and the absence of search. |
| apps/api/test/browser.test.ts | Updates browser journeys to choose projects directly through menu items. |

<sub>Reviews (2): Last reviewed commit: ["Fix project menu test selectors"](https://github.com/egma-ai/egma/commit/f8f48089cb12a50adacc336cac83c47927a18f92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56467560)</sub>

**Context used:**

- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->