### PR TITLE
feat(observability): the surface is Observability, its screen is Traces, and LiveKit onboarding reads like a first-trace setup

### DIFF
--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -879,15 +879,15 @@ describe("what a project recorded in production", () => {
       });
 
       // The six rows the three clusters hold — the unlabelled standing pair at
-      // the top, the three Simulations rows, and Monitoring's one. Settings is
-      // not one of them and neither is a simulation.
+      // the top, the three Simulations rows, and OBSERVABILITY's one. Settings
+      // is not one of them and neither is a simulation.
       for (const area of [
         "Agents",
         "Graders",
         "Tests",
         "Personas",
         "Runs",
-        "Transcripts",
+        "Traces",
       ]) {
         expect(
           await sidebar.getByRole("link", { name: area, exact: true }).count(),
@@ -905,12 +905,13 @@ describe("what a project recorded in production", () => {
        * redirect on every visit, and a reserved neighbour under the same area
        * could become the landing by accident.
        *
-       * The word `Monitoring` is the group's now, so the item says what its
-       * page is. The address it carries did not move with the word.
+       * The group says `OBSERVABILITY` and the row says `Traces` (developer
+       * decision, 2026-08-25). Only the words moved: the address it carries is
+       * the one it always was.
        */
       expect(
         await sidebar
-          .getByRole("link", { name: "Transcripts", exact: true })
+          .getByRole("link", { name: "Traces", exact: true })
           .getAttribute("href"),
       ).toBe(`/projects/${project ?? ""}/monitoring/transcripts`);
 
@@ -1147,7 +1148,7 @@ describe("what a project recorded in production", () => {
       // label over the title and no purpose sentence under it. The sidebar
       // already says which section this is and which project it belongs to,
       // and the table says what it holds.
-      expect(shown).toContain("Transcripts");
+      expect(shown).toContain("Traces");
       expect(shown).not.toContain(
         "What your agents did in production, newest first.",
       );
@@ -3612,7 +3613,7 @@ describe("the complete product, walked in order in a second project", () => {
                * the loop below only ever says that what *is* here is allowed,
                * so an empty-ish bar satisfies every line of it. Six is the
                * whole of `NAVIGATION_GROUPS` — Agents, Graders, Tests,
-               * Personas, Runs, Transcripts — and a row added or dropped
+               * Personas, Runs, Traces — and a row added or dropped
                * should be a decision somebody takes here on purpose.
                */
               expect(addresses, addresses.join(", ")).toHaveLength(6);

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -736,7 +736,15 @@ async function send(secret: string, resourceSpans: unknown[]): Promise<void> {
  * `apps/web/test/transcripts.test.ts`, where every string they can render lives
  * in one file. Both are worth having: that one catches a word before it can
  * reach a screen, and this one catches a word that reached one anyway.
+ *
+ * **The screen's own name is the second carve-out**, and it is one word wide —
+ * the same one `transcripts.test.ts` makes, for the same reason. The developer
+ * renamed the surface to Traces on 2026-08-25, so the sidebar row and the list
+ * heading both say it on every page this helper reads. `trace` stays banned in
+ * every sentence around them: the artifact a person opens is a **transcript**,
+ * and this rule is what keeps it one.
  */
+const SURFACE_NAME = /\bTraces\b/gu;
 const NEVER_SHOWN = [
   "trace",
   "span",
@@ -750,9 +758,10 @@ const NEVER_SHOWN = [
 ];
 
 function saysNothingBanned(shown: string): void {
+  const said = shown.replaceAll(SURFACE_NAME, "");
   for (const banned of NEVER_SHOWN) {
     expect(
-      new RegExp(`\\b${banned}`, "iu").test(shown),
+      new RegExp(`\\b${banned}`, "iu").test(said),
       `the page says "${banned}"`,
     ).toBe(false);
   }

--- a/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { listAgents, startMonitoring } from "@egma/platform-api/client";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
@@ -76,11 +77,51 @@ import { useProjectRead } from "../../../../ui/resource.ts";
  * `monitor_livekit(ctx)` and `AgentSession.start` are identifiers a person
  * types into their editor rather than product vocabulary.
  */
-const STEPS = [
-  "Install the Egma SDK.",
-  "Call monitor_livekit(ctx) before AgentSession.start.",
-  "Set EGMA_URL and EGMA_API_KEY in the agent's environment.",
-] as const;
+
+/**
+ * The one line a person adds to their agent, on its own contained surface so
+ * that it can be copied whole. It is the SDK's own name and is never reworded.
+ */
+const SNIPPET = "monitor_livekit(ctx)";
+
+/**
+ * The identifier the line has to come before, shown as code inside the
+ * sentence for the same reason: it is what a person searches their own file
+ * for, not a phrase egma chose.
+ */
+const BEFORE = "AgentSession.start";
+
+/**
+ * The three numbered steps, in the shape the developer asked for on
+ * 2026-08-25: a short bold heading and one muted sentence each, the way
+ * Langfuse heads its first-trace onboarding.
+ *
+ * **The technical content is the same three steps it has always been**, folded
+ * from three flat sentences into three headed ones: the SDK, the one line with
+ * both SDK identifiers verbatim, and the two environment variables — with the
+ * last step now the one that says what happens next, because a person who has
+ * done the work is owed the answer to "and then?".
+ */
+const STEPS: readonly {
+  readonly title: string;
+  readonly body: string;
+  /** Whether this is the step the snippet and its Copy button belong to. */
+  readonly snippet?: true;
+}[] = [
+  {
+    title: "Install the Egma SDK",
+    body: "Add it to the environment your agent runs in, then set EGMA_URL and EGMA_API_KEY there.",
+  },
+  {
+    title: "Add one line to your agent",
+    body: "One line, and it goes ahead of",
+    snippet: true,
+  },
+  {
+    title: "Run your agent",
+    body: "Its traces appear in Traces within seconds of finishing.",
+  },
+];
 
 const COPY = {
   title: "Monitor an agent",
@@ -118,9 +159,24 @@ const COPY = {
   notYours: (role: string) =>
     `Your ${role} role cannot start monitoring. Ask an organization admin to ` +
     "change your role, then try again.",
+  /**
+   * The head of the LiveKit half, in the shape of Langfuse's first-trace
+   * onboarding (developer decision, 2026-08-25).
+   *
+   * **The chip is honest rather than decorative.** This half is only ever
+   * drawn for an agent nothing has arrived from — the picker lists agents that
+   * are not yet monitored — so *waiting* is a fact about this agent, not a
+   * mood. It is the warning family because nothing is wrong yet and nothing is
+   * working yet either, and the word carries that without the colour.
+   */
+  livekitWaiting: "Waiting for the first trace",
+  livekitTitle: "Time to log the first trace",
   livekitLead:
-    "From then on, this agent's production transcripts appear in Transcripts " +
-    "as they finish. Nothing is stored on the agent, and there is no switch.",
+    "It takes about a minute, and there is nothing to switch on afterwards.",
+  copy: "Copy",
+  copied: "Copied",
+  copyFailed:
+    "Egma could not reach the clipboard. Select the line above and copy it.",
 } as const;
 
 /** How many agents one roster read asks for. The contract's own ceiling. */
@@ -613,13 +669,93 @@ function RetellStart({
 }
 
 /**
- * The LiveKit half: three steps, and nothing else.
+ * The one line, on its own surface, with the way to take it.
+ *
+ * The copy behaviour is the API-keys screen's, kept the same on purpose: try
+ * the clipboard, say *Copied* when it worked, and — when the browser refuses
+ * or has no clipboard at all — say so and point at the text, which is still on
+ * screen and still selectable. A button that silently did nothing is the one
+ * outcome a copy control must never have.
+ */
+function Snippet(): ReactNode {
+  const [state, setState] = useState<"idle" | "copied" | "failed">("idle");
+
+  /*
+   * *Copied* is a receipt rather than a new label, so it goes away on its own.
+   * The timer is cleared on unmount and whenever the state moves again, so a
+   * sheet closed straight after a press sets nothing on a gone component.
+   */
+  useEffect(() => {
+    if (state !== "copied") return undefined;
+    const timer = setTimeout(() => setState("idle"), 2000);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  async function copy(): Promise<void> {
+    try {
+      if (navigator.clipboard === undefined) {
+        throw new Error("clipboard unavailable");
+      }
+      await navigator.clipboard.writeText(SNIPPET);
+      setState("copied");
+    } catch {
+      setState("failed");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/*
+        The bordered code surface `DESIGN.md` gives identifiers: the mono
+        stack, the quiet neutral fill, and the product's one radius, which is
+        none. It scrolls sideways rather than wrapping, because a line broken
+        mid-identifier is a line somebody types back wrong.
+      */}
+      <div className="flex items-start gap-2">
+        <pre className="m-0 min-w-0 flex-1 overflow-x-auto rounded-input border border-border bg-surface-soft p-3 font-mono text-xs leading-(--line-normal) text-foreground">
+          <code>{SNIPPET}</code>
+        </pre>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="flex-none"
+          onClick={() => void copy()}
+        >
+          {state === "copied" ? COPY.copied : COPY.copy}
+        </Button>
+      </div>
+      {/*
+        Said out loud when it happens, for a reader who is not watching the
+        button — and never as colour alone, which is what `DESIGN.md` asks.
+      */}
+      <p aria-live="polite" className="sr-only">
+        {state === "copied" ? COPY.copied : ""}
+      </p>
+      {state === "failed" ? (
+        <p className="m-0 text-sm leading-(--line-normal) text-faint">
+          {COPY.copyFailed}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The LiveKit half: what to do first, in three numbered steps.
  *
  * **It reads no server state and writes none.** Push is ungated by design —
  * the door authenticates with the project key, tenancy comes from the key, and
  * the stored evidence is the whole record of an agent pushing. So there is no
  * row to write here and no switch to flip, and re-opening these steps for the
- * same agent is idempotent rather than a second act.
+ * same agent is idempotent rather than a second act. The Copy button touches
+ * the clipboard and nothing else.
+ *
+ * **The shape is Langfuse's first-trace onboarding, in this product's system**
+ * (developer decision, 2026-08-25): a state chip, a heading with one sentence
+ * under it, and then the steps down a connected spine. What it replaced was
+ * three flat sentences with a faint number beside each, which said the same
+ * things and gave a person no sense of being partway through anything.
  */
 function LiveKitSteps({
   chooser,
@@ -628,32 +764,76 @@ function LiveKitSteps({
   readonly chooser: ReactNode;
   readonly onClose: () => void;
 }) {
+  const last = STEPS.length - 1;
+
   return (
     <>
       <SheetBody>
         {chooser}
 
         <div className={`flex flex-col gap-4 ${ARRIVES}`}>
-          <ol className="m-0 flex list-none flex-col gap-4 p-0">
+          <div className="flex flex-col gap-2">
+            <Badge variant="warning">{COPY.livekitWaiting}</Badge>
+            {/*
+              A heading inside the panel rather than a second title bar: the
+              sheet's own title says which panel this is, and this says what
+              the panel is asking for right now.
+            */}
+            <h3 className="m-0 text-base leading-(--line-tight) font-medium text-foreground">
+              {COPY.livekitTitle}
+            </h3>
+            <p className="m-0 text-sm leading-(--line-normal) text-faint">
+              {COPY.livekitLead}
+            </p>
+          </div>
+
+          <ol className="m-0 flex list-none flex-col p-0">
             {STEPS.map((step, at) => (
-              <li key={step} className="flex gap-3">
+              <li
+                key={step.title}
+                className={`relative flex gap-3 ${at === last ? "" : "pb-5"}`}
+              >
                 {/*
-                  A fixed-width slot, so the three sentences start on one lane
-                  however wide the numbers get. `DESIGN.md` asks for tabular
-                  numerals wherever figures line up.
+                  The spine, which is the thing that makes three steps read as
+                  one sequence. It runs from under one number to the next and
+                  stops at the last, so the list ends rather than trailing off.
                 */}
-                <span className="w-4 flex-none text-sm text-faint tabular-nums">
+                {at === last ? null : (
+                  <span
+                    aria-hidden="true"
+                    className="absolute top-6 bottom-0 left-3 w-px -translate-x-1/2 bg-border"
+                  />
+                )}
+                {/*
+                  A square, filled with the ink and lettered in the paper —
+                  `DESIGN.md` has one radius and it is none, so the number chip
+                  is a square like every other mark in the product. Tabular
+                  numerals keep the three on one lane.
+                */}
+                <span className="z-1 flex size-6 flex-none items-center justify-center bg-foreground text-xs font-medium text-background tabular-nums">
                   {at + 1}
                 </span>
-                <span className="text-sm leading-(--line-normal) text-foreground">
-                  {step}
-                </span>
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <p className="m-0 text-sm leading-(--line-normal) font-medium text-foreground">
+                    {step.title}
+                  </p>
+                  <p className="m-0 text-sm leading-(--line-normal) text-faint">
+                    {step.body}
+                    {step.snippet === undefined ? null : (
+                      <>
+                        {" "}
+                        <code className="font-mono text-xs text-foreground">
+                          {BEFORE}
+                        </code>
+                        .
+                      </>
+                    )}
+                  </p>
+                  {step.snippet === undefined ? null : <Snippet />}
+                </div>
               </li>
             ))}
           </ol>
-          <p className="m-0 text-sm leading-(--line-normal) text-faint">
-            {COPY.livekitLead}
-          </p>
         </div>
       </SheetBody>
 

--- a/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { listAgents, startMonitoring } from "@egma/platform-api/client";
 
 import { Badge } from "@/components/ui/badge";
@@ -163,16 +163,27 @@ const COPY = {
    * The head of the LiveKit half, in the shape of Langfuse's first-trace
    * onboarding (developer decision, 2026-08-25).
    *
-   * **The chip is honest rather than decorative.** This half is only ever
-   * drawn for an agent nothing has arrived from — the picker lists agents that
-   * are not yet monitored — so *waiting* is a fact about this agent, not a
-   * mood. It is the warning family because nothing is wrong yet and nothing is
-   * working yet either, and the word carries that without the colour.
+   * **The chip is a fact about this agent rather than decoration, so there are
+   * two of them.** Push is ungated, and this half is drawn for every LiveKit
+   * agent the picker lists — including one whose evidence has *already*
+   * arrived, because there is no pull switch to sort them by. Telling that
+   * agent's owner they are waiting for a first trace would be egma being wrong
+   * about the one thing this panel exists to report, so `lastReceivedAt`
+   * decides which pair of words is said.
+   *
+   * Waiting is the warning family: nothing is broken and nothing is working
+   * yet either. Receiving is the success family. Either way the steps stay
+   * below — for the second agent, and for anybody checking what they did.
    */
   livekitWaiting: "Waiting for the first trace",
   livekitTitle: "Time to log the first trace",
   livekitLead:
     "It takes about a minute, and there is nothing to switch on afterwards.",
+  livekitReceiving: "Receiving traces",
+  livekitReceivingTitle: "Egma is already receiving from this agent",
+  livekitReceivingLead:
+    "Setup is done, and the steps below stay as reference for the next agent " +
+    "you point at Egma.",
   copy: "Copy",
   copied: "Copied",
   copyFailed:
@@ -447,7 +458,7 @@ function Picker({
   }
 
   if (pickerPlatformOf(agent) === "livekit") {
-    return <LiveKitSteps chooser={chooser} onClose={onClose} />;
+    return <LiveKitSteps agent={agent} chooser={chooser} onClose={onClose} />;
   }
 
   return (
@@ -680,16 +691,26 @@ function RetellStart({
 function Snippet(): ReactNode {
   const [state, setState] = useState<"idle" | "copied" | "failed">("idle");
 
-  /*
-   * *Copied* is a receipt rather than a new label, so it goes away on its own.
-   * The timer is cleared on unmount and whenever the state moves again, so a
-   * sheet closed straight after a press sets nothing on a gone component.
+  /**
+   * The receipt's own timer, held rather than derived from the state.
+   *
+   * **A second press has to start the two seconds over.** Keying the timeout
+   * off `state` looked tidier and was wrong: pressing Copy again while the
+   * receipt is still up sets `copied` on top of `copied`, which is no change
+   * at all — so the first press's timer ran on and took the receipt away part
+   * way through the second one. One timer, cleared before the next is started,
+   * and cleared again on unmount so a sheet closed straight after a press sets
+   * nothing on a gone component.
    */
-  useEffect(() => {
-    if (state !== "copied") return undefined;
-    const timer = setTimeout(() => setState("idle"), 2000);
-    return () => clearTimeout(timer);
-  }, [state]);
+  const receipt = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function stopReceipt(): void {
+    if (receipt.current === null) return;
+    clearTimeout(receipt.current);
+    receipt.current = null;
+  }
+
+  useEffect(() => stopReceipt, []);
 
   async function copy(): Promise<void> {
     try {
@@ -697,8 +718,11 @@ function Snippet(): ReactNode {
         throw new Error("clipboard unavailable");
       }
       await navigator.clipboard.writeText(SNIPPET);
+      stopReceipt();
       setState("copied");
+      receipt.current = setTimeout(() => setState("idle"), 2000);
     } catch {
+      stopReceipt();
       setState("failed");
     }
   }
@@ -758,13 +782,23 @@ function Snippet(): ReactNode {
  * things and gave a person no sense of being partway through anything.
  */
 function LiveKitSteps({
+  agent,
   chooser,
   onClose,
 }: {
+  readonly agent: ListedAgentWithConnections;
   readonly chooser: ReactNode;
   readonly onClose: () => void;
 }) {
   const last = STEPS.length - 1;
+  /*
+   * **Read, not stored.** This is the one fact the list read already carries
+   * about a pushing agent, and looking at it writes nothing and asks nothing
+   * extra — the stores-nothing ruling is about what this half *records*, and
+   * it still records nothing. A field that is already in the roster answer is
+   * not a LiveKit monitored-state; it is the evidence's own arrival time.
+   */
+  const receiving = agent.lastReceivedAt !== null;
 
   return (
     <>
@@ -773,17 +807,19 @@ function LiveKitSteps({
 
         <div className={`flex flex-col gap-4 ${ARRIVES}`}>
           <div className="flex flex-col gap-2">
-            <Badge variant="warning">{COPY.livekitWaiting}</Badge>
+            <Badge variant={receiving ? "success" : "warning"}>
+              {receiving ? COPY.livekitReceiving : COPY.livekitWaiting}
+            </Badge>
             {/*
               A heading inside the panel rather than a second title bar: the
               sheet's own title says which panel this is, and this says what
               the panel is asking for right now.
             */}
             <h3 className="m-0 text-base leading-(--line-tight) font-medium text-foreground">
-              {COPY.livekitTitle}
+              {receiving ? COPY.livekitReceivingTitle : COPY.livekitTitle}
             </h3>
             <p className="m-0 text-sm leading-(--line-normal) text-faint">
-              {COPY.livekitLead}
+              {receiving ? COPY.livekitReceivingLead : COPY.livekitLead}
             </p>
           </div>
 

--- a/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
+++ b/apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx
@@ -163,19 +163,24 @@ const COPY = {
    * The head of the LiveKit half, in the shape of Langfuse's first-trace
    * onboarding (developer decision, 2026-08-25).
    *
-   * **The chip is a fact about this agent rather than decoration, so there are
-   * two of them.** Push is ungated, and this half is drawn for every LiveKit
-   * agent the picker lists — including one whose evidence has *already*
-   * arrived, because there is no pull switch to sort them by. Telling that
-   * agent's owner they are waiting for a first trace would be egma being wrong
-   * about the one thing this panel exists to report, so `lastReceivedAt`
-   * decides which pair of words is said.
+   * **The chip says only what egma can check.**
    *
-   * Waiting is the warning family: nothing is broken and nothing is working
-   * yet either. Receiving is the success family. Either way the steps stay
-   * below — for the second agent, and for anybody checking what they did.
+   * It used to read *Waiting for the first trace*, which is a claim about this
+   * agent's history — and egma cannot make that claim for a LiveKit agent.
+   * `lastReceivedAt` is a subselect from `monitoring_state`
+   * (`packages/db/src/access/agents.ts`), and only a *pull* agent ever gets a
+   * row there, so a push agent reads `null` whether nothing has arrived or a
+   * thousand traces have. A chip that said *waiting* to somebody whose agent
+   * had been reporting all week would be egma being wrong about the one thing
+   * this panel exists to report.
+   *
+   * *Listening for traces* is true unconditionally, because it describes
+   * egma's own posture rather than the agent's past: the door is open and the
+   * project key is the whole of what it wants. It stays the warning family —
+   * nothing is broken and nothing is working yet either — and the steps stay
+   * below it either way.
    */
-  livekitWaiting: "Waiting for the first trace",
+  livekitWaiting: "Listening for traces",
   livekitTitle: "Time to log the first trace",
   livekitLead:
     "It takes about a minute, and there is nothing to switch on afterwards.",
@@ -797,6 +802,13 @@ function LiveKitSteps({
    * extra — the stores-nothing ruling is about what this half *records*, and
    * it still records nothing. A field that is already in the roster answer is
    * not a LiveKit monitored-state; it is the evidence's own arrival time.
+   *
+   * **This branch is dormant on purpose**: `lastReceivedAt` is a subselect
+   * from `monitoring_state` (`packages/db/src/access/agents.ts`) and only a
+   * pull agent has a row there, so it reads `null` for every push agent until
+   * somebody decides — at founder level, against the stores-nothing ruling —
+   * that ingestion should stamp one. The words are written and tested so that
+   * the day the signal exists this half already tells the truth about it.
    */
   const receiving = agent.lastReceivedAt !== null;
 

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -115,12 +115,20 @@ const COLUMNS: readonly {
 const CELL = "border-r border-b border-border p-0 align-top last:border-r-0";
 /*
  * **The row's own ⋮ lane, and it is not a fifth column.** The four columns are
- * the test's content; this is the house table's fixed `--table-action-width`
- * slot, which every row of every list in the product carries so the triggers
- * line up in one lane. The boards are silent on it, so the current screen's
- * verb stays: a test is deleted from its row.
+ * the test's content; this is the house table's trailing slot, which every row
+ * of every list in the product carries so the triggers line up in one lane.
+ * The boards are silent on it, so the current screen's verb stays: a test is
+ * deleted from its row.
+ *
+ * **It is the labelled width, because this grid says Actions over it.** The
+ * unlabelled `--table-action-width` is sized for a ⋮ and nothing else, so the
+ * word ran out through the table's own right hairline. Header and body cells
+ * read the one token — and so does the `<col>` this table's fixed layout
+ * actually measures — so the lane stays one straight edge from the heading to
+ * the last row.
  */
-const ACTION = "w-(--table-action-width) border-b border-border p-0 text-center align-top";
+const ACTION =
+  "w-(--table-action-labelled-width) border-b border-border p-0 text-center align-top";
 const PAD = "px-2.5 py-2";
 const TEXT = "text-sm leading-(--line-caption) text-foreground";
 /*
@@ -1348,7 +1356,7 @@ export function TestsGrid(props: GridProps) {
           {COLUMNS.map((column) => (
             <col key={column.field} style={{ width: column.width }} />
           ))}
-          <col style={{ width: "var(--table-action-width)" }} />
+          <col style={{ width: "var(--table-action-labelled-width)" }} />
         </colgroup>
         <thead>
           <tr className="bg-surface-soft">
@@ -1368,7 +1376,7 @@ export function TestsGrid(props: GridProps) {
               is what it holds, and every reader gets the same word now.
             */}
             <th
-              className="w-(--table-action-width) border-b border-border px-2.5 py-2 text-center text-sm font-normal text-faint"
+              className="w-(--table-action-labelled-width) border-b border-border px-4 py-2 text-center text-sm font-normal whitespace-nowrap text-faint"
               scope="col"
             >
               Actions

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -2,8 +2,9 @@ import { projectPath, sectionIn } from "./project-context.ts";
 
 /**
  * The project navigation has one unlabelled group for Agents and Graders, one
- * Simulations group, and one Monitoring group. Every link carries the project.
- * Groups control presentation only; the address decides the active item.
+ * Simulations group, and one OBSERVABILITY group. Every link carries the
+ * project. Groups control presentation only; the address decides the active
+ * item.
  */
 
 export type SectionId =
@@ -68,10 +69,22 @@ export const NAVIGATION_GROUPS: readonly NavigationGroup[] = [
       { id: "runs", label: "Runs" },
     ],
   },
+  /*
+   * **The group says OBSERVABILITY and its one row says Traces** (developer
+   * decision, 2026-08-25). Only the words moved: the section id stays
+   * `monitoring` and the address stays `/monitoring/transcripts`, because a
+   * rename that moved an address would break every saved link for a change
+   * nobody asked for.
+   *
+   * `trace` is a real word in this domain rather than a borrowed one — it is
+   * what a person's own agent emits and what the SDK reports — so the screen
+   * is named for what lands on it. The **transcript** stays the name of the
+   * artifact a person opens and reads.
+   */
   {
     id: "monitoring",
-    label: "Monitoring",
-    items: [{ id: "monitoring", label: "Transcripts", opens: ["transcripts"] }],
+    label: "OBSERVABILITY",
+    items: [{ id: "monitoring", label: "Traces", opens: ["transcripts"] }],
   },
 ];
 

--- a/apps/web/lib/transcript-copy.ts
+++ b/apps/web/lib/transcript-copy.ts
@@ -17,7 +17,8 @@
  * The URLs are deliberately not copy. The v1 endpoint's own path is a machine
  * surface — matching it is how somebody reading the network tab finds the
  * request — and no page ever prints it as a word. What a person navigates is
- * **Monitoring**, and what they open there is a **transcript**.
+ * **Traces**, under **OBSERVABILITY**, and what they open there is a
+ * **transcript**.
  */
 
 /** The list page. */
@@ -28,13 +29,17 @@ export const LIST = {
    * decided. Two copies of the word that could disagree would be one too many,
    * and this is the one the page renders.
    *
-   * **It says Transcripts rather than Monitoring** (board `JGS-0`). Monitoring
-   * is the sidebar *group*, and it is no longer a screen: the one monitoring
-   * verb lives here now, on the screen where its results land. A title bar
-   * repeating the group's word said the section's name twice and the page's
-   * name nowhere.
+   * **It says Traces** (developer decision, 2026-08-25). It used to say
+   * Transcripts, under a sidebar group that used to say Monitoring; the group
+   * says OBSERVABILITY now and this screen is named for what lands on it.
+   *
+   * The rename is a *surface* rename and nothing else. The address did not
+   * move, and neither did the artifact's name: what a person opens from this
+   * list is still a **transcript**, and every row, fact and label below still
+   * says so. `trace` is honest here because it is the word a person's own SDK
+   * uses for what it reports — it is not the storage row leaking upward.
    */
-  title: "Transcripts",
+  title: "Traces",
   /** What the table is called where somebody hears it rather than sees it. */
   tableLabel: "Production transcripts in this project",
   loadingWhat: "this project's production transcripts",

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -1822,7 +1822,7 @@ describe("the role the shell shows", () => {
 
     expect(await screen.findByText("page")).toBeDefined();
     // No link into a project the address never named — not Agents, not Tests,
-    // not Runs, not Transcripts, and no href under /projects at all.
+    // not Runs, not Traces, and no href under /projects at all.
     for (const item of NAVIGATION_ITEMS) {
       expect(screen.queryByRole("link", { name: item })).toBeNull();
     }
@@ -1864,10 +1864,10 @@ describe("the role the shell shows", () => {
    * it goes.
    *
    * The words are the ones the groups left behind: the Monitoring group's item
-   * says `Transcripts`, and the Simulations group's says `Runs`. Both addresses
+   * says `Traces`, and the Simulations group's says `Runs`. Both addresses
    * are the ones they always were.
    */
-  it("puts Transcripts in the sidebar, opening this project's transcript list", async () => {
+  it("puts Traces in the sidebar, opening this project's transcript list", async () => {
     routed.pathname = "/projects/prj_2/agents";
     apiAnswers({
       "/api/me": { status: 200, body: meWith("admin") },
@@ -1881,7 +1881,7 @@ describe("the role the shell shows", () => {
 
     expect(await screen.findByText("page")).toBeDefined();
 
-    const transcripts = screen.getAllByRole("link", { name: "Transcripts" })[0];
+    const transcripts = screen.getAllByRole("link", { name: "Traces" })[0];
     expect(transcripts?.getAttribute("href")).toBe(
       "/projects/prj_2/monitoring/transcripts",
     );

--- a/apps/web/test/monitor-agent-sheet.test.tsx
+++ b/apps/web/test/monitor-agent-sheet.test.tsx
@@ -223,11 +223,11 @@ describe("how the picker opens", () => {
    * instead, it would disagree with the address the first time somebody pressed
    * Back — which is exactly the reload the blanket rule exists to prevent.
    */
-  it("stays shut on the plain Transcripts address", async () => {
+  it("stays shut on the plain Traces address", async () => {
     stub({});
     render(<MonitoringTranscriptsPage />);
 
-    await screen.findByRole("heading", { level: 1, name: "Transcripts" });
+    await screen.findByRole("heading", { level: 1, name: "Traces" });
     expect(screen.queryByRole("dialog", { name: "Monitor an agent" })).toBeNull();
     // And the roster is not even read, because nothing is asking about it.
     expect(screen.queryByLabelText("Agent")).toBeNull();
@@ -279,7 +279,7 @@ describe("how the picker opens", () => {
     expect(globalThis.location.pathname).toBe("/projects/prj_2/monitoring/start");
     expect(routed.replace).not.toHaveBeenCalled();
     expect(document.querySelector("main")?.textContent ?? "").toContain(
-      "Transcripts",
+      "Traces",
     );
   });
 
@@ -622,7 +622,12 @@ describe("the LiveKit half", () => {
   /**
    * Push is ungated by design: the door authenticates with the project key,
    * tenancy comes from the key, and the stored evidence is the whole record of
-   * an agent pushing. So this half is three sentences and a way out.
+   * an agent pushing. So this half is three steps and a way out.
+   *
+   * **The steps were restyled on 2026-08-25 and say the same things.** The
+   * shape is Langfuse's first-trace onboarding — a state chip, a heading, then
+   * numbered steps — and every technical name a person has to type is still
+   * here: the SDK, both SDK identifiers, and both environment variables.
    */
   it("shows the three steps, and offers nothing to start", async () => {
     withThePicker();
@@ -635,18 +640,66 @@ describe("the LiveKit half", () => {
 
     await screen.findByLabelText("Agent");
     for (const step of [
-      "Install the Egma SDK.",
-      "Call monitor_livekit(ctx) before AgentSession.start.",
-      "Set EGMA_URL and EGMA_API_KEY in the agent's environment.",
+      "Install the Egma SDK",
+      "Add one line to your agent",
+      "Run your agent",
     ]) {
       expect(screen.getByText(step), step).toBeDefined();
     }
+    // The names a person types are unchanged, wherever the words moved to.
+    for (const name of [
+      "EGMA_URL and EGMA_API_KEY",
+      "monitor_livekit(ctx)",
+      "AgentSession.start",
+    ]) {
+      expect(screen.getByText(name, { exact: false }), name).toBeDefined();
+    }
+    // The steps read as a sequence: three numbers down one spine.
+    expect(
+      [...screen.getAllByRole("listitem")].filter((one) =>
+        /^[123]/u.test(one.textContent ?? ""),
+      ),
+    ).toHaveLength(3);
     expect(screen.queryByRole("button", { name: "Start pulling" })).toBeNull();
     expect(screen.queryByLabelText("Retell API key*")).toBeNull();
     // Two ways out and no way in: the ✕ in the head, and the footer's own.
     expect(screen.getAllByRole("button", { name: "Close" })).toHaveLength(2);
 
     // And it stores nothing: the roster read is the only ask it made.
+    expect(seen.filter((one) => one.method === "POST")).toEqual([]);
+  });
+
+  /**
+   * **The one line is copyable, and the copy touches nothing but the
+   * clipboard.** A person reading these steps is in their own editor, and a
+   * line they have to retype by eye is a line they retype wrong.
+   */
+  it("copies the one line, and still writes nothing to Egma", async () => {
+    withThePicker();
+    const written: string[] = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          written.push(text);
+          return Promise.resolve();
+        },
+      },
+    });
+    const { seen } = stub({
+      agents: [
+        agent({ id: "agt_lk", name: "Livekit agent", agentPlatform: "livekit" }),
+      ],
+    });
+    render(<MonitoringTranscriptsPage />);
+
+    const copy = await screen.findByRole("button", { name: "Copy" });
+    fireEvent.click(copy);
+
+    expect(written).toEqual(["monitor_livekit(ctx)"]);
+    expect(
+      await screen.findByRole("button", { name: "Copied" }),
+    ).toBeDefined();
     expect(seen.filter((one) => one.method === "POST")).toEqual([]);
   });
 });
@@ -665,9 +718,15 @@ describe("the LiveKit half", () => {
  * `monitor_livekit(ctx)` and `AgentSession.start` are identifiers somebody
  * types into their own editor — renaming them to suit egma's vocabulary would
  * make the instructions wrong.
+ *
+ * **`trace` came off this list on 2026-08-25**, when the developer named the
+ * screen Traces and asked for this half to be modelled on Langfuse's
+ * first-trace onboarding. It is not the storage row leaking upward: it is the
+ * word the SDK a person is being told to install uses for what it reports, and
+ * this panel is the one surface in the product that talks about that SDK.
+ * `span` stays banned, because nothing here has any business naming one.
  */
 const NEVER_SAID = [
-  "trace",
   "span",
   "call",
   "caller",

--- a/apps/web/test/monitor-agent-sheet.test.tsx
+++ b/apps/web/test/monitor-agent-sheet.test.tsx
@@ -670,6 +670,62 @@ describe("the LiveKit half", () => {
   });
 
   /**
+   * **The head tells the truth about *this* agent.**
+   *
+   * Push is ungated, so this half is drawn for every LiveKit agent the picker
+   * lists — and nothing sorts out the one whose evidence has already arrived.
+   * Greeting that agent's owner with "waiting for the first trace" would be
+   * egma being wrong about the one thing this panel reports, so the roster's
+   * own `lastReceivedAt` decides the chip and the two lines under it.
+   */
+  it("says it is waiting only while nothing has arrived", async () => {
+    withThePicker();
+    stub({
+      agents: [
+        agent({ id: "agt_lk", name: "Livekit agent", agentPlatform: "livekit" }),
+      ],
+    });
+    render(<MonitoringTranscriptsPage />);
+
+    await screen.findByLabelText("Agent");
+    expect(screen.getByText("Waiting for the first trace")).toBeDefined();
+    expect(screen.getByText("Time to log the first trace")).toBeDefined();
+    expect(screen.queryByText("Receiving traces")).toBeNull();
+  });
+
+  it("says it is receiving once evidence has arrived, and keeps the steps", async () => {
+    withThePicker();
+    stub({
+      agents: [
+        agent({
+          id: "agt_lk",
+          name: "Livekit agent",
+          agentPlatform: "livekit",
+          lastReceivedAt: "2026-08-25T09:14:02.000Z",
+        }),
+      ],
+    });
+    render(<MonitoringTranscriptsPage />);
+
+    await screen.findByLabelText("Agent");
+    expect(screen.getByText("Receiving traces")).toBeDefined();
+    expect(
+      screen.getByText("Egma is already receiving from this agent"),
+    ).toBeDefined();
+    expect(screen.queryByText("Waiting for the first trace")).toBeNull();
+    expect(screen.queryByText("Time to log the first trace")).toBeNull();
+
+    // The steps stay under it, as reference rather than as an instruction.
+    for (const step of [
+      "Install the Egma SDK",
+      "Add one line to your agent",
+      "Run your agent",
+    ]) {
+      expect(screen.getByText(step), step).toBeDefined();
+    }
+  });
+
+  /**
    * **The one line is copyable, and the copy touches nothing but the
    * clipboard.** A person reading these steps is in their own editor, and a
    * line they have to retype by eye is a line they retype wrong.

--- a/apps/web/test/monitor-agent-sheet.test.tsx
+++ b/apps/web/test/monitor-agent-sheet.test.tsx
@@ -672,13 +672,17 @@ describe("the LiveKit half", () => {
   /**
    * **The head tells the truth about *this* agent.**
    *
-   * Push is ungated, so this half is drawn for every LiveKit agent the picker
-   * lists — and nothing sorts out the one whose evidence has already arrived.
-   * Greeting that agent's owner with "waiting for the first trace" would be
-   * egma being wrong about the one thing this panel reports, so the roster's
-   * own `lastReceivedAt` decides the chip and the two lines under it.
+   * The chip claims only what egma can check. *Waiting for the first trace*
+   * was a claim about this agent's history, and egma cannot make it for a
+   * LiveKit agent: `lastReceivedAt` is a subselect from `monitoring_state`
+   * and only a pull agent has a row there, so a push agent reads `null`
+   * however much it has reported. *Listening for traces* describes egma's own
+   * posture instead, which is true whatever has arrived.
+   *
+   * The receiving half below is dormant for the same reason, and is kept and
+   * tested so that it is already right the day that signal exists.
    */
-  it("says it is waiting only while nothing has arrived", async () => {
+  it("says it is listening, and claims nothing about what has arrived", async () => {
     withThePicker();
     stub({
       agents: [
@@ -688,7 +692,7 @@ describe("the LiveKit half", () => {
     render(<MonitoringTranscriptsPage />);
 
     await screen.findByLabelText("Agent");
-    expect(screen.getByText("Waiting for the first trace")).toBeDefined();
+    expect(screen.getByText("Listening for traces")).toBeDefined();
     expect(screen.getByText("Time to log the first trace")).toBeDefined();
     expect(screen.queryByText("Receiving traces")).toBeNull();
   });
@@ -712,7 +716,7 @@ describe("the LiveKit half", () => {
     expect(
       screen.getByText("Egma is already receiving from this agent"),
     ).toBeDefined();
-    expect(screen.queryByText("Waiting for the first trace")).toBeNull();
+    expect(screen.queryByText("Listening for traces")).toBeNull();
     expect(screen.queryByText("Time to log the first trace")).toBeNull();
 
     // The steps stay under it, as reference rather than as an instruction.

--- a/apps/web/test/monitoring.test.tsx
+++ b/apps/web/test/monitoring.test.tsx
@@ -319,17 +319,17 @@ describe("what the Monitoring list asks egma for", () => {
   });
 
   /**
-   * **Transcripts, not Monitoring.** Monitoring is the sidebar group; this is
+   * **Traces, not Monitoring.** OBSERVABILITY is the sidebar group; this is
    * the one page under it, and since the separate monitoring screen retired it
    * is where the one monitoring verb lives too (board `JGS-0`). A title bar
    * repeating the group's word said the section's name twice over.
    */
-  it("heads the page Transcripts", async () => {
+  it("heads the page Traces", async () => {
     stub({ rows: [ONE_ROW] });
     render(<MonitoringTranscriptsPage />);
 
     expect(
-      await screen.findByRole("heading", { level: 1, name: "Transcripts" }),
+      await screen.findByRole("heading", { level: 1, name: "Traces" }),
     ).toBeDefined();
   });
 });

--- a/apps/web/test/project-shell.test.ts
+++ b/apps/web/test/project-shell.test.ts
@@ -126,7 +126,7 @@ describe("the product navigation", () => {
     expect(NAVIGATION_GROUPS.map((group) => group.label)).toEqual([
       null,
       "Simulations",
-      "Monitoring",
+      "OBSERVABILITY",
     ]);
   });
 
@@ -180,15 +180,15 @@ describe("the product navigation", () => {
    * address — the transcript list, reached without a redirect and without a
    * reserved neighbour under the area being able to become the landing.
    */
-  it("puts one Transcripts item under Monitoring, opening the transcript list", () => {
+  it("puts one Traces item under OBSERVABILITY, opening the transcript list", () => {
     const monitoring = NAVIGATION_GROUPS[2];
     expect(monitoring?.id).toBe("monitoring");
-    expect(monitoring?.items.map((item) => item.label)).toEqual(["Transcripts"]);
+    expect(monitoring?.items.map((item) => item.label)).toEqual(["Traces"]);
 
     const transcripts = everyLink("prj_2").find(
       (link) => link.id === "monitoring",
     );
-    expect(transcripts?.label).toBe("Transcripts");
+    expect(transcripts?.label).toBe("Traces");
     expect(transcripts?.href).toBe("/projects/prj_2/monitoring/transcripts");
   });
 

--- a/apps/web/test/sidebar-groups.test.tsx
+++ b/apps/web/test/sidebar-groups.test.tsx
@@ -64,7 +64,7 @@ const GROUPS: readonly {
 }[] = [
   { label: null, items: ["Agents", "Graders"] },
   { label: "Simulations", items: ["Tests", "Personas", "Runs"] },
-  { label: "Monitoring", items: ["Transcripts"] },
+  { label: "OBSERVABILITY", items: ["Traces"] },
 ];
 
 /** The clusters as drawn, labelled or not — a named region is only two of them. */
@@ -202,7 +202,7 @@ describe("the grouped sidebar", () => {
     expect([...hrefs].sort()).toEqual(EVERY_ADDRESS);
   });
 
-  it("says Runs and Transcripts, and no longer says Simulation runs", () => {
+  it("says Runs and Traces, and no longer says Simulation runs", () => {
     drawShell();
 
     const navigation = sidebarNavigation();
@@ -211,13 +211,15 @@ describe("the grouped sidebar", () => {
     ).toBe("/projects/prj_2/runs");
     expect(
       within(navigation)
-        .getByRole("link", { name: "Transcripts" })
+        .getByRole("link", { name: "Traces" })
         .getAttribute("href"),
     ).toBe("/projects/prj_2/monitoring/transcripts");
     expect(
       within(navigation).queryByRole("link", { name: "Simulation runs" }),
     ).toBeNull();
-    expect(within(navigation).queryByRole("link", { name: "Monitoring" })).toBeNull();
+    expect(
+      within(navigation).queryByRole("link", { name: "OBSERVABILITY" }),
+    ).toBeNull();
   });
 
   /**
@@ -230,7 +232,7 @@ describe("the grouped sidebar", () => {
     ["/projects/prj_2/graders", "Graders"],
     ["/projects/prj_2/personas/prs_3", "Personas"],
     ["/projects/prj_2/runs/run_9", "Runs"],
-    ["/projects/prj_2/monitoring/transcripts/5c1e4b0f", "Transcripts"],
+    ["/projects/prj_2/monitoring/transcripts/5c1e4b0f", "Traces"],
   ])("lights one row on %s, and says which", (pathname, lit) => {
     drawShell(pathname);
 
@@ -358,7 +360,7 @@ describe("the grouped sidebar", () => {
     const switcher = within(bar!).getByRole("button", { name: /^Organization Acme/ });
     const account = within(bar!).getByRole("button", { name: /account menu$/ });
     const agents = within(bar!).getByRole("link", { name: "Agents" });
-    const transcripts = within(bar!).getByRole("link", { name: "Transcripts" });
+    const transcripts = within(bar!).getByRole("link", { name: "Traces" });
 
     expect(at(organization)).toBe(0);
     expect(at(switcher)).toBe(1);

--- a/apps/web/test/transcripts.test.ts
+++ b/apps/web/test/transcripts.test.ts
@@ -595,7 +595,14 @@ describe("the two kinds of audio a transcript can offer", () => {
  * something a person is shown. `session` is the one carve-out and it is not a
  * loophole — it names a signed-in browser session and never an exchange —
  * so it is checked for separately below.
+ *
+ * **The screen's own name is the second carve-out**, and it is one word wide.
+ * The developer renamed the surface to Traces on 2026-08-25, so `LIST.title`
+ * says it and the detail page's breadcrumb repeats it. `trace` stays banned in
+ * every sentence around them: the artifact a person opens is a **transcript**,
+ * and this rule is what keeps it one.
  */
+const SURFACE_NAME = /\bTraces\b/gu;
 const NEVER_SAID = [
   "trace",
   "span",
@@ -652,9 +659,10 @@ describe("what the pages say out loud", () => {
    */
   it("uses no storage word and no banned one", () => {
     for (const sentence of everySentence(EVERY_WORD)) {
+      const said = sentence.replaceAll(SURFACE_NAME, "");
       for (const banned of NEVER_SAID) {
         expect(
-          new RegExp(`\\b${banned}`, "iu").test(sentence),
+          new RegExp(`\\b${banned}`, "iu").test(said),
           `"${sentence}" says "${banned}"`,
         ).toBe(false);
       }

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -301,6 +301,22 @@
   --table-action-width: 48px;
 
   /*
+   * The same lane, on a table that says **Actions** over it.
+   *
+   * A ⋮ needs 48px and a word does not: "Actions" at `--text-sm` is about
+   * 54px, and the header padding either side of it is `--row-padding-x`, so
+   * the lane a labelled trailing column needs is a little over 86px. The
+   * tests grid names its lane out loud and was drawing it at the unlabelled
+   * width, which put the word through the table's own right hairline.
+   *
+   * It is a second token rather than a wider first one because the two are
+   * different facts: a lane holding only a ⋮ is 48px in every list in the
+   * product, and widening all of them to suit one heading would move a lane
+   * a person's eye follows down every table.
+   */
+  --table-action-labelled-width: 96px;
+
+  /*
    * How wide each surface is. Every one of these lived in a class list as a
    * bare number until 2026-08-23; a size is a design value like a colour is,
    * and `DESIGN.md` says a component holds neither.


### PR DESCRIPTION
Two developer asks from live prod testing.

**The rename**: the sidebar group is **OBSERVABILITY** and its item is **Traces**; the page heading and detail breadcrumbs follow (they read the shared copy source). Routes unchanged (/monitoring/transcripts stays). The artifact word "transcript" is untouched everywhere it names the artifact; the vocabulary lint gains a one-word Traces carve-out mirroring the SDK-names pattern, so "trace" stays banned in surrounding prose.

**LiveKit onboarding**, a warn "Waiting for the first trace" chip; "Time to log the first trace" + one faint sentence; three square ink-numbered steps down a hairline spine (Install the Egma SDK / Add one line to your agent / Run your agent); `monitor_livekit(ctx)` in a bordered mono block with a Copy button (the API-keys receipt pattern: Copied state, aria-live, clipboard guard); "Its traces appear in Traces within seconds of finishing." The branch still stores nothing and POSTs nothing — a new test asserts it.

Tests updated by reading and verified per-file: 219 passing across the six edited web test files + 39 on transcript-detail; browser-walk sidebar/heading expectations updated (six-row walk says Traces). pnpm typecheck exit 0. Full lanes run here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790277878&installation_model_id=431960&pr_number=231&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F231&signature=006454b51785269f2355abd19e97e46de98dd69bed6f0a0b95bf209adc7a8c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR renames the monitoring navigation surface to Observability → Traces while preserving existing routes and artifact terminology. It also redesigns LiveKit onboarding as a first-trace setup guide with numbered steps, copyable SDK code, and truthful listening-state messaging.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/monitoring/monitor-sheet.tsx | Reworks LiveKit onboarding, adds clipboard feedback, and avoids unsupported claims about whether a LiveKit agent has previously sent telemetry. |
| apps/web/lib/navigation.ts | Renames the navigation group and destination labels while retaining the existing monitoring route. |
| apps/web/lib/transcript-copy.ts | Updates shared list and breadcrumb copy from Transcripts to Traces without renaming transcript artifacts. |
| apps/api/test/browser.test.ts | Updates browser-walk and vocabulary expectations for the renamed Observability and Traces surface. |
| apps/web/test/monitor-agent-sheet.test.tsx | Adds coverage for LiveKit onboarding presentation, clipboard behavior, and the absence of server writes. |

<sub>Reviews (3): Last reviewed commit: ["fix(web): let the LiveKit chip claim onl..."](https://github.com/egma-ai/egma/commit/d5f3a65fcd2ae3d1b4a9394c5b53dbfc74a371b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56796383)</sub>

**Context used:**

- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)
- Knowledge Base — [Operator workflows](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/operator-workflows.md)

<!-- /greptile_comment -->