### PR TITLE
test(browser): every copied-link row audited; the retired test row fixed twice

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2987,7 +2987,14 @@ describe("the complete product, walked in order in a second project", () => {
       const written = await writeResponse;
       expect(written.status(), await written.text()).toBe(201);
       const body = (await written.json()) as { id: string };
-      testAddress = `${origin}${at("tests", body.id)}`;
+      /*
+       * `at` already carries the origin — it is the address builder every
+       * sibling row in the copied-link table composes with. Prefixing it a
+       * second time made a URL with the origin in it twice, which no browser
+       * can navigate to, and the row that holds it is one the journey only
+       * reaches after every step above it has passed.
+       */
+      testAddress = at("tests", body.id);
 
       // One click, one create, and the row is an ordinary grid row on the same
       // address — writing a test never navigated anywhere.
@@ -3314,10 +3321,15 @@ describe("the complete product, walked in order in a second project", () => {
         says: "Save test",
       },
       {
-        // The retired test address, kept as a deep link: it resolves the
-        // test's suite and lands on that suite's grid.
+        /*
+         * The retired test address, kept as a deep link: it resolves the
+         * test's suite and lands on that suite's grid — so, like the retired
+         * agent address above, it says where it lands. The test page went with
+         * the 2026-08-24 rework; a test is a row of its suite's grid now.
+         */
         what: "one test",
         address: testAddress,
+        lands: suiteAddress,
         says: "Reschedules a booked appointment",
       },
       { what: "Personas", address: at("personas"), says: "Impatient Rita" },


### PR DESCRIPTION
The clean runner reached the copied-link table's "one test" row for the first time and found its origin doubled. Fixed, and the same row's second latent defect with it: the retired test address redirects to its suite's grid, so it now carries `lands: suiteAddress` — it would have failed the very next run the way the "one agent" row did.

To end the one-defect-per-run cycle, every row in the table was audited (address composition + does-it-land-on-itself), including reading the route code for the three rows whose behaviour the rework changed. `testAddress` was the only doubled origin; the two `lands` rows are the only redirects. Full audit table in the working notes.

`tsc -p tsconfig.tests.json` clean. The browser lane runs on the final PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790269368&installation_model_id=431960&pr_number=224&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F224&signature=140d8367eea5f8bba6d1122cebd68086bb8e9f53840e67f5208056400b53c603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs the copied-link browser audit for the retired test route.
- Removes a duplicate origin prefix from the stored test URL.
- Records the suite grid as the retired test URL’s expected landing destination.
- Expands comments documenting the redirect and URL-composition contracts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the corrected URL and redirect expectation matching the browser route implementation.

The test address builder already includes the origin and project scope, while the retired test route canonically redirects to the same suite URL now recorded by the audit.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/api/test/browser.test.ts | Correctly constructs the retired test’s absolute project-scoped URL and verifies that it redirects to the canonical suite grid. |

<sub>Reviews (1): Last reviewed commit: ["test(browser): one origin per address, a..."](https://github.com/egma-ai/egma/commit/c33bf3125a4e0e76907b49d73203091b46bba6a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56738943)</sub>

**Context used:**

- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)

<!-- /greptile_comment -->