### PR TITLE
Pass threshold header aligns with its numbers

### DIFF
--- a/apps/web/app/projects/[projectId]/graders/page.tsx
+++ b/apps/web/app/projects/[projectId]/graders/page.tsx
@@ -173,11 +173,12 @@ function RowOpener({
   );
 }
 
-/** The score a simulation has to reach, as a measure: two places, tabular. */
+/**
+ * The score a simulation has to reach, as a measure: two places, tabular. The
+ * column says which edge it reads from, so the header stays with the figures.
+ */
 function PassThreshold({ value }: { readonly value: number }) {
-  return (
-    <span className="block text-right tabular-nums">{value.toFixed(2)}</span>
-  );
+  return <span className="tabular-nums">{value.toFixed(2)}</span>;
 }
 
 /**
@@ -253,6 +254,7 @@ function activeColumns(
     {
       key: "threshold",
       header: "Pass threshold",
+      align: "end",
       cell: (grader) => <PassThreshold value={grader.passThreshold} />,
     },
     {

--- a/apps/web/test/data-table-row-link.test.tsx
+++ b/apps/web/test/data-table-row-link.test.tsx
@@ -96,6 +96,70 @@ describe("DataTable row links", () => {
   });
 });
 
+const ALIGNED_COLUMNS: readonly Column<Row>[] = [
+  {
+    key: "name",
+    header: "Grader",
+    primary: true,
+    cell: (row) => row.name,
+  },
+  {
+    key: "threshold",
+    header: "Pass threshold",
+    align: "end",
+    cell: () => "0.80",
+  },
+  {
+    key: "registered",
+    header: "Registered",
+    cell: (row) => row.registered,
+  },
+];
+
+/** The one class token, read off the element rather than out of a string. */
+function alignsRight(element: HTMLElement): boolean {
+  return element.classList.contains("text-right");
+}
+
+function valueOf(cell: HTMLElement): HTMLElement {
+  return cell.querySelector("[data-slot=cell]") as HTMLElement;
+}
+
+describe("DataTable numeric columns", () => {
+  it("keeps an aligned column's header on the edge its values read from", () => {
+    render(
+      <DataTable
+        label="Graders"
+        columns={ALIGNED_COLUMNS}
+        rows={[ROW]}
+        keyOf={(row) => row.id}
+      />,
+    );
+    const table = screen.getByRole("table", { name: "Graders" });
+
+    expect(
+      alignsRight(
+        within(table).getByRole("columnheader", { name: "Pass threshold" }),
+      ),
+    ).toBe(true);
+    expect(
+      alignsRight(valueOf(within(table).getByRole("cell", { name: "0.80" }))),
+    ).toBe(true);
+
+    /* A column that asked for nothing keeps the table's own left edge. */
+    expect(
+      alignsRight(
+        within(table).getByRole("columnheader", { name: "Registered" }),
+      ),
+    ).toBe(false);
+    expect(
+      alignsRight(
+        valueOf(within(table).getByRole("cell", { name: "2026-08-15" })),
+      ),
+    ).toBe(false);
+  });
+});
+
 /** A row control whose open panel lives in `body`, the way the ⋮ menu does. */
 function PortalMenu() {
   const [open, setOpen] = useState(false);

--- a/apps/web/ui/data-table.tsx
+++ b/apps/web/ui/data-table.tsx
@@ -61,6 +61,12 @@ export type Column<Row> = {
   readonly hideOnMobile?: boolean;
   /** Identifiers, counts and times, which read straight in the mono face. */
   readonly mono?: boolean;
+  /**
+   * Numbers read from their right edge, so a column of them may say so. The
+   * header moves with its values: a label left on the other edge of the lane
+   * floats away from the figures it names.
+   */
+  readonly align?: "end";
   /** A row control. It stays at the trailing edge in both table layouts. */
   readonly action?: boolean;
   /**
@@ -235,6 +241,7 @@ export function DataTable<Row>({
                      */
                     "data-[action=true]:px-0",
                     hiddenWhenStacked(column) && "stacked:hidden",
+                    column.align === "end" && "text-right",
                   )}
                   data-action={column.action === true ? "true" : undefined}
                   data-mobile-hidden={mobileHidden(column)}
@@ -389,6 +396,8 @@ export function DataTable<Row>({
                          */
                         column === primary && "text-foreground",
                         column.mono === true && "font-mono text-sm",
+                        /* The values' edge, which the header cell above shares. */
+                        column.align === "end" && "text-right",
                         /*
                          * The action cell's own shape, read off the cell it
                          * sits in rather than off a prop this file re-tested.


### PR DESCRIPTION
The `Column` type in the shared data table gains an optional `align: "end"`, which puts `text-right` on both the header cell and the value span, and the graders list passes it on the Pass threshold column. Its numbers were already right-aligned by the cell itself while the header stayed on the left of the lane, so the label floated away from the figures it names — alignment lives in the shared component, so the page could not fix the header on its own.

One focused assertion in `apps/web/test/data-table-row-link.test.tsx` covers it: an aligned column's columnheader and value carry the class, an unaligned one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790356553&installation_model_id=431960&pr_number=244&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F244&signature=0c9e18b9722b7c11b8df939c39ad2a497196c3d08db85c5d3df7150bded64e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an end-alignment option to the shared DataTable and uses it for grader pass thresholds, with a focused class-level test.
- Extends `Column<Row>` with `align: "end"`.
- Applies `text-right` to aligned headers and value wrappers.
- Moves pass-threshold alignment responsibility into DataTable.
- Adds coverage asserting alignment utility classes.

<h3>Confidence Score: 4/5</h3>

The pass-threshold alignment remains broken and should be fixed before merging because the values no longer have a full-width element from which to align right.

The header receives right alignment on its full table-header cell, while the value receives it only on a content-width inline span after the prior block-level alignment was removed.

**Files Needing Attention:** apps/web/ui/data-table.tsx, apps/web/app/projects/[projectId]/graders/page.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/ui/data-table.tsx | Adds shared end alignment, but applies value alignment to an inline span that does not occupy the cell width. |
| apps/web/app/projects/[projectId]/graders/page.tsx | Enables shared alignment for Pass threshold while removing the block-level element that previously aligned its values. |
| apps/web/test/data-table-row-link.test.tsx | Verifies class presence but does not detect whether the utility produces actual visual alignment. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fgrader-threshold-align%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fgrader-threshold-align%22.%0A%0AGreploop%20egma-ai%2Fegma%20PR%20%23244%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=egma-ai%2Fegma&pr=244&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22egma-ai%2Fegma%22%20on%20the%20existing%20branch%20%22claude%2Fgrader-threshold-align%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fgrader-threshold-align%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fweb%2Fui%2Fdata-table.tsx%3A399%0A**Inline%20span%20defeats%20alignment**%0A%0AWhen%20a%20desktop%20column%20uses%20%60align%3A%20%22end%22%60%2C%20%60text-right%60%20is%20applied%20only%20to%20a%20content-width%20inline%20span%2C%20so%20the%20value%20remains%20at%20the%20cell's%20left%20edge%20while%20the%20header%20moves%20right%2C%20leaving%20pass-threshold%20values%20misaligned%20with%20their%20header.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fui%2Fdata-table.tsx%3A399%0A**Inline%20span%20defeats%20alignment**%0A%0AWhen%20a%20desktop%20column%20uses%20%60align%3A%20%22end%22%60%2C%20%60text-right%60%20is%20applied%20only%20to%20a%20content-width%20inline%20span%2C%20so%20the%20value%20remains%20at%20the%20cell's%20left%20edge%20while%20the%20header%20moves%20right%2C%20leaving%20pass-threshold%20values%20misaligned%20with%20their%20header.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=egma-ai%2Fegma&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(web): pass threshold header aligns w..."](https://github.com/egma-ai/egma/commit/e6f507a850df0c9a77578ac811b3873774b7495a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57162877)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->