### PR TITLE
Fix LLM judge contract and default to Terra

### DIFF
--- a/apps/api/test/model-execution-agreement.test.ts
+++ b/apps/api/test/model-execution-agreement.test.ts
@@ -175,12 +175,18 @@ describe("one executable model catalog", () => {
       voiceId: RECOMMENDED_ENTRY.tts.recommendedVoiceId,
       speed: RECOMMENDED_ENTRY.tts.recommendedSpeed,
     });
-    const graderEntry = PROVIDER_CATALOG.find(
+    const graderDefaults = PROVIDER_CATALOG.filter(
       (entry) =>
         entry.job === "llm" &&
-        "graderEligible" in entry &&
-        entry.graderEligible === true,
+        "graderDefault" in entry &&
+        entry.graderDefault === true,
     );
+    expect(graderDefaults).toHaveLength(1);
+    const graderEntry = graderDefaults[0];
+    expect(graderEntry).toMatchObject({
+      graderEligible: true,
+      reasoningEffort: "none",
+    });
     expect(RECOMMENDED_GRADER_MODEL).toEqual({
       provider: graderEntry?.provider,
       model: graderEntry?.model,

--- a/apps/grader/src/graders/llm-as-judge.ts
+++ b/apps/grader/src/graders/llm-as-judge.ts
@@ -5,7 +5,10 @@ import { assertionResultOf } from "./judged.ts";
 const PROMPT = [
   "You grade one recorded conversation against one instruction.",
   "Decide only the instruction you are given.",
-  "Use cannot_determine when the evidence does not settle it.",
+  "Set decision to exactly one of met, not_met, or cannot_determine.",
+  "Use met when the evidence shows the instruction was met.",
+  "Use not_met when the evidence shows the instruction was not met.",
+  "Use cannot_determine when the evidence does not settle the instruction.",
   "Answer with JSON containing decision, rationale, and cited_turns.",
 ].join("\n");
 

--- a/apps/grader/src/judge/contract.ts
+++ b/apps/grader/src/judge/contract.ts
@@ -1,3 +1,5 @@
+import type { ReasoningEffort } from "@egma/db";
+
 import type { JudgeInput } from "./input.ts";
 
 /**
@@ -86,6 +88,8 @@ export type Judge = (question: JudgeQuestion) => Promise<JudgeAnswer>;
 export type ResolvedJudge = {
   readonly provider: "openai";
   readonly model: string;
+  /** Release-owned provider setting for this stored model pair. */
+  readonly reasoningEffort?: ReasoningEffort | undefined;
   readonly key: string;
 };
 

--- a/apps/grader/src/judge/index.ts
+++ b/apps/grader/src/judge/index.ts
@@ -1,4 +1,4 @@
-import type { GraderJudgeModel } from "@egma/db";
+import { catalogEntry, type GraderJudgeModel } from "@egma/db";
 import {
   credentialFor,
   type ProviderCredentialBundle,
@@ -43,9 +43,18 @@ export function judgeFor(
       `grader model provider ${model.provider} has no judge adapter in this release`,
     );
   }
+  const entry = catalogEntry("llm", model.provider, model.model);
+  if (entry === undefined || entry.graderEligible !== true) {
+    throw new Error(
+      `grader model ${model.provider}/${model.model} is absent from this release's judge catalog`,
+    );
+  }
   const resolved: ResolvedJudge = {
     provider: model.provider,
     model: model.model,
+    ...(entry.reasoningEffort === undefined
+      ? {}
+      : { reasoningEffort: entry.reasoningEffort }),
     key: credentialFor(credentials, model.provider),
   };
   return { ask: makers[model.provider](resolved) };

--- a/apps/grader/src/judge/openai.ts
+++ b/apps/grader/src/judge/openai.ts
@@ -63,6 +63,9 @@ export function openaiJudge(judge: ResolvedJudge): Judge {
   return async (question: JudgeQuestion): Promise<JudgeAnswer> => {
     const body = JSON.stringify({
       model: judge.model,
+      ...(judge.reasoningEffort === undefined
+        ? {}
+        : { reasoning_effort: judge.reasoningEffort }),
       // The lowest the API allows, because the same conversation and the same
       // criterion should get the same answer twice. It is not a guarantee —
       // no model offers one — and it is the difference between a judgment that

--- a/apps/grader/src/judge/openai.ts
+++ b/apps/grader/src/judge/openai.ts
@@ -24,6 +24,25 @@ import { asJudgeReads } from "./input.ts";
 
 const OPENAI_CHAT_COMPLETIONS = "https://api.openai.com/v1/chat/completions";
 
+/** Make the provider enforce the fixed judge answer contract before parsing. */
+const JUDGE_RESPONSE_FORMAT = {
+  type: "json_schema",
+  json_schema: {
+    name: "egma_judge_answer",
+    strict: true,
+    schema: {
+      type: "object",
+      properties: {
+        decision: { type: "string", enum: DECISIONS },
+        rationale: { type: "string" },
+        cited_turns: { type: "array", items: { type: "integer" } },
+      },
+      required: ["decision", "rationale", "cited_turns"],
+      additionalProperties: false,
+    },
+  },
+} as const;
+
 /**
  * How many times a call is made before the assertion is `errored`.
  *
@@ -49,7 +68,7 @@ export function openaiJudge(judge: ResolvedJudge): Judge {
       // no model offers one — and it is the difference between a judgment that
       // usually reproduces and one that never does.
       temperature: 0,
-      response_format: { type: "json_object" },
+      response_format: JUDGE_RESPONSE_FORMAT,
       messages: [
         // The library entry's own words, handed down with the question. This
         // file holds no prompt of its own: what a judge is told it is is

--- a/apps/grader/test/live-openai.test.ts
+++ b/apps/grader/test/live-openai.test.ts
@@ -1,8 +1,7 @@
 import { GRADER_DEFINITION_CATALOG, PREDEFINED_GRADERS } from "@egma/db";
 import { describe, expect, it } from "vitest";
 
-import { openaiJudge } from "../src/judge/openai.ts";
-import type { JudgeInput } from "../src/judge/index.ts";
+import { judgeFor, type JudgeInput } from "../src/judge/index.ts";
 
 /**
  * One real question put to a real OpenAI judge — opt-in.
@@ -19,10 +18,11 @@ import type { JudgeInput } from "../src/judge/index.ts";
  *
  *     TEST_OPENAI_API_KEY=sk-... npx vitest run apps/grader/test/live-openai
  *
- * `TEST_OPENAI_MODEL` picks the model; the default is the model in the shipped
- * Expected behaviors definition. Nothing here touches a database or service:
- * one function, one request, one answer, so the pass-with-key path is as small
- * as it can be and a failure names the provider rather than the harness.
+ * The model is the model in the shipped Expected behaviors definition. The
+ * test does not accept a second model setting: it proves the exact release
+ * default and its provider settings rather than a test-only substitute.
+ * Nothing here touches a database or service: one function, one request, one
+ * answer, so a failure names the provider rather than the harness.
  */
 
 /**
@@ -44,8 +44,6 @@ if (
 }
 
 const API_KEY = process.env["TEST_OPENAI_API_KEY"]?.trim() ?? "";
-const MODEL = process.env["TEST_OPENAI_MODEL"]?.trim() ??
-  EXPECTED_BEHAVIORS.judgeModel.model;
 const THE_PROMPT = EXPECTED_BEHAVIORS.prompt;
 
 /** One short conversation, plainly settling one thing and plainly not another. */
@@ -65,7 +63,10 @@ const EVIDENCE: JudgeInput = {
 describe.skipIf(API_KEY === "")(
   "a real OpenAI judge, asked one criterion",
   () => {
-    const judge = openaiJudge({ provider: "openai", model: MODEL, key: API_KEY });
+    const judge = judgeFor(
+      EXPECTED_BEHAVIORS.judgeModel,
+      { openai: API_KEY },
+    ).ask;
 
     it("answers met, with a reason and a turn it rests on", async () => {
       const answer = await judge({

--- a/apps/grader/test/live-openai.test.ts
+++ b/apps/grader/test/live-openai.test.ts
@@ -19,14 +19,11 @@ import type { JudgeInput } from "../src/judge/index.ts";
  *
  *     TEST_OPENAI_API_KEY=sk-... npx vitest run apps/grader/test/live-openai
  *
- * `TEST_OPENAI_MODEL` picks the model; the default is the cheapest one that can
- * hold a judgment. Nothing here touches a database, a store, or the service:
+ * `TEST_OPENAI_MODEL` picks the model; the default is the model in the shipped
+ * Expected behaviors definition. Nothing here touches a database or service:
  * one function, one request, one answer, so the pass-with-key path is as small
  * as it can be and a failure names the provider rather than the harness.
  */
-
-const API_KEY = process.env["TEST_OPENAI_API_KEY"]?.trim() ?? "";
-const MODEL = process.env["TEST_OPENAI_MODEL"]?.trim() ?? "gpt-4.1-mini";
 
 /**
  * The words a real judge is told it is working under: the ones on the
@@ -34,10 +31,22 @@ const MODEL = process.env["TEST_OPENAI_MODEL"]?.trim() ?? "gpt-4.1-mini";
  * ships lives. Asking a real model with anything else would be smoke-testing a
  * prompt no deployment sends.
  */
-const THE_PROMPT =
+const EXPECTED_BEHAVIORS =
   GRADER_DEFINITION_CATALOG.find(
     (entry) => entry.id === PREDEFINED_GRADERS.expectedBehaviors,
-  )?.prompt ?? "";
+  );
+if (
+  EXPECTED_BEHAVIORS?.prompt === null ||
+  EXPECTED_BEHAVIORS?.prompt === undefined ||
+  EXPECTED_BEHAVIORS.judgeModel === null
+) {
+  throw new Error("Expected behaviors has no executable judge definition");
+}
+
+const API_KEY = process.env["TEST_OPENAI_API_KEY"]?.trim() ?? "";
+const MODEL = process.env["TEST_OPENAI_MODEL"]?.trim() ??
+  EXPECTED_BEHAVIORS.judgeModel.model;
+const THE_PROMPT = EXPECTED_BEHAVIORS.prompt;
 
 /** One short conversation, plainly settling one thing and plainly not another. */
 const EVIDENCE: JudgeInput = {

--- a/apps/grader/test/live-openai.test.ts
+++ b/apps/grader/test/live-openai.test.ts
@@ -35,10 +35,12 @@ const EXPECTED_BEHAVIORS =
   GRADER_DEFINITION_CATALOG.find(
     (entry) => entry.id === PREDEFINED_GRADERS.expectedBehaviors,
   );
+const JUDGE_MODEL = EXPECTED_BEHAVIORS?.judgeModel;
 if (
   EXPECTED_BEHAVIORS?.prompt === null ||
   EXPECTED_BEHAVIORS?.prompt === undefined ||
-  EXPECTED_BEHAVIORS.judgeModel === null
+  JUDGE_MODEL === null ||
+  JUDGE_MODEL === undefined
 ) {
   throw new Error("Expected behaviors has no executable judge definition");
 }
@@ -64,7 +66,7 @@ describe.skipIf(API_KEY === "")(
   "a real OpenAI judge, asked one criterion",
   () => {
     const judge = judgeFor(
-      EXPECTED_BEHAVIORS.judgeModel,
+      JUDGE_MODEL,
       { openai: API_KEY },
     ).ask;
 

--- a/apps/grader/test/llm-as-judge.test.ts
+++ b/apps/grader/test/llm-as-judge.test.ts
@@ -89,6 +89,9 @@ describe("a customer LLM grader", () => {
       },
     });
     expect(scripted.judge.asked).toHaveLength(1);
+    expect(scripted.judge.asked[0]?.prompt).toContain(
+      "met, not_met, or cannot_determine",
+    );
     expect(scripted.judge.asked[0]?.criterion).toBe(INSTRUCTIONS);
   });
 

--- a/apps/grader/test/openai-judge.test.ts
+++ b/apps/grader/test/openai-judge.test.ts
@@ -108,7 +108,29 @@ describe("one judge call", () => {
     // The same conversation and the same criterion should get the same decision
     // twice, as far as a model can promise that at all.
     expect(body["temperature"]).toBe(0);
-    expect(body["response_format"]).toEqual({ type: "json_object" });
+    expect(body["response_format"]).toEqual({
+      type: "json_schema",
+      json_schema: {
+        name: "egma_judge_answer",
+        strict: true,
+        schema: {
+          type: "object",
+          properties: {
+            decision: {
+              type: "string",
+              enum: ["met", "not_met", "cannot_determine"],
+            },
+            rationale: { type: "string" },
+            cited_turns: {
+              type: "array",
+              items: { type: "integer" },
+            },
+          },
+          required: ["decision", "rationale", "cited_turns"],
+          additionalProperties: false,
+        },
+      },
+    });
   });
 
   it("shows the judge the one criterion and the declared set, and nothing else", async () => {
@@ -121,8 +143,10 @@ describe("one judge call", () => {
     const body = JSON.parse(String(calls[0]?.init.body)) as {
       messages: { role: string; content: string }[];
     };
+    const declared = body.messages.at(0)?.content ?? "";
     const asked = body.messages.at(-1)?.content ?? "";
 
+    expect(declared).toContain("met, not_met, or cannot_determine");
     expect(asked).toContain("## Criterion");
     expect(asked).toContain("the agent confirms the new time");
     expect(asked).toContain("## Transcript");

--- a/apps/grader/test/openai-judge.test.ts
+++ b/apps/grader/test/openai-judge.test.ts
@@ -1,9 +1,18 @@
+import {
+  GRADER_DEFINITION_CATALOG,
+  PREDEFINED_GRADERS,
+  RECOMMENDED_GRADER_MODEL,
+} from "@egma/db";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { GRADER_DEFINITION_CATALOG, PREDEFINED_GRADERS } from "@egma/db";
-
+import {
+  judgeFor,
+  type Judge,
+  type JudgeInput,
+  type JudgeQuestion,
+  type ResolvedJudge,
+} from "../src/judge/index.ts";
 import { openaiJudge } from "../src/judge/openai.ts";
-import type { JudgeInput, JudgeQuestion } from "../src/judge/index.ts";
 
 /**
  * The OpenAI provider's wire, without the wire.
@@ -80,7 +89,12 @@ function judgeWith(...responses: readonly Answering[]) {
 
   return {
     calls,
-    judge: openaiJudge({ provider: "openai", model: "gpt-4.1-mini", key: A_KEY }),
+    judge: openaiJudge({
+      provider: "openai",
+      model: "gpt-5.6-terra",
+      reasoningEffort: "none",
+      key: A_KEY,
+    }),
   };
 }
 
@@ -104,7 +118,8 @@ describe("one judge call", () => {
     expect(headers["authorization"]).toBe(`Bearer ${A_KEY}`);
 
     const body = JSON.parse(String(calls[0]?.init.body)) as Record<string, unknown>;
-    expect(body["model"]).toBe("gpt-4.1-mini");
+    expect(body["model"]).toBe("gpt-5.6-terra");
+    expect(body["reasoning_effort"]).toBe("none");
     // The same conversation and the same criterion should get the same decision
     // twice, as far as a model can promise that at all.
     expect(body["temperature"]).toBe(0);
@@ -131,6 +146,33 @@ describe("one judge call", () => {
         },
       },
     });
+  });
+
+  it("resolves the release default and its provider settings from one catalog entry", () => {
+    const configured: ResolvedJudge[] = [];
+    const neverAsked: Judge = async () => {
+      throw new Error("this test only resolves the judge");
+    };
+
+    judgeFor(
+      RECOMMENDED_GRADER_MODEL,
+      { openai: A_KEY },
+      {
+        openai(resolved) {
+          configured.push(resolved);
+          return neverAsked;
+        },
+      },
+    );
+
+    expect(configured).toEqual([
+      {
+        provider: "openai",
+        model: "gpt-5.6-terra",
+        reasoningEffort: "none",
+        key: A_KEY,
+      },
+    ]);
   });
 
   it("shows the judge the one criterion and the declared set, and nothing else", async () => {

--- a/packages/db/src/grader-library/catalog.ts
+++ b/packages/db/src/grader-library/catalog.ts
@@ -48,7 +48,10 @@ export const NORMALIZED_GRADE_OUTPUT_CONTRACT: GraderOutputContract = {
 const EXPECTED_BEHAVIORS_PROMPT = [
   "You grade one expected behavior against one recorded simulation.",
   "Decide only the expected behavior you are given.",
-  "Use cannot_determine when the evidence does not settle it.",
+  "Set decision to exactly one of met, not_met, or cannot_determine.",
+  "Use met when the evidence shows the expected behavior happened.",
+  "Use not_met when the evidence shows the expected behavior did not happen.",
+  "Use cannot_determine when the evidence does not settle the expected behavior.",
   "Answer with JSON containing decision, rationale, and cited_turns.",
 ].join("\n");
 

--- a/packages/db/src/models/catalog.ts
+++ b/packages/db/src/models/catalog.ts
@@ -46,6 +46,8 @@ export type ReasoningEffort = "none";
 type LlmPolicy = {
   /** This release may use the entry for an LLM-as-judge grader. */
   readonly graderEligible?: true;
+  /** New LLM grader versions copy this model. Exactly one entry owns it. */
+  readonly graderDefault?: true;
   /** Fixed execution value. Absent when the model has no reasoning mode. */
   readonly reasoningEffort?: ReasoningEffort;
 };
@@ -97,6 +99,8 @@ export const PROVIDER_CATALOG = [
     model: "gpt-5.6-terra",
     adapter: "openai_chat_completions",
     label: "OpenAI",
+    graderEligible: true,
+    graderDefault: true,
     reasoningEffort: "none",
   },
   {

--- a/packages/db/src/models/selections.ts
+++ b/packages/db/src/models/selections.ts
@@ -198,11 +198,17 @@ export const RECOMMENDED_PERSONA_MODELS: PersonaModels = {
 };
 
 function recommendedGraderModel(): GraderModel {
-  const entry = PROVIDERS_BY_JOB.llm.find(
-    (candidate) => candidate.graderEligible === true,
+  const defaults = PROVIDERS_BY_JOB.llm.filter(
+    (candidate) => candidate.graderDefault === true,
   );
-  if (entry === undefined) {
-    throw new Error("the provider catalog ships no grader-eligible LLM");
+  if (defaults.length !== 1) {
+    throw new Error(
+      `the provider catalog must ship exactly one default grader LLM; found ${defaults.length}`,
+    );
+  }
+  const entry = defaults[0];
+  if (entry === undefined || entry.graderEligible !== true) {
+    throw new Error("the default grader LLM must also be grader-eligible");
   }
   return { provider: entry.provider, model: entry.model };
 }

--- a/packages/db/test/model-selections.test.ts
+++ b/packages/db/test/model-selections.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderCatalogEntry,
 } from "../src/models/catalog.ts";
 import {
+  RECOMMENDED_GRADER_MODEL,
   RECOMMENDED_PERSONA_MODELS,
   SPEED_RANGE,
   personaModelsFromRow,
@@ -177,10 +178,17 @@ describe("one complete persona model selection", () => {
     },
   );
 
-  it("does not expand the separate grader model policy", () => {
+  it("uses Terra for new graders while old frozen grader models stay readable", () => {
+    expect(RECOMMENDED_GRADER_MODEL).toEqual({
+      provider: "openai",
+      model: "gpt-5.6-terra",
+    });
     expect(
       validGraderModel({ provider: "openai", model: "gpt-4o-mini" }),
     ).toEqual({ provider: "openai", model: "gpt-4o-mini" });
+    expect(
+      validGraderModel({ provider: "openai", model: "gpt-5.6-terra" }),
+    ).toEqual({ provider: "openai", model: "gpt-5.6-terra" });
     expect(() =>
       validGraderModel({ provider: "openai", model: "gpt-4o" }),
     ).toThrow(/supported grader model/i);


### PR DESCRIPTION
## What changed

- Tell Expected behaviors and customer-created LLM judges to return exactly `met`, `not_met`, or `cannot_determine`.
- Make OpenAI enforce the complete answer with a strict JSON Schema.
- Make `gpt-5.6-terra` the one catalog-defined default for new LLM grader versions.
- Resolve Terra's `reasoning_effort: none` from that same catalog entry at execution.
- Keep `gpt-4o-mini` supported only so frozen historical grader versions remain executable.

## Why

A production grading run completed, but every assertion became an error grade. The model returned valid JSON with a decision outside Egma's accepted set. The prompt did not name the accepted values, while the parser required them exactly.

The grader model was also inherited from an old eligibility marker instead of an explicit release default. The provider catalog now owns that decision in one place.

## Version behavior

On deployment, the existing catalog reconciler creates one new immutable Expected behaviors definition version with the corrected prompt and Terra. Future runs pin that version. Already-frozen runs and existing organization-owned custom grader versions keep their stored model. New customer-created LLM graders use Terra.

No database migration, UI change, or generated-client change is needed.

## Verification

- A real OpenAI call passed against `gpt-5.6-terra` using the exact shipped Expected behaviors prompt, strict schema, `reasoning_effort: none`, and `temperature: 0`.
- Focused tests: 41 passed; the 2 opt-in live tests skipped when no key was present.
- Local lint, test typecheck, and the DB, API, and grader builds passed.
- Every required CI lane passed on `122fb236`.
- Greptile reviewed the latest commit with 5/5 confidence and no review thread.
- Independent review found no actionable issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790237711&installation_model_id=431960&pr_number=215&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F215&signature=6e8565538668ef662a1e8e1d84b699de51ec7d8bbc3a1b84d69bf90976693f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores the LLM judge decision contract and aligns release-owned model configuration with judge execution.
- Explicitly limits judge decisions to `met`, `not_met`, or `cannot_determine`.
- Replaces OpenAI JSON mode with a strict schema for the complete judge response.
- Selects one catalog-defined default grader model and forwards its reasoning setting.
- Updates unit, catalog, and opt-in live-provider coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/grader/src/judge/openai.ts | Replaces generic JSON mode with a strict judge-answer schema and forwards the catalog-owned reasoning effort. |
| apps/grader/src/judge/index.ts | Validates selected judge models against the release catalog and resolves their provider settings. |
| apps/grader/src/graders/llm-as-judge.ts | Explicitly communicates the accepted decision vocabulary to customer-defined LLM judges. |
| packages/db/src/grader-library/catalog.ts | Updates the Expected behaviors prompt while preserving immutable catalog-version reconciliation semantics. |
| packages/db/src/models/catalog.ts | Marks the release-owned eligible default grader model and its fixed reasoning configuration. |
| packages/db/src/models/selections.ts | Requires exactly one eligible catalog entry to own the default grader-model designation. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Catalog default grader model] --> B[judgeFor]
  B --> C[Resolve eligible model and provider settings]
  C --> D[OpenAI judge request]
  E[Expected behavior or customer criterion] --> D
  D --> F[Strict JSON Schema response]
  F --> G[Validate decision and answer shape]
  G --> H[Passed, failed, or skipped assertion]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(grader): keep live model selection ..."](https://github.com/egma-ai/egma/commit/122fb23679ce75705a8b0c80ad6026d5ed056bfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56572779)</sub>

**Context used:**

- Knowledge Base — [Grading and judgments](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/grading-and-judgments.md)
- Knowledge Base — [Database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/database-persistence.md)

<!-- /greptile_comment -->