### PR TITLE
feat(web): egma opens behind one honest session screen

### DIFF
--- a/apps/api/src/auth/naming.ts
+++ b/apps/api/src/auth/naming.ts
@@ -17,13 +17,58 @@
 export const DEFAULT_PROJECT_NAME = "Default";
 
 /**
+ * The domains where the first label is a mail provider rather than a company.
+ *
+ * **A list is the cheap half of this, and it used to be the reason there was
+ * none.** The argument against it was that free-mail providers have to be kept
+ * up to date forever, so `ada@gmail.com` was offered `Gmail` and the editable
+ * field was left to carry it. What that missed is that a wrong default is not
+ * neutral: an organization actually called `Gmail` is what a person accepts on
+ * the fastest path through the shortest form in the product, and then lives
+ * with. Twenty names cover very nearly every personal address, the field still
+ * decides, and a provider missing from this list falls back to exactly the
+ * behaviour that was there before.
+ *
+ * The first label, not the whole domain, so `hotmail.co.uk` needs no line of
+ * its own. Ambiguous labels a company could also own — `mail`, `email` — are
+ * deliberately absent.
+ */
+const PERSONAL_MAIL = new Set([
+  "gmail",
+  "googlemail",
+  "outlook",
+  "hotmail",
+  "live",
+  "msn",
+  "yahoo",
+  "ymail",
+  "icloud",
+  "me",
+  "mac",
+  "aol",
+  "proton",
+  "protonmail",
+  "pm",
+  "gmx",
+  "zoho",
+  "yandex",
+  "fastmail",
+  "hey",
+]);
+
+function capitalized(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
  * `ada@acme.example` becomes `Acme`. The first label of the domain, because
  * that is what a person calls their company, and title case because that is how
  * they write it down.
  *
- * A personal address becomes `Gmail`, which is wrong and does not matter: the
- * field is editable, and the alternative is a list of free-mail providers to
- * keep up to date forever.
+ * `ada.lovelace@gmail.com` becomes `Ada's organization`, because a personal
+ * address names no company and the person is the only thing in it. The first
+ * run of letters and digits in the local part is the given name closely enough
+ * for a value somebody is about to read and can change.
  */
 export function organizationNameFromEmail(email: string): string {
   const at = email.lastIndexOf("@");
@@ -31,10 +76,13 @@ export function organizationNameFromEmail(email: string): string {
   const label = domain.split(".")[0] ?? "";
   const cleaned = label.replaceAll(/[^\p{L}\p{N}]+/gu, " ").trim();
   if (cleaned === "") return "My organization";
-  return cleaned
-    .split(" ")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+
+  if (PERSONAL_MAIL.has(cleaned.toLowerCase())) {
+    const first = email.slice(0, at).split(/[^\p{L}\p{N}]+/u)[0] ?? "";
+    return first === "" ? "My organization" : `${capitalized(first)}'s organization`;
+  }
+
+  return cleaned.split(" ").map(capitalized).join(" ");
 }
 
 /** How long a slug is allowed to get before it stops being readable. */

--- a/apps/api/src/auth/naming.ts
+++ b/apps/api/src/auth/naming.ts
@@ -33,7 +33,7 @@ export const DEFAULT_PROJECT_NAME = "Default";
  * its own. Ambiguous labels a company could also own — `mail`, `email` — are
  * deliberately absent.
  */
-const PERSONAL_MAIL = new Set([
+export const PERSONAL_MAIL = new Set([
   "gmail",
   "googlemail",
   "outlook",
@@ -78,7 +78,9 @@ export function organizationNameFromEmail(email: string): string {
   if (cleaned === "") return "My organization";
 
   if (PERSONAL_MAIL.has(cleaned.toLowerCase())) {
-    const first = email.slice(0, at).split(/[^\p{L}\p{N}]+/u)[0] ?? "";
+    // Lowercased first, so a name shouted in the address bar is not
+    // shouted back: ADA@GMAIL.COM is Ada, not ADA.
+    const first = email.slice(0, at).toLowerCase().split(/[^\p{L}\p{N}]+/u)[0] ?? "";
     return first === "" ? "My organization" : `${capitalized(first)}'s organization`;
   }
 

--- a/apps/api/src/routes/signup.ts
+++ b/apps/api/src/routes/signup.ts
@@ -38,6 +38,17 @@ export type SignupRoutesOptions = {
   /** The origin the provider is configured for, and the one it trusts. */
   readonly baseUrl: string;
   readonly singleOrganization: boolean;
+  /**
+   * Whether a new identity has to confirm its address before it can sign in.
+   *
+   * It is the mail transport's `delivers` and nothing else, exactly as the
+   * provider's own `requireEmailVerification` is, so there is one setting and
+   * not two. Signup is where it changes what a person must do next: with mail
+   * configured the provider deliberately issues no session, and a page that did
+   * not know would send somebody into a product they cannot open yet and leave
+   * them back at the sign-in door with no reason given.
+   */
+  readonly emailVerificationRequired: boolean;
 };
 
 type SignupBody = {
@@ -180,6 +191,7 @@ export async function signupRoutes(
       organization: { id: landing.organizationId, name: landing.organizationName },
       project: { id: landing.projectId, name: landing.projectName },
       role: landing.role,
+      emailVerificationRequired: options.emailVerificationRequired,
     });
   });
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -387,6 +387,10 @@ export function buildApi(options: ServerOptions): Api {
     authBasePath: AUTH_BASE_PATH,
     baseUrl: config.baseUrl,
     singleOrganization: config.singleOrganization,
+    // The same value the provider reads for `requireEmailVerification`, from
+    // the same place, so signup cannot say one thing and the provider do
+    // another.
+    emailVerificationRequired: emailSender.delivers,
   });
 
   void app.register(meRoutes, { provider: identity.provider });

--- a/apps/api/test/provider-refusal.test.ts
+++ b/apps/api/test/provider-refusal.test.ts
@@ -70,6 +70,9 @@ async function bothDoors(answer: () => Response): Promise<FastifyInstance> {
     authBasePath: "/api/auth",
     baseUrl: config.baseUrl,
     singleOrganization: false,
+    // Nothing here reaches a successful signup, and the transport this stands
+    // in for is the log one, which posts nothing and requires nothing.
+    emailVerificationRequired: false,
   });
   await app.ready();
   return app;

--- a/apps/web/app/invite/page.tsx
+++ b/apps/web/app/invite/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 import { Field } from "../../ui/form.tsx";
+import { SessionLoading } from "../../ui/session-loading.tsx";
 import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
@@ -53,6 +54,19 @@ export default function InvitePage() {
   const [problem, setProblem] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [attempt, setAttempt] = useState(0);
+  /**
+   * The address a confirmation link was posted to, once one has been.
+   *
+   * **This is the likeliest page in the product to meet it, not the least.**
+   * An invitation can only be delivered by an instance with a mail transport,
+   * and that is exactly the instance on which the provider requires the
+   * address to be confirmed and issues no session for a new identity. So the
+   * colleague who accepted an invitation was the one being walked into a
+   * product they could not open, and turned around at the sign-in door.
+   */
+  const [confirming, setConfirming] = useState<string | null>(null);
+  /** Accepted with a session in hand, and on the way to the product. */
+  const [leaving, setLeaving] = useState(false);
 
   useEffect(() => {
     const given = new URLSearchParams(window.location.search).get("token") ?? "";
@@ -126,6 +140,16 @@ export default function InvitePage() {
         body: JSON.stringify(body),
       });
       if (response.ok) {
+        // Only signing up can leave without a session; accepting as somebody
+        // already signed in is done with the session they arrived holding.
+        const accepted = (await response.json().catch(() => ({}))) as {
+          emailVerificationRequired?: boolean;
+        };
+        if (accepted.emailVerificationRequired === true) {
+          setConfirming(String(body.email ?? ""));
+          return;
+        }
+        setLeaving(true);
         window.location.assign(DEFAULT_SIGNED_IN_PATH);
         return;
       }
@@ -140,13 +164,39 @@ export default function InvitePage() {
     }
   }
 
-  if (state.status === "loading") {
+  if (leaving) return <SessionLoading label="Joining" />;
+
+  /*
+   * The account exists and the address has not been confirmed. It is the end
+   * of the page rather than a notice on it: there is nothing left to type, and
+   * the next thing to do is not on this screen at all.
+   */
+  if (confirming !== null) {
     return (
-      <StatePage
-        title="Loading invitation"
-        lead="Checking the invitation link."
-      />
+      <AuthShell
+        eyebrow="One step left"
+        title="Check your inbox"
+        lead={
+          <>
+            Egma sent a confirmation link to{" "}
+            <strong className="font-medium text-foreground">{confirming}</strong>.
+            Open it to confirm the address, then sign in.
+          </>
+        }
+      >
+        <LinkLine>
+          Confirmed it? <a href="/sign-in">Sign in</a>.
+        </LinkLine>
+        <LinkLine>
+          Nothing arrived after a few minutes? Look in your spam folder, or ask
+          whoever invited you.
+        </LinkLine>
+      </AuthShell>
     );
+  }
+
+  if (state.status === "loading") {
+    return <SessionLoading label="Checking the invitation link" />;
   }
 
   if (state.status === "failed") {

--- a/apps/web/app/invite/page.tsx
+++ b/apps/web/app/invite/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useState } from "react";
 
+import { readSession } from "../../lib/me.ts";
 import {
   DEFAULT_SIGNED_IN_PATH,
   withReturnTo,
@@ -90,28 +91,26 @@ export default function InvitePage() {
         return;
       }
 
-      // Somebody already signed in is offered the button rather than the form.
-      // Somebody signed in as a different person is told so by the refusal, and
-      // that is better than this page guessing what they meant.
-      const me = await fetch("/api/me").catch(() => null);
+      /*
+       * Somebody already signed in is offered the button rather than the form.
+       * Somebody signed in as a different person is told so by the refusal, and
+       * that is better than this page guessing what they meant.
+       *
+       * **Through the bounded read, like every other session read.** This one
+       * decides whether the page leaves `loading`, and `loading` now draws the
+       * cover with the document behind it inert — so a server that accepts the
+       * connection and then says nothing would leave the invited colleague on
+       * a page they cannot retry from, navigate away from, or accept on. It
+       * also stops this page hand-checking the shape of an answer the rest of
+       * the product reads through one type.
+       */
+      const me = await readSession();
       if (!current) return;
-      if (me === null || (me.status !== 401 && !me.ok)) {
+      if (me.status !== "ready" && me.status !== "signed-out") {
         setState({ status: "failed" });
         return;
       }
-      let signedInAs: string | null = null;
-      if (me.ok) {
-        signedInAs = await me
-          .json()
-          .then((body: { user?: { email?: unknown } }) =>
-            typeof body.user?.email === "string" ? body.user.email : null,
-          )
-          .catch(() => null);
-        if (signedInAs === null) {
-          setState({ status: "failed" });
-          return;
-        }
-      }
+      const signedInAs = me.status === "ready" ? me.value.user.email : null;
 
       setState({
         status: "ready",

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -1,25 +1,14 @@
-import { ProductStatePage } from "../ui/shell.tsx";
+import { SessionLoading } from "../ui/session-loading.tsx";
 
 /**
- * What the router draws between the press and
- * `/` arriving.
+ * What the router draws between the press and `/` arriving.
  *
- * **No indicator, deliberately.** The entrance's own waiting state is this
- * header and nothing under it, so a fallback that added a card would put one
- * on screen for the length of the route change and take it away again the
- * moment the page mounted — the shape-change every other file here exists to
- * remove. What the boundary buys is that the entrance paints at once instead
- * of the previous page being held.
- *
- * Its header is the page's own down to its shape — the same eyebrow or the
- * same crumbs, never one standing in for the other — so nothing is redrawn a
- * second way when the page arrives. `agents/loading.tsx` carries the
- * reasoning every one of these shares.
+ * It is the entrance's own waiting state, which is now the same one the
+ * entrance shows while the session read is in flight — so the route change and
+ * the read behind it are one wait rather than two screens replacing each other.
+ * `SessionLoading` owns the delay before it draws, so a warm route still
+ * arrives without this ever having been on screen.
  */
 export default function EntranceLoading() {
-  return (
-    <div data-slot="route-loading">
-      <ProductStatePage title="Opening Egma" lead="Checking your session." />
-    </div>
-  );
+  return <SessionLoading label="Opening Egma" />;
 }

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -6,8 +6,13 @@ import { SessionLoading } from "../ui/session-loading.tsx";
  * It is the entrance's own waiting state, which is now the same one the
  * entrance shows while the session read is in flight — so the route change and
  * the read behind it are one wait rather than two screens replacing each other.
- * `SessionLoading` owns the delay before it draws, so a warm route still
- * arrives without this ever having been on screen.
+ * **It has no delay, and that is a trade rather than an oversight.** The other
+ * route fallbacks in this application wait `--duration-popover-in` before
+ * drawing anything, so a warm route is never covered by a box that appears and
+ * vanishes. This one is opaque on its first frame instead: a shell is mounted
+ * at the root address, and a fifth of a second of transparency here is a fifth
+ * of a second of the dashboard showing to somebody who may not be signed in.
+ * Being early costs a brief mark on a warm load; being late costs the guess.
  */
 export default function EntranceLoading() {
   return <SessionLoading label="Opening Egma" />;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,8 +5,8 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { readJson, type Answer } from "../lib/api.ts";
-import { firstProjectOf, roleOf, type Me } from "../lib/me.ts";
+import type { Answer } from "../lib/api.ts";
+import { firstProjectOf, readSession, roleOf, type Me } from "../lib/me.ts";
 import { projectLanding } from "../lib/project-context.ts";
 import { NEW_PROJECT_PATH } from "../lib/settings.ts";
 import { Actions } from "../ui/section.tsx";
@@ -37,7 +37,14 @@ export default function RootPage() {
     let current = true;
     setAnswer(null);
 
-    void readJson<Me>("/api/me").then((next) => {
+    /*
+     * Bounded, for the reason the shell's own read is: the branch below
+     * covers the whole document and makes it inert, so a read that never
+     * answers would be a page nobody can touch rather than one saying it
+     * could not reach egma. Running out lands on the failure state, which
+     * has a way to try again.
+     */
+    void readSession().then((next) => {
       if (!current) return;
 
       if (next.status === "signed-out") {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -62,10 +62,20 @@ export default function RootPage() {
   }, [attempt, router]);
 
   /*
-   * Nothing is guessed while the session read is in flight, and nothing is
-   * guessed once it comes back signed out either — that branch is already on
-   * its way to `/sign-in`, and the product shell it used to draw in the
-   * meantime was a dashboard shown to somebody who has no account open.
+   * Nothing is guessed while the read is in flight. The product shell this
+   * used to draw in the meantime was a dashboard shown to somebody who may
+   * have no account open at all.
+   *
+   * **The entrance covers itself rather than leaving it to the shell**, and
+   * the reason is what happens after the answer arrives: `/` is the one
+   * address that never stops here, and the shell's own cover comes down the
+   * moment the session settles — which is the moment *before* the redirect
+   * lands, not after it.
+   *
+   * `signed-out` is written beside `null` for that same reason, and it is a
+   * lock rather than a live branch: the redirect above returns before
+   * `setAnswer`, so no render reaches this holding that status today. It costs
+   * one word, and it is the one state that must never uncover.
    */
   if (answer === null || answer.status === "signed-out") {
     return <SessionLoading label="Opening Egma" />;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,7 @@ import { firstProjectOf, roleOf, type Me } from "../lib/me.ts";
 import { projectLanding } from "../lib/project-context.ts";
 import { NEW_PROJECT_PATH } from "../lib/settings.ts";
 import { Actions } from "../ui/section.tsx";
+import { SessionLoading } from "../ui/session-loading.tsx";
 import { ProductStatePage } from "../ui/shell.tsx";
 
 /**
@@ -60,13 +61,14 @@ export default function RootPage() {
     };
   }, [attempt, router]);
 
+  /*
+   * Nothing is guessed while the session read is in flight, and nothing is
+   * guessed once it comes back signed out either — that branch is already on
+   * its way to `/sign-in`, and the product shell it used to draw in the
+   * meantime was a dashboard shown to somebody who has no account open.
+   */
   if (answer === null || answer.status === "signed-out") {
-    return (
-      <ProductStatePage
-        title="Opening Egma"
-        lead="Checking your session."
-      />
-    );
+    return <SessionLoading label="Opening Egma" />;
   }
 
   /**

--- a/apps/web/app/sign-in/page.tsx
+++ b/apps/web/app/sign-in/page.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 import { Field } from "../../ui/form.tsx";
+import { SessionLoading } from "../../ui/session-loading.tsx";
 import { AuthForm, AuthShell, LinkLine, Notice } from "../ui.tsx";
 
 function PasswordVisibilityIcon({ visible }: { readonly visible: boolean }) {
@@ -51,6 +52,14 @@ export default function SignInPage() {
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [problem, setProblem] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  /**
+   * The password was accepted and the browser is on its way out of this page.
+   *
+   * A whole document load stands between the answer and the product, and a form
+   * sitting there with a greyed-out button is the page pretending nothing has
+   * happened. This is the same screen the entrance and signing out show.
+   */
+  const [leaving, setLeaving] = useState(false);
   /** Somebody sent here by a terminal's approval page goes back to it. */
   const [returnTo, setReturnTo] = useState<string | null>(null);
 
@@ -68,6 +77,7 @@ export default function SignInPage() {
         body: JSON.stringify({ email, password }),
       });
       if (response.ok) {
+        setLeaving(true);
         window.location.assign(returnTo ?? DEFAULT_SIGNED_IN_PATH);
         return;
       }
@@ -81,6 +91,8 @@ export default function SignInPage() {
       setSubmitting(false);
     }
   }
+
+  if (leaving) return <SessionLoading label="Signing in" />;
 
   return (
     <AuthShell

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -170,7 +170,9 @@ export default function SignUpPage() {
   }
 
   if (availability === null) {
-    return <SessionLoading label="Opening Egma" />;
+    // Its own sentence, because this is its own question: not who is here, but
+    // whether this instance still takes a first account at all.
+    return <SessionLoading label="Checking whether this instance is ready for setup" />;
   }
 
   if (!availability.open) {

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 import { Field } from "../../ui/form.tsx";
+import { SessionLoading } from "../../ui/session-loading.tsx";
 import { AuthForm, AuthShell, LinkLine, Notice, StatePage } from "../ui.tsx";
 
 /**
@@ -49,6 +50,18 @@ export default function SignUpPage() {
   const [projectName, setProjectName] = useState(DEFAULT_PROJECT_NAME);
   const [problem, setProblem] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  /**
+   * The address a confirmation link was posted to, once one has been.
+   *
+   * **The step that used to be invisible.** Where the instance has a mail
+   * transport, the provider deliberately opens no session until the address is
+   * confirmed — so the page that went straight on to the product sent people to
+   * a door that turned them around, with nothing anywhere saying a message was
+   * waiting for them. This is that message, said on the page that caused it.
+   */
+  const [confirming, setConfirming] = useState<string | null>(null);
+  /** Signed in already, and the browser is on its way to the product. */
+  const [leaving, setLeaving] = useState(false);
   /**
    * Where to go afterwards. Somebody who arrived here from a terminal's
    * approval page goes back to it with their code intact, rather than landing
@@ -95,6 +108,14 @@ export default function SignUpPage() {
         body: JSON.stringify({ email, password, organizationName, projectName }),
       });
       if (response.ok) {
+        const created = (await response.json().catch(() => ({}))) as {
+          emailVerificationRequired?: boolean;
+        };
+        if (created.emailVerificationRequired === true) {
+          setConfirming(email);
+          return;
+        }
+        setLeaving(true);
         window.location.assign(returnTo ?? DEFAULT_SIGNED_IN_PATH);
         return;
       }
@@ -109,13 +130,47 @@ export default function SignUpPage() {
     }
   }
 
-  if (availability === null) {
+  if (leaving) return <SessionLoading label="Setting up Egma" />;
+
+  /*
+   * The account exists and the address has not been confirmed. This is the end
+   * of the page rather than a notice on it: there is nothing left to type here,
+   * and the next thing to do is not on this screen at all.
+   */
+  if (confirming !== null) {
     return (
-      <StatePage
-        title="Loading Egma"
-        lead="Checking whether this instance is ready for setup."
-      />
+      <AuthShell
+        eyebrow="One step left"
+        title="Check your inbox"
+        lead={
+          <>
+            Egma sent a confirmation link to{" "}
+            <strong className="font-medium text-foreground">{confirming}</strong>.
+            Open it to confirm the address, then sign in.
+          </>
+        }
+      >
+        <LinkLine>
+          Confirmed it?{" "}
+          <a
+            href={
+              returnTo === null ? "/sign-in" : withReturnTo("/sign-in", returnTo)
+            }
+          >
+            Sign in
+          </a>
+          .
+        </LinkLine>
+        <LinkLine>
+          Nothing arrived after a few minutes? Look in your spam folder, or ask
+          whoever runs this Egma instance.
+        </LinkLine>
+      </AuthShell>
     );
+  }
+
+  if (availability === null) {
+    return <SessionLoading label="Opening Egma" />;
   }
 
   if (!availability.open) {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -85,11 +85,24 @@ export function unreachable<T>(): Answer<T> {
   };
 }
 
-/** One read, with the project named in it where the caller named one. */
-export async function readJson<T>(path: string): Promise<Answer<T>> {
+/**
+ * One read, with the project named in it where the caller named one.
+ *
+ * **The signal is optional and nothing here decides one.** A read that has to
+ * be bounded says so at the call, because how long a wait is worth depends on
+ * what is waiting on it — a deadline written here would be one that every
+ * request in the product silently inherited. An abort lands in the same catch
+ * as a refused connection, and means the same thing to a page: egma did not
+ * answer.
+ */
+export async function readJson<T>(
+  path: string,
+  options?: { readonly signal?: AbortSignal },
+): Promise<Answer<T>> {
   try {
     const response = await fetch(path, {
       cache: "no-store",
+      ...(options?.signal === undefined ? {} : { signal: options.signal }),
     });
     const body = await response.json().catch(() => null);
     return answerFor<T>(response.status, body);

--- a/apps/web/lib/me.ts
+++ b/apps/web/lib/me.ts
@@ -1,3 +1,4 @@
+import { readJson, type Answer } from "./api.ts";
 import { roleFrom, type Role } from "./roles.ts";
 
 /**
@@ -67,4 +68,38 @@ export function roleOf(me: Me): Role {
 /** The project an entry address with none in it opens. */
 export function firstProjectOf(me: Me): Project | undefined {
   return me.projects[0];
+}
+
+/**
+ * How long the session read may take before egma calls it a failure.
+ *
+ * **It is the one read in this product with a deadline, and what is standing on
+ * it is the reason.** Every other request fails into a page that is already
+ * drawn: a list says it could not load, and the application stays usable around
+ * it. This one holds a cover over the whole document with everything behind it
+ * inert — which is right while the answer is on its way, and a frozen page if
+ * it never comes.
+ *
+ * A connection refused, dropped or reset rejects, and that path always worked.
+ * What this closes is a server that accepts the connection and then says
+ * nothing: no error, no response, and a browser limit of its own measured in
+ * minutes. Twelve seconds is long enough that no real answer is thrown away and
+ * short enough that nobody waits in front of a page they cannot touch.
+ */
+export const SESSION_READ_TIMEOUT_MS = 12_000;
+
+/**
+ * Who is signed in, bounded.
+ *
+ * Both readers of `/api/me` — the shell's session and the entrance — come
+ * through here, so the deadline is one value rather than two that could drift,
+ * and neither of them can be the one that forgets it. A read that runs out
+ * arrives as an ordinary failure, which lands the pages on the states they
+ * already have for one: `Session unavailable` in the shell, and the entrance's
+ * own sentence with a way to try again.
+ */
+export async function readSession(
+  timeoutMs: number = SESSION_READ_TIMEOUT_MS,
+): Promise<Answer<Me>> {
+  return readJson<Me>("/api/me", { signal: AbortSignal.timeout(timeoutMs) });
 }

--- a/apps/web/lib/signup-defaults.ts
+++ b/apps/web/lib/signup-defaults.ts
@@ -13,15 +13,49 @@
 
 export const DEFAULT_PROJECT_NAME = "Default";
 
-/** `ada@acme.example` becomes `Acme`. */
+/** The API's copy of this list carries the reasoning for it. */
+const PERSONAL_MAIL = new Set([
+  "gmail",
+  "googlemail",
+  "outlook",
+  "hotmail",
+  "live",
+  "msn",
+  "yahoo",
+  "ymail",
+  "icloud",
+  "me",
+  "mac",
+  "aol",
+  "proton",
+  "protonmail",
+  "pm",
+  "gmx",
+  "zoho",
+  "yandex",
+  "fastmail",
+  "hey",
+]);
+
+function capitalized(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * `ada@acme.example` becomes `Acme`, and `ada@gmail.com` becomes
+ * `Ada's organization`.
+ */
 export function organizationNameFromEmail(email: string): string {
   const at = email.lastIndexOf("@");
   const domain = at === -1 ? "" : email.slice(at + 1).trim();
   const label = domain.split(".")[0] ?? "";
   const cleaned = label.replace(/[^\p{L}\p{N}]+/gu, " ").trim();
   if (cleaned === "") return "My organization";
-  return cleaned
-    .split(" ")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+
+  if (PERSONAL_MAIL.has(cleaned.toLowerCase())) {
+    const first = email.slice(0, at).split(/[^\p{L}\p{N}]+/u)[0] ?? "";
+    return first === "" ? "My organization" : `${capitalized(first)}'s organization`;
+  }
+
+  return cleaned.split(" ").map(capitalized).join(" ");
 }

--- a/apps/web/lib/signup-defaults.ts
+++ b/apps/web/lib/signup-defaults.ts
@@ -14,7 +14,7 @@
 export const DEFAULT_PROJECT_NAME = "Default";
 
 /** The API's copy of this list carries the reasoning for it. */
-const PERSONAL_MAIL = new Set([
+export const PERSONAL_MAIL = new Set([
   "gmail",
   "googlemail",
   "outlook",
@@ -53,7 +53,9 @@ export function organizationNameFromEmail(email: string): string {
   if (cleaned === "") return "My organization";
 
   if (PERSONAL_MAIL.has(cleaned.toLowerCase())) {
-    const first = email.slice(0, at).split(/[^\p{L}\p{N}]+/u)[0] ?? "";
+    // Lowercased first, so a name shouted in the address bar is not
+    // shouted back: ADA@GMAIL.COM is Ada, not ADA.
+    const first = email.slice(0, at).toLowerCase().split(/[^\p{L}\p{N}]+/u)[0] ?? "";
     return first === "" ? "My organization" : `${capitalized(first)}'s organization`;
   }
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/test/auth-controls.test.tsx
+++ b/apps/web/test/auth-controls.test.tsx
@@ -6,9 +6,25 @@ import ApproveDevicePage from "../app/device/approve/page.tsx";
 import DeviceCodePage from "../app/device/page.tsx";
 import ForgotPasswordPage from "../app/forgot-password/page.tsx";
 import InvitePage from "../app/invite/page.tsx";
+import RootPage from "../app/page.tsx";
 import ResetPasswordPage from "../app/reset-password/page.tsx";
 import SignInPage from "../app/sign-in/page.tsx";
 import SignUpPage from "../app/signup/page.tsx";
+
+/**
+ * The entrance redirects, so the only thing it needs from the router is that.
+ * One object for the whole run, because that is what Next hands back and
+ * because the entrance's effect names the router among its dependencies.
+ */
+const routed = vi.hoisted(() => {
+  const replace = vi.fn();
+  return { replace, router: { replace } };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routed.router,
+  usePathname: () => "/",
+}));
 
 function json(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -20,7 +36,61 @@ function json(status: number, body: unknown): Response {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  routed.replace.mockClear();
   window.history.replaceState({}, "", "/");
+});
+
+/**
+ * One screen for every moment egma does not yet know who is here.
+ *
+ * The four moments were four different screens, and two of them were a guess:
+ * opening the product drew the signed-in shell — sidebar, navigation, account
+ * menu — over the sentence "Checking your session", and then replaced the whole
+ * of it with the sign-in page. What these hold is that no page is chosen before
+ * the answer arrives, and that the same component covers all four.
+ */
+describe("the screen egma shows while the session is unresolved", () => {
+  function waiting(): HTMLElement {
+    return screen.getByRole("status");
+  }
+
+  it("draws no product shell at the entrance while the session read is in flight", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => json(401, {})));
+    render(<RootPage />);
+
+    expect(waiting().dataset.slot).toBe("route-loading");
+    expect(waiting().textContent).toBe("Opening Egma");
+    // The three things a signed-out person was being shown a moment ago.
+    expect(screen.queryByText("Checking your session.")).toBeNull();
+    expect(document.querySelector("aside")).toBeNull();
+    expect(screen.queryByRole("navigation")).toBeNull();
+
+    await waitFor(() => expect(routed.replace).toHaveBeenCalledWith("/sign-in"));
+    // And still nothing guessed on the way out.
+    expect(waiting().dataset.slot).toBe("route-loading");
+  });
+
+  it("covers signing in with the same screen rather than a form that has stopped answering", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, search: "", href: "" });
+    vi.stubGlobal("fetch", vi.fn(async () => json(200, {})));
+    render(<SignInPage />);
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "ada@acme.example" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "correct horse" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => expect(waiting().textContent).toBe("Signing in"));
+    expect(waiting().dataset.slot).toBe("route-loading");
+    // The form is gone rather than sitting there with a greyed-out button for
+    // the length of a whole document load.
+    expect(screen.queryByLabelText("Password")).toBeNull();
+    expect(assign).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("the shared controls on access pages", () => {
@@ -100,6 +170,45 @@ describe("the shared controls on access pages", () => {
     ).toBeTruthy();
     expect(screen.getByText("Trust the voice agents you ship in production.")).toBeTruthy();
     expect(document.querySelector("canvas")).toBeNull();
+  });
+
+  /**
+   * Where the instance posts mail, the provider deliberately opens no session
+   * until the address is confirmed. The page used to walk straight on into the
+   * product, which turned everybody around at the sign-in door with nothing
+   * anywhere saying a message was waiting for them.
+   */
+  it("sends somebody to their inbox when the address has to be confirmed first", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, search: "", href: "" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) =>
+        String(input) === "/api/signup"
+          ? json(201, { emailVerificationRequired: true })
+          : json(200, { open: true }),
+      ),
+    );
+    render(<SignUpPage />);
+
+    fireEvent.change(await screen.findByLabelText("Email"), {
+      target: { value: "ada@acme.example" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "correct horse" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create my Egma instance" }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Check your inbox" }),
+    ).toBeTruthy();
+    // Which inbox, because that is the one thing somebody has to know.
+    expect(screen.getByText("ada@acme.example").tagName).toBe("STRONG");
+    expect(screen.getByRole("link", { name: "Sign in" })).toBeTruthy();
+    // And nobody was sent into a product their session cannot open yet.
+    expect(assign).not.toHaveBeenCalled();
   });
 
   it("keeps a claimed instance invitation clear and does not repeat the heading", async () => {

--- a/apps/web/test/auth-controls.test.tsx
+++ b/apps/web/test/auth-controls.test.tsx
@@ -58,7 +58,7 @@ describe("the screen egma shows while the session is unresolved", () => {
     vi.stubGlobal("fetch", vi.fn(async () => json(401, {})));
     render(<RootPage />);
 
-    expect(waiting().dataset.slot).toBe("route-loading");
+    expect(waiting().dataset.slot).toBe("session-loading");
     expect(waiting().textContent).toBe("Opening Egma");
     // The three things a signed-out person was being shown a moment ago.
     expect(screen.queryByText("Checking your session.")).toBeNull();
@@ -67,7 +67,7 @@ describe("the screen egma shows while the session is unresolved", () => {
 
     await waitFor(() => expect(routed.replace).toHaveBeenCalledWith("/sign-in"));
     // And still nothing guessed on the way out.
-    expect(waiting().dataset.slot).toBe("route-loading");
+    expect(waiting().dataset.slot).toBe("session-loading");
   });
 
   it("covers signing in with the same screen rather than a form that has stopped answering", async () => {
@@ -85,7 +85,7 @@ describe("the screen egma shows while the session is unresolved", () => {
     fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
     await waitFor(() => expect(waiting().textContent).toBe("Signing in"));
-    expect(waiting().dataset.slot).toBe("route-loading");
+    expect(waiting().dataset.slot).toBe("session-loading");
     // The form is gone rather than sitting there with a greyed-out button for
     // the length of a whole document load.
     expect(screen.queryByLabelText("Password")).toBeNull();

--- a/apps/web/test/auth-controls.test.tsx
+++ b/apps/web/test/auth-controls.test.tsx
@@ -267,6 +267,57 @@ describe("the shared controls on access pages", () => {
     expect(screen.getByRole("button", { name: "Join Acme" })).toBeTruthy();
   });
 
+  /**
+   * An invitation can only be delivered by an instance that posts mail, and
+   * that is precisely the instance where the provider requires the address to
+   * be confirmed and issues no session for a new identity. So the invited
+   * colleague is the likeliest person in the product to meet this, and the one
+   * this page used to walk into a product they could not open.
+   */
+  it("sends an invited colleague to their inbox when the address has to be confirmed first", async () => {
+    window.history.replaceState({}, "", "/invite?token=inv_1");
+    const assign = vi.fn();
+    vi.stubGlobal("location", {
+      assign,
+      search: "?token=inv_1",
+      href: "http://egma.test/invite?token=inv_1",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const path = new URL(String(input), "http://egma.test").pathname;
+        if (path === "/api/invitations/lookup") {
+          return json(200, {
+            state: "pending",
+            email: "ada@example.com",
+            role: "member",
+            organization: { name: "Acme" },
+          });
+        }
+        if (path === "/api/me") return json(401, {});
+        if (path === "/api/signup") {
+          return json(201, { emailVerificationRequired: true });
+        }
+        throw new Error(`nothing stubbed for ${path}`);
+      }),
+    );
+
+    render(<InvitePage />);
+
+    fireEvent.change(await screen.findByLabelText("Choose a password"), {
+      target: { value: "correct horse" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Join Acme" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Check your inbox" }),
+    ).toBeTruthy();
+    // The invitation's own address, which is the one the link went to.
+    expect(screen.getByText("ada@example.com").tagName).toBe("STRONG");
+    expect(screen.getByRole("link", { name: "Sign in" })).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+  });
+
   it("keeps password recovery and completion native to the browser", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => json(200, {})));
     const forgot = render(<ForgotPasswordPage />);

--- a/apps/web/test/components.test.tsx
+++ b/apps/web/test/components.test.tsx
@@ -1757,6 +1757,15 @@ describe("the role the shell shows", () => {
     );
   });
 
+  /**
+   * A cold load of a product address: a bookmark opened, or reload pressed.
+   *
+   * The frame mounts with nobody in it, and what used to stand in the two slots
+   * that had no value yet was the sentence "Checking your session…" — the
+   * application's own news, said twice, by two controls that cannot act on it.
+   * The cover says it once now, and each slot draws the shape of the value it
+   * is waiting for.
+   */
   it("claims nothing at all while the session read is in flight", async () => {
     apiAnswers({ "/api/me": "never", "/v1/agents": "never" });
     render(
@@ -1767,7 +1776,17 @@ describe("the role the shell shows", () => {
 
     expect(await screen.findByText("page")).toBeDefined();
     expect(screen.queryByText(/view only/i)).toBeNull();
-    expect(screen.getAllByText(/Checking your session/).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/Checking your session/)).toHaveLength(0);
+
+    // One cover, and nothing behind it left in reach of a Tab step.
+    const covering = screen.getByRole("status");
+    expect(covering.dataset.slot).toBe("session-loading");
+    expect(covering.getAttribute("aria-busy")).toBe("true");
+    expect(
+      [...document.body.children]
+        .filter((one) => !one.contains(covering))
+        .filter((one) => !one.hasAttribute("inert")),
+    ).toEqual([]);
 
     fireEvent.click(screen.getAllByRole("button", { name: /^Account / })[0]!);
     const settings = screen.getByRole("menuitem", { name: "Settings" });

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -49,9 +49,19 @@ describe("the names the signup form offers", () => {
     ["ada@localhost", "Localhost"],
     ["ada@", "My organization"],
     ["not-an-email", "My organization"],
+    /*
+     * A personal address names no company, so what is offered is the person
+     * rather than their mail provider. An organization called `Gmail` is what
+     * the fastest path through this form used to produce, and what somebody
+     * then lived with.
+     */
+    ["ada@gmail.com", "Ada's organization"],
+    ["ada.lovelace@GMAIL.com", "Ada's organization"],
+    ["ada+egma@hotmail.co.uk", "Ada's organization"],
+    ["-@icloud.com", "My organization"],
   ];
 
-  it.each(cases)("takes the organization from the email domain: %s", (email, expected) => {
+  it.each(cases)("takes the organization from the email: %s", (email, expected) => {
     expect(organizationNameFromEmail(email)).toBe(expected);
   });
 

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_PROJECT_NAME as API_DEFAULT_PROJECT_NAME,
   organizationNameFromEmail as apiOrganizationNameFromEmail,
+  PERSONAL_MAIL as API_PERSONAL_MAIL,
 } from "../../api/src/auth/naming.ts";
 import { safeReturnPath as apiSafeReturnPath } from "../../api/src/auth/password-reset.ts";
 import { CODES } from "../../api/src/http/refusals.ts";
@@ -28,6 +29,7 @@ import {
 import {
   DEFAULT_PROJECT_NAME,
   organizationNameFromEmail,
+  PERSONAL_MAIL,
 } from "../lib/signup-defaults.ts";
 
 /**
@@ -58,6 +60,8 @@ describe("the names the signup form offers", () => {
     ["ada@gmail.com", "Ada's organization"],
     ["ada.lovelace@GMAIL.com", "Ada's organization"],
     ["ada+egma@hotmail.co.uk", "Ada's organization"],
+    // An address typed in capitals is the same person, not a shouted one.
+    ["ADA@GMAIL.COM", "Ada's organization"],
     ["-@icloud.com", "My organization"],
   ];
 
@@ -82,6 +86,23 @@ describe("the names the signup form offers", () => {
       );
     }
     expect(DEFAULT_PROJECT_NAME).toBe(API_DEFAULT_PROJECT_NAME);
+  });
+
+  /**
+   * The cases above sample the rule; this holds the whole of it.
+   *
+   * The two copies decide which addresses are personal from a list of twenty
+   * names, and a sample of three cannot see a nineteenth added on one side
+   * only. Comparing the sets is what makes a one-sided edit fail here rather
+   * than in front of somebody whose organization is called `Fastmail`.
+   */
+  it("knows the same personal mail providers on both sides", () => {
+    expect([...PERSONAL_MAIL].sort()).toEqual([...API_PERSONAL_MAIL].sort());
+    for (const provider of PERSONAL_MAIL) {
+      const email = `ada.lovelace@${provider}.example`;
+      expect(organizationNameFromEmail(email)).toBe("Ada's organization");
+      expect(apiOrganizationNameFromEmail(email)).toBe("Ada's organization");
+    }
   });
 });
 /** Every source file under the web application, excluding what it did not write. */

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   DEFAULT_PROJECT_NAME as API_DEFAULT_PROJECT_NAME,
@@ -10,6 +10,8 @@ import {
 } from "../../api/src/auth/naming.ts";
 import { safeReturnPath as apiSafeReturnPath } from "../../api/src/auth/password-reset.ts";
 import { CODES } from "../../api/src/http/refusals.ts";
+import { readJson } from "../lib/api.ts";
+import { readSession, SESSION_READ_TIMEOUT_MS } from "../lib/me.ts";
 import {
   NOTHING_TO_HEAR,
   offersNothing,
@@ -42,6 +44,68 @@ const WEB = path.join(import.meta.dirname, "..");
 /** One conversation, inside the project's monitoring section. */
 const TRANSCRIPT_PAGE =
   "app/projects/[projectId]/monitoring/transcripts/[transcriptId]/page.tsx";
+
+/**
+ * The one read in this application with a deadline on it.
+ *
+ * While it is in flight the whole document is covered and everything behind
+ * the cover is inert, so this read failing to answer is not the same kind of
+ * event as any other read failing to answer: it is a page nobody can touch.
+ * A refused or dropped connection rejects and always ended the wait. A server
+ * that accepts the connection and then says nothing does neither, and that is
+ * the one these hold.
+ */
+describe("reading who is signed in", () => {
+  /** A connection that is open and silent: no response, and no error either. */
+  function stalls(): void {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_path: string, init?: RequestInit) =>
+          new Promise<Response>((_keep, give) => {
+            init?.signal?.addEventListener("abort", () => {
+              give((init.signal as AbortSignal).reason);
+            });
+          }),
+      ),
+    );
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("gives up on a server that accepts the connection and then says nothing", async () => {
+    stalls();
+
+    const answer = await readSession(5);
+
+    // The ordinary failure every page already answers: the shell settles on
+    // it and lifts the cover, and the entrance offers a way to try again.
+    expect(answer.status).toBe("failed");
+    expect(answer).toMatchObject({ refusal: { error: "unreachable" } });
+  });
+
+  it("waits long enough that a slow answer is still an answer", () => {
+    expect(SESSION_READ_TIMEOUT_MS).toBeGreaterThanOrEqual(8_000);
+    expect(SESSION_READ_TIMEOUT_MS).toBeLessThanOrEqual(15_000);
+  });
+
+  /**
+   * The deadline belongs to this read and not to reading JSON. Every other
+   * request in the product fails into a page that is already drawn and stays
+   * usable around it, and a deadline in the shared helper would be one they
+   * all silently inherited.
+   */
+  it("puts no deadline on any other read", async () => {
+    stalls();
+
+    void readJson("/v1/agents");
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    expect((init as RequestInit | undefined)?.signal).toBeUndefined();
+  });
+});
 
 describe("the names the signup form offers", () => {
   const cases: readonly [string, string][] = [

--- a/apps/web/test/pages.test.ts
+++ b/apps/web/test/pages.test.ts
@@ -105,6 +105,35 @@ describe("reading who is signed in", () => {
     const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
     expect((init as RequestInit | undefined)?.signal).toBeUndefined();
   });
+
+  /**
+   * A deadline is only worth anything if every session read goes through it,
+   * and the invitation page is why this is written down: it asked `/api/me`
+   * with a plain fetch of its own, so it kept the exact stall the shell and
+   * the entrance had just been given a bound for — on the one page where the
+   * person waiting has no account yet and nowhere else to go.
+   *
+   * A page that asks this question again with a fetch of its own is that bug
+   * again, and this is what says so while it is being written.
+   */
+  it("is the only way any page asks who is signed in", async () => {
+    const allowed = new Set([
+      // Where the read and its deadline live.
+      "lib/me.ts",
+      // Names the path so this process forwards it, and reads nothing.
+      "next.config.ts",
+    ]);
+
+    for (const [file, source] of await pageSources()) {
+      if (allowed.has(file)) continue;
+      // Comments name the address all over this application. What matters is
+      // that no line of code asks for it.
+      const code = source.replaceAll(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/gu, "");
+      expect(code, `${file} reads the session without a deadline`).not.toContain(
+        "/api/me",
+      );
+    }
+  });
 });
 
 describe("the names the signup form offers", () => {

--- a/apps/web/test/settings.test.tsx
+++ b/apps/web/test/settings.test.tsx
@@ -35,15 +35,26 @@ import { observeRequest, type FetchInput } from "./platform-request.ts";
  * it is not about the project the selector is showing.
  */
 
-const routed = vi.hoisted(() => ({
-  push: vi.fn(),
-  pathname: "/projects/prj_1/settings",
-  projectId: "prj_1",
-}));
+const routed = vi.hoisted(() => {
+  const push = vi.fn();
+  return {
+    push,
+    /*
+     * One router object for the whole run, because that is what Next hands
+     * back. A fresh one on every call is not a harmless test convenience: an
+     * effect that names the router among its dependencies re-runs on every
+     * render, and the entrance's does — so the mock by itself turned reading
+     * the session into a loop that never settled.
+     */
+    router: { push, replace: vi.fn(), back: vi.fn() },
+    pathname: "/projects/prj_1/settings",
+    projectId: "prj_1",
+  };
+});
 
 vi.mock("next/navigation", () => ({
   usePathname: () => routed.pathname,
-  useRouter: () => ({ push: routed.push, replace: vi.fn(), back: vi.fn() }),
+  useRouter: () => routed.router,
   useParams: () => ({ projectId: routed.projectId }),
 }));
 

--- a/apps/web/ui/session-loading.tsx
+++ b/apps/web/ui/session-loading.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
 /**
  * The one screen egma shows while it does not yet know who is here.
  *
@@ -8,32 +11,67 @@
  * session", and replace the whole of it a moment later. Somebody signed out
  * met a dashboard that was never theirs; somebody signed in met a page saying
  * egma was unsure. Both are a screen chosen before the answer arrived. This is
- * what stands there instead, at all four points where the session is
- * unresolved or changing: opening the product, the route fallback under it,
- * signing in, and signing out.
+ * what stands there instead, everywhere the session is unresolved or changing:
+ * the entrance, any product address on a cold load, signing in, signing up,
+ * and signing out.
  *
  * **The mark is still.** `DESIGN.md` forbids animating the logo, so what moves
  * is a separate indicator under it — the "fast, quiet indicator" that file
  * gives a loading state — and its motion lives in `tailwind-theme.css` beside
- * the run mark's turn, keyed on the `session-progress` slot below.
+ * the run mark's turn, keyed on the `session-progress` slot below. The segment
+ * is ink rather than the brand orange, which is the ruling `progress.tsx`
+ * already wrote down for the one other bar in this product that fills.
  *
- * **It is opaque on its first frame, and deliberately does not take the wait
- * every other loading state here takes.** A route fallback fades in after
- * `--duration-popover-in` so that a warm route is never covered by a box that
- * appears and vanishes. This one has the opposite job: the persistent product
- * boundary keeps a shell mounted at the root address, so a screen that spent a
- * fifth of a second transparent would show exactly the guess it exists to
- * cover. Being early is what it is for.
+ * **It says what it is waiting for.** A wordmark and a moving bar alone are a
+ * screen with no words on it, and `DESIGN.md` asks every state to say what
+ * happened. The line is short, quiet, and different on each moment, because
+ * they are different waits.
  *
- * `fixed` rather than a page layout, so the same component is both the whole of
- * an entrance and the cover over a shell that is being signed out of.
+ * **It is opaque on its first frame**, and deliberately does not take the wait
+ * every other loading state here takes. A route fallback fades in after
+ * `--duration-popover-in` so a warm route is never covered by a box that
+ * appears and vanishes. This one has the opposite job: a shell is mounted
+ * behind it, so a screen that spent a fifth of a second transparent would show
+ * exactly the guess it exists to cover.
+ *
+ * **It leaves the document behind it, and takes it out of reach.** The cover
+ * goes to the end of `document.body` so nothing anchored inside the shell — a
+ * sticky sidebar at `z-20`, a sheet at `z-30`, a toast at `z-50` — floats over
+ * it. Everything else in the body goes `inert` while it stands, because a
+ * control hidden from eyes and still reachable by Tab or by a screen reader is
+ * worse than one that is simply there. That is the trade a dialog already
+ * makes.
  */
 export function SessionLoading({ label }: { readonly label: string }) {
-  return (
+  const [host, setHost] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // Read before appending, so the cover's own host is never in the list, and
+    // anything already inert for another reason is left exactly as it was.
+    const covered = [...document.body.children].filter(
+      (one) => !one.hasAttribute("inert"),
+    );
+    for (const one of covered) one.setAttribute("inert", "");
+
+    const node = document.createElement("div");
+    node.dataset.slot = "session-loading-host";
+    document.body.append(node);
+    setHost(node);
+
+    return () => {
+      for (const one of covered) one.removeAttribute("inert");
+      node.remove();
+    };
+  }, []);
+
+  if (host === null) return null;
+
+  return createPortal(
     <div
       data-slot="session-loading"
       className="fixed inset-0 z-50 grid place-items-center bg-background px-6"
       role="status"
+      aria-busy="true"
     >
       <div className="flex flex-col items-center gap-6">
         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -46,23 +84,25 @@ export function SessionLoading({ label }: { readonly label: string }) {
           className="block h-8 w-auto [[data-theme=dark]_&]:invert"
           src="/brand/egma-wordmark.svg"
           /*
-           * Empty on purpose. The whole screen is one `status`, and the
-           * sentence below is what it announces — a second name here would
-           * have a screen reader read the product's name and then the same
-           * name again inside what is happening to it.
+           * Empty on purpose. The line below says what is happening, and a
+           * name here would have a screen reader read the product's name and
+           * then the same name again inside the sentence about it.
            */
           alt=""
           height={32}
         />
-        <span
-          data-slot="session-progress"
-          className="block h-0.5 w-40 overflow-hidden bg-border"
-          aria-hidden="true"
-        >
-          <span className="block h-full w-1/3 bg-brand" />
-        </span>
-        <span className="sr-only">{label}</span>
+        <div className="flex flex-col items-center gap-3">
+          <span
+            data-slot="session-progress"
+            className="block h-0.5 w-40 overflow-hidden bg-border"
+            aria-hidden="true"
+          >
+            <span className="block h-full w-1/3 bg-foreground" />
+          </span>
+          <p className="m-0 text-sm text-muted-foreground">{label}</p>
+        </div>
       </div>
-    </div>
+    </div>,
+    host,
   );
 }

--- a/apps/web/ui/session-loading.tsx
+++ b/apps/web/ui/session-loading.tsx
@@ -17,10 +17,13 @@
  * gives a loading state — and its motion lives in `tailwind-theme.css` beside
  * the run mark's turn, keyed on the `session-progress` slot below.
  *
- * It carries `route-loading` so it inherits that file's wait before drawing: a
- * session that answers inside `--duration-popover-in` is never covered by this
- * at all, because a screen that appears and vanishes inside a fifth of a second
- * reads as a fault rather than as speed.
+ * **It is opaque on its first frame, and deliberately does not take the wait
+ * every other loading state here takes.** A route fallback fades in after
+ * `--duration-popover-in` so that a warm route is never covered by a box that
+ * appears and vanishes. This one has the opposite job: the persistent product
+ * boundary keeps a shell mounted at the root address, so a screen that spent a
+ * fifth of a second transparent would show exactly the guess it exists to
+ * cover. Being early is what it is for.
  *
  * `fixed` rather than a page layout, so the same component is both the whole of
  * an entrance and the cover over a shell that is being signed out of.
@@ -28,7 +31,7 @@
 export function SessionLoading({ label }: { readonly label: string }) {
   return (
     <div
-      data-slot="route-loading"
+      data-slot="session-loading"
       className="fixed inset-0 z-50 grid place-items-center bg-background px-6"
       role="status"
     >

--- a/apps/web/ui/session-loading.tsx
+++ b/apps/web/ui/session-loading.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * The one screen egma shows while it does not yet know who is here.
+ *
+ * **It guesses nothing.** Opening the product used to draw the signed-in shell
+ * — sidebar, navigation, account menu — over the sentence "Checking your
+ * session", and replace the whole of it a moment later. Somebody signed out
+ * met a dashboard that was never theirs; somebody signed in met a page saying
+ * egma was unsure. Both are a screen chosen before the answer arrived. This is
+ * what stands there instead, at all four points where the session is
+ * unresolved or changing: opening the product, the route fallback under it,
+ * signing in, and signing out.
+ *
+ * **The mark is still.** `DESIGN.md` forbids animating the logo, so what moves
+ * is a separate indicator under it — the "fast, quiet indicator" that file
+ * gives a loading state — and its motion lives in `tailwind-theme.css` beside
+ * the run mark's turn, keyed on the `session-progress` slot below.
+ *
+ * It carries `route-loading` so it inherits that file's wait before drawing: a
+ * session that answers inside `--duration-popover-in` is never covered by this
+ * at all, because a screen that appears and vanishes inside a fifth of a second
+ * reads as a fault rather than as speed.
+ *
+ * `fixed` rather than a page layout, so the same component is both the whole of
+ * an entrance and the cover over a shell that is being signed out of.
+ */
+export function SessionLoading({ label }: { readonly label: string }) {
+  return (
+    <div
+      data-slot="route-loading"
+      className="fixed inset-0 z-50 grid place-items-center bg-background px-6"
+      role="status"
+    >
+      <div className="flex flex-col items-center gap-6">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          /*
+           * Sized by its own viewBox, exactly as the access surface's `Brand`
+           * and the sidebar's mark are: a width in the class list would be a
+           * second declaration of the logo's proportion.
+           */
+          className="block h-8 w-auto [[data-theme=dark]_&]:invert"
+          src="/brand/egma-wordmark.svg"
+          /*
+           * Empty on purpose. The whole screen is one `status`, and the
+           * sentence below is what it announces — a second name here would
+           * have a screen reader read the product's name and then the same
+           * name again inside what is happening to it.
+           */
+          alt=""
+          height={32}
+        />
+        <span
+          data-slot="session-progress"
+          className="block h-0.5 w-40 overflow-hidden bg-border"
+          aria-hidden="true"
+        >
+          <span className="block h-full w-1/3 bg-brand" />
+        </span>
+        <span className="sr-only">{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -25,6 +25,7 @@ import {
 
 import { Badge } from "@/components/ui/badge";
 import { SheetHost } from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import {
   SidebarBrand,
@@ -352,9 +353,23 @@ function OrganizationMenu({
           className="flex min-h-(--control-lg) min-w-0 flex-1 items-center px-2"
           data-slot="organization-status"
         >
-          <span className="min-w-0 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-muted-foreground">
-            {settled ? "No organization" : "Checking your session…"}
-          </span>
+          {/*
+           * **A bar, not a sentence, while nobody has answered.** This slot
+           * used to say "Checking your session…" — the sentence the developer
+           * met on opening the product, one control down. It is also a claim
+           * this bar has no business making: the session is the whole
+           * application's business, `SessionLoading` is what says it, and a
+           * sidebar row saying it too is the same news twice from a place that
+           * cannot act on it. What belongs here is what belongs in any slot
+           * whose value has not arrived: the shape of the value.
+           */}
+          {settled ? (
+            <span className="min-w-0 overflow-hidden text-sm text-ellipsis whitespace-nowrap text-muted-foreground">
+              No organization
+            </span>
+          ) : (
+            <Skeleton className="h-3 w-28" />
+          )}
         </div>
       </>
     );
@@ -469,7 +484,17 @@ function AccountMenu({
 }) {
   const [signingOut, setSigningOut] = useState(false);
   const email = me?.user.email ?? "";
-  const standing = me !== null ? email : settled ? "Session unavailable" : "Checking your session…";
+  /**
+   * The control's own name for whoever it stands for.
+   *
+   * Three states, and the middle one used to be "Checking your session…" —
+   * the application's news, said by a control that is not the application. It
+   * is "Loading account" now: this control is loading this account, which is
+   * both true and the only part of it this control knows. The visible slot
+   * draws a bar rather than the words, because a sentence in a name slot is a
+   * value that is not a name.
+   */
+  const standing = me !== null ? email : settled ? "Session unavailable" : "Loading account";
   const initial = me !== null ? (email.trim().slice(0, 1).toUpperCase() || "E") : "·";
 
   async function signOut(): Promise<void> {
@@ -534,9 +559,13 @@ function AccountMenu({
             </span>
             {compact ? null : (
               <span className="min-w-0">
-                <span className="block overflow-hidden text-sm text-ellipsis whitespace-nowrap">
-                  {standing}
-                </span>
+                {me === null && !settled ? (
+                  <Skeleton className="h-3 w-24" />
+                ) : (
+                  <span className="block overflow-hidden text-sm text-ellipsis whitespace-nowrap">
+                    {standing}
+                  </span>
+                )}
                 {role === null ? null : (
                   /* 12px: the micro label the boards give the role line (`720-0`). */
                   <span className="block text-2xs tracking-(--tracking-label) text-faint uppercase">
@@ -708,9 +737,26 @@ function ShellFrame({
     />
   );
 
+  /**
+   * A cold load of a product address, before the session read has answered.
+   *
+   * Opening `/projects/…` from a bookmark, or pressing reload on one, mounts
+   * this whole frame with nobody in it — an organization bar, a project
+   * selector and an account control all standing there with no facts behind
+   * them. That is the same guessed screen the entrance used to draw, on every
+   * other address in the product, so it takes the same cover.
+   *
+   * **The entrance is left to draw its own**, and that is the one exception. It
+   * has to stay covered past the moment the session settles, because `/` never
+   * stops there: it is on its way to a project or to sign-in, and a shell
+   * uncovered between those two moments is the flash all of this removes.
+   */
+  const unresolved = !session.settled && pathname !== "/";
+
   return (
     <SessionContext.Provider value={session}>
     <DraftNavigationProvider>
+    {unresolved ? <SessionLoading label="Opening Egma" /> : null}
     <div
       className={cn(
         "grid min-h-svh bg-background",

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -40,9 +40,9 @@ import {
   SidebarProvider,
 } from "@/components/ui/sidebar";
 
-import { readJson } from "../lib/api.ts";
 import {
   organizationOf,
+  readSession,
   roleOf,
   type Me,
   type Organization,
@@ -126,7 +126,14 @@ export function useSession(initial?: Me): Session {
   const refresh = useCallback(async () => {
     const thisRequest = request.current + 1;
     request.current = thisRequest;
-    const answer = await readJson<Me>("/api/me");
+    /*
+     * Bounded, and `settled` below is why. A read that never answers used to
+     * leave a shell with empty slots in it; it now leaves a cover with the
+     * document behind it inert, so a server that accepts the connection and
+     * then says nothing would freeze the page rather than degrade it. The
+     * deadline turns that into an ordinary failure, and this line runs.
+     */
+    const answer = await readSession();
     if (!mounted.current || request.current !== thisRequest) return;
 
     if (answer.status === "ready") setMe(answer.value);

--- a/apps/web/ui/shell.tsx
+++ b/apps/web/ui/shell.tsx
@@ -64,6 +64,7 @@ import {
 } from "./page-navigation.tsx";
 import { ProjectSelector } from "./project-selector.tsx";
 import { Toolbar } from "./section.tsx";
+import { SessionLoading } from "./session-loading.tsx";
 import { settingsPath } from "./settings-nav.tsx";
 import { useTheme } from "./theme.tsx";
 
@@ -482,80 +483,89 @@ function AccountMenu({
   }
 
   return (
-    <Menu
-      label={`Account ${standing}. Open the account menu`}
-      triggerClassName={cn(
-        "grid w-full min-w-0 items-center gap-3",
-        /*
-         * **7px, and the missing pixel is the plate's own hairline.** This
-         * trigger reserves its hover border as a transparent one so hovering
-         * shifts nothing, and `box-sizing: border-box` means that border spends
-         * a pixel of the inset before the padding starts. Written as 8px it put
-         * the avatar on 17 while every nav icon stood on 16 — the one thing
-         * still out of the bar's lane. Written as 8 minus the hairline it lands
-         * on 16 exactly, and the gap from the plate's visible edge to the
-         * avatar is a true 8px, which is what a borderless nav row already
-         * draws between its plate and its icon.
-         */
-        "grid-cols-[var(--control-md)_minmax(0,1fr)] min-h-(--control-lg) py-1",
-        "px-[calc(var(--space-2)-1px)]",
-        "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
-        "transition-transform duration-(--duration-press) ease-out",
-        "pointer-coarse:min-h-(--tap-target)",
-        "pointer-hover:border-border pointer-hover:bg-surface",
-        "[&:active:not(:focus-visible)]:scale-97",
-        "motion-reduce:transition-none",
-        "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
-        compact && "w-(--tap-target) min-h-(--tap-target) grid-cols-[var(--tap-target)] p-0",
-      )}
-      openClassName="border-border bg-surface"
-      placement={placement}
-      trigger={
-        <>
-          <span
-            className={cn(
-              "grid size-(--control-md) flex-none place-items-center",
-              "rounded-none border border-border bg-surface-soft text-sm",
-              compact && "size-(--tap-target)",
-            )}
-            data-slot="account-avatar"
-            aria-hidden="true"
-          >
-            {initial}
-          </span>
-          {compact ? null : (
-            <span className="min-w-0">
-              <span className="block overflow-hidden text-sm text-ellipsis whitespace-nowrap">
-                {standing}
-              </span>
-              {role === null ? null : (
-                /* 12px: the micro label the boards give the role line (`720-0`). */
-                <span className="block text-2xs tracking-(--tracking-label) text-faint uppercase">
-                  {canAuthor(role) ? role : VIEW_ONLY}
-                </span>
+    <>
+      {/*
+       * Signing out is a document load away from the sign-in page, and until
+       * this cover existed the whole of it was a menu item that said
+       * "Signing out…" behind a shell still showing the session being ended.
+       * It is the entrance's own screen, so the two ends of a visit look alike.
+       */}
+      {signingOut ? <SessionLoading label="Signing out" /> : null}
+      <Menu
+        label={`Account ${standing}. Open the account menu`}
+        triggerClassName={cn(
+          "grid w-full min-w-0 items-center gap-3",
+          /*
+           * **7px, and the missing pixel is the plate's own hairline.** This
+           * trigger reserves its hover border as a transparent one so hovering
+           * shifts nothing, and `box-sizing: border-box` means that border spends
+           * a pixel of the inset before the padding starts. Written as 8px it put
+           * the avatar on 17 while every nav icon stood on 16 — the one thing
+           * still out of the bar's lane. Written as 8 minus the hairline it lands
+           * on 16 exactly, and the gap from the plate's visible edge to the
+           * avatar is a true 8px, which is what a borderless nav row already
+           * draws between its plate and its icon.
+           */
+          "grid-cols-[var(--control-md)_minmax(0,1fr)] min-h-(--control-lg) py-1",
+          "px-[calc(var(--space-2)-1px)]",
+          "cursor-pointer rounded-input border border-transparent bg-transparent text-left",
+          "transition-transform duration-(--duration-press) ease-out",
+          "pointer-coarse:min-h-(--tap-target)",
+          "pointer-hover:border-border pointer-hover:bg-surface",
+          "[&:active:not(:focus-visible)]:scale-97",
+          "motion-reduce:transition-none",
+          "motion-reduce:[&:active:not(:focus-visible)]:scale-100",
+          compact && "w-(--tap-target) min-h-(--tap-target) grid-cols-[var(--tap-target)] p-0",
+        )}
+        openClassName="border-border bg-surface"
+        placement={placement}
+        trigger={
+          <>
+            <span
+              className={cn(
+                "grid size-(--control-md) flex-none place-items-center",
+                "rounded-none border border-border bg-surface-soft text-sm",
+                compact && "size-(--tap-target)",
               )}
+              data-slot="account-avatar"
+              aria-hidden="true"
+            >
+              {initial}
             </span>
-          )}
-        </>
-      }
-    >
-      {(close) => (
-        <>
-          <MenuLabel>{standing}</MenuLabel>
-          <MenuItem
-            {...(settingsHref === null ? { disabled: true } : { href: settingsHref })}
-            onClick={close}
-          >
-            Settings
-          </MenuItem>
-          <MenuDivider />
-          <ThemeItem />
-          <MenuItem disabled={signingOut} onClick={() => void signOut()}>
-            {signingOut ? "Signing out…" : "Sign out"}
-          </MenuItem>
-        </>
-      )}
-    </Menu>
+            {compact ? null : (
+              <span className="min-w-0">
+                <span className="block overflow-hidden text-sm text-ellipsis whitespace-nowrap">
+                  {standing}
+                </span>
+                {role === null ? null : (
+                  /* 12px: the micro label the boards give the role line (`720-0`). */
+                  <span className="block text-2xs tracking-(--tracking-label) text-faint uppercase">
+                    {canAuthor(role) ? role : VIEW_ONLY}
+                  </span>
+                )}
+              </span>
+            )}
+          </>
+        }
+      >
+        {(close) => (
+          <>
+            <MenuLabel>{standing}</MenuLabel>
+            <MenuItem
+              {...(settingsHref === null ? { disabled: true } : { href: settingsHref })}
+              onClick={close}
+            >
+              Settings
+            </MenuItem>
+            <MenuDivider />
+            <ThemeItem />
+            <MenuItem disabled={signingOut} onClick={() => void signOut()}>
+              {signingOut ? "Signing out…" : "Sign out"}
+            </MenuItem>
+          </>
+        )}
+      </Menu>
+    </>
   );
 }
 

--- a/apps/web/ui/tailwind-theme.css
+++ b/apps/web/ui/tailwind-theme.css
@@ -806,6 +806,20 @@
 }
 
 /*
+ * The segment crossing the track on the screen that stands in for a session
+ * nobody has answered for yet.
+ *
+ * `translate` and nothing else, for the reason the drawer's keyframes give: it
+ * is composited, and it leaves the segment's own width to the class list rather
+ * than replacing it. It starts and ends clear of the track, so the crossing has
+ * no visible beginning and no visible end to read as a stall.
+ */
+@keyframes egma-session-progress {
+  from { translate: -100% 0; }
+  to { translate: 300% 0; }
+}
+
+/*
  * The skeleton's breath: one dip and back, so a bar never leaves the page.
  *
  * It is written here rather than borrowed from Tailwind's own pulse, which is
@@ -936,6 +950,24 @@
     [data-slot="state-mark"][data-motion="active"] {
       animation: none;
     }
+  }
+
+  /*
+   * The same rule for the screen that stands in while a session is unresolved.
+   *
+   * The Egma mark above this never moves — `DESIGN.md` forbids animating the
+   * logo — so one segment crossing a hairline track is the whole of the quiet
+   * indicator. Four drawer-enters for a crossing: a token rather than a number,
+   * and slow enough to read as work rather than as alarm.
+   *
+   * Reduced motion is answered once, in `globals.css`, which holds every
+   * animation to a single frame. What is left is a segment standing in its
+   * track — the same trade the skeleton bars make — and the sentence this
+   * screen announces carries the meaning either way.
+   */
+  [data-slot="session-progress"] > * {
+    animation: egma-session-progress calc(var(--duration-drawer-in) * 4)
+      var(--ease-in-out) infinite;
   }
 
   /*


### PR DESCRIPTION
Part of the prod-polish pass of 2026-08-26 (developer annotations 1–5 from live prod). Targets the integration branch, not main.

## What

- **One session screen** (items 1, 3, 4): a shared `SessionLoading` cover — static Egma wordmark, foreground ink segment on a hairline track, a visible line saying what it waits for — portalled to `document.body`, `role="status"` + `aria-busy`, with everything behind it made `inert`. It stands wherever Egma does not yet know who is here: the entrance at `/`, cold loads and refreshes of any product route, signing in, signing up, signing out, and the invite lookup. The "Checking your session…" strings are gone (the two sidebar slots honestly skeleton while org/account data loads).
- **Verify-your-mailbox** (item 2): with SMTP configured, sign-up returns no session (`emailVerificationRequired` on the 201 body, wired from the same `emailSender.delivers` the provider reads — the two cannot disagree). The signup page now draws a "Check your inbox" screen with the address instead of bouncing to sign-in unexplained. The **invite page had the same bounce** — every invited colleague hit it — and now draws the same screen.
- **Org name** (item 5): the signup form already had an explicit, editable, required Organization field; the defect was the prefill — `ada@gmail.com` produced an organization literally named "Gmail". Both copies of the derivation (api + web) now treat 20 personal-mail domains as the person: `Ada's organization`, case-normalized. A parity test compares the two sets and all twenty derivations, so a one-sided edit fails.

## Checks

Scoped fast lane: 610 tests across 28 files (web + api signup/invitations/provider-refusal), all green; web typecheck, tests tsconfig, repo lint clean. Live browser proof in light/dark/mobile: cover, inbox screen, invite screen, inert focus containment, prefill. Independent review + adversarial verification done pre-PR (inert bookkeeping correct by construction; the cover cannot strand — `settled` always flips, network failure lands on truthful terminal states; merge proven clean against both sibling branches).

## Recorded leftovers (deliberate)

- Mail-provider employees (`ada@zoho.com`) prefill as the person; the field is editable.
- Multi-label work domains (`mail.acme.co.uk` → "Mail") — pre-existing first-label rule.
- The org-slot skeleton has no accessible name (unreachable while covered); the lookup pages reuse the full cover (one-loader choice); `*`/`[optional]` label grammar on the access pages is a separate cross-page pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790439492&installation_model_id=431960&pr_number=251&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F251&signature=82334ba0048790bc0e5ba951d75dd637ef1a8f54383532140d51bb132beceb5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a shared full-screen session-loading state, bounds all `/api/me` reads, explains verification-required signup outcomes, and improves personal-email organization defaults.
- Routes shell, entrance, and invitation session checks through the shared bounded reader.
- Adds mailbox-confirmation states for signup and invitation acceptance.
- Adds an inert, portalled loading cover for unresolved and transitioning sessions.
- Keeps API and web organization-name derivation aligned for personal-mail domains.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported stalled-session paths now use the bounded session reader and transition to terminal states after failures.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/lib/me.ts | Centralizes `/api/me` behind a bounded session reader that converts timeout failures into the existing response model. |
| apps/web/app/invite/page.tsx | Uses the bounded session reader and adds an explicit mailbox-confirmation completion state. |
| apps/web/ui/session-loading.tsx | Adds the shared portalled loading cover and restores body inert attributes during cleanup. |
| apps/web/ui/shell.tsx | Covers unresolved and sign-out transitions while routing session refreshes through the bounded reader. |
| apps/api/src/routes/signup.ts | Exposes whether email verification is required using the provider’s mail-delivery configuration. |
| apps/api/src/auth/naming.ts | Derives editable organization defaults from the user name for known personal-mail domains. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant B as Browser
  participant W as Web application
  participant A as API
  B->>W: Open entrance, product, or invitation
  W->>B: Show SessionLoading and make background inert
  W->>A: Bounded /api/me read
  alt Session is ready
    A-->>W: Account and organization
    W->>B: Remove cover and show product
  else Signed out
    A-->>W: 401
    W->>B: Continue to sign-in
  else Timeout or transport failure
    W->>B: Remove cover and show retryable failure
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): the invitation page asks who i..."](https://github.com/egma-ai/egma/commit/20986452c5a5554073ff33922e49cc606ff02659) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57565710)</sub>

**Context used:**

- Knowledge Base — [Web application](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/web-application.md)
- Knowledge Base — [API workflows and resource management](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/api-workflows.md)

<!-- /greptile_comment -->