### PR TITLE
fix(web): the grader tables share their width instead of pooling it into one lane

### DIFF
--- a/apps/web/app/projects/[projectId]/graders/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/page.tsx
@@ -180,6 +180,21 @@ function PassThreshold({ value }: { readonly value: number }) {
   );
 }
 
+/**
+ * **The name lane is stated; the facts share what is left.**
+ *
+ * `ui/data-table.tsx` gives the slack to the columns that ask for no width, so
+ * a list that states a width for all but one of them hands that one column
+ * every spare pixel. Every fact on a grader is short — a chip, "All", "20%",
+ * "0.80" — so the column that took the slack drew a lane of empty paper mid-
+ * table, and the measures ended up pushed against the ⋮ lane far to its right.
+ *
+ * Personas can state five widths because the column it leaves out is
+ * Description, which is prose and fills whatever it is given. This list has no
+ * such column, so it states only the 260px name lane the boards give every list
+ * and lets the five facts divide the rest between them in proportion to what
+ * each one has to say.
+ */
 function activeColumns(
   mayAuthor: boolean,
   open: (grader: ProjectGrader) => void,
@@ -190,7 +205,7 @@ function activeColumns(
       key: "name",
       header: "Grader",
       primary: true,
-      width: "240px",
+      width: "260px",
       cell: (grader) => (
         <RowOpener
           name={graderDefinitionDisplayName(
@@ -204,14 +219,12 @@ function activeColumns(
     {
       key: "type",
       header: "Type",
-      width: "160px",
       hideOnMobile: true,
       cell: (grader) => <GraderTypeChip type={grader.type} />,
     },
     {
       key: "modalities",
       header: "Modalities",
-      width: "170px",
       hideOnMobile: true,
       cell: (grader) => (
         <GraderModalityChips modalities={grader.modalities} />
@@ -233,7 +246,6 @@ function activeColumns(
     {
       key: "production",
       header: "Production",
-      width: "130px",
       cell: (grader) => (
         <ScopeValue value={productionScopeSummary(grader.scope)} />
       ),
@@ -241,7 +253,6 @@ function activeColumns(
     {
       key: "threshold",
       header: "Pass threshold",
-      width: "140px",
       cell: (grader) => <PassThreshold value={grader.passThreshold} />,
     },
     {
@@ -318,21 +329,18 @@ function libraryColumns(
     {
       key: "owner",
       header: "Owner",
-      width: "120px",
       hideOnMobile: true,
       cell: (entry) => graderOwnerLabel(entry.owner),
     },
     {
       key: "type",
       header: "Type",
-      width: "160px",
       hideOnMobile: true,
       cell: (entry) => <GraderTypeChip type={entry.type} />,
     },
     {
       key: "modalities",
       header: "Modalities",
-      width: "170px",
       hideOnMobile: true,
       cell: (entry) => <GraderModalityChips modalities={entry.modalities} />,
     },


### PR DESCRIPTION
Both grader tables (Active and Library) stated a fixed width on every column but one, and the DataTable hands all spare width to the one column that asks for none — the short-valued Simulations / Project use lane. ~262px pooled there and shoved Production and Pass threshold against the row-menu lane.

Fix: each grader table now states only the 260px name lane that Personas and Agents already use; the fact columns divide the rest, and the fixed 48px row-menu lane is untouched.

Proof: graders page tests 20/20, web typecheck clean, and a Chromium measurement at 1440 — the worst empty lane drops from 262px in one column to 170px spread across all of them.

Merging on the developer's direct instruction (in-session, with the deploy consequence known).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790354424&installation_model_id=431960&pr_number=243&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F243&signature=7fb2a9271c4a9eb346c1875b57b30009fb9b54f36f67507a5f2580acd685c8ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects uneven width allocation in the Active and Library grader tables by fixing only the 260px name lane and allowing short fact columns to share the remaining space.
- Removes fixed widths from the Active table’s type, modalities, production, and pass-threshold columns.
- Removes fixed widths from the Library table’s owner, type, and modalities columns.
- Aligns the grader name lane with the 260px convention used by sibling resource lists.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The changes are limited to presentation width preferences, preserve the fixed action lane and constrained-layout behavior, and do not alter grader data or interactions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/projects/[projectId]/graders/page.tsx | Adjusts both grader table column definitions to distribute spare width across fact columns; no concrete regression was identified. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): the graders list spreads its s..."](https://github.com/egma-ai/egma/commit/727f2eea2965c29e107ae0020a184337a7598bd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57147922)</sub>

<!-- /greptile_comment -->