### PR TITLE
fix(tests): behavior numbers read 1. in the test's own ink

### DIFF
--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -522,8 +522,8 @@ function BehaviorLines({
     <div className="flex flex-col gap-0.5">
       {behaviors.map((behavior, at) => (
         <div className="flex items-baseline gap-1.5" key={`behavior-${String(at)}`}>
-          <span className="flex-none text-sm tabular-nums text-faint">
-            {at + 1}
+          <span className="flex-none text-sm tabular-nums text-foreground">
+            {at + 1}.
           </span>
           <input
             className={QUIET_INPUT}
@@ -706,7 +706,7 @@ function CellBody({
       <div className="flex flex-col gap-0.5">
         {draft.expectedBehaviors.map((behavior, at) => (
           <span className={TEXT} key={`behavior-${String(at)}`}>
-            <span className="tabular-nums text-faint">{at + 1}</span> {behavior}
+            <span className="tabular-nums text-foreground">{at + 1}.</span> {behavior}
           </span>
         ))}
       </div>


### PR DESCRIPTION
The developer's ask from prod: the Expected behaviors line numbers render as "1." (with the dot) in the same foreground ink as the sentences, instead of bare faint numerals. Two edits in tests-grid.tsx cover all three surfaces (the shared BehaviorLines render serves the woken cell and the entry row; the read-only cell numbers separately). No spacing change — the number span stays flex-none/tabular-nums so lines shift together. No test expectations pinned the old format (aria-labels and the browser walk's sentence matches are unaffected). pnpm typecheck green; CI is the gate per the developer's instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790283596&installation_model_id=431960&pr_number=234&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F234&signature=30dccf82df61c31be647f2cdeac89fc7447b5d3c1317342cd7a7ae4fa09e4c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates expected-behavior line numbers across editable and read-only test-grid surfaces to include a trailing period and use foreground text color.
- Renders behavior numbers as `1.`, `2.`, and so on.
- Applies the foreground color to numbering without changing layout or accessible labels.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changes are limited to number punctuation and text color, preserve existing spacing and accessible labels, and introduce no blocking or non-blocking issue.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Consistently updates editable and read-only behavior numbering presentation with no functional or accessibility regression identified. |

<sub>Reviews (1): Last reviewed commit: ["fix(tests): behavior numbers read 1. in ..."](https://github.com/egma-ai/egma/commit/a5b58b15226b656894b1b81c15450b07ff08e2ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56833059)</sub>

<!-- /greptile_comment -->