### PR TITLE
test(browser): the walk meets the redirecting alias and the moved suite menu

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -3221,6 +3221,17 @@ describe("the complete product, walked in order in a second project", () => {
      * arriving is proved rather than assumed.
      */
     readonly says: string;
+    /**
+     * Where this address ends up, when that is not itself.
+     *
+     * **Only a retired address carries one.** A page that still exists lands
+     * on its own address, and saying so is half of what this table checks — so
+     * the equality below reads this field rather than being loosened, and a
+     * row that quietly stopped arriving cannot pass by having its expectation
+     * relaxed. A redirect is a promise of its own: the address goes on
+     * working, and it is honest about where it took you.
+     */
+    readonly lands?: string;
   };
 
   /**
@@ -3257,13 +3268,20 @@ describe("the complete product, walked in order in a second project", () => {
         says: "Its name in Egma",
       },
       /*
-       * **A retired address, kept in the table on purpose.** It redirects to
-       * the agents list, so what settles is the list — and the phrase is the
-       * agent's name, which the list says on its row. It stays listed because
-       * a copied link to it must keep arriving somewhere, and this table is
-       * where that promise is checked.
+       * **A retired address, kept in the table on purpose.** The agent page is
+       * gone and this address redirects to the agents list, so it lands
+       * somewhere other than itself — which is what `lands` is for. The phrase
+       * is the agent's name, which the list says on its row.
+       *
+       * It stays listed because a copied link to it must keep arriving
+       * somewhere, and this table is where that promise is checked.
        */
-      { what: "one agent", address: agentAddress, says: "The Support line" },
+      {
+        what: "one agent",
+        address: agentAddress,
+        lands: at("agents"),
+        says: "The Support line",
+      },
       {
         what: "Add a connection",
         address: `${agentAddress}/connections/new`,
@@ -3551,7 +3569,7 @@ describe("the complete product, walked in order in a second project", () => {
             await opened.setViewportSize({ width: 1280, height: 900 });
             await opened.goto(route.address);
             await landedOn(opened, route);
-            expect(opened.url(), route.what).toBe(route.address);
+            expect(opened.url(), route.what).toBe(route.lands ?? route.address);
 
             if (index === 0) {
               const sidebar = opened.locator("aside");
@@ -4657,10 +4675,19 @@ describe("the complete product, walked in order in a second project", () => {
       await walk.goto(suiteAddress);
       await saysWithin(walk, "Reschedules a booked appointment");
 
-      // Renaming and deleting a suite live in the suite's own ⋮ menu now, and
-      // the rename surface is a side sheet named by the suite it is about.
-      await walk.getByRole("button", { name: "Open the suite menu" }).click();
-      await walk.getByRole("menuitem", { name: "Rename suite" }).click();
+      /*
+       * **Managing a suite lives on the suites list, not inside the suite.**
+       * The suite screen's toolbar ⋮ went with the 2026-08-24 rework: that
+       * screen is the tests grid now, and its toolbar carries only "Write a
+       * test". Rename and Delete are on the row, where the suite is a thing
+       * among other things rather than the page you are standing in.
+       */
+      await walk.goto(at("tests"));
+      await saysWithin(walk, "Support reception");
+      await walk
+        .getByRole("button", { name: "Open the menu for Support reception" })
+        .click();
+      await walk.getByRole("menuitem", { name: "Rename", exact: true }).click();
       const rename = walk.getByRole("dialog", {
         name: "Support reception",
       });
@@ -4675,6 +4702,7 @@ describe("the complete product, walked in order in a second project", () => {
       await rename.getByRole("button", { name: "Save name" }).click();
       const renamed = await renameResponse;
       expect(renamed.status(), await renamed.text()).toBe(200);
+      // The row carries the new name, on the list the rename was made from.
       await saysWithin(walk, "Northside Ford");
 
       // A run reads the suite's current name. Renaming does not create a suite
@@ -4685,9 +4713,12 @@ describe("the complete product, walked in order in a second project", () => {
       expect(await summary.innerText()).not.toContain("Support reception");
       expect(await summary.innerText()).not.toContain("(deleted)");
 
-      await walk.goto(suiteAddress);
+      // And deleting is the same row's menu, under the same hairline.
+      await walk.goto(at("tests"));
       await saysWithin(walk, "Northside Ford");
-      await walk.getByRole("button", { name: "Open the suite menu" }).click();
+      await walk
+        .getByRole("button", { name: "Open the menu for Northside Ford" })
+        .click();
       await walk.getByRole("menuitem", { name: "Delete suite" }).click();
       const deletion = walk.getByRole("dialog", {
         name: "Delete Northside Ford?",


### PR DESCRIPTION
Fixes the final PR's two remaining browser-lane failures, both pre-rework expectations (one file, +44/−13).

1. The copied-link table's "one agent" row: the retired agent address redirects to the agents list by design, so the checker's URL equality failed. `ProductRoute` gains an optional `lands` field — where an address ends up when that is not itself — and the equality reads `lands ?? address`. Only the redirect row carries one; every normal row still must land on its own address, so the check is not weakened.
2. The suite rename/delete step waited for the toolbar ⋮ the rework removed. The step now walks the real UI: the suites list row menu (accessible names read off the components — `Open the menu for …`, `Rename`, `Delete suite`, dialog `Delete …?`). Every run-survival assertion is intact: the run summary keeps the old name, the DELETE is asserted 204, and the list ends on the truthful empty state.

Verified by reading the UI code; `tsc -p tsconfig.tests.json` clean. The browser lane runs on the final PR's clean runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790268433&installation_model_id=431960&pr_number=222&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F222&signature=ff424d4c4fe9cffb312235c2dda7c755de48aeadf05639c3c17445d339b55942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the browser walk to recognize the retired agent-detail redirect and to manage suite rename/deletion through the current suites-list row menu.
- Adds an explicit redirect destination to the retired agent route fixture while preserving strict URL checks for all other routes.
- Updates accessible selectors and navigation for suite rename and deletion.
- Retains assertions that historical run evidence survives suite rename and deletion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the revised expectations match the current redirect and suite-list UI behavior.

The redirect target exactly matches the new expected landing URL, and the suite rename/delete selectors align with the accessible roles, labels, dialog names, and asynchronous list refresh behavior exposed by the current components.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/test/browser.test.ts | Updates browser-test expectations and suite-management interactions consistently with the current redirect and accessible UI contracts; no actionable defect found. |

<sub>Reviews (1): Last reviewed commit: ["test(browser): a retired address says wh..."](https://github.com/egma-ai/egma/commit/3c7b69ce6ce8c9f836bcb95cbe3d1fc49f93409e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56732220)</sub>

**Context used:**

- Knowledge Base — [Operator workflows](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/operator-workflows.md)
- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->