### PR TITLE
test(browser): the register walk meets the query-state connect flow

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2555,14 +2555,22 @@ describe("the complete product, walked in order in a second project", () => {
       await saysWithin(walk, "No agents in this project yet");
 
       /*
-       * **One panel does both halves.** The agent and its first way in used to
-       * be two pages with a forward between them, and an agent that never
-       * reached the second one sat in the list unreachable. `/agents/new` is
-       * still the address — the CLI and the documentation print it — and what
-       * it opens is the side sheet over this list.
+       * **One panel does both halves, and opening it is not a navigation.**
+       * The agent and its first way in used to be two pages with a forward
+       * between them, and an agent that never reached the second one sat in
+       * the list unreachable. Now the control changes query state on the
+       * address the person is already at (founder ruling, 2026-08-24) — it no
+       * longer sends the browser to `/agents/new`, which is why this used to
+       * wait for that address and time out.
+       *
+       * `/agents/new` is still an address and still opens this panel; the
+       * copied-link table below is where that promise is checked, because that
+       * is what a link in the CLI or the documentation actually does.
        */
       await walk.getByRole("link", { name: "Connect an agent" }).first().click();
-      await walk.waitForURL(new RegExp(`/projects/${second}/agents/new$`));
+      await walk.waitForURL(
+        new RegExp(`/projects/${second}/agents\\?sheet=connect$`),
+      );
       await reactHasTakenOver(walk, "form");
 
       // One field for the agent, and the shortness is the product's decision:
@@ -2623,8 +2631,19 @@ describe("the complete product, walked in order in a second project", () => {
        * agent page is retired (founder ruling, 2026-08-24): everything it held
        * is on the row behind the panel, so a save that navigated would be
        * taking somebody away from what they just made.
+       *
+       * **What is waited for is the outcome, not a navigation.** Closing is a
+       * query-state change on the address the panel was opened over, so there
+       * is no load to wait for: the panel goes, the row arrives, and the
+       * address settles back to the bare list. Waiting on any one of the three
+       * alone would pass while the other two had not happened.
        */
-      await walk.waitForURL(new RegExp(`/projects/${second}/agents$`));
+      await expect
+        .poll(() => walk.getByRole("dialog").count(), { timeout: 30_000 })
+        .toBe(0);
+      await expect
+        .poll(() => walk.url(), { timeout: 30_000 })
+        .toMatch(new RegExp(`/projects/${second}/agents$`));
       await saysWithin(walk, "The Support line");
       await saysWithin(walk, "Retell staging");
 
@@ -2693,8 +2712,16 @@ describe("the complete product, walked in order in a second project", () => {
        * address is asserted as well as the words, because "it says the agent's
        * name" would also be true of the page that used to be here.
        */
-      await walk.goto(agentAddress);
-      await walk.waitForURL(new RegExp(`/projects/${second}/agents$`));
+      /*
+       * `commit` rather than `load`: this address answers with a redirect, so
+       * what is being waited for is where it lands, not the paint of a page
+       * that was never going to be drawn. The two assertions under it are the
+       * arrival, and they are the ones worth failing on.
+       */
+      await walk.goto(agentAddress, { waitUntil: "commit", timeout: 60_000 });
+      await walk.waitForURL(new RegExp(`/projects/${second}/agents$`), {
+        timeout: 60_000,
+      });
       await saysWithin(walk, "The Support line");
       expect(
         await walk.getByRole("table", { name: "Agents in this project" }).count(),
@@ -2713,8 +2740,7 @@ describe("the complete product, walked in order in a second project", () => {
        * **The row names the agent as plain text, and its ⋮ is the way in.**
        * This list is the one agent screen (`6ZJ-0`), so the name is a name
        * rather than a link, and the underline on this row belongs to the
-       * connections alone. Open agent still carries the address the panel
-       * landed on.
+       * connections alone — there is no page behind the name to promise.
        */
       const named = walk
         .locator('table[aria-label="Agents in this project"] tbody tr')


### PR DESCRIPTION
Fixes the final PR's browser-lane failure. The walk clicked "Connect an agent" and waited for `/agents/new` — an address the button no longer visits (it is a query-state link now), so the wait expired before the save and the whole sequential journey cascaded.

Changes (one file, +37/−11): the open waits for `?sheet=connect`; the post-save wait is three outcomes (dialog gone, URL settled on the bare list, row present); the retired agent address `goto`s with `waitUntil: "commit"` since it answers with a redirect; two stale comments corrected. Swept the journey — no other expectation of the class (the grid and monitoring steps were already written for their new realities).

Local evidence, stated plainly: the register step and its dependents dropped out of the failure list across two clean local runs (24 → 17 failures, the remainder being `page.goto` timeouts on untouched plain routes — dev-server compile latency on a loaded laptop, with `next build` exiting 0). The full-journey verdict belongs to this repo's clean CI runner on the final PR, where the browser lane runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790264218&installation_model_id=431960&pr_number=221&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F221&signature=14cfdbdd2ac3a2fb73ee752bd5ad796b47dfa8e91476fa65cf4ab1c3b401c329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the sequential browser journey to match the agents UI’s query-state connect flow and retired-agent redirect behavior.

- Waits for the connect sheet at `?sheet=connect` rather than the obsolete `/agents/new` navigation.
- Verifies post-save dialog closure, canonical list URL, and rendered agent data.
- Uses commit-level navigation when exercising the server-redirected retired agent address.
- Corrects comments describing the current agents experience.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the revised waits align with the current query-state and server-redirect behavior while retaining content-level outcome checks.

The connect link has the asserted query URL, successful registration is followed by checks for sheet closure, URL cleanup, and refreshed row content, and the retired agent route redirects server-side to the destination subsequently asserted by the test.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/test/browser.test.ts | Updates browser-test synchronization to reflect query-driven sheets and a server-redirected compatibility route; no actionable defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["test(browser): the walk waits for the pa..."](https://github.com/egma-ai/egma/commit/73b669eb82dfee86f3dc60ee21b6be3b9bcb5c60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56702797)</sub>

<!-- /greptile_comment -->