### PR TITLE
test: pin required platform for every agent

### DIFF
--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -590,6 +590,45 @@ describe("registering an agent", () => {
     expect(rows[0]).toEqual({ agents: "1", connections: "1" });
   });
 
+  it.each([
+    {
+      platform: "retell",
+      connection: registration().connection,
+    },
+    {
+      platform: "livekit",
+      connection: {
+        agentPlatform: "livekit",
+        connectionType: "livekit_room",
+        accessVariant: "livekit_room.project_credentials",
+        modality: "voice",
+        config: { url: "wss://acme.livekit.cloud" },
+        credentials: {
+          apiKey: "livekit-api-key-WXYZ",
+          apiSecret: "livekit-api-secret-WXYZ",
+        },
+      },
+    },
+  ])(
+    "requires the agent platform for $platform even when its first connection names one",
+    async ({ platform, connection }) => {
+      api = await createApi(`agents_register_requires_${platform}`);
+      const ada = await signUp(api.app, "ada@acme.example", "Acme");
+
+      const refused = await post("/v1/agents", withKey(ada.secret), {
+        name: "Agent without a declared platform",
+        connection,
+      });
+
+      expect(refused.status).toBe(400);
+      expect(refused.body).toEqual({
+        error: "invalid_request",
+        message: "an agent platform is required and must be retell or livekit",
+      });
+      expect(await agentRowCount()).toBe(0);
+    },
+  );
+
   it("leaves no agent behind when the connection payload is refused", async () => {
     api = await createApi("agents_all_or_nothing");
     const ada = await signUp(api.app, "ada@acme.example", "Acme");

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -703,7 +703,64 @@ describe("registering an agent", () => {
     });
   }
 
-  it("sends the name and the first way in, and nothing about the provider", async () => {
+  it("sends the required platform for a first Retell agent", async () => {
+    apiAnswers({
+      "/api/me": { status: 200, body: meWith("member") },
+      "/v1/connection-options": { status: 200, body: TYPES },
+      "/v1/agents": [
+        { status: 200, body: { agents: [], nextPageToken: null } },
+        { status: 201, body: { result: "created", agent: AGENT } },
+      ],
+      "/v1/agents:discover": {
+        status: 200,
+        body: {
+          agents: [
+            {
+              platformAgentId: "agent_voice_1",
+              name: "Appointment line",
+              connectionCandidates: [
+                {
+                  agentPlatform: "retell",
+                  connectionType: "phone_number",
+                  accessVariant: "phone_number.public_e164",
+                  modality: "voice",
+                  productLabel: "Retell phone",
+                  config: { phoneNumber: "+14155550100" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    render(<RegisterAgentPage />);
+
+    fireEvent.change(await screen.findByLabelText("Name"), {
+      target: { value: "Front desk" },
+    });
+    fireEvent.click(await screen.findByRole("radio", { name: "Voice" }));
+    fireEvent.change(await screen.findByLabelText("Retell API key"), {
+      target: { value: "retell-secret-A1B2C3D4WXYZ" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Load Retell agents" }));
+    await screen.findByLabelText("Retell agent");
+    fireEvent.click(screen.getByRole("button", { name: "Connect agent" }));
+
+    await waitFor(() => expect(sent).toHaveLength(2));
+    expect(sent[1]?.url).toBe("/v1/agents?projectId=prj_1");
+    expect(sent[1]?.body).toMatchObject({
+      name: "Front desk",
+      agentPlatform: "retell",
+      connection: {
+        agentPlatform: "retell",
+        connectionType: "phone_number",
+        accessVariant: "phone_number.public_e164",
+        modality: "voice",
+      },
+    });
+  });
+
+  it("sends the required platform for a first LiveKit agent", async () => {
     sheetAnswers(
       { status: 201, body: { result: "created", agent: AGENT } },
       { status: 200, body: { agents: [LISTED_AGENT], nextPageToken: null } },


### PR DESCRIPTION
## What
- prove first-agent registration sends the agent-level platform for both Retell and LiveKit
- prove the API refuses both Retell and LiveKit registrations when only the connection names the platform

## Decision
agentPlatform is a required property of every agent. It is not inferred from a connection and there is no compatibility path for the earlier request shape. The only supported values are retell and livekit.

The production error came from an already-loaded web bundle during the split deployment. The matching web bundle is now deployed. These tests pin the general rule across every platform Egma currently supports.

## Verification
- all 107 agent tests passed on the strict revision before this parameterization
- focused Retell and LiveKit API and web tests pass after the parameterization

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens agent-registration coverage for the required agent-level platform field.
- Verifies that API registrations are rejected when only the initial connection declares Retell or LiveKit.
- Verifies that the web registration flow sends the agent-level platform for both supported platforms.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/test/agents.test.ts | Adds parameterized API coverage confirming that connection-level platform data cannot substitute for the required agent-level field. |
| apps/web/test/agents-pages.test.tsx | Expands registration-page coverage to assert agent-level platform submission for both Retell and LiveKit. |

<sub>Reviews (4): Last reviewed commit: ["test: pin required platform for every ag..."](https://github.com/egma-ai/egma/commit/5cc0e99b07df96e78d33af6d43ed7b86c860c8c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56507512)</sub>

<!-- /greptile_comment -->