### PR TITLE
fix(tests): switching persona pickers commits the open one first

### DIFF
--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -280,12 +280,15 @@ function Arriving({
  */
 function PersonaPicker({
   projectId,
+  owner,
   chosen,
   known,
   onChange,
   onDone,
 }: {
   readonly projectId: string;
+  /** Whose picking this is: the owning test's id, or `"entry"` for the row. */
+  readonly owner: string;
   readonly chosen: readonly string[];
   readonly known: ReadonlyMap<string, Named>;
   readonly onChange: (ids: readonly string[], named: ReadonlyMap<string, Named>) => void;
@@ -310,24 +313,30 @@ function PersonaPicker({
    * find, which is the defect the founder named on 2026-08-25.
    *
    * `mousedown` rather than `click`, so the close happens before focus moves —
-   * the same instant Done would have. The lane marked `data-persona-picker` is
-   * this surface *and* the "+ Add a persona" trigger, so pressing the trigger
-   * to shut the picker is not read as an outside click and then re-opened.
+   * the same instant Done would have.
+   *
+   * **"Elsewhere" is measured against this picker's owner, not against the
+   * marker alone.** `data-persona-picker` sits on this surface *and* on every
+   * "+ Add a persona" trigger, so a marker with no owner in it made the *other*
+   * row's trigger count as inside: the picking moved to that row, Done never
+   * ran, and the personas ticked here went with no save and no word said. Only
+   * this owner's own marks are inside. Every other target — the other trigger
+   * included — runs Done first, and the trigger's own click then opens its own
+   * picker, because a mousedown lands before the click it belongs to.
    */
   useEffect(() => {
     function elsewhere(event: MouseEvent): void {
       const target = event.target;
-      if (
-        target instanceof Element &&
-        target.closest("[data-persona-picker]") !== null
-      ) {
-        return;
-      }
+      const marked =
+        target instanceof Element
+          ? target.closest("[data-persona-picker]")
+          : null;
+      if (marked?.getAttribute("data-persona-picker") === owner) return;
       done.current();
     }
     document.addEventListener("mousedown", elsewhere);
     return () => document.removeEventListener("mousedown", elsewhere);
-  }, []);
+  }, [owner]);
 
   /*
    * **Every persona the project holds, not the first page of them.**
@@ -400,7 +409,7 @@ function PersonaPicker({
       className="absolute top-full left-0 z-20 mt-1 w-[300px] origin-top border border-border bg-surface shadow-popover"
       role="dialog"
       aria-label="Choose personas"
-      data-persona-picker=""
+      data-persona-picker={owner}
     >
       <div className="border-b border-border">
         <input
@@ -602,6 +611,7 @@ function CellBody({
   draft,
   known,
   projectId,
+  owner,
   picking,
   onPick,
   onChange,
@@ -614,6 +624,8 @@ function CellBody({
   readonly draft: Draft;
   readonly known: ReadonlyMap<string, Named>;
   readonly projectId: string;
+  /** This row's test id, which is what its picking is held under. */
+  readonly owner: string;
   readonly picking: boolean;
   readonly onPick: (open: boolean) => void;
   readonly onChange: (next: Draft) => void;
@@ -716,7 +728,7 @@ function CellBody({
         <button
           className={ADD_LINE}
           type="button"
-          data-persona-picker=""
+          data-persona-picker={owner}
           onMouseDown={(event) => event.preventDefault()}
           onClick={() => onPick(!picking)}
         >
@@ -726,6 +738,7 @@ function CellBody({
       {woken && picking ? (
         <PersonaPicker
           projectId={projectId}
+          owner={owner}
           chosen={draft.personas}
           known={known}
           onChange={(ids, named) => {
@@ -972,10 +985,18 @@ export function TestsGrid(props: GridProps) {
    */
   function rest(mine?: Session): void {
     if (mine !== undefined && wokenNow.current?.at !== mine.at) return;
+    /*
+     * Whose picking this may put away: its own, and nothing else. A commit is
+     * awaited, and by the time it answers the picking can belong to another
+     * row or to the entry row — the same rule that gives `picking` an owner
+     * rather than a boolean. Closing it here shut a picker somebody had just
+     * opened, over a save they had already stopped watching.
+     */
+    const owner = mine?.testId ?? wokenNow.current?.testId ?? null;
     woken(null);
     holdDraft(null);
     setCellRefused(null);
-    setPicking(null);
+    setPicking((held) => (owner !== null && held === owner ? null : held));
   }
 
   async function commit(test: ListedTest, field: Field): Promise<void> {
@@ -1204,6 +1225,7 @@ export function TestsGrid(props: GridProps) {
             draft={draft}
             known={known}
             projectId={projectId}
+            owner={test.id}
             picking={woken && picking === test.id}
             onPick={(open) => setPicking(open ? test.id : null)}
             onChange={holdDraft}
@@ -1303,7 +1325,7 @@ export function TestsGrid(props: GridProps) {
               <button
                 className={ADD_LINE}
                 type="button"
-                data-persona-picker=""
+                data-persona-picker="entry"
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() =>
                   setPicking(picking === "entry" ? null : "entry")
@@ -1314,6 +1336,7 @@ export function TestsGrid(props: GridProps) {
               {picking === "entry" ? (
                 <PersonaPicker
                   projectId={projectId}
+                  owner="entry"
                   chosen={entry.personas}
                   known={known}
                   onChange={(ids, named) => {

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -741,6 +741,83 @@ describe("the suite-first Tests route", () => {
     });
   });
 
+  it("commits an open picker before the other row's trigger takes the picking", async () => {
+    const CALM = { id: "prs_2", name: "Calm Ben", archivedAt: null };
+    routed.pathname = "/projects/prj_1/tests/suites/ste_1";
+    routed.params = { projectId: "prj_1", suiteId: "ste_1" };
+    answers({
+      "/api/me": { status: 200, body: meWith("admin") },
+      "/v1/test-suites/ste_1": { status: 200, body: suiteBody() },
+      "/v1/tests": {
+        status: 200,
+        body: { tests: [testBody({ personas: [PERSONA] })], nextPageToken: null },
+      },
+      "/v1/tests/tst_1": {
+        status: 200,
+        body: testBody({
+          personas: [PERSONA, CALM],
+          version: 2,
+          versionId: "tstv_2",
+        }),
+      },
+      "/v1/personas": {
+        status: 200,
+        body: { personas: [PERSONA, CALM], nextPageToken: null },
+      },
+    });
+
+    render(<TestSuitePage />);
+
+    expect(await screen.findByText("Books service")).toBeTruthy();
+    fireEvent.click(await screen.findByRole("button", { name: "+ Write a test" }));
+
+    // Wake the stored row's Personas cell, open its picker, tick a second
+    // caller there. Nothing is saved yet — Done is what saves.
+    const written = screen.getByText("Books service").closest("tr");
+    if (written === null) throw new Error("the test's row is not on screen");
+    fireEvent.click(within(written).getByText("Impatient Rita"));
+    fireEvent.click(within(written).getByRole("button", { name: "+ Add a persona" }));
+    fireEvent.click(await screen.findByLabelText("Calm Ben"));
+    expect(sent.some((request) => request.method === "PATCH")).toBe(false);
+
+    // Now press the *entry row's* trigger. It wears the same picker marker, so
+    // an unowned marker read this as a click inside the open picker: the
+    // picking moved and the tick above went with no save and no word said.
+    const entryRow = screen.getByLabelText("Name").closest("tr");
+    if (entryRow === null) throw new Error("the entry row is not on screen");
+    const entryTrigger = within(entryRow).getByRole("button", {
+      name: "+ Add a persona",
+    });
+    fireEvent.mouseDown(entryTrigger);
+    fireEvent.click(entryTrigger);
+
+    // The click that followed the mousedown opened the entry row's own picker,
+    // and it is the only one standing.
+    expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
+    expect(
+      within(entryRow).getByRole("dialog", { name: "Choose personas" }),
+    ).toBeTruthy();
+
+    // The mousedown ran the open picker's Done first: exactly what the Done
+    // button sends, carrying the version the cell read.
+    await waitFor(() => {
+      expect(sent.filter((request) => request.method === "PATCH")).toEqual([
+        {
+          path: "/v1/tests/tst_1",
+          method: "PATCH",
+          body: { personas: ["prs_1", "prs_2"], expectedVersionId: "tstv_1" },
+        },
+      ]);
+    });
+
+    // …and that answer, landing on a cell whose picking is long gone, leaves
+    // the entry row's picker exactly where somebody put it.
+    expect(screen.getAllByRole("dialog", { name: "Choose personas" })).toHaveLength(1);
+    expect(
+      within(entryRow).getByRole("dialog", { name: "Choose personas" }),
+    ).toBeTruthy();
+  });
+
   it("saves a name against the revision it read, not the version", async () => {
     gridAnswers({
       saved: {


### PR DESCRIPTION
Closes the last open Greptile thread from #230. The outside-click exemption used a bare data-persona-picker marker carried by both "+ Add a persona" triggers, so clicking the other trigger switched picker ownership without running the open picker's Done — ticked selections silently lost. The marker now names its owner and the mousedown handler exempts only the open picker's own surfaces; any other target commits first, then the clicked trigger opens its own picker.

Verification surfaced the second half of the same defect: the awaited commit's rest() closed ANY open picker, so the fix's own save would have shut the picker the person just moved to. rest now puts away only the picking it owns — the rule the ownership model already documents.

The test asserts both checkpoints (order at click time; survival after the late answer) and was mutation-checked: with the bare marker restored it fails on exactly the lost commit while all 29 pre-existing tests stay green. 30 passing; pnpm typecheck exit 0. CI runs the rest here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790279944&installation_model_id=431960&pr_number=232&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F232&signature=c52da4aa12a659134ffc5ea4daaeed2a25bdb9e73b74c1d05a4ba275dbce2b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes persona-picker switching so the currently open stored-row picker commits before ownership moves, while a late save only closes the picker it owns.
- Adds owner-specific `data-persona-picker` markers to picker surfaces and triggers.
- Restricts asynchronous picker cleanup to the originating test.
- Adds a regression test covering commit ordering and survival of the newly opened entry picker.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The owner-scoped event handling commits the stored picker before switching, and session-aware cleanup preserves a picker that belongs to the newly selected owner; the regression test covers both checkpoints.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Introduces owner-scoped picker boundaries and cleanup so switching commits the prior picker without allowing its late response to close the new one. |
| apps/web/test/test-suites-pages.test.tsx | Adds focused regression coverage for save-before-switch ordering and preservation of the destination picker after the asynchronous response. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant S as Stored-row picker
    participant G as TestsGrid
    participant E as Entry picker
    participant A as Platform API
    U->>E: mousedown entry trigger
    E->>S: outside-owner event
    S->>G: Done / commit selections
    G->>A: PATCH personas
    U->>E: click entry trigger
    E->>G: set picking owner to entry
    A-->>G: save response
    G->>G: rest only stored-row owner
    G-->>E: entry picker remains open
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): give the persona picker&#39;s mark..."](https://github.com/egma-ai/egma/commit/b792e5cc28cb4e9b957bc835b03d07ecfc0b7afd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56810045)</sub>

<!-- /greptile_comment -->