### PR TITLE
fix(web): the developer's prod-testing polish round — eight fixes

### DIFF
--- a/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connect-sheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronDownIcon } from "lucide-react";
 import { useEffect, useId, useState, type ReactNode } from "react";
 import {
   addConnection,
@@ -36,6 +37,7 @@ import {
 import { platformAnswer, platformClient } from "@/lib/platform-client.ts";
 import { agentPlatformLabel } from "@/lib/transcripts.ts";
 import { Field, Help, Problem } from "@/ui/form.tsx";
+import { Menu, MenuItem } from "@/ui/menu.tsx";
 import { Empty, Failure, Loading, NotFound } from "@/ui/page-state.tsx";
 import { useUnsavedChanges } from "@/ui/settings-read.ts";
 
@@ -708,23 +710,25 @@ export function ConnectAgentSheet({
    * link into an agent on the fourth page of the list still shows its own name
    * rather than falling back to "Create a new agent".
    */
-  const choices: readonly { readonly id: string; readonly label: string }[] = [
+  const choices: readonly AgentChoice[] = [
     ...agents.map((one) => ({
       id: one.id,
-      label: labelFor(one.name, agentPlatformText(one)),
+      name: one.name,
+      platform: agentPlatformText(one),
     })),
     ...(chosenAgent !== NEW_AGENT && !agents.some((one) => one.id === chosenAgent)
       ? [
-          {
-            id: chosenAgent,
-            label:
-              known === null
-                ? "This agent"
-                : labelFor(known.name, agentPlatformLabel(known.agentPlatform)),
-          },
+          known === null
+            ? { id: chosenAgent, name: "This agent", platform: null }
+            : {
+                id: chosenAgent,
+                name: known.name,
+                platform: agentPlatformLabel(known.agentPlatform),
+              },
         ]
       : []),
   ];
+  const chosen = choices.find((one) => one.id === chosenAgent);
 
   function body(): ReactNode {
     /*
@@ -768,20 +772,59 @@ export function ConnectAgentSheet({
           * registered twice.
           */}
         <Field label="Agent*" htmlFor="agent-choice">
-          <Select
-            aria-required="true"
-            id="agent-choice"
-            value={chosenAgent}
+          <Menu
+            label="Agent*"
+            triggerId="agent-choice"
             disabled={saving}
-            onChange={(event) => chooseAgent(event.target.value)}
+            placement="below-start"
+            panelClassName="w-(--radix-popover-trigger-width) max-w-none"
+            triggerClassName={cn(
+              "flex min-h-(--control-lg) w-full min-w-0 cursor-pointer items-center gap-2 px-3",
+              "rounded-input border border-input bg-surface text-left text-base text-foreground",
+              "pointer-coarse:min-h-(--tap-target)",
+              "disabled:cursor-not-allowed disabled:opacity-60",
+            )}
+            trigger={
+              <>
+                {chosen === undefined ? (
+                  <span className="min-w-0 flex-1">Create a new agent</span>
+                ) : (
+                  <AgentChoiceLabel name={chosen.name} platform={chosen.platform} />
+                )}
+                <ChevronDownIcon
+                  className="size-4 flex-none text-faint"
+                  aria-hidden="true"
+                  strokeWidth={1.75}
+                />
+              </>
+            }
           >
-            {choices.map((one) => (
-              <option key={one.id} value={one.id}>
-                {one.label}
-              </option>
-            ))}
-            <option value={NEW_AGENT}>Create a new agent</option>
-          </Select>
+            {(close) => (
+              <>
+                {choices.map((one) => (
+                  <MenuItem
+                    key={one.id}
+                    selected={one.id === chosenAgent}
+                    onClick={() => {
+                      chooseAgent(one.id);
+                      close();
+                    }}
+                  >
+                    <AgentChoiceLabel name={one.name} platform={one.platform} />
+                  </MenuItem>
+                ))}
+                <MenuItem
+                  selected={chosenAgent === NEW_AGENT}
+                  onClick={() => {
+                    chooseAgent(NEW_AGENT);
+                    close();
+                  }}
+                >
+                  Create a new agent
+                </MenuItem>
+              </>
+            )}
+          </Menu>
         </Field>
 
         {creating ? (
@@ -1002,15 +1045,46 @@ export function ConnectAgentSheet({
   );
 }
 
+/** One agent the picker offers: its name, and where it already lives. */
+type AgentChoice = {
+  readonly id: string;
+  readonly name: string;
+  readonly platform: string | null;
+};
+
 /**
- * "remedy phase 1 · Retell", the way the board writes an agent in the picker.
+ * "remedy phase 1" in the product's text colour, then "Retell" faint beside it.
+ *
+ * The name is the answer to "which agent is this" and the platform is context
+ * for it, so they are not drawn at the same weight. The row used to read
+ * "remedy phase 1 · Retell" in one colour, where the platform argued with the
+ * name for the first read of every option.
+ *
+ * **The name truncates and the platform does not.** A long name that pushed the
+ * platform off the end would leave two agents of the same family looking
+ * identical, which is the one thing the platform is there to prevent.
  *
  * The platform arrives already in a person's words, because an agent on two
  * platforms is named with both of them and the list column and this picker
  * must not word that answer differently.
  */
-function labelFor(name: string, platforms: string | null): string {
-  return platforms === null ? name : `${name} · ${platforms}`;
+function AgentChoiceLabel({
+  name,
+  platform,
+}: {
+  readonly name: string;
+  readonly platform: string | null;
+}) {
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-2">
+      <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+        {name}
+      </span>
+      {platform === null ? null : (
+        <span className="flex-none text-faint">{platform}</span>
+      )}
+    </span>
+  );
 }
 
 /**

--- a/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/agents/connection-sheet.tsx
@@ -399,24 +399,29 @@ export function ConnectionSheet({
               * nobody had asked to change yet, which made every read of a
               * connection look like a form.
               */}
-            <SheetHeader>
+            <SheetHeader
+              {...(connection === null || role === null || editing !== null
+                ? {}
+                : {
+                    actions: (
+                      <RowMenu label={`Actions for ${connection.name}`}>
+                        <RowMenuItem
+                          onSelect={startEditing}
+                          {...(whyNotRead === undefined ? {} : { why: whyNotRead })}
+                        >
+                          Edit connection
+                        </RowMenuItem>
+                        <RowMenuDestructive
+                          onSelect={() => setArchiving(true)}
+                          {...(mayAuthor ? {} : { why: whyNotMine })}
+                        >
+                          Delete connection
+                        </RowMenuDestructive>
+                      </RowMenu>
+                    ),
+                  })}
+            >
               <SheetTitle>{title}</SheetTitle>
-              {connection === null || role === null || editing !== null ? null : (
-                <RowMenu label={`Actions for ${connection.name}`}>
-                  <RowMenuItem
-                    onSelect={startEditing}
-                    {...(whyNotRead === undefined ? {} : { why: whyNotRead })}
-                  >
-                    Edit connection
-                  </RowMenuItem>
-                  <RowMenuDestructive
-                    onSelect={() => setArchiving(true)}
-                    {...(mayAuthor ? {} : { why: whyNotMine })}
-                  >
-                    Delete connection
-                  </RowMenuDestructive>
-                </RowMenu>
-              )}
             </SheetHeader>
             <SheetBody>{body()}</SheetBody>
             {connection === null || role === null || editing === null ? null : (

--- a/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, type ReactNode } from "react";
 import { listAgents, startMonitoring } from "@egma/platform-api/client";
 
@@ -27,6 +28,7 @@ import {
   platformAnswer,
   platformClient,
 } from "../../../../lib/platform-client.ts";
+import { projectPath } from "../../../../lib/project-context.ts";
 import { Field, Problem, Refused } from "../../../../ui/form.tsx";
 import { Empty, Failure, Loading, NotFound } from "../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
@@ -101,6 +103,16 @@ const COPY = {
     "Add another agent, or come back when there is one Egma is not watching.",
   noAgents: "No agents in this project yet",
   noAgentsLead: "Connect the agent you want Egma to watch, then monitor it here.",
+  /**
+   * The one thing left to do when the list is empty, and it is a real move to
+   * another screen.
+   *
+   * Both empty sentences promise it — *add another agent*, *connect the agent
+   * you want Egma to watch* — and both used to offer nothing but Close, so the
+   * promise was a dead end. The word is the agents screen's own, because it
+   * lands on that screen with that screen's sheet already open.
+   */
+  connect: "Connect an agent",
   missingKey: "Enter this agent's Retell API key.",
   missingPlatformAgentId: "Enter Retell's own id for this agent.",
   notYours: (role: string) =>
@@ -305,7 +317,21 @@ function Picker({
             lead={none ? COPY.noAgentsLead : COPY.nothingLeftLead}
           />
         </SheetBody>
+        {/*
+          **The verb the sentence promises, and it leaves this screen.** There
+          is no agent left to monitor, so the only move is to connect one — and
+          connecting is the agents screen's own job. The address carries that
+          screen's connect sheet with it, so one press lands on the open panel
+          rather than on a list somebody has to find the button on again. This
+          is a real navigation, which the no-redirect ruling allows: the ruling
+          is about sheets that draw over the screen they belong to.
+        */}
         <SheetFooter>
+          <Button asChild size="lg">
+            <Link href={`${projectPath(projectId, "agents")}?sheet=connect`}>
+              {COPY.connect}
+            </Link>
+          </Button>
           <Button type="button" size="lg" variant="secondary" onClick={onClose}>
             {COPY.close}
           </Button>

--- a/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
+++ b/apps/web/app/projects/[projectId]/tests/suite-screen.tsx
@@ -40,9 +40,14 @@ import { TestsGrid } from "./tests-grid.tsx";
  *
  * **Suite management is not here.** Rename, Run suite and Delete suite live on
  * the suites list's row menu, where one screen owns every verb a suite has
- * (founder's ruling, 2026-08-24). What this screen carries is one action —
- * Write a test — and it puts the caret in the grid's entry row rather than
- * opening anything.
+ * (founder's ruling, 2026-08-24).
+ *
+ * **Writing a test is the grid's own verb, and the toolbar has none.** The
+ * ghost row at the foot of the grid says "+ Write a test" where the row it
+ * opens will stand, so a second button in the title bar said the same word
+ * twice and pointed away from the place the caret lands. It went on
+ * 2026-08-25. The two ways in are the ghost row and the `/tests/new?suite=`
+ * address, which both open the entry row in place.
  */
 export function SuiteScreen({
   projectId,
@@ -123,25 +128,6 @@ export function SuiteScreen({
     mayAuthor || role === null
       ? undefined
       : `Your ${String(role)} role cannot write tests. Ask an organization admin to change your role.`;
-
-  /**
-   * "Write a test" focuses the grid's entry row; it opens nothing.
-   *
-   * The address stays where it is when the row opens from this button. The
-   * `/tests/new?suite=` address still lands with the row open, which is what
-   * keeps a copied link honest — but pressing the button is not a navigation.
-   */
-  const writeAction =
-    role === null ? undefined : (
-      <Button
-        type="button"
-        disabled={!mayAuthor}
-        {...(whyNotWrite === undefined ? {} : { why: whyNotWrite })}
-        onClick={() => setEntryOpen(true)}
-      >
-        Write a test
-      </Button>
-    );
 
   function body() {
     if (
@@ -267,7 +253,6 @@ export function SuiteScreen({
             onChange={(event) => setSearch(event.target.value)}
           />
         }
-        action={currentSuite === null ? undefined : writeAction}
       />
       <PageBody>{body()}</PageBody>
     </ProductPage>

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -288,6 +288,38 @@ function PersonaPicker({
   const [refused, setRefused] = useState<string | null>(null);
   /** Whether egma holds more than this picker read. Said out loud if so. */
   const [truncated, setTruncated] = useState(false);
+  /** The newest way out, so the listener below never closes over a stale one. */
+  const done = useRef(onDone);
+  useEffect(() => {
+    done.current = onDone;
+  });
+
+  /*
+   * **A click anywhere else closes this picker, and it closes it the way Done
+   * does** — the choices ticked so far are kept, because ticking a checkbox has
+   * already changed the draft. A picker that stayed open under a click that
+   * plainly meant "elsewhere" left the only way out a button somebody had to
+   * find, which is the defect the founder named on 2026-08-25.
+   *
+   * `mousedown` rather than `click`, so the close happens before focus moves —
+   * the same instant Done would have. The lane marked `data-persona-picker` is
+   * this surface *and* the "+ Add a persona" trigger, so pressing the trigger
+   * to shut the picker is not read as an outside click and then re-opened.
+   */
+  useEffect(() => {
+    function elsewhere(event: MouseEvent): void {
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest("[data-persona-picker]") !== null
+      ) {
+        return;
+      }
+      done.current();
+    }
+    document.addEventListener("mousedown", elsewhere);
+    return () => document.removeEventListener("mousedown", elsewhere);
+  }, []);
 
   /*
    * **Every persona the project holds, not the first page of them.**
@@ -360,6 +392,7 @@ function PersonaPicker({
       className="absolute top-full left-0 z-20 mt-1 w-[300px] origin-top border border-border bg-surface shadow-popover"
       role="dialog"
       aria-label="Choose personas"
+      data-persona-picker=""
     >
       <div className="border-b border-border">
         <input
@@ -422,6 +455,19 @@ function PersonaPicker({
   );
 }
 
+/**
+ * The lines a cell keeps once nobody is typing into them.
+ *
+ * A numbered line with nothing on it is scaffolding, not a behavior, so it
+ * never survives a commit: the platform is sent the trimmed list either way,
+ * and the cell must not go on drawing a line 3 that says nothing.
+ */
+function withoutTrailingBlanks(behaviors: readonly string[]): readonly string[] {
+  let end = behaviors.length;
+  while (end > 1 && (behaviors[end - 1] ?? "").trim() === "") end -= 1;
+  return behaviors.slice(0, end);
+}
+
 /** The behaviors of one cell, as numbered lines with one caret at a time. */
 function BehaviorLines({
   behaviors,
@@ -434,12 +480,26 @@ function BehaviorLines({
   readonly onCommit: () => void;
   readonly onCancel: () => void;
 }) {
-  const last = useRef<HTMLInputElement | null>(null);
-  const [adding, setAdding] = useState(false);
+  const lines = useRef<(HTMLInputElement | null)[]>([]);
+  /**
+   * Which line the caret is owed, and it is always a line that just moved.
+   *
+   * Adding a line and deleting one are the same problem seen twice: the caret
+   * has to land on a line the render after this one draws. Holding the index
+   * rather than a ref to "the last one" is what lets Backspace put the caret
+   * at the end of the line *above* the one it removed.
+   */
+  const [caretAt, setCaretAt] = useState<number | null>(null);
 
   useEffect(() => {
-    if (adding) last.current?.focus();
-  }, [adding, behaviors.length]);
+    if (caretAt === null) return;
+    const line = lines.current[caretAt];
+    setCaretAt(null);
+    if (line === null || line === undefined) return;
+    line.focus();
+    const end = line.value.length;
+    line.setSelectionRange(end, end);
+  }, [caretAt, behaviors]);
 
   return (
     <div className="flex flex-col gap-0.5">
@@ -453,7 +513,9 @@ function BehaviorLines({
             aria-label={`Expected behavior ${String(at + 1)}`}
             value={behavior}
             autoComplete="off"
-            ref={at === behaviors.length - 1 ? last : undefined}
+            ref={(node) => {
+              lines.current[at] = node;
+            }}
             onChange={(event) => {
               const next = [...behaviors];
               next[at] = event.target.value;
@@ -463,11 +525,29 @@ function BehaviorLines({
               if (event.key === "Enter") {
                 event.preventDefault();
                 if (behavior.trim() === "") {
+                  // Enter on a blank line means "I am done", so the blank
+                  // lines under it go with it rather than lingering.
+                  const kept = withoutTrailingBlanks(behaviors);
+                  if (kept.length !== behaviors.length) onChange(kept);
                   onCommit();
                   return;
                 }
-                setAdding(true);
+                setCaretAt(at + 1);
                 onChange([...behaviors.slice(0, at + 1), "", ...behaviors.slice(at + 1)]);
+                return;
+              }
+              /*
+               * **Backspace on an empty line removes it.** A line added by
+               * mistake had no way out: it holds nothing, so there is nothing
+               * to delete character by character, and it sat there numbered.
+               * The caret goes to the end of the line above, which is where
+               * Backspace means it to go. The last line standing is the cell's
+               * only writing surface, so it stays.
+               */
+              if (event.key === "Backspace" && behavior === "" && behaviors.length > 1) {
+                event.preventDefault();
+                setCaretAt(at === 0 ? 0 : at - 1);
+                onChange(behaviors.filter((_, index) => index !== at));
                 return;
               }
               if (event.key === "Escape") {
@@ -484,7 +564,7 @@ function BehaviorLines({
         type="button"
         onMouseDown={(event) => event.preventDefault()}
         onClick={() => {
-          setAdding(true);
+          setCaretAt(behaviors.length);
           onChange([...behaviors, ""]);
         }}
       >
@@ -628,6 +708,7 @@ function CellBody({
         <button
           className={ADD_LINE}
           type="button"
+          data-persona-picker=""
           onMouseDown={(event) => event.preventDefault()}
           onClick={() => onPick(!picking)}
         >
@@ -766,6 +847,16 @@ export function TestsGrid(props: GridProps) {
   const [picking, setPicking] = useState<string | null>(null);
   const [known, setKnown] = useState<ReadonlyMap<string, Named>>(new Map());
   const [entry, setEntry] = useState<Draft | null>(null);
+  /**
+   * Which entry cell the caret is in, and it is the only one that may wake.
+   *
+   * **The whole entry row used to wear the 2px ink edge at once** — four heavy
+   * boxes shouting together the moment somebody asked to write a test. The
+   * wake means "this is the cell you are in", so it follows the caret, and a
+   * row nobody has touched yet rests on the grid's own hairlines like every
+   * other row (founder, 2026-08-25).
+   */
+  const [entryFocus, setEntryFocus] = useState<Field | null>(null);
   const [entryRefused, setEntryRefused] = useState<string | null>(null);
   const [entrySaving, setEntrySaving] = useState(false);
   const [discarding, setDiscarding] = useState(false);
@@ -798,6 +889,8 @@ export function TestsGrid(props: GridProps) {
   const openEntry = useCallback(() => {
     setEntry((held) => held ?? EMPTY_DRAFT);
     setEntryRefused(null);
+    // A fresh row is at rest until the caret lands, which it does below.
+    setEntryFocus(null);
     onWriting(true);
     window.requestAnimationFrame(() => entryName.current?.focus());
   }, [onWriting]);
@@ -1155,7 +1248,17 @@ export function TestsGrid(props: GridProps) {
   function entryCell(field: Field): ReactNode {
     if (entry === null) return null;
     return (
-      <td className={cn(CELL, WOKEN)} key={field}>
+      <td
+        className={cn(CELL, entryFocus === field && WOKEN)}
+        key={field}
+        onFocus={() => setEntryFocus(field)}
+        onBlur={(event) => {
+          if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            return;
+          }
+          setEntryFocus((held) => (held === field ? null : held));
+        }}
+      >
         <div className={PAD}>
           {field === "name" ? (
             <input
@@ -1192,6 +1295,7 @@ export function TestsGrid(props: GridProps) {
               <button
                 className={ADD_LINE}
                 type="button"
+                data-persona-picker=""
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() =>
                   setPicking(picking === "entry" ? null : "entry")
@@ -1258,15 +1362,16 @@ export function TestsGrid(props: GridProps) {
               </th>
             ))}
             {/*
-              The trailing slot is empty in the header and still present: it is
-              what holds the lane open above the first ⋮, exactly as the house
-              table draws it.
+              The trailing lane is named out loud. It was a blank cell with the
+              words hidden for screen readers only, so on screen the ⋮ column
+              was the one column of the grid with no header over it. "Actions"
+              is what it holds, and every reader gets the same word now.
             */}
             <th
-              className="w-(--table-action-width) border-b border-border p-0"
+              className="w-(--table-action-width) border-b border-border px-2.5 py-2 text-center text-sm font-normal text-faint"
               scope="col"
             >
-              <span className="sr-only">Test actions</span>
+              Actions
             </th>
           </tr>
         </thead>
@@ -1293,8 +1398,13 @@ export function TestsGrid(props: GridProps) {
           {entry === null ? null : (
             <tr data-entry-row="">
               {COLUMNS.map((column) => entryCell(column.field))}
-              {/* Nothing to delete yet: the entry row holds the lane and no ⋮. */}
-              <td className={cn(ACTION, WOKEN)} />
+              {/*
+                Nothing to delete yet, so this cell holds the lane open and
+                says nothing: no wake, no edge, nothing to click. A row that is
+                not written has no action to offer, and dressing the lane like
+                an editable cell promised one.
+              */}
+              <td className={ACTION} />
             </tr>
           )}
           {mayAuthor && entry === null ? (

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -201,10 +201,20 @@ function SheetContent({
 function SheetHeader({
   className,
   children,
+  actions,
   closeLabel = "Close",
   showCloseButton = true,
   ...props
 }: ComponentProps<"div"> & {
+  /**
+   * The panel's own controls, drawn on the title's line beside the close.
+   *
+   * A sheet that manages a record carries a ⋮ for it, and the boards draw that
+   * ⋮ in the head next to the ✕ rather than under the name. Passed here instead
+   * of as a child because the children are the title column: anything put there
+   * lands on a line of its own below the name, which is what it looked like.
+   */
+  readonly actions?: ReactNode;
   readonly closeLabel?: string;
   readonly showCloseButton?: boolean;
 }) {
@@ -219,21 +229,26 @@ function SheetHeader({
       {...props}
     >
       <div className="flex min-w-0 flex-col gap-1">{children}</div>
-      {showCloseButton ? (
-        <SheetClose
-          className={cn(
-            "-mt-1 -mr-1 inline-flex size-(--control-lg) flex-none cursor-pointer",
-            "items-center justify-center rounded-button border border-transparent",
-            "text-muted-foreground",
-            /* Named, so the focus ring is not among them. See `button.tsx`. */
-            "transition-[color,background-color] duration-(--duration-hover) ease-out",
-            "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
-          )}
-        >
-          <XIcon className="size-4" />
-          <span className="sr-only">{closeLabel}</span>
-        </SheetClose>
-      ) : null}
+      {actions === undefined && !showCloseButton ? null : (
+        <div className="-mt-1 -mr-1 flex flex-none items-center gap-1">
+          {actions}
+          {showCloseButton ? (
+            <SheetClose
+              className={cn(
+                "inline-flex size-(--control-lg) flex-none cursor-pointer",
+                "items-center justify-center rounded-button border border-transparent",
+                "text-muted-foreground",
+                /* Named, so the focus ring is not among them. See `button.tsx`. */
+                "transition-[color,background-color] duration-(--duration-hover) ease-out",
+                "pointer-hover:bg-surface-soft pointer-hover:text-foreground",
+              )}
+            >
+              <XIcon className="size-4" />
+              <span className="sr-only">{closeLabel}</span>
+            </SheetClose>
+          ) : null}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/test/agents-pages.test.tsx
+++ b/apps/web/test/agents-pages.test.tsx
@@ -1133,14 +1133,26 @@ describe("adding a connection", () => {
     expect(
       await screen.findByRole("heading", { name: "Connect an agent" }),
     ).toBeTruthy();
-    const picker = (await screen.findByLabelText("Agent*")) as HTMLSelectElement;
-    expect(picker.value).toBe("agt_1");
-    expect(picker.selectedOptions[0]?.textContent).toBe("Front desk · Retell");
+    const picker = await screen.findByLabelText("Agent*");
+    /*
+     * **The name and the platform are two spans, not one string.** The picker
+     * draws the agent's name in the product's text colour and the platform
+     * faint beside it, which a native `<option>` cannot do — so the closed
+     * control says both, and the platform is the one wearing `text-faint`.
+     */
+    expect(picker.textContent).toContain("Front desk");
+    expect(picker.textContent).toContain("Retell");
+    expect(within(picker).getByText("Retell").className).toContain("text-faint");
+
     /*
      * **Making a new agent is still an option, and it is the last one.** Reuse
      * is the ordinary case; creation is the fallback under it (`I79-0`).
      */
-    const options = [...picker.options].map((one) => one.textContent);
+    fireEvent.click(picker);
+    const options = within(screen.getByRole("menu", { name: "Agent*" }))
+      .getAllByRole("menuitem")
+      .map((one) => one.textContent);
+    expect(options[0]).toContain("Front desk");
     expect(options.at(-1)).toBe("Create a new agent");
     expect(
       screen.getByText("The label shown for this connection in Egma."),

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -1640,7 +1640,8 @@ describe("the role the shell shows", () => {
     expect(mark?.getAttribute("height")).toBe("32");
     expect(organization.querySelector("img")).toBeNull();
     expect(organization.textContent).toContain("Acme");
-    expect(organization.textContent).toContain("Free");
+    /* The bar says the organization, and no plan chip beside it. */
+    expect(organization.textContent).not.toContain("Free");
     expect(
       organization.querySelector('[data-slot="organization-name"]')?.className,
     ).toContain("text-sm");
@@ -1659,8 +1660,14 @@ describe("the role the shell shows", () => {
     const summary = within(
       screen.getByRole("dialog", { name: "Open organization menu for Acme" }),
     );
-    expect(summary.getByText("Free Plan")).toBeTruthy();
-    expect(summary.getByText("Admin")).toBeTruthy();
+    /*
+     * The panel is the mark and the name. The plan was hard-written copy for a
+     * fact `/api/me` does not carry, and the role is already said by the
+     * account control at the foot of this same sidebar.
+     */
+    expect(summary.getByText("Acme")).toBeTruthy();
+    expect(summary.queryByText("Free Plan")).toBeNull();
+    expect(summary.queryByText("Admin")).toBeNull();
     expect(summary.queryByText("Organization settings")).toBeNull();
   });
 

--- a/apps/web/test/monitor-agent-sheet.test.tsx
+++ b/apps/web/test/monitor-agent-sheet.test.tsx
@@ -370,6 +370,18 @@ describe("which agents the picker lists", () => {
       }),
     ).toBeDefined();
     expect(screen.queryByRole("button", { name: "Start pulling" })).toBeNull();
+
+    /*
+     * **The sentence promises "add another agent", so the panel carries the
+     * move that does it.** Close alone was a dead end. Connecting belongs to
+     * the agents screen, so this is a real navigation, and it lands with that
+     * screen's connect sheet already open.
+     */
+    expect(
+      screen.getByRole("link", { name: "Connect an agent" }).getAttribute("href"),
+    ).toBe("/projects/prj_2/agents?sheet=connect");
+    // The way out stays: the head's own ✕ and the footer's Close.
+    expect(screen.getAllByRole("button", { name: "Close" }).length).toBeGreaterThan(0);
   });
 
   /**

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -271,7 +271,7 @@ describe("the suite-first Tests route", () => {
     expect(routed.push).toHaveBeenCalledWith("/projects/prj_1/tests/suites/ste_1");
   });
 
-  it("teaches the first test in the grid and carries only Write a test", async () => {
+  it("teaches the first test in the grid and keeps every verb inside it", async () => {
     routed.pathname = "/projects/prj_1/tests/suites/ste_1";
     routed.params = { projectId: "prj_1", suiteId: "ste_1" };
     answers({
@@ -283,7 +283,14 @@ describe("the suite-first Tests route", () => {
     render(<TestSuitePage />);
 
     expect(await screen.findByRole("heading", { name: "Northside Ford" })).toBeTruthy();
-    for (const header of ["Name", "Scenario", "Expected behaviors", "Personas"]) {
+    // The trailing ⋮ lane is named out loud, like every other column.
+    for (const header of [
+      "Name",
+      "Scenario",
+      "Expected behaviors",
+      "Personas",
+      "Actions",
+    ]) {
       expect(screen.getByRole("columnheader", { name: header }), header).toBeTruthy();
     }
     // An empty suite is the grid and one teaching row, not an empty-state card.
@@ -292,8 +299,10 @@ describe("the suite-first Tests route", () => {
     expect(screen.getByRole("button", { name: "+ Write a test" })).toBeTruthy();
 
     // Suite management moved to the suites list. Nothing here runs, renames or
-    // deletes a suite, and there is no toolbar ⋮ left to hold them.
-    expect(screen.getByRole("button", { name: "Write a test" })).toBeTruthy();
+    // deletes a suite, and there is no toolbar ⋮ left to hold them. Writing is
+    // the grid's ghost row alone: the toolbar button said the same word twice
+    // and went on 2026-08-25.
+    expect(screen.queryByRole("button", { name: "Write a test" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Run suite" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Open the suite menu" })).toBeNull();
   });
@@ -313,13 +322,12 @@ describe("the suite-first Tests route", () => {
     render(<TestSuitePage />);
 
     expect(await screen.findByText("Books service")).toBeTruthy();
-    const write = screen.getByRole("button", { name: "Write a test" });
-    expect((write as HTMLButtonElement).disabled).toBe(true);
-    fireEvent.click(write);
 
-    // A viewer's grid never wakes: no ghost row to write into, and a click on a
-    // cell leaves the cell as it was.
+    // A viewer's grid never wakes: no ghost row to write into, no toolbar
+    // button standing in for it, and a click on a cell leaves the cell as it
+    // was.
     expect(screen.queryByRole("button", { name: "+ Write a test" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Write a test" })).toBeNull();
     fireEvent.click(screen.getByText("The caller books service."));
     expect(screen.queryByLabelText("Scenario")).toBeNull();
     expect(sent.some((request) => ["POST", "PATCH", "DELETE"].includes(request.method))).toBe(
@@ -648,14 +656,14 @@ describe("the suite-first Tests route", () => {
     });
   });
 
-  it("focuses the entry row from the toolbar and from the retired write address", async () => {
+  it("focuses the entry row from the ghost row and from the retired write address", async () => {
     gridAnswers({ tests: [] });
 
     render(<TestSuitePage />);
 
-    // The toolbar's own button: the entry row opens with the caret in Name,
-    // and the address does not move.
-    fireEvent.click(await screen.findByRole("button", { name: "Write a test" }));
+    // The grid's own ghost row, which is the only way in now: the entry row
+    // opens with the caret in Name, and the address does not move.
+    fireEvent.click(await screen.findByRole("button", { name: "+ Write a test" }));
     await waitFor(() => {
       expect(document.activeElement).toBe(screen.getByLabelText("Name"));
     });

--- a/apps/web/ui/menu.tsx
+++ b/apps/web/ui/menu.tsx
@@ -58,6 +58,17 @@ export type MenuProps = {
   readonly trigger: ReactNode;
   readonly triggerClassName?: string;
   readonly openClassName?: string;
+  /**
+   * The button's own id, for a `<label for>` that has to point at it.
+   *
+   * A panel standing in for a form control is still a field with a name drawn
+   * above it, and a label that points at nothing is a label a person cannot
+   * click and assistive technology cannot follow. A button is a labelable
+   * element, so the id is all that is missing.
+   */
+  readonly triggerId?: string;
+  /** A control that cannot be used yet — while the form it sits in is saving. */
+  readonly disabled?: boolean;
   /** Which edge of the trigger anchors the panel. */
   readonly placement?:
     | "below-start"
@@ -136,6 +147,8 @@ export function Menu({
   trigger,
   triggerClassName,
   openClassName,
+  triggerId,
+  disabled,
   placement = "below-start",
   panelRole = "menu",
   panelClassName,
@@ -223,6 +236,8 @@ export function Menu({
           ref={holdTrigger}
           aria-haspopup={panelRole}
           aria-label={label}
+          {...(triggerId === undefined ? {} : { id: triggerId })}
+          {...(disabled === undefined ? {} : { disabled })}
         >
           {trigger}
         </PopoverTrigger>

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -297,27 +297,21 @@ function Navigation({
   );
 }
 
-/*
- * Billing is not part of `/api/me` yet. Every organization in this release is
- * on the same plan, so this stays explicit UI copy instead of pretending the
- * session contains subscription data. Do not show it without a real
- * organization; a loading or failed session has made no plan claim.
- */
-const CURRENT_PLAN = { badge: "Free", name: "Free Plan" } as const;
-
-const ROLE_LABEL: Record<Role, string> = {
-  admin: "Admin",
-  member: "Member",
-  viewer: "Viewer",
-};
-
 /**
  * The organization identity at the top of the signed-in sidebar.
  *
  * There is one organization per session today, so this panel gives context and
- * does not offer a false switcher. The paired arrows still open a useful
- * surface: organization name, current plan and the person's real membership
- * role. Organization settings stay out until that product level exists.
+ * does not offer a false switcher. The paired arrows still open a small
+ * surface: the organization's mark and its name. Organization settings stay out
+ * until that product level exists.
+ *
+ * **The bar and the panel say the organization's name, and nothing else.**
+ * Both used to carry a "Free" chip and a "Free Plan · Admin" line under the
+ * name. Billing is not part of `/api/me`, so that plan was hard-written copy
+ * standing where a fact belongs, and the role it sat beside is already said by
+ * the account control at the foot of the same sidebar. Two claims, one of them
+ * invented and one of them repeated, above the name they were meant to
+ * describe.
  *
  * **The mark is identity, not a control.** It sits beside the menu trigger
  * rather than inside it, so the hover plate, focus indicator and press feedback
@@ -326,11 +320,9 @@ const ROLE_LABEL: Record<Role, string> = {
  */
 function OrganizationMenu({
   organization,
-  role,
   settled,
 }: {
   readonly organization: Organization | undefined;
-  readonly role: Role | null;
   readonly settled: boolean;
 }) {
   const mark = (
@@ -388,9 +380,6 @@ function OrganizationMenu({
             >
               {organization.name}
             </span>
-            <Badge className="px-1 text-xs" shape="count" data-slot="organization-plan">
-              {CURRENT_PLAN.badge}
-            </Badge>
             <ChevronsUpDownIcon
               className="size-3 flex-none text-faint"
               aria-hidden="true"
@@ -407,19 +396,8 @@ function OrganizationMenu({
             >
               {initial}
             </span>
-            <span className="min-w-0">
-              <span className="block overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground">
-                {organization.name}
-              </span>
-              <span className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-                <span>{CURRENT_PLAN.name}</span>
-                {role === null ? null : (
-                  <>
-                    <span className="h-3 w-px bg-border" aria-hidden="true" />
-                    <span>{ROLE_LABEL[role]}</span>
-                  </>
-                )}
-              </span>
+            <span className="min-w-0 overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground">
+              {organization.name}
             </span>
           </div>
         )}
@@ -735,11 +713,7 @@ function ShellFrame({
       >
         {/* Organization context owns the top bar; project context stays below. */}
         <SidebarBrand className="gap-2 [&>[data-slot=menu]]:min-w-0 [&>[data-slot=menu]]:flex-1">
-          <OrganizationMenu
-            organization={organization}
-            role={role}
-            settled={session.settled}
-          />
+          <OrganizationMenu organization={organization} settled={session.settled} />
         </SidebarBrand>
         <SidebarHeader className="px-4">{selector(false)}</SidebarHeader>
         {shown === null ? null : <Navigation projectId={shown} pathname={pathname} />}


### PR DESCRIPTION
Eight fixes from the developer's live production pass, built by two parallel agents on disjoint surfaces and combined here. Per the developer's instruction: no local suite runs (typecheck + the directly-affected test files only) — this CI run is the gate.

**Agents & shell**
1. The connection sheet's ⋮ (Edit/Delete) now sits in the header row beside the ✕, via a proper `actions` slot on SheetHeader — no more floating menu under the title.
2. The agent picker is two-tone: agent name in ink, platform in faint, long names ellipsized so the platform never pushes out — converted from the native select to the house menu pattern (same keyboard behavior; "Create a new agent" stays last).
3. The "Free" plan chip is gone from the org bar and its popup — both show the organization name only. (The account control's role line at the sidebar bottom stays.)

**Tests grid & monitoring**
4. The toolbar "Write a test" button is removed — the grid's ghost "+ Write a test" row and the /tests/new?suite= alias are the ways in.
5. The entry row no longer draws heavy ink borders on every cell at once — only the cell holding the caret wakes; the trailing action lane has a visible "Actions" header and an inert cell in the entry row.
6. Backspace on an empty behavior line deletes the line (caret to the previous line's end); trailing blank lines are pruned on commit.
7. Clicking outside the persona picker closes it exactly as Done does (selections kept).
8. The monitor picker's every-agent-monitored state now leads with "Connect an agent" linking to the agents screen with the connect sheet open, keeping Close.

Affected test expectations updated by reading and verified per-file (agents-pages + components: 110 passing; test-suites-pages + monitor-agent-sheet: 51 passing); browser-walk expectations checked — the walk clicks the ghost row and the copied-link "Save test" row stays true. pnpm typecheck exit 0 on both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790276163&installation_model_id=431960&pr_number=230&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F230&signature=3674dbf2d79adda372120e4a017d9b70900e841b20a0165f96ad3ae3089ab5ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR polishes several web workflows around agent connection, monitoring, test authoring, sheets, and organization identity.
- Moves connection actions into the shared sheet header and converts agent selection to the house menu pattern.
- Adds a direct monitoring-to-agent-connection path and simplifies organization display.
- Refines the tests grid’s entry styling, behavior-line editing, persona-picker dismissal, and action column.
- Removes the redundant suite toolbar writing action and updates affected tests.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until switching from an existing test’s persona picker to the entry-row picker commits the existing row’s selections.

The new global inside-click marker lets a reachable second persona trigger unmount the active existing-row picker without executing its Done-equivalent persistence callback.

**Files Needing Attention:** apps/web/app/projects/[projectId]/tests/tests-grid.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Adds focus styling, behavior-line deletion and pruning, action-column labeling, and outside-click dismissal; the global persona-picker marker allows switching pickers without committing the current row. |
| apps/web/app/projects/[projectId]/agents/connect-sheet.tsx | Replaces the native agent selector with a styled menu while preserving the selected agent in React state. |
| apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx | Adds a project-scoped link from empty monitoring states to the agents screen with its connection sheet requested. |
| apps/web/components/ui/sheet.tsx | Adds a dedicated header-actions slot beside the sheet close control. |
| apps/web/ui/menu.tsx | Adds trigger IDs and disabled-state forwarding to support menu-based form fields. |
| apps/web/ui/shell.tsx | Removes unsupported plan copy and duplicated role text from organization identity surfaces. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Existing test persona picker open] --> B[User clicks entry-row persona trigger]
  B --> C{Global data-persona-picker match}
  C -->|Classified as inside| D[Skip current picker onDone]
  B --> E[Set shared picker state to entry]
  E --> F[Existing picker unmounts]
  D --> G[Existing test selections are not committed]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fprod-polish%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fprod-polish%22.%0A%0AGreploop%20egma-ai%2Fegma%20PR%20%23230%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=egma-ai%2Fegma&pr=230&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fprod-polish%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fprod-polish%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fweb%2Fapp%2Fprojects%2F%5BprojectId%5D%2Ftests%2Ftests-grid.tsx%3A314-317%0A**Picker%20switch%20skips%20commit**%0A%0AWhen%20an%20existing%20test's%20persona%20picker%20and%20the%20new-test%20entry%20row%20are%20both%20open%2C%20clicking%20the%20entry%20row's%20persona%20trigger%20is%20classified%20as%20an%20inside%20click%20because%20both%20surfaces%20use%20%60data-persona-picker%60.%20The%20shared%20picker%20state%20then%20switches%20to%20the%20entry%20row%20without%20running%20the%20existing%20picker's%20Done%20callback%2C%20leaving%20those%20persona%20selections%20unpersisted%20and%20allowing%20a%20later%20cell%20edit%20to%20discard%20them.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=230&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fapp%2Fprojects%2F%5BprojectId%5D%2Ftests%2Ftests-grid.tsx%3A314-317%0A**Picker%20switch%20skips%20commit**%0A%0AWhen%20an%20existing%20test's%20persona%20picker%20and%20the%20new-test%20entry%20row%20are%20both%20open%2C%20clicking%20the%20entry%20row's%20persona%20trigger%20is%20classified%20as%20an%20inside%20click%20because%20both%20surfaces%20use%20%60data-persona-picker%60.%20The%20shared%20picker%20state%20then%20switches%20to%20the%20entry%20row%20without%20running%20the%20existing%20picker's%20Done%20callback%2C%20leaving%20those%20persona%20selections%20unpersisted%20and%20allowing%20a%20later%20cell%20edit%20to%20discard%20them.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=230&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Merge the grid and monitoring half of th..."](https://github.com/egma-ai/egma/commit/cfec84305b2c9e01f327453208838ba40edd0863) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56785162)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)
- Knowledge Base — [Operator workflows](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/operator-workflows.md)

<!-- /greptile_comment -->