### PR TITLE
fix(shell): one left lane down the sidebar

### DIFF
--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -211,8 +211,9 @@ function SidebarGroup({
  *
  * Weight 400 and the compact label treatment, which is what the bar already
  * used for the one group label it had. It is quiet on purpose: the label says
- * where a row belongs, and the row is the thing being read. `px-3` is the row's
- * own padding, so the label starts exactly where the row's content starts.
+ * where a row belongs, and the row is the thing being read. `px-2` is the row's
+ * own padding, so the label starts exactly where the row's icon starts — on the
+ * bar's 16px gutter, in line with the project block above it.
  */
 function SidebarGroupLabel({ className, ...props }: ComponentProps<"h2">) {
   const labelId = useContext(SidebarGroupLabelId);
@@ -227,7 +228,7 @@ function SidebarGroupLabel({ className, ...props }: ComponentProps<"h2">) {
          * margin of the label's as well made it 8. The boards put the label
          * one gap above its first row like every other pair in the column.
          */
-        "my-0 px-3 text-sm text-faint tracking-(--tracking-label) uppercase",
+        "my-0 px-2 text-sm text-faint tracking-(--tracking-label) uppercase",
         className,
       )}
       {...props}
@@ -291,6 +292,15 @@ function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
  * already gives a compact control. The 44px tap target is not traded away for
  * that: `pointer-coarse` puts it straight back on every touch screen, which is
  * the same rule the segmented choice control already uses.
+ *
+ * **The row's 8px padding is what puts its icon on the bar's 16px gutter.** The
+ * column around it is inset 8, so 8 and 8 land the icon exactly where the Egma
+ * mark, the word `Project`, the project name and the group labels already
+ * start: one left edge down the whole sidebar. It was 12 against a column inset
+ * of 16, which put every icon and every group label 12px right of the project
+ * block above them. The Ember mark is unaffected either way — it is absolutely
+ * placed on the row's own leading edge and pushes nothing, so a lit row's icon
+ * stands on the same line as a quiet one's.
  */
 function SidebarMenuButton({
   className,
@@ -312,7 +322,7 @@ function SidebarMenuButton({
       aria-current={isActive ? "page" : undefined}
       className={cn(
         "relative flex w-full min-w-0 items-center gap-3",
-        "min-h-(--control-md) rounded-button px-3",
+        "min-h-(--control-md) rounded-button px-2",
         "pointer-coarse:min-h-(--tap-target)",
         "text-sm text-muted-foreground no-underline",
         "transition-[color,background-color] duration-(--duration-hover) ease-out",

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -491,7 +491,19 @@ function AccountMenu({
       label={`Account ${standing}. Open the account menu`}
       triggerClassName={cn(
         "grid w-full min-w-0 items-center gap-3",
-        "grid-cols-[var(--control-md)_minmax(0,1fr)] min-h-(--control-lg) px-2 py-1",
+        /*
+         * **7px, and the missing pixel is the plate's own hairline.** This
+         * trigger reserves its hover border as a transparent one so hovering
+         * shifts nothing, and `box-sizing: border-box` means that border spends
+         * a pixel of the inset before the padding starts. Written as 8px it put
+         * the avatar on 17 while every nav icon stood on 16 — the one thing
+         * still out of the bar's lane. Written as 8 minus the hairline it lands
+         * on 16 exactly, and the gap from the plate's visible edge to the
+         * avatar is a true 8px, which is what a borderless nav row already
+         * draws between its plate and its icon.
+         */
+        "grid-cols-[var(--control-md)_minmax(0,1fr)] min-h-(--control-lg) py-1",
+        "px-[calc(var(--space-2)-1px)]",
         "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
         "transition-transform duration-(--duration-press) ease-out",
         "pointer-coarse:min-h-(--tap-target)",
@@ -731,9 +743,21 @@ function ShellFrame({
         </SidebarBrand>
         <SidebarHeader className="px-4">{selector(false)}</SidebarHeader>
         {shown === null ? null : <Navigation projectId={shown} pathname={pathname} />}
-        <SidebarFooter className="px-4">
+        {/*
+         * 8px, the navigation column's inset, so the account plate is the same
+         * 208px block as a nav row and stands 8px off both edges of the bar.
+         * The avatar rides the 16px lane from inside it — see `AccountMenu`,
+         * which pays for its own hairline.
+         */}
+        <SidebarFooter className="px-2">
           {role !== null && !canAuthor(role) ? (
-            <Badge title="Your role can read, not author">{VIEW_ONLY}</Badge>
+            /*
+             * The chip has no plate to sit inside, so it takes the 8px back as
+             * a margin and starts on the lane with everything else.
+             */
+            <Badge className="mx-2" title="Your role can read, not author">
+              {VIEW_ONLY}
+            </Badge>
           ) : null}
           <AccountMenu
             me={me}

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -258,12 +258,19 @@ function Navigation({
     <SidebarProvider onNavigate={onNavigate}>
       {/*
        * The 16px gutter is the bar's, and it is on every block in the column
-       * rather than on the column itself. The organization bar's hairline has to
-       * run the full 224px, so the `<aside>` can carry no side padding — and
-       * the rows are 192px wide with their Ember mark exactly on the gutter,
-       * which is what the boards draw (`725-0`, `72Z-0`).
+       * rather than on the column itself. The organization bar's hairline has
+       * to run the full 224px, so the `<aside>` can carry no side padding.
+       *
+       * **8px here, because the gutter belongs to the row's icon and not to the
+       * row's plate.** The Egma mark, the word `Project`, the project name and
+       * every group label all start at 16px; a row whose own padding is 8 puts
+       * its icon on that same line, so the bar reads as one lane top to bottom
+       * instead of a project block and a navigation block 12px apart. The plate
+       * is 8px in from both edges as a result, 208px wide, and the Ember mark
+       * rides its leading edge — absolutely placed, so the icon lane is the same
+       * on the lit row and on every quiet one.
        */}
-      <SidebarContent className="px-4" asChild>
+      <SidebarContent className="px-2" asChild>
         <nav aria-label="Product navigation">
           {groups.map((group) => (
             <SidebarGroup key={group.id} labelled={group.label !== null}>


### PR DESCRIPTION
The developer's alignment ask, from the Browserbase reference: the sidebar's Project block, group labels, nav icons, and account control now share one left edge — DESIGN.md's 16px gutter, where the Egma mark and Project block already sat. Five padding values moved (nav inset, row and label padding, footer inset, account trigger), nothing structural; the active row's 2px Ember mark rides its plate unchanged, and the account trigger's inset pays for its transparent hover border explicitly (calc(var(--space-2)-1px)) so the visible-edge-to-avatar gap is a true 8px like every nav row.

Final x: mark 16 · Project 16 · group labels 16 (were 28) · row icons 16 (were 28) · avatar 16 (was 25) · View-only chip 16.

Flagged in passing, not fixed here: the compact account trigger's p-0 loses to px-* under this Tailwind's emit order, so the mobile top-bar avatar has always carried 8px of unintended padding — a look change on another surface, its own fix.

Per the developer's instruction: no local test runs — CI runs everything here. pnpm typecheck was run and is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790272398&installation_model_id=431960&pr_number=227&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F227&signature=47d5af12d535b4a419db3bfeef11e9ac02bdc914fd1bb04eedf79f8616b74478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the persistent product sidebar around a shared 16px content lane.
- Reduces navigation container, menu-row, and group-label insets.
- Aligns the account avatar by compensating for its transparent border.
- Preserves the viewer badge position while widening the footer account plate.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the sidebar spacing changes remaining consistent across the reachable desktop and mobile layouts.

The changed padding widens available navigation space, keeps relative active indicators intact, and uses valid existing design tokens to align footer controls without changing behavior or interaction boundaries.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/components/ui/sidebar.tsx | Reduces group-label and menu-button padding so their content aligns with the sidebar’s 16px lane; no concrete regression was identified. |
| apps/web/ui/shell.tsx | Coordinates navigation and footer insets, account-trigger border compensation, and viewer-badge margins across desktop and mobile shell usage. |

<sub>Reviews (1): Last reviewed commit: ["fix(shell): bring the account control on..."](https://github.com/egma-ai/egma/commit/a3e51a5ea63824d4dddc03206de4296f5ab5caa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56758564)</sub>

<!-- /greptile_comment -->