### PR TITLE
fix(grader): survive Postgres listener disconnects

### DIFF
--- a/apps/grader/src/service.ts
+++ b/apps/grader/src/service.ts
@@ -166,7 +166,15 @@ export function startService(options: ServiceOptions): Service {
   const pacing: Pacing = { hold: holdBeforeRetry };
 
   const finished = (async (): Promise<void> => {
-    watching = await watchGradingWork(nudge);
+    watching = await watchGradingWork(nudge, (error: unknown) => {
+      log.warn(
+        platformEvent("egma.grading_listener.failed", {
+          "error.type": "grading_listener_failed",
+          "exception.type": safeExceptionType(error),
+        }),
+        "grader work listener failed; reconnecting",
+      );
+    });
     log.info(
       platformEvent("egma.service.started", { capacity: config.capacity }),
       "grader service started",

--- a/apps/grader/test/lifecycle.test.ts
+++ b/apps/grader/test/lifecycle.test.ts
@@ -1,0 +1,156 @@
+import { spawn } from "node:child_process";
+import { setTimeout as after } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+import { expect, it } from "vitest";
+
+import {
+  createMigratedDatabase,
+  type MigratedDatabase,
+} from "../../../packages/db/test/support/database.ts";
+import { MAINTENANCE_CLICKHOUSE_URL } from
+  "../../../packages/db/test/support/store-urls.ts";
+
+const GRADER_ENTRY = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+const CLAIMANT = "grader-lifecycle-test";
+
+type Exit = {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+};
+
+type Backend = {
+  readonly pid: number;
+  readonly query: string;
+};
+
+async function eventually<T>(
+  description: string,
+  inspect: () => Promise<T | undefined>,
+  timeoutMilliseconds: number,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMilliseconds;
+  while (Date.now() < deadline) {
+    const found = await inspect();
+    if (found !== undefined) return found;
+    await after(50);
+  }
+  throw new Error(`timed out waiting for ${description}`);
+}
+
+async function graderBackends(database: MigratedDatabase): Promise<Backend[]> {
+  const result = await database.sql<Backend>(
+    `select pid, query
+       from pg_stat_activity
+      where datname = current_database()
+        and application_name = $1
+      order by pid`,
+    [CLAIMANT],
+  );
+  return result.rows;
+}
+
+it("stays running and reconnects when its work listener is terminated while idle", async () => {
+  const database = await createMigratedDatabase("grader_listener_lifecycle");
+  const childUrl = new URL(database.url);
+  childUrl.searchParams.set("application_name", CLAIMANT);
+
+  let stdout = "";
+  let stderr = "";
+  const child = spawn(process.execPath, [GRADER_ENTRY], {
+    env: {
+      PATH: process.env["PATH"] ?? "",
+      DATABASE_URL: childUrl.toString(),
+      CLICKHOUSE_URL: MAINTENANCE_CLICKHOUSE_URL,
+      EGMA_GRADER_CLAIMANT: CLAIMANT,
+      EGMA_GRADER_LOG_LEVEL: "INFO",
+      EGMA_GRADER_SWEEP_SECONDS: "30",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  child.stderr.on("data", (chunk: string) => (stderr += chunk));
+  const exited = new Promise<Exit>((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+
+  try {
+    await eventually(
+      "the grader to start",
+      async () => stdout.includes("grader service started") || undefined,
+      5_000,
+    );
+
+    // The ordinary query pool keeps one idle connection for ten seconds. Wait
+    // until only the dedicated LISTEN connection remains, so terminating it
+    // proves whether the service owns its lifetime instead of borrowing the
+    // pool's last socket.
+    const firstListener = await eventually(
+      "the ordinary pool to become idle",
+      async () => {
+        const backends = await graderBackends(database);
+        if (backends.length !== 1) return undefined;
+        return /^listen egma_grading_work$/iu.test(backends[0]?.query ?? "")
+          ? backends[0]?.pid
+          : undefined;
+      },
+      15_000,
+    );
+
+    const killed = await database.sql<{
+      readonly terminated: boolean;
+    }>("select pg_terminate_backend($1) as terminated", [firstListener]);
+    expect(killed.rows[0]?.terminated).toBe(true);
+
+    const nextListener = await eventually(
+      "the grader to reconnect its work listener",
+      async () => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          throw new Error(
+            `grader exited instead of reconnecting\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          );
+        }
+        const listener = (await graderBackends(database)).find(
+          (backend) =>
+            backend.pid !== firstListener &&
+            /^listen egma_grading_work$/iu.test(backend.query),
+        );
+        return listener?.pid;
+      },
+      5_000,
+    );
+    expect(nextListener).not.toBe(firstListener);
+    expect(child.exitCode).toBeNull();
+
+    const listenerFailure = stdout
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .find(
+        (line) =>
+          line["otel.event.name"] === "egma.grading_listener.failed",
+      );
+    expect(listenerFailure).toMatchObject({
+      "error.type": "grading_listener_failed",
+      "exception.type": expect.stringMatching(
+        /^[A-Za-z][A-Za-z0-9_.-]{0,127}$/u,
+      ),
+      msg: "grader work listener failed; reconnecting",
+    });
+    expect(JSON.stringify(listenerFailure)).not.toContain(
+      "Connection terminated unexpectedly",
+    );
+
+    child.kill("SIGTERM");
+    await expect(exited).resolves.toEqual({ code: 0, signal: null });
+    expect(stdout).toContain("grader service stopped");
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await exited;
+    }
+    await database.drop();
+  }
+}, 30_000);

--- a/packages/db/src/access/grading.ts
+++ b/packages/db/src/access/grading.ts
@@ -824,8 +824,11 @@ export async function claimGradingJobs(
   });
 }
 
-export function watchGradingWork(onWork: () => void): Promise<Listening> {
-  return listen(GRADING_WORK_CHANNEL, onWork);
+export function watchGradingWork(
+  onWork: () => void,
+  onListenerFailure?: (error: unknown) => void,
+): Promise<Listening> {
+  return listen(GRADING_WORK_CHANNEL, onWork, onListenerFailure);
 }
 
 function theJob(auth: AuthContext, id: string): SQL {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -139,6 +139,7 @@ const RELISTEN_AFTER_MILLISECONDS = 1_000;
 export async function listen(
   channel: string,
   onNotification: () => void,
+  onFailure: (error: unknown) => void = () => undefined,
 ): Promise<Listening> {
   const url = databaseUrl;
   if (url === undefined) throw new Error("not connected to Postgres");
@@ -152,6 +153,13 @@ export async function listen(
   let closed = false;
   let client: pg.Client | undefined;
   let waking: NodeJS.Timeout | undefined;
+  let failureReported = false;
+
+  const reportFailure = (error: unknown): void => {
+    if (failureReported) return;
+    failureReported = true;
+    onFailure(error);
+  };
 
   const rebuild = (): void => {
     if (closed || waking !== undefined) return;
@@ -159,9 +167,9 @@ export async function listen(
       waking = undefined;
       void establish();
     }, RELISTEN_AFTER_MILLISECONDS);
-    // A pending reconnection must never hold the process open by itself: the
-    // service exits when its work is done, not when its timers are.
-    waking.unref();
+    // This wait is part of the listener's lifetime. If the dropped socket was
+    // the process's last handle, keeping this timer referenced is what lets a
+    // standing worker reconnect instead of exiting. `close` clears it.
   };
 
   const establish = async (): Promise<void> => {
@@ -169,7 +177,9 @@ export async function listen(
     const connecting = new pg.Client({ connectionString: url });
     // Registered before connecting, because a connection that dies has to
     // arrive here rather than at an unhandled rejection.
-    connecting.on("error", () => {
+    connecting.on("error", (error: unknown) => {
+      if (closed) return;
+      reportFailure(error);
       if (client === connecting) client = undefined;
       connecting.end().catch(() => undefined);
       rebuild();
@@ -181,7 +191,8 @@ export async function listen(
     try {
       await connecting.connect();
       await connecting.query(`listen ${channel}`);
-    } catch {
+    } catch (error) {
+      reportFailure(error);
       connecting.end().catch(() => undefined);
       rebuild();
       return;
@@ -192,6 +203,7 @@ export async function listen(
       return;
     }
     client = connecting;
+    failureReported = false;
     onNotification();
   };
 


### PR DESCRIPTION
## What changed

- keep the Postgres work-listener reconnect timer referenced so an idle grader cannot exit before reconnecting
- emit one privacy-safe structured warning per listener outage, then reset it after recovery
- add a process-level regression that runs the built grader, waits until it is truly idle, terminates its listener backend, requires a new listener, and verifies clean SIGTERM shutdown

## Why

The grader is a standing worker. An empty queue is normal. Production exited with code 13 when its LISTEN socket disappeared and the unreferenced reconnect timer was the only remaining work. Docker then stopped the container because its main process had exited.

## Verification

- red proof on current main: exact unsettled top-level-await warning and process exit instead of reconnect
- lifecycle regression: pass
- grader tests plus pool-shutdown tests: 33 passed; 2 opt-in live-provider tests skipped
- pnpm typecheck: pass, including build, lint, generated-contract check, test TypeScript, and web TypeScript
- complete fast lane: 2,977 passed; two unrelated 30-second contention timeouts both passed immediately when rerun alone on the same commit
- independent standards review: no violations
- independent specification review: no findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790316804&installation_model_id=431960&pr_number=236&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F236&signature=2f89674b6d21caa6e596f30e8134e069a8b633e05ab6abf6ee28b48f20772647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the grader remain alive while its dedicated PostgreSQL work listener reconnects and adds privacy-safe, outage-deduplicated warning telemetry.
- Keeps the reconnect timer referenced until recovery or explicit listener closure.
- Propagates listener failures through the grading access layer to structured grader logging.
- Adds a process-level regression covering idle disconnect, reconnection, telemetry, and clean shutdown.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or maintainability issues identified.

The reconnect timer now correctly owns the idle worker’s lifetime, explicit close clears that timer, successful recovery resets warning suppression, and the lifecycle regression exercises the intended disconnect and shutdown path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/client.ts | Keeps listener reconnect work alive, deduplicates outage reporting until recovery, and preserves explicit timer and connection cleanup. |
| packages/db/src/access/grading.ts | Extends the grading listener wrapper to forward an optional listener-failure observer. |
| apps/grader/src/service.ts | Emits one privacy-safe structured warning for each listener outage. |
| apps/grader/test/lifecycle.test.ts | Adds an end-to-end process regression for idle listener termination, reconnection, safe logging, and SIGTERM shutdown. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant PG as PostgreSQL
  participant Listener as Dedicated listener
  participant Grader as Grader service
  PG--xListener: LISTEN connection drops
  Listener->>Grader: Emit one sanitized warning
  Listener->>Listener: Start referenced reconnect timer
  Listener->>PG: Reconnect and issue LISTEN
  Listener->>Grader: Nudge claim loop
  Note over Listener: Reset outage-warning state after recovery
  Grader->>Listener: close() on SIGTERM
  Listener->>Listener: Clear pending reconnect timer
  Listener->>PG: End dedicated connection
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(grader): survive work-listener disco..."](https://github.com/egma-ai/egma/commit/0ba356e9d6fe46a14f353858f60bc96825153a35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56969877)</sub>

**Context used:**

- Knowledge Base — [Grading and judgments](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/grading-and-judgments.md)
- Knowledge Base — [Database persistence](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/database-persistence.md)

<!-- /greptile_comment -->