### PR TITLE
Grader screen legibility rework

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,7 +68,7 @@ Rules:
 
 - Keep the canonical geometry, proportions, and black-and-white treatment.
 - Do not recolor, stretch, rotate, outline, shadow, or animate the logo.
-- The signed-in sidebar starts with the Egma loop mark beside the current organization, its `Free` plan chip and paired arrows, in a 56px bar with a hairline under it. Use the square light/dark mark asset, not the full wordmark. (Developer decision, 2026-08-24, from the approved Paper refinement.)
+- The signed-in sidebar starts with the Egma loop mark beside the current organization and paired arrows, in a 56px bar with a hairline under it. Use the square light/dark mark asset, not the full wordmark. (Developer decision, 2026-08-24, from the approved Paper refinement. The `Free` plan chip left this bar by developer decision, 2026-08-25 on the Paper canvas, implemented the same day.)
 - The sidebar mark follows the access pages' existing dark-theme treatment: black line art is printed white by inversion.
 - Project context is a separate control under the organization bar. It always shows the word `Project`, the current project name and paired arrows.
 - Auth, onboarding, and public brand surfaces may use the full logo.
@@ -213,7 +213,7 @@ rgba(122, 49, 23, 0.02) -130px 256px 115px 0
 
 - Neutral Paper is the application canvas.
 - The sidebar is a quiet paper region separated by a neutral hairline.
-- The organization control is the topmost thing in the sidebar. It holds the Egma mark, organization name, current plan and paired arrows in a bar of its own.
+- The organization control is the topmost thing in the sidebar. It holds the Egma mark, organization name and paired arrows in a bar of its own.
 - The project selector is a separate control under the organization bar and keeps the word `Project` visible.
 - Navigation uses text and small line icons.
 - The active item uses Ember Wash and a small Ember mark on its leading edge. Its icon follows the row's text colour; the mark is the brand signal and there is only one.
@@ -243,9 +243,8 @@ The measurements, all of them theme values:
 
 ### Organization and project controls
 
-- Keep organization and project as two clear controls. The organization bar shows the Egma mark, organization name, the fixed `Free` release-plan chip and paired arrows. The project control below shows the explicit `Project` label, project name and paired arrows. (Developer decision, 2026-08-24.)
-- The organization menu is informational in the current one-organization model. It shows the organization name, `Free Plan`, and the person's real `Admin`, `Member`, or `Viewer` role. It does not offer organization switching or Organization settings yet.
-- `Free` is fixed release copy because billing data does not exist in the session yet. Show it only after a real organization has loaded; do not make a plan claim while loading or when the organization is absent.
+- Keep organization and project as two clear controls. The organization bar shows the Egma mark, organization name and paired arrows. The project control below shows the explicit `Project` label, project name and paired arrows. (Developer decision, 2026-08-24.)
+- The organization menu is informational in the current one-organization model. It shows a grey `Organization` label and the organization name. It does not offer organization switching or Organization settings yet. The label is the `Project` label's own recipe, one control down. (Developer decision, 2026-08-25 on the Paper canvas. The `Free Plan` line and the role line left the menu that same day: billing is not in the session read, and the role is already said by the account control at the foot of the same sidebar. The `Organization` label arrived 2026-08-26.)
 - The project selector is a direct list with no search field. It keeps the project name neutral when open and continues to support keyboard use, Escape, focus return, URL-based selection, and unsaved-work protection. (Developer decision, 2026-08-24.)
 - Open each menu from its trigger with an origin-aware transition.
 - Do not add fake teams, sample projects, or a second navigation model.

--- a/apps/api/test/browser.test.ts
+++ b/apps/api/test/browser.test.ts
@@ -2135,9 +2135,12 @@ describe("the project grader library", () => {
         .toBe(1);
       expect(await page.getByRole("tab", { name: "Grader library" }).count())
         .toBe(1);
-      expect(await page.innerText("main")).toContain(
-        "All simulations · Production off",
-      );
+      const expectedBehaviorsRow = page
+        .locator("table")
+        .getByRole("row")
+        .filter({ hasText: "Expected behaviors" });
+      expect(await expectedBehaviorsRow.innerText()).toContain("All");
+      expect(await expectedBehaviorsRow.innerText()).toContain("Off");
 
       await page.getByRole("tab", { name: "Grader library" }).click();
       const latency = page
@@ -2146,16 +2149,14 @@ describe("the project grader library", () => {
         .filter({ hasText: "Response latency" });
       await latency.waitFor();
       expect(await latency.innerText()).toContain("Available");
-      await latency
-        .getByRole("button", { name: "Open the menu for Response latency" })
-        .click();
-      await page.getByRole("menuitem", { name: "View details" }).click();
+      /* The whole row opens the review sheet now; the ⋮ holds Use in project. */
+      await latency.click();
 
       const details = page.getByRole("dialog", { name: "Response latency" });
       await details.waitFor();
       await expect
         .poll(() => details.innerText(), { timeout: 30_000 })
-        .toContain("turn response latency");
+        .toContain("Turn response latency");
       expect(await details.innerText()).toContain(
         "Maximum average response time: 3 seconds by default",
       );
@@ -2171,11 +2172,11 @@ describe("the project grader library", () => {
         .getByRole("row")
         .filter({ hasText: "Response latency" });
       await activeLatency.waitFor();
-      expect(await activeLatency.innerText()).toContain("All simulations");
+      expect(await activeLatency.innerText()).toContain("All");
       await activeLatency
         .getByRole("button", { name: "Open the menu for Response latency" })
         .click();
-      await page.getByRole("menuitem", { name: "View and edit" }).click();
+      await page.getByRole("menuitem", { name: "Edit" }).click();
       const activeLatencyDetails = page.getByRole("dialog", {
         name: "Response latency",
       });
@@ -2202,8 +2203,7 @@ describe("the project grader library", () => {
         .getByRole("row")
         .filter({ hasText: BROWSER_CUSTOM_GRADER });
       await activeCustom.waitFor();
-      expect(await activeCustom.innerText()).toContain("Organization");
-      expect(await activeCustom.innerText()).toContain("LLM judge");
+      expect(await activeCustom.innerText()).toContain("llm_as_judge");
     },
     SETTLE,
   );
@@ -2854,7 +2854,8 @@ describe("the complete product, walked in order in a second project", () => {
     async () => {
       await walk.goto(at("graders"));
       await walk.waitForSelector("text=Expected behaviors");
-      await saysWithin(walk, "All simulations · Production off");
+      await saysWithin(walk, "Simulations");
+      await saysWithin(walk, "Production");
 
       expect(
         await walk
@@ -2880,7 +2881,7 @@ describe("the complete product, walked in order in a second project", () => {
       await secondProjectGrader
         .getByRole("button", { name: "Open the menu for Expected behaviors" })
         .click();
-      await walk.getByRole("menuitem", { name: "View and edit" }).click();
+      await walk.getByRole("menuitem", { name: "Edit" }).click();
       const thresholdEditor = walk.getByRole("dialog", {
         name: "Expected behaviors",
       });

--- a/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
+++ b/apps/web/app/projects/[projectId]/graders/grader-sheets.tsx
@@ -8,6 +8,7 @@ import {
   useGraderInProject,
 } from "@egma/platform-api/client";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -22,18 +23,21 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import type { Refusal } from "../../../../lib/api.ts";
 import {
   EMPTY_GRADER_SCOPE,
   graderDefinitionDisplayName,
-  graderModalitiesLabel,
+  graderEvidenceLabel,
+  graderModalityLabel,
   graderOwnerLabel,
-  graderTypeLabel,
-  productionScopeLabel,
-  simulationScopeLabel,
+  productionScopeSummary,
+  simulationScopeSummary,
+  SCOPE_OFF,
   type GraderLibraryEntry,
   type GraderModality,
   type GraderSettingDefinition,
+  type GraderType,
   type ProjectGrader,
   type ProjectGraderScope,
 } from "../../../../lib/graders.ts";
@@ -43,10 +47,160 @@ import {
 } from "../../../../lib/platform-client.ts";
 import { Field, Refused } from "../../../../ui/form.tsx";
 import { NumberField } from "../../../../ui/number-field.tsx";
-import { Loading } from "../../../../ui/page-state.tsx";
+import { Empty, Loading } from "../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
 import { useUnsavedChanges } from "../../../../ui/settings-read.ts";
 import { ScopeFields } from "./scope-fields.tsx";
+
+/**
+ * The words this surface repeats, written once.
+ *
+ * The pass threshold is asked for in three places — using a library grader,
+ * editing an active one, creating a custom one — and a sentence that drifted
+ * between them would be three different promises about one number.
+ */
+const COPY = {
+  passThreshold: "Pass threshold*",
+  passThresholdHint:
+    "From 0 to 1. A simulation passes this grader at or above this score.",
+  gradingInstructionsHint:
+    "Describe what the agent must do. The grader returns a score between 0 and 1.",
+  reads: "The evidence this grader needs from a simulation.",
+} as const;
+
+/**
+ * One chip, and every chip on this surface is this one.
+ *
+ * It is the shared `Badge` with two things said about it: the count shape's
+ * 22px height, which is the small chip this product already draws beside a row
+ * of facts, and no fill, because `DESIGN.md` asks a chip for a hairline and a
+ * word. The verdict shape is deliberately not used here — it letter-spaces and
+ * capitalises, and `llm_as_judge` is an identifier that must read exactly as
+ * the API writes it.
+ */
+function GraderChip({
+  variant = "neutral",
+  mono = false,
+  children,
+}: {
+  readonly variant?: "neutral" | "success";
+  /** An identifier, in the shared monospace stack. */
+  readonly mono?: boolean;
+  readonly children: ReactNode;
+}) {
+  return (
+    <Badge
+      className={cn("bg-transparent", mono && "font-mono")}
+      shape="count"
+      variant={variant}
+    >
+      {children}
+    </Badge>
+  );
+}
+
+/** What a grader is, as the API's own word for it. */
+export function GraderTypeChip({ type }: { readonly type: GraderType }) {
+  return <GraderChip mono>{type}</GraderChip>;
+}
+
+/** Which modalities a grader can grade — one chip each, never a joined phrase. */
+export function GraderModalityChips({
+  modalities,
+}: {
+  readonly modalities: readonly GraderModality[];
+}) {
+  if (modalities.length === 0) return <span className="text-faint">None</span>;
+  return (
+    <span className="inline-flex items-center gap-2">
+      {modalities.map((modality) => (
+        <GraderChip key={modality}>{graderModalityLabel(modality)}</GraderChip>
+      ))}
+    </span>
+  );
+}
+
+/**
+ * Whether this project already grades with a library entry.
+ *
+ * Active is the success chip: the green hairline and green word are the only
+ * colour on the row, and the word carries the state on its own for anybody who
+ * cannot see the colour.
+ */
+export function ProjectUseChip({ active }: { readonly active: boolean }) {
+  return (
+    <GraderChip variant={active ? "success" : "neutral"}>
+      {active ? "Active" : "Available"}
+    </GraderChip>
+  );
+}
+
+/**
+ * One scope column's word, drawn the same in the list and in the sheet.
+ *
+ * `Off` is the absence of a scope rather than a scope, so it is faint: a column
+ * of graders should let the eye fall on the ones that are grading something.
+ */
+export function ScopeValue({ value }: { readonly value: string }) {
+  return (
+    <span className={value === SCOPE_OFF ? "text-faint" : undefined}>
+      {value}
+    </span>
+  );
+}
+
+/** A labelled row of facts, in one lane, in a sheet. */
+function Facts({ children }: { readonly children: ReactNode }) {
+  return (
+    <dl className="m-0 grid grid-cols-[112px_minmax(0,1fr)] gap-x-3 gap-y-2 text-sm">
+      {children}
+    </dl>
+  );
+}
+
+/** One fact in that lane. */
+function Fact({
+  label,
+  children,
+}: {
+  readonly label: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <>
+      <dt className="text-faint">{label}</dt>
+      <dd className="m-0 leading-(--line-normal) text-muted-foreground">
+        {children}
+      </dd>
+    </>
+  );
+}
+
+/** One part of a sheet's body, under its own heading. */
+function Section({
+  title,
+  lead,
+  children,
+}: {
+  readonly title: string;
+  /** One faint line saying what the part below is. */
+  readonly lead?: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-t border-border pt-5">
+      <div className="flex flex-col gap-1">
+        <p className="m-0 text-sm font-medium text-foreground">{title}</p>
+        {lead === undefined ? null : (
+          <p className="m-0 text-sm leading-(--line-normal) text-faint">
+            {lead}
+          </p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
 
 type SettingsDraft = Readonly<Record<string, string>>;
 
@@ -118,8 +272,7 @@ function SettingsFields({
 }) {
   if (definitions.length === 0) return null;
   return (
-    <div className="flex flex-col gap-4 border-t border-border pt-5">
-      <p className="m-0 text-sm font-medium text-foreground">Settings</p>
+    <Section title="Settings">
       {definitions.map((definition) => {
         const value = draft[definition.key] ?? "";
         const converted = settingValue(definition, value);
@@ -158,7 +311,7 @@ function SettingsFields({
           />
         );
       })}
-    </div>
+    </Section>
   );
 }
 
@@ -178,9 +331,16 @@ function PassThresholdField({
     parsed >= 0 &&
     parsed <= 1;
   return (
+    /*
+     * The star on the label is presentation, and the field says the same thing
+     * to a screen reader through `required` — the native attribute the
+     * accessibility tree reads as the required state. `DESIGN.md` asks that a
+     * starred label never be only a picture; this is that promise kept by the
+     * control rather than by a second attribute beside it.
+     */
     <NumberField
       id="grader-pass-threshold"
-      label="Pass threshold"
+      label={COPY.passThreshold}
       value={value}
       onChange={onChange}
       min={0}
@@ -189,7 +349,7 @@ function PassThresholdField({
       disabled={disabled}
       required
       invalid={!valid}
-      hint="This decides only whether this grader's own result passes."
+      hint={COPY.passThresholdHint}
     />
   );
 }
@@ -202,35 +362,56 @@ function thresholdValue(value: string): number | null {
     : null;
 }
 
-function Facts({ entry }: { readonly entry: GraderLibraryEntry }) {
-  const evidence = entry.requiredEvidence.map((one) =>
-    one.replaceAll("_", " "),
-  );
+/**
+ * What a library grader is, before anybody chooses it.
+ *
+ * **The description is the first row of the list rather than a paragraph over
+ * it.** It is one of the facts, and a sentence floating above a labelled lane
+ * read as the sheet's own introduction instead of as this grader's. A grader
+ * with no description has no row: an empty lane says less than nothing.
+ */
+function LibraryFacts({ entry }: { readonly entry: GraderLibraryEntry }) {
   return (
-    <dl className="m-0 grid grid-cols-[112px_minmax(0,1fr)] gap-x-3 gap-y-2 text-sm">
-      <dt className="text-faint">Owner</dt>
-      <dd className="m-0 text-muted-foreground">
-        {graderOwnerLabel(entry.owner)}
-      </dd>
-      <dt className="text-faint">Type</dt>
-      <dd className="m-0 text-muted-foreground">
-        {graderTypeLabel(entry.type)}
-      </dd>
-      <dt className="text-faint">Modalities</dt>
-      <dd className="m-0 text-muted-foreground">
-        {graderModalitiesLabel(entry.modalities)}
-      </dd>
-      <dt className="text-faint">Reads</dt>
-      <dd className="m-0 text-muted-foreground">
-        {evidence.length === 0 ? "No trace evidence" : evidence.join(", ")}
-      </dd>
-      <dt className="text-faint">Project use</dt>
-      <dd className="m-0 text-muted-foreground">
-        {entry.activeProjectGraderId === null
-          ? "Not active in this project"
-          : "Active in this project"}
-      </dd>
-    </dl>
+    <Facts>
+      {entry.description === null ? null : (
+        <Fact label="Description">{entry.description}</Fact>
+      )}
+      <Fact label="Owner">{graderOwnerLabel(entry.owner)}</Fact>
+      <Fact label="Type">
+        <GraderTypeChip type={entry.type} />
+      </Fact>
+      <Fact label="Modalities">
+        <GraderModalityChips modalities={entry.modalities} />
+      </Fact>
+      <Fact label="Project use">
+        <ProjectUseChip active={entry.activeProjectGraderId !== null} />
+      </Fact>
+    </Facts>
+  );
+}
+
+/**
+ * The evidence this grader needs, as its own part of the sheet.
+ *
+ * It was a row in the fact list, where a list of six sources ran past the lane
+ * and read as one long value. It is a section now, because "what does this
+ * grader look at" is the question somebody choosing a grader asks second.
+ */
+function ReadsSection({ entry }: { readonly entry: GraderLibraryEntry }) {
+  return (
+    <Section title="Reads" lead={COPY.reads}>
+      {entry.requiredEvidence.length === 0 ? (
+        <p className="m-0 text-sm text-muted-foreground">No trace evidence</p>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          {entry.requiredEvidence.map((evidence) => (
+            <GraderChip key={evidence}>
+              {graderEvidenceLabel(evidence)}
+            </GraderChip>
+          ))}
+        </div>
+      )}
+    </Section>
   );
 }
 
@@ -279,6 +460,7 @@ export function LibraryGraderSheet({
   entry,
   projectId,
   open,
+  mode: opened = "details",
   mayAuthor,
   onClose,
   onUsed,
@@ -287,15 +469,23 @@ export function LibraryGraderSheet({
   readonly entry: GraderLibraryEntry;
   readonly projectId: string;
   readonly open: boolean;
+  /**
+   * Which half of this sheet the opener asked for.
+   *
+   * A row press is a person reading, so it opens the review. The row menu's
+   * **Use in project** is a person who has already decided, so it opens the
+   * form and does not make them press past the review to reach it.
+   */
+  readonly mode?: "details" | "use";
   readonly mayAuthor: boolean;
   readonly onClose: () => void;
   readonly onUsed: () => void;
   readonly onEditActive: (projectGraderId: string) => void;
 }) {
-  const [mode, setMode] = useState<"details" | "use">("details");
+  const [mode, setMode] = useState<"details" | "use">(opened);
   useEffect(() => {
-    if (open) setMode("details");
-  }, [open]);
+    if (open) setMode(opened);
+  }, [open, opened]);
   return (
     <Sheet open={open} onOpenChange={(next) => !next && onClose()}>
       <SheetContent aria-describedby={undefined}>
@@ -347,31 +537,28 @@ function LibraryDetails({
   return (
     <>
       <SheetBody>
-        {entry.description === null ? null : (
-          <p className="m-0 text-sm leading-(--line-normal) text-muted-foreground">
-            {entry.description}
-          </p>
-        )}
-        <Facts entry={entry} />
+        <LibraryFacts entry={entry} />
+        <ReadsSection entry={entry} />
         {entry.settingDefinitions.length === 0 ? null : (
-          <div className="flex flex-col gap-2 border-t border-border pt-5">
-            <p className="m-0 text-sm font-medium text-foreground">Settings</p>
-            {entry.settingDefinitions.map((setting) => (
-              <p className="m-0 text-sm text-muted-foreground" key={setting.key}>
-                {setting.label}: {defaultSettingLabel(setting)} by default
-              </p>
-            ))}
-          </div>
+          <Section title="Settings">
+            <div className="flex flex-col gap-2">
+              {entry.settingDefinitions.map((setting) => (
+                <p
+                  className="m-0 text-sm text-muted-foreground"
+                  key={setting.key}
+                >
+                  {setting.label}: {defaultSettingLabel(setting)} by default
+                </p>
+              ))}
+            </div>
+          </Section>
         )}
         {entry.gradingInstructions === null ? null : (
-          <div className="flex flex-col gap-2 border-t border-border pt-5">
-            <p className="m-0 text-sm font-medium text-foreground">
-              Grading instructions
-            </p>
+          <Section title="Grading instructions">
             <p className="m-0 whitespace-pre-wrap text-sm leading-(--line-normal) text-muted-foreground">
               {entry.gradingInstructions}
             </p>
-          </div>
+          </Section>
         )}
       </SheetBody>
       <SheetFooter>
@@ -391,7 +578,6 @@ function LibraryDetails({
           <Button
             type="button"
             size="lg"
-            variant="secondary"
             onClick={() => onEditActive(entry.activeProjectGraderId as string)}
           >
             View active grader
@@ -524,7 +710,6 @@ export function ActiveGraderSheet({
   mayAuthor,
   onClose,
   onSaved,
-  onRemove,
 }: {
   readonly grader: ProjectGrader;
   readonly projectId: string;
@@ -532,7 +717,6 @@ export function ActiveGraderSheet({
   readonly mayAuthor: boolean;
   readonly onClose: () => void;
   readonly onSaved: () => void;
-  readonly onRemove: () => void;
 }) {
   return (
     <Sheet open={open} onOpenChange={(next) => !next && onClose()}>
@@ -560,7 +744,6 @@ export function ActiveGraderSheet({
               open={open}
               mayAuthor={mayAuthor}
               onSaved={onSaved}
-              onRemove={onRemove}
             />
           )}
         </DefinitionRead>
@@ -576,7 +759,6 @@ function EditGraderForm({
   open,
   mayAuthor,
   onSaved,
-  onRemove,
 }: {
   readonly grader: ProjectGrader;
   readonly entry: GraderLibraryEntry;
@@ -584,7 +766,6 @@ function EditGraderForm({
   readonly open: boolean;
   readonly mayAuthor: boolean;
   readonly onSaved: () => void;
-  readonly onRemove: () => void;
 }) {
   const [scope, setScope] = useState<ProjectGraderScope>(grader.scope);
   const [scopeRevision, setScopeRevision] = useState(0);
@@ -666,23 +847,27 @@ function EditGraderForm({
     >
       <SheetBody>
         {refused === null ? null : <Refused message={refused.message} />}
-        <dl className="m-0 grid grid-cols-[112px_minmax(0,1fr)] gap-x-3 gap-y-2 text-sm">
-          <dt className="text-faint">Owner</dt>
-          <dd className="m-0 text-muted-foreground">
-            {graderOwnerLabel(grader.owner)}
-          </dd>
-          <dt className="text-faint">Type</dt>
-          <dd className="m-0 text-muted-foreground">
-            {graderTypeLabel(grader.type)}
-          </dd>
-          <dt className="text-faint">Modalities</dt>
-          <dd className="m-0 text-muted-foreground">
-            {graderModalitiesLabel(grader.modalities)}
-          </dd>
-        </dl>
-        {grader.scopeEditable ? (
-          <div className="flex flex-col gap-3 border-t border-border pt-5">
-            <p className="m-0 text-sm font-medium text-foreground">Scope</p>
+        <Facts>
+          <Fact label="Owner">{graderOwnerLabel(grader.owner)}</Fact>
+          <Fact label="Type">
+            <GraderTypeChip type={grader.type} />
+          </Fact>
+          <Fact label="Modalities">
+            <GraderModalityChips modalities={grader.modalities} />
+          </Fact>
+        </Facts>
+        {/*
+         * **A scope nobody here can change is read in the same lane the facts
+         * above it are.** It used to be two sentences under a "Fixed by Egma"
+         * caption, which answered a question nobody asked — the controls are
+         * simply not there — while saying the two evidence sources in a shape
+         * that matched neither the list behind the sheet nor the form that
+         * replaces this block on an editable grader. The caption is gone
+         * (developer decision, 2026-08-25) and the two lines are the two
+         * columns of the list, word for word.
+         */}
+        <Section title="Scope">
+          {grader.scopeEditable ? (
             <ScopeFields
               key={scopeRevision}
               projectId={projectId}
@@ -691,21 +876,17 @@ function EditGraderForm({
               onChange={setScope}
               onValidityChange={setScopeValid}
             />
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2 border-t border-border pt-5">
-            <div className="flex items-center justify-between gap-3">
-              <p className="m-0 text-sm font-medium text-foreground">Scope</p>
-              <span className="text-sm text-faint">Fixed by Egma</span>
-            </div>
-            <p className="m-0 text-sm text-muted-foreground">
-              {simulationScopeLabel(grader)}
-            </p>
-            <p className="m-0 text-sm text-muted-foreground">
-              {productionScopeLabel(grader)}
-            </p>
-          </div>
-        )}
+          ) : (
+            <Facts>
+              <Fact label="Simulations">
+                <ScopeValue value={simulationScopeSummary(grader.scope)} />
+              </Fact>
+              <Fact label="Production">
+                <ScopeValue value={productionScopeSummary(grader.scope)} />
+              </Fact>
+            </Facts>
+          )}
+        </Section>
         <SettingsFields
           definitions={entry.settingDefinitions}
           draft={settings}
@@ -720,22 +901,14 @@ function EditGraderForm({
           />
         </div>
       </SheetBody>
-      <SheetFooter
-        destructive={
-          grader.removable ? (
-            <Button
-              type="button"
-              size="lg"
-              variant="ghost"
-              className="px-0 text-failure pointer-hover:text-failure"
-              disabled={saving || !mayAuthor}
-              onClick={onRemove}
-            >
-              Remove grader
-            </Button>
-          ) : undefined
-        }
-      >
+      {/*
+       * **The footer answers and gets out of the way, and nothing else.**
+       * Removing a grader left this sheet with the redesign: it is a thing done
+       * *to* a row rather than a thing said *in* the editor, so it is offered
+       * by the ⋮ on the row — in the active list and in the library — and it
+       * still opens the same confirmation that names the grader.
+       */}
+      <SheetFooter>
         <Button
           type="submit"
           size="lg"
@@ -759,6 +932,93 @@ function EditGraderForm({
   );
 }
 
+/**
+ * Which kind of grader is being written, as the two segments of one control.
+ *
+ * **It is a radio group, not two buttons**, and the recipe is the one the
+ * connect sheet already draws: one of these is true and the other is not, the
+ * arrow keys move between them, and only the chosen one is a tab stop.
+ *
+ * **The chosen segment carries a two-pixel Ember line on its top edge**, over a
+ * plain fill, plus weight 500 so the state is not colour alone (`DESIGN.md`,
+ * developer decision 2026-08-24).
+ */
+function MechanismChoice({
+  value,
+  disabled,
+  onChange,
+}: {
+  readonly value: GraderType;
+  readonly disabled: boolean;
+  readonly onChange: (next: GraderType) => void;
+}) {
+  const segments: readonly { readonly value: GraderType; readonly label: string }[] =
+    [
+      { value: "llm_as_judge", label: "LLM judge" },
+      { value: "code", label: "Code" },
+    ];
+
+  function step(by: number): void {
+    const here = segments.findIndex((one) => one.value === value);
+    const next = segments[(here + by + segments.length) % segments.length];
+    if (next !== undefined) onChange(next.value);
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="m-0 text-sm text-faint" id="custom-grader-mechanism-label">
+        Mechanism
+      </p>
+      <div
+        aria-labelledby="custom-grader-mechanism-label"
+        className="flex w-fit border border-border"
+        role="radiogroup"
+      >
+        {segments.map((segment, index) => (
+          <button
+            aria-checked={segment.value === value}
+            className={cn(
+              "relative flex min-h-(--control-md) cursor-pointer items-center justify-center px-6",
+              "border-0 bg-transparent text-sm",
+              "transition-colors duration-(--duration-hover) ease-out",
+              "disabled:cursor-not-allowed disabled:opacity-55",
+              index > 0 && "border-l border-border",
+              /*
+               * The line is painted by the segment rather than mounted as an
+               * element, so choosing the other one moves one edge.
+               */
+              "before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:content-['']",
+              "before:origin-left before:bg-brand before:transition-[opacity,transform]",
+              "before:duration-(--duration-hover) before:ease-out",
+              "motion-reduce:before:transition-none",
+              segment.value === value
+                ? "font-medium text-foreground before:scale-x-100 before:opacity-100"
+                : "text-muted-foreground before:scale-x-0 before:opacity-0 pointer-hover:text-foreground",
+            )}
+            disabled={disabled}
+            key={segment.value}
+            onClick={() => onChange(segment.value)}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                event.preventDefault();
+                step(1);
+              } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                event.preventDefault();
+                step(-1);
+              }
+            }}
+            role="radio"
+            tabIndex={segment.value === value ? 0 : -1}
+            type="button"
+          >
+            {segment.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function CreateCustomGraderSheet({
   projectId,
   open,
@@ -770,6 +1030,14 @@ export function CreateCustomGraderSheet({
   readonly onClose: () => void;
   readonly onCreated: () => void;
 }) {
+  /**
+   * Which kind of grader this sheet is writing.
+   *
+   * Only the LLM judge can be written today, and the other segment says so
+   * rather than being missing: a person who came here to write a code grader is
+   * told when it arrives instead of being left to wonder whether Egma has one.
+   */
+  const [mechanism, setMechanism] = useState<GraderType>("llm_as_judge");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
@@ -785,6 +1053,7 @@ export function CreateCustomGraderSheet({
   const [refused, setRefused] = useState<Refusal | null>(null);
   useEffect(() => {
     if (!open) return;
+    setMechanism("llm_as_judge");
     setName("");
     setDescription("");
     setInstructions("");
@@ -863,7 +1132,7 @@ export function CreateCustomGraderSheet({
         <SheetHeader>
           <SheetTitle>Create custom grader</SheetTitle>
           <SheetDescription>
-            Create an LLM judge for this organization and use it in this project.
+            Create a grader for this organization and use it in this project.
           </SheetDescription>
         </SheetHeader>
         <form
@@ -874,85 +1143,132 @@ export function CreateCustomGraderSheet({
           }}
         >
           <SheetBody>
-            {refused === null ? null : <Refused message={refused.message} />}
-            <Field label="Name" htmlFor="custom-grader-name">
-              <Input
-                id="custom-grader-name"
-                value={name}
-                disabled={saving}
-                autoComplete="off"
-                onChange={(event) => setName(event.target.value)}
+            {/*
+             * **The choice is the first thing in the body**, because it decides
+             * what the rest of the body is. Nothing typed is thrown away by
+             * changing it: every value below lives in this component, so the
+             * other segment and back leaves the form exactly as it was.
+             */}
+            <MechanismChoice
+              value={mechanism}
+              disabled={saving}
+              onChange={setMechanism}
+            />
+            {mechanism === "code" ? (
+              <Empty
+                title="Code graders are coming soon"
+                lead="Write pass rules in code and run them on every simulation. Custom code graders arrive in a later release."
               />
-            </Field>
-            <Field
-              label="Description"
-              htmlFor="custom-grader-description"
-              hint="Optional. Explain what quality this grader checks."
-            >
-              <Textarea
-                id="custom-grader-description"
-                value={description}
-                disabled={saving}
-                rows={3}
-                onChange={(event) => setDescription(event.target.value)}
-              />
-            </Field>
-            <Field
-              label="Grading instructions"
-              htmlFor="custom-grader-instructions"
-              hint="Describe what the agent must do for this grader to return a score of 1."
-            >
-              <Textarea
-                id="custom-grader-instructions"
-                value={instructions}
-                disabled={saving}
-                rows={7}
-                onChange={(event) => setInstructions(event.target.value)}
-              />
-            </Field>
-            <fieldset className="m-0 flex flex-col gap-3 border-0 p-0">
-              <legend className="mb-1 text-sm font-medium text-foreground">
-                Compatible modalities
-              </legend>
-              {(["chat", "voice"] as const).map((modality) => (
-                <label
-                  className="flex min-h-(--control-md) items-center gap-3 text-sm text-foreground"
-                  key={modality}
-                >
-                  <Checkbox
-                    checked={modalities.includes(modality)}
+            ) : (
+              <>
+                {refused === null ? null : <Refused message={refused.message} />}
+                <Field label="Name*" htmlFor="custom-grader-name">
+                  <Input
+                    id="custom-grader-name"
+                    value={name}
                     disabled={saving}
-                    onChange={(event) =>
-                      toggleModality(modality, event.target.checked)
-                    }
+                    aria-required="true"
+                    autoComplete="off"
+                    onChange={(event) => setName(event.target.value)}
                   />
-                  {modality === "chat" ? "Chat" : "Voice"}
-                </label>
-              ))}
-            </fieldset>
-            <div className="flex flex-col gap-3 border-t border-border pt-5">
-              <p className="m-0 text-sm font-medium text-foreground">Scope</p>
-              <ScopeFields
-                key={scopeRevision}
-                projectId={projectId}
-                scope={scope}
-                disabled={saving}
-                onChange={setScope}
-                onValidityChange={setScopeValid}
-              />
-            </div>
-            <div className="border-t border-border pt-5">
-              <PassThresholdField
-                value={threshold}
-                disabled={saving}
-                onChange={setThreshold}
-              />
-            </div>
+                </Field>
+                {/*
+                 * One line, at the height of the name above it. A description
+                 * is the phrase a person reads beside this grader in a list,
+                 * and a seven-line box invited a paragraph that no list can
+                 * show.
+                 */}
+                <Field
+                  label="Description [optional]"
+                  htmlFor="custom-grader-description"
+                  hint="Explain what quality this grader checks."
+                >
+                  <Input
+                    id="custom-grader-description"
+                    value={description}
+                    disabled={saving}
+                    autoComplete="off"
+                    onChange={(event) => setDescription(event.target.value)}
+                  />
+                </Field>
+                <Field
+                  label="Grading instructions*"
+                  htmlFor="custom-grader-instructions"
+                  hint={COPY.gradingInstructionsHint}
+                >
+                  <Textarea
+                    id="custom-grader-instructions"
+                    value={instructions}
+                    disabled={saving}
+                    aria-required="true"
+                    rows={7}
+                    onChange={(event) => setInstructions(event.target.value)}
+                  />
+                </Field>
+                {/*
+                 * A group rather than a field: at least one of these two has
+                 * to be chosen, and neither checkbox is required on its own.
+                 * `aria-required` is not a supported state on a group, so the
+                 * star's promise is kept where assistive technology reads it —
+                 * the described line below, and `aria-invalid` while nothing
+                 * is chosen.
+                 */}
+                <fieldset
+                  aria-describedby="custom-grader-modalities-help"
+                  aria-invalid={modalities.length === 0 ? true : undefined}
+                  className="m-0 flex flex-col gap-3 border-0 p-0"
+                >
+                  <legend className="mb-1 text-sm font-medium text-foreground">
+                    Compatible modalities*
+                  </legend>
+                  {(["chat", "voice"] as const).map((modality) => (
+                    <label
+                      className="flex min-h-(--control-md) items-center gap-3 text-sm text-foreground"
+                      key={modality}
+                    >
+                      <Checkbox
+                        checked={modalities.includes(modality)}
+                        disabled={saving}
+                        onChange={(event) =>
+                          toggleModality(modality, event.target.checked)
+                        }
+                      />
+                      {graderModalityLabel(modality)}
+                    </label>
+                  ))}
+                  <p
+                    className="m-0 text-sm text-faint"
+                    id="custom-grader-modalities-help"
+                  >
+                    Choose at least one.
+                  </p>
+                </fieldset>
+                <Section title="Scope">
+                  <ScopeFields
+                    key={scopeRevision}
+                    projectId={projectId}
+                    scope={scope}
+                    disabled={saving}
+                    onChange={setScope}
+                    onValidityChange={setScopeValid}
+                  />
+                </Section>
+                <div className="border-t border-border pt-5">
+                  <PassThresholdField
+                    value={threshold}
+                    disabled={saving}
+                    onChange={setThreshold}
+                  />
+                </div>
+              </>
+            )}
           </SheetBody>
           <SheetFooter>
-            <Button type="submit" size="lg" busy={saving} disabled={!valid}>
-              {saving ? "Creating…" : "Create grader"}
-            </Button>
+            {mechanism === "code" ? null : (
+              <Button type="submit" size="lg" busy={saving} disabled={!valid}>
+                {saving ? "Creating…" : "Create grader"}
+              </Button>
+            )}
             <SheetClose asChild>
               <Button
                 type="button"

--- a/apps/web/app/projects/[projectId]/graders/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/page.tsx
@@ -16,13 +16,13 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 import type { Answer, Refusal } from "../../../../lib/api.ts";
 import {
   graderDefinitionDisplayName,
-  graderModalitiesLabel,
   graderOwnerLabel,
-  graderTypeLabel,
-  scopeSummary,
+  productionScopeSummary,
+  simulationScopeSummary,
   type GraderLibraryEntry,
   type GraderLibraryPage,
   type ProjectGrader,
@@ -38,7 +38,7 @@ import { canAuthor } from "../../../../lib/roles.ts";
 import { DataTable, type Column } from "../../../../ui/data-table.tsx";
 import { Dialog } from "../../../../ui/dialog.tsx";
 import { Refused } from "../../../../ui/form.tsx";
-import { MenuItem } from "../../../../ui/menu.tsx";
+import { MenuDivider, MenuItem } from "../../../../ui/menu.tsx";
 import {
   Empty,
   Failure,
@@ -46,7 +46,7 @@ import {
   NotFound,
 } from "../../../../ui/page-state.tsx";
 import { useProjectRead } from "../../../../ui/resource.ts";
-import { RowMenu } from "../../../../ui/row-menu.tsx";
+import { DestructiveItem, RowMenu } from "../../../../ui/row-menu.tsx";
 import {
   AppShell,
   PageBody,
@@ -57,7 +57,11 @@ import {
 import {
   ActiveGraderSheet,
   CreateCustomGraderSheet,
+  GraderModalityChips,
+  GraderTypeChip,
   LibraryGraderSheet,
+  ProjectUseChip,
+  ScopeValue,
 } from "./grader-sheets.tsx";
 
 async function readAllProjectGraders(
@@ -127,9 +131,59 @@ export default function GradersPage() {
   );
 }
 
+/**
+ * The row's own name, and the thing that opens it.
+ *
+ * **A grader is read and edited in a sheet, so the row's name is a button
+ * rather than a link.** The boards open the sheet from anywhere on the row; a
+ * real control carrying the name is what makes that reachable by keyboard, and
+ * it takes the product's Ember focus ring from `globals.css` without asking.
+ * The name keeps the row's ordinary weight and turns Ember under a pointer,
+ * which is the feedback the shared table already gives a row somebody is
+ * pointing at.
+ *
+ * The row as a whole answers the pointer through the shared table's
+ * `onRowActivate`; this button stays because it is the keyboard path and the
+ * one control the accessibility tree holds for the action.
+ */
+function RowOpener({
+  name,
+  onOpen,
+}: {
+  readonly name: string;
+  readonly onOpen: () => void;
+}) {
+  return (
+    <button
+      className={cn(
+        "cursor-pointer border-0 bg-transparent p-0",
+        "text-left text-sm text-foreground",
+        /* The cell leaves this button unclipped for its focus ring, so the
+         * truncation the cell gave up is carried here. */
+        "block max-w-full overflow-hidden text-ellipsis whitespace-nowrap",
+        "transition-colors duration-(--duration-hover) ease-out",
+        "pointer-hover:text-brand",
+        "motion-reduce:transition-none",
+      )}
+      onClick={onOpen}
+      type="button"
+    >
+      {name}
+    </button>
+  );
+}
+
+/** The score a simulation has to reach, as a measure: two places, tabular. */
+function PassThreshold({ value }: { readonly value: number }) {
+  return (
+    <span className="block text-right tabular-nums">{value.toFixed(2)}</span>
+  );
+}
+
 function activeColumns(
   mayAuthor: boolean,
   open: (grader: ProjectGrader) => void,
+  remove: (grader: ProjectGrader) => void,
 ): readonly Column<ProjectGrader>[] {
   return [
     {
@@ -137,64 +191,116 @@ function activeColumns(
       header: "Grader",
       primary: true,
       width: "240px",
-      cell: (grader) =>
-        graderDefinitionDisplayName(grader.graderDefinitionId, grader.name),
-    },
-    {
-      key: "owner",
-      header: "Owner",
-      width: "120px",
-      hideOnMobile: true,
-      cell: (grader) => graderOwnerLabel(grader.owner),
+      cell: (grader) => (
+        <RowOpener
+          name={graderDefinitionDisplayName(
+            grader.graderDefinitionId,
+            grader.name,
+          )}
+          onOpen={() => open(grader)}
+        />
+      ),
     },
     {
       key: "type",
       header: "Type",
-      width: "140px",
+      width: "160px",
       hideOnMobile: true,
-      cell: (grader) => graderTypeLabel(grader.type),
+      cell: (grader) => <GraderTypeChip type={grader.type} />,
     },
     {
-      key: "scope",
-      header: "Scope",
-      cell: (grader) => scopeSummary(grader.scope),
+      key: "modalities",
+      header: "Modalities",
+      width: "170px",
+      hideOnMobile: true,
+      cell: (grader) => (
+        <GraderModalityChips modalities={grader.modalities} />
+      ),
+    },
+    /*
+     * **Two evidence sources, two columns.** They were one dot-joined sentence
+     * — "All simulations · Production off" — which cannot be scanned down a
+     * list: the eye has to read past the first half of every row to find the
+     * second. Each has its own lane now, and each says one word where it can.
+     */
+    {
+      key: "simulations",
+      header: "Simulations",
+      cell: (grader) => (
+        <ScopeValue value={simulationScopeSummary(grader.scope)} />
+      ),
+    },
+    {
+      key: "production",
+      header: "Production",
+      width: "130px",
+      cell: (grader) => (
+        <ScopeValue value={productionScopeSummary(grader.scope)} />
+      ),
     },
     {
       key: "threshold",
       header: "Pass threshold",
-      width: "150px",
-      mono: true,
-      cell: (grader) => grader.passThreshold.toFixed(2),
+      width: "140px",
+      cell: (grader) => <PassThreshold value={grader.passThreshold} />,
     },
     {
-      key: "action",
-      header: "Actions",
+      key: "actions",
+      header: "Row actions",
       action: true,
-      cell: (grader) => (
-        <RowMenu
-          label={`Open the menu for ${graderDefinitionDisplayName(
-            grader.graderDefinitionId,
-            grader.name,
-          )}`}
-        >
-          {(close) => (
-            <MenuItem
-              onClick={() => {
-                close();
-                open(grader);
-              }}
-            >
-              {mayAuthor ? "View and edit" : "View details"}
-            </MenuItem>
-          )}
-        </RowMenu>
-      ),
+      cell: (grader) => {
+        const name = graderDefinitionDisplayName(
+          grader.graderDefinitionId,
+          grader.name,
+        );
+        return (
+          <RowMenu label={`Open the menu for ${name}`}>
+            {(close) => (
+              <>
+                <MenuItem
+                  onClick={() => {
+                    close();
+                    open(grader);
+                  }}
+                >
+                  {/* A viewer's sheet is read-only, and the item says so. */}
+                  {mayAuthor ? "Edit" : "View details"}
+                </MenuItem>
+                {/*
+                 * **Only a grader this project may drop offers to be dropped.**
+                 * Expected behaviors is not removable, so its menu is one item
+                 * rather than one item and a refusal.
+                 */}
+                {grader.removable ? (
+                  <>
+                    <MenuDivider />
+                    <DestructiveItem
+                      disabled={!mayAuthor}
+                      onClick={() => {
+                        close();
+                        remove(grader);
+                      }}
+                    >
+                      Remove grader
+                    </DestructiveItem>
+                  </>
+                ) : null}
+              </>
+            )}
+          </RowMenu>
+        );
+      },
     },
   ];
 }
 
 function libraryColumns(
+  mayAuthor: boolean,
   open: (entry: GraderLibraryEntry) => void,
+  use: (entry: GraderLibraryEntry) => void,
+  openActive: (projectGraderId: string) => void,
+  activeGraderOf: (projectGraderId: string) => ProjectGrader | undefined,
+  remove: (grader: ProjectGrader) => void,
 ): readonly Column<GraderLibraryEntry>[] {
   return [
     {
@@ -202,7 +308,12 @@ function libraryColumns(
       header: "Grader",
       primary: true,
       width: "260px",
-      cell: (entry) => graderDefinitionDisplayName(entry.id, entry.name),
+      cell: (entry) => (
+        <RowOpener
+          name={graderDefinitionDisplayName(entry.id, entry.name)}
+          onOpen={() => open(entry)}
+        />
+      ),
     },
     {
       key: "owner",
@@ -214,46 +325,82 @@ function libraryColumns(
     {
       key: "type",
       header: "Type",
-      width: "140px",
+      width: "160px",
       hideOnMobile: true,
-      cell: (entry) => graderTypeLabel(entry.type),
+      cell: (entry) => <GraderTypeChip type={entry.type} />,
     },
     {
       key: "modalities",
       header: "Modalities",
-      width: "150px",
+      width: "170px",
       hideOnMobile: true,
-      cell: (entry) => graderModalitiesLabel(entry.modalities),
+      cell: (entry) => <GraderModalityChips modalities={entry.modalities} />,
     },
     {
       key: "status",
       header: "Project use",
-      cell: (entry) =>
-        entry.activeProjectGraderId === null ? "Available" : "Active",
+      cell: (entry) => (
+        <ProjectUseChip active={entry.activeProjectGraderId !== null} />
+      ),
     },
     {
-      key: "action",
-      header: "Actions",
+      key: "actions",
+      header: "Row actions",
       action: true,
-      cell: (entry) => (
-        <RowMenu
-          label={`Open the menu for ${graderDefinitionDisplayName(
-            entry.id,
-            entry.name,
-          )}`}
-        >
-          {(close) => (
-            <MenuItem
-              onClick={() => {
-                close();
-                open(entry);
-              }}
-            >
-              View details
-            </MenuItem>
-          )}
-        </RowMenu>
-      ),
+      cell: (entry) => {
+        const name = graderDefinitionDisplayName(entry.id, entry.name);
+        const activeId = entry.activeProjectGraderId;
+        const active = activeId === null ? undefined : activeGraderOf(activeId);
+        return (
+          <RowMenu label={`Open the menu for ${name}`}>
+            {(close) =>
+              activeId === null ? (
+                <MenuItem
+                  disabled={!mayAuthor}
+                  onClick={() => {
+                    close();
+                    use(entry);
+                  }}
+                >
+                  Use in project
+                </MenuItem>
+              ) : (
+                <>
+                  <MenuItem
+                    onClick={() => {
+                      close();
+                      openActive(activeId);
+                    }}
+                  >
+                    View active grader
+                  </MenuItem>
+                  {/*
+                   * The library row can drop the grader this project is
+                   * running, and only when that grader is one the project may
+                   * drop. Whether it is, is a fact about the active grader —
+                   * the library entry does not carry it — so the row reads it
+                   * off the active list beside it.
+                   */}
+                  {active !== undefined && active.removable ? (
+                    <>
+                      <MenuDivider />
+                      <DestructiveItem
+                        disabled={!mayAuthor}
+                        onClick={() => {
+                          close();
+                          remove(active);
+                        }}
+                      >
+                        Remove grader
+                      </DestructiveItem>
+                    </>
+                  ) : null}
+                </>
+              )
+            }
+          </RowMenu>
+        );
+      },
     },
   ];
 }
@@ -276,6 +423,8 @@ function ProjectGraders({ projectId }: { readonly projectId: string }) {
     null,
   );
   const [libraryOpen, setLibraryOpen] = useState(false);
+  /** Which half of the library sheet its opener asked for. */
+  const [libraryMode, setLibraryMode] = useState<"details" | "use">("details");
   const [activeGrader, setActiveGrader] = useState<ProjectGrader | null>(null);
   const [activeOpen, setActiveOpen] = useState(false);
   const [removing, setRemoving] = useState<ProjectGrader | null>(null);
@@ -310,6 +459,42 @@ function ProjectGraders({ projectId }: { readonly projectId: string }) {
     );
   }
 
+  function openGrader(grader: ProjectGrader): void {
+    setSaid(null);
+    setActiveGrader(grader);
+    setActiveOpen(true);
+  }
+
+  function openLibrary(
+    entry: GraderLibraryEntry,
+    mode: "details" | "use",
+  ): void {
+    setSaid(null);
+    setLibraryEntry(entry);
+    setLibraryMode(mode);
+    setLibraryOpen(true);
+  }
+
+  /**
+   * Which active grader a library entry is running as, when the list beside it
+   * has been read. It answers one question the entry cannot: whether the
+   * project may drop it.
+   */
+  function activeGraderOf(projectGraderId: string): ProjectGrader | undefined {
+    const answer = active.answer;
+    return answer?.status === "ready"
+      ? answer.value.graders.find((one) => one.id === projectGraderId)
+      : undefined;
+  }
+
+  /** The one destructive path, opened from a row menu in either list. */
+  function askToRemove(grader: ProjectGrader): void {
+    setSaid(null);
+    setActiveOpen(false);
+    setLibraryOpen(false);
+    setRemoving(grader);
+  }
+
   function activePanel(): ReactNode {
     const answer = active.answer;
     if (answer === null || answer.status === "signed-out") {
@@ -334,13 +519,10 @@ function ProjectGraders({ projectId }: { readonly projectId: string }) {
     return (
       <DataTable
         label="Active graders"
-        columns={activeColumns(mayAuthor, (grader) => {
-          setSaid(null);
-          setActiveGrader(grader);
-          setActiveOpen(true);
-        })}
+        columns={activeColumns(mayAuthor, openGrader, askToRemove)}
         rows={answer.value.graders}
         keyOf={(grader) => grader.id}
+        onRowActivate={openGrader}
         stackWhenConstrained
       />
     );
@@ -370,28 +552,27 @@ function ProjectGraders({ projectId }: { readonly projectId: string }) {
     return (
       <DataTable
         label="Grader library"
-        columns={libraryColumns((entry) => {
-          setSaid(null);
-          setLibraryEntry(entry);
-          setLibraryOpen(true);
-        })}
+        columns={libraryColumns(
+          mayAuthor,
+          (entry) => openLibrary(entry, "details"),
+          (entry) => openLibrary(entry, "use"),
+          openActive,
+          activeGraderOf,
+          askToRemove,
+        )}
         rows={answer.value.graderLibraryEntries}
         keyOf={(entry) => entry.id}
+        onRowActivate={(entry) => openLibrary(entry, "details")}
         stackWhenConstrained
       />
     );
   }
 
   function openActive(projectGraderId: string): void {
-    const answer = active.answer;
-    const grader =
-      answer?.status === "ready"
-        ? answer.value.graders.find((one) => one.id === projectGraderId)
-        : undefined;
+    const grader = activeGraderOf(projectGraderId);
     setLibraryOpen(false);
     if (grader !== undefined) {
-      setActiveGrader(grader);
-      setActiveOpen(true);
+      openGrader(grader);
       return;
     }
     setSaid("This grader is active. Refresh Active graders to open its policy.");
@@ -453,6 +634,7 @@ function ProjectGraders({ projectId }: { readonly projectId: string }) {
           entry={libraryEntry}
           projectId={projectId}
           open={libraryOpen}
+          mode={libraryMode}
           mayAuthor={mayAuthor}
           onClose={() => setLibraryOpen(false)}
           onUsed={() => {
@@ -474,10 +656,6 @@ function ProjectGraders({ projectId }: { readonly projectId: string }) {
           onSaved={() => {
             setActiveOpen(false);
             refreshAll("Grader changes saved.");
-          }}
-          onRemove={() => {
-            setRemoving(activeGrader);
-            setActiveOpen(false);
           }}
         />
       )}

--- a/apps/web/lib/graders.ts
+++ b/apps/web/lib/graders.ts
@@ -19,6 +19,8 @@ export type SimulationScopeSelector =
   ProjectGraderScope["simulations"][number];
 export type GraderSettingDefinition =
   GraderLibraryEntry["settingDefinitions"][number];
+export type GraderRequiredEvidence =
+  GraderLibraryEntry["requiredEvidence"][number];
 
 /**
  * The one predefined definition whose stored key needs product copy.
@@ -43,65 +45,76 @@ export function graderOwnerLabel(owner: GraderOwner): string {
   return owner === "egma" ? "Egma" : "Organization";
 }
 
-export function graderTypeLabel(type: GraderType): string {
-  return type === "llm_as_judge" ? "LLM judge" : "Code";
+/**
+ * There is no `graderTypeLabel`, and that is a decision rather than an
+ * omission.
+ *
+ * "LLM judge" and "Code" were product words for `llm_as_judge` and `code`, and
+ * the two never agreed: the API's word is what a person reads in a request, in
+ * a webhook and in the library's own contract. **The type now reads as the
+ * identifier it is** — the raw value, in the monospace stack, in a chip
+ * (developer decision, 2026-08-25). A screen that wants it only has to draw
+ * `grader.type`, so a helper that renamed it would be a second name to keep in
+ * step with nothing.
+ */
+
+/** One modality, as the word a person reads on a chip. */
+export function graderModalityLabel(modality: GraderModality): string {
+  return modality === "chat" ? "Chat" : "Voice";
 }
 
-export function graderModalitiesLabel(
-  modalities: readonly GraderModality[],
-): string {
-  if (modalities.length === 2) return "Chat and voice";
-  if (modalities[0] === "chat") return "Chat";
-  if (modalities[0] === "voice") return "Voice";
-  return "None";
-}
+/**
+ * What a grader grading nothing says, in either scope column.
+ *
+ * It is named because the columns draw it in the faint colour: "Off" is the
+ * absence of a scope rather than a scope, and a page deciding that by comparing
+ * against a literal it wrote itself would drift the first time this word does.
+ */
+export const SCOPE_OFF = "Off";
 
-/** Compact table copy. The nested selector list belongs in the detail sheet. */
-export function scopeSummary(scope: ProjectGraderScope): string {
+/**
+ * What the Simulations column says: `All`, the suites and tests counted, or
+ * `Off`.
+ *
+ * The two evidence sources are two columns rather than one dot-joined
+ * sentence, so each is scannable down its own lane (approved boards,
+ * 2026-08-25). The pluralisation is the one the single summary used.
+ */
+export function simulationScopeSummary(scope: ProjectGraderScope): string {
   const all = scope.simulations.some((selector) => selector.kind === "all");
+  if (all) return "All";
   const suites = scope.simulations.filter(
     (selector) => selector.kind === "test_suite",
   ).length;
   const tests = scope.simulations.filter(
     (selector) => selector.kind === "test",
   ).length;
-  const simulations = all
-    ? "All simulations"
-    : suites + tests === 0
-      ? "Simulations off"
-      : [
-          suites === 0
-            ? null
-            : `${String(suites)} test suite${suites === 1 ? "" : "s"}`,
-          tests === 0
-            ? null
-            : `${String(tests)} test${tests === 1 ? "" : "s"}`,
-        ]
-          .filter((part): part is string => part !== null)
-          .join(", ");
-  const production =
-    scope.production === null
-      ? "Production off"
-      : `${String(scope.production.samplePercent)}% of production`;
-  return `${simulations} · ${production}`;
+  if (suites + tests === 0) return SCOPE_OFF;
+  return [
+    suites === 0 ? null : `${String(suites)} test suite${suites === 1 ? "" : "s"}`,
+    tests === 0 ? null : `${String(tests)} test${tests === 1 ? "" : "s"}`,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(", ");
 }
 
-/** Product copy kept for callers that show the two evidence sources separately. */
-export function simulationScopeLabel(grader: ProjectGrader): string {
-  const all = grader.scope.simulations.some(
-    (selector) => selector.kind === "all",
-  );
-  return all
-    ? "Grades all simulations"
-    : grader.scope.simulations.length === 0
-      ? "Does not grade simulations"
-      : "Grades selected simulations";
+/** What the Production column says: the sampled share, or `Off`. */
+export function productionScopeSummary(scope: ProjectGraderScope): string {
+  return scope.production === null
+    ? SCOPE_OFF
+    : `${String(scope.production.samplePercent)}%`;
 }
 
-export function productionScopeLabel(grader: ProjectGrader): string {
-  return grader.scope.production === null
-    ? "Production off"
-    : `Grades ${String(grader.scope.production.samplePercent)}% of production`;
+/**
+ * One piece of evidence a grader reads, in words rather than in its stored key.
+ *
+ * The keys are the contract's — `test_expected_behaviors`, `tool_calls` — and
+ * every one of them is an ordinary sentence with underscores in it, so the
+ * words are the key with its separators and its capital restored.
+ */
+export function graderEvidenceLabel(evidence: GraderRequiredEvidence): string {
+  const words = evidence.replaceAll("_", " ");
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
 }
 
 export const EMPTY_GRADER_SCOPE: ProjectGraderScope = {

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -1661,11 +1661,19 @@ describe("the role the shell shows", () => {
       screen.getByRole("dialog", { name: "Open organization menu for Acme" }),
     );
     /*
-     * The panel is the mark and the name. The plan was hard-written copy for a
-     * fact `/api/me` does not carry, and the role is already said by the
-     * account control at the foot of this same sidebar.
+     * The panel is the mark, the grey word `Organization` and the name that
+     * word names. The plan was hard-written copy for a fact `/api/me` does not
+     * carry, and the role is already said by the account control at the foot of
+     * this same sidebar.
      */
-    expect(summary.getByText("Acme")).toBeTruthy();
+    const eyebrow = summary.getByText("Organization");
+    const organizationName = summary.getByText("Acme");
+    /* Directly above the name, the way `Project` sits above the project's. */
+    expect(eyebrow.nextElementSibling).toBe(organizationName);
+    /* The `Project` label's own recipe: 12px, faint, and left in sentence case. */
+    expect(eyebrow.className).toContain("text-2xs");
+    expect(eyebrow.className).toContain("text-faint");
+    expect(eyebrow.className).not.toContain("uppercase");
     expect(summary.queryByText("Free Plan")).toBeNull();
     expect(summary.queryByText("Admin")).toBeNull();
     expect(summary.queryByText("Organization settings")).toBeNull();

--- a/apps/web/test/data-table-row-link.test.tsx
+++ b/apps/web/test/data-table-row-link.test.tsx
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { DataTable, type Column } from "../ui/data-table.tsx";
@@ -85,5 +93,90 @@ describe("DataTable row links", () => {
       (within(table).getAllByRole("row")[1] as HTMLElement).dataset
         .stretchPrimaryLink,
     ).toBeUndefined();
+  });
+});
+
+/** A row control whose open panel lives in `body`, the way the ⋮ menu does. */
+function PortalMenu() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open menu
+      </button>
+      {open
+        ? createPortal(
+            <div data-testid="portal-panel">Panel padding</div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}
+
+const ACTIVATION_COLUMNS: readonly Column<Row>[] = [
+  {
+    key: "name",
+    header: "Grader",
+    primary: true,
+    cell: (row) => <button type="button">{row.name}</button>,
+  },
+  {
+    key: "registered",
+    header: "Registered",
+    cell: (row) => row.registered,
+  },
+  {
+    key: "actions",
+    header: "Actions",
+    action: true,
+    cell: () => <PortalMenu />,
+  },
+];
+
+describe("DataTable row activation", () => {
+  it("activates from the row surface and leaves control clicks alone", () => {
+    const activated: string[] = [];
+    render(
+      <DataTable
+        label="Graders"
+        columns={ACTIVATION_COLUMNS}
+        rows={[ROW]}
+        keyOf={(row) => row.id}
+        onRowActivate={(row) => activated.push(row.id)}
+      />,
+    );
+    const table = screen.getByRole("table", { name: "Graders" });
+    const row = within(table).getAllByRole("row")[1] as HTMLElement;
+
+    /* Dead space on the row is the row's. */
+    fireEvent.click(within(row).getByRole("cell", { name: "2026-08-15" }));
+    expect(activated).toEqual(["agt_1"]);
+
+    /* The name button and the menu trigger keep their own clicks. */
+    fireEvent.click(within(row).getByRole("button", { name: "Front desk" }));
+    fireEvent.click(within(row).getByRole("button", { name: "Open menu" }));
+    expect(activated).toEqual(["agt_1"]);
+
+    /*
+     * The open panel is portalled to `body`, so its clicks still bubble the
+     * React tree into this row — and must not be the row's.
+     */
+    fireEvent.click(screen.getByTestId("portal-panel"));
+    expect(activated).toEqual(["agt_1"]);
+  });
+
+  it("keeps rows inert when no activation is asked for", () => {
+    render(
+      <DataTable
+        label="Graders"
+        columns={ACTIVATION_COLUMNS}
+        rows={[ROW]}
+        keyOf={(row) => row.id}
+      />,
+    );
+    const table = screen.getByRole("table", { name: "Graders" });
+    const row = within(table).getAllByRole("row")[1] as HTMLElement;
+    expect(row.className).not.toContain("cursor-pointer");
   });
 });

--- a/apps/web/test/graders-pages.test.tsx
+++ b/apps/web/test/graders-pages.test.tsx
@@ -176,6 +176,22 @@ const LATENCY: ProjectGrader = {
   ...DATES,
 };
 
+/** A grader scoped to some of the project's work, and a share of production. */
+const SELECTED: ProjectGrader = {
+  ...LATENCY,
+  id: "grd_selected",
+  graderDefinitionId: "grl_selected",
+  name: "Selected scope",
+  scope: {
+    simulations: [
+      { kind: "test_suite", id: "ste_1" },
+      { kind: "test", id: "tst_1" },
+      { kind: "test", id: "tst_2" },
+    ],
+    production: { samplePercent: 25 },
+  },
+};
+
 const EXPECTED_DEFINITION: GraderLibraryEntry = {
   id: EXPECTED_BEHAVIORS_GRADER_DEFINITION_ID,
   name: "expected_behaviors",
@@ -239,11 +255,36 @@ function standardAnswers(
   };
 }
 
-async function openRowMenu(name: string, item: string): Promise<void> {
+async function openRowMenu(name: string): Promise<HTMLElement> {
   fireEvent.click(
     await screen.findByRole("button", { name: `Open the menu for ${name}` }),
   );
+  return await screen.findByRole("menu", { name: `Open the menu for ${name}` });
+}
+
+async function chooseRowMenuItem(name: string, item: string): Promise<void> {
+  await openRowMenu(name);
   fireEvent.click(await screen.findByRole("menuitem", { name: item }));
+}
+
+/** The names a row's ⋮ offers, in the order it offers them. */
+async function rowMenuItems(name: string): Promise<readonly string[]> {
+  const menu = await openRowMenu(name);
+  return within(menu)
+    .getAllByRole("menuitem")
+    .map((item) => item.textContent ?? "");
+}
+
+/** Opening a row the way the boards do: by pressing the row's own name. */
+async function openRow(name: string): Promise<void> {
+  fireEvent.click(await screen.findByRole("button", { name }));
+}
+
+/** The row a named grader is on, so one cell's word is read where it belongs. */
+function rowOf(name: string): HTMLElement {
+  const row = screen.getByRole("button", { name }).closest("tr");
+  if (row === null) throw new Error(`no row for ${name}`);
+  return row;
 }
 
 function ScopeHarness() {
@@ -407,12 +448,20 @@ describe("the project Graders surface", () => {
     expect(screen.getAllByText("Active graders")).toHaveLength(1);
     expect(screen.queryByText(/what active means/i)).toBeNull();
     expect(screen.queryByRole("button", { name: /add predefined grader/i })).toBeNull();
-    expect(screen.getByText("All simulations · Production off")).toBeTruthy();
+    /* The scope is two columns now, never one dot-joined sentence. */
+    expect(screen.queryByText(/·/)).toBeNull();
+    expect(
+      screen.getByRole("columnheader", { name: "Simulations" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("columnheader", { name: "Production" }),
+    ).toBeTruthy();
 
     fireEvent.click(screen.getByRole("tab", { name: "Grader library" }));
     expect(await screen.findByText("Response latency")).toBeTruthy();
     expect(screen.getAllByText("Grader library")).toHaveLength(1);
     expect(screen.getByText("Available")).toBeTruthy();
+    expect(screen.getByText("Active")).toBeTruthy();
     expect(asked.map((one) => one.path)).toEqual(
       expect.arrayContaining([
         "/v1/graders?projectId=prj_1",
@@ -522,7 +571,7 @@ describe("the project Graders surface", () => {
 
     expect(await screen.findByText("Expected behaviors")).toBeTruthy();
     expect(screen.getByText("expected_behaviors")).toBeTruthy();
-    await openRowMenu("expected_behaviors", "View and edit");
+    await chooseRowMenuItem("expected_behaviors", "Edit");
     expect(
       await screen.findByRole("dialog", { name: "expected_behaviors" }),
     ).toBeTruthy();
@@ -568,11 +617,11 @@ describe("the project Graders surface", () => {
     );
     await closeAfterMotion("Create custom grader");
 
-    await openRowMenu("Expected behaviors", "View and edit");
+    await openRow("Expected behaviors");
     await closeAfterMotion("Expected behaviors");
 
     fireEvent.click(screen.getByRole("tab", { name: "Grader library" }));
-    await openRowMenu("Response latency", "View details");
+    await openRow("Response latency");
     await closeAfterMotion("Response latency");
   });
 
@@ -591,10 +640,15 @@ describe("the project Graders surface", () => {
     });
     render(<GradersPage />);
     fireEvent.click(await screen.findByRole("tab", { name: "Grader library" }));
-    await openRowMenu("Response latency", "View details");
+    await openRow("Response latency");
 
     const details = await screen.findByRole("dialog", { name: "Response latency" });
-    expect(within(details).getByText("turn response latency")).toBeTruthy();
+    expect(
+      within(details).getByText(
+        "The evidence this grader needs from a simulation.",
+      ),
+    ).toBeTruthy();
+    expect(within(details).getByText("Turn response latency")).toBeTruthy();
     expect(within(details).queryByLabelText("Maximum average response time")).toBeNull();
     fireEvent.click(within(details).getByRole("button", { name: "Use in project" }));
 
@@ -616,7 +670,7 @@ describe("the project Graders surface", () => {
     });
   });
 
-  it("creates only an LLM judge with Grading instructions and no mechanism picker", async () => {
+  it("creates an LLM judge from the chosen segment, under the starred label grammar", async () => {
     const customDefinition: GraderLibraryEntry = {
       ...LATENCY_DEFINITION,
       id: "grl_custom",
@@ -650,14 +704,60 @@ describe("the project Graders surface", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Create custom grader" }));
 
     const sheet = await screen.findByRole("dialog", { name: "Create custom grader" });
-    expect(within(sheet).getByLabelText("Grading instructions")).toBeTruthy();
-    for (const absent of ["Type", "Model", "Output type", "Code"]) {
-      expect(within(sheet).queryByLabelText(absent)).toBeNull();
+    expect(
+      within(sheet).getByText(
+        "Create a grader for this organization and use it in this project.",
+      ),
+    ).toBeTruthy();
+    /* The LLM judge is the segment a person lands on. */
+    expect(
+      within(sheet)
+        .getByRole("radio", { name: "LLM judge" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+
+    /* Every mandatory label ends in a star, and says so to a screen reader. */
+    for (const starred of [
+      "Name*",
+      "Grading instructions*",
+      "Pass threshold*",
+    ]) {
+      const field = within(sheet).getByLabelText(starred);
+      expect(field.getAttribute("aria-required"), starred).toBe("true");
     }
-    fireEvent.change(within(sheet).getByLabelText("Name"), {
+    /*
+     * `aria-required` is not a supported state on a group, so the modalities
+     * star keeps its promise through the described line instead.
+     */
+    const modalitiesGroup = within(sheet).getByRole("group", {
+      name: "Compatible modalities*",
+    });
+    expect(modalitiesGroup.getAttribute("aria-required")).toBeNull();
+    const helpId = modalitiesGroup.getAttribute("aria-describedby");
+    expect(helpId).toBeTruthy();
+    expect(document.getElementById(helpId ?? "")?.textContent).toBe(
+      "Choose at least one.",
+    );
+
+    /* A description is one line, at the height of the name above it. */
+    const description = within(sheet).getByLabelText("Description [optional]");
+    expect(description.tagName).toBe("INPUT");
+
+    expect(
+      within(sheet).getByText(
+        "Describe what the agent must do. The grader returns a score between 0 and 1.",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(sheet).getByText(
+        "From 0 to 1. A simulation passes this grader at or above this score.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.change(within(sheet).getByLabelText("Name*"), {
       target: { value: "Polite resolution" },
     });
-    fireEvent.change(within(sheet).getByLabelText("Grading instructions"), {
+    fireEvent.change(within(sheet).getByLabelText("Grading instructions*"), {
       target: {
         value: "The agent stays polite and resolves the request.",
       },
@@ -732,7 +832,7 @@ describe("the project Graders surface", () => {
       },
     });
     render(<GradersPage />);
-    await openRowMenu("Response latency", "View and edit");
+    await chooseRowMenuItem("Response latency", "Edit");
 
     let sheet = await screen.findByRole("dialog", { name: "Response latency" });
     fireEvent.click(within(sheet).getByLabelText("Grades simulations"));
@@ -746,7 +846,7 @@ describe("the project Graders surface", () => {
         .toBeNull();
     });
 
-    await openRowMenu("Response latency", "View and edit");
+    await chooseRowMenuItem("Response latency", "Edit");
     sheet = await screen.findByRole("dialog", { name: "Response latency" });
     await waitFor(() => {
       expect(
@@ -772,13 +872,20 @@ describe("the project Graders surface", () => {
       "PATCH /v1/graders/grd_expected": { status: 200, body: changed },
     });
     render(<GradersPage />);
-    await openRowMenu("Expected behaviors", "View and edit");
+    await chooseRowMenuItem("Expected behaviors", "Edit");
 
     const sheet = await screen.findByRole("dialog", { name: "Expected behaviors" });
-    expect(within(sheet).getByText("Fixed by Egma")).toBeTruthy();
-    expect(within(sheet).getByText("Grades all simulations")).toBeTruthy();
+    /* The caption that answered a question nobody asked is gone. */
+    expect(within(sheet).queryByText("Fixed by Egma")).toBeNull();
+    expect(within(sheet).getByText("Scope")).toBeTruthy();
+    /* The two read-only rows say what the two columns behind the sheet say. */
+    expect(within(sheet).getByText("Simulations")).toBeTruthy();
+    expect(within(sheet).getByText("All")).toBeTruthy();
+    expect(within(sheet).getByText("Production")).toBeTruthy();
+    expect(within(sheet).getByText("Off")).toBeTruthy();
+    expect(within(sheet).getByText("llm_as_judge")).toBeTruthy();
     expect(within(sheet).queryByRole("button", { name: "Remove grader" })).toBeNull();
-    fireEvent.change(within(sheet).getByLabelText("Pass threshold"), {
+    fireEvent.change(within(sheet).getByLabelText("Pass threshold*"), {
       target: { value: "0.8" },
     });
     fireEvent.click(within(sheet).getByRole("button", { name: "Save changes" }));
@@ -814,9 +921,13 @@ describe("the project Graders surface", () => {
       "DELETE /v1/graders/grd_latency": { status: 204, body: null },
     });
     render(<GradersPage />);
-    await openRowMenu("Response latency", "View and edit");
+    await chooseRowMenuItem("Response latency", "Edit");
 
-    let sheet = await screen.findByRole("dialog", { name: "Response latency" });
+    const sheet = await screen.findByRole("dialog", { name: "Response latency" });
+    /* Removing left this footer for the row menu, even where removal is allowed. */
+    expect(
+      within(sheet).queryByRole("button", { name: "Remove grader" }),
+    ).toBeNull();
     fireEvent.click(within(sheet).getByLabelText("Grades simulations"));
     fireEvent.click(within(sheet).getByRole("button", { name: "Save changes" }));
     await waitFor(() => {
@@ -828,9 +939,8 @@ describe("the project Graders surface", () => {
     });
     expect(asked.some((one) => one.method === "DELETE")).toBe(false);
 
-    await openRowMenu("Response latency", "View and edit");
-    sheet = await screen.findByRole("dialog", { name: "Response latency" });
-    fireEvent.click(within(sheet).getByRole("button", { name: "Remove grader" }));
+    /* Removing is the row's act now, and it still names what would go. */
+    await chooseRowMenuItem("Response latency", "Remove grader");
     const confirmation = await screen.findByRole("dialog", {
       name: "Remove Response latency?",
     });
@@ -861,7 +971,16 @@ describe("the project Graders surface", () => {
     });
     expect((create as HTMLButtonElement).disabled).toBe(true);
     fireEvent.click(screen.getByRole("tab", { name: "Grader library" }));
-    await openRowMenu("Response latency", "View details");
+
+    const menu = await openRowMenu("Response latency");
+    expect(
+      (within(menu).getByRole("menuitem", {
+        name: "Use in project",
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    fireEvent.keyDown(menu, { key: "Escape" });
+
+    await openRow("Response latency");
     const details = await screen.findByRole("dialog", { name: "Response latency" });
     expect(within(details).getByText("Grades the average response time for a trace.")).toBeTruthy();
     expect(
@@ -869,5 +988,215 @@ describe("the project Graders surface", () => {
         name: "Use in project",
       }) as HTMLButtonElement).disabled,
     ).toBe(true);
+  });
+
+  it("reads a grader's type as the API's own word and its modalities as chips", async () => {
+    apiAnswers(standardAnswers("admin", [EXPECTED, LATENCY]));
+    render(<GradersPage />);
+
+    expect(await screen.findByText("Expected behaviors")).toBeTruthy();
+    const expected = rowOf("Expected behaviors");
+    expect(within(expected).getByText("llm_as_judge")).toBeTruthy();
+    expect(within(expected).getByText("Chat")).toBeTruthy();
+    expect(within(expected).getByText("Voice")).toBeTruthy();
+    /* The product words the raw value replaced are nowhere on the row. */
+    expect(within(expected).queryByText("LLM judge")).toBeNull();
+    expect(within(expected).queryByText("Chat and voice")).toBeNull();
+    expect(within(rowOf("Response latency")).getByText("code")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Grader library" }));
+    expect(await screen.findByText("Response latency")).toBeTruthy();
+    expect(
+      within(rowOf("Response latency")).getByText("code"),
+    ).toBeTruthy();
+  });
+
+  it("says each evidence source in its own column, and says Off quietly", async () => {
+    apiAnswers(standardAnswers("admin", [EXPECTED, SELECTED]));
+    render(<GradersPage />);
+
+    expect(await screen.findByText("Expected behaviors")).toBeTruthy();
+    const expected = rowOf("Expected behaviors");
+    expect(within(expected).getByText("All")).toBeTruthy();
+    expect(within(expected).getByText("Off").className).toContain("text-faint");
+    expect(within(expected).getByText("1.00")).toBeTruthy();
+
+    const selected = rowOf("Selected scope");
+    expect(within(selected).getByText("1 test suite, 2 tests")).toBeTruthy();
+    expect(within(selected).getByText("25%")).toBeTruthy();
+  });
+
+  it("opens a grader from its row and offers Remove only where a grader may go", async () => {
+    apiAnswers({
+      ...standardAnswers("admin", [EXPECTED, LATENCY]),
+      [`GET /v1/grader-library/${EXPECTED_BEHAVIORS_GRADER_DEFINITION_ID}`]: {
+        status: 200,
+        body: EXPECTED_DEFINITION,
+      },
+    });
+    render(<GradersPage />);
+
+    expect(await screen.findByText("Expected behaviors")).toBeTruthy();
+    expect(await rowMenuItems("Expected behaviors")).toEqual(["Edit"]);
+    fireEvent.keyDown(
+      await screen.findByRole("menu", {
+        name: "Open the menu for Expected behaviors",
+      }),
+      { key: "Escape" },
+    );
+    expect(await rowMenuItems("Response latency")).toEqual([
+      "Edit",
+      "Remove grader",
+    ]);
+    fireEvent.keyDown(
+      await screen.findByRole("menu", {
+        name: "Open the menu for Response latency",
+      }),
+      { key: "Escape" },
+    );
+
+    await openRow("Expected behaviors");
+    expect(
+      await screen.findByRole("dialog", { name: "Expected behaviors" }),
+    ).toBeTruthy();
+  });
+
+  it("opens a grader from anywhere on its row, not only the name", async () => {
+    apiAnswers({
+      ...standardAnswers("admin", [EXPECTED, LATENCY]),
+      [`GET /v1/grader-library/${EXPECTED_BEHAVIORS_GRADER_DEFINITION_ID}`]: {
+        status: 200,
+        body: EXPECTED_DEFINITION,
+      },
+    });
+    render(<GradersPage />);
+
+    const name = await screen.findByText("Expected behaviors");
+    const row = name.closest("tr");
+    if (row === null) throw new Error("the grader name is not in a table row");
+    fireEvent.click(row);
+    expect(
+      await screen.findByRole("dialog", { name: "Expected behaviors" }),
+    ).toBeTruthy();
+  });
+
+  it("offers the library row the active grader, or the way to use it", async () => {
+    const activeLatencyDefinition = {
+      ...LATENCY_DEFINITION,
+      activeProjectGraderId: LATENCY.id,
+    };
+    apiAnswers({
+      ...standardAnswers("admin", [EXPECTED, LATENCY], [
+        EXPECTED_DEFINITION,
+        activeLatencyDefinition,
+      ]),
+      "GET /v1/grader-library/grl_latency": {
+        status: 200,
+        body: activeLatencyDefinition,
+      },
+      "DELETE /v1/graders/grd_latency": { status: 204, body: null },
+    });
+    render(<GradersPage />);
+    fireEvent.click(await screen.findByRole("tab", { name: "Grader library" }));
+    expect(await screen.findByText("Response latency")).toBeTruthy();
+
+    /* Egma's own grader is active and cannot be dropped: one item. */
+    expect(await rowMenuItems("Expected behaviors")).toEqual([
+      "View active grader",
+    ]);
+    fireEvent.keyDown(
+      await screen.findByRole("menu", {
+        name: "Open the menu for Expected behaviors",
+      }),
+      { key: "Escape" },
+    );
+
+    expect(await rowMenuItems("Response latency")).toEqual([
+      "View active grader",
+      "Remove grader",
+    ]);
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Remove grader" }),
+    );
+    expect(
+      await screen.findByRole("dialog", { name: "Remove Response latency?" }),
+    ).toBeTruthy();
+  });
+
+  it("opens the library sheet on the review, and on the form from Use in project", async () => {
+    apiAnswers({
+      ...standardAnswers(),
+      "GET /v1/grader-library/grl_latency": {
+        status: 200,
+        body: LATENCY_DEFINITION,
+      },
+    });
+    render(<GradersPage />);
+    fireEvent.click(await screen.findByRole("tab", { name: "Grader library" }));
+
+    await openRow("Response latency");
+    let sheet = await screen.findByRole("dialog", { name: "Response latency" });
+    expect(
+      within(sheet).getByText(
+        "Review this grader before choosing it for the project.",
+      ),
+    ).toBeTruthy();
+    expect(within(sheet).getByText("Available")).toBeTruthy();
+    const close = within(sheet).getAllByRole("button", { name: "Close" }).at(-1);
+    if (close === undefined) throw new Error("the sheet has no close button");
+    fireEvent.click(close);
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Response latency" }),
+      ).toBeNull();
+    });
+
+    await chooseRowMenuItem("Response latency", "Use in project");
+    sheet = await screen.findByRole("dialog", { name: "Response latency" });
+    expect(
+      within(sheet).getByText("Choose how this project will use the grader."),
+    ).toBeTruthy();
+    expect(
+      within(sheet).getByLabelText("Maximum average response time"),
+    ).toBeTruthy();
+  });
+
+  it("holds a typed LLM judge while the Code segment says what is coming", async () => {
+    apiAnswers(standardAnswers());
+    render(<GradersPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create custom grader" }),
+    );
+
+    const sheet = await screen.findByRole("dialog", {
+      name: "Create custom grader",
+    });
+    fireEvent.change(within(sheet).getByLabelText("Name*"), {
+      target: { value: "Polite resolution" },
+    });
+
+    fireEvent.click(within(sheet).getByRole("radio", { name: "Code" }));
+    expect(
+      within(sheet).getByText("Code graders are coming soon"),
+    ).toBeTruthy();
+    expect(
+      within(sheet).getByText(
+        "Write pass rules in code and run them on every simulation. Custom code graders arrive in a later release.",
+      ),
+    ).toBeTruthy();
+    /* Nothing to create in this state, so nothing offers to. */
+    expect(
+      within(sheet).queryByRole("button", { name: "Create grader" }),
+    ).toBeNull();
+    expect(within(sheet).getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(within(sheet).queryByLabelText("Name*")).toBeNull();
+
+    fireEvent.click(within(sheet).getByRole("radio", { name: "LLM judge" }));
+    expect(
+      (within(sheet).getByLabelText("Name*") as HTMLInputElement).value,
+    ).toBe("Polite resolution");
+    expect(
+      within(sheet).getByRole("button", { name: "Create grader" }),
+    ).toBeTruthy();
   });
 });

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
+import { ROW_HOVER } from "./evidence.tsx";
+
 /**
  * A page of rows, described once and drawn once.
  *
@@ -108,6 +110,7 @@ export function DataTable<Row>({
   rows,
   keyOf,
   stretchPrimaryLink = false,
+  onRowActivate,
   stackWhenConstrained = false,
   more,
   pagination,
@@ -122,6 +125,17 @@ export function DataTable<Row>({
    * row. There is still only one link in the accessibility tree.
    */
   readonly stretchPrimaryLink?: boolean;
+  /**
+   * Makes the whole row a pointer target for one action that opens in place —
+   * a sheet, not a URL. `stretchPrimaryLink` is for rows whose name is a real
+   * link; this is for rows whose name is a real button. The row answers the
+   * pointer and lights up under it with the evidence surface's own hover mix;
+   * the keyboard path stays the primary cell's button, so the accessibility
+   * tree still holds exactly one control for the one action. A click that
+   * lands on a control inside the row — the ⋮ menu, the name button itself —
+   * is that control's, not the row's.
+   */
+  readonly onRowActivate?: (row: Row) => void;
   /**
    * Switches this same semantic table to labelled rows when its own container,
    * rather than the browser viewport, is too narrow for all of its columns.
@@ -227,12 +241,42 @@ export function DataTable<Row>({
                   "stacked:flex stacked:flex-col stacked:gap-1",
                   "stacked:border-t stacked:border-border stacked:px-(--row-padding-x) stacked:py-3",
                   "stacked:first:border-t-0",
+                  onRowActivate !== undefined && [
+                    "cursor-pointer transition-colors duration-(--duration-hover) ease-out",
+                    /* The evidence surface's own hover mix; one recipe for a row under the pointer. */
+                    ROW_HOVER,
+                    "motion-reduce:transition-none",
+                  ],
                 )}
                 data-slot="data-table-row"
                 data-stretch-primary-link={
                   stretchPrimaryLink ? "true" : undefined
                 }
                 key={keyOf(row)}
+                onClick={
+                  onRowActivate === undefined
+                    ? undefined
+                    : (event) => {
+                        const pressed = event.target as HTMLElement;
+                        /*
+                         * A portalled surface — the ⋮ panel lives in `body` —
+                         * still bubbles through the React tree to this row, so
+                         * containment is checked before anything else: a click
+                         * that is not physically inside the row is not the
+                         * row's.
+                         */
+                        if (!event.currentTarget.contains(pressed)) return;
+                        /* A control inside the row keeps its own click. */
+                        if (
+                          pressed.closest(
+                            "button, a, input, label, select, textarea",
+                          ) !== null
+                        ) {
+                          return;
+                        }
+                        onRowActivate(row);
+                      }
+                }
               >
                 {columns.map((column) => (
                   <TableCell
@@ -299,7 +343,15 @@ export function DataTable<Row>({
                   >
                     <span
                       className={cn(
-                        "block overflow-hidden text-ellipsis whitespace-nowrap",
+                        column === primary && onRowActivate !== undefined
+                          ? /*
+                             * An activatable row's name is a real button, and
+                             * the focus indicator draws outside its box; this
+                             * cell must not clip it. The button truncates its
+                             * own text instead.
+                             */
+                            "block overflow-visible whitespace-nowrap"
+                          : "block overflow-hidden text-ellipsis whitespace-nowrap",
                         /*
                          * The name of the row, at the ordinary weight. The
                          * boards write it in the same 400 as the facts beside

--- a/apps/web/ui/evidence.tsx
+++ b/apps/web/ui/evidence.tsx
@@ -59,9 +59,11 @@ import { Empty } from "./page-state.tsx";
  * without becoming a surface of its own, and nothing else in the product wants
  * it. A token would be a name with one caller, so the recipe stays an arbitrary
  * value here; a second surface that ever wants the same tint earns the token
- * then.
+ * then. The data table's activatable rows are that second surface, so the
+ * recipe is exported rather than retyped — still one string, now with two
+ * callers instead of a copy.
  */
-const ROW_HOVER =
+export const ROW_HOVER =
   "pointer-hover:bg-[color-mix(in_srgb,var(--surface-soft)_62%,transparent)]";
 
 /** Identifiers, scores and clock times, in the shared monospace face. */

--- a/apps/web/ui/number-field.tsx
+++ b/apps/web/ui/number-field.tsx
@@ -154,6 +154,7 @@ export function NumberField({
           disabled={disabled}
           readOnly={readOnly}
           required={required}
+          aria-required={required === true ? true : undefined}
           aria-invalid={invalid === true ? true : undefined}
           aria-describedby={described === "" ? undefined : described}
           autoComplete="off"

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -302,16 +302,23 @@ function Navigation({
  *
  * There is one organization per session today, so this panel gives context and
  * does not offer a false switcher. The paired arrows still open a small
- * surface: the organization's mark and its name. Organization settings stay out
- * until that product level exists.
+ * surface: the organization's mark, the quiet word `Organization`, and the name
+ * that word names. Organization settings stay out until that product level
+ * exists.
  *
- * **The bar and the panel say the organization's name, and nothing else.**
- * Both used to carry a "Free" chip and a "Free Plan · Admin" line under the
- * name. Billing is not part of `/api/me`, so that plan was hard-written copy
- * standing where a fact belongs, and the role it sat beside is already said by
- * the account control at the foot of the same sidebar. Two claims, one of them
- * invented and one of them repeated, above the name they were meant to
- * describe.
+ * **Neither the bar nor the panel claims anything about the organization but
+ * its name.** Both used to carry a "Free" chip and a "Free Plan · Admin" line
+ * under the name. Billing is not part of `/api/me`, so that plan was
+ * hard-written copy standing where a fact belongs, and the role it sat beside
+ * is already said by the account control at the foot of the same sidebar. Two
+ * claims, one of them invented and one of them repeated, above the name they
+ * were meant to describe.
+ *
+ * What stands there now is a label rather than a claim. The panel opens on a
+ * name with no page around it, so the grey `Organization` over it says which
+ * kind of name it is — the same thing the word `Project` does for the control
+ * directly below, drawn the same way. (Developer decision, 2026-08-25 on the
+ * Paper canvas.)
  *
  * **The mark is identity, not a control.** It sits beside the menu trigger
  * rather than inside it, so the hover plate, focus indicator and press feedback
@@ -396,8 +403,18 @@ function OrganizationMenu({
             >
               {initial}
             </span>
-            <span className="min-w-0 overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground">
-              {organization.name}
+            <span className="min-w-0">
+              {/*
+               * The project control's own label, on the row above the name it
+               * names. Same step, same faint colour, same sentence case: two
+               * controls one under the other, each saying what its name is.
+               */}
+              <span className="block overflow-hidden text-2xs leading-(--line-normal) text-ellipsis whitespace-nowrap text-faint">
+                Organization
+              </span>
+              <span className="block overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-foreground">
+                {organization.name}
+              </span>
             </span>
           </div>
         )}


### PR DESCRIPTION
## What this is

The graders surface rebuilt to the approved Paper boards (page **06A — Grader rework**) and the canvas comment rulings, in one pass.

## Changes

**Active graders table** — type (`llm_as_judge` / `code`) and modality chips; scope shown as two backend-true columns (Simulations: All / picked list / Off · Production: Off / sample %); pass threshold right-aligned in tabular numerals; the whole row opens the edit sheet; row ⋮ holds Edit plus Remove grader where the grader is removable.

**Grader library table** — chips for type, modalities, and project use (green outline `Active`, neutral `Available`); row opens the review sheet; row ⋮ mirrors the sheet action per state (View active grader / Use in project).

**Sheets** — review sheet: description-first fact list, Reads section with its explainer and evidence chips, Settings when present; edit sheet: About facts, Scope without the "Fixed by Egma" caption, threshold with the 0-to-1 rule spelled out, Remove moved out of the footer; create sheet: LLM judge / Code segments (Code = honest coming-soon card), single-line description, `*` / `[optional]` label grammar, score-between-0-and-1 helper copy.

**Shared** — `DataTable` gains opt-in `onRowActivate` (pointer-target rows, evidence hover mix, containment guard so portalled ⋮ panels and inner controls keep their own clicks; keyboard path stays the primary cell's control). `NumberField` emits `aria-required`. The sidebar org menu gains its grey `Organization` eyebrow.

**DESIGN.md** — records the dated developer decisions: Free chip gone from the org bar, the trimmed org menu with its new label, grader type as a mono identifier.

## Verification

- 148 tests across the six touched-surface files, plus 183 neighbor tests over every other DataTable consumer — all green locally.
- Both web typechecks and the production build pass.
- An independent review pass ran before this PR; its two blocking findings (portalled-menu clicks activating rows; the modalities group's unsupported `aria-required`) and four same-push findings are fixed here, with regression tests.

## Known follow-ups (deliberately not in this PR)

- Create-sheet segment switch can drop an un-persisted "Grades simulations" tick when nothing was picked yet (component-local state; the saved scope is unaffected).
- `PassThresholdField` keeps `step={0.01}`, so a native validity refusal at e.g. `0.333` predates this change.
- Viewers see "View details" (not "Edit") in the row menu — preserved from live behavior; say the word to flip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790323793&installation_model_id=431960&pr_number=239&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F239&signature=6eb6582725af97eef9e726f5c6bc268b02984e7f2c3ed77f3ae835ab04c2518c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reworks the grader-management interface for improved legibility and clearer row interactions.
- Splits active-grader scope into simulation and production columns and adds consistent chips for grader metadata.
- Rebuilds grader review, edit, and creation sheets with clearer facts, evidence, settings, and validation copy.
- Adds opt-in whole-row activation to the shared data table while preserving nested-control behavior.
- Updates sidebar organization labeling, accessibility attributes, design guidance, and regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/graders/grader-sheets.tsx | Reworks grader sheets, metadata presentation, creation mechanism selection, and form accessibility without leaving the previously reported draft-persistence issue reachable. |
| apps/web/app/projects/[projectId]/graders/page.tsx | Rebuilds grader tables with row activation, split scope columns, metadata chips, and contextual edit/remove actions. |
| apps/web/ui/data-table.tsx | Adds opt-in pointer row activation while preserving nested controls and keyboard access through the primary cell. |
| apps/web/lib/graders.ts | Adds presentation helpers for grader evidence, modalities, and separate simulation and production scope summaries. |
| apps/web/ui/number-field.tsx | Exposes required state through the rendered number input. |
| apps/web/ui/shell.tsx | Simplifies the organization menu and adds its descriptive eyebrow label. |
| apps/web/test/graders-pages.test.tsx | Updates and expands regression coverage for the redesigned grader tables, sheets, actions, and validation behavior. |
| apps/web/test/data-table-row-link.test.tsx | Covers row activation and containment behavior around nested and portalled interactive controls. |

<sub>Reviews (2): Last reviewed commit: ["test(browser): drive the reworked grader..."](https://github.com/egma-ai/egma/commit/6f21b8202638d83560c3793057ad60736c8cf8ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56994839)</sub>

<!-- /greptile_comment -->