### PR TITLE
chore(db): remove legacy migration baggage

### DIFF
--- a/packages/db/clickhouse-migrations/0000_baseline.sql
+++ b/packages/db/clickhouse-migrations/0000_baseline.sql
@@ -1,10 +1,8 @@
 -- PRE-PRODUCTION BASELINE RESET, confirmed by the founder on 2026-08-25.
 -- This file replaces the prior ClickHouse migration chain. Self-hosted
--- databases that ran it must be recreated. A managed store may instead adopt
--- this exact file hash only after an operator verifies every old ledger hash
--- and the logical schema; old ledger rows may remain for rollback. Every
--- statement is guarded because ClickHouse has no transaction around a migration
--- file and a boot must be able to resume after a partial failure.
+-- databases that ran it must be recreated. Every statement is guarded because
+-- ClickHouse has no transaction around a migration file and a boot must be able
+-- to resume after a partial failure.
 
 -- One row is one span. The sorting key is the immutable span identity, while
 -- the shorter primary key keeps organization, project, and trace reads cheap.

--- a/packages/db/migrations/0000_baseline.sql
+++ b/packages/db/migrations/0000_baseline.sql
@@ -1,10 +1,8 @@
 -- PRE-PRODUCTION BASELINE RESET, confirmed by the founder on 2026-08-25.
 -- This file replaces PostgreSQL migrations 0000 through 0046. Self-hosted
--- databases that ran them must be recreated. A managed store may instead adopt
--- this exact file hash only after an operator verifies every old ledger hash
--- and the logical schema; old ledger rows may remain for rollback. The baseline
--- creates only the current schema and current catalog rows; it carries no
--- rename, backfill, or general compatibility path.
+-- databases that ran them must be recreated. The baseline creates only the
+-- current schema and current catalog rows; it carries no rename, backfill, or
+-- compatibility path.
 CREATE EXTENSION IF NOT EXISTS citext;
 --> statement-breakpoint
 CREATE TABLE "account" (

--- a/packages/db/migrations/README.md
+++ b/packages/db/migrations/README.md
@@ -8,13 +8,10 @@ migration chains are not a normal upgrade path; recreate a self-hosted database
 or volume that applied them before running this build. New migrations start at
 `0001`.
 
-A verified managed pre-production database may use one exceptional adoption
-path. Before this build starts, its operator must prove that every legacy
-migration name and hash is known and that the logical schema matches this
-baseline, then record this exact baseline name and hash. Legacy ledger rows may
-remain so the old image can still roll back. The runner accepts unknown legacy
-rows only when the exact current baseline hash is already recorded. This is an
-operator cutover procedure, not an in-place self-host upgrade.
+Every migration ledger starts at this exact baseline. A build refuses unknown
+rows without that marker. With it, an older build may ignore rows appended by a
+newer build so a normal additive rollback can still boot. No prior migration
+name, hash, or row is part of this epoch.
 
 One rule keeps every deploy and every rollback safe, and it binds both
 stores — the Postgres files here and the ClickHouse files in
@@ -54,9 +51,9 @@ In practice:
   repair that local ledger. After merge or use outside local development, add
   a new file instead; the runner refuses a changed recorded file. The
   founder-approved 2026-08-25 baseline reset is the one exception: Egma was
-  still pre-production, the managed stores adopt the exact baseline hash before
-  the new image deploys, and their legacy rows remain for an old-image rollback.
-  Future migration history is immutable again from this baseline forward.
+  still pre-production, so every store starts at this baseline and the prior
+  ledgers have no supported rollback path. Future migration history is
+  immutable again from this baseline forward.
 - **ClickHouse migrations must resume safely.** There is no transaction around
   a file, so every schema statement uses `IF EXISTS`, `IF NOT EXISTS` or
   `CREATE OR REPLACE`, and survives a second run after a partial failure. An

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -31,13 +31,6 @@ const { namespace: LOCK_NAMESPACE, id: LOCK_ID } = MIGRATION_ADVISORY_LOCK;
 const BOOKKEEPING_SCHEMA = "egma_meta";
 const BOOKKEEPING_TABLE = `${BOOKKEEPING_SCHEMA}.migration`;
 
-/**
- * A managed pre-production store may adopt this exact baseline out of band
- * after an operator verifies its old ledger and logical schema. Its recorded
- * hash is the deliberate adoption marker; the filename alone is not proof.
- */
-const CURRENT_BASELINE_MIGRATION = "0000_baseline.sql";
-
 export type Migration = {
   readonly name: string;
   readonly sql: string;
@@ -105,17 +98,15 @@ export function pendingMigrations(
     }
   }
 
-  // A verified database may adopt a squashed baseline out of band while its
-  // old ledger rows remain for rollback. The exact baseline hash is the proof
-  // that this was deliberate. Without it, an old store must stop before fresh
-  // baseline DDL can run against tables that already exist.
-  const baseline = migrations.find(
-    (migration) => migration.name === CURRENT_BASELINE_MIGRATION,
-  );
-  const adoptedBaseline =
+  // An older additive build must still boot after a newer build has appended
+  // migrations. The exact first file proves that the ledger belongs to this
+  // migration epoch; without it, unknown rows are a different history rather
+  // than future rows that a rollback may safely ignore.
+  const baseline = migrations[0];
+  const hasExactBaseline =
     baseline !== undefined &&
     alreadyApplied.get(baseline.name) === baseline.hash;
-  if (unsupported.length > 0 && !adoptedBaseline) {
+  if (unsupported.length > 0 && !hasExactBaseline) {
     throw new Error(
       `database records migrations that this build does not contain: ${unsupported.join(", ")}; ` +
         "recreate the database before running this build",


### PR DESCRIPTION
## What

- remove every legacy migration name, hash, and ledger row from the active system
- require the exact current baseline before an older build may ignore rows appended by future migrations
- remove managed legacy-cutover language and describe the clean reset

## Production cutover

Before this commit deploys, the managed PostgreSQL and ClickHouse ledgers will be reduced to exactly 0000_baseline.sql with the hashes from this commit. The schema and application data do not change. The previous migration ledgers and their old-image rollback path are deliberately removed because Egma is pre-production.

## Verification

- full suite in CI
- Greptile plus independent spec and standards reviews on the exact head
- exact post-deploy SHA, image, ledger, migration no-op, and health checks

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the managed legacy-ledger adoption path and establishes the new baseline as the sole migration epoch.

- Requires an exact baseline hash before older builds may tolerate unknown, newer ledger rows.
- Updates the PostgreSQL and ClickHouse baseline headers and migration policy documentation to remove legacy rollback compatibility.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/migrate.ts | Replaces the legacy adoption branch with migration-epoch validation based on the exact first migration. |
| packages/db/migrations/README.md | Documents the clean baseline reset, unsupported prior ledgers, and additive rollback behavior within the new epoch. |
| packages/db/migrations/0000_baseline.sql | Updates the PostgreSQL baseline header to remove the managed legacy-ledger compatibility procedure. |
| packages/db/clickhouse-migrations/0000_baseline.sql | Updates the ClickHouse baseline header to require recreation rather than legacy-ledger adoption. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Service startup] --> B[Read sorted migration files]
  B --> C[Read migration ledger]
  C --> D{Recorded file hash changed?}
  D -->|Yes| E[Refuse startup]
  D -->|No| F{Unknown ledger rows exist?}
  F -->|No| G[Apply pending migrations]
  F -->|Yes| H{Exact first migration recorded?}
  H -->|No| E
  H -->|Yes| G
  G --> I[Serve requests]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(db): remove legacy migration compa..."](https://github.com/egma-ai/egma/commit/4927007a9bf6a7d2aca7e44fdf2eabbb5b8dd645) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56776141)</sub>

**Context used:**

- Knowledge Base — [Database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/database-persistence.md)

<!-- /greptile_comment -->