### PR TITLE
docs(db): remove migration history references

### DIFF
--- a/packages/db/clickhouse-migrations/0000_baseline.sql
+++ b/packages/db/clickhouse-migrations/0000_baseline.sql
@@ -1,8 +1,7 @@
--- PRE-PRODUCTION BASELINE RESET, confirmed by the founder on 2026-08-25.
--- This file replaces the prior ClickHouse migration chain. Self-hosted
--- databases that ran it must be recreated. Every statement is guarded because
--- ClickHouse has no transaction around a migration file and a boot must be able
--- to resume after a partial failure.
+-- CURRENT PRE-PRODUCTION BASELINE.
+-- Creates only the current ClickHouse schema. Every statement is guarded
+-- because ClickHouse has no transaction around a migration file and a boot
+-- must be able to resume after a partial failure.
 
 -- One row is one span. The sorting key is the immutable span identity, while
 -- the shorter primary key keeps organization, project, and trace reads cheap.

--- a/packages/db/migrations/0000_baseline.sql
+++ b/packages/db/migrations/0000_baseline.sql
@@ -1,8 +1,6 @@
--- PRE-PRODUCTION BASELINE RESET, confirmed by the founder on 2026-08-25.
--- This file replaces PostgreSQL migrations 0000 through 0046. Self-hosted
--- databases that ran them must be recreated. The baseline creates only the
--- current schema and current catalog rows; it carries no rename, backfill, or
--- compatibility path.
+-- CURRENT PRE-PRODUCTION BASELINE.
+-- Creates only the current PostgreSQL schema and current catalog rows. It has
+-- no rename, backfill, or compatibility steps.
 CREATE EXTENSION IF NOT EXISTS citext;
 --> statement-breakpoint
 CREATE TABLE "account" (

--- a/packages/db/migrations/README.md
+++ b/packages/db/migrations/README.md
@@ -2,16 +2,12 @@
 
 ## Current baseline
 
-The founder confirmed a full pre-production reset on 2026-08-25. PostgreSQL
-and ClickHouse each start from one `0000_baseline.sql` file. The prior
-migration chains are not a normal upgrade path; recreate a self-hosted database
-or volume that applied them before running this build. New migrations start at
-`0001`.
+PostgreSQL and ClickHouse each start from one `0000_baseline.sql` file. New
+migrations start at `0001`.
 
 Every migration ledger starts at this exact baseline. A build refuses unknown
 rows without that marker. With it, an older build may ignore rows appended by a
-newer build so a normal additive rollback can still boot. No prior migration
-name, hash, or row is part of this epoch.
+newer build so a normal additive rollback can still boot.
 
 One rule keeps every deploy and every rollback safe, and it binds both
 stores — the Postgres files here and the ClickHouse files in
@@ -35,25 +31,13 @@ In practice:
   product tests run on those images.
 - **Add freely.** New tables, new nullable columns, new indexes — code that
   does not know them never sees them.
-- **Prelaunch cleanup is the explicit exception.** A one-step removal is allowed
-  only when the founder confirms that no older API or rollback contract is
-  supported. Record that decision in the migration and accept that the prior
-  build cannot run after the change. The same exception covers a ClickHouse
-  rebuild that no `ALTER` can reach: a sorting key is fixed at creation, so a
-  table whose filing order has to change is dropped and recreated, and the file
-  that does it carries the justification and amends whatever earlier file said
-  the shape was final.
 - **Remove in two releases, not one.** Stop reading the thing first and ship
   that; drop it in a later release than the one that stopped using it. A
   rename is an add and a remove, in that order, never one statement.
 - **Freeze shipped history, not local state.** Before merge, a migration may be
   rewritten or squashed even if a local development database applied it;
   repair that local ledger. After merge or use outside local development, add
-  a new file instead; the runner refuses a changed recorded file. The
-  founder-approved 2026-08-25 baseline reset is the one exception: Egma was
-  still pre-production, so every store starts at this baseline and the prior
-  ledgers have no supported rollback path. Future migration history is
-  immutable again from this baseline forward.
+  a new file instead; the runner refuses a changed recorded file.
 - **ClickHouse migrations must resume safely.** There is no transaction around
   a file, so every schema statement uses `IF EXISTS`, `IF NOT EXISTS` or
   `CREATE OR REPLACE`, and survives a second run after a partial failure. An

--- a/packages/db/test/provisioning-starter-persona.test.ts
+++ b/packages/db/test/provisioning-starter-persona.test.ts
@@ -92,7 +92,7 @@ async function waitUntilBlockedBy(blockerPid: number): Promise<void> {
 
 let acme: Provisioned;
 let globex: Provisioned;
-let legacy: { readonly auth: AuthContext; readonly personaId: string };
+let existingProject: { readonly auth: AuthContext; readonly personaId: string };
 
 beforeAll(async () => {
   database = await createConnectedDatabase("egma_provided_personas", {
@@ -124,7 +124,7 @@ beforeAll(async () => {
     "update project set default_persona_id = $1 where id = $2",
     [local.id, projectId],
   );
-  legacy = { auth, personaId: local.id };
+  existingProject = { auth, personaId: local.id };
 
   await seedPersonaLibrary();
   acme = await signUp("acme-persona-library");
@@ -164,10 +164,12 @@ describe("the shared default persona", () => {
     });
   });
 
-  it("is seeded idempotently without a boot-time legacy adoption path", async () => {
+  it("is seeded idempotently and keeps an existing project's default", async () => {
     expect(await seedPersonaLibrary()).toEqual([]);
     expect(await seedPersonaLibrary()).toEqual([]);
-    expect(await defaultOf(legacy.auth.projectId ?? "")).toBe(legacy.personaId);
+    expect(await defaultOf(existingProject.auth.projectId ?? "")).toBe(
+      existingProject.personaId,
+    );
   });
 
   it("appears once in each project's library", async () => {


### PR DESCRIPTION
## Result

The active tree now describes only the current migration epoch. It does not preserve narrative about the deleted PostgreSQL or ClickHouse chains.

## Changes

- make both baseline headers describe only the current schema
- remove the old-chain reset story and dated exception from the migration README
- keep only the forward migration and rollback rules needed from `0000_baseline.sql` onward
- rename the final stale `legacy` provisioning-test wording to the current existing-project behavior

## Verification

- `git diff --check`
- repository search finds no tracked old migration identity, hash, chain, adoption, or cutover reference in scope
- no migration-only test or fixture remains
- exact-head independent standards/spec review: no findings
- PostgreSQL baseline SHA-256: `75713aa6226794d073423ca6cc960be53733f4df25d55acaccf9e24d0ad511b3`
- ClickHouse baseline SHA-256: `d34e899173c4a4ae5cab2a695bea420008684af18107fe2e9dfb15e5444f10e3`

The complete suite is intentionally left to CI, per the founder request. Deployment requires the coordinated fileless production-ledger compaction immediately before the new API image starts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes historical migration-reset language so the active documentation describes only the current baseline epoch.
- Rewords the PostgreSQL and ClickHouse baseline headers.
- Removes old-chain, reset-exception, and cutover language from the migration README.
- Renames the provisioning test fixture and description to describe an existing project directly.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until the baseline hash changes are avoided or existing migration ledgers are handled compatibly.

The baseline files remain changed after being treated as immutable migration history, so databases that recorded the prior hashes will reject them during startup.

**Files Needing Attention:** packages/db/migrations/0000_baseline.sql and packages/db/clickhouse-migrations/0000_baseline.sql

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/migrations/0000_baseline.sql | Rewords the PostgreSQL baseline header without changing its SQL statements. |
| packages/db/clickhouse-migrations/0000_baseline.sql | Rewords the ClickHouse baseline header while retaining its resumability explanation. |
| packages/db/migrations/README.md | Removes historical reset and exception narratives while retaining forward-migration and rollback rules. |
| packages/db/test/provisioning-starter-persona.test.ts | Renames a fixture and test description without changing the tested behavior. |

<sub>Reviews (2): Last reviewed commit: ["docs(db): remove migration history refer..."](https://github.com/egma-ai/egma/commit/3d8ce33067e8083c3b8059cc53bab1b9f65ba2d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56781715)</sub>

<!-- /greptile_comment -->