### PR TITLE
Fix cached npx upgrades for the CLI

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -61,17 +61,45 @@ jobs:
         # Root build is lint + tsc -b over every project the CLI is built from.
         run: pnpm build
 
-      - name: Prove the tarball runs
-        # The same check a person would do by hand: pack it, install it
-        # somewhere clean, and run the command. Catches a missing runtime
-        # dependency or a broken bin entry before it reaches anyone.
+      - name: Pack the public CLI
+        id: pack
+        # pnpm rewrites workspace dependency ranges to publishable versions.
+        # npm does not. npm still performs the final publish for trusted OIDC.
         run: |
           set -e
           dir="$(mktemp -d)"
-          (cd apps/cli && npm pack --pack-destination "$dir")
-          tarball="$(ls "$dir"/*.tgz)"
-          cd "$dir"
+          pnpm --config.node-linker=hoisted --filter @egma/cli pack --pack-destination "$dir"
+          echo "tarball=$(ls "$dir"/*.tgz)" >> "$GITHUB_OUTPUT"
+
+      - name: Prove new and upgraded installs
+        # Pack once, then prove both user paths: a clean install and an upgrade
+        # from the current public version. The upgrade proof catches invalid
+        # registry metadata that a clean install of bundled files can hide.
+        run: |
+          set -e
+          tarball="${{ steps.pack.outputs.tarball }}"
+          dir="$(dirname "$tarball")"
+          tar -xOf "$tarball" package/package.json > "$dir/packed-package.json"
+          node -e '
+            const manifest = require(process.argv[1]);
+            const invalid = Object.entries(manifest.dependencies ?? {})
+              .filter(([, spec]) => String(spec).startsWith("workspace:"));
+            if (invalid.length > 0) {
+              const names = invalid.map(([name]) => name).join(", ");
+              console.error(`Published dependencies use workspace protocol: ${names}`);
+              process.exit(1);
+            }
+          ' "$dir/packed-package.json"
+          mkdir "$dir/clean"
+          cd "$dir/clean"
           npm init -y > /dev/null
+          npm install "$tarball" --no-audit --no-fund
+          ./node_modules/.bin/egma --version
+          mkdir "$dir/upgrade"
+          cd "$dir/upgrade"
+          npm init -y > /dev/null
+          previous="$(npm view @egma/cli version)"
+          npm install "@egma/cli@$previous" --no-audit --no-fund
           npm install "$tarball" --no-audit --no-fund
           ./node_modules/.bin/egma --version
 
@@ -83,16 +111,16 @@ jobs:
         # The dry run is the only place this shows up. Treat it as fatal.
         run: |
           set -e
-          out="$(npm publish --dry-run 2>&1)"
+          status=0
+          out="$(npm publish --dry-run "${{ steps.pack.outputs.tarball }}" 2>&1)" || status=$?
           echo "$out"
           if echo "$out" | grep -qi "auto-corrected some errors"; then
-            echo "::error::npm would rewrite apps/cli/package.json before publishing. Fix it rather than shipping the rewrite." >&2
+            echo "::error::npm would rewrite the packed manifest before publishing. Fix it rather than shipping the rewrite." >&2
             exit 1
           fi
-        working-directory: apps/cli
+          exit "$status"
 
       - name: Publish to npm
         # npm, not pnpm: OIDC trusted publishing lives in the npm CLI.
         # No NODE_AUTH_TOKEN — the OIDC exchange is the credential.
-        run: npm publish
-        working-directory: apps/cli
+        run: npm publish "${{ steps.pack.outputs.tarball }}"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egma/cli",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "description": "The Egma wizard and client: npx @egma/cli walks a developer to their first run.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What changed

- pack the CLI with pnpm so public workspace dependencies become valid SemVer
- publish the exact tarball that passed the checks
- test both a clean install and an upgrade from the current npm version
- print npm dry-run failures before exiting
- bump the hotfix version to 0.2.14

## Root cause

`@egma/cli@0.2.13` published `workspace:*` for two bundled runtime dependencies. A clean install could use the bundles, but npm failed while replacing a cached 0.2.12 install. Release CI tested only the clean path.

## Proof

- reproduced 0.2.12 -> 0.2.13: `EUNSUPPORTEDPROTOCOL`
- proved 0.2.13 -> packed 0.2.14 succeeds
- proved a clean packed 0.2.14 install succeeds
- proved the packed manifest has `0.0.0` dependency versions and keeps both bundles
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `npm publish --dry-run <tarball>`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790472760&installation_model_id=431960&pr_number=253&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F253&signature=c108f4c29928c053cd2d6c858bf432074d9d9cc02f8b41bdfb94229c9ced163f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes the CLI release workflow to create a single pnpm-packed artifact and use that artifact for installation tests, npm dry-run validation, and publication. It also bumps the CLI hotfix version.

- Packs the CLI with pnpm so workspace dependency specifications are rewritten for publication.
- Tests both clean installation and upgrade from the current npm release.
- Publishes exactly the tarball that passed validation and preserves dry-run diagnostics.
- Bumps `@egma/cli` from 0.2.13 to 0.2.14.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the packed artifact is exercised through both installation paths and reused consistently for validation and publication.

The workflow builds before packing, rejects residual workspace dependency protocols, runs the resulting CLI after clean and upgrade installs, and publishes the exact tarball that passed those checks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release-cli.yml | Packs once with pnpm, validates clean and upgrade installs, reports dry-run failures, and publishes the same checked tarball. |
| apps/cli/package.json | Bumps the CLI package version from 0.2.13 to 0.2.14 for the packaging hotfix. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  B[Build workspace] --> P[Pack CLI with pnpm]
  P --> M[Validate packed manifest]
  M --> C[Test clean install]
  C --> U[Test upgrade install]
  U --> D[npm publish dry run]
  D --> R[Publish same tarball]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): publish installable workspace ..."](https://github.com/egma-ai/egma/commit/cfe36bf25665658568bac80184b9f9624ca48792) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57757773)</sub>

<!-- /greptile_comment -->