### PR TITLE
fix(web): every table reads from one declared edge

### DIFF
--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -91,10 +91,16 @@ const WHOLE_ORGANIZATION = "";
  * wider than the slot and grows it, and with no padding of its own the button
  * then sits against the panel's own hairline. This puts the row's padding back
  * inside the cell, where the width is the caller's problem rather than the
- * table's. It is the row's padding by name, so it cannot drift off the edge
- * every other cell in this table reads from.
+ * table's. It is the row's padding by name rather than a bare `px-4`, so it
+ * reads the same declaration the cells beside it do.
+ *
+ * **And it stops at the narrow layout, because there the row already pays
+ * it.** A stacked row is a padded block — `stacked:px-(--row-padding-x)` on
+ * the row, `stacked:p-0` on every cell — so a control cell keeping its own
+ * would stand at 32px while every value above it sat at 16.
  */
-const ROW_ACTIONS = "flex items-center justify-end gap-2 px-(--row-padding-x)";
+const ROW_ACTIONS =
+  "flex items-center justify-end gap-2 px-(--row-padding-x) stacked:px-0";
 
 /**
  * The only copy of a newly minted secret.

--- a/apps/web/app/projects/[projectId]/settings/keys/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/keys/page.tsx
@@ -91,9 +91,10 @@ const WHOLE_ORGANIZATION = "";
  * wider than the slot and grows it, and with no padding of its own the button
  * then sits against the panel's own hairline. This puts the row's padding back
  * inside the cell, where the width is the caller's problem rather than the
- * table's.
+ * table's. It is the row's padding by name, so it cannot drift off the edge
+ * every other cell in this table reads from.
  */
-const ROW_ACTIONS = "flex items-center justify-end gap-2 px-4";
+const ROW_ACTIONS = "flex items-center justify-end gap-2 px-(--row-padding-x)";
 
 /**
  * The only copy of a newly minted secret.

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -113,13 +113,13 @@ type Tab = "people" | "invitations";
  * that.
  */
 const ROW_ACTIONS = [
-  "grid grid-cols-[max-content_max-content] items-center gap-2 px-4",
+  "grid grid-cols-[max-content_max-content] items-center gap-2 px-(--row-padding-x)",
   "[&>span]:col-span-2 [&>span]:row-start-2 [&>span]:text-left",
   "[&>span]:w-0 [&>span]:min-w-full [&>span]:whitespace-normal",
 ].join(" ");
 
 /** The same lane, for a row that offers one control and no reason. */
-const ROW_ACTION = "flex items-center justify-end gap-2 px-4";
+const ROW_ACTION = "flex items-center justify-end gap-2 px-(--row-padding-x)";
 
 export default function PeopleSettingsPage() {
   const { projectId } = useParams<{ projectId: string }>();

--- a/apps/web/app/projects/[projectId]/settings/people/page.tsx
+++ b/apps/web/app/projects/[projectId]/settings/people/page.tsx
@@ -111,15 +111,22 @@ type Tab = "people" | "invitations";
  * pair afterwards. The sentence also has to be told it may wrap: the shared
  * cell keeps every other fact on one line, and a row control's cell inherits
  * that.
+ *
+ * **The side padding stops at the narrow layout, because there the row already
+ * pays it.** A stacked row is a padded block — `stacked:px-(--row-padding-x)`
+ * on the row, `stacked:p-0` on every cell — so a control cell keeping its own
+ * would stand at 32px while every value above it sat at 16.
  */
 const ROW_ACTIONS = [
-  "grid grid-cols-[max-content_max-content] items-center gap-2 px-(--row-padding-x)",
+  "grid grid-cols-[max-content_max-content] items-center gap-2",
+  "px-(--row-padding-x) stacked:px-0",
   "[&>span]:col-span-2 [&>span]:row-start-2 [&>span]:text-left",
   "[&>span]:w-0 [&>span]:min-w-full [&>span]:whitespace-normal",
 ].join(" ");
 
 /** The same lane, for a row that offers one control and no reason. */
-const ROW_ACTION = "flex items-center justify-end gap-2 px-(--row-padding-x)";
+const ROW_ACTION =
+  "flex items-center justify-end gap-2 px-(--row-padding-x) stacked:px-0";
 
 export default function PeopleSettingsPage() {
   const { projectId } = useParams<{ projectId: string }>();

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -1403,8 +1403,9 @@ export function TestsGrid(props: GridProps) {
         clips exactly that. `overflow-x: auto` also computes `overflow-y` to
         `auto`, so the naive wrapper would have cut a 240px picker off at the
         table's own bottom edge. The choice is one class or the other, never
-        both: while a picker is open the grid may overflow, which costs a
-        person nothing, and when it is shut the grid scrolls.
+        both: while a picker is open the grid may overflow, and when it shuts
+        the grid scrolls again. On a phone the toggle also resets the sideways
+        scroll — the price of this grid having no narrow layout yet.
       */}
       <div className={picking === null ? "overflow-x-auto" : "overflow-visible"}>
       <table className="w-full min-w-(--tests-grid-min-width) table-fixed border-collapse border border-border bg-surface text-sm">

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -1389,7 +1389,25 @@ export function TestsGrid(props: GridProps) {
         askToDiscard();
       }}
     >
-      <table className="w-full table-fixed border-collapse border border-border bg-surface text-sm">
+      {/*
+        The grid scrolls sideways rather than squeezing, the way every other
+        table's `TablePanel` already does. Four percentage columns and a fixed
+        lane share whatever width there is, and this grid has no narrow layout
+        to fall back to, so under `--tests-grid-min-width` the columns stopped
+        holding a readable word. A phone scrolls it; a tablet and up does not.
+
+        **It stops scrolling while a persona picker is open, and that is not a
+        detail.** The shared table may hold its rows in a scrolling panel
+        because its ⋮ opens in a portal; this grid's picker is an absolutely
+        positioned panel inside the cell it belongs to, and a scroll container
+        clips exactly that. `overflow-x: auto` also computes `overflow-y` to
+        `auto`, so the naive wrapper would have cut a 240px picker off at the
+        table's own bottom edge. The choice is one class or the other, never
+        both: while a picker is open the grid may overflow, which costs a
+        person nothing, and when it is shut the grid scrolls.
+      */}
+      <div className={picking === null ? "overflow-x-auto" : "overflow-visible"}>
+      <table className="w-full min-w-(--tests-grid-min-width) table-fixed border-collapse border border-border bg-surface text-sm">
         <caption className="sr-only">Tests in this suite</caption>
         <colgroup>
           {COLUMNS.map((column) => (
@@ -1478,6 +1496,7 @@ export function TestsGrid(props: GridProps) {
           ) : null}
         </tbody>
       </table>
+      </div>
 
       {more}
 

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -129,7 +129,18 @@ const CELL = "border-r border-b border-border p-0 align-top last:border-r-0";
  */
 const ACTION =
   "w-(--table-action-labelled-width) border-b border-border p-0 text-center align-top";
-const PAD = "px-2.5 py-2";
+/**
+ * The lane's padding, and it is the house table's rather than this grid's own.
+ *
+ * This is the one table in the product that is not drawn from
+ * `components/ui/table.tsx`, and it had been reading from 10px where every
+ * other list reads from `--row-padding-x`. Six pixels is enough to see: a
+ * person who walks Agents, Runs, Personas and then a suite watches the first
+ * column step left, and 10px is not on `DESIGN.md`'s spacing scale to begin
+ * with. Header and cells both read this, so the column keeps one edge from the
+ * heading to the last row — which is the same promise the shared table makes.
+ */
+const PAD = "px-(--row-padding-x) py-(--row-padding-y)";
 const TEXT = "text-sm leading-(--line-caption) text-foreground";
 /*
  * A woken cell wears its 2px ink edge as an inset shadow rather than a border,
@@ -1385,7 +1396,10 @@ export function TestsGrid(props: GridProps) {
           <tr className="bg-surface-soft">
             {COLUMNS.map((column) => (
               <th
-                className="border-r border-b border-border px-2.5 py-2 text-left text-sm font-normal text-faint last:border-r-0"
+                className={cn(
+                  PAD,
+                  "border-r border-b border-border text-left text-sm font-normal text-faint last:border-r-0",
+                )}
                 key={column.field}
                 scope="col"
               >
@@ -1399,7 +1413,10 @@ export function TestsGrid(props: GridProps) {
               is what it holds, and every reader gets the same word now.
             */}
             <th
-              className="w-(--table-action-labelled-width) border-b border-border px-4 py-2 text-center text-sm font-normal whitespace-nowrap text-faint"
+              className={cn(
+                PAD,
+                "w-(--table-action-labelled-width) border-b border-border text-center text-sm font-normal whitespace-nowrap text-faint",
+              )}
               scope="col"
             >
               Actions

--- a/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
+++ b/apps/web/app/projects/[projectId]/tests/tests-grid.tsx
@@ -17,6 +17,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { LANE_X } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import {
   platformAnswer,
@@ -139,8 +140,12 @@ const ACTION =
  * column step left, and 10px is not on `DESIGN.md`'s spacing scale to begin
  * with. Header and cells both read this, so the column keeps one edge from the
  * heading to the last row — which is the same promise the shared table makes.
+ *
+ * The edge itself is imported rather than copied: this grid is the one table
+ * that inherits nothing from `components/ui/table.tsx`, and two files naming
+ * the same edge separately is how it drifted off it the first time.
  */
-const PAD = "px-(--row-padding-x) py-(--row-padding-y)";
+const PAD = `${LANE_X} py-(--row-padding-y)`;
 const TEXT = "text-sm leading-(--line-caption) text-foreground";
 /*
  * A woken cell wears its 2px ink edge as an inset shadow rather than a border,

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -39,7 +39,8 @@ import { cn } from "@/lib/utils";
  * edge two files declare apart is an edge that drifts. What is still written
  * out by hand is the side padding the two settings tables put back inside
  * their own control cells, where the class list is a caller's rather than
- * this file's.
+ * this file's, and the stacked row's own copy in `ui/data-table.tsx`, which
+ * pads a different layout and cannot drift this one.
  *
  * Two things align some other way, and both are deliberate:
  *

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -25,6 +25,21 @@ import { cn } from "@/lib/utils";
  * row heights it lines up with.
  */
 
+/**
+ * The edge every column reads from, written once.
+ *
+ * **A header and the cells under it are one column, so they share one
+ * declaration.** Two copies of the same padding are two things that can be
+ * changed apart, and a header that drifts off its own figures is the defect
+ * this names away. The rule is the whole of the product's column alignment:
+ * one left edge per lane, header and value on it, in every table.
+ *
+ * The other half of the rule is that nothing overrides it. A cell aligns its
+ * content some other way only where the content is not a fact to scan — the
+ * row's own control lane, which is centred in a slot of fixed width.
+ */
+const LANE_X = "px-(--row-padding-x)";
+
 /** The bordered surface a table is drawn on. */
 function TablePanel({ className, ...props }: ComponentProps<"div">) {
   return (
@@ -83,7 +98,8 @@ function TableHead({ className, ...props }: ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-(--row-height) border-b border-border px-(--row-padding-x)",
+        "h-(--row-height) border-b border-border",
+        LANE_X,
         "text-left font-normal whitespace-nowrap text-faint",
         className,
       )}
@@ -105,7 +121,8 @@ function TableCell({ className, ...props }: ComponentProps<"td">) {
       data-slot="table-cell"
       className={cn(
         "border-t border-border align-middle",
-        "px-(--row-padding-x) py-(--row-padding-y)",
+        LANE_X,
+        "py-(--row-padding-y)",
         className,
       )}
       {...props}

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -31,14 +31,24 @@ import { cn } from "@/lib/utils";
  * **A header and the cells under it are one column, so they share one
  * declaration.** Two copies of the same padding are two things that can be
  * changed apart, and a header that drifts off its own figures is the defect
- * this names away. The rule is the whole of the product's column alignment:
- * one left edge per lane, header and value on it, in every table.
+ * this names away. The rule is the wide layout's column alignment: one left
+ * edge per lane, header and value on it, in every table.
  *
- * The other half of the rule is that nothing overrides it. A cell aligns its
- * content some other way only where the content is not a fact to scan — the
- * row's own control lane, which is centred in a slot of fixed width.
+ * It is exported because one table in the product is not built from these
+ * parts — the inline-editing suite grid in `tests/tests-grid.tsx` — and an
+ * edge two files declare apart is an edge that drifts. What is still written
+ * out by hand is the side padding the two settings tables put back inside
+ * their own control cells, where the class list is a caller's rather than
+ * this file's.
+ *
+ * Two things align some other way, and both are deliberate:
+ *
+ * - The row's own control lane, centred in a slot of fixed width.
+ * - Every non-primary value in the **stacked** layout, which `ui/data-table`
+ *   right-aligns against its label. A narrow row is a label-and-value list
+ *   rather than a set of columns, so it has no shared edge to keep.
  */
-const LANE_X = "px-(--row-padding-x)";
+export const LANE_X = "px-(--row-padding-x)";
 
 /** The bordered surface a table is drawn on. */
 function TablePanel({ className, ...props }: ComponentProps<"div">) {

--- a/apps/web/test/data-table-row-link.test.tsx
+++ b/apps/web/test/data-table-row-link.test.tsx
@@ -96,6 +96,43 @@ describe("DataTable row links", () => {
   });
 });
 
+/**
+ * One left edge per column, header and values on it.
+ *
+ * The rule is written once in `components/ui/table.tsx` and every table in the
+ * product inherits it, so this asserts the token rather than a pixel: a header
+ * and the cells under it name the same padding, and the only cell that aligns
+ * its content any other way is the row's own control lane.
+ */
+describe("DataTable column alignment", () => {
+  const LANE = "px-(--row-padding-x)";
+
+  it("puts every header and its cells on one edge", () => {
+    render(
+      <DataTable
+        label="Agents"
+        columns={[...COLUMNS.slice(0, 2), { ...COLUMNS[2]!, action: true }]}
+        rows={[ROW]}
+        keyOf={(row) => row.id}
+      />,
+    );
+    const table = screen.getByRole("table", { name: "Agents" });
+    const headers = within(table).getAllByRole("columnheader");
+    const cells = within(table).getAllByRole("cell");
+
+    /* The facts: header and value read from the same declared edge. */
+    for (const element of [...headers.slice(0, 2), ...cells.slice(0, 2)]) {
+      expect(element.className).toContain(LANE);
+      expect(element.className).not.toContain("text-right");
+    }
+
+    /* The control lane: no side padding, in the header and in the row. */
+    expect(headers[2]!.className).toContain("data-[action=true]:px-0");
+    expect(cells[2]!.className).toContain("data-[action=true]:px-0");
+    expect(cells[2]!.dataset.action).toBe("true");
+  });
+});
+
 /** A row control whose open panel lives in `body`, the way the ⋮ menu does. */
 function PortalMenu() {
   const [open, setOpen] = useState(false);

--- a/apps/web/test/data-table-row-link.test.tsx
+++ b/apps/web/test/data-table-row-link.test.tsx
@@ -101,12 +101,14 @@ describe("DataTable row links", () => {
  *
  * The rule is written once in `components/ui/table.tsx` and every table in the
  * product inherits it, so this asserts the token rather than a pixel: a header
- * and the cells under it name the same padding, and the only cell that aligns
- * its content any other way is the row's own control lane.
+ * and the cells under it name the same padding, and the two deliberate
+ * exceptions — the row's own control lane, and the stacked layout's
+ * right-aligned values — are the ones `components/ui/table.tsx` names.
  *
  * The lane's own `px-0` is written unconditionally and applied by the
- * `data-action` attribute, so the attribute is what this asserts. Reading the
- * class back would pass on every cell in the table and prove nothing.
+ * `data-action` attribute, so the attribute is what proves which cell is the
+ * lane. The class is still read back once, on the lane itself, because the
+ * mark strips nothing unless the rule stays written on the shared parts.
  */
 describe("DataTable column alignment", () => {
   const LANE = "px-(--row-padding-x)";
@@ -135,6 +137,11 @@ describe("DataTable column alignment", () => {
      * is what takes the side padding off both. */
     expect(headers[2]!.dataset.action).toBe("true");
     expect(cells[2]!.dataset.action).toBe("true");
+
+    /* And the rule the mark applies. Without this pair the attribute could
+     * stand while the padding it strips quietly returns. */
+    expect(headers[2]!.className).toContain("data-[action=true]:px-0");
+    expect(cells[2]!.className).toContain("data-[action=true]:px-0");
   });
 });
 

--- a/apps/web/test/data-table-row-link.test.tsx
+++ b/apps/web/test/data-table-row-link.test.tsx
@@ -103,6 +103,10 @@ describe("DataTable row links", () => {
  * product inherits it, so this asserts the token rather than a pixel: a header
  * and the cells under it name the same padding, and the only cell that aligns
  * its content any other way is the row's own control lane.
+ *
+ * The lane's own `px-0` is written unconditionally and applied by the
+ * `data-action` attribute, so the attribute is what this asserts. Reading the
+ * class back would pass on every cell in the table and prove nothing.
  */
 describe("DataTable column alignment", () => {
   const LANE = "px-(--row-padding-x)";
@@ -120,15 +124,16 @@ describe("DataTable column alignment", () => {
     const headers = within(table).getAllByRole("columnheader");
     const cells = within(table).getAllByRole("cell");
 
-    /* The facts: header and value read from the same declared edge. */
+    /* The facts: header and value read from the same declared edge, and
+     * neither is marked as the lane that leaves it. */
     for (const element of [...headers.slice(0, 2), ...cells.slice(0, 2)]) {
-      expect(element.className).toContain(LANE);
-      expect(element.className).not.toContain("text-right");
+      expect(element.className, element.textContent ?? "").toContain(LANE);
+      expect(element.dataset.action, element.textContent ?? "").toBeUndefined();
     }
 
-    /* The control lane: no side padding, in the header and in the row. */
-    expect(headers[2]!.className).toContain("data-[action=true]:px-0");
-    expect(cells[2]!.className).toContain("data-[action=true]:px-0");
+    /* The control lane, marked in the header as well as in the row: the mark
+     * is what takes the side padding off both. */
+    expect(headers[2]!.dataset.action).toBe("true");
     expect(cells[2]!.dataset.action).toBe("true");
   });
 });

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -1791,7 +1791,10 @@ describe("the suite grid's columns", () => {
     for (const header of screen.getAllByRole("columnheader")) {
       expect(header.className, header.textContent ?? "").toContain(LANE);
     }
-    const padded = name.closest("td")?.firstElementChild as HTMLElement;
-    expect(padded.className).toContain(LANE);
+    const padded = name.closest("td")?.firstElementChild;
+    /* Named rather than cast: a missing box should say which box is missing,
+     * not read a property off `undefined` three lines later. */
+    expect(padded, "the name cell's padded box").toBeInstanceOf(HTMLElement);
+    expect((padded as HTMLElement).className).toContain(LANE);
   });
 });

--- a/apps/web/test/test-suites-pages.test.tsx
+++ b/apps/web/test/test-suites-pages.test.tsx
@@ -1770,3 +1770,28 @@ describe("the suite-first Tests route", () => {
     expect(routed.push).toHaveBeenCalledWith("/projects/prj_1/runs/run_1");
   });
 });
+
+/**
+ * One left edge per column, in the one table not drawn from the shared kit.
+ *
+ * `tests-grid.tsx` is a raw `<table>`, so it inherits nothing and had been
+ * reading from 10px where every other list in the product reads from
+ * `--row-padding-x`. This asserts the token on the header and on the cell's
+ * own padded box, which is what stops the grid drifting off the lane again.
+ */
+describe("the suite grid's columns", () => {
+  const LANE = "px-(--row-padding-x)";
+
+  it("reads from the same edge as every other table in the product", async () => {
+    gridAnswers();
+
+    render(<TestSuitePage />);
+
+    const name = await screen.findByText("Books service");
+    for (const header of screen.getAllByRole("columnheader")) {
+      expect(header.className, header.textContent ?? "").toContain(LANE);
+    }
+    const padded = name.closest("td")?.firstElementChild as HTMLElement;
+    expect(padded.className).toContain(LANE);
+  });
+});

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -317,6 +317,23 @@
   --table-action-labelled-width: 96px;
 
   /*
+   * The narrowest the suite grid may be drawn before it scrolls sideways.
+   *
+   * That grid is the one table in the product with no narrow layout: its cells
+   * are edited in place, so the stacked label-and-value form every list uses
+   * on a phone is a screen of its own rather than a variant, and it is not
+   * written yet. Until it is, four percentage columns and a 96px lane share
+   * whatever width there is, and below about 660px the last of them stops
+   * holding a readable word.
+   *
+   * 720px is the floor and it is chosen to be under the 768px tablet width, so
+   * every screen from a tablet upwards draws the whole grid and only a phone
+   * scrolls it. A table that scrolls inside its own panel is the honest
+   * failure here; columns squeezed to two letters each are not.
+   */
+  --tests-grid-min-width: 720px;
+
+  /*
    * How wide each surface is. Every one of these lived in a class list as a
    * bare number until 2026-08-23; a size is a design value like a colour is,
    * and `DESIGN.md` says a component holds neither.


### PR DESCRIPTION
Part of the prod-polish pass of 2026-08-26 (developer annotation 8: "the columns in every table in the platform should be aligned"). Targets the integration branch, not main.

## What

- One shared `LANE_X` edge (`px-(--row-padding-x)`) declared once in `components/ui/table.tsx` and read by header and cells alike, so the two can never drift apart. Exported and reused by the one table not built from these parts — the inline-editing suite grid — which leaves its old 10px padding (off the spacing scale) and joins the platform's 16px lane.
- The three hand-written control-cell paddings in Settings (keys, people ×2) now name the same token, with `stacked:px-0` so a phone's stacked rows stop paying for padding twice.
- The suite grid scrolls sideways under a new `--tests-grid-min-width: 720px` floor instead of squeezing on a phone — conditional on no persona picker being open, because the picker is not portalled and a scroll container would clip it (recorded: portalling the picker belongs to the grid's narrow-layout ticket).
- Numeric columns stay on the left edge **deliberately**: PR #245 removed the `align` option and ruled every value reads from the lane's left edge; both the implementation and two independent review passes confirmed left-edge is the faithful reading. If a variable-width numeric column ever arrives, right-alignment returns as a `Column` option, never a page-file `text-right`.

## Checks

Inventory proved exactly two table systems in the product; all ten shared-kit screens were already on the lane. Scoped fast lane: 283/283 across the ten table-bearing files, plus 36/36 on the two touched test files after review. Web typecheck + repo lint clean. Independent review + verification pass done pre-PR (verdict: correct, minimal, platform-wide; merge proven clean against the tests-screen branch).

## Recorded leftovers (deliberate)

- The persona-picker popover's own 10px padding (a popover, not columns).
- The suite grid's 36px rows vs DESIGN.md's 40/52 bar, TablePanel adoption, a real narrow layout for the grid, and portalling its picker.
- On a phone, toggling the picker resets the grid's sideways scroll (documented in-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790439479&installation_model_id=431960&pr_number=250&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F250&signature=084ba97651ab9f13bde706e3a69869d692322d767bff6e9cd5c079879bb030a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes table-column horizontal padding behind a shared lane utility and applies it to the standalone test-suite grid and Settings control cells.
- Adds responsive horizontal scrolling and a minimum width to the inline-editing suite grid.
- Keeps non-portalled persona pickers unclipped by disabling the grid scroll container while a picker is open.
- Adds alignment-focused tests for shared data tables and the suite grid.
- Introduces a theme token for the suite grid’s minimum width.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security failures identified.

The shared Tailwind utilities are statically discoverable, responsive overrides preserve the intended padding ownership, and the grid overflow behavior keeps the non-portalled picker reachable without introducing a demonstrated functional failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/components/ui/table.tsx | Exports one static horizontal-padding utility and reuses it consistently in shared table headers and cells. |
| apps/web/app/projects/[projectId]/tests/tests-grid.tsx | Adopts the shared lane, adds a 720px width floor, and conditionally changes overflow to avoid clipping in-cell persona pickers. |
| apps/web/app/projects/[projectId]/settings/keys/page.tsx | Aligns action controls with the shared lane and removes duplicate padding in stacked rows. |
| apps/web/app/projects/[projectId]/settings/people/page.tsx | Applies the shared lane token to member and invitation controls with the intended stacked-layout override. |
| apps/web/ui/tailwind-theme.css | Defines the suite grid’s responsive minimum-width token. |
| apps/web/test/data-table-row-link.test.tsx | Adds structural coverage that shared headers and cells consume the same lane utility while action cells suppress it. |
| apps/web/test/test-suites-pages.test.tsx | Adds coverage that the standalone suite grid consumes the shared horizontal lane. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): the alignment notes say only t..."](https://github.com/egma-ai/egma/commit/19c41094971b768724dabc7ec2c673a9feb43684) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57565641)</sub>

<!-- /greptile_comment -->