### PR TITLE
Refine organization hover tile

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -227,6 +227,7 @@ The measurements, all of them theme values:
 | Part | Value |
 | --- | ---: |
 | Sidebar width | 224px |
+| Sidebar Egma mark | 32px |
 | Sidebar organization bar | 56px |
 | Page title bar | 56px |
 | Sidebar gutter, page gutter | 16px, 24px |

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -1632,11 +1632,19 @@ describe("the role the shell shows", () => {
     const organization = within(sidebar).getByRole("button", {
       name: "Open organization menu for Acme",
     });
-    expect(organization.querySelector("img")?.getAttribute("src")).toBe(
+    const organizationBar = organization.closest('[data-slot="sidebar-brand"]');
+    const mark = organizationBar?.querySelector("img");
+    expect(mark?.getAttribute("src")).toBe(
       "/brand/egma-mark-light.svg",
     );
+    expect(mark?.getAttribute("width")).toBe("32");
+    expect(mark?.getAttribute("height")).toBe("32");
+    expect(organization.querySelector("img")).toBeNull();
     expect(organization.textContent).toContain("Acme");
     expect(organization.textContent).toContain("Free");
+    expect(
+      organization.querySelector('[data-slot="organization-name"]')?.className,
+    ).toContain("text-sm");
     expect(organization.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
       "true",
     );

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -317,6 +317,11 @@ const ROLE_LABEL: Record<Role, string> = {
  * does not offer a false switcher. The paired arrows still open a useful
  * surface: organization name, current plan and the person's real membership
  * role. Organization settings stay out until that product level exists.
+ *
+ * **The mark is identity, not a control.** It sits beside the menu trigger
+ * rather than inside it, so the hover plate, focus indicator and press feedback
+ * cover only the organization control. The organization name stays on the
+ * 14px product-text step; making it smaller would leave the accepted scale.
  */
 function OrganizationMenu({
   organization,
@@ -330,91 +335,95 @@ function OrganizationMenu({
   const mark = (
     /* eslint-disable-next-line @next/next/no-img-element */
     <img
-      className="size-7 flex-none [[data-theme=dark]_&]:invert"
+      className="size-(--sidebar-mark-size) flex-none [[data-theme=dark]_&]:invert"
       src="/brand/egma-mark-light.svg"
       alt="Egma"
-      width={28}
-      height={28}
+      width={32}
+      height={32}
     />
   );
 
   if (organization === undefined) {
     return (
-      <div
-        className="flex min-h-(--control-lg) w-full min-w-0 items-center gap-2"
-        data-slot="organization-status"
-      >
+      <>
         {mark}
-        <span className="min-w-0 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-muted-foreground">
-          {settled ? "No organization" : "Checking your session…"}
-        </span>
-      </div>
+        <div
+          className="flex min-h-(--control-lg) min-w-0 flex-1 items-center px-2"
+          data-slot="organization-status"
+        >
+          <span className="min-w-0 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-muted-foreground">
+            {settled ? "No organization" : "Checking your session…"}
+          </span>
+        </div>
+      </>
     );
   }
 
   const initial = organization.name.trim().slice(0, 1).toUpperCase() || "E";
 
   return (
-    <Menu
-      label={`Open organization menu for ${organization.name}`}
-      triggerClassName={cn(
-        "flex min-h-(--control-lg) w-full min-w-0 items-center gap-2 p-0",
-        "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
-        "transition-transform duration-(--duration-press) ease-out",
-        "pointer-hover:border-border pointer-hover:bg-surface-soft",
-        "[&:active:not(:focus-visible)]:scale-97",
-        "motion-reduce:transition-none",
-        "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
-      )}
-      openClassName="border-border bg-surface-soft"
-      placement="below-start"
-      panelRole="dialog"
-      panelClassName="w-[280px] p-3"
-      trigger={
-        <>
-          {mark}
-          <span
-            className="min-w-0 flex-1 overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground"
-            data-slot="organization-name"
-          >
-            {organization.name}
-          </span>
-          <Badge className="text-xs" shape="count" data-slot="organization-plan">
-            {CURRENT_PLAN.badge}
-          </Badge>
-          <ChevronsUpDownIcon
-            className="size-3 flex-none text-faint"
-            aria-hidden="true"
-            strokeWidth={1.75}
-          />
-        </>
-      }
-    >
-      {() => (
-        <div className="flex min-w-0 items-center gap-3 p-2" data-slot="organization-summary">
-          <span
-            className="grid size-10 flex-none place-items-center rounded-none border border-border bg-surface-soft text-sm text-muted-foreground"
-            aria-hidden="true"
-          >
-            {initial}
-          </span>
-          <span className="min-w-0">
-            <span className="block overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground">
+    <>
+      {mark}
+      <Menu
+        label={`Open organization menu for ${organization.name}`}
+        triggerClassName={cn(
+          "flex min-h-(--control-lg) w-full min-w-0 items-center gap-1 px-2",
+          "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
+          "transition-transform duration-(--duration-press) ease-out",
+          "pointer-hover:border-border pointer-hover:bg-surface-soft",
+          "[&:active:not(:focus-visible)]:scale-97",
+          "motion-reduce:transition-none",
+          "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
+        )}
+        openClassName="border-border bg-surface-soft"
+        placement="below-start"
+        panelRole="dialog"
+        panelClassName="w-[280px] p-3"
+        trigger={
+          <>
+            <span
+              className="min-w-0 flex-1 overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground"
+              data-slot="organization-name"
+            >
               {organization.name}
             </span>
-            <span className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-              <span>{CURRENT_PLAN.name}</span>
-              {role === null ? null : (
-                <>
-                  <span className="h-3 w-px bg-border" aria-hidden="true" />
-                  <span>{ROLE_LABEL[role]}</span>
-                </>
-              )}
+            <Badge className="px-1 text-xs" shape="count" data-slot="organization-plan">
+              {CURRENT_PLAN.badge}
+            </Badge>
+            <ChevronsUpDownIcon
+              className="size-3 flex-none text-faint"
+              aria-hidden="true"
+              strokeWidth={1.75}
+            />
+          </>
+        }
+      >
+        {() => (
+          <div className="flex min-w-0 items-center gap-3 p-2" data-slot="organization-summary">
+            <span
+              className="grid size-10 flex-none place-items-center rounded-none border border-border bg-surface-soft text-sm text-muted-foreground"
+              aria-hidden="true"
+            >
+              {initial}
             </span>
-          </span>
-        </div>
-      )}
-    </Menu>
+            <span className="min-w-0">
+              <span className="block overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground">
+                {organization.name}
+              </span>
+              <span className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+                <span>{CURRENT_PLAN.name}</span>
+                {role === null ? null : (
+                  <>
+                    <span className="h-3 w-px bg-border" aria-hidden="true" />
+                    <span>{ROLE_LABEL[role]}</span>
+                  </>
+                )}
+              </span>
+            </span>
+          </div>
+        )}
+      </Menu>
+    </>
   );
 }
 
@@ -711,7 +720,7 @@ function ShellFrame({
         )}
       >
         {/* Organization context owns the top bar; project context stays below. */}
-        <SidebarBrand className="[&>[data-slot=menu]]:min-w-0 [&>[data-slot=menu]]:flex-1">
+        <SidebarBrand className="gap-2 [&>[data-slot=menu]]:min-w-0 [&>[data-slot=menu]]:flex-1">
           <OrganizationMenu
             organization={organization}
             role={role}

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -316,6 +316,8 @@
    */
   --sheet-width: 440px;
   --sheet-width-wide: 640px;
+  /* The signed-in sidebar's Egma mark, larger now that it is not a trigger. */
+  --sidebar-mark-size: 32px;
   /*
    * The access panel, which is 440px for a different reason than a side sheet
    * is. A sheet is that wide because it is a modal panel over a list that


### PR DESCRIPTION
## Summary
- keep the Egma mark outside the organization menu trigger
- give only the organization control the square hover and open state
- increase the sidebar Egma mark from 28px to 32px
- keep the organization name at the approved 14px step and reclaim width with tighter plan-chip spacing

## Proof
- focused component tests: 88 passed
- web TypeScript check: passed
- browser check: light and dark hover states; 32px logo is outside the 44px organization trigger

The full suite and production build were not run, per request. CI will provide the full check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790211026&installation_model_id=431960&pr_number=209&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F209&signature=b3ae3ca26a4dd82243e8a2285c11c50a191d617e1503b14efda2401524aac188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refines the signed-in sidebar organization control while preserving its existing menu behavior.
- Moves the Egma mark outside the organization menu trigger and increases it to 32px.
- Limits hover, open, press, and focus treatment to the organization control.
- Tightens organization-name and plan-chip layout and documents the updated design measurement.
- Extends component assertions for the new structure and typography.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional, accessibility, layout, or security regression identified.

The new sibling structure remains compatible with SidebarBrand’s direct-child flex rules, the menu trigger retains focus and overflow handling, and the mark sizing uses supported and correctly scoped theme syntax.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/shell.tsx | Restructures the organization bar into sibling brand and menu elements while retaining valid flex sizing, truncation, focus, and menu behavior. |
| apps/web/ui/tailwind-theme.css | Adds a globally available 32px sidebar-mark token using an established Tailwind custom-property utility pattern. |
| apps/web/test/components.test.tsx | Updates shell assertions to verify the mark is outside the trigger, remains 32px, and preserves the approved organization-name typography. |
| DESIGN.md | Documents the new 32px sidebar Egma mark measurement consistently with the implementation. |

<sub>Reviews (1): Last reviewed commit: ["Refine organization hover tile"](https://github.com/egma-ai/egma/commit/fb0fd6ff7cfb1a8f62eb0d31af4b973b5eb25a6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56479611)</sub>

<!-- /greptile_comment -->