### PR TITLE
feat(contract): persona rework 02 — work-order v5, the simulator speaks the identity name

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ which is the only record of a report that never got through. Both survive the
 container being restarted, replaced or rebuilt; only `docker compose down -v`
 removes them, and that is what it is for.
 
-Every production simulation carries one contract-v4 work order. Its pinned
+Every production simulation carries one contract-v5 work order. Its pinned
 persona version supplies the LLM, STT, and TTS selections. The model catalog
 resolves each selection to a simulator adapter. The API then adds only the
 provider keys those adapters need. Chat carries only the LLM key; voice carries
@@ -287,8 +287,9 @@ Reasoning effort remains an LLM catalog capability, but this release fixes
 every reasoning-capable model at `none`; persona authors cannot turn reasoning
 on. Non-reasoning models carry no reasoning parameter. The TTS selection also
 owns the voice id and speed. The platform Default Persona v1 selects
-`gpt-5.6-terra` with reasoning effort `none`. Persona traits contain behavior
-only.
+`gpt-5.6-terra` with reasoning effort `none`. The persona block carries who is
+calling — the `name` the persona gives the agent, their `personality`, and the
+roleplay `language`, all three required — and no technical setting of any kind.
 
 Two deployment controls remain:
 

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -16,9 +16,12 @@ Five seams shape the inside, and each exists to be swapped without
 touching the others:
 
 - **The persona brain** (`persona.py`) — one component for every modality,
-  forever. It composes the spec's persona traits and scenario instructions
-  into a system prompt, takes the `human` side of the transcript turn by
-  turn, and decides when the exchange is concluded.
+  forever. It composes the spec's authored persona — the name they give the
+  agent, how they behave, the language they speak — and the scenario
+  instructions into a system prompt, takes the `human` side of the transcript
+  turn by turn, and decides when the exchange is concluded. The name is stated
+  rather than left to the model, so the same test hears the same person on
+  every run.
 - **The model client** (`model.py`) — where the persona's words come from.
   `scripted` walks the scenario deterministically and is what CI and the
   local story run on; `openai` speaks the OpenAI chat-completions shape to
@@ -192,17 +195,18 @@ configures no media backend to place a call through.
 next heartbeat; `POST /workbench/specs` queues another spec while
 everything runs.
 
-Model and speech choices are not container settings. Every contract-v4 work
+Model and speech choices are not container settings. Every contract-v5 work
 order carries one complete `models` block from the pinned persona version. The
 API resolves each catalog selection to an explicit adapter before it creates
 that work order. Chat requires the direct LLM key. Voice also requires the
-direct STT and TTS keys. The TTS selection owns `voice_id` and `speed`; persona
-traits contain behavior only.
+direct STT and TTS keys. The TTS selection owns `voice_id` and `speed`; the
+`persona` block carries who is calling — `name`, `personality`, `language`, all
+three required — and says nothing about how they are rendered.
 
 The model catalog owns which provider/model pairs the product accepts. The
 simulation contract checks only the work-order shape. The simulator dispatches
 the named adapter and rejects an adapter it does not ship; it does not keep a
-second model allowlist. There is no container or traits fallback. The scripted
+second model allowlist. There is no container or persona fallback. The scripted
 model and speech pair exist only as explicit test injections.
 
 Voice activity detection is still deployment configuration. Real speech uses

--- a/apps/simulator/src/egma_simulator/config.py
+++ b/apps/simulator/src/egma_simulator/config.py
@@ -269,7 +269,7 @@ class MediaSettings:
         has no media backend. A work order cannot create one.
 
         **It never refuses.** This runs for every simulation, and most
-        simulations never dial. Contract v4 gives a phone simulation one
+        simulations never dial. Contract v5 gives a phone simulation one
         complete carrier and gives every non-phone simulation none. A missing
         deployment media backend is still checked by the phone plug, because
         failing chat work over a phone path it never uses would be wrong.

--- a/apps/simulator/src/egma_simulator/contract.py
+++ b/apps/simulator/src/egma_simulator/contract.py
@@ -25,7 +25,7 @@ from jsonschema import Draft202012Validator, FormatChecker
 
 CONTRACT_DIR_ENV = "EGMA_SIMULATION_CONTRACT_DIR"
 
-SPEC_SCHEMA_FILENAME = "simulation-spec.v4.schema.json"
+SPEC_SCHEMA_FILENAME = "simulation-spec.v5.schema.json"
 REPORT_SCHEMA_FILENAME = "simulation-report.v1.schema.json"
 
 # The endings a failed simulation may carry, spelled here because this is

--- a/apps/simulator/src/egma_simulator/persona.py
+++ b/apps/simulator/src/egma_simulator/persona.py
@@ -1,11 +1,17 @@
 """The persona brain: one component, shared by every modality forever.
 
-It composes the persona's authored human traits and the test's scenario into a
-system prompt, takes turns — the transcript's ``human`` side — and decides
-when the exchange is concluded. What it does not know is deliberate: it
-never sees a platform (that is the plug's business) and never produces its
-own words (that is the model client's), so the same brain conducts a chat
-today and speaks through voice legs when those arrive.
+It composes the authored persona — the name they answer to, how they behave,
+the language they speak — and the test's scenario into a system prompt, takes
+turns — the transcript's ``human`` side — and decides when the exchange is
+concluded. What it does not know is deliberate: it never sees a platform
+(that is the plug's business) and never produces its own words (that is the
+model client's), so the same brain conducts a chat today and speaks through
+voice legs when those arrive.
+
+The name is stated in the frame rather than left among the details the model
+may invent. A prompt that licensed one produced a different person on every
+run of the same test, which made a name-keyed mock world impossible and an
+old transcript unanswerable about who the agent actually heard.
 
 Role mapping is from the persona's own seat at the table: the persona is
 the ``assistant`` the model plays, and the agent under test is the
@@ -19,11 +25,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
 
 from pipecat.processors.aggregators.llm_context import LLMContext
 
 from .model import PERSONA_TOOLS, ModelClient, PersonaReply
+from .spec import AuthoredPersona
 
 OPENING_NUDGE = (
     "(The conversation is open and the agent is listening. Speak your first turn.)"
@@ -38,6 +44,10 @@ Here's the bigger picture - you are part of a broader voice agent testing platfo
 
 You have certain quirks of your own behavior and your own personality and how you do things in certain situations. Your job is to emulate a given scenario with your specific personality traits and emulate the scenario so that we can look at the conversation between you (the simulated human persona) and the voice agent to evaluate at scale how the voice agent behaves under the given scenario.
 
+# Who you are
+
+Your name is {name}. Give that name when the agent asks who is calling, and use it whenever you introduce yourself.
+
 # Your personality
 
 {personality}
@@ -50,18 +60,21 @@ You have certain quirks of your own behavior and your own personality and how yo
 
 - Stay in character’s personality for the whole exchange. Never mention being a simulator, or an AI.
 - The roleplay language is {language}
-- You are allowed to make up details in order to fulfill the scenario unless explicitly stated otherwise. Examples include your name, appointment details, or other details that someone in your situation might have handy.
+- You are allowed to make up details in order to fulfill the scenario unless explicitly stated otherwise. Examples include appointment details, or other details that someone in your situation might have handy. Your name is not one of them: it is given above, and you never answer to another.
 - Pursue what you came for until it is concluded to your satisfaction, and let your personality decide how patiently.
 - When your goal is concluded and nothing further is needed, say a brief goodbye and end your reply with the `end_call` tool
 """
 
 
-def compose_system_prompt(traits: dict[str, Any], scenario_instructions: str) -> str:
+def compose_system_prompt(
+    authored: AuthoredPersona, scenario_instructions: str
+) -> str:
     """The exact platform prompt, filled from the claimed persona and test."""
     return _PROMPT_FRAME.format(
-        personality=traits["personality"],
+        name=authored.name,
+        personality=authored.personality,
         scenario=scenario_instructions,
-        language=traits["language"],
+        language=authored.language,
     )
 
 
@@ -90,11 +103,11 @@ class Persona:
     def __init__(
         self,
         *,
-        traits: dict[str, Any],
+        authored: AuthoredPersona,
         scenario_instructions: str,
         model: ModelClient,
     ) -> None:
-        self._system_prompt = compose_system_prompt(traits, scenario_instructions)
+        self._system_prompt = compose_system_prompt(authored, scenario_instructions)
         self._model = model
 
     @property

--- a/apps/simulator/src/egma_simulator/plugs/phone.py
+++ b/apps/simulator/src/egma_simulator/plugs/phone.py
@@ -122,7 +122,7 @@ class PhoneCall:
                 f"{BACKEND_VARIABLE} on this container to one of "
                 f"{sorted(BACKENDS)}"
             )
-        # **The moment a carrier's own refusals belong.** Contract v4 already
+        # **The moment a carrier's own refusals belong.** Contract v5 already
         # proved that this phone work order carries a complete route. Here a
         # call is about to be placed, so backend-specific value checks belong
         # here and a refusal names why this simulation cannot dial.

--- a/apps/simulator/src/egma_simulator/service.py
+++ b/apps/simulator/src/egma_simulator/service.py
@@ -292,7 +292,7 @@ class RunningSimulation:
             )
             self._assembled = assembled
             persona = Persona(
-                traits=self._spec.persona_traits,
+                authored=self._spec.persona,
                 scenario_instructions=self._spec.scenario_instructions,
                 model=model,
             )

--- a/apps/simulator/src/egma_simulator/spec.py
+++ b/apps/simulator/src/egma_simulator/spec.py
@@ -50,6 +50,34 @@ class MockTool:
 
 
 @dataclass(frozen=True)
+class AuthoredPersona:
+    """Who talks on the human side of the transcript, as the author wrote them.
+
+    Three values, and the contract requires all three, so nothing below has
+    to decide what an absent one would have meant — deciding that would be
+    deciding who the agent heard.
+
+    The name is the persona's own, the one they give the agent when asked.
+    It is not the team's label for the library row, which never crosses this
+    wire, and it is not the model's invention: the prompt states it, so the
+    same test hears the same person on every run.
+    """
+
+    name: str
+    personality: str
+    language: str
+
+    @classmethod
+    def from_document(cls, written: Any) -> AuthoredPersona:
+        """Read the required, already validated persona block."""
+        return cls(
+            name=written["name"],
+            personality=written["personality"],
+            language=written["language"],
+        )
+
+
+@dataclass(frozen=True)
 class PlatformCarrier:
     """The SIP trunk a deployment uses for phone simulations.
 
@@ -191,8 +219,8 @@ class SimulationSpec:
 
     limits: Limits
 
-    persona_traits: dict[str, Any]
-    """The persona version's complete authored human traits."""
+    persona: AuthoredPersona
+    """Who the pinned persona version says is calling, whole."""
 
     agent_platform: str | None
     """What runs the agent. Provenance only; never adapter dispatch."""
@@ -245,7 +273,7 @@ class SimulationSpec:
                 max_duration_seconds=limits["max_duration_seconds"],
                 max_turns=limits["max_turns"],
             ),
-            persona_traits=document["persona"]["traits"],
+            persona=AuthoredPersona.from_document(document["persona"]),
             agent_platform=connection["agent_platform"],
             connection_type=connection["connection_type"],
             access_variant=connection["access_variant"],

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -566,6 +566,9 @@ A_SCENARIO = "State the first point. State the second point."
 
 A_PERSONALITY = "Terse test person; sticks to the script."
 
+A_NAME = "Robin"
+"""The name this persona gives the agent — authored, never improvised."""
+
 
 def a_spec(
     simulation_id: str,
@@ -575,6 +578,7 @@ def a_spec(
     personality: str,
     max_turns: int,
     max_duration_seconds: int,
+    name: str = A_NAME,
     modality: str = "chat",
     models: dict | None = None,
     mock_tools: list[dict] | None = None,
@@ -590,12 +594,14 @@ def a_spec(
     really sends for a project that mocks nothing, and a spec that said
     ``[]`` would be exercising a shape nothing produces."""
     spec = {
-        "contract_version": 4,
+        "contract_version": 5,
         "simulation_id": simulation_id,
         "modality": modality,
         "connection": connection,
         "persona": {
-            "traits": {"personality": personality, "language": "en-US"}
+            "name": name,
+            "personality": personality,
+            "language": "en-US",
         },
         "scenario": {"instructions": scenario},
         "limits": {
@@ -675,6 +681,7 @@ def scripted_spec(
     *,
     scenario: str = A_SCENARIO,
     personality: str = A_PERSONALITY,
+    name: str = A_NAME,
     greeting: str | None = None,
     replies: list[str | None] | None = None,
     ends_after_replies: bool = False,
@@ -715,6 +722,7 @@ def scripted_spec(
         platform=platform,
         scenario=scenario,
         personality=personality,
+        name=name,
         max_turns=max_turns,
         max_duration_seconds=max_duration_seconds,
         models=models,

--- a/apps/simulator/tests/test_client_claims.py
+++ b/apps/simulator/tests/test_client_claims.py
@@ -57,6 +57,6 @@ async def test_a_claim_declares_how_long_it_will_wait(recording_control_plane):
             "claimant": "sim-under-test",
             "capacity": 3,
             "wait_seconds": 7.0,
-            "contract_versions": [4],
+            "contract_versions": [5],
         }
     ]

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -20,6 +20,7 @@ from egma_simulator.contract import (
     ContractViolation,
     contract_dir,
     report_validator,
+    spec_contract_version,
     spec_validator,
     validate_report,
     validate_spec,
@@ -73,15 +74,27 @@ EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
     ),
     "spec/phone-carrier-missing.json": ("", "required", "platform"),
     "spec/persona-missing-language.json": (
-        "/persona/traits",
+        "/persona",
         "required",
         "language",
     ),
     "spec/persona-technical-voice.json": (
-        "/persona/traits",
+        "/persona",
         "additionalProperties",
         "voice",
     ),
+    # The persona block the contract carried until v5: authored behavior in a
+    # `traits` wrapper, with an accent and a background noise nobody ran. The
+    # whole shape is refused at the wrapper, which is what makes the flat
+    # block the only one there is rather than the one this process prefers.
+    "spec/persona-traits-wrapper.json": (
+        "/persona",
+        "additionalProperties",
+        "traits",
+    ),
+    # A work order in the version before this one. There is no tolerance for
+    # it here: the version is a `const`, so the old number is a refusal and
+    # not a branch.
     "spec/wrong-contract-version.json": ("/contract_version", "const", None),
     "spec/voice-missing-stt-key.json": (
         "/models/stt",
@@ -123,10 +136,31 @@ def place_of(error: ValidationError) -> str:
 
 
 def test_each_schema_compiles_and_pins_its_contract_version():
-    assert spec_validator().schema["properties"]["contract_version"]["const"] == 4
+    assert spec_validator().schema["properties"]["contract_version"]["const"] == 5
     assert report_validator().schema["properties"]["contract_version"]["const"] == 1
-    assert spec_validator().schema["$id"] == "urn:egma:simulation-contract:spec:v4"
+    assert spec_validator().schema["$id"] == "urn:egma:simulation-contract:spec:v5"
     assert report_validator().schema["$id"] == "urn:egma:simulation-contract:report:v1"
+
+
+def test_this_simulator_reads_one_version_and_refuses_the_one_before_it():
+    """One contract version, and no tolerance for its predecessor.
+
+    The version the claim client advertises is read out of the schema this
+    process validates with, so a claim can never ask for a version the
+    parser does not implement. A work order in the version before it is
+    refused as a document — there is no branch that would read it.
+    """
+    document = read_json(
+        contract_dir() / "fixtures" / "spec" / "valid" / "chat-retell.json"
+    )
+    assert document["contract_version"] == spec_contract_version() == 5
+
+    with pytest.raises(ContractViolation) as refusal:
+        SimulationSpec.from_document({**document, "contract_version": 4})
+    assert any(
+        complaint.startswith("/contract_version")
+        for complaint in refusal.value.complaints
+    ), refusal.value.complaints
 
 
 def test_phone_connection_stays_phone_while_models_select_voice_legs():

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -73,6 +73,14 @@ EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
         "model",
     ),
     "spec/phone-carrier-missing.json": ("", "required", "platform"),
+    # The three authored values move together, so each one's absence is a
+    # fixture of its own rather than a case only the other side of the wire
+    # exercises in a clone-and-delete test.
+    "spec/persona-missing-name.json": (
+        "/persona",
+        "required",
+        "name",
+    ),
     "spec/persona-missing-language.json": (
         "/persona",
         "required",
@@ -161,6 +169,39 @@ def test_this_simulator_reads_one_version_and_refuses_the_one_before_it():
         complaint.startswith("/contract_version")
         for complaint in refusal.value.complaints
     ), refusal.value.complaints
+
+
+def test_a_persona_value_of_only_whitespace_is_refused_by_this_engine_too():
+    """The one keyword whose meaning could differ between the two readers.
+
+    ``pattern`` is checked by Ajv's ECMA-262 engine where the control plane
+    builds a work order, and by Python's ``re`` here. A blank name that one
+    engine refused and the other accepted is exactly the silent drift these
+    shared schemas exist to prevent, so the refusal is asserted on this side
+    as well: such a name is present by the letter and absent by the reading,
+    and it would put "Your name is  ." in the prompt.
+    """
+    document = read_json(
+        contract_dir() / "fixtures" / "spec" / "valid" / "chat-retell.json"
+    )
+    persona = document["persona"]
+
+    for field in ("name", "personality", "language"):
+        for blank in (" ", "   ", "\t", "\n", " \t\n "):
+            with pytest.raises(ContractViolation) as refusal:
+                SimulationSpec.from_document(
+                    {**document, "persona": {**persona, field: blank}}
+                )
+            assert any(
+                complaint.startswith(f"/persona/{field}")
+                for complaint in refusal.value.complaints
+            ), (field, blank, refusal.value.complaints)
+
+        # The rule stops exactly there: whitespace around real content is the
+        # author's own spacing, not an empty field. The wire refuses what says
+        # nothing and does not tidy what somebody wrote.
+        padded = f" {persona[field]} "
+        validate_spec({**document, "persona": {**persona, field: padded}})
 
 
 def test_phone_connection_stays_phone_while_models_select_voice_legs():

--- a/apps/simulator/tests/test_live_deepgram.py
+++ b/apps/simulator/tests/test_live_deepgram.py
@@ -43,6 +43,7 @@ from egma_simulator.conductor import VoiceConductor
 from egma_simulator.media import VoiceMedia
 from egma_simulator.model import ScriptedModel
 from egma_simulator.persona import Persona
+from egma_simulator.spec import AuthoredPersona
 from egma_simulator.speech import (
     SAMPLE_WIDTH_BYTES,
     PersonaVoice,
@@ -177,7 +178,9 @@ async def test_a_real_transcriber_reads_a_real_sentence(tmp_path: Path):
 
     await conductor.conduct(
         persona=Persona(
-            traits={"personality": "Patient.", "language": "en-US"},
+            authored=AuthoredPersona(
+                name="Alex", personality="Patient.", language="en-US"
+            ),
             scenario_instructions="Anything; the line does not listen.",
             model=ScriptedModel("Anything; the line does not listen."),
         ),

--- a/apps/simulator/tests/test_model.py
+++ b/apps/simulator/tests/test_model.py
@@ -357,7 +357,7 @@ async def test_runtime_model_forwards_the_claimed_reasoning_policy(
     if reasoning_effort is not None:
         llm["reasoning_effort"] = reasoning_effort
     document = {
-        "contract_version": 4,
+        "contract_version": 5,
         "simulation_id": "sim_direct_model_selection",
         "modality": "chat",
         "connection": {
@@ -368,10 +368,9 @@ async def test_runtime_model_forwards_the_claimed_reasoning_policy(
             "credentials": None,
         },
         "persona": {
-            "traits": {
-                "personality": "Patient and direct.",
-                "language": "en-US",
-            }
+            "name": "Alex",
+            "personality": "Patient and direct.",
+            "language": "en-US",
         },
         "scenario": {"instructions": "Ask for the next appointment."},
         "limits": {"max_duration_seconds": 300, "max_turns": 20},

--- a/apps/simulator/tests/test_persona.py
+++ b/apps/simulator/tests/test_persona.py
@@ -1,6 +1,7 @@
-"""The persona brain: traits and scenario in, a turn-taking speaker out.
+"""The persona brain: an authored person and a scenario in, a turn-taking
+speaker out.
 
-The brain owns the composition — how authored traits and the scenario
+The brain owns the composition — how the authored persona and the scenario
 become a system prompt — and the mapping between the transcript's two
 speakers and the model's chat roles. What actually produces words sits
 behind the model-client seam, so everything here is tested with the
@@ -12,6 +13,7 @@ scripted client or a recording fake.
 
 from __future__ import annotations
 
+from conftest import load_fixture_spec
 from pipecat.processors.aggregators.llm_context import LLMContext
 
 from egma_simulator.model import PERSONA_TOOLS, PersonaReply, ScriptedModel
@@ -22,22 +24,19 @@ from egma_simulator.persona import (
     compose_system_prompt,
     messages_for,
 )
+from egma_simulator.spec import AuthoredPersona, SimulationSpec
 
-TRAITS = {
-    "personality": "Margaret, 68, retired schoolteacher. Polite but flustered.",
-    "language": "en-US",
-    "manner": "Warm and direct.",
-    "patience": "Waits once before asking again.",
-    "accent": "Neutral American English.",
-    "backgroundNoise": "A quiet waiting room.",
-    "underFriction": "Becomes firmer without becoming rude.",
-}
+AUTHORED = AuthoredPersona(
+    name="Margaret",
+    personality="Margaret, 68, retired schoolteacher. Polite but flustered.",
+    language="en-US",
+)
 
 SCENARIO = "Move my cleaning to Thursday. Conclude once it is read back."
 
 
 def test_the_system_prompt_is_the_platform_prompt_verbatim():
-    prompt = compose_system_prompt(TRAITS, SCENARIO)
+    prompt = compose_system_prompt(AUTHORED, SCENARIO)
 
     assert prompt == f"""\
 # Background
@@ -46,9 +45,13 @@ Here's the bigger picture - you are part of a broader voice agent testing platfo
 
 You have certain quirks of your own behavior and your own personality and how you do things in certain situations. Your job is to emulate a given scenario with your specific personality traits and emulate the scenario so that we can look at the conversation between you (the simulated human persona) and the voice agent to evaluate at scale how the voice agent behaves under the given scenario.
 
+# Who you are
+
+Your name is {AUTHORED.name}. Give that name when the agent asks who is calling, and use it whenever you introduce yourself.
+
 # Your personality
 
-{TRAITS["personality"]}
+{AUTHORED.personality}
 
 # The situation you are trying to roleplay with the agent
 
@@ -57,30 +60,71 @@ You have certain quirks of your own behavior and your own personality and how yo
 # Important Rules
 
 - Stay in character’s personality for the whole exchange. Never mention being a simulator, or an AI.
-- The roleplay language is {TRAITS["language"]}
-- You are allowed to make up details in order to fulfill the scenario unless explicitly stated otherwise. Examples include your name, appointment details, or other details that someone in your situation might have handy.
+- The roleplay language is {AUTHORED.language}
+- You are allowed to make up details in order to fulfill the scenario unless explicitly stated otherwise. Examples include appointment details, or other details that someone in your situation might have handy. Your name is not one of them: it is given above, and you never answer to another.
 - Pursue what you came for until it is concluded to your satisfaction, and let your personality decide how patiently.
 - When your goal is concluded and nothing further is needed, say a brief goodbye and end your reply with the `end_call` tool
 """
 
 
-def test_the_system_prompt_uses_only_personality_language_and_scenario():
-    prompt = compose_system_prompt(TRAITS, SCENARIO)
+def test_the_prompt_states_the_name_instead_of_licensing_an_invented_one():
+    """The whole point of the authored name.
 
-    assert TRAITS["manner"] not in prompt
-    assert TRAITS["patience"] not in prompt
-    assert TRAITS["accent"] not in prompt
-    assert TRAITS["backgroundNoise"] not in prompt
-    assert TRAITS["underFriction"] not in prompt
+    The invented-details rule used to offer "your name" as its first
+    example, so the same test met the agent as Sarah on Monday and Jessica
+    on Tuesday. The name is now stated, and the rule no longer lists it —
+    both halves matter, because either one alone leaves the model a choice.
+    """
+    prompt = compose_system_prompt(AUTHORED, SCENARIO)
+
+    assert f"Your name is {AUTHORED.name}." in prompt
+    assert "Examples include your name" not in prompt
+    # The rule itself stands; only the name has left its examples.
+    assert "You are allowed to make up details" in prompt
+
+
+def test_the_system_prompt_carries_no_technical_settings():
+    """Who they are, and nothing about how they are rendered.
+
+    Voice, speed and model choices belong to the work order's models block
+    and are the pipeline's business. A prompt that mentioned them would be
+    telling the model about machinery it has no part in.
+    """
+    prompt = compose_system_prompt(AUTHORED, SCENARIO)
+
     assert '"voice"' not in prompt
     assert '"models"' not in prompt
     assert "[CONCLUDED]" not in prompt
 
 
 def test_the_system_prompt_is_deterministic():
-    assert compose_system_prompt(TRAITS, SCENARIO) == compose_system_prompt(
-        TRAITS, SCENARIO
+    assert compose_system_prompt(AUTHORED, SCENARIO) == compose_system_prompt(
+        AUTHORED, SCENARIO
     )
+
+
+def test_the_prompt_for_a_claimed_simulation_names_the_persona():
+    """The chain the work order exists to close.
+
+    A claimed document is held to the contract, read into a spec, and built
+    into a brain. The name the persona version authored is the name the
+    prompt states — so the agent hears the same person on every run of the
+    same test, which is what a name-keyed mock world will one day need.
+    """
+    document = load_fixture_spec("chat-scripted-flustered.json")
+    authored_name = document["persona"]["name"]
+    assert authored_name, "the contract requires a name; the fixture must carry one"
+
+    spec = SimulationSpec.from_document(document)
+    persona = Persona(
+        authored=spec.persona,
+        scenario_instructions=spec.scenario_instructions,
+        model=ScriptedModel(spec.scenario_instructions),
+    )
+
+    assert spec.persona.name == authored_name
+    prompt = persona.messages([])[0]["content"]
+    assert f"Your name is {authored_name}." in prompt
 
 
 def test_history_maps_to_chat_roles_from_the_personas_side():
@@ -113,7 +157,7 @@ def test_an_empty_history_gets_the_opening_nudge():
 
 def test_every_persona_context_advertises_the_native_end_call_tool():
     persona = Persona(
-        traits=TRAITS,
+        authored=AUTHORED,
         scenario_instructions=SCENARIO,
         model=ScriptedModel(SCENARIO),
     )
@@ -145,7 +189,7 @@ async def test_the_persona_speaks_through_its_model():
             return None
 
     model = RecordingModel()
-    persona = Persona(traits=TRAITS, scenario_instructions=SCENARIO, model=model)
+    persona = Persona(authored=AUTHORED, scenario_instructions=SCENARIO, model=model)
 
     reply = await persona.next_turn([Turn("agent", "Front desk, hello.")])
 
@@ -159,7 +203,7 @@ async def test_the_persona_speaks_through_its_model():
 
 async def test_the_persona_on_the_scripted_model_walks_and_concludes():
     persona = Persona(
-        traits=TRAITS,
+        authored=AUTHORED,
         scenario_instructions="First thing. Second thing.",
         model=ScriptedModel("First thing. Second thing."),
     )

--- a/apps/simulator/tests/test_persona.py
+++ b/apps/simulator/tests/test_persona.py
@@ -94,6 +94,21 @@ def test_the_system_prompt_carries_no_technical_settings():
 
     assert '"voice"' not in prompt
     assert '"models"' not in prompt
+
+
+def test_the_prompt_offers_one_way_to_conclude_and_not_the_retired_marker():
+    """How the persona says it is done, and the way it no longer says it.
+
+    Concluding is the native ``end_call`` tool. ``[CONCLUDED]`` was the text
+    marker that came before it, and the model client already refuses to read
+    one as control — ``test_a_literal_old_marker_has_no_control_meaning`` in
+    the model suite is that half. This is the other: a prompt that still
+    taught the marker would have the model emit a sentinel nothing acts on,
+    and stay in an exchange it believed it had ended.
+    """
+    prompt = compose_system_prompt(AUTHORED, SCENARIO)
+
+    assert "`end_call` tool" in prompt
     assert "[CONCLUDED]" not in prompt
 
 

--- a/apps/simulator/tests/test_persona_pipeline.py
+++ b/apps/simulator/tests/test_persona_pipeline.py
@@ -44,12 +44,17 @@ from egma_simulator.model import (
 )
 from egma_simulator.persona import OPENING_NUDGE, Persona, Turn
 from egma_simulator.spans import SpanEmitter, trace_id_for
+from egma_simulator.spec import AuthoredPersona
 from egma_simulator.speech import (
     PersonaVoice,
     SpeechProviders,
     build_legs,
     decode_speech,
     encode_speech,
+)
+
+AUTHORED = AuthoredPersona(
+    name="Alex", personality="Patient.", language="en-US"
 )
 
 SECRET = "egma-secret-must-not-enter-telemetry"
@@ -273,7 +278,7 @@ async def test_the_final_persona_pipeline_uses_pipecats_native_service_spans(
 ):
     model = SecretModel()
     persona = Persona(
-        traits={"personality": "Patient.", "language": "en-US"},
+        authored=AUTHORED,
         scenario_instructions="Ask one safe question.",
         model=model,
     )
@@ -404,7 +409,7 @@ async def test_a_provider_cannot_echo_its_key_into_the_native_model_span():
     )
     model._session = EchoSession()  # type: ignore[assignment]
     persona = Persona(
-        traits={"personality": "Patient.", "language": "en-US"},
+        authored=AUTHORED,
         scenario_instructions="Ask safely.",
         model=model,
     )
@@ -454,7 +459,7 @@ async def test_a_successful_provider_cannot_echo_its_key_to_voice_or_evidence():
     )
     model._session = SuccessfulEchoSession()  # type: ignore[assignment]
     persona = Persona(
-        traits={"personality": "Patient.", "language": "en-US"},
+        authored=AUTHORED,
         scenario_instructions="Ask safely.",
         model=model,
     )

--- a/apps/simulator/tests/test_plug_livekit.py
+++ b/apps/simulator/tests/test_plug_livekit.py
@@ -718,7 +718,7 @@ async def room_walk(
     assert assembled.conductor is not None
     conducted = await assembled.conductor.conduct(
         persona=Persona(
-            traits=spec.persona_traits,
+            authored=spec.persona,
             scenario_instructions=spec.scenario_instructions,
             model=ScriptedModel(spec.scenario_instructions),
         ),
@@ -1266,7 +1266,7 @@ async def test_a_real_transport_join_refusal_reaches_the_running_pipeline(
         with pytest.raises(PlugError) as refused:
             await conductor.conduct(
                 persona=Persona(
-                    traits=spec.persona_traits,
+                    authored=spec.persona,
                     scenario_instructions=spec.scenario_instructions,
                     model=ScriptedModel(spec.scenario_instructions),
                 ),

--- a/apps/simulator/tests/test_plug_phone.py
+++ b/apps/simulator/tests/test_plug_phone.py
@@ -196,7 +196,7 @@ async def _conduct_phone(tmp_path: Path, **overrides: object) -> _PhoneRun:
 
     conducted = await conductor.conduct(
         persona=Persona(
-            traits=spec.persona_traits,
+            authored=spec.persona,
             scenario_instructions=spec.scenario_instructions,
             model=ScriptedModel(spec.scenario_instructions),
         ),

--- a/apps/simulator/tests/test_quarantine.py
+++ b/apps/simulator/tests/test_quarantine.py
@@ -263,15 +263,14 @@ def test_an_unconfigured_simulator_loads_no_provider_library():
 
         def spec_for(connection, platform=None):
             document = {
-                "contract_version": 4,
+                "contract_version": 5,
                 "simulation_id": "sim-unconfigured",
                 "modality": "voice",
                 "connection": connection,
                 "persona": {
-                    "traits": {
-                        "personality": "Terse.",
-                        "language": "en-US",
-                    }
+                    "name": "Robin",
+                    "personality": "Terse.",
+                    "language": "en-US",
                 },
                 "scenario": {"instructions": "One point."},
                 "limits": {"max_duration_seconds": 30, "max_turns": 8},
@@ -332,7 +331,7 @@ def test_an_unconfigured_simulator_loads_no_provider_library():
 
         def persona_for(spec):
             return Persona(
-                traits=spec.persona_traits,
+                authored=spec.persona,
                 scenario_instructions=spec.scenario_instructions,
                 model=ScriptedModel(spec.scenario_instructions),
             )

--- a/apps/simulator/tests/test_service.py
+++ b/apps/simulator/tests/test_service.py
@@ -25,7 +25,7 @@ from egma_simulator.client import ClaimFailure
 from egma_simulator.config import SimulatorConfig
 from egma_simulator.redaction import SecretRegistry
 from egma_simulator.service import SimulatorService
-from egma_simulator.spec import SimulationSpec
+from egma_simulator.spec import AuthoredPersona, SimulationSpec
 
 
 class RecordingExecutor:
@@ -234,10 +234,11 @@ def test_the_typed_spec_reads_what_the_document_says():
     assert spec.scenario_instructions == "Hello there."
     assert spec.limits.max_turns == 7
     assert spec.connection_type == "scripted"
-    assert spec.persona_traits == {
-        "personality": "Terse test person; sticks to the script.",
-        "language": "en-US",
-    }
+    assert spec.persona == AuthoredPersona(
+        name="Robin",
+        personality="Terse test person; sticks to the script.",
+        language="en-US",
+    )
     assert spec.models.llm.model == "gpt-4o-mini"
 
 

--- a/apps/simulator/tests/test_voice.py
+++ b/apps/simulator/tests/test_voice.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import pytest
 from conftest import (
+    A_NAME,
     A_PERSONALITY,
     assert_one_speaker_to_a_channel,
     loopback_spec,
@@ -48,7 +49,7 @@ from egma_simulator.recording import (
     channels_of,
     dual_channel_wav,
 )
-from egma_simulator.spec import SimulationSpec
+from egma_simulator.spec import AuthoredPersona, SimulationSpec
 from egma_simulator.speech import (
     CONVERSATION_VAD,
     SAMPLES_PER_BYTE,
@@ -149,7 +150,7 @@ async def observe(
 
     conducted = await conductor.conduct(
         persona=Persona(
-            traits=spec.persona_traits,
+            authored=spec.persona,
             scenario_instructions=spec.scenario_instructions,
             model=ScriptedModel(spec.scenario_instructions),
         ),
@@ -199,10 +200,11 @@ def test_the_persona_voice_comes_from_the_pinned_tts_selection():
         0.9,
     )
 
-    assert spec.persona_traits == {
-        "personality": A_PERSONALITY,
-        "language": "en-US",
-    }
+    assert spec.persona == AuthoredPersona(
+        name=A_NAME,
+        personality=A_PERSONALITY,
+        language="en-US",
+    )
 
 
 # -- The voice activity detector ---------------------------------------------

--- a/apps/simulator/tests/test_walk.py
+++ b/apps/simulator/tests/test_walk.py
@@ -18,14 +18,17 @@ from egma_simulator.model import GOODBYE, ScriptedModel
 from egma_simulator.persona import Persona
 from egma_simulator.plugs import AgentReply
 from egma_simulator.plugs.scripted import ScriptedCounterpart
+from egma_simulator.spec import AuthoredPersona
 from egma_simulator.walk import Conducted, WalkControls, conduct
 
-TRAITS = {"personality": "Terse test person.", "language": "en-US"}
+AUTHORED = AuthoredPersona(
+    name="Robin", personality="Terse test person.", language="en-US"
+)
 
 
 def persona_for(scenario: str) -> Persona:
     return Persona(
-        traits=TRAITS,
+        authored=AUTHORED,
         scenario_instructions=scenario,
         model=ScriptedModel(scenario),
     )

--- a/packages/simulation-contract/fixtures/spec/invalid/adapter-missing.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/adapter-missing.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_fixture_adapter_missing",
   "modality": "voice",
   "connection": {
@@ -10,9 +10,9 @@
     "credentials": null
   },
   "persona": {
-    "traits": {
-      "personality": "Patient and direct.", "language": "en-US"
-    }
+    "name": "Alex",
+    "personality": "Patient and direct.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Ask for the next available appointment."

--- a/packages/simulation-contract/fixtures/spec/invalid/chat-carrying-speech-key.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/chat-carrying-speech-key.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_fixture_chat_carrying_speech_key",
   "modality": "chat",
   "connection": {
@@ -9,7 +9,7 @@
     "config": { "retellAgentId": "agent_fixture" },
     "credentials": null
   },
-  "persona": { "traits": { "personality": "Patient and direct.", "language": "en-US" } },
+  "persona": { "name": "Alex", "personality": "Patient and direct.", "language": "en-US" },
   "scenario": { "instructions": "Ask for an appointment." },
   "limits": { "max_duration_seconds": 300, "max_turns": 20 },
   "models": {

--- a/packages/simulation-contract/fixtures/spec/invalid/limits-missing.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/limits-missing.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
   "modality": "chat",
   "connection": {
@@ -14,9 +14,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Move a dental cleaning from Tuesday to Thursday."

--- a/packages/simulation-contract/fixtures/spec/invalid/mock-tool-answering-two-ways.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/mock-tool-answering-two-ways.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K4RE4P0D3S8VXHNB2GQZT6MF",
   "modality": "voice",
   "connection": {
@@ -15,9 +15,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Terse and to the point; asks one thing and waits.", "language": "en-US"
-    }
+    "name": "Sam",
+    "personality": "Terse and to the point; asks one thing and waits.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Ask whether Thursday morning is free."

--- a/packages/simulation-contract/fixtures/spec/invalid/modality-unknown.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/modality-unknown.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
   "modality": "email",
   "connection": {
@@ -14,9 +14,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Move a dental cleaning from Tuesday to Thursday."

--- a/packages/simulation-contract/fixtures/spec/invalid/models-missing.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/models-missing.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_fixture_models_missing",
   "modality": "chat",
   "connection": {
@@ -9,7 +9,7 @@
     "config": { "retellAgentId": "agent_fixture" },
     "credentials": null
   },
-  "persona": { "traits": { "personality": "Patient and direct.", "language": "en-US" } },
+  "persona": { "name": "Alex", "personality": "Patient and direct.", "language": "en-US" },
   "scenario": { "instructions": "Ask for an appointment." },
   "limits": { "max_duration_seconds": 300, "max_turns": 20 }
 }

--- a/packages/simulation-contract/fixtures/spec/invalid/persona-missing-language.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/persona-missing-language.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_fixture_persona_missing_language",
   "modality": "chat",
   "connection": {
@@ -10,9 +10,8 @@
     "credentials": null
   },
   "persona": {
-    "traits": {
-      "personality": "Patient and direct."
-    }
+    "name": "Alex",
+    "personality": "Patient and direct."
   },
   "scenario": { "instructions": "Ask for an appointment." },
   "limits": { "max_duration_seconds": 300, "max_turns": 20 },

--- a/packages/simulation-contract/fixtures/spec/invalid/persona-missing-name.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/persona-missing-name.json
@@ -1,0 +1,34 @@
+{
+  "contract_version": 5,
+  "simulation_id": "sim_fixture_persona_missing_name",
+  "modality": "chat",
+  "connection": {
+    "agent_platform": null,
+    "connection_type": "scripted",
+    "access_variant": "scripted.in_memory",
+    "config": {},
+    "credentials": null
+  },
+  "persona": {
+    "personality": "Patient and direct.",
+    "language": "en-US"
+  },
+  "scenario": { "instructions": "Ask for an appointment." },
+  "limits": { "max_duration_seconds": 300, "max_turns": 20 },
+  "models": {
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "adapter": "openai_chat_completions",
+      "key": "fixture-not-a-real-secret-llm"
+    },
+    "stt": { "provider": "deepgram", "model": "nova-3-general", "adapter": "deepgram" },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "adapter": "cartesia",
+      "voice_id": "fixture-voice",
+      "speed": 1
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/invalid/persona-traits-wrapper.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/persona-traits-wrapper.json
@@ -1,6 +1,6 @@
 {
   "contract_version": 5,
-  "simulation_id": "sim_fixture_persona_technical_voice",
+  "simulation_id": "sim_fixture_persona_traits_wrapper",
   "modality": "chat",
   "connection": {
     "agent_platform": null,
@@ -10,13 +10,11 @@
     "credentials": null
   },
   "persona": {
-    "name": "Alex",
-    "personality": "Patient and direct.",
-    "language": "en-US",
-    "voice": {
-      "provider": "cartesia",
-      "voiceId": "wrong-owner",
-      "speed": 1
+    "traits": {
+      "personality": "Patient and direct.",
+      "language": "en-US",
+      "accent": "Neutral American English.",
+      "backgroundNoise": "A quiet waiting room."
     }
   },
   "scenario": { "instructions": "Ask for an appointment." },

--- a/packages/simulation-contract/fixtures/spec/invalid/phone-carrier-missing.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/phone-carrier-missing.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_fixture_phone_carrier_missing",
   "modality": "voice",
   "connection": {
@@ -12,9 +12,9 @@
     "credentials": null
   },
   "persona": {
-    "traits": {
-      "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.", "language": "en-US"
-    }
+    "name": "Dev",
+    "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Your card was charged twice for the same order this morning. You want the duplicate charge reversed and a confirmation number before you hang up. If asked to stay on hold for more than a moment, push back once, then accept."

--- a/packages/simulation-contract/fixtures/spec/invalid/platform-block-unknown.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/platform-block-unknown.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K4QW7M4E8YB2FVN0H9TZQWEU",
   "modality": "chat",
   "connection": {
@@ -14,9 +14,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Move a dental cleaning from Tuesday to Thursday."

--- a/packages/simulation-contract/fixtures/spec/invalid/unknown-field.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/unknown-field.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
   "modality": "chat",
   "connection": {
@@ -14,9 +14,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Move a dental cleaning from Tuesday to Thursday."

--- a/packages/simulation-contract/fixtures/spec/invalid/voice-missing-stt-key.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/voice-missing-stt-key.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_fixture_voice_missing_stt_key",
   "modality": "voice",
   "connection": {
@@ -9,7 +9,7 @@
     "config": { "phoneNumber": "+15550000000" },
     "credentials": null
   },
-  "persona": { "traits": { "personality": "Patient and direct.", "language": "en-US" } },
+  "persona": { "name": "Alex", "personality": "Patient and direct.", "language": "en-US" },
   "scenario": { "instructions": "Ask for an appointment." },
   "limits": { "max_duration_seconds": 300, "max_turns": 20 },
   "models": {

--- a/packages/simulation-contract/fixtures/spec/invalid/wrong-contract-version.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/wrong-contract-version.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 3,
+  "contract_version": 4,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
   "modality": "chat",
   "connection": {
@@ -14,9 +14,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Move a dental cleaning from Tuesday to Thursday."

--- a/packages/simulation-contract/fixtures/spec/valid/chat-retell-without-platform.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-retell-without-platform.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K4QW7M4E8YB2FVN0H9TZQWET",
   "modality": "chat",
   "connection": {
@@ -14,9 +14,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Move a dental cleaning from Tuesday to Thursday."

--- a/packages/simulation-contract/fixtures/spec/valid/chat-retell.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-retell.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWER",
   "modality": "chat",
   "connection": {
@@ -14,9 +14,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "You booked a dental cleaning for next Tuesday and need to move it to Thursday the same week. You do not remember the exact time of the original appointment. Conclude once the new time has been read back to you."

--- a/packages/simulation-contract/fixtures/spec/valid/chat-scripted-flustered.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-scripted-flustered.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWET",
   "modality": "chat",
   "connection": {
@@ -19,9 +19,9 @@
     "credentials": null
   },
   "persona": {
-    "traits": {
-      "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.", "language": "en-US"
-    }
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "I booked a cleaning for next Tuesday but I need to move it to Thursday that same week. My name is Margaret Hale, sorry to be a bother. The half past two slot would suit me nicely."

--- a/packages/simulation-contract/fixtures/spec/valid/chat-scripted-hurried.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-scripted-hurried.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWEU",
   "modality": "chat",
   "connection": {
@@ -19,9 +19,9 @@
     "credentials": null
   },
   "persona": {
-    "traits": {
-      "personality": "Dev, 34, messaging from a train platform. In a hurry, fires off short messages, expects quick answers.", "language": "en-US"
-    }
+    "name": "Dev",
+    "personality": "Dev, 34, messaging from a train platform. In a hurry, fires off short messages, expects quick answers.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "My card was charged twice for the same order this morning. I need the duplicate charge reversed and a confirmation number before my train arrives. Please be quick about it."

--- a/packages/simulation-contract/fixtures/spec/valid/voice-livekit-mocked-tools.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-livekit-mocked-tools.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K4RE2V6B8N0PZQTM5CHXW7JD",
   "modality": "voice",
   "connection": {
@@ -16,9 +16,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.", "language": "en-US"
-    }
+    "name": "Eleanor",
+    "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month. Find out what the practice offers you when the diary turns out to be full."

--- a/packages/simulation-contract/fixtures/spec/valid/voice-livekit-token-endpoint.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-livekit-token-endpoint.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K5TB2H8Y4P7QCWF9XKMD6RZN",
   "modality": "voice",
   "connection": {
@@ -15,9 +15,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.", "language": "en-US"
-    }
+    "name": "Eleanor",
+    "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."

--- a/packages/simulation-contract/fixtures/spec/valid/voice-livekit.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-livekit.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K4RD9Q7X2M5NBVE8TJHC3PYW",
   "modality": "voice",
   "connection": {
@@ -17,9 +17,9 @@
     }
   },
   "persona": {
-    "traits": {
-      "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.", "language": "en-US"
-    }
+    "name": "Eleanor",
+    "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."

--- a/packages/simulation-contract/fixtures/spec/valid/voice-loopback.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-loopback.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K3XQ7M4E8YB2FVN0H9TZQWEV",
   "modality": "voice",
   "connection": {
@@ -20,9 +20,9 @@
     "credentials": null
   },
   "persona": {
-    "traits": {
-      "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.", "language": "en-US"
-    }
+    "name": "Dev",
+    "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "My card was charged twice for the same order this morning. I need the duplicate charge reversed and a confirmation number before my train arrives. Please be quick about it."

--- a/packages/simulation-contract/fixtures/spec/valid/voice-phone-platform-configured.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-phone-platform-configured.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 4,
+  "contract_version": 5,
   "simulation_id": "sim_01K4QW7M4E8YB2FVN0H9TZQWES",
   "modality": "voice",
   "connection": {
@@ -12,9 +12,9 @@
     "credentials": null
   },
   "persona": {
-    "traits": {
-      "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.", "language": "en-US"
-    }
+    "name": "Dev",
+    "personality": "Dev, 34, calling from a train platform. In a hurry, talks over slow answers, background noise comes and goes.",
+    "language": "en-US"
   },
   "scenario": {
     "instructions": "Your card was charged twice for the same order this morning. You want the duplicate charge reversed and a confirmation number before you hang up."

--- a/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "urn:egma:simulation-contract:spec:v4",
-  "title": "Simulation spec (v4)",
-  "description": "The only simulation work-order contract. The connection type selects the simulator connection adapter, the access variant selects its authority and configuration, and the agent platform records provenance only. The pinned persona version supplies one complete LLM, STT, and TTS selection. The model catalog resolves each selection's runtime adapter, while the control plane resolves current direct provider credentials when it prepares the claim. The simulator has no platform or container fallback for model or voice choices.",
+  "$id": "urn:egma:simulation-contract:spec:v5",
+  "title": "Simulation spec (v5)",
+  "description": "The only simulation work-order contract. The connection type selects the simulator connection adapter, the access variant selects its authority and configuration, and the agent platform records provenance only. The pinned persona version supplies the authored person whole — the name they give the agent, their personality, and the roleplay language — and one complete LLM, STT, and TTS selection. The model catalog resolves each selection's runtime adapter, while the control plane resolves current direct provider credentials when it prepares the claim. The simulator has no platform or container fallback for model or voice choices.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -19,7 +19,7 @@
     "contract_version": {
       "description": "The one spec version this simulator implements.",
       "type": "integer",
-      "const": 4
+      "const": 5
     },
     "simulation_id": {
       "description": "The simulation this spec conducts. Opaque to the simulator.",
@@ -71,34 +71,25 @@
       }
     },
     "persona": {
-      "description": "Who talks on the human side of the transcript.",
+      "description": "Who talks on the human side of the transcript: the authored person, flat and whole. Every value here is required, because a simulator that had to decide what an absent one meant would be deciding who the agent heard. Technical voice settings are not authored behavior and live only in models.tts.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["traits"],
+      "required": ["name", "personality", "language"],
       "properties": {
-        "traits": {
-          "description": "Authored behavior only. Technical voice settings live only in models.tts.",
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["personality", "language"],
-          "properties": {
-            "personality": {
-              "type": "string",
-              "minLength": 1
-            },
-            "language": {
-              "type": "string",
-              "minLength": 1
-            },
-            "accent": {
-              "type": "string",
-              "minLength": 1
-            },
-            "backgroundNoise": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
+        "name": {
+          "description": "The human name this person gives the agent. It is authored on the pinned persona version and stated in the prompt, never improvised by the model and never the team's own label for the library row — which is what makes the same test hear the same person on every run.",
+          "type": "string",
+          "minLength": 1
+        },
+        "personality": {
+          "description": "Who they are and how they behave, in the author's own words.",
+          "type": "string",
+          "minLength": 1
+        },
+        "language": {
+          "description": "The language the roleplay is conducted in.",
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
@@ -71,7 +71,7 @@
       }
     },
     "persona": {
-      "description": "Who talks on the human side of the transcript: the authored person, flat and whole. Every value here is required, because a simulator that had to decide what an absent one meant would be deciding who the agent heard. Technical voice settings are not authored behavior and live only in models.tts.",
+      "description": "Who talks on the human side of the transcript: the authored person, flat and whole. Every value here is required, because a simulator that had to decide what an absent one meant would be deciding who the agent heard. Each must also carry a non-whitespace character: a name of one space is present by the letter and absent by the reading, and would put \"Your name is  .\" in the prompt — the same ambiguity an absent name would. That is the rule the persona version's own columns keep, non-empty after trim, held here at the wire as well. Technical voice settings are not authored behavior and live only in models.tts.",
       "type": "object",
       "additionalProperties": false,
       "required": ["name", "personality", "language"],
@@ -79,17 +79,20 @@
         "name": {
           "description": "The human name this person gives the agent. It is authored on the pinned persona version and stated in the prompt, never improvised by the model and never the team's own label for the library row — which is what makes the same test hear the same person on every run.",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S"
         },
         "personality": {
           "description": "Who they are and how they behave, in the author's own words.",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S"
         },
         "language": {
           "description": "The language the roleplay is conducted in.",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S"
         }
       }
     },

--- a/packages/simulation-contract/src/documents.ts
+++ b/packages/simulation-contract/src/documents.ts
@@ -75,7 +75,7 @@ function complaintsFrom(
  * complaint per attempt that will never be retried.
  */
 export function specComplaints(document: unknown): readonly string[] {
-  compiledSpec ??= compileFromDisk("simulation-spec.v4.schema.json");
+  compiledSpec ??= compileFromDisk("simulation-spec.v5.schema.json");
   return complaintsFrom(compiledSpec, document);
 }
 

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -146,6 +146,14 @@ const EXPECTED_REJECTION: Record<string, Rejection> = {
     keyword: "required",
     property: "platform",
   },
+  // The three authored values move together, so each one's absence is a
+  // fixture of its own rather than a case one clone-and-delete test covers
+  // on one side of the wire.
+  "spec/persona-missing-name.json": {
+    at: "/persona",
+    keyword: "required",
+    property: "name",
+  },
   "spec/persona-missing-language.json": {
     at: "/persona",
     keyword: "required",
@@ -354,9 +362,13 @@ describe("the two schemas, as one contract", () => {
       true,
     );
 
-    // Whole: none of the three is optional. A simulator handed a persona
-    // without one of them would have to decide what it meant, and deciding
-    // that is deciding who the agent heard.
+    // Whole: none of the three is optional, and none may be present in name
+    // only. A simulator handed a persona without one of them would have to
+    // decide what it meant, and deciding that is deciding who the agent
+    // heard — which a name of one space leaves just as undecided, while
+    // reading "Your name is  ." into the prompt. Absent, empty and blank are
+    // one rule with three diagnostics, and it is the rule the persona
+    // version's own columns keep: non-empty after trim.
     for (const required of ["name", "personality", "language"] as const) {
       const spec = structuredClone(base);
       delete personaOf(spec)[required];
@@ -378,6 +390,31 @@ describe("the two schemas, as one contract", () => {
           keyword: "minLength",
         }),
       );
+
+      for (const blank of [" ", "   ", "\t", "\n", " \t\n "]) {
+        const whitespace = structuredClone(base);
+        personaOf(whitespace)[required] = blank;
+        expect(
+          validators.spec(whitespace),
+          `${required} accepted ${JSON.stringify(blank)}`,
+        ).toBe(false);
+        expect(validators.spec.errors).toContainEqual(
+          expect.objectContaining({
+            instancePath: `/persona/${required}`,
+            keyword: "pattern",
+          }),
+        );
+      }
+
+      // And the rule stops exactly there. Whitespace around real content is
+      // the author's own spacing, not an empty field: the wire refuses what
+      // says nothing, and does not tidy what somebody wrote.
+      const padded = structuredClone(base);
+      personaOf(padded)[required] = ` ${String(personaOf(base)[required])} `;
+      expect(
+        validators.spec(padded),
+        ajv.errorsText(validators.spec.errors),
+      ).toBe(true);
     }
 
     // Closed: the wrapper the block used to have, and the two authored

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -66,7 +66,7 @@ async function fixturesUnder(
 const ajv = new Ajv2020({ strict: true, allErrors: true });
 addFormats(ajv);
 
-const specSchema = await readJson("schemas", "simulation-spec.v4.schema.json");
+const specSchema = await readJson("schemas", "simulation-spec.v5.schema.json");
 const reportSchema = await readJson(
   "schemas",
   "simulation-report.v1.schema.json",
@@ -147,15 +147,27 @@ const EXPECTED_REJECTION: Record<string, Rejection> = {
     property: "platform",
   },
   "spec/persona-missing-language.json": {
-    at: "/persona/traits",
+    at: "/persona",
     keyword: "required",
     property: "language",
   },
   "spec/persona-technical-voice.json": {
-    at: "/persona/traits",
+    at: "/persona",
     keyword: "additionalProperties",
     property: "voice",
   },
+  // The persona block the contract carried until v5: authored behavior in a
+  // `traits` wrapper, with an accent and a background noise nobody ran. The
+  // whole shape is refused at the wrapper, which is what makes the flat block
+  // the only one there is rather than the one the simulator prefers.
+  "spec/persona-traits-wrapper.json": {
+    at: "/persona",
+    keyword: "additionalProperties",
+    property: "traits",
+  },
+  // A work order in the version before this one. There is no tolerance for it
+  // anywhere: the version is a `const`, so the old number is a refusal and not
+  // a branch.
   "spec/wrong-contract-version.json": {
     at: "/contract_version",
     keyword: "const",
@@ -217,12 +229,12 @@ describe("the two schemas, as one contract", () => {
         (schema.properties as Record<string, Record<string, unknown>>)
           .contract_version as Record<string, unknown>
       ).const;
-    expect(versionOf(specSchema)).toBe(4);
+    expect(versionOf(specSchema)).toBe(5);
     expect(versionOf(reportSchema)).toBe(1);
   });
 
   it("each carry an identity a $ref or an error message can name", () => {
-    expect(specSchema.$id).toBe("urn:egma:simulation-contract:spec:v4");
+    expect(specSchema.$id).toBe("urn:egma:simulation-contract:spec:v5");
     expect(reportSchema.$id).toBe("urn:egma:simulation-contract:report:v1");
   });
 
@@ -318,36 +330,68 @@ describe("the two schemas, as one contract", () => {
     }
   });
 
-  it("keeps only the authored persona traits that still cross the wire", async () => {
+  it("carries the authored person flat, whole, and closed", async () => {
     const base = await readJson(
       "fixtures",
       "spec",
       "valid",
       "voice-loopback.json",
     );
-    const withTrait = (name: string, value: string): Record<string, unknown> => {
-      const spec = structuredClone(base);
-      const persona = spec.persona as Record<string, Record<string, unknown>>;
-      const traits = persona.traits;
-      if (traits === undefined) throw new Error("the fixture has no traits");
-      traits[name] = value;
-      return spec;
+    const personaOf = (spec: Record<string, unknown>): Record<string, unknown> => {
+      const persona = spec.persona as Record<string, unknown> | undefined;
+      if (persona === undefined) throw new Error("the fixture has no persona");
+      return persona;
     };
 
-    for (const retained of ["accent", "backgroundNoise"]) {
-      expect(
-        validators.spec(withTrait(retained, "authored detail")),
-        `${retained}: ${ajv.errorsText(validators.spec.errors)}`,
-      ).toBe(true);
-    }
+    // Flat: the three authored values sit on the block itself, so there is
+    // one place to read who this is.
+    expect(Object.keys(personaOf(base)).sort()).toEqual([
+      "language",
+      "name",
+      "personality",
+    ]);
+    expect(validators.spec(base), ajv.errorsText(validators.spec.errors)).toBe(
+      true,
+    );
 
-    for (const removed of ["manner", "patience", "underFriction"]) {
-      expect(validators.spec(withTrait(removed, "retired detail"))).toBe(false);
+    // Whole: none of the three is optional. A simulator handed a persona
+    // without one of them would have to decide what it meant, and deciding
+    // that is deciding who the agent heard.
+    for (const required of ["name", "personality", "language"] as const) {
+      const spec = structuredClone(base);
+      delete personaOf(spec)[required];
+      expect(validators.spec(spec)).toBe(false);
       expect(validators.spec.errors).toContainEqual(
         expect.objectContaining({
-          instancePath: "/persona/traits",
+          instancePath: "/persona",
+          keyword: "required",
+          params: { missingProperty: required },
+        }),
+      );
+
+      const empty = structuredClone(base);
+      personaOf(empty)[required] = "";
+      expect(validators.spec(empty)).toBe(false);
+      expect(validators.spec.errors).toContainEqual(
+        expect.objectContaining({
+          instancePath: `/persona/${required}`,
+          keyword: "minLength",
+        }),
+      );
+    }
+
+    // Closed: the wrapper the block used to have, and the two authored
+    // details no run ever read, are refused here rather than ignored — the
+    // form cannot promise again what nothing delivers.
+    for (const retired of ["traits", "accent", "backgroundNoise"] as const) {
+      const spec = structuredClone(base);
+      personaOf(spec)[retired] = "retired detail";
+      expect(validators.spec(spec)).toBe(false);
+      expect(validators.spec.errors).toContainEqual(
+        expect.objectContaining({
+          instancePath: "/persona",
           keyword: "additionalProperties",
-          params: { additionalProperty: removed },
+          params: { additionalProperty: retired },
         }),
       );
     }


### PR DESCRIPTION
Ticket 02 of the persona rework (spec: planning `.scratch/persona-rework/`, decision 8). Second of four PRs into `integration/persona-rework`; runs parallel to #237 (schema).

## What this does

- The work-order contract takes one clean bump to **v5**: the persona block becomes flat, closed, and fully required — `name` (the identity name the persona gives the agent), `personality`, `language` — refusing a traits wrapper, an `accent` key, or a `backgroundNoise` key outright. All three fields refuse whitespace-only values in both validation engines (Ajv and Python `re`), so "Your name is  ." can never be composed. The models block is byte-identical to v4 (proved subtree-by-subtree in review).
- The simulator parses **only v5** and refuses v4 at `/contract_version`. No fallbacks: the persona reads through a frozen `AuthoredPersona` record with strict indexing.
- The composed system prompt gains "# Who you are — Your name is {name}…", and the invented-details rule (rule 53) stops licensing the model to invent a name: same test, same heard name, every run. There is exactly one prompt-composition site and one Persona construction, so the name reaches every simulation mode (LiveKit, phone, loopback, chat-scripted, retell).
- Public docs that this change falsified are corrected (root README's contract-v4 claims; the simulator README).

## Evidence

- Contract package: **59/59** (fast project) + build clean. Simulator: **621 passed / 6 skipped** full suite on the base commit; scoped re-runs green on the fix commit; ruff clean.
- Independent two-axis review (standards + spec) completed; must-fix and accepted findings applied in `6b0951b2`, including a `persona-missing-name.json` fixture registered in both rejection maps for cross-engine symmetry.

## Expected CI note

apps/api's fast-lane tests fail on this PR **by design**: its claim assembler still emits the v4 shape and six of its test files load the deleted v4 schema by path. Ticket 03 rewrites the assembler on this same integration branch; the branch is proven whole at ticket 04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790322552&installation_model_id=431960&pr_number=238&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F238&signature=4f09e3a40ec0a193908b84b92ecadbee9dbd2f9c6857b6169e15f41e04aacf11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR advances the simulation work-order contract from v4 to v5 and makes the persona a required, flat record containing its name, personality, and language.

- Updates both TypeScript and Python contract readers to validate only v5.
- Introduces a frozen `AuthoredPersona` model and carries its identity name into the simulator’s system prompt.
- Migrates shared fixtures and cross-engine contract tests to the v5 persona shape.
- Updates simulator tests and public documentation for the new identity behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge into its stated integration branch, with no unacknowledged actionable defect established in the changed v5 contract or simulator path.

The v5 schema, both validators, typed simulator parsing, prompt composition, fixtures, and tests are aligned; the remaining API incompatibility is an explicitly documented intermediate state deferred to the next integration-branch ticket.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/simulation-contract/schemas/simulation-spec.v5.schema.json | Defines the v5 boundary with a closed, flat persona block and required non-whitespace name, personality, and language fields. |
| packages/simulation-contract/src/documents.ts | Switches the TypeScript validator to compile and enforce the v5 work-order schema. |
| apps/simulator/src/egma_simulator/contract.py | Switches simulator-side contract loading and advertised version discovery to the v5 schema. |
| apps/simulator/src/egma_simulator/spec.py | Adds the immutable `AuthoredPersona` representation and strictly parses the validated flat persona block. |
| apps/simulator/src/egma_simulator/persona.py | Composes the authored identity name into the common persona prompt and removes permission to invent another name. |
| apps/simulator/src/egma_simulator/service.py | Passes the parsed authored persona into the single shared Persona construction used by simulation modes. |
| packages/simulation-contract/test/contract.test.ts | Expands TypeScript contract coverage for v5 versioning, persona shape, required fields, and blank-value rejection. |
| apps/simulator/tests/test_contract_fixtures.py | Mirrors v5 contract and whitespace validation coverage in the Python engine. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Persona version and test inputs] --> B[API work-order assembler]
  B --> C[v5 schema validation]
  C --> D[Simulator claim validation]
  D --> E[AuthoredPersona]
  E --> F[System prompt with identity name]
  F --> G{Simulation modality}
  G -->|Chat| H[Chat walk]
  G -->|Voice| I[Voice conductor]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(contract): refuse a blank persona, a..."](https://github.com/egma-ai/egma/commit/6b0951b2e24493c459ad350989579cf4a51804c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56989418)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Simulation contract](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulation-contract.md)
- Knowledge Base — [Simulator personas and scenarios](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-personas-and-scenarios.md)
- Knowledge Base — [Simulator execution pipeline](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-execution.md)
</details>


<!-- /greptile_comment -->