### PR TITLE
Fix required agent platform deployment

### DIFF
--- a/packages/db/migrations/0042_agents_own_platform_monitoring.sql
+++ b/packages/db/migrations/0042_agents_own_platform_monitoring.sql
@@ -27,14 +27,6 @@
 -- `revision` leaves `agent` and `connection` — concurrent edits become
 -- last-writer-wins, accepted pre-launch. Grader library revisions are a
 -- different system and are untouched.
---
--- Every agent must name its platform after this cutover. An old agent inherits
--- it only when its connections agree on one non-null platform. A bare agent or
--- an agent whose connections name different platforms stops this migration.
--- Migration 0038 stored LiveKit as `livekit_agents`; normalize that shipped
--- value before deciding whether the connections agree and before copying it.
--- This incompatibility is accepted prelaunch; there is no older API or data
--- contract to preserve.
 
 TRUNCATE TABLE "retell_call_retry";--> statement-breakpoint
 CREATE TABLE "monitoring_state" (
@@ -82,25 +74,6 @@ ALTER TABLE "connection" DROP CONSTRAINT "connection_agent_platform_allowed";-->
 ALTER TABLE "connection" DROP CONSTRAINT "connection_kind_allowed";--> statement-breakpoint
 DROP INDEX "retell_call_retry_due_idx";--> statement-breakpoint
 ALTER TABLE "agent" ADD COLUMN "agent_platform" text;--> statement-breakpoint
-UPDATE "agent"
-SET "agent_platform" = "one_platform"."agent_platform"
-FROM (
-	SELECT
-		"agent_id",
-		min(CASE
-			WHEN "agent_platform" = 'livekit_agents' THEN 'livekit'
-			ELSE "agent_platform"
-		END) AS "agent_platform"
-	FROM "connection"
-	WHERE "agent_platform" IS NOT NULL
-	GROUP BY "agent_id"
-	HAVING count(DISTINCT CASE
-		WHEN "agent_platform" = 'livekit_agents' THEN 'livekit'
-		ELSE "agent_platform"
-	END) = 1
-) AS "one_platform"
-WHERE "agent"."id" = "one_platform"."agent_id";--> statement-breakpoint
-ALTER TABLE "agent" ALTER COLUMN "agent_platform" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "agent" ADD COLUMN "platform_agent_id" text;--> statement-breakpoint
 ALTER TABLE "agent" ADD COLUMN "monitoring_api_key" text;--> statement-breakpoint
 ALTER TABLE "agent" ADD COLUMN "monitoring_api_key_hint" text;--> statement-breakpoint
@@ -119,7 +92,7 @@ ALTER TABLE "agent" DROP COLUMN "revision";--> statement-breakpoint
 ALTER TABLE "connection" DROP COLUMN "agent_platform";--> statement-breakpoint
 ALTER TABLE "connection" DROP COLUMN "revision";--> statement-breakpoint
 ALTER TABLE "retell_call_retry" DROP COLUMN "retell_monitored_agent_id";--> statement-breakpoint
-ALTER TABLE "agent" ADD CONSTRAINT "agent_platform_allowed" CHECK ("agent"."agent_platform" in ('retell', 'livekit'));--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "agent_platform_allowed" CHECK ("agent"."agent_platform" in ('retell', 'livekit_agents'));--> statement-breakpoint
 ALTER TABLE "agent" ADD CONSTRAINT "agent_monitoring_key_hint_agrees" CHECK (("agent"."monitoring_api_key" is null) = ("agent"."monitoring_api_key_hint" is null));--> statement-breakpoint
 ALTER TABLE "agent" ADD CONSTRAINT "agent_monitoring_key_needs_platform" CHECK ("agent"."monitoring_api_key" is null or "agent"."agent_platform" is not null);--> statement-breakpoint
 ALTER TABLE "agent" ADD CONSTRAINT "agent_pull_needs_binding" CHECK ("agent"."pull_production_calls" = false or ("agent"."agent_platform" is not null and "agent"."platform_agent_id" is not null and "agent"."monitoring_api_key" is not null));--> statement-breakpoint

--- a/packages/db/migrations/0044_require_agent_platform.sql
+++ b/packages/db/migrations/0044_require_agent_platform.sql
@@ -1,0 +1,12 @@
+-- 0042 is already recorded in the hosted test database and is immutable.
+-- Apply the required-platform cutover here instead. Agents created after 0042
+-- may hold its original LiveKit value, which is normalized before the new
+-- constraint is installed. Pre-0042 agents have no recoverable platform after
+-- that migration dropped connection.agent_platform; a reset must remove those
+-- null rows before this accepted pre-launch cutover can run.
+ALTER TABLE "agent" DROP CONSTRAINT "agent_platform_allowed";--> statement-breakpoint
+UPDATE "agent"
+SET "agent_platform" = 'livekit'
+WHERE "agent_platform" = 'livekit_agents';--> statement-breakpoint
+ALTER TABLE "agent" ALTER COLUMN "agent_platform" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "agent_platform_allowed" CHECK ("agent"."agent_platform" in ('retell', 'livekit'));

--- a/packages/db/migrations/meta/0042_snapshot.json
+++ b/packages/db/migrations/meta/0042_snapshot.json
@@ -1738,7 +1738,7 @@
           "name": "agent_platform",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "platform_agent_id": {
           "name": "platform_agent_id",
@@ -1928,7 +1928,7 @@
         },
         "agent_platform_allowed": {
           "name": "agent_platform_allowed",
-          "value": "\"agent\".\"agent_platform\" in ('retell', 'livekit')"
+          "value": "\"agent\".\"agent_platform\" in ('retell', 'livekit_agents')"
         },
         "agent_monitoring_key_hint_agrees": {
           "name": "agent_monitoring_key_hint_agrees",

--- a/packages/db/migrations/meta/0044_snapshot.json
+++ b/packages/db/migrations/meta/0044_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "82cf2aa3-91c2-484b-8a36-ca896c34098e",
-  "prevId": "5c97cfca-9954-4a6e-bcbb-c482935af621",
+  "id": "d6f7a510-ff39-4a54-bfd3-7db025fa5b98",
+  "prevId": "82cf2aa3-91c2-484b-8a36-ca896c34098e",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1738,7 +1738,7 @@
           "name": "agent_platform",
           "type": "text",
           "primaryKey": false,
-          "notNull": false
+          "notNull": true
         },
         "platform_agent_id": {
           "name": "platform_agent_id",
@@ -1928,7 +1928,7 @@
         },
         "agent_platform_allowed": {
           "name": "agent_platform_allowed",
-          "value": "\"agent\".\"agent_platform\" in ('retell', 'livekit_agents')"
+          "value": "\"agent\".\"agent_platform\" in ('retell', 'livekit')"
         },
         "agent_monitoring_key_hint_agrees": {
           "name": "agent_monitoring_key_hint_agrees",

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1787607288253,
       "tag": "0043_grader_library_and_authoring",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1787622851386,
+      "tag": "0044_require_agent_platform",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/test/migrations.test.ts
+++ b/packages/db/test/migrations.test.ts
@@ -59,6 +59,22 @@ async function addHistoricalMigration(
 }
 
 describe("the migration files", () => {
+  /**
+   * 0042 reached the hosted test database before the agent-platform cutover.
+   * Its bytes are now part of that database's migration history. A later
+   * schema change must use a new migration instead of changing this hash.
+   */
+  it("keeps the deployed 0042 migration immutable", async () => {
+    const deployed = (await readMigrations()).find(
+      (migration) =>
+        migration.name === "0042_agents_own_platform_monitoring.sql",
+    );
+
+    expect(deployed?.hash).toBe(
+      "e811c2066c1ee01af8d7e358a16dc9caded5f37a517cec9526b860acf4ab0160",
+    );
+  });
+
   it("are numbered plain SQL, applied in that order", async () => {
     const migrations = await readMigrations();
     expect(migrations.length).toBeGreaterThan(0);
@@ -4989,7 +5005,7 @@ describe("agents own platform monitoring (0042)", () => {
   const frontDesk = newId("agt");
   const backOffice = newId("agt");
   const chatConnection = newId("con");
-  const liveKitConnection = newId("con");
+  const phoneConnection = newId("con");
 
   beforeAll(async () => {
     database = await createEmptyDatabase("agents_own_platform_monitoring");
@@ -5027,9 +5043,8 @@ describe("agents own platform monitoring (0042)", () => {
       );
     }
 
-    // Two connection kinds and both old platform values, so the rename has
-    // more than one value to carry and the LiveKit vocabulary cutover is
-    // proved against data written by the immutable 0038 migration.
+    // Two connection kinds, so the rename has more than one value to carry
+    // and a column of one repeated value cannot pass for a carried one.
     await client.query(
       `insert into connection
          (id, organization_id, project_id, agent_id, name, agent_platform,
@@ -5043,10 +5058,10 @@ describe("agents own platform monitoring (0042)", () => {
       `insert into connection
          (id, organization_id, project_id, agent_id, name, agent_platform,
           connection_kind, modality, topology, access_variant, config, revision)
-       values ($1, $2, $3, $4, 'Room', 'livekit_agents', 'livekit_room', 'voice',
-          'hosted-broker', 'livekit_room.project_credentials',
-          '{"url":"wss://support.livekit.cloud"}'::jsonb, $5)`,
-      [liveKitConnection, organizationId, projectId, backOffice, newId("rev")],
+       values ($1, $2, $3, $4, 'Line', 'retell', 'phone_number', 'voice',
+          'egma-dials-in', 'phone_number.public_e164',
+          '{"e164":"+15550000000"}'::jsonb, $5)`,
+      [phoneConnection, organizationId, projectId, backOffice, newId("rev")],
     );
 
     // The whole of what the old build owned: a setup object, one selected
@@ -5117,7 +5132,7 @@ describe("agents own platform monitoring (0042)", () => {
     );
     expect(rows).toEqual([
       { name: "Chat", connection_type: "retell_chat_api" },
-      { name: "Room", connection_type: "livekit_room" },
+      { name: "Line", connection_type: "phone_number" },
     ]);
     // The rename is in place, and the two columns the connection no longer
     // owns went with it: the platform now sits on the agent, and concurrent
@@ -5153,7 +5168,7 @@ describe("agents own platform monitoring (0042)", () => {
     expect(rows).toEqual([
       {
         name: "Back office",
-        agent_platform: "livekit",
+        agent_platform: null,
         platform_agent_id: null,
         monitoring_api_key: null,
         monitoring_api_key_hint: null,
@@ -5161,15 +5176,15 @@ describe("agents own platform monitoring (0042)", () => {
       },
       {
         name: "Front desk",
-        agent_platform: "retell",
+        agent_platform: null,
         platform_agent_id: null,
         monitoring_api_key: null,
         monitoring_api_key_hint: null,
         pull_production_calls: false,
       },
     ]);
-    // The platform comes from each agent's one existing connection. Nothing
-    // else is carried from the retired monitoring rows.
+    // Nothing is carried from the selected-agent rows: an installed agent is
+    // unbound and not pulling until a person pastes a key onto it.
     const gone = await client.query<{ column_name: string }>(
       `select column_name from information_schema.columns
         where table_schema = 'public' and table_name = 'agent'
@@ -5197,14 +5212,14 @@ describe("agents own platform monitoring (0042)", () => {
   it("refuses a switch on that is not a whole binding", async () => {
     const halfBound = newId("agt");
     await client.query(
-      `insert into agent (id, organization_id, project_id, name, agent_platform)
-       values ($1, $2, $3, 'Half bound', 'retell')`,
+      `insert into agent (id, organization_id, project_id, name)
+       values ($1, $2, $3, 'Half bound')`,
       [halfBound, organizationId, projectId],
     );
     await expect(
       client.query(
-        `update agent set platform_agent_id = 'agent_half',
-            pull_production_calls = true
+        `update agent set agent_platform = 'retell',
+            platform_agent_id = 'agent_half', pull_production_calls = true
           where id = $1`,
         [halfBound],
       ),
@@ -5212,7 +5227,7 @@ describe("agents own platform monitoring (0042)", () => {
     // The key and its hint travel together, whichever way round they are set.
     await expect(
       client.query(
-        `update agent set monitoring_api_key = 'sealed'
+        `update agent set agent_platform = 'retell', monitoring_api_key = 'sealed'
           where id = $1`,
         [halfBound],
       ),
@@ -5246,5 +5261,97 @@ describe("agents own platform monitoring (0042)", () => {
         [second],
       ),
     ).rejects.toMatchObject({ constraint: "agent_pulled_platform_agent_unique" });
+  });
+});
+
+describe("the required agent platform cutover (0044)", () => {
+  let database: EmptyDatabase;
+  let before: string;
+  let client: pg.Client;
+
+  const organizationId = newId("org");
+  const projectId = newId("prj");
+  const bareAgent = newId("agt");
+  const retellAgent = newId("agt");
+  const liveKitAgent = newId("agt");
+
+  beforeAll(async () => {
+    database = await createEmptyDatabase("required_agent_platform");
+    before = await mkdtemp(path.join(os.tmpdir(), "egma-before-0044-"));
+    for (const migration of await readMigrations()) {
+      if (migration.name < "0044") {
+        await writeFile(path.join(before, migration.name), migration.sql);
+      }
+    }
+    await runMigrations(database.url, before);
+
+    client = new pg.Client({ connectionString: database.url });
+    await client.connect();
+    await client.query(
+      `insert into organization (id, name, slug)
+       values ($1, 'Platform cutover', 'platform-cutover')`,
+      [organizationId],
+    );
+    await client.query(
+      `insert into project (id, organization_id, name, slug, revision)
+       values ($1, $2, 'Platform cutover', 'platform-cutover', $3)`,
+      [projectId, organizationId, newId("rev")],
+    );
+  });
+
+  afterAll(async () => {
+    await client.end();
+    await rm(before, { recursive: true, force: true });
+    await database.drop();
+  });
+
+  it("stops on an old agent whose platform cannot be recovered", async () => {
+    await client.query(
+      `insert into agent (id, organization_id, project_id, name)
+       values ($1, $2, $3, 'Needs reset')`,
+      [bareAgent, organizationId, projectId],
+    );
+
+    await expect(runMigrations(database.url)).rejects.toThrow(
+      /migration 0044_require_agent_platform\.sql failed/,
+    );
+
+    const recorded = await client.query<{ count: string }>(
+      `select count(*)::text as count from egma_meta.migration
+        where name = '0044_require_agent_platform.sql'`,
+    );
+    expect(recorded.rows).toEqual([{ count: "0" }]);
+  });
+
+  it("applies after the reset and normalizes the shipped LiveKit value", async () => {
+    await client.query("delete from agent where id = $1", [bareAgent]);
+    await client.query(
+      `insert into agent
+         (id, organization_id, project_id, name, agent_platform)
+       values
+         ($1, $3, $4, 'Retell', 'retell'),
+         ($2, $3, $4, 'LiveKit', 'livekit_agents')`,
+      [retellAgent, liveKitAgent, organizationId, projectId],
+    );
+
+    const result = await runMigrations(database.url);
+    expect(result.applied).toEqual(["0044_require_agent_platform.sql"]);
+
+    const agents = await client.query<{
+      name: string;
+      agent_platform: string;
+    }>("select name, agent_platform from agent order by name");
+    expect(agents.rows).toEqual([
+      { name: "LiveKit", agent_platform: "livekit" },
+      { name: "Retell", agent_platform: "retell" },
+    ]);
+
+    const columns = await client.query<{ is_nullable: string }>(
+      `select is_nullable from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'agent'
+          and column_name = 'agent_platform'`,
+    );
+    expect(columns.rows).toEqual([{ is_nullable: "NO" }]);
   });
 });


### PR DESCRIPTION
## What failed

PR #208 changed migration 0042 after the hosted test database had already recorded it. The API migration runner correctly refused the new hash during startup, so the deploy health check failed.

## Fix

- restore migration 0042 and its historical snapshots byte-for-byte
- add migration 0044 for the required `agent_platform` cutover
- normalize the shipped `livekit_agents` value to `livekit`
- pin the deployed 0042 hash and test the exact upgrade path

## Data requirement

0044 intentionally stops if an old agent still has a null platform. Reset those test agent rows before redeploy, as agreed for this pre-launch cutover.

## Proof

- focused regression: 3 passed
- complete Postgres and ClickHouse migration suites: 171 passed
- `pnpm build`
- `pnpm exec tsc -p tsconfig.tests.json`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790215082&installation_model_id=431960&pr_number=210&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F210&signature=98de5431acf2f84d4852f84460bb2638ccd9f1eb8b973b6708ad2fa34438afe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the deployed 0042 migration and historical snapshots, then performs the required agent-platform cutover in a new 0044 migration.

- Pins the immutable 0042 SHA-256 hash to prevent future history drift.
- Normalizes `livekit_agents` to `livekit` before enforcing a non-null platform and the canonical allowed values.
- Tests the intentional failure on unrecoverable null rows and the successful reset-and-upgrade path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intentional null-platform deployment prerequisite clearly documented and directly exercised by the migration tests.

The restored 0042 bytes match the pinned historical hash, the new snapshot lineage is consistent, and 0044 transactionally normalizes legacy values before enforcing the current schema contract.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/migrations/0042_agents_own_platform_monitoring.sql | Restores the deployed nullable, legacy-vocabulary migration bytes so recorded hashes remain valid. |
| packages/db/migrations/0044_require_agent_platform.sql | Moves normalization and required-platform enforcement into a new transactional migration with an intentional null-data hard stop. |
| packages/db/migrations/meta/0044_snapshot.json | Records the post-cutover non-null platform schema and correctly follows the 0043 snapshot. |
| packages/db/migrations/meta/_journal.json | Appends migration 0044 in the expected sequence. |
| packages/db/test/migrations.test.ts | Pins the historical 0042 hash and exercises both the blocked and successful 0044 upgrade paths. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[API startup] --> B[Validate applied migration hashes]
  B --> C[Apply restored 0042 history]
  C --> D[Apply 0043]
  D --> E[Apply 0044]
  E --> F[Normalize livekit_agents to livekit]
  F --> G{Null agent platforms remain?}
  G -->|Yes| H[Rollback 0044 and stop startup]
  G -->|No| I[Set NOT NULL and canonical CHECK]
  I --> J[Start API]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: move required platform to a new mig..."](https://github.com/egma-ai/egma/commit/4cd1f097ea77b683d19b3ae0c47eb32486171816) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56494855)</sub>

**Context used:**

- Knowledge Base — [Database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/database-persistence.md)

<!-- /greptile_comment -->