### PR TITLE
Record the not-live rule: no backward compatibility until launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ The first open-source platform purpose-built to help teams shipping voice agents
 
 **If `egma-planning/AGENTS.md` exists in your checkout, read it now and follow it in full** — it carries additional instructions for this repo. If it doesn't exist, ignore this and carry on; nothing here depends on it.
 
+# engineering rules
+
+1. The product is not live. No change needs backward compatibility — not a database schema, not an API body, not a wire contract. Make the clean cut: one destructive migration is fine, old shapes are deleted rather than deprecated, and nothing keeps dual support. Delete this rule the day egma has production customers.
+
 # communication rules
 
 0. ALWAYS use the built in /wait-what skill while communicating to the developer.


### PR DESCRIPTION
One standing instruction from the developer, made durable in AGENTS.md so every agent session inherits it: **the product is not live, so no change needs backward compatibility** — not a database schema, not an API body, not a wire contract. Clean cuts, destructive migrations, delete instead of deprecate. The rule names its own expiry: delete it the day egma has production customers.

First applied by the persona-rework effort (egma-planning #63), whose spec and all four tickets carry the same ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790314674&installation_model_id=431960&pr_number=235&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F235&signature=96ec7fd3f2a36cf05899be9c189ab4c51440697e82372e24db2e9d9972b79a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR records a repository-wide engineering rule that backward compatibility is unnecessary before launch and directs contributors to prefer clean, destructive transitions.
- Adds the rule to `AGENTS.md`.
- Defines its scope across schemas, API bodies, and wire contracts.
- States that the rule should be removed when the product gains production customers.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The new instruction clearly states its scope, intended pre-launch applicability, and expiry condition without changing runtime behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds the documented pre-launch policy for clean-cut contract and schema changes; no actionable defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["docs(agents): record the not-live ruling..."](https://github.com/egma-ai/egma/commit/b43716ad98b4339ecd3dec8cd6a1b0c182bceca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56963454)</sub>

<!-- /greptile_comment -->