### PR TITLE
fix(monitoring): the transcript status mark drops its stale round intent

### DIFF
--- a/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx
@@ -427,14 +427,21 @@ export default function TranscriptPage({
               </span>
               <Badge variant={errored > 0 ? "failure" : "success"}>
                 {/*
-                  The dot the hand-drawn chip carried as `::before`, kept. It is
-                  `bg-current` and the same circle either way, so it separates
-                  nothing on its own — `Recorded` and `1 error` are what say which
-                  state this is. It is the chip's mark, not its meaning.
+                  The mark the hand-drawn chip carried as `::before`, kept —
+                  and **a square, not a dot**. Every status marker in the
+                  product is a square (`DESIGN.md`, developer decision
+                  2026-08-24): it follows the one-radius rule rather than
+                  sitting outside it, and it keeps the single round shape left
+                  in the system meaning one thing, a radio button.
+
+                  It is `bg-current` and the same square either way, so it
+                  separates nothing on its own — `Recorded` and `1 error` are
+                  what say which state this is. It is the chip's mark, not its
+                  meaning.
                 */}
                 <span
                   aria-hidden="true"
-                  className="size-1.5 shrink-0 rounded-chip bg-current"
+                  className="size-1.5 shrink-0 bg-current"
                 />
                 {errored === 0 ? DETAIL.recorded : DETAIL.errors(errored)}
               </Badge>


### PR DESCRIPTION
Follow-up to #216, one commit. The transcript detail's state mark carried `rounded-chip` and a comment calling it a circle — the one-radius rule already renders it square, so the class stated an intent the design system no longer allows (and it would go round again the day `--radius-pill` got a value back). Dropped the class, corrected the comment, same treatment ticket 01 gave the evidence timeline marker. No pixel difference expected.

Tests: apps/web/test/transcript-detail.test.tsx + monitoring.test.tsx — 58 passed; pnpm typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790242134&installation_model_id=431960&pr_number=219&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F219&signature=5632d5cfc910d730b552b81fa2e1e67ce81bdeed00b60b33ec99ac9240f819e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the stale `rounded-chip` class from the transcript status marker and updates its explanatory comment to document the intended square shape.
- Keeps the status marker aligned with the design system’s one-radius rule.
- Does not alter transcript status logic, content, accessibility, or data flow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The change is limited to the intended shape of a decorative, aria-hidden status marker and leaves status behavior, semantics, and accessibility unchanged.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx | Removes a border-radius utility from an aria-hidden decorative marker and updates the adjacent documentation; no actionable defect identified. |

<sub>Reviews (1): Last reviewed commit: ["style(monitoring): square the transcript..."](https://github.com/egma-ai/egma/commit/0e3ef97c9fa5fa447dc2082d5a6cb86bd625db7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56590560)</sub>

<!-- /greptile_comment -->