### PR TITLE
Require CI and Greptile monitoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ The first open-source platform purpose-built to help teams shipping voice agents
 1. whenever you are taking to the developer iterating on this project with you - speak in simple human language, no overcomplicated jargons. always talk in ASD-STE100 Simplified Technical English. 
 2. trace the full story (what is being worked on, why its important, what's the decsion in front and its consequences). be truthful. 
 3. for a batch of UI annotations, inventory every comment first, group the work by product surface with one owner per surface, finish each group before one independent review, then run one integrated test, build, and browser proof.
+4. whenever you raise or update a pull request, monitor every required CI check and the Greptile review after the latest push. Fix test failures and applicable Greptile comments on the same branch. Reply with a clear reason when a Greptile comment should not be applied. Do not report the pull request as ready until every required check passes and every Greptile thread is fixed or answered.
 
 # design system
 


### PR DESCRIPTION
Adds a persistent project instruction: after every PR push, monitor required CI and Greptile through completion, fix failures and applicable comments, answer comments that are not applied, and only then report the PR as ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790209549&installation_model_id=431960&pr_number=207&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F207&signature=4cc8b3bb416ec1fed0f9e8be93b8ee0b833825cbfae7ab713e248496f8d52929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a persistent contributor instruction for pull-request readiness.
- Requires monitoring all required CI checks and the Greptile review after each push.
- Requires failures and applicable comments to be resolved, with rejected comments answered, before reporting readiness.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The new instruction is internally consistent, introduces no runtime or build behavior, and clearly defines the checks required before a pull request is reported as ready.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds a clear operational instruction for monitoring and resolving CI and Greptile feedback after pull-request updates. |

<sub>Reviews (1): Last reviewed commit: ["Require CI and Greptile monitoring"](https://github.com/egma-ai/egma/commit/55523d88f57f1622d5abb657b88326285300c66f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56473760)</sub>

<!-- /greptile_comment -->