### PR TITLE
fix(tests): different cells save concurrently; no second edit is dropped

### DIFF
--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -655,6 +655,34 @@ export function TestsGrid(props: GridProps) {
    * refuses is the same cell twice — an Enter followed by the blur it causes.
    */
   const inFlight = useRef<Set<string>>(new Set());
+  /**
+   * The tail of each test's queue, so one test's saves happen in order.
+   *
+   * **Two cells of the same test cannot go at once, and the reason is the
+   * version guard.** A content edit carries the version it was read at, so two
+   * content cells committed together would carry the *same* one: the first
+   * mints a new version and the second is refused for holding the version it
+   * has just replaced. That refusal would be about nothing a person did, and if
+   * the caret had already moved it would have nowhere to be shown — an edit
+   * gone with no request left standing and no sentence, which is the one thing
+   * this grid promises never to do.
+   *
+   * Different tests keep no queue between them: their guards are separate rows,
+   * so they are independent by construction and run side by side.
+   */
+  const queued = useRef<Map<string, Promise<void>>>(new Map());
+  /**
+   * The newest version and revision egma has answered with, per test.
+   *
+   * A queued save reads its guard from here at the moment it is sent rather
+   * than from the render that started it, so the save in front of it hands the
+   * one behind it the version it just minted. `onSaved` writes the same answer
+   * into the screen's state; this is the copy that is true immediately, because
+   * a queued continuation cannot wait for a render.
+   */
+  const latest = useRef<Map<string, { versionId: string; revision: string }>>(
+    new Map(),
+  );
   const [cellDraft, setCellDraft] = useState<Draft | null>(null);
   const [cellRefused, setCellRefused] = useState<string | null>(null);
   /**
@@ -675,6 +703,16 @@ export function TestsGrid(props: GridProps) {
   const [deleteInFlight, setDeleteInFlight] = useState(false);
   const [deleteRefused, setDeleteRefused] = useState<string | null>(null);
   const entryName = useRef<HTMLInputElement>(null);
+
+  /*
+   * A different suite is a different set of rows, so nothing a previous one
+   * learned about versions or had in flight may follow it here.
+   */
+  useEffect(() => {
+    queued.current = new Map();
+    latest.current = new Map();
+    inFlight.current = new Set();
+  }, [projectId, suiteId]);
 
   /* Every persona a row already names has a name, so a cell can show it. */
   useEffect(() => {
@@ -782,40 +820,67 @@ export function TestsGrid(props: GridProps) {
     }
     inFlight.current.add(key);
     setCellRefused(null);
+
     /*
-     * One field, and the guard the platform asks that field for. A content
-     * edit carries the version it was read at, so a save cannot land on top of
+     * One field, and the guard the platform asks that field for. A content edit
+     * carries the version it was read at, so a save cannot land on top of
      * somebody else's; a name is identity and carries the revision instead.
+     *
+     * Both are read here rather than closed over, because this runs when the
+     * queue reaches it: the save in front may have minted a version since, and
+     * carrying the older one would be refused for no reason a person could act
+     * on. A genuine refusal now means what it says — somebody else moved this
+     * test — which is exactly what the sentence in the cell is for.
      */
-    const answer = await platformAnswer(
-      updateTest(
-        {
-          testId: test.id,
-          projectId,
-          [field]: value,
-          ...(isContent(field)
-            ? { expectedVersionId: test.versionId }
-            : { expectedRevision: test.revision }),
-        } as Parameters<typeof updateTest>[0],
-        { client: platformClient },
-      ),
+    const send = async (): Promise<void> => {
+      const guard = latest.current.get(test.id) ?? {
+        versionId: test.versionId,
+        revision: test.revision,
+      };
+      const answer = await platformAnswer(
+        updateTest(
+          {
+            testId: test.id,
+            projectId,
+            [field]: value,
+            ...(isContent(field)
+              ? { expectedVersionId: guard.versionId }
+              : { expectedRevision: guard.revision }),
+          } as Parameters<typeof updateTest>[0],
+          { client: platformClient },
+        ),
+      );
+      inFlight.current.delete(key);
+      if (answer.status === "signed-out") {
+        window.location.replace("/sign-in");
+        return;
+      }
+      const now = wokenNow.current;
+      const stillMine = now?.testId === mine.testId && now.field === mine.field;
+      if (answer.status !== "ready") {
+        // A refusal belongs beside the cell it is about. If the caret has moved
+        // on, the sentence has nowhere truthful to sit, and the save simply did
+        // not happen — the stored value stands either way.
+        if (stillMine) setCellRefused(answer.refusal.message);
+        return;
+      }
+      // What the next save on this test must carry, true from this instant.
+      latest.current.set(test.id, {
+        versionId: answer.value.versionId,
+        revision: answer.value.revision,
+      });
+      onSaved(answer.value);
+      rest(mine);
+    };
+
+    // Behind whatever this test is already saving, and nothing else.
+    const ahead = queued.current.get(test.id) ?? Promise.resolve();
+    const run = ahead.then(send, send);
+    queued.current.set(
+      test.id,
+      run.catch(() => undefined),
     );
-    inFlight.current.delete(key);
-    if (answer.status === "signed-out") {
-      window.location.replace("/sign-in");
-      return;
-    }
-    const now = wokenNow.current;
-    const stillMine = now?.testId === mine.testId && now.field === mine.field;
-    if (answer.status !== "ready") {
-      // A refusal belongs beside the cell it is about. If the caret has moved
-      // on, the sentence has nowhere truthful to sit, and the save simply did
-      // not happen — the stored value stands either way.
-      if (stillMine) setCellRefused(answer.refusal.message);
-      return;
-    }
-    onSaved(answer.value);
-    rest(mine);
+    await run;
   }
 
   async function write(): Promise<void> {

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -639,7 +639,22 @@ export function TestsGrid(props: GridProps) {
    * render.
    */
   const wokenNow = useRef<Woken | null>(null);
-  const savingNow = useRef(false);
+  /**
+   * The cells with a save in flight, which is a set and not a flag.
+   *
+   * **A flag made one cell's save stop another cell's.** Blurring cell A starts
+   * its request; committing cell B while that request is still open met a
+   * global "something is saving" and returned early, so B's edit was neither
+   * sent nor kept — and waking the next cell replaced the draft, so what was
+   * typed into B went with it. Silently, which is the one thing this grid
+   * promises never to do.
+   *
+   * Two different cells are independent by construction: each save carries only
+   * its own field and only its own version or revision guard, so they cannot
+   * overwrite one another and there is nothing to serialize. What the set still
+   * refuses is the same cell twice — an Enter followed by the blur it causes.
+   */
+  const inFlight = useRef<Set<string>>(new Set());
   const [cellDraft, setCellDraft] = useState<Draft | null>(null);
   const [cellRefused, setCellRefused] = useState<string | null>(null);
   /**
@@ -733,10 +748,12 @@ export function TestsGrid(props: GridProps) {
   }
 
   async function commit(test: ListedTest, field: Field): Promise<void> {
-    if (cellDraft === null || savingNow.current) return;
     // Which cell this commit is of, held across the await so the answer can
-    // only ever land back on the cell that asked.
+    // only ever land back on the cell that asked — and so that one cell's
+    // save in flight never speaks for another's.
     const mine = { testId: test.id, field };
+    const key = `${mine.testId}:${mine.field}`;
+    if (cellDraft === null || inFlight.current.has(key)) return;
     const stored = draftOf(test);
     const problem = whyFieldRefuses(field, cellDraft);
     if (problem !== null) {
@@ -763,7 +780,7 @@ export function TestsGrid(props: GridProps) {
       rest(mine);
       return;
     }
-    savingNow.current = true;
+    inFlight.current.add(key);
     setCellRefused(null);
     /*
      * One field, and the guard the platform asks that field for. A content
@@ -783,7 +800,7 @@ export function TestsGrid(props: GridProps) {
         { client: platformClient },
       ),
     );
-    savingNow.current = false;
+    inFlight.current.delete(key);
     if (answer.status === "signed-out") {
       window.location.replace("/sign-in");
       return;

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -757,6 +757,113 @@ describe("the suite-first Tests route", () => {
     });
   });
 
+  it("serializes two cells of one test, so the second carries the version the first minted", async () => {
+    // Scenario is committed and its PATCH is held open. Behaviors of the SAME
+    // test are then edited and blurred. Both carry a version guard, so sending
+    // them together would hand the platform the same version twice and the
+    // second would be refused for holding one the first had just replaced.
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    routed.pathname = "/projects/prj_1/tests/suites/ste_1";
+    routed.params = { projectId: "prj_1", suiteId: "ste_1" };
+    answers({
+      "/api/me": { status: 200, body: meWith("admin") },
+      "/v1/test-suites/ste_1": { status: 200, body: suiteBody() },
+      "/v1/tests": {
+        status: 200,
+        body: { tests: [testBody({ personas: [PERSONA] })], nextPageToken: null },
+      },
+      "/v1/tests/tst_1": [
+        {
+          status: 200,
+          body: testBody({
+            personas: [PERSONA],
+            scenario: "The caller books a service slot.",
+            version: 2,
+            versionId: "tstv_2",
+            revision: "rev_2",
+          }),
+          waitFor: held,
+        },
+        {
+          status: 200,
+          body: testBody({
+            personas: [PERSONA],
+            scenario: "The caller books a service slot.",
+            expectedBehaviors: ["Offers an available time", "Reads the price back"],
+            version: 3,
+            versionId: "tstv_3",
+            revision: "rev_3",
+          }),
+        },
+      ],
+      "/v1/personas": {
+        status: 200,
+        body: { personas: [PERSONA], nextPageToken: null },
+      },
+    });
+
+    render(<TestSuitePage />);
+
+    const row = (await screen.findByText("Books service")).closest("tr");
+    if (row === null) throw new Error("the test's row is not on screen");
+
+    // Commit the scenario. Its request hangs.
+    fireEvent.click(within(row).getByText("The caller books service."));
+    const scenario = within(row).getByLabelText("Scenario");
+    fireEvent.change(scenario, {
+      target: { value: "The caller books a service slot." },
+    });
+    fireEvent.keyDown(scenario, { key: "Enter" });
+
+    // Edit the behaviors of the same test and blur, while scenario is pending.
+    fireEvent.click(within(row).getByText("Offers an available time"));
+    fireEvent.click(within(row).getByRole("button", { name: "+ Add a behavior" }));
+    fireEvent.change(within(row).getByLabelText("Expected behavior 2"), {
+      target: { value: "Reads the price back" },
+    });
+    fireEvent.blur(within(row).getByLabelText("Expected behavior 2"));
+
+    // The second request waits: one test saves in order, so nothing carries a
+    // version another save has already replaced.
+    await waitFor(() => {
+      expect(sent.filter((request) => request.method === "PATCH")).toHaveLength(1);
+    });
+    expect(sent.filter((request) => request.method === "PATCH")[0]).toEqual({
+      path: "/v1/tests/tst_1",
+      method: "PATCH",
+      body: {
+        scenario: "The caller books a service slot.",
+        expectedVersionId: "tstv_1",
+      },
+    });
+
+    release();
+
+    // Then it goes, carrying the version the first save minted — so it lands
+    // rather than being refused for holding a version that no longer exists.
+    await waitFor(() => {
+      expect(sent.filter((request) => request.method === "PATCH")).toHaveLength(2);
+    });
+    expect(sent.filter((request) => request.method === "PATCH")[1]).toEqual({
+      path: "/v1/tests/tst_1",
+      method: "PATCH",
+      body: {
+        expectedBehaviors: ["Offers an available time", "Reads the price back"],
+        expectedVersionId: "tstv_2",
+      },
+    });
+
+    // Both values read back, and no refusal was ever shown.
+    await waitFor(() => {
+      expect(screen.getByText("The caller books a service slot.")).toBeTruthy();
+    });
+    expect(screen.getByText("Reads the price back")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("sends a second cell's edit while the first is still in flight", async () => {
     // A's PATCH is held open. B is committed while it hangs — two different
     // cells, each carrying only its own field and its own guard, so there is

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -757,6 +757,120 @@ describe("the suite-first Tests route", () => {
     });
   });
 
+  it("sends a second cell's edit while the first is still in flight", async () => {
+    // A's PATCH is held open. B is committed while it hangs — two different
+    // cells, each carrying only its own field and its own guard, so there is
+    // nothing to serialize and nothing may be dropped.
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    routed.pathname = "/projects/prj_1/tests/suites/ste_1";
+    routed.params = { projectId: "prj_1", suiteId: "ste_1" };
+    answers({
+      "/api/me": { status: 200, body: meWith("admin") },
+      "/v1/test-suites/ste_1": { status: 200, body: suiteBody() },
+      "/v1/tests": {
+        status: 200,
+        body: {
+          tests: [
+            testBody({ personas: [PERSONA] }),
+            testBody({
+              id: "tst_2",
+              versionId: "tstv_2",
+              revision: "rev_2",
+              name: "Cancels service",
+              scenario: "The caller cancels.",
+              personas: [PERSONA],
+            }),
+          ],
+          nextPageToken: null,
+        },
+      },
+      "/v1/tests/tst_1": {
+        status: 200,
+        body: testBody({ personas: [PERSONA], scenario: "A saved late." }),
+        waitFor: held,
+      },
+      "/v1/tests/tst_2": {
+        status: 200,
+        body: testBody({
+          id: "tst_2",
+          versionId: "tstv_2",
+          revision: "rev_2",
+          name: "Cancels service",
+          scenario: "B saved while A hung.",
+          personas: [PERSONA],
+        }),
+      },
+      "/v1/personas": {
+        status: 200,
+        body: { personas: [PERSONA], nextPageToken: null },
+      },
+    });
+
+    render(<TestSuitePage />);
+
+    // Commit A by blurring it. Its request hangs.
+    const rowA = (await screen.findByText("Books service")).closest("tr");
+    if (rowA === null) throw new Error("row A is not on screen");
+    fireEvent.click(within(rowA).getByText("The caller books service."));
+    const scenarioA = within(rowA).getByLabelText("Scenario");
+    fireEvent.change(scenarioA, { target: { value: "A saved late." } });
+    fireEvent.keyDown(scenarioA, { key: "Enter" });
+
+    // Wake B, type, and commit it while A is still pending.
+    const rowB = screen.getByText("Cancels service").closest("tr");
+    if (rowB === null) throw new Error("row B is not on screen");
+    fireEvent.click(within(rowB).getByText("The caller cancels."));
+    const scenarioB = within(rowB).getByLabelText("Scenario");
+    fireEvent.change(scenarioB, { target: { value: "B saved while A hung." } });
+    fireEvent.keyDown(scenarioB, { key: "Enter" });
+
+    // B's request goes out at once rather than waiting on A or being dropped.
+    await waitFor(() => {
+      expect(
+        sent.filter((request) => request.path === "/v1/tests/tst_2"),
+      ).toEqual([
+        {
+          path: "/v1/tests/tst_2",
+          method: "PATCH",
+          body: {
+            scenario: "B saved while A hung.",
+            expectedVersionId: "tstv_2",
+          },
+        },
+      ]);
+    });
+
+    release();
+
+    // Both saves land, each carrying only its own field and its own guard.
+    await waitFor(() => {
+      expect(sent.filter((request) => request.method === "PATCH")).toEqual([
+        {
+          path: "/v1/tests/tst_1",
+          method: "PATCH",
+          body: { scenario: "A saved late.", expectedVersionId: "tstv_1" },
+        },
+        {
+          path: "/v1/tests/tst_2",
+          method: "PATCH",
+          body: {
+            scenario: "B saved while A hung.",
+            expectedVersionId: "tstv_2",
+          },
+        },
+      ]);
+    });
+
+    // And both rows read back what was saved — nothing was lost on the way.
+    await waitFor(() => {
+      expect(screen.getByText("A saved late.")).toBeTruthy();
+    });
+    expect(screen.getByText("B saved while A hung.")).toBeTruthy();
+  });
+
   it("lands a late cell save on its own cell, never on the one now being typed in", async () => {
     // A's PATCH is held open. While it hangs, the caret moves to B and types.
     let release!: () => void;


### PR DESCRIPTION
Fixes the final PR's duplicate Greptile P1 (tests-grid.tsx:736). The double-submit guard was one global boolean, so committing cell B while cell A's save was pending returned early — B's edit neither sent, nor queued, nor refused, and the next wake replaced the sole draft, silently discarding the typed value.

The guard is now a per-cell set (testId:field): different cells commit concurrently — each save carries only its own field and version guard, so they are independent by construction — while the same cell still cannot double-submit. The late-response rules keep working under concurrency (completions rest only their own cell via the live refs). Checked rather than assumed: the shared draft state did not force the global flag (commits read their value before awaiting), so only the flag moved.

Test holds A's PATCH open, commits B mid-flight, asserts B's request goes out immediately, both PATCHes land with only their own fields, both rows read back saved — and it was mutation-checked against the restored global guard (B's request never happens).

Gates: apps/web/test/test-suites-pages.test.tsx 24 passed · pnpm typecheck exit 0 · real next build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790268453&installation_model_id=431960&pr_number=223&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F223&signature=ec81279c50f947a496b62285dc50fa8fb45be1dd308b9d52bb2764016cd0995e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the global save guard with per-cell in-flight tracking, while serializing edits to the same test so each queued request receives the latest version and revision guards.
- Allows saves for different tests to proceed concurrently.
- Orders saves for the same test and carries forward guards from successful responses.
- Adds regression coverage for both same-test serialization and cross-test concurrency.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Replaces global save exclusion with per-cell tracking and per-test queues, resolving the previously reported same-test version conflict by refreshing guards between queued saves. |
| apps/web/test/test-suites-pages.test.tsx | Adds focused coverage proving same-test saves are serialized and different-test saves proceed concurrently without dropping either edit. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant G as Tests grid
    participant Q as Per-test queue
    participant A as Platform API
    U->>G: Commit cell A
    G->>Q: Enqueue save A
    Q->>A: PATCH with current guard
    U->>G: Commit cell B on same test
    G->>Q: Enqueue save B
    A-->>Q: Updated test and fresh guards
    Q->>A: PATCH B with fresh guard
    A-->>G: Updated test
    Note over G,A: Saves for different tests use separate queues and may run concurrently
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tests): one test saves in order, so ..."](https://github.com/egma-ai/egma/commit/1fc0cea2d107b1d037055a3d9724f0aef9975965) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56732556)</sub>

<!-- /greptile_comment -->