### PR TITLE
Retell web-call plug: the simulator conducts over the draft

### DIFF
--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -49,9 +49,12 @@ touching the others:
   travels. One driver per way in, behind a four-method seam: create a
   Pipecat transport, dial, wait until somebody answers, tear it down.
   `livekit.py` places real phone calls over the SIP trunk carried by the
-  claimed work order; `livekit_room.py` holds an exchange in the
-  customer's own room and dispatches their agent into it, where "dial" means asking for a
-  worker rather than placing a call; `scripted.py` is the local stand-in
+  claimed work order; `livekit_room.py` holds an exchange in a room
+  joined three ways — one egma makes and dispatches into, one a
+  customer's own endpoint mints the way into, and one a platform opened
+  for a call of its own — where "dial" means asking for a worker rather
+  than placing a call, and asks for nobody at all on the two shapes egma
+  holds no key pair for; `scripted.py` is the local stand-in
   that answers a call nobody placed, and is what CI runs on. The two that
   join a room share `room.py`, which is the joining itself. Nothing above
   the seam — the plug's lifecycle, the pipeline, the recording, the
@@ -502,7 +505,8 @@ src/egma_simulator/
   media/          The media-backend seam: how a voice exchange's Pipecat
                   transport is created. Its __init__ docstring is the
                   driver author's whole brief; livekit.py places real calls over a SIP
-                  trunk, livekit_room.py dispatches an agent into a room,
+                  trunk, livekit_room.py joins a room three ways and
+                  dispatches an agent into the one egma makes,
                   room.py is the joining the two of them share, and
                   scripted.py is the one CI converses through.
   pipeline.py     One pipeline per simulation, built from its spec: which

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -39,8 +39,12 @@ touching the others:
   what answers, so a Retell agent, a Vapi agent and a person behind a
   number are all one plug. `livekit` reaches an agent where it lives: a
   room made in the customer's own LiveKit project, joined outbound, with
-  the agent's worker dispatched into it. To write the next, read the
-  `plugs/__init__.py` docstring; it is the entire brief.
+  the agent's worker dispatched into it. `retell_web_call` reaches a
+  Retell *voice* agent the same way its browser callers do: egma creates
+  the call itself — against a named version of the agent, with this
+  simulation's variables attached — and Retell answers with a way into a
+  LiveKit room, so the plug creates and the room media joins. To write the
+  next, read the `plugs/__init__.py` docstring; it is the entire brief.
 - **The media backends** (`media/`) — how a voice exchange's audio
   travels. One driver per way in, behind a four-method seam: create a
   Pipecat transport, dial, wait until somebody answers, tear it down.
@@ -491,8 +495,10 @@ src/egma_simulator/
   plugs/          The platform-plug seam. Its __init__ docstring is the
                   plug author's whole brief; scripted.py chats,
                   loopback.py speaks, retell.py is the first real
-                  platform, phone.py dials a number, and livekit.py holds
-                  an exchange in the agent's own room.
+                  platform, phone.py dials a number, livekit.py holds
+                  an exchange in the agent's own room, and
+                  retell_web_call.py creates a Retell web call and
+                  conducts it in the room that call opens.
   media/          The media-backend seam: how a voice exchange's Pipecat
                   transport is created. Its __init__ docstring is the
                   driver author's whole brief; livekit.py places real calls over a SIP

--- a/apps/simulator/src/egma_simulator/media/livekit_room.py
+++ b/apps/simulator/src/egma_simulator/media/livekit_room.py
@@ -160,6 +160,19 @@ with is worse than one it refuses by name.
 """
 
 ENDPOINT_CREDENTIAL_KEYS = frozenset({"headers"})
+PLATFORM_NAMED_ROOM = "the room the platform opened"
+"""What egma calls a room it did not name.
+
+The given-token shape joins a room somebody else made, and its real name
+belongs to them: egma is handed a way in and never told what the room is
+called. So this is a description and deliberately not an identifier —
+Pipecat prints the room name into every connect and disconnect line, and a
+name invented here would read like a room that could be looked up, in
+telemetry where no such room exists. What joins the two sides on this
+shape is the platform's own id for the exchange, which the plug carries as
+the provider reference.
+"""
+
 ENDPOINT_SCHEME = "https://"
 
 TOKEN_ALIASES = ("token", "participantToken", "accessToken")
@@ -646,9 +659,14 @@ class LiveKitRoomBackend:
         # A room egma opens itself is named after nothing, because nobody
         # else has to recognise it. A room egma asks for a token into is
         # named after the simulation, because the endpoint being asked has
-        # to be able to check the name against its own rules.
+        # to be able to check the name against its own rules. A room a
+        # platform opened is **not named here at all**: it has a name
+        # already, egma is never told it, and inventing one would put a
+        # string in every log line that exists in nobody's telemetry.
         self._room_name = (
-            fresh_room_name()
+            PLATFORM_NAMED_ROOM
+            if settings.given_token
+            else fresh_room_name()
             if settings.mints_its_own
             else room_name_for(simulation_id)
         )
@@ -659,8 +677,11 @@ class LiveKitRoomBackend:
     @property
     def room_name(self) -> str:
         """The room this exchange is conducted in — one room, one
-        simulation, and what the report carries as the provider
-        reference."""
+        simulation, and what the report carries as the provider reference
+        on the two shapes where egma named it. On the shape where a
+        platform did, this is :data:`PLATFORM_NAMED_ROOM`: a description
+        rather than a name, and the provider reference is the platform's
+        own id for the exchange instead."""
         return self._room_name
 
     async def create_transport(self) -> VoiceMedia:

--- a/apps/simulator/src/egma_simulator/media/livekit_room.py
+++ b/apps/simulator/src/egma_simulator/media/livekit_room.py
@@ -23,10 +23,10 @@ verbs every media driver has (see :mod:`egma_simulator.media`):
    Deleting is what ends everything the room held, including a dispatched
    worker.
 
-## The two ways in
+## The three ways in
 
-Step 1 is where the connection's two shapes differ, and they differ over
-one question: who mints the token that opens the room.
+Step 1 is where the connection's shapes differ, and they differ over one
+question: who mints the token that opens the room.
 
 - **egma mints it.** The connection carries the project's ``apiKey`` and
   ``apiSecret``. egma creates a fresh ``egma-sim-``-prefixed room, signs a
@@ -39,11 +39,18 @@ one question: who mints the token that opens the room.
   it cannot dispatch — that is the endpoint's job, and the reason a room
   nobody joined gives says so — and it cannot delete, so it leaves the
   room for the customer's own empty timeout to close.
+- **A platform minted it, opening the room itself.** The caller was handed
+  a ``given_token`` and the platform's own server URL — what a call created
+  through somebody's API comes back as — so egma asks nobody for anything:
+  it joins, and the token is spent on that one join. Getting the agent in
+  was the platform's own doing when it opened the room, and deleting is
+  beyond a token that only opens one; egma leaves and the platform closes
+  what it made.
 
-Above :class:`WayIn` the two are one code path. Everything after "a token
-and a room name exist" — joining, waiting, conducting, leaving — is the
-same code either way, which is what keeps the second shape from being a
-second driver.
+Above :class:`WayIn` the three are one code path. Everything after "a
+token and a room name exist" — joining, waiting, conducting, leaving — is
+the same code whichever it was, which is what keeps a second shape from
+being a second driver.
 
 Two deliberate differences from the driver that places a phone call:
 
@@ -312,13 +319,16 @@ def unreachable_refusal(what_failed: str, url: str, told: str) -> MediaBackendEr
 
 @dataclass(frozen=True)
 class RoomSettings:
-    """One LiveKit room's coordinates, as a connection block spells them.
+    """One LiveKit room's coordinates, however egma came by them.
 
-    Two shapes live in here, and which one a connection is in is decided
-    by one config key: a ``tokenEndpoint`` means egma asks the customer
-    for its way into the room instead of minting one. The fields the other
-    shape uses are left empty rather than absent, so everything below can
-    ask :attr:`mints_its_own` once and read the rest plainly.
+    Three shapes live in here, and they are three answers to one question:
+    who minted the token that opens the room. Egma mints it from the
+    project's key pair; or a ``tokenEndpoint`` means egma asks the customer
+    for one; or a ``given_token`` means egma was handed one already — by a
+    platform that opened the room itself, which is what a call created
+    through somebody's API comes back as. The fields the other shapes use
+    are left empty rather than absent, so everything below can ask
+    :attr:`mints_its_own` once and read the rest plainly.
     """
 
     url: str
@@ -343,15 +353,24 @@ class RoomSettings:
     )
     """What egma sends to authenticate itself to that endpoint."""
 
+    given_token: str = field(default="", repr=False)
+    """A way into a room that somebody else already opened.
+
+    Empty on both shapes that come by their own. Where it is set, the room
+    exists before egma knows about it, ``url`` is the platform's own server
+    rather than the customer's, and the token opens that one room for one
+    join — so it is registered as the secret it is.
+    """
+
     @property
     def mints_its_own(self) -> bool:
         """Whether egma holds the key pair that signs its own tokens.
 
-        The whole difference between the two shapes, asked once. Where it
-        is false egma has a token and nothing else: no room to create, no
+        The whole difference between the shapes, asked once. Where it is
+        false egma has a token and nothing else: no room to create, no
         worker to dispatch, and no room to delete when it is over.
         """
-        return not self.token_endpoint
+        return not (self.token_endpoint or self.given_token)
 
     @property
     def secrets(self) -> tuple[str, ...]:
@@ -364,7 +383,11 @@ class RoomSettings:
         """
         return tuple(
             held
-            for held in (self.api_secret, *self.endpoint_headers.values())
+            for held in (
+                self.api_secret,
+                self.given_token,
+                *self.endpoint_headers.values(),
+            )
             if held
         )
 
@@ -689,10 +712,16 @@ class LiveKitRoomBackend:
     async def _way_in(self) -> WayIn:
         """A token and a room, however this connection comes by them.
 
-        Either egma makes the room and signs its own token for it, or it
-        asks the customer's endpoint for one — and everything after this
-        is the same either way.
+        Egma makes the room and signs its own token for it, or asks the
+        customer's endpoint for one, or was handed one for a room a
+        platform opened itself — and everything after this is the same
+        whichever it was.
         """
+        if self._settings.given_token:
+            # Nothing is reached for here: the room is already open and the
+            # way in was part of whatever opened it. One token, one join —
+            # these are spent on use, so there is no second one to ask for.
+            return WayIn(url=self._settings.url, token=self._settings.given_token)
         if not self._settings.mints_its_own:
             return await self._token_from_endpoint()
 
@@ -717,10 +746,11 @@ class LiveKitRoomBackend:
         a project to workers registered without a name — so creating the
         room *was* the request, and there is nothing more to ask for.
 
-        A connection that asks an endpoint for its tokens asks for nothing
-        here at all. Dispatching takes the key pair egma deliberately was
-        not given, so putting a worker in the room is the endpoint's job
-        and egma's part is to be in the room when it arrives.
+        A connection that did not mint its own token asks for nothing here
+        at all. Dispatching takes the key pair egma deliberately was not
+        given, so putting a worker in the room is somebody else's job —
+        the token endpoint's, or the platform's that opened the room — and
+        egma's part is to be in the room when it arrives.
         """
         if self._room is None:
             raise MediaBackendError("an agent was requested before a room transport")
@@ -765,15 +795,16 @@ class LiveKitRoomBackend:
         above. A room left running would go on costing the customer, and
         the one call that could have stopped it is this one.
 
-        Two paths skip it. One is where no room was ever asked for,
-        because a delete for a room nobody made could only fail. The other
-        is the connection that asks an endpoint for its tokens: a token
-        minted to join one room carries no power to delete it, so egma
-        leaves and the room stands empty. What closes it then is the
+        Every path where no room was ever asked for skips it, because a
+        delete for a room nobody made could only fail — which is both
+        shapes that were handed their token. A token minted to join one
+        room carries no power to delete it, so egma leaves and the room
+        stands empty. What closes it then is whoever opened it: the
         customer's own empty timeout on the room — which is why the
-        hardening recipe asks for a short one on ``egma-sim-`` rooms.
-        Trying the delete anyway would spend a request to be refused and
-        put a line in the log about a failure that was never a failure.
+        hardening recipe asks for a short one on ``egma-sim-`` rooms — or
+        the platform that made the room for its own call. Trying the
+        delete anyway would spend a request to be refused and put a line
+        in the log about a failure that was never a failure.
         """
         room, self._room = self._room, None
         try:
@@ -1048,6 +1079,15 @@ class LiveKitRoomBackend:
 
     def _nobody_came(self, seconds: float) -> str:
         """Why nobody turned up, worded for whoever has to go and look."""
+        if self._settings.given_token:
+            # The room and whoever was meant to be in it both belong to the
+            # platform that opened it. Egma joined and waited; that is the
+            # whole of what this driver can honestly say happened.
+            return (
+                f"no agent joined the room within {seconds:.0f}s — the "
+                f"platform opened it, handed Egma the way in, and never put "
+                f"an agent in it"
+            )
         if not self._settings.mints_its_own:
             # Whose job it was, said plainly. egma asked for a token and
             # joined with it; it holds no key pair, so it could not have

--- a/apps/simulator/src/egma_simulator/pipeline.py
+++ b/apps/simulator/src/egma_simulator/pipeline.py
@@ -120,6 +120,12 @@ def assemble(
         config=spec.connection_config,
         credentials=spec.credentials,
         simulation_id=spec.simulation_id,
+        # Handed over exactly as the spec carried them, to every plug, for
+        # the same reason the mock-tool seam is: which of them reaches a
+        # platform that keeps versions or renders variables is the plug's
+        # own answer, not a list kept here of the ones that do.
+        agent_version=spec.agent_version,
+        dynamic_variables=spec.dynamic_variables,
         mock_tools=mock_tools,
         media=media,
     )

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -14,10 +14,15 @@ requires reading anything beyond this file, that is a bug in this file.
 ## What a plug receives
 
 A plug is constructed once per simulation, from the claimed spec, with
-eight keyword arguments:
+nine keyword arguments:
 
 - ``modality`` — ``"chat"`` or ``"voice"``. A plug that cannot speak the
   requested modality must refuse at construction (raise ``PlugError``).
+- ``access_variant`` — which authority and configuration path inside the
+  connection type this spec means. It is always spelled out and is never
+  inferred from which config keys turned up, so a plug that holds one
+  variant refuses every other at construction, and a plug that holds two
+  reads the connection the way the named one says to.
 - ``config`` — the connection's non-secret reach configuration, exactly as
   authored. **Its keys belong to the plug**: nothing else reads them, no
   schema constrains them, and each plug documents and validates its own.
@@ -42,8 +47,11 @@ eight keyword arguments:
   version nobody meant between one simulation and the next. It is never
   parsed, never renumbered and never turned into words — a number stays a
   number and a name stays a name, because the platform is the only thing
-  that knows what either means. Every other plug takes it and drops it, and
-  its record claims nothing about versions.
+  that knows what either means. The one thing dropped is space around it,
+  which is nobody's version: the wire accepts ``"  latest  "`` because the
+  contract only asks a name to say something, and what goes to the platform
+  is ``"latest"``. Every other plug takes it and drops it, and its record
+  claims nothing about versions.
 - ``dynamic_variables`` — the variables this one simulation is conducted
   with, for the agent's platform to render into the world the agent under
   test sees. A mapping of names to strings, empty in the ordinary case, and
@@ -169,6 +177,11 @@ from typing import Protocol, runtime_checkable
 
 from ..contract import ERROR
 from ..media import VoiceMedia
+from ..redaction import REDACTED
+
+QUOTED_REFUSAL_CHARS = 200
+"""How much of a refusal's body is quoted into a reason: enough to carry
+the platform's own words about what was wrong, short of pasting a page."""
 
 
 @dataclass(frozen=True)
@@ -216,6 +229,23 @@ class PlugError(Exception):
     def __init__(self, message: str, *, ending: str = ERROR) -> None:
         super().__init__(message)
         self.ending = ending
+
+
+def quotable(told: str, *secrets: str) -> str:
+    """Somebody else's words, minus this connection's own, short enough to
+    read.
+
+    A refusal is worth far more with the platform's own sentence in it, and
+    those words are not the quoter's to trust: a platform careless enough
+    to echo a key back would otherwise put it in a failure reason and in
+    the traceback logged beneath it. So the scrubbing happens here, where
+    the secret is known — and here rather than in each plug, because two
+    plugs reaching one platform must not scrub it two different ways.
+    """
+    for secret in secrets:
+        if secret:
+            told = told.replace(secret, REDACTED)
+    return told[:QUOTED_REFUSAL_CHARS]
 
 
 def named_version(agent_version: object) -> int | str | None:

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -14,7 +14,7 @@ requires reading anything beyond this file, that is a bug in this file.
 ## What a plug receives
 
 A plug is constructed once per simulation, from the claimed spec, with
-six keyword arguments:
+eight keyword arguments:
 
 - ``modality`` — ``"chat"`` or ``"voice"``. A plug that cannot speak the
   requested modality must refuse at construction (raise ``PlugError``).
@@ -34,6 +34,25 @@ six keyword arguments:
   plug that has to *tell the platform* which simulation it is in has any
   use for it, and most have none — a plug that does not need it takes it
   and drops it.
+- ``agent_version`` — which version of the agent under test to conduct
+  against, exactly as its platform names its versions, or ``None`` for the
+  platform's own default. Only a plug reaching a platform that keeps
+  versions has any use for it, and such a plug asks for it **by name every
+  time**: a platform whose default is "the newest one" can be pointed at a
+  version nobody meant between one simulation and the next. It is never
+  parsed, never renumbered and never turned into words — a number stays a
+  number and a name stays a name, because the platform is the only thing
+  that knows what either means. Every other plug takes it and drops it, and
+  its record claims nothing about versions.
+- ``dynamic_variables`` — the variables this one simulation is conducted
+  with, for the agent's platform to render into the world the agent under
+  test sees. A mapping of names to strings, empty in the ordinary case, and
+  **passed on byte for byte**: a plug neither reads them, adds to them, nor
+  tidies a value, because a value the simulator changed is a value the agent
+  never saw. Egma's own attribution variable is among them where the run put
+  one there, and it is what a tool call the platform makes rides back to
+  this simulation on. A plug whose platform renders no such thing takes them
+  and drops them.
 - ``mock_tools`` — egma's side of the mock-tool exchange for this
   simulation (:class:`egma_simulator.mock_tools.MockToolSeam`), already
   holding the answers the run resolved. Only a plug that can **put egma in
@@ -196,6 +215,72 @@ class PlugError(Exception):
         self.ending = ending
 
 
+def named_version(agent_version: object) -> int | str | None:
+    """The version a plug will ask its platform for, read once.
+
+    Here rather than in each plug that uses it, because it is a fact of the
+    claimed spec and not of any one platform: two plugs reaching the same
+    platform must not disagree about what a version reference is.
+
+    What comes out is what went in — a number stays a number, a name stays a
+    name, and neither is renumbered, trimmed into meaning, or turned into the
+    other. Surrounding space is the one thing dropped, because it is nobody's
+    version; a reference of nothing but space is refused rather than sent,
+    since a platform asked for the version named ``"   "`` fails in its own
+    words, far from the spec that said it.
+    """
+    if agent_version is None:
+        return None
+    if isinstance(agent_version, bool) or not isinstance(agent_version, int | str):
+        raise PlugError(
+            "an agent version is how the platform names its versions — a "
+            f"number or a name; got {type(agent_version).__name__}"
+        )
+    if isinstance(agent_version, int):
+        if agent_version < 0:
+            raise PlugError(f"an agent version cannot be {agent_version}")
+        return agent_version
+    if not agent_version.strip():
+        raise PlugError("an agent version must say which version, not nothing")
+    return agent_version.strip()
+
+
+def rendered_variables(dynamic_variables: object) -> dict[str, str]:
+    """The variables one simulation is conducted with, read once.
+
+    Shared for the reason above, and strict for one of its own: these travel
+    to the agent under test unread, so the last place a mistake in them can
+    be named is here. Every value is a string because a rendered variable is
+    a string, and an empty one is kept — a variable set to nothing renders as
+    nothing, which is not what a variable nobody set does.
+
+    A refusal names the variable and never its value: what a simulation
+    carries can be a caller's own details, and a sentence about a mistake
+    should not go on to repeat them.
+    """
+    if dynamic_variables is None:
+        return {}
+    if not isinstance(dynamic_variables, dict):
+        raise PlugError(
+            "dynamic variables are names against strings; got "
+            f"{type(dynamic_variables).__name__}"
+        )
+    unnamed = [name for name in dynamic_variables if not str(name).strip()]
+    if unnamed:
+        raise PlugError("a dynamic variable with no name is set by nobody")
+    unrendered = sorted(
+        str(name)
+        for name, value in dynamic_variables.items()
+        if not isinstance(value, str)
+    )
+    if unrendered:
+        raise PlugError(
+            f"dynamic variable(s) {unrendered} carry something that is not a "
+            "string, and a rendered variable is a string"
+        )
+    return {str(name): value for name, value in dynamic_variables.items()}
+
+
 def failed_ending(fault: BaseException) -> str:
     """Which of the contract's failed endings one fault deserves.
 
@@ -249,7 +334,7 @@ class VoiceConnection(Protocol):
 PlugFactory = Callable[..., ConnectionPlug | VoiceConnection]
 """What the registry hands back: called with ``modality=``,
 ``access_variant=``, ``config=``, ``credentials=``, ``simulation_id=``,
-``mock_tools=`` and ``media=``
+``agent_version=``, ``dynamic_variables=``, ``mock_tools=`` and ``media=``
 keywords, it returns one plug for one simulation — in practice, the plug
 class itself."""
 
@@ -264,6 +349,7 @@ def plug_for(connection_type: str) -> PlugFactory | None:
     from .loopback import LoopbackCounterpart
     from .phone import PhoneCall
     from .retell import RetellChat
+    from .retell_web_call import RetellWebCall
     from .scripted import ScriptedCounterpart
 
     return {
@@ -271,5 +357,6 @@ def plug_for(connection_type: str) -> PlugFactory | None:
         "loopback": LoopbackCounterpart,
         "phone_number": PhoneCall,
         "retell_chat_api": RetellChat,
+        "retell_web_call": RetellWebCall,
         "scripted": ScriptedCounterpart,
     }.get(connection_type)

--- a/apps/simulator/src/egma_simulator/plugs/__init__.py
+++ b/apps/simulator/src/egma_simulator/plugs/__init__.py
@@ -71,7 +71,10 @@ eight keyword arguments:
 
 Constructors validate and hold; they never do I/O. A constructor that
 raises means the simulation fails with an honest reason before the
-connection is ever opened.
+connection is ever opened. Two of the eight are read for you where a plug
+uses them — :func:`named_version` and :func:`rendered_variables` below —
+so that two plugs reaching one platform cannot disagree about what a
+version reference is or what a variable may hold.
 
 ## Chat or voice: same job, different currency
 

--- a/apps/simulator/src/egma_simulator/plugs/livekit.py
+++ b/apps/simulator/src/egma_simulator/plugs/livekit.py
@@ -105,14 +105,18 @@ class LiveKitRoom:
         config: dict[str, Any],
         credentials: object,
         simulation_id: str,
+        agent_version: object = None,
+        dynamic_variables: object = None,
         mock_tools: MockToolSeam | None = None,
         media: object = None,
         driver: Any = None,
     ) -> None:
         # A room is reached with this connection's URL and authority. It does
         # not use the deployment's phone media bridge or the platform carrier
-        # resolved for a phone simulation.
-        del media
+        # resolved for a phone simulation. A worker is whatever the customer
+        # is running: LiveKit keeps no versions of it, and the only thing egma
+        # tells it is the dispatch context below.
+        del media, agent_version, dynamic_variables
 
         if modality != "voice":
             raise PlugError(

--- a/apps/simulator/src/egma_simulator/plugs/loopback.py
+++ b/apps/simulator/src/egma_simulator/plugs/loopback.py
@@ -31,10 +31,15 @@ class LoopbackCounterpart:
         config: dict[str, Any],
         credentials: object,
         simulation_id: str | None = None,
+        agent_version: object = None,
+        dynamic_variables: object = None,
         mock_tools: object = None,
         media: object = None,
     ) -> None:
+        # There is no platform here to keep versions or render variables:
+        # the counterpart is this process talking to itself.
         del access_variant, credentials, simulation_id, mock_tools, media
+        del agent_version, dynamic_variables
         if modality != "voice":
             raise PlugError(
                 f"the loopback counterpart speaks voice only; a {modality!r} "

--- a/apps/simulator/src/egma_simulator/plugs/phone.py
+++ b/apps/simulator/src/egma_simulator/plugs/phone.py
@@ -76,14 +76,18 @@ class PhoneCall:
         config: dict[str, Any],
         credentials: object,
         simulation_id: str | None = None,
+        agent_version: object = None,
+        dynamic_variables: object = None,
         mock_tools: object = None,
         media: MediaSettings | None = None,
     ) -> None:
         # A phone call is reached over the public telephone network, which
         # has never carried anything but a number, so this plug has
         # nothing to tell the far end about the simulation and no way to
-        # stand in front of its tools.
-        del simulation_id, mock_tools
+        # stand in front of its tools. It cannot name a version or set a
+        # variable either: egma is the caller, and the call is made by
+        # whoever answers the number.
+        del simulation_id, mock_tools, agent_version, dynamic_variables
 
         if access_variant != "phone_number.public_e164":
             raise PlugError(

--- a/apps/simulator/src/egma_simulator/plugs/retell.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell.py
@@ -58,8 +58,14 @@ from typing import Any
 import aiohttp
 
 from ..client import UNREACHABLE
-from ..redaction import REDACTED
-from . import AgentReply, PlugError, ToolCall, named_version, rendered_variables
+from . import (
+    AgentReply,
+    PlugError,
+    ToolCall,
+    named_version,
+    quotable,
+    rendered_variables,
+)
 
 DEFAULT_BASE_URL = "https://api.retellai.com"
 """Retell's own API, where a connection with no base URL is reached."""
@@ -75,16 +81,13 @@ TIMEOUT_SECONDS = 60.0
 on the agent's own model, and anything past it is a platform that has
 stopped answering rather than one thinking."""
 
-QUOTED_REFUSAL_CHARS = 200
-"""How much of a refusal's body is quoted into the reason: enough to carry
-the platform's own words about what was wrong, short of pasting a page."""
-
 _KNOWN_KEYS = {"retellAgentId", "baseUrl"}
 
-_CREDENTIAL_KEYS = {"apiKey"}
-"""Exactly what the control plane seals for a retell connection. Refused
-strictly, and for the same reason it is refused there: a secret handed over
-that nothing reads was handed over by mistake."""
+CREDENTIAL_KEYS = {"apiKey"}
+"""Exactly what the control plane seals for a retell connection, whichever
+way a simulation reaches one. Refused strictly, and for the same reason it
+is refused there: a secret handed over that nothing reads was handed over
+by mistake."""
 
 
 class RetellChat:
@@ -144,7 +147,7 @@ class RetellChat:
             raise PlugError(
                 "a retell connection needs credentials shaped {apiKey}"
             )
-        stray = set(credentials) - _CREDENTIAL_KEYS
+        stray = set(credentials) - CREDENTIAL_KEYS
         if stray:
             raise PlugError(
                 f"retell credentials hold no key(s) {sorted(stray)}; they are "
@@ -221,7 +224,7 @@ class RetellChat:
         finally:
             await session.close()
 
-    def _opening(self) -> dict:
+    def _opening(self) -> dict[str, Any]:
         """The one request that opens the exchange.
 
         Which agent, and — only where the spec said so — which version of it
@@ -239,10 +242,6 @@ class RetellChat:
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}"}
-
-    def _quotable(self, told: str) -> str:
-        """The platform's own words, minus the key, short enough to read."""
-        return told.replace(self._api_key, REDACTED)[:QUOTED_REFUSAL_CHARS]
 
     async def _call(self, method: str, path: str, payload: dict) -> dict:
         """One Retell call, or a refusal saying what happened without the key."""
@@ -264,13 +263,13 @@ class RetellChat:
         except UNREACHABLE as unreachable:
             raise PlugError(
                 f"retell was unreachable at {url}: "
-                f"{self._quotable(repr(unreachable))}"
+                f"{quotable(repr(unreachable), self._api_key)}"
             ) from unreachable
 
         if status // 100 != 2:
             raise PlugError(
                 f"retell answered {status} to {path} at {self._base_url}: "
-                f"{self._quotable(body)}"
+                f"{quotable(body, self._api_key)}"
             )
         try:
             document = json.loads(body)

--- a/apps/simulator/src/egma_simulator/plugs/retell.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell.py
@@ -15,6 +15,20 @@ Its config keys, like every plug's, are its own:
   loopback, and a proxy stand in front of the platform for a deployment
   that needs one.
 
+Two facts about the simulation ride the same ``create-chat`` call when the
+claimed spec carries them, and change nothing when it does not:
+
+- the **agent version** to open the chat against, named explicitly so the
+  exchange cannot land on a version somebody created since — which is how a
+  run over a mocked world reaches that world's own draft;
+- the **dynamic variables** this simulation is conducted with, handed to
+  Retell as ``retell_llm_dynamic_variables`` for its own response engine to
+  render, byte for byte.
+
+A spec carrying neither produces exactly the request this plug has always
+sent: the field is absent from the body, not present and empty, because an
+empty one is a value Retell would render.
+
 Credentials are shaped ``{"apiKey": ...}`` — the shape the control plane
 seals — and are read for the ``Authorization`` header and nothing else.
 They are never logged, never returned, and never put into an exception
@@ -45,7 +59,7 @@ import aiohttp
 
 from ..client import UNREACHABLE
 from ..redaction import REDACTED
-from . import AgentReply, PlugError, ToolCall
+from . import AgentReply, PlugError, ToolCall, named_version, rendered_variables
 
 DEFAULT_BASE_URL = "https://api.retellai.com"
 """Retell's own API, where a connection with no base URL is reached."""
@@ -84,6 +98,8 @@ class RetellChat:
         config: dict[str, Any],
         credentials: object,
         simulation_id: str | None = None,
+        agent_version: object = None,
+        dynamic_variables: object = None,
         mock_tools: object = None,
         media: object = None,
     ) -> None:
@@ -141,6 +157,8 @@ class RetellChat:
         self._agent_id = agent_id.strip()
         self._base_url = base_url.strip().rstrip("/")
         self._api_key = api_key.strip()
+        self._agent_version = named_version(agent_version)
+        self._dynamic_variables = rendered_variables(dynamic_variables)
         self._timeout = aiohttp.ClientTimeout(total=TIMEOUT_SECONDS)
         self._session: aiohttp.ClientSession | None = None
         self._chat_id: str | None = None
@@ -157,9 +175,7 @@ class RetellChat:
 
     async def open(self) -> str | None:
         self._session = aiohttp.ClientSession()
-        opened = await self._call(
-            "POST", "/create-chat", {"agent_id": self._agent_id}
-        )
+        opened = await self._call("POST", "/create-chat", self._opening())
         chat_id = opened.get("chat_id")
         if not isinstance(chat_id, str) or not chat_id:
             raise PlugError("retell opened a chat with no chat_id to hold it by")
@@ -204,6 +220,22 @@ class RetellChat:
                         pass
         finally:
             await session.close()
+
+    def _opening(self) -> dict:
+        """The one request that opens the exchange.
+
+        Which agent, and — only where the spec said so — which version of it
+        and what this simulation is conducted with. Absent stays absent: a
+        version Retell was not asked for is a version it chooses itself, and
+        an empty variable block is not the same as none, because Retell
+        renders what it is given.
+        """
+        opening: dict = {"agent_id": self._agent_id}
+        if self._agent_version is not None:
+            opening["agent_version"] = self._agent_version
+        if self._dynamic_variables:
+            opening["retell_llm_dynamic_variables"] = self._dynamic_variables
+        return opening
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._api_key}"}

--- a/apps/simulator/src/egma_simulator/plugs/retell_web_call.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_web_call.py
@@ -1,0 +1,404 @@
+"""Retell web call: the agent under test, reached by voice over WebRTC.
+
+The third plug that reaches an agent where it lives, and the first that
+reaches a *voice* agent on somebody else's platform. Egma creates the call
+itself — ``create-web-call``, against the agent and, where the spec named
+one, against a **named version** of it, with this simulation's variables
+attached — and Retell answers with a way into a room. That room is a
+LiveKit one: the way in is a server URL and an access token, which is
+exactly what :mod:`egma_simulator.media.livekit_room` already joins, so
+this module is thin. Creating the call is the only place it touches
+Retell's API; everything after it is the room media the simulator already
+has.
+
+Its config keys, like every plug's, are its own:
+
+- ``retellAgentId`` (string, required) — the agent the call is placed
+  against, exactly as the control plane stores it.
+- ``baseUrl`` (string, optional) — where Retell's API answers, defaulting
+  to Retell itself. What lets a test create a call against a
+  Retell-shaped server on loopback, and a proxy stand in front of the
+  platform for a deployment that needs one.
+- ``roomHost`` (string, optional) — where the room a web call opens is,
+  defaulting to :data:`RETELL_ROOM_HOST` below. See that constant for why
+  it is a value and not a line of code.
+
+Credentials are shaped ``{"apiKey": ...}`` — the shape the control plane
+seals — and are read for the ``Authorization`` header and nothing else.
+Retell's answer carries a second secret, the room's access token, and it
+is treated as one from the moment it arrives: registered for scrubbing
+before anything can quote it, and named in no message, log or report.
+
+**What "the agent answered" means here.** Retell's own participant is in
+the room and its audio is flowing. A call that was created and whose room
+nobody joined never tested anything, so it fails as ``AGENT_NEVER_JOINED``
+and is never graded as the agent failing. ``NOT_ANSWERED`` belongs to a
+line that rang out, and nothing rings here: egma creates the call and
+joins the room it opens, so this lane never claims it.
+
+**One call, one join.** A web call's access token is spent on the join —
+Retell mints it for that one entry — so there is no rejoining and no
+second attempt. Asking this plug for a second transport is refused rather
+than tried, because trying would be a request Retell has already answered.
+
+**Egma leaves; Retell closes.** The room is Retell's own, opened for its
+own call, and a token that opens one room carries no power to delete it.
+So teardown is a departure, which is also what ends the call from egma's
+side.
+
+**Egma is not in this agent's tool path.** A mocked world on Retell is
+built out of the agent's own configuration, and the tool calls in it
+travel from Retell to egma's endpoint rather than through the room. So the
+mock-tool seam is taken and dropped here, deliberately: this plug never
+offers the exchange in the room, and the record therefore claims nothing
+about tools, which is the truth.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import aiohttp
+
+from ..client import UNREACHABLE
+from ..contract import AGENT_NEVER_JOINED
+from ..media import MediaBackendError, VoiceMedia
+from ..media.livekit_room import URL_SCHEMES, LiveKitRoomBackend, RoomSettings
+from ..redaction import REDACTED
+from . import PlugError, named_version, rendered_variables
+from .retell import DEFAULT_BASE_URL
+
+RETELL_ROOM_HOST = "wss://retell-ai-4ihahnq7.livekit.cloud"
+"""Where every Retell web call's room is.
+
+Retell's own infrastructure, and the same host for every account: its
+browser SDK connects to this one URL with the token the API hands back.
+It is a value here, and overridable by the connection's ``roomHost``, for
+the two reasons a constant of somebody else's is: a deployment can follow
+Retell moving its infrastructure without waiting for a release of egma,
+and there is exactly one place to change when a new SDK release moves it.
+Track it against ``retell-client-js-sdk`` when that package is bumped.
+"""
+
+CREATE_PATH = "/v2/create-web-call"
+"""Where a web call is created. Named here so a refusal can say it."""
+
+TIMEOUT_SECONDS = 30.0
+"""The most creating one call may take. Retell registers a call and
+answers; anything past this is a platform that has stopped answering."""
+
+AGENT_JOIN_SECONDS = 30.0
+"""How long the room may stand empty before nobody coming is the answer.
+
+Long enough for Retell to put its agent in the room it just opened and
+for that agent's first audio to flow; short of a simulation's duration
+limit doing the job instead, which would put ``limit_reached`` on a record
+whose real story is that nothing ever turned up.
+"""
+
+QUOTED_REFUSAL_CHARS = 200
+"""How much of a refusal's body is quoted into the reason: enough to carry
+the platform's own words about what was wrong, short of pasting a page."""
+
+_KNOWN_KEYS = {"retellAgentId", "baseUrl", "roomHost"}
+
+_CREDENTIAL_KEYS = {"apiKey"}
+"""Exactly what the control plane seals for a retell connection. Refused
+strictly, and for the same reason it is refused there: a secret handed over
+that nothing reads was handed over by mistake."""
+
+
+class RetellWebCall:
+    """One Retell web call, created and joined and left, per instance."""
+
+    def __init__(
+        self,
+        *,
+        modality: str,
+        access_variant: str,
+        config: dict[str, Any],
+        credentials: object,
+        simulation_id: str,
+        agent_version: object = None,
+        dynamic_variables: object = None,
+        mock_tools: object = None,
+        media: object = None,
+        driver: Any = None,
+    ) -> None:
+        # Retell carries this call's audio itself, so the deployment's
+        # carrier is nothing to it. And egma is not in this agent's tool
+        # path: a mocked Retell world answers from egma's own endpoint,
+        # which the agent reaches over the internet and not across the
+        # room, so the seam is taken and dropped and the record claims
+        # nothing about tools.
+        del media, mock_tools
+
+        if access_variant != "retell_web_call.api_key":
+            raise PlugError(
+                "the retell web-call adapter does not support access variant "
+                f"{access_variant!r}"
+            )
+
+        if modality != "voice":
+            raise PlugError(
+                f"the retell web-call plug speaks voice only; a {modality!r} "
+                "simulation over retell is the chat plug's job"
+            )
+
+        unknown = set(config) - _KNOWN_KEYS
+        if unknown:
+            raise PlugError(
+                f"the retell web-call plug does not know config key(s) "
+                f"{sorted(unknown)}; it knows {sorted(_KNOWN_KEYS)}"
+            )
+
+        agent_id = config.get("retellAgentId")
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            raise PlugError(
+                "retell web-call config: retellAgentId must be a non-empty string"
+            )
+
+        base_url = config.get("baseUrl", DEFAULT_BASE_URL)
+        if not isinstance(base_url, str) or not base_url.strip():
+            raise PlugError(
+                "retell web-call config: baseUrl must be a non-empty string"
+            )
+
+        room_host = config.get("roomHost", RETELL_ROOM_HOST)
+        if not isinstance(room_host, str) or not room_host.strip():
+            raise PlugError(
+                "retell web-call config: roomHost must be a non-empty string — "
+                "where the room a web call opens is"
+            )
+        room_host = room_host.strip()
+        if not room_host.startswith(URL_SCHEMES):
+            raise PlugError(
+                f"retell web-call config: roomHost must start with one of "
+                f"{', '.join(URL_SCHEMES)}; got {room_host!r}"
+            )
+
+        if not isinstance(credentials, dict):
+            raise PlugError(
+                "a retell web-call connection needs credentials shaped {apiKey}"
+            )
+        stray = set(credentials) - _CREDENTIAL_KEYS
+        if stray:
+            raise PlugError(
+                f"retell web-call credentials hold no key(s) {sorted(stray)}; "
+                "they are shaped {apiKey}"
+            )
+        api_key = credentials.get("apiKey")
+        if not isinstance(api_key, str) or not api_key.strip():
+            raise PlugError(
+                "retell web-call credentials: apiKey must be a non-empty string"
+            )
+
+        self._agent_id = agent_id.strip()
+        self._base_url = base_url.strip().rstrip("/")
+        self._room_host = room_host
+        self._api_key = api_key.strip()
+        self._agent_version = named_version(agent_version)
+        self._dynamic_variables = rendered_variables(dynamic_variables)
+        self._simulation_id = simulation_id
+        # Which driver holds the room is not the spec's to choose: there is
+        # one, and it is the room driver. The keyword is for tests, which
+        # put a room-shaped fake behind the same seam rather than stand up
+        # a LiveKit.
+        self._driver_factory = driver or LiveKitRoomBackend
+        self._timeout = aiohttp.ClientTimeout(total=TIMEOUT_SECONDS)
+        self._call_id: str | None = None
+        self._spent = False
+        self._room: Any = None
+        self._media: VoiceMedia | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Where this call is created — the URL every refusal names."""
+        return self._base_url
+
+    @property
+    def room_host(self) -> str:
+        """Where the room this call opens is."""
+        return self._room_host
+
+    @property
+    def provider_reference(self) -> str | None:
+        """Retell's own id for this call, once there is one to hold it by.
+
+        The join between egma's record and Retell's telemetry, and it is
+        the call rather than the room: the room is Retell's, named by
+        Retell, and never told to egma — the call id is what both sides
+        can look the same exchange up by.
+        """
+        return self._call_id
+
+    @property
+    def far_end_left(self) -> bool:
+        """Whether Retell's agent has left the room. Its participant
+        leaving *is* the agent ending the exchange, here as in any room."""
+        return self._media is not None and self._media.ended.is_set()
+
+    async def prepare(self) -> VoiceMedia:
+        """Create the call, then build the transport for the room it opens."""
+        if self._spent:
+            # Not tried and refused: refused before it is tried. Retell
+            # mints an access token for one entry into one room, so a
+            # second attempt on this call is a request whose answer is
+            # already known, and asking would only make the reason worse.
+            raise PlugError(
+                "a retell web call is joined once and its access token is "
+                "spent on that join; conducting again needs a new call"
+            )
+        self._spent = True
+
+        created = await self._create_call()
+        self._room = self._built(
+            settings=RoomSettings(url=self._room_host, given_token=created["token"]),
+            simulation_id=self._simulation_id,
+            # Deliberately none: egma does not stand in this agent's tool
+            # path, so nothing is offered in the room and the record makes
+            # no claim about tools it never saw.
+            mock_tools=None,
+        )
+        try:
+            self._media = await self._room.create_transport()
+            return self._media
+        except MediaBackendError as refused:
+            raise PlugError(self._about_the_room(refused), ending=refused.ending) from (
+                refused
+            )
+
+    async def open(self) -> None:
+        """Wait for Retell's agent to be in the room and to be heard.
+
+        Nothing is heard here. The line is open the moment the agent's
+        audio flows; the running Pipecat transport then carries both
+        sides, including the agent's opening.
+        """
+        if self._room is None:
+            raise PlugError("a retell web call was opened before it was created")
+        try:
+            await self._room.dial()
+            await self._room.wait_answered(AGENT_JOIN_SECONDS)
+        except MediaBackendError as refused:
+            raise PlugError(self._about_the_room(refused), ending=refused.ending) from (
+                refused
+            )
+
+    async def close(self) -> None:
+        """Leave the room. Safe from every state.
+
+        There is nothing else to do and nothing else egma may do: the room
+        belongs to Retell, which closes it once egma is gone, and the
+        access token that opened it was only ever a way in.
+        """
+        self._media = None
+        room, self._room = self._room, None
+        if room is not None:
+            await room.teardown()
+
+    # -- The one place this plug reaches Retell ------------------------------
+
+    async def _create_call(self) -> dict[str, str]:
+        """Create the call, or refuse in a sentence that carries no secret."""
+        url = f"{self._base_url}{CREATE_PATH}"
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.post(
+                    url,
+                    json=self._creation(),
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                    timeout=self._timeout,
+                ) as response,
+            ):
+                status = response.status
+                body = await response.text()
+        except UNREACHABLE as unreachable:
+            raise PlugError(
+                f"retell was unreachable at {url}: "
+                f"{self._quotable(repr(unreachable))}"
+            ) from unreachable
+
+        if status // 100 != 2:
+            raise PlugError(
+                f"retell answered {status} to {CREATE_PATH} at {self._base_url} "
+                f"and created no web call: {self._quotable(body)}"
+            )
+        try:
+            document = json.loads(body)
+        except ValueError as unreadable:
+            raise PlugError(
+                f"retell answered {CREATE_PATH} with something that is not JSON"
+            ) from unreadable
+        if not isinstance(document, dict):
+            raise PlugError(
+                f"retell answered {CREATE_PATH} with "
+                f"{type(document).__name__}, not an object"
+            )
+
+        call_id = document.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            raise PlugError("retell created a web call with no call_id to hold it by")
+        token = document.get("access_token")
+        if not isinstance(token, str) or not token:
+            raise PlugError(
+                f"retell created web call {call_id} with no access_token, so "
+                "there is no way into the room it opened"
+            )
+        # Held from here as the credential it is: whoever has it can join
+        # this call's room. It is registered with the room driver's own
+        # scrubbing below, before anything can quote it.
+        self._call_id = call_id
+        return {"call_id": call_id, "token": token}
+
+    def _creation(self) -> dict:
+        """What one web call is created with.
+
+        Which agent, and — only where the spec said so — which version of
+        it and what this simulation is conducted with. The version is named
+        explicitly whenever there is one: Retell's own default is the
+        newest version, which is a moving target and, on a mocked run, the
+        very draft the run must not be at the mercy of.
+        """
+        creation: dict = {"agent_id": self._agent_id}
+        if self._agent_version is not None:
+            creation["agent_version"] = self._agent_version
+        if self._dynamic_variables:
+            creation["retell_llm_dynamic_variables"] = self._dynamic_variables
+        return creation
+
+    # -- Saying what went wrong, in this plug's own terms --------------------
+
+    def _built(self, **arguments: Any) -> Any:
+        """One room driver, or this plug's refusal in its words."""
+        try:
+            return self._driver_factory(**arguments)
+        except MediaBackendError as refused:
+            raise PlugError(str(refused), ending=refused.ending) from refused
+
+    def _about_the_room(self, refused: MediaBackendError) -> str:
+        """One room refusal, worded for whoever has to go and look.
+
+        Two things go wrong in a room Retell opened, and they are not the
+        same thing to a person reading a record. Nobody turning up is about
+        the agent — the call was made, the room was joined, and Retell put
+        nothing in it. Not getting in at all is about the way in, and this
+        plug knows the one fact that explains most of those: the token is
+        spent on the join and does not wait around.
+        """
+        told = str(refused)
+        where = f"retell web call {self._call_id}" if self._call_id else "the web call"
+        if refused.ending == AGENT_NEVER_JOINED:
+            return f"{where}: {told}"
+        return (
+            f"{where} was created, but Egma could not get into the room it "
+            f"opened: {told}. A web call's access token opens one room once, "
+            f"so a token already used, or created and left, is refused and a "
+            f"new call has to be created"
+        )
+
+    def _quotable(self, told: str) -> str:
+        """The platform's own words, minus the key, short enough to read."""
+        return told.replace(self._api_key, REDACTED)[:QUOTED_REFUSAL_CHARS]

--- a/apps/simulator/src/egma_simulator/plugs/retell_web_call.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_web_call.py
@@ -65,20 +65,31 @@ from ..client import UNREACHABLE
 from ..contract import AGENT_NEVER_JOINED
 from ..media import MediaBackendError, VoiceMedia
 from ..media.livekit_room import URL_SCHEMES, LiveKitRoomBackend, RoomSettings
-from ..redaction import REDACTED
-from . import PlugError, named_version, rendered_variables
-from .retell import DEFAULT_BASE_URL
+from . import PlugError, named_version, quotable, rendered_variables
+from .retell import CREDENTIAL_KEYS, DEFAULT_BASE_URL
 
 RETELL_ROOM_HOST = "wss://retell-ai-4ihahnq7.livekit.cloud"
 """Where every Retell web call's room is.
 
-Retell's own infrastructure, and the same host for every account: its
-browser SDK connects to this one URL with the token the API hands back.
-It is a value here, and overridable by the connection's ``roomHost``, for
-the two reasons a constant of somebody else's is: a deployment can follow
-Retell moving its infrastructure without waiting for a release of egma,
-and there is exactly one place to change when a new SDK release moves it.
-Track it against ``retell-client-js-sdk`` when that package is bumped.
+Retell's own infrastructure, and the same host for every account: the API
+hands back an access token and nothing about where to spend it, because
+its browser SDK has the host built in.
+
+**Where this value comes from, so the next person can check it.** Read on
+2026-08-27 out of ``retell-client-js-sdk`` version 2.0.8, ``src/index.ts``,
+which calls ``room.connect("wss://retell-ai-4ihahnq7.livekit.cloud",
+accessToken)`` with the host as a literal. That package is **not a
+dependency of this repository** — nothing here runs Retell's browser SDK —
+so there is no lockfile entry to diff against and no build that would
+notice it moving. To re-verify, read that file at the newest published
+version of the package and compare the literal. The same reading confirmed
+the token is a LiveKit room JWT, which is why the room media below can join
+it at all.
+
+Because nothing automatic can catch a change, the connection's ``roomHost``
+is the escape hatch: a deployment can follow Retell moving its
+infrastructure without waiting for a release of egma, and this constant is
+the one place to change when the next SDK reading says it moved.
 """
 
 CREATE_PATH = "/v2/create-web-call"
@@ -97,16 +108,7 @@ limit doing the job instead, which would put ``limit_reached`` on a record
 whose real story is that nothing ever turned up.
 """
 
-QUOTED_REFUSAL_CHARS = 200
-"""How much of a refusal's body is quoted into the reason: enough to carry
-the platform's own words about what was wrong, short of pasting a page."""
-
 _KNOWN_KEYS = {"retellAgentId", "baseUrl", "roomHost"}
-
-_CREDENTIAL_KEYS = {"apiKey"}
-"""Exactly what the control plane seals for a retell connection. Refused
-strictly, and for the same reason it is refused there: a secret handed over
-that nothing reads was handed over by mistake."""
 
 
 class RetellWebCall:
@@ -182,7 +184,7 @@ class RetellWebCall:
             raise PlugError(
                 "a retell web-call connection needs credentials shaped {apiKey}"
             )
-        stray = set(credentials) - _CREDENTIAL_KEYS
+        stray = set(credentials) - CREDENTIAL_KEYS
         if stray:
             raise PlugError(
                 f"retell web-call credentials hold no key(s) {sorted(stray)}; "
@@ -247,13 +249,17 @@ class RetellWebCall:
             # second attempt on this call is a request whose answer is
             # already known, and asking would only make the reason worse.
             raise PlugError(
-                "a retell web call is created once and joined once — its "
-                "access token is spent on that join — so conducting again "
-                "needs a new call"
+                "a retell web call is joined once — its access token is "
+                "spent on that join — so conducting again needs a new call"
             )
-        self._conducted = True
 
+        # Marked once there is something to spend, and not before: a
+        # creation that failed minted no token and left no call at Retell,
+        # so it is a thing that did not happen rather than a thing already
+        # used up, and saying otherwise would send whoever reads the reason
+        # looking for a call that never existed.
         token = await self._create_call()
+        self._conducted = True
         self._room = self._built(
             settings=RoomSettings(url=self._room_host, given_token=token),
             simulation_id=self._simulation_id,
@@ -324,13 +330,13 @@ class RetellWebCall:
         except UNREACHABLE as unreachable:
             raise PlugError(
                 f"retell was unreachable at {url}: "
-                f"{self._quotable(repr(unreachable))}"
+                f"{quotable(repr(unreachable), self._api_key)}"
             ) from unreachable
 
         if status // 100 != 2:
             raise PlugError(
                 f"retell answered {status} to {CREATE_PATH} at {self._base_url} "
-                f"and created no web call: {self._quotable(body)}"
+                f"and created no web call: {quotable(body, self._api_key)}"
             )
         try:
             document = json.loads(body)
@@ -360,7 +366,7 @@ class RetellWebCall:
         self._call_id = call_id
         return token
 
-    def _creation(self) -> dict:
+    def _creation(self) -> dict[str, Any]:
         """What one web call is created with.
 
         Which agent, and — only where the spec said so — which version of
@@ -406,6 +412,3 @@ class RetellWebCall:
             f"new call has to be created"
         )
 
-    def _quotable(self, told: str) -> str:
-        """The platform's own words, minus the key, short enough to read."""
-        return told.replace(self._api_key, REDACTED)[:QUOTED_REFUSAL_CHARS]

--- a/apps/simulator/src/egma_simulator/plugs/retell_web_call.py
+++ b/apps/simulator/src/egma_simulator/plugs/retell_web_call.py
@@ -208,7 +208,7 @@ class RetellWebCall:
         self._driver_factory = driver or LiveKitRoomBackend
         self._timeout = aiohttp.ClientTimeout(total=TIMEOUT_SECONDS)
         self._call_id: str | None = None
-        self._spent = False
+        self._conducted = False
         self._room: Any = None
         self._media: VoiceMedia | None = None
 
@@ -241,20 +241,21 @@ class RetellWebCall:
 
     async def prepare(self) -> VoiceMedia:
         """Create the call, then build the transport for the room it opens."""
-        if self._spent:
-            # Not tried and refused: refused before it is tried. Retell
+        if self._conducted:
+            # Refused before it is tried, not tried and refused. Retell
             # mints an access token for one entry into one room, so a
             # second attempt on this call is a request whose answer is
             # already known, and asking would only make the reason worse.
             raise PlugError(
-                "a retell web call is joined once and its access token is "
-                "spent on that join; conducting again needs a new call"
+                "a retell web call is created once and joined once — its "
+                "access token is spent on that join — so conducting again "
+                "needs a new call"
             )
-        self._spent = True
+        self._conducted = True
 
-        created = await self._create_call()
+        token = await self._create_call()
         self._room = self._built(
-            settings=RoomSettings(url=self._room_host, given_token=created["token"]),
+            settings=RoomSettings(url=self._room_host, given_token=token),
             simulation_id=self._simulation_id,
             # Deliberately none: egma does not stand in this agent's tool
             # path, so nothing is offered in the room and the record makes
@@ -265,9 +266,9 @@ class RetellWebCall:
             self._media = await self._room.create_transport()
             return self._media
         except MediaBackendError as refused:
-            raise PlugError(self._about_the_room(refused), ending=refused.ending) from (
-                refused
-            )
+            raise PlugError(
+                self._about_the_room(refused), ending=refused.ending
+            ) from refused
 
     async def open(self) -> None:
         """Wait for Retell's agent to be in the room and to be heard.
@@ -282,9 +283,9 @@ class RetellWebCall:
             await self._room.dial()
             await self._room.wait_answered(AGENT_JOIN_SECONDS)
         except MediaBackendError as refused:
-            raise PlugError(self._about_the_room(refused), ending=refused.ending) from (
-                refused
-            )
+            raise PlugError(
+                self._about_the_room(refused), ending=refused.ending
+            ) from refused
 
     async def close(self) -> None:
         """Leave the room. Safe from every state.
@@ -300,8 +301,13 @@ class RetellWebCall:
 
     # -- The one place this plug reaches Retell ------------------------------
 
-    async def _create_call(self) -> dict[str, str]:
-        """Create the call, or refuse in a sentence that carries no secret."""
+    async def _create_call(self) -> str:
+        """Create the call and come back with the way into its room.
+
+        Or refuse in a sentence that carries no secret: what a person needs
+        is the status Retell answered with, the URL it answered from, and
+        Retell's own words about what was wrong. None of the three is one.
+        """
         url = f"{self._base_url}{CREATE_PATH}"
         try:
             async with (
@@ -347,11 +353,12 @@ class RetellWebCall:
                 f"retell created web call {call_id} with no access_token, so "
                 "there is no way into the room it opened"
             )
-        # Held from here as the credential it is: whoever has it can join
-        # this call's room. It is registered with the room driver's own
-        # scrubbing below, before anything can quote it.
+        # The token is held from here as the credential it is: whoever has
+        # it can join this call's room. It goes straight into the room
+        # settings, which register it with the driver's own scrubbing
+        # before anything downstream can quote it.
         self._call_id = call_id
-        return {"call_id": call_id, "token": token}
+        return token
 
     def _creation(self) -> dict:
         """What one web call is created with.

--- a/apps/simulator/src/egma_simulator/plugs/scripted.py
+++ b/apps/simulator/src/egma_simulator/plugs/scripted.py
@@ -62,14 +62,18 @@ class ScriptedCounterpart:
         config: dict[str, Any],
         credentials: object,
         simulation_id: str | None = None,
+        agent_version: object = None,
+        dynamic_variables: object = None,
         mock_tools: object = None,
         media: object = None,
     ) -> None:
         # The scripted counterpart takes no credentials; anything handed
         # over is ignored unread, the way a sentinel-planting test expects.
         # It has nobody to tell which simulation this is, either, nobody's
-        # tools to stand in front of, and no telephone network to reach.
+        # tools to stand in front of, no telephone network to reach, and no
+        # platform keeping versions or rendering variables.
         del access_variant, credentials, simulation_id, mock_tools, media
+        del agent_version, dynamic_variables
 
         if modality != "chat":
             raise PlugError(

--- a/apps/simulator/src/egma_simulator/spec.py
+++ b/apps/simulator/src/egma_simulator/spec.py
@@ -240,6 +240,28 @@ class SimulationSpec:
     models: SelectedModels
     """The only source for LLM, STT, TTS, and technical voice choices."""
 
+    agent_version: int | str | None = None
+    """Which version of the agent under test this simulation is conducted
+    against, exactly as the platform names its versions.
+
+    ``None`` is the ordinary case and means the platform's own default. The
+    simulator neither invents a version nor reinterprets one: a number stays
+    a number and a name stays a name, because the platform is the only thing
+    that knows what either means. A plug reaching a platform with no such
+    idea takes it and drops it.
+    """
+
+    dynamic_variables: dict[str, str] = field(default_factory=dict)
+    """The variables this one simulation is conducted with, for the agent's
+    own platform to render.
+
+    Empty is the ordinary case. Nothing here reads them — egma's own
+    attribution variable included, which is what a tool call the platform
+    makes rides back to this simulation on. They are carried to the plug and
+    handed on byte for byte, because a value the simulator tidied would be a
+    value the agent under test never saw.
+    """
+
     mock_tools: tuple[MockTool, ...] = ()
     """What egma answers for while this simulation runs, already resolved.
 
@@ -263,6 +285,8 @@ class SimulationSpec:
         connection = document["connection"]
         limits = document["limits"]
         return cls(
+            agent_version=document.get("agent_version"),
+            dynamic_variables=dict(document.get("dynamic_variables") or {}),
             mock_tools=_mock_tools(document.get("mock_tools") or []),
             platform=WorkOrderPlatform.from_document(document.get("platform")),
             models=SelectedModels.from_document(document["models"]),

--- a/apps/simulator/tests/conftest.py
+++ b/apps/simulator/tests/conftest.py
@@ -583,6 +583,8 @@ def a_spec(
     models: dict | None = None,
     mock_tools: list[dict] | None = None,
     platform: dict | None = None,
+    agent_version: object = None,
+    dynamic_variables: dict[str, str] | None = None,
 ) -> dict:
     """The envelope every spec shares: one persona, one scenario, one set of
     walls, one exchange. What differs between two specs is the connection
@@ -610,6 +612,13 @@ def a_spec(
         },
         "models": models or direct_models(modality=modality),
     }
+    if agent_version is not None:
+        # Absent rather than null for the reason below: a spec that named
+        # no version is what the control plane really sends for a run that
+        # takes the platform's own default.
+        spec["agent_version"] = agent_version
+    if dynamic_variables:
+        spec["dynamic_variables"] = dynamic_variables
     if mock_tools:
         spec["mock_tools"] = mock_tools
     if platform:

--- a/apps/simulator/tests/retell_stub.py
+++ b/apps/simulator/tests/retell_stub.py
@@ -1,9 +1,10 @@
-"""CI's Retell: a local HTTP server shaped like Retell's chat API.
+"""CI's Retell: a local HTTP server shaped like Retell's own API.
 
-Three endpoints, the ones the plug speaks — ``create-chat``,
-``create-chat-completion``, ``end-chat`` — answering with Retell's own
-field names, status codes and bearer-key auth, from a script. Real HTTP on
-a loopback port, because the plug's whole job is speaking a platform's wire
+The endpoints the two Retell plugs speak — ``create-chat``,
+``create-chat-completion``, ``end-chat`` for the chat lane and
+``create-web-call`` for the web-call one — answering with Retell's own field
+names, status codes and bearer-key auth, from a script. Real HTTP on a
+loopback port, because a plug's whole job is speaking a platform's wire
 protocol and a mock of that protocol would prove the mock instead.
 
 The stub is deliberately strict where the real platform is: a request
@@ -12,9 +13,14 @@ was never opened is refused 422, and a chat that has ended refuses further
 completions. Those refusals are what the plug's failure paths are tested
 against.
 
-It also records every call it served, so a test can assert the plug drove
-the whole exchange — opened once, delivered in order, ended at the platform
-— rather than only that a transcript came out.
+It also records every call it served — the whole request body included — so
+a test can assert the plug drove the exchange and asked for exactly what the
+spec said: opened once against the named version with this simulation's
+variables attached, delivered in order, ended at the platform.
+
+What it deliberately is **not** is a room. A web call is created here and
+conducted in a LiveKit room somewhere else, so this server hands out the
+access token and stops; the room that token opens is :mod:`room_stub`.
 """
 
 from __future__ import annotations
@@ -71,8 +77,25 @@ class RetellStub:
     to reach. Nothing here can stop a platform doing it; the plug is what
     has to survive it."""
 
+    web_call_token: str = "stub-web-call-token-not-a-real-secret"
+    """What ``create-web-call`` hands back as the way into the room.
+
+    A fresh one per creation, numbered, because Retell's are single-use: a
+    test asserting egma joined with *this* creation's token would pass by
+    accident if every creation minted the same string."""
+
+    refuses_web_call: str | None = None
+    """The platform's own words when it will not create the call at all."""
+
+    web_call_without_a_token: bool = False
+    """A creation the platform answers 2xx with nothing to join by — the
+    shape a plug must refuse rather than carry half an exchange on."""
+
     calls: list[dict] = field(default_factory=list)
     """Every request served, in order — the whole exchange on the record."""
+
+    web_calls: list[dict] = field(default_factory=list)
+    """Every web call created, in order, as the platform holds it."""
 
     chats: dict[str, dict] = field(default_factory=dict)
 
@@ -118,7 +141,14 @@ class RetellStub:
         chat_id = f"chat_{len(self.chats) + 1:04d}"
         self.chats[chat_id] = {"agent_id": agent_id, "delivered": 0, "ended": False}
         self.calls.append(
-            {"endpoint": "create-chat", "agent_id": agent_id, "chat_id": chat_id}
+            {
+                "endpoint": "create-chat",
+                "agent_id": agent_id,
+                "chat_id": chat_id,
+                # The body verbatim, so a test can say what the plug asked
+                # for and — just as much — what it did not ask for.
+                "body": body,
+            }
         )
         opening = [self._message("agent", self.greeting)] if self.greeting else []
         return web.json_response(
@@ -211,6 +241,49 @@ class RetellStub:
             }
         )
 
+    async def _create_web_call(self, request: web.Request) -> web.Response:
+        """One web call, registered — and the way into its room handed back.
+
+        Retell answers this with a LiveKit access token and nothing else
+        about where the room is: the host is Retell's own infrastructure,
+        which the caller already has to know. So does this stub, which
+        knows nothing about rooms at all.
+        """
+        self._authorized(request)
+        body = await request.json()
+        agent_id = body.get("agent_id")
+        if not isinstance(agent_id, str) or not agent_id:
+            raise web.HTTPUnprocessableEntity(text="agent_id is required")
+        if self.refuses_web_call is not None:
+            raise web.HTTPUnprocessableEntity(
+                text=json.dumps({"error_message": self.refuses_web_call}),
+                content_type="application/json",
+            )
+
+        placed = len(self.web_calls) + 1
+        call = {
+            "endpoint": "create-web-call",
+            "call_id": f"call_{placed:04d}",
+            "agent_id": agent_id,
+            "agent_version": body.get("agent_version"),
+            "access_token": f"{self.web_call_token}-{placed}",
+            "body": body,
+        }
+        self.web_calls.append(call)
+        self.calls.append(call)
+        answered = {
+            "call_id": call["call_id"],
+            "call_type": "web_call",
+            "agent_id": agent_id,
+            "call_status": "registered",
+            "access_token": call["access_token"],
+        }
+        if body.get("agent_version") is not None:
+            answered["agent_version"] = body["agent_version"]
+        if self.web_call_without_a_token:
+            del answered["access_token"]
+        return web.json_response(answered, status=201)
+
     async def _end_chat(self, request: web.Request) -> web.Response:
         self._authorized(request)
         chat_id = request.match_info["chat_id"]
@@ -226,6 +299,7 @@ class RetellStub:
         app.router.add_post("/create-chat-completion", self._create_chat_completion)
         app.router.add_get("/get-chat/{chat_id}", self._get_chat)
         app.router.add_patch("/end-chat/{chat_id}", self._end_chat)
+        app.router.add_post("/v2/create-web-call", self._create_web_call)
         return app
 
 

--- a/apps/simulator/tests/retell_stub.py
+++ b/apps/simulator/tests/retell_stub.py
@@ -254,23 +254,29 @@ class RetellStub:
         agent_id = body.get("agent_id")
         if not isinstance(agent_id, str) or not agent_id:
             raise web.HTTPUnprocessableEntity(text="agent_id is required")
+
+        # Recorded before the refusal, not after it: a request a platform
+        # turned down is still a request it was asked, and a test that
+        # wants to know whether egma really asked again has nowhere else to
+        # look. Only a call that was really created joins `web_calls`.
+        call = {
+            "endpoint": "create-web-call",
+            "agent_id": agent_id,
+            "agent_version": body.get("agent_version"),
+            "body": body,
+        }
+        self.calls.append(call)
         if self.refuses_web_call is not None:
+            call["refused"] = self.refuses_web_call
             raise web.HTTPUnprocessableEntity(
                 text=json.dumps({"error_message": self.refuses_web_call}),
                 content_type="application/json",
             )
 
         placed = len(self.web_calls) + 1
-        call = {
-            "endpoint": "create-web-call",
-            "call_id": f"call_{placed:04d}",
-            "agent_id": agent_id,
-            "agent_version": body.get("agent_version"),
-            "access_token": f"{self.web_call_token}-{placed}",
-            "body": body,
-        }
+        call["call_id"] = f"call_{placed:04d}"
+        call["access_token"] = f"{self.web_call_token}-{placed}"
         self.web_calls.append(call)
-        self.calls.append(call)
         answered = {
             "call_id": call["call_id"],
             "call_type": "web_call",

--- a/apps/simulator/tests/room_stub.py
+++ b/apps/simulator/tests/room_stub.py
@@ -51,6 +51,9 @@ The script it is built with:
   under test.
 - ``refuses_room`` / ``refuses_dispatch`` — the platform's own words when
   it will not make the room, or will not dispatch into it.
+- ``refuses_join`` — the platform's own words when it will not take the
+  way in at all, which is what a spent or expired token looks like from
+  egma's seat.
 - ``refuses_rpc`` — a participant that will not take the mock-tool methods
   at all, which must cost the exchange and never the conversation.
 """
@@ -166,7 +169,22 @@ class StubRoom:
         return self._transport.media
 
     async def wait_connected(self) -> None:
-        """The local room is connected as soon as its processors exist."""
+        """The local room is connected as soon as its processors exist —
+        unless this LiveKit will not take the way in it was offered.
+
+        A token that opens one room once is refused the second time and
+        after it has waited too long, and what egma sees then is a room it
+        cannot get into. The refusal is built by the driver's own
+        :func:`platform_refusal`, so the sentence a person reads is
+        production's rather than this file's.
+        """
+        refusal = self._backend.stub.refuses_join
+        if refusal is not None:
+            raise platform_refusal(
+                "the room could not be joined",
+                "permission_denied",
+                self._backend.quotable(refusal),
+            )
         return None
 
     async def leave(self) -> None:
@@ -286,8 +304,17 @@ class RoomStubBackend(LiveKitRoomBackend):
 
     @property
     def endpoint_dispatches(self) -> bool:
-        """Whether getting the agent in was somebody else's job."""
+        """Whether getting the agent in was somebody else's job.
+
+        True for both shapes that were handed a token: egma holds no key
+        pair, so the agent arrives because whoever minted the token put it
+        there, or does not arrive at all.
+        """
         return not self._settings.mints_its_own
+
+    def quotable(self, told: str) -> str:
+        """The driver's own scrubbing, reachable from the room beside it."""
+        return self._quotable(told)
 
     # -- Where the driver reaches a LiveKit, and this stands in for one -------
 
@@ -361,6 +388,9 @@ class RoomStub:
     agent_publishes_audio: bool = True
     refuses_room: str | None = None
     refuses_dispatch: str | None = None
+    refuses_join: str | None = None
+    """A LiveKit that will not take the way in it was offered — a token
+    already spent, or one that waited too long to be used."""
     refuses_rpc: str | None = None
     """A participant that will not take the mock-tool methods at all — the
     one refusal that must cost the exchange and nothing else."""

--- a/apps/simulator/tests/test_contract_fixtures.py
+++ b/apps/simulator/tests/test_contract_fixtures.py
@@ -50,7 +50,19 @@ def read_json(path: Path) -> dict:
 # the property it names where the keyword names one. The same pins as the
 # TypeScript suite's EXPECTED_REJECTION, kept in its shape on purpose.
 EXPECTED_REJECTION: dict[str, tuple[str, str, str | None]] = {
+    # A version reference is the platform's own, and it is passed on
+    # untouched. One made of spaces is present by the letter and absent by
+    # the reading, and it would ask a platform for a version named "   ".
+    "spec/agent-version-blank.json": ("/agent_version", "pattern", None),
     "spec/chat-carrying-speech-key.json": ("/models/stt", "not", None),
+    # A rendered variable is a string. A number here would reach a platform
+    # as whichever spelling of it the sender's JSON writer happened to pick,
+    # so the wire refuses it rather than choosing one.
+    "spec/dynamic-variable-not-a-string.json": (
+        "/dynamic_variables/open_slots",
+        "type",
+        None,
+    ),
     "spec/limits-missing.json": ("", "required", "limits"),
     "spec/adapter-missing.json": (
         "/models/stt",
@@ -202,6 +214,50 @@ def test_a_persona_value_of_only_whitespace_is_refused_by_this_engine_too():
         # nothing and does not tidy what somebody wrote.
         padded = f" {persona[field]} "
         validate_spec({**document, "persona": {**persona, field: padded}})
+
+
+def test_a_spec_carries_a_named_version_and_this_simulations_variables():
+    """The two optional fields, absent and present, read the way a plug
+    will be handed them.
+
+    Absent is the ordinary case and is what every spec looked like before
+    this: no version means the platform's own default, and no variables
+    mean an agent conducted with whatever its own configuration says. What
+    is present is passed on untouched — a number stays a number, and an
+    empty value stays an empty value, because a variable set to nothing is
+    not the same as one nobody set.
+    """
+    plain = read_json(
+        contract_dir() / "fixtures" / "spec" / "valid" / "chat-retell.json"
+    )
+    assert "agent_version" not in plain
+    assert "dynamic_variables" not in plain
+    spec = SimulationSpec.from_document(plain)
+    assert spec.agent_version is None
+    assert spec.dynamic_variables == {}
+
+    numbered = read_json(
+        contract_dir() / "fixtures" / "spec" / "valid" / "voice-retell-web-call.json"
+    )
+    spec = SimulationSpec.from_document(numbered)
+    assert spec.connection_type == "retell_web_call"
+    assert spec.agent_version == 106
+    assert spec.dynamic_variables == {
+        "egma_simulation": numbered["simulation_id"],
+        "is_existing": "false",
+        "lookup_status": "no_match",
+    }
+
+    named = read_json(
+        contract_dir()
+        / "fixtures"
+        / "spec"
+        / "valid"
+        / "chat-retell-over-a-named-version.json"
+    )
+    spec = SimulationSpec.from_document(named)
+    assert spec.agent_version == "latest"
+    assert spec.dynamic_variables["caller_name"] == ""
 
 
 def test_phone_connection_stays_phone_while_models_select_voice_legs():

--- a/apps/simulator/tests/test_plug_retell.py
+++ b/apps/simulator/tests/test_plug_retell.py
@@ -25,15 +25,31 @@ from egma_simulator.redaction import REDACTED
 SENTINEL_KEY = "SENTINEL-retell-key-9f2c4a7b1e8d"
 
 
+UNSET = object()
+"""What "the spec carried nothing here" looks like to the builder below,
+told apart from an explicit ``None`` that a test means to hand over."""
+
+
 def retell(
-    config: dict, *, modality: str = "chat", key: str | None = SENTINEL_KEY
+    config: dict,
+    *,
+    modality: str = "chat",
+    key: str | None = SENTINEL_KEY,
+    agent_version: object = UNSET,
+    dynamic_variables: object = UNSET,
 ) -> RetellChat:
     credentials = None if key is None else {"apiKey": key}
+    carried: dict = {}
+    if agent_version is not UNSET:
+        carried["agent_version"] = agent_version
+    if dynamic_variables is not UNSET:
+        carried["dynamic_variables"] = dynamic_variables
     return RetellChat(
         modality=modality,
         access_variant="retell_chat_api.api_key",
         config=config,
         credentials=credentials,
+        **carried,
     )
 
 
@@ -177,6 +193,157 @@ async def test_an_answer_that_carried_no_words_is_an_answer_without_words(
 
     assert await plug.deliver("Hello?") == AgentReply(text=None, ended=False)
     await plug.close()
+
+
+# -- Conducting over a named version, with this simulation's variables -------
+
+
+async def test_a_chat_carrying_neither_asks_for_exactly_what_it_always_did(
+    start_retell_stub,
+):
+    """The unchanged case, pinned at the wire rather than described.
+
+    Most chats name no version and carry no variables, and for those the
+    request is the one this plug has always sent — the agent and nothing
+    else. An absent field is absent: Retell renders an empty variable block
+    as values, and a version it was not asked for is a version it chooses
+    itself.
+    """
+    running = await start_retell_stub(api_key=SENTINEL_KEY, greeting="Front desk.")
+    plug = retell({"retellAgentId": "agent_plain", "baseUrl": running.base_url})
+    await plug.open()
+    await plug.close()
+
+    assert running.stub.calls[0]["body"] == {"agent_id": "agent_plain"}
+
+
+@pytest.mark.parametrize("version", [106, "latest", "prod"])
+async def test_a_chat_is_opened_against_the_version_the_spec_named(
+    start_retell_stub, version: object
+):
+    """A version rides to Retell exactly as the spec spelled it.
+
+    A number stays a number and a name stays a name: the platform is the
+    only thing that knows what either means, and a mocked run's whole
+    isolation rests on the exchange landing on the version egma branched
+    rather than on whatever is newest by the time the chat opens.
+    """
+    running = await start_retell_stub(api_key=SENTINEL_KEY, greeting="Front desk.")
+    plug = retell(
+        {"retellAgentId": "agent_drafted", "baseUrl": running.base_url},
+        agent_version=version,
+    )
+    await plug.open()
+    await plug.close()
+
+    assert running.stub.calls[0]["body"] == {
+        "agent_id": "agent_drafted",
+        "agent_version": version,
+    }
+
+
+async def test_this_simulations_variables_reach_retell_byte_for_byte(
+    start_retell_stub,
+):
+    """What the run resolved is what the agent's platform renders.
+
+    Egma's own attribution variable is among them, and it is what a tool
+    call Retell makes rides back to this simulation on — so a plug that
+    tidied, dropped or renamed one would take the simulation's tool facts
+    with it. An empty value is carried too: it renders as nothing, which is
+    not what a variable nobody set does.
+    """
+    carried = {
+        "egma_simulation": "sim_01K5T2W8ZC4H6QJDXN9MRB7VFA",
+        "is_existing": "false",
+        "caller_name": "",
+        "note": "  spaces the author meant  ",
+    }
+    running = await start_retell_stub(api_key=SENTINEL_KEY, greeting="Front desk.")
+    plug = retell(
+        {"retellAgentId": "agent_varied", "baseUrl": running.base_url},
+        agent_version=106,
+        dynamic_variables=carried,
+    )
+    await plug.open()
+    await plug.close()
+
+    assert running.stub.calls[0]["body"] == {
+        "agent_id": "agent_varied",
+        "agent_version": 106,
+        "retell_llm_dynamic_variables": carried,
+    }
+
+
+@pytest.mark.parametrize(
+    ("agent_version", "dynamic_variables"),
+    [
+        (None, None),
+        (None, {}),
+        (UNSET, {}),
+        (None, UNSET),
+    ],
+)
+async def test_nothing_carried_is_nothing_sent_however_it_is_spelled(
+    start_retell_stub, agent_version: object, dynamic_variables: object
+):
+    """No version and no variables, in every shape the control plane can
+    write them: the request stays the one it always was."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY, greeting="Front desk.")
+    plug = retell(
+        {"retellAgentId": "agent_plain", "baseUrl": running.base_url},
+        agent_version=agent_version,
+        dynamic_variables=dynamic_variables,
+    )
+    await plug.open()
+    await plug.close()
+
+    assert running.stub.calls[0]["body"] == {"agent_id": "agent_plain"}
+
+
+@pytest.mark.parametrize(
+    ("agent_version", "dynamic_variables"),
+    [
+        ("   ", UNSET),
+        (-1, UNSET),
+        (10.5, UNSET),
+        (True, UNSET),
+        ({"version": 106}, UNSET),
+        (UNSET, "egma_simulation=sim_1"),
+        (UNSET, {"egma_simulation": 7}),
+        (UNSET, {"egma_simulation": None}),
+        (UNSET, {"": "sim_1"}),
+    ],
+)
+def test_a_version_or_a_variable_the_plug_cannot_send_is_refused(
+    agent_version: object, dynamic_variables: object
+):
+    """Refused at construction, before a chat exists.
+
+    These travel to the agent under test unread, so this is the last place a
+    mistake in them can be named at all — and naming it here costs a
+    simulation nothing, because nothing has been opened yet.
+    """
+    with pytest.raises(PlugError):
+        retell(
+            {"retellAgentId": "agent_1"},
+            agent_version=agent_version,
+            dynamic_variables=dynamic_variables,
+        )
+
+
+def test_a_refusal_about_a_variable_names_it_and_never_its_value():
+    """What a simulation carries can be a caller's own details, so a
+    sentence about a mistake in them must not repeat them."""
+    with pytest.raises(PlugError) as refusal:
+        retell(
+            {"retellAgentId": "agent_1"},
+            dynamic_variables={"patient_record": 8842, "caller_name": "Margaret Hale"},
+        )
+    told = str(refusal.value)
+    assert "patient_record" in told
+    assert "8842" not in told
+    assert "Margaret Hale" not in told
 
 
 @pytest.mark.parametrize(

--- a/apps/simulator/tests/test_plug_retell.py
+++ b/apps/simulator/tests/test_plug_retell.py
@@ -217,9 +217,22 @@ async def test_a_chat_carrying_neither_asks_for_exactly_what_it_always_did(
     assert running.stub.calls[0]["body"] == {"agent_id": "agent_plain"}
 
 
-@pytest.mark.parametrize("version", [106, "latest", "prod"])
+@pytest.mark.parametrize(
+    ("spelled", "sent"),
+    [
+        (106, 106),
+        ("latest", "latest"),
+        ("prod", "prod"),
+        # The wire asks a name only to say something, so a padded one is a
+        # document the schema accepts and this side has to settle: space
+        # around a version is spacing and never part of it, and asking a
+        # platform for the version named "  latest  " would fail in the
+        # platform's own words, a long way from the spec that said it.
+        ("  latest  ", "latest"),
+    ],
+)
 async def test_a_chat_is_opened_against_the_version_the_spec_named(
-    start_retell_stub, version: object
+    start_retell_stub, spelled: object, sent: object
 ):
     """A version rides to Retell exactly as the spec spelled it.
 
@@ -231,14 +244,14 @@ async def test_a_chat_is_opened_against_the_version_the_spec_named(
     running = await start_retell_stub(api_key=SENTINEL_KEY, greeting="Front desk.")
     plug = retell(
         {"retellAgentId": "agent_drafted", "baseUrl": running.base_url},
-        agent_version=version,
+        agent_version=spelled,
     )
     await plug.open()
     await plug.close()
 
     assert running.stub.calls[0]["body"] == {
         "agent_id": "agent_drafted",
-        "agent_version": version,
+        "agent_version": sent,
     }
 
 

--- a/apps/simulator/tests/test_plug_retell_web_call.py
+++ b/apps/simulator/tests/test_plug_retell_web_call.py
@@ -33,7 +33,8 @@ from room_stub import RoomStub
 
 from egma_simulator.blob import FilesystemBlobStore
 from egma_simulator.contract import AGENT_NEVER_JOINED, ERROR, NOT_ANSWERED
-from egma_simulator.media.livekit_room import RoomSettings
+from egma_simulator.media.livekit_room import PLATFORM_NAMED_ROOM, RoomSettings
+from egma_simulator.media.room import ROOM_PREFIX, room_name_for
 from egma_simulator.model import GOODBYE, ScriptedModel
 from egma_simulator.persona import Persona
 from egma_simulator.pipeline import assemble
@@ -196,6 +197,20 @@ async def web_call_walk(
     return conducted, turns, assembled
 
 
+def assert_egma_only_joined(room: RoomStub) -> None:
+    """Egma made no room, asked for nobody, and deleted nothing.
+
+    All three halves of the same property, and the safety-carrying one:
+    the room belongs to Retell. Egma holds a token that opens it and
+    nothing more, so a request to create, to dispatch or to delete would
+    be a power egma does not have — and asking for one would spend a
+    request to be refused, or, worse, would work against the wrong LiveKit.
+    """
+    assert room.rooms == [], "egma made no room; Retell opened it"
+    assert room.dispatches == [], "egma asked for nobody; Retell puts its own agent in"
+    assert room.deleted == [], "egma deleted nothing; Retell closes what it made"
+
+
 def test_the_registry_knows_the_retell_web_call_plug():
     assert plug_for("retell_web_call") is RetellWebCall
 
@@ -268,6 +283,7 @@ async def test_a_web_call_spec_conducts_a_whole_simulation(
     # And the record's join to Retell's telemetry is the call, which is the
     # one name both sides can look this exchange up by.
     assert conducted.provider_reference == created["call_id"]
+    assert_egma_only_joined(room)
 
     # The recording resolves, the way it does for every voice simulation.
     audio = assembled.audio
@@ -302,7 +318,7 @@ async def test_the_agent_ending_the_call_is_the_agent_ending_it(
         ("human", "Sentence number 1."),
         ("agent", "I am afraid I have to go. Goodbye."),
     ]
-    assert room.deleted == [], "the room is Retell's to close"
+    assert_egma_only_joined(room)
 
 
 async def test_a_limit_ends_the_call_and_egma_still_leaves(
@@ -325,7 +341,7 @@ async def test_a_limit_ends_the_call_and_egma_still_leaves(
 
     assert conducted.ending == "limit_reached"
     assert not room.room.joined, "egma left the room it was in"
-    assert room.deleted == []
+    assert_egma_only_joined(room)
 
 
 async def test_a_call_naming_no_version_and_no_variables_asks_for_the_agent(
@@ -408,6 +424,29 @@ async def test_a_creation_retell_refuses_is_a_fault_in_its_words(
     assert SENTINEL_KEY not in told
     assert room.joined_with == [], "no room is joined for a call that was refused"
     assert plug.provider_reference is None
+
+
+async def test_a_creation_that_failed_left_nothing_to_be_spent(start_retell_stub):
+    """A creation Retell refused minted no token and left no call.
+
+    So the next attempt is a first attempt, and what it gets back is the
+    platform's refusal again — never "the token is spent", which would send
+    whoever reads it looking for a call that was never created.
+    """
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY, refuses_web_call="that agent has no version 106"
+    )
+    plug = web_call(RoomStub(), base_url=running.base_url)
+
+    for _attempt in range(2):
+        with pytest.raises(PlugError) as refused:
+            await plug.prepare()
+        told = str(refused.value)
+        assert "has no version 106" in told
+        assert "spent" not in told
+    await plug.close()
+
+    assert len(running.stub.calls) == 2, "each attempt really asked Retell"
 
 
 async def test_a_creation_that_hands_back_no_way_in_is_refused(start_retell_stub):
@@ -555,7 +594,7 @@ async def test_an_agent_that_never_joins_is_never_the_agent_failing(
     told = str(never_came.value)
     assert running.stub.web_calls[0]["call_id"] in told
     assert "never put an agent in it" in told
-    assert room.deleted == []
+    assert_egma_only_joined(room)
 
 
 async def test_an_agent_that_joins_and_publishes_nothing_never_joined_either(
@@ -619,7 +658,7 @@ async def test_egma_leaves_the_room_however_the_simulation_ends(
         tmp_path, natural, monkeypatch, base_url=running.base_url, scenario="One point."
     )
     assert not natural.room.joined
-    assert natural.deleted == []
+    assert_egma_only_joined(natural)
 
     canceled = RoomStub(greeting="Remedy after hours.", replies=["Noted."])
     conducted, _turns, _assembled = await web_call_walk(
@@ -632,7 +671,8 @@ async def test_egma_leaves_the_room_however_the_simulation_ends(
     )
     assert conducted.status == "canceled"
     assert not canceled.room.joined
-    assert canceled.deleted == []
+    assert_egma_only_joined(canceled)
+
 
 
 class CancelsOnceUnderWay(WalkControls):
@@ -705,6 +745,33 @@ async def test_nothing_a_simulation_produces_carries_the_key_or_the_token(
     for piece in produced:
         assert SENTINEL_KEY not in piece
         assert minted not in piece
+
+
+async def test_egma_never_invents_a_name_for_a_room_retell_named(
+    start_retell_stub,
+):
+    """The room has a name already, and egma is never told it.
+
+    Pipecat prints the room name into every connect and disconnect line, so
+    a name made up here — ``egma-sim-<simulation>``, the one egma uses for
+    rooms it opens itself — would put a string in the logs that exists in
+    nobody's telemetry and that no one can look up on either side. What
+    joins the two records is Retell's call id, which the plug carries as
+    the provider reference instead.
+    """
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(greeting="Remedy after hours.")
+    plug = web_call(room, base_url=running.base_url)
+    await plug.prepare()
+    await plug.close()
+
+    named = room.backends[0].room_name
+    assert named == PLATFORM_NAMED_ROOM
+    assert not named.startswith(ROOM_PREFIX), "that prefix is for rooms egma opens"
+    assert A_SIMULATION not in named
+    assert room_name_for(A_SIMULATION) != named
+    # And the reference the record really carries is Retell's own.
+    assert plug.provider_reference == running.stub.web_calls[0]["call_id"]
 
 
 def test_the_way_in_is_a_secret_the_settings_know_they_hold():
@@ -832,9 +899,13 @@ async def test_the_room_is_reached_at_the_host_the_connection_named(
 
 
 def test_the_plug_and_the_stub_agree_on_where_a_web_call_is_created():
-    """Otherwise every test above pins this suite's habits, not Retell's:
-    a stub that served whatever path it was asked for would prove nothing
-    about the one Retell really answers on."""
+    """The two sides of this suite name one path, rather than a stub that
+    serves whatever it is asked for.
+
+    It does not say the path is Retell's — nothing hermetic can. What
+    settles that is the API reference, and the ``/v2/`` prefix the shared
+    Retell client already uses for the calls it makes.
+    """
     from retell_stub import RetellStub
 
     served = {

--- a/apps/simulator/tests/test_plug_retell_web_call.py
+++ b/apps/simulator/tests/test_plug_retell_web_call.py
@@ -22,6 +22,7 @@ room it has no power to delete.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -679,7 +680,7 @@ async def test_nothing_a_simulation_produces_carries_the_key_or_the_token(
 
     produced: list[str] = []
     try:
-        _conducted, _turns, assembled = await web_call_walk(
+        conducted, _turns, assembled = await web_call_walk(
             tmp_path,
             room,
             monkeypatch,
@@ -688,6 +689,10 @@ async def test_nothing_a_simulation_produces_carries_the_key_or_the_token(
         )
         recording = (tmp_path / assembled.audio["recording"]).read_bytes()
         produced.append(recording.decode("latin-1"))
+        # What the record is built out of, including the one thing this
+        # plug puts on it by name: Retell's call id, which is a reference
+        # and not a way into anything.
+        produced += [repr(conducted), json.dumps(assembled.audio)]
     except PlugError as refused:
         produced += [str(refused), repr(refused.__cause__)]
 

--- a/apps/simulator/tests/test_plug_retell_web_call.py
+++ b/apps/simulator/tests/test_plug_retell_web_call.py
@@ -1,0 +1,838 @@
+"""The Retell web-call plug: a call egma creates, in a room Retell opens.
+
+Two counterparts, one for each half of what this plug does, and neither of
+them a mock of egma's own code:
+
+- **Creating the call** goes to the Retell-shaped HTTP server on loopback
+  (:mod:`retell_stub`), the same one the chat plug is held against. What is
+  proved about the request egma sends is proved over a socket, against
+  Retell's own field names and status codes.
+- **Joining the room** goes to the room-shaped LiveKit CI already runs
+  (:mod:`room_stub`), which stands in for the places the room driver
+  reaches a LiveKit and leaves every other line of it real. A web call *is*
+  a LiveKit room joined by url and token, so the room this plug conducts in
+  is the room every other voice simulation conducts in.
+
+What is pinned here is the whole story: the call created against the
+version the spec named with this simulation's variables attached, the room
+joined with the token that creation handed back, a conversation held in it,
+every way the two halves fail said honestly and typed, and egma leaving a
+room it has no power to delete.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from conftest import A_PERSONALITY, A_SCENARIO, a_spec
+from room_stub import RoomStub
+
+from egma_simulator.blob import FilesystemBlobStore
+from egma_simulator.contract import AGENT_NEVER_JOINED, ERROR, NOT_ANSWERED
+from egma_simulator.media.livekit_room import RoomSettings
+from egma_simulator.model import GOODBYE, ScriptedModel
+from egma_simulator.persona import Persona
+from egma_simulator.pipeline import assemble
+from egma_simulator.plugs import PlugError, VoiceConnection, failed_ending, plug_for
+from egma_simulator.plugs import retell_web_call as web_call_plug
+from egma_simulator.plugs.retell_web_call import (
+    RETELL_ROOM_HOST,
+    RetellWebCall,
+)
+from egma_simulator.redaction import REDACTED
+from egma_simulator.spec import SimulationSpec
+from egma_simulator.speech import SCRIPTED_PAIR
+from egma_simulator.walk import Conducted, WalkControls
+
+SENTINEL_KEY = "SENTINEL-retell-web-call-key-4c81de"
+"""The account key that creates the call. A sentinel because every path
+below is scanned for it, on the way through and on the way out."""
+
+AN_AGENT = "agent_b0e2e9cb267c47e7e7026cd8e8"
+A_SIMULATION = "sim-web-call-001"
+A_DRAFT = 106
+"""The version a mocked run branched. Named at creation every time: Retell's
+own default is whatever version is newest, which on a mocked run is exactly
+the draft nobody may be at the mercy of."""
+
+THE_VARIABLES = {
+    "egma_simulation": A_SIMULATION,
+    "is_existing": "false",
+    "caller_name": "",
+}
+"""What this simulation is conducted with. Egma's attribution variable is
+among them — it is what a tool call Retell makes rides back to this
+simulation on — and one value is deliberately empty, because a variable set
+to nothing is not the same as one nobody set."""
+
+
+def web_call_spec(
+    simulation_id: str = A_SIMULATION,
+    *,
+    base_url: str,
+    agent_id: str = AN_AGENT,
+    room_host: str | None = None,
+    agent_version: object = A_DRAFT,
+    dynamic_variables: object = None,
+    scenario: str = A_SCENARIO,
+    max_turns: int = 60,
+    max_duration_seconds: int = 600,
+    mock_tools: list[dict] | None = None,
+) -> dict:
+    """One voice spec whose connection names a Retell web call.
+
+    Deliberately the same shape as the room and phone builders: a web-call
+    simulation differs from every other voice one by its connection block
+    and by the two facts the lane rides on, and by nothing else.
+    """
+    config: dict = {"retellAgentId": agent_id, "baseUrl": base_url}
+    if room_host is not None:
+        config["roomHost"] = room_host
+    return a_spec(
+        simulation_id,
+        modality="voice",
+        connection={
+            "agent_platform": "retell",
+            "connection_type": "retell_web_call",
+            "access_variant": "retell_web_call.api_key",
+            "config": config,
+            "credentials": {"apiKey": SENTINEL_KEY},
+        },
+        agent_version=agent_version,
+        dynamic_variables=(
+            THE_VARIABLES if dynamic_variables is None else dynamic_variables
+        ),
+        scenario=scenario,
+        personality=A_PERSONALITY,
+        max_turns=max_turns,
+        max_duration_seconds=max_duration_seconds,
+        mock_tools=mock_tools,
+    )
+
+
+UNSET = object()
+"""What "this test says nothing about it" looks like to the builder below,
+told apart from an explicit ``None`` a test means to hand over."""
+
+
+def web_call(
+    room: RoomStub,
+    *,
+    base_url: str,
+    modality: str = "voice",
+    config: dict | None = None,
+    credentials: object = UNSET,
+    agent_version: object = A_DRAFT,
+    dynamic_variables: object = None,
+) -> RetellWebCall:
+    """One web-call plug, against both counterparts."""
+    return RetellWebCall(
+        modality=modality,
+        access_variant="retell_web_call.api_key",
+        config=(
+            {"retellAgentId": AN_AGENT, "baseUrl": base_url}
+            if config is None
+            else config
+        ),
+        credentials=(
+            {"apiKey": SENTINEL_KEY} if credentials is UNSET else credentials
+        ),
+        simulation_id=A_SIMULATION,
+        agent_version=agent_version,
+        dynamic_variables=(
+            THE_VARIABLES if dynamic_variables is None else dynamic_variables
+        ),
+        driver=room.driver,
+    )
+
+
+async def web_call_walk(
+    tmp_path: Path,
+    room: RoomStub,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    base_url: str,
+    controls: WalkControls | None = None,
+    **overrides: Any,
+) -> tuple[Conducted, list[tuple[str, str]], Any]:
+    """One web-call simulation, conducted the way the service conducts it.
+
+    The spec goes in at the top — through the plug registry and the
+    pipeline the service assembles — so what is exercised below the two
+    counterparts is every line the service would run, the Pipecat conductor
+    that drives the room included.
+    """
+    monkeypatch.setattr(web_call_plug, "LiveKitRoomBackend", room.driver)
+    spec = SimulationSpec.from_document(web_call_spec(base_url=base_url, **overrides))
+    turns: list[tuple[str, str]] = []
+
+    async def on_utterance(speaker: str, text: str, _began: int, _ended: int) -> None:
+        turns.append((speaker, text))
+
+    async def ignore(*_facts: object) -> None:
+        return None
+
+    assembled = assemble(
+        spec, blobs=FilesystemBlobStore(tmp_path), speech=SCRIPTED_PAIR
+    )
+    assert assembled.conductor is not None
+    conducted = await assembled.conductor.conduct(
+        persona=Persona(
+            authored=spec.persona,
+            scenario_instructions=spec.scenario_instructions,
+            model=ScriptedModel(spec.scenario_instructions),
+        ),
+        max_turns=spec.limits.max_turns,
+        max_duration_seconds=spec.limits.max_duration_seconds,
+        controls=controls if controls is not None else WalkControls(),
+        name="sim:web-call-test",
+        on_utterance=on_utterance,
+        on_measured=ignore,
+    )
+    return conducted, turns, assembled
+
+
+def test_the_registry_knows_the_retell_web_call_plug():
+    assert plug_for("retell_web_call") is RetellWebCall
+
+
+def test_a_web_call_is_one_pipecat_voice_connection():
+    """The seam gives Pipecat the transport instead of exchanging PCM."""
+    connection = web_call(RoomStub(), base_url="http://127.0.0.1:1")
+    assert isinstance(connection, VoiceConnection)
+    assert not hasattr(connection, "exchange")
+    assert not hasattr(connection, "sample_rate_hz")
+
+
+# -- One whole simulation ----------------------------------------------------
+
+
+async def test_a_web_call_spec_conducts_a_whole_simulation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """The whole story, from a spec alone.
+
+    A spec whose connection names a Retell web call becomes a conversation:
+    the call is created against the version the spec named with this
+    simulation's variables attached, the room that creation opened is
+    joined with the token it handed back, the turns are exchanged, and the
+    record's join to Retell's telemetry is Retell's own call id.
+    """
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(
+        greeting="Remedy after hours, how can I help?",
+        replies=["Of course — could I take your name?", "Booked for Thursday."],
+    )
+    conducted, turns, assembled = await web_call_walk(
+        tmp_path,
+        room,
+        monkeypatch,
+        base_url=running.base_url,
+        scenario=(
+            "I need to move my Tuesday cleaning to Thursday. My name is Margaret Hale."
+        ),
+    )
+
+    assert turns == [
+        ("agent", "Remedy after hours, how can I help?"),
+        ("human", "I need to move my Tuesday cleaning to Thursday."),
+        ("agent", "Of course — could I take your name?"),
+        ("human", "My name is Margaret Hale."),
+        ("agent", "Booked for Thursday."),
+        ("human", GOODBYE),
+    ]
+    assert conducted.status == "completed"
+    assert conducted.ending == "persona_concluded"
+
+    # One call, created against the named version with the variables
+    # attached — and against nothing else.
+    assert [call["endpoint"] for call in running.stub.calls] == ["create-web-call"]
+    created = running.stub.web_calls[0]
+    assert created["body"] == {
+        "agent_id": AN_AGENT,
+        "agent_version": A_DRAFT,
+        "retell_llm_dynamic_variables": THE_VARIABLES,
+    }
+
+    # The room was joined with what that creation handed back, at Retell's
+    # own host — the token from *this* call, not a token from anywhere.
+    assert len(room.joined_with) == 1
+    way_in = room.joined_with[0]
+    assert way_in.token == created["access_token"]
+    assert way_in.url == RETELL_ROOM_HOST
+
+    # And the record's join to Retell's telemetry is the call, which is the
+    # one name both sides can look this exchange up by.
+    assert conducted.provider_reference == created["call_id"]
+
+    # The recording resolves, the way it does for every voice simulation.
+    audio = assembled.audio
+    assert set(audio) == {"recording"}
+    assert "://" not in audio["recording"]
+    assert (tmp_path / audio["recording"]).read_bytes()
+
+
+async def test_the_agent_ending_the_call_is_the_agent_ending_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """Retell's participant leaving is the agent ending the exchange, and
+    everything said up to that moment stays on the record."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(
+        greeting="Remedy after hours.",
+        replies=["I am afraid I have to go. Goodbye."],
+        hangs_up_after_replies=True,
+    )
+    conducted, turns, _assembled = await web_call_walk(
+        tmp_path,
+        room,
+        monkeypatch,
+        base_url=running.base_url,
+        scenario=" ".join(f"Sentence number {n}." for n in range(1, 41)),
+    )
+
+    assert conducted.status == "completed"
+    assert conducted.ending == "agent_ended"
+    assert turns == [
+        ("agent", "Remedy after hours."),
+        ("human", "Sentence number 1."),
+        ("agent", "I am afraid I have to go. Goodbye."),
+    ]
+    assert room.deleted == [], "the room is Retell's to close"
+
+
+async def test_a_limit_ends_the_call_and_egma_still_leaves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """A simulation stopped by its own walls ends deliberately, and it is
+    never the agent failing. Egma leaves the room either way."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(
+        greeting="Remedy after hours.", replies=["One.", "Two.", "Three."]
+    )
+    conducted, _turns, _assembled = await web_call_walk(
+        tmp_path,
+        room,
+        monkeypatch,
+        base_url=running.base_url,
+        scenario="First. Second. Third. Fourth.",
+        max_turns=3,
+    )
+
+    assert conducted.ending == "limit_reached"
+    assert not room.room.joined, "egma left the room it was in"
+    assert room.deleted == []
+
+
+async def test_a_call_naming_no_version_and_no_variables_asks_for_the_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """Both facts are optional here as everywhere. An unmocked run over
+    this connection names no version and carries no variables, and the
+    creation is then the agent and nothing else — because a version Retell
+    was not asked for is one it chooses itself, and an empty variable block
+    is a set of values it would render."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(greeting="Remedy after hours.", replies=["Noted."])
+    await web_call_walk(
+        tmp_path,
+        room,
+        monkeypatch,
+        base_url=running.base_url,
+        agent_version=None,
+        dynamic_variables={},
+        scenario="One point.",
+    )
+
+    assert running.stub.web_calls[0]["body"] == {"agent_id": AN_AGENT}
+
+
+async def test_egma_never_stands_in_this_agents_tool_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """A mocked Retell world answers from egma's own endpoint, which the
+    agent reaches over the internet and not across the room. So this plug
+    offers nothing in the room even for a simulation that resolved mock
+    answers, and the record claims nothing about tools — which is the
+    truth, because egma never stood in their path to learn anything."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(greeting="Remedy after hours.", replies=["Noted."])
+    _conducted, _turns, assembled = await web_call_walk(
+        tmp_path,
+        room,
+        monkeypatch,
+        base_url=running.base_url,
+        scenario="One point.",
+        mock_tools=[
+            {
+                "tool_name": "get_availability",
+                "answer": {"answer": {"slots": []}},
+                "delay_milliseconds": 0,
+            }
+        ],
+    )
+
+    assert assembled.mock_tool_coverage is None
+    assert assembled.tool_calls() == []
+    # Nothing was offered in the room, so there is nothing there to call.
+    assert not room.standing_ready.is_set()
+
+
+# -- Every way a web call fails to become a simulation -----------------------
+
+
+async def test_a_creation_retell_refuses_is_a_fault_in_its_words(
+    start_retell_stub,
+):
+    """A platform that will not create the call is somebody's to fix, and
+    what it said is the whole diagnosis. Nothing is joined afterwards."""
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY,
+        refuses_web_call="agent_b0e2e9cb267c47e7e7026cd8e8 has no version 106",
+    )
+    room = RoomStub()
+    plug = web_call(room, base_url=running.base_url)
+
+    with pytest.raises(PlugError) as refused:
+        await plug.prepare()
+    await plug.close()
+
+    told = str(refused.value)
+    assert failed_ending(refused.value) == ERROR
+    assert "has no version 106" in told, "the platform's own words are the diagnosis"
+    assert "422" in told
+    assert SENTINEL_KEY not in told
+    assert room.joined_with == [], "no room is joined for a call that was refused"
+    assert plug.provider_reference is None
+
+
+async def test_a_creation_that_hands_back_no_way_in_is_refused(start_retell_stub):
+    """A 2xx with no access token is a call egma cannot conduct. Half an
+    exchange is worse than an honest refusal, so it is refused."""
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY, web_call_without_a_token=True
+    )
+    room = RoomStub()
+    plug = web_call(room, base_url=running.base_url)
+
+    with pytest.raises(PlugError) as refused:
+        await plug.prepare()
+    await plug.close()
+
+    assert failed_ending(refused.value) == ERROR
+    assert "access_token" in str(refused.value)
+    assert room.joined_with == []
+
+
+async def test_a_key_the_platform_refuses_fails_without_saying_the_key(
+    start_retell_stub,
+):
+    running = await start_retell_stub(api_key="the-only-key-this-stub-honors")
+    room = RoomStub()
+    plug = web_call(room, base_url=running.base_url)
+
+    with pytest.raises(PlugError) as refused:
+        await plug.prepare()
+    await plug.close()
+
+    told = str(refused.value)
+    assert "401" in told, "the reason has to name what the platform said"
+    assert SENTINEL_KEY not in told, "the refusal carried the credential"
+
+
+async def test_a_platform_that_says_the_key_back_is_quoted_without_it(
+    start_retell_stub,
+):
+    """A refusal carries the platform's own words, and those are not this
+    plug's to trust: a platform careless enough to echo the key back must
+    not get it repeated into a reason, a log line, or the traceback under
+    one."""
+    running = await start_retell_stub(
+        api_key="the-only-key-this-stub-honors", echo_key_in_refusal=True
+    )
+    plug = web_call(RoomStub(), base_url=running.base_url)
+
+    with pytest.raises(PlugError) as refused:
+        await plug.prepare()
+    await plug.close()
+
+    told = str(refused.value)
+    assert "invalid api key" in told, "the platform's own words are still quoted"
+    assert SENTINEL_KEY not in told
+    assert REDACTED in told
+
+
+async def test_a_platform_that_answers_nowhere_fails_without_saying_the_key():
+    """A closed port: the other way a platform is absent."""
+    plug = web_call(RoomStub(), base_url="http://127.0.0.1:1")
+
+    with pytest.raises(PlugError) as refused:
+        await plug.prepare()
+    await plug.close()
+
+    told = str(refused.value)
+    assert "127.0.0.1:1" in told, "the reason has to name what could not be reached"
+    assert failed_ending(refused.value) == ERROR
+    assert SENTINEL_KEY not in told
+    assert SENTINEL_KEY not in repr(refused.value.__cause__)
+
+
+async def test_a_token_is_spent_on_its_join_and_never_offered_twice(
+    start_retell_stub,
+):
+    """One call, one join. Retell mints the access token for one entry into
+    one room, so a second attempt on the same call is refused here rather
+    than sent — the answer is already known, and asking would spend a
+    request to be told so."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(greeting="Remedy after hours.")
+    plug = web_call(room, base_url=running.base_url)
+
+    await plug.prepare()
+    with pytest.raises(PlugError) as refused:
+        await plug.prepare()
+    await plug.close()
+
+    told = str(refused.value)
+    assert failed_ending(refused.value) == ERROR
+    assert "spent" in told
+    assert "new call" in told
+    # And no second call was created behind the refusal.
+    assert len(running.stub.web_calls) == 1
+
+
+async def test_a_room_that_will_not_take_the_way_in_says_why(start_retell_stub):
+    """A token already used, or created and left, is refused at the room.
+
+    What a person sees then is a call that exists and a room they cannot
+    get into, so the refusal carries both: the platform's own words, and
+    the one fact that explains most of them.
+    """
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(refuses_join="access token is no longer valid")
+    plug = web_call(room, base_url=running.base_url)
+
+    await plug.prepare()
+    with pytest.raises(PlugError) as refused:
+        await plug.open()
+    await plug.close()
+
+    told = str(refused.value)
+    assert failed_ending(refused.value) == ERROR
+    assert "access token is no longer valid" in told
+    assert "opens one room once" in told
+    assert running.stub.web_calls[0]["call_id"] in told
+    assert running.stub.web_calls[0]["access_token"] not in told
+    assert SENTINEL_KEY not in told
+
+
+async def test_an_agent_that_never_joins_is_never_the_agent_failing(
+    monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """The call is created, the room opens, and Retell puts nothing in it.
+
+    Nothing was tested, so nothing is graded: the ending says the agent
+    never joined. It is deliberately not ``NOT_ANSWERED`` — nothing rings
+    on a web call, because egma creates the call and joins the room it
+    opens rather than waiting for a line to be picked up.
+    """
+    monkeypatch.setattr(web_call_plug, "AGENT_JOIN_SECONDS", 0.05)
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(agent_joins=False)
+    plug = web_call(room, base_url=running.base_url)
+
+    await plug.prepare()
+    with pytest.raises(PlugError) as never_came:
+        await plug.open()
+    await plug.close()
+
+    assert failed_ending(never_came.value) == AGENT_NEVER_JOINED
+    assert failed_ending(never_came.value) != NOT_ANSWERED
+    told = str(never_came.value)
+    assert running.stub.web_calls[0]["call_id"] in told
+    assert "never put an agent in it" in told
+    assert room.deleted == []
+
+
+async def test_an_agent_that_joins_and_publishes_nothing_never_joined_either(
+    monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """The agent answered means its participant is there *and* its audio is
+    flowing. A participant with no audio is a call that failed to start,
+    and conducting against it would grade an agent that never spoke."""
+    monkeypatch.setattr(web_call_plug, "AGENT_JOIN_SECONDS", 0.05)
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(agent_publishes_audio=False)
+    plug = web_call(room, base_url=running.base_url)
+
+    await plug.prepare()
+    with pytest.raises(PlugError) as silent:
+        await plug.open()
+    await plug.close()
+
+    assert failed_ending(silent.value) == AGENT_NEVER_JOINED
+    assert "audio" in str(silent.value)
+
+
+def test_the_wait_for_the_agent_is_bounded_and_shorter_than_a_simulation():
+    """A wait that outran a simulation's duration limit would put
+    ``limit_reached`` on a record whose real story is that nothing came."""
+    assert 0 < web_call_plug.AGENT_JOIN_SECONDS <= 60
+
+
+async def test_closing_a_call_that_was_never_created_is_safe():
+    """``close`` is called whatever happened, including before anything was
+    created — and a plug that never made a call must not try to leave a
+    room that was never joined."""
+    room = RoomStub()
+    plug = web_call(room, base_url="http://127.0.0.1:1")
+    await plug.close()
+    await plug.close()
+    assert room.joined_rooms == []
+
+
+async def test_opening_before_creating_is_refused_rather_than_guessed():
+    plug = web_call(RoomStub(), base_url="http://127.0.0.1:1")
+    with pytest.raises(PlugError) as refused:
+        await plug.open()
+    assert failed_ending(refused.value) == ERROR
+
+
+# -- Egma leaves; Retell closes ---------------------------------------------
+
+
+async def test_egma_leaves_the_room_however_the_simulation_ends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_retell_stub
+):
+    """The room is Retell's own, opened for its own call, and a token that
+    opens one room carries no power to delete it. So egma leaves on every
+    way out and asks for no deletion on any of them — a delete it has no
+    right to make would spend a request to be refused."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+
+    natural = RoomStub(greeting="Remedy after hours.", replies=["Noted."])
+    await web_call_walk(
+        tmp_path, natural, monkeypatch, base_url=running.base_url, scenario="One point."
+    )
+    assert not natural.room.joined
+    assert natural.deleted == []
+
+    canceled = RoomStub(greeting="Remedy after hours.", replies=["Noted."])
+    conducted, _turns, _assembled = await web_call_walk(
+        tmp_path,
+        canceled,
+        monkeypatch,
+        base_url=running.base_url,
+        controls=CancelsOnceUnderWay(),
+        scenario="One point.",
+    )
+    assert conducted.status == "canceled"
+    assert not canceled.room.joined
+    assert canceled.deleted == []
+
+
+class CancelsOnceUnderWay(WalkControls):
+    """A cancel directive that lands after the exchange has opened."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._steps = 0
+
+    async def guard(self, coroutine):
+        self._steps += 1
+        if self._steps > 1:
+            self.request_cancel()
+        return await super().guard(coroutine)
+
+
+# -- Nothing carries a credential -------------------------------------------
+
+
+@pytest.mark.parametrize("agent_joins", [True, False])
+async def test_nothing_a_simulation_produces_carries_the_key_or_the_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    start_retell_stub,
+    agent_joins: bool,
+):
+    """The sentinel scan, on the path that works and the path that does not.
+
+    Two secrets are in the process for a web call — the account key that
+    creates it and the access token that opens its room — and neither may
+    reach a person. A whole simulation runs with both really in hand, and
+    then everything it produced is read for them: every log line, the
+    refusal and the exception under it, the driver printed out, and, where
+    there was one, every byte of the recording.
+    """
+    monkeypatch.setattr(web_call_plug, "AGENT_JOIN_SECONDS", 0.05)
+    caplog.set_level(logging.DEBUG)
+    running = await start_retell_stub(
+        api_key=SENTINEL_KEY, web_call_token="SENTINEL-web-call-access-token-a91f7"
+    )
+    room = RoomStub(
+        greeting="Remedy after hours.", replies=["Noted."], agent_joins=agent_joins
+    )
+
+    produced: list[str] = []
+    try:
+        _conducted, _turns, assembled = await web_call_walk(
+            tmp_path,
+            room,
+            monkeypatch,
+            base_url=running.base_url,
+            scenario="One point.",
+        )
+        recording = (tmp_path / assembled.audio["recording"]).read_bytes()
+        produced.append(recording.decode("latin-1"))
+    except PlugError as refused:
+        produced += [str(refused), repr(refused.__cause__)]
+
+    produced += [record.getMessage() for record in caplog.records]
+    produced.append(repr(room.backends[0]))
+    produced.append(repr(room.backends[0]._settings))
+
+    minted = running.stub.web_calls[0]["access_token"]
+    assert any(produced), "there was nothing to scan, which always passes"
+    for piece in produced:
+        assert SENTINEL_KEY not in piece
+        assert minted not in piece
+
+
+def test_the_way_in_is_a_secret_the_settings_know_they_hold():
+    """The token is registered before anything can quote it, so a room that
+    echoed it back would get it scrubbed like any other credential."""
+    settings = RoomSettings(url=RETELL_ROOM_HOST, given_token="a-token")
+    assert settings.secrets == ("a-token",)
+    assert "a-token" not in repr(settings)
+    assert not settings.mints_its_own, "egma minted nothing; it was handed this"
+
+
+# -- Connections the plug does not understand --------------------------------
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"retellAgentId": ""},
+        {"retellAgentId": 7},
+        {"retellAgentId": AN_AGENT, "baseUrl": 12},
+        {"retellAgentId": AN_AGENT, "baseUrl": ""},
+        {"retellAgentId": AN_AGENT, "roomHost": ""},
+        {"retellAgentId": AN_AGENT, "roomHost": 7},
+        {"retellAgentId": AN_AGENT, "roomHost": "retell-ai.livekit.cloud"},
+        {"retellAgentId": AN_AGENT, "retellAgentld": "a typo"},
+        {"retellAgentId": AN_AGENT, "apiKey": "a secret in the wrong block"},
+        {"retellAgentId": AN_AGENT, "agentName": "a room's key, not this one's"},
+    ],
+)
+def test_config_the_plug_does_not_understand_is_refused(config: dict):
+    with pytest.raises(PlugError):
+        web_call(RoomStub(), base_url="http://127.0.0.1:1", config=config)
+
+
+def test_a_config_typo_is_named_in_the_refusal():
+    with pytest.raises(PlugError) as refusal:
+        web_call(
+            RoomStub(),
+            base_url="http://127.0.0.1:1",
+            config={"retellAgentId": AN_AGENT, "roomHostt": "a typo"},
+        )
+    assert "roomHostt" in str(refusal.value)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [None, {}, {"apiKey": ""}, {"apiKey": 7}, {"api_key": "wrong-name-000000"}],
+)
+def test_credentials_of_the_wrong_shape_are_refused(credentials: object):
+    with pytest.raises(PlugError):
+        web_call(RoomStub(), base_url="http://127.0.0.1:1", credentials=credentials)
+
+
+def test_a_credential_refusal_names_the_key_and_never_its_value():
+    with pytest.raises(PlugError) as refusal:
+        web_call(
+            RoomStub(),
+            base_url="http://127.0.0.1:1",
+            credentials={"apiKey": SENTINEL_KEY, "apiSecret": SENTINEL_KEY},
+        )
+    assert "apiSecret" in str(refusal.value)
+    assert SENTINEL_KEY not in str(refusal.value)
+
+
+def test_the_plug_speaks_voice_only():
+    with pytest.raises(PlugError) as refusal:
+        web_call(RoomStub(), base_url="http://127.0.0.1:1", modality="chat")
+    assert "chat" in str(refusal.value)
+
+
+def test_an_access_variant_this_plug_does_not_hold_is_refused():
+    with pytest.raises(PlugError) as refusal:
+        RetellWebCall(
+            modality="voice",
+            access_variant="retell_chat_api.api_key",
+            config={"retellAgentId": AN_AGENT},
+            credentials={"apiKey": SENTINEL_KEY},
+            simulation_id=A_SIMULATION,
+        )
+    assert "retell_chat_api.api_key" in str(refusal.value)
+
+
+def test_the_room_host_is_retells_own_and_a_connection_may_name_another():
+    """One value, in one place, tracked against Retell's own SDK — and
+    overridable, so a deployment can follow Retell moving its
+    infrastructure without waiting for a release of egma."""
+    assert RETELL_ROOM_HOST.startswith("wss://")
+    assert "livekit" in RETELL_ROOM_HOST
+
+    stock = web_call(RoomStub(), base_url="http://127.0.0.1:1")
+    assert stock.room_host == RETELL_ROOM_HOST
+
+    named = web_call(
+        RoomStub(),
+        base_url="http://127.0.0.1:1",
+        config={
+            "retellAgentId": AN_AGENT,
+            "baseUrl": "http://127.0.0.1:1",
+            "roomHost": "wss://retell-eu.livekit.cloud",
+        },
+    )
+    assert named.room_host == "wss://retell-eu.livekit.cloud"
+
+
+async def test_the_room_is_reached_at_the_host_the_connection_named(
+    start_retell_stub,
+):
+    """Whatever the connection says is where the join goes."""
+    running = await start_retell_stub(api_key=SENTINEL_KEY)
+    room = RoomStub(greeting="Remedy after hours.")
+    plug = web_call(
+        room,
+        base_url=running.base_url,
+        config={
+            "retellAgentId": AN_AGENT,
+            "baseUrl": running.base_url,
+            "roomHost": "wss://retell-eu.livekit.cloud",
+        },
+    )
+    await plug.prepare()
+    await plug.close()
+
+    assert room.joined_with[0].url == "wss://retell-eu.livekit.cloud"
+
+
+def test_the_plug_and_the_stub_agree_on_where_a_web_call_is_created():
+    """Otherwise every test above pins this suite's habits, not Retell's:
+    a stub that served whatever path it was asked for would prove nothing
+    about the one Retell really answers on."""
+    from retell_stub import RetellStub
+
+    served = {
+        resource.canonical for resource in RetellStub().build_app().router.resources()
+    }
+    assert web_call_plug.CREATE_PATH in served

--- a/packages/simulation-contract/fixtures/spec/invalid/agent-version-blank.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/agent-version-blank.json
@@ -1,0 +1,49 @@
+{
+  "contract_version": 5,
+  "simulation_id": "sim_01K5T38H2WD4E5RYP7VM3QKB6N",
+  "modality": "chat",
+  "connection": {
+    "agent_platform": "retell",
+    "connection_type": "retell_chat_api",
+    "access_variant": "retell_chat_api.api_key",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "agent_version": "   ",
+  "persona": {
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered.",
+    "language": "en-US"
+  },
+  "scenario": {
+    "instructions": "Move next Tuesday's cleaning to Thursday the same week."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "models": {
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "adapter": "openai_chat_completions",
+      "key": "fixture-not-a-real-secret-llm"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "adapter": "deepgram"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "adapter": "cartesia",
+      "voice_id": "warm-alto-2",
+      "speed": 0.9
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/invalid/dynamic-variable-not-a-string.json
+++ b/packages/simulation-contract/fixtures/spec/invalid/dynamic-variable-not-a-string.json
@@ -1,0 +1,52 @@
+{
+  "contract_version": 5,
+  "simulation_id": "sim_01K5T35F9YB3C1ZXQ6TN8MWD2H",
+  "modality": "chat",
+  "connection": {
+    "agent_platform": "retell",
+    "connection_type": "retell_chat_api",
+    "access_variant": "retell_chat_api.api_key",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "dynamic_variables": {
+    "egma_simulation": "sim_01K5T35F9YB3C1ZXQ6TN8MWD2H",
+    "open_slots": 3
+  },
+  "persona": {
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered.",
+    "language": "en-US"
+  },
+  "scenario": {
+    "instructions": "Move next Tuesday's cleaning to Thursday the same week."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "models": {
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "adapter": "openai_chat_completions",
+      "key": "fixture-not-a-real-secret-llm"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "adapter": "deepgram"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "adapter": "cartesia",
+      "voice_id": "warm-alto-2",
+      "speed": 0.9
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/valid/chat-retell-over-a-named-version.json
+++ b/packages/simulation-contract/fixtures/spec/valid/chat-retell-over-a-named-version.json
@@ -1,0 +1,53 @@
+{
+  "contract_version": 5,
+  "simulation_id": "sim_01K5T31D6PJ2A0YWQ8VE4NRK7M",
+  "modality": "chat",
+  "connection": {
+    "agent_platform": "retell",
+    "connection_type": "retell_chat_api",
+    "access_variant": "retell_chat_api.api_key",
+    "config": {
+      "retellAgentId": "agent_2f6c9e8d7b5a4c3e2f1d0a9b8c"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "agent_version": "latest",
+  "dynamic_variables": {
+    "egma_simulation": "sim_01K5T31D6PJ2A0YWQ8VE4NRK7M",
+    "caller_name": ""
+  },
+  "persona": {
+    "name": "Margaret",
+    "personality": "Margaret, 68, retired schoolteacher. Polite but easily flustered; asks for things to be repeated and apologises for it.",
+    "language": "en-US"
+  },
+  "scenario": {
+    "instructions": "You booked a dental cleaning for next Tuesday and need to move it to Thursday the same week. You do not remember the exact time of the original appointment. Conclude once the new time has been read back to you."
+  },
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_turns": 60
+  },
+  "models": {
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "adapter": "openai_chat_completions",
+      "key": "fixture-not-a-real-secret-llm"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "adapter": "deepgram"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "adapter": "cartesia",
+      "voice_id": "warm-alto-2",
+      "speed": 0.9
+    }
+  }
+}

--- a/packages/simulation-contract/fixtures/spec/valid/voice-retell-web-call.json
+++ b/packages/simulation-contract/fixtures/spec/valid/voice-retell-web-call.json
@@ -1,0 +1,63 @@
+{
+  "contract_version": 5,
+  "simulation_id": "sim_01K5T2W8ZC4H6QJDXN9MRB7VFA",
+  "modality": "voice",
+  "connection": {
+    "agent_platform": "retell",
+    "connection_type": "retell_web_call",
+    "access_variant": "retell_web_call.api_key",
+    "config": {
+      "retellAgentId": "agent_b0e2e9cb267c47e7e7026cd8e8"
+    },
+    "credentials": {
+      "apiKey": "fixture-not-a-real-secret-0000000000000000"
+    }
+  },
+  "agent_version": 106,
+  "dynamic_variables": {
+    "egma_simulation": "sim_01K5T2W8ZC4H6QJDXN9MRB7VFA",
+    "is_existing": "false",
+    "lookup_status": "no_match"
+  },
+  "persona": {
+    "name": "Eleanor",
+    "personality": "Retired teacher, 68, calling from a quiet kitchen. Polite, thorough, repeats details back to be sure she has them right.",
+    "language": "en-US"
+  },
+  "scenario": {
+    "instructions": "Your six-month check-up is on Tuesday and you now have to be somewhere else that morning. You want it moved to any Thursday in the next month, and you want the new date read back to you before the call ends."
+  },
+  "limits": {
+    "max_duration_seconds": 300,
+    "max_turns": 40
+  },
+  "models": {
+    "llm": {
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "adapter": "openai_chat_completions",
+      "key": "fixture-not-a-real-secret-llm"
+    },
+    "stt": {
+      "provider": "deepgram",
+      "model": "nova-3-general",
+      "adapter": "deepgram",
+      "key": "fixture-not-a-real-secret-stt"
+    },
+    "tts": {
+      "provider": "cartesia",
+      "model": "sonic-3.5",
+      "adapter": "cartesia",
+      "voice_id": "measured-alto-3",
+      "speed": 0.95,
+      "key": "fixture-not-a-real-secret-tts"
+    }
+  },
+  "mock_tools": [
+    {
+      "tool_name": "get_availability",
+      "answer": { "answer": { "slots": [] } },
+      "delay_milliseconds": 250
+    }
+  ]
+}

--- a/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
@@ -124,6 +124,19 @@
         }
       }
     },
+    "agent_version": {
+      "description": "Which version of the agent under test this simulation is conducted against, exactly as the platform names its versions: a number where a platform numbers them, a name where it names them. Absent is the ordinary case and means the platform's own default. The simulator never invents a version and never reinterprets one — what is written here is what the platform is asked for — and a connection that cannot be conducted over a named version takes it and drops it.",
+      "oneOf": [
+        { "type": "integer", "minimum": 0 },
+        { "type": "string", "minLength": 1, "pattern": "\\S" }
+      ]
+    },
+    "dynamic_variables": {
+      "description": "The variables this one simulation is conducted with, resolved by the control plane and rendered by the agent's own platform. Values are strings because a rendered variable is a string; a name carrying an empty one is a variable set to nothing, which is not the same as a variable nobody set. Absent is the ordinary case. The simulator passes them through byte for byte and reads none of them — Egma's own attribution variable included, which is how a tool call the platform makes finds its way back to this simulation.",
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "propertyNames": { "minLength": 1, "pattern": "\\S" }
+    },
     "mock_tools": {
       "description": "Resolved mock-tool answers for this simulation.",
       "type": "array",

--- a/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
+++ b/packages/simulation-contract/schemas/simulation-spec.v5.schema.json
@@ -125,7 +125,7 @@
       }
     },
     "agent_version": {
-      "description": "Which version of the agent under test this simulation is conducted against, exactly as the platform names its versions: a number where a platform numbers them, a name where it names them. Absent is the ordinary case and means the platform's own default. The simulator never invents a version and never reinterprets one — what is written here is what the platform is asked for — and a connection that cannot be conducted over a named version takes it and drops it.",
+      "description": "Which version of the agent under test this simulation is conducted against, exactly as the platform names its versions: a number where a platform numbers them, a name where it names them. Absent is the ordinary case and means the platform's own default. The simulator never invents a version and never reinterprets one — what is written here is what the platform is asked for — and a connection that cannot be conducted over a named version takes it and drops it. A name has only to say something, so surrounding space is accepted here and dropped on the way to the platform: it is spacing, never part of a version.",
       "oneOf": [
         { "type": "integer", "minimum": 0 },
         { "type": "string", "minLength": 1, "pattern": "\\S" }

--- a/packages/simulation-contract/test/contract.test.ts
+++ b/packages/simulation-contract/test/contract.test.ts
@@ -97,9 +97,23 @@ type Rejection = {
 };
 
 const EXPECTED_REJECTION: Record<string, Rejection> = {
+  // A version reference is the platform's own, and it is passed on
+  // untouched. One made of spaces is present by the letter and absent by
+  // the reading, and it would ask a platform for a version named "   ".
+  "spec/agent-version-blank.json": {
+    at: "/agent_version",
+    keyword: "pattern",
+  },
   "spec/chat-carrying-speech-key.json": {
     at: "/models/stt",
     keyword: "not",
+  },
+  // A rendered variable is a string. A number here would reach a platform
+  // as whichever spelling of it the sender's JSON writer happened to pick,
+  // so the wire refuses it rather than choosing one.
+  "spec/dynamic-variable-not-a-string.json": {
+    at: "/dynamic_variables/open_slots",
+    keyword: "type",
   },
   "spec/limits-missing.json": {
     at: "",
@@ -291,6 +305,62 @@ describe("the two schemas, as one contract", () => {
         }),
       );
     }
+  });
+
+  it("carries a named agent version and this simulation's variables, or neither", async () => {
+    // Both are optional and independent: a lane that conducts over a named
+    // version may carry no variables, and one that carries variables may
+    // take the platform's own default version. Absent is the ordinary case,
+    // and every other valid fixture is a spec without them.
+    const carried = await readJson(
+      "fixtures",
+      "spec",
+      "valid",
+      "voice-retell-web-call.json",
+    );
+    expect(carried.agent_version).toBe(106);
+    expect(carried.dynamic_variables).toMatchObject({
+      egma_simulation: carried.simulation_id as string,
+    });
+
+    for (const dropped of [
+      [],
+      ["agent_version"],
+      ["dynamic_variables"],
+      ["agent_version", "dynamic_variables"],
+    ] as const) {
+      const spec = structuredClone(carried);
+      for (const name of dropped) delete spec[name];
+      expect(
+        validators.spec(spec),
+        `without ${dropped.join(" and ") || "nothing"}: ${ajv.errorsText(
+          validators.spec.errors,
+        )}`,
+      ).toBe(true);
+    }
+
+    // A version is whatever the platform calls its versions, and the two
+    // lanes that ride this field name them differently: a mocked run names
+    // the draft it branched by number, and a run over a moving reference
+    // names it in words. Neither is reinterpreted on the way through.
+    for (const version of [0, 106, "latest", "prod"]) {
+      const spec = structuredClone(carried);
+      spec.agent_version = version;
+      expect(
+        validators.spec(spec),
+        `${JSON.stringify(version)}: ${ajv.errorsText(validators.spec.errors)}`,
+      ).toBe(true);
+    }
+
+    // A variable set to nothing is not the same as a variable nobody set:
+    // an empty value renders empty rather than falling back to a default,
+    // so the wire has to be able to say it.
+    const emptied = structuredClone(carried);
+    emptied.dynamic_variables = { egma_simulation: "sim_1", caller_name: "" };
+    expect(
+      validators.spec(emptied),
+      ajv.errorsText(validators.spec.errors),
+    ).toBe(true);
   });
 
   it("keeps catalog membership out of the wire contract", async () => {


### PR DESCRIPTION
Ticket 02 of the retell-mock-tools effort (planning: `.scratch/retell-mock-tools/issues/02-the-simulator-conducts-over-the-draft.md`). Part of the retell-lanes integration; lands on the integration branch, not main.

## What this carries

- **A new `retell_web_call` simulator plug**: creates the web call against the *named* draft version with the simulation's dynamic variables attached, then joins the returned room — a Retell web call is a LiveKit room joined by url and token, so the existing room media does the joining. Tokens are single-use (one call per creation, no rejoin); "the agent answered" is Retell's participant present and publishing audio; `NOT_ANSWERED` is never claimed on this lane (nothing rings) — an empty or silent room is `AGENT_NEVER_JOINED`. Egma leaves at the end; Retell closes the room. The plug takes `mock_tools` and drops it: tool facts come from the platform's mock endpoint, not from in-room observation.
- **The contract's two new lane-neutral optional fields**, minted for both Retell efforts: `agent_version` (int or non-blank string) and `dynamic_variables` (name → string), with fixtures absent and present and rejection-map entries in both contract engines.
- **The chat plug passes both through** chat creation when the claimed spec carries them, wire-identical behavior when it does not (proved at the request body).
- The room driver gains a third way into a room — a caller-handed token — under which nothing dispatches and nothing deletes (asserted together in the tests), and no room name is ever invented for a room Retell owns and named.
- The Retell room host is pinned as a named constant with its provenance recorded (`retell-client-js-sdk` 2.0.8, read 2026-08-27), with a per-connection `roomHost` override as the escape hatch.

## Review

Independently reviewed against the ticket and spec before this PR: no blockers; all ten review findings (room-name fabrication, host provenance, half-pinned safety assertions, padded-version pin, README drift, premature spent-token flag, duplicated scrub helpers, plug-brief keyword count, an overclaiming docstring, bare `dict` annotations) fixed in `78bd8a0`.

Known deferrals, recorded for the integration PR: the mid-run room token is scrubbed by the driver's own registry but not registered process-wide (matches the existing token-endpoint lane's prior art); the control-plane registry row for this connection type ships on the parallel ticket-01 branch, so `simulatorAdapter` flips when the lanes meet.

## Tests

Scoped suites (`test_plug_retell_web_call` 46, plug/contract suites 253), contract vitest (40), `pnpm --filter @egma/simulator test` (692 passed; one pre-existing voice-timing load flake that passes alone and differs per run), `pnpm build`, `tsc -p tsconfig.tests.json` — all green. CI runs the full suite here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABEAtGrwfsBnCBx2RvsRm6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABEAtGrwfsBnCBx2RvsRm6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/egma-ai/codesmith/egma/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790503669&installation_model_id=431960&pr_number=255&repository=egma-ai%2Fegma&return_to=https%3A%2F%2Fgithub.com%2Fegma-ai%2Fegma%2Fpull%2F255&signature=d159e03eab8d957d2c115b4be89094d3e49d1f71cf1f863f975b0f4ae1383af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a Retell voice web-call simulator plug and extends the shared simulation specification with optional agent-version and dynamic-variable inputs.
- Creates Retell web calls and joins their LiveKit rooms using caller-provided, single-use tokens.
- Adds a given-token access path to the shared LiveKit room backend without dispatch or deletion privileges.
- Passes agent versions and dynamic variables through Retell chat and web-call creation payloads.
- Extends contract fixtures and Python/TypeScript contract coverage for the new optional fields.
- Adds end-to-end simulator tests for call creation, room lifecycle, error classification, cleanup, and secret redaction.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge into its stated integration branch, with the deferred control-plane registration explicitly assigned to the parallel lane.

The new simulator path preserves the voice connection lifecycle, distinguishes agent absence from media faults, avoids exercising authority over Retell-owned rooms, and keeps credentials and room tokens out of surfaced errors.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/simulator/src/egma_simulator/plugs/retell_web_call.py | Adds the Retell web-call lifecycle, request validation, payload construction, room handoff, failure translation, and provider-reference handling without an accepted defect. |
| apps/simulator/src/egma_simulator/media/livekit_room.py | Adds a caller-provided token path that joins an externally owned room while correctly skipping dispatch, room creation, and deletion. |
| apps/simulator/src/egma_simulator/plugs/__init__.py | Extends the common plug contract and centralizes validated version, variable, and refusal-redaction helpers. |
| apps/simulator/src/egma_simulator/plugs/retell.py | Passes optional version and dynamic-variable values through chat creation while preserving the previous payload when absent. |
| apps/simulator/src/egma_simulator/spec.py | Reads the two new optional contract fields into the simulator work-order model. |
| packages/simulation-contract/schemas/simulation-spec.v5.schema.json | Defines lane-neutral validation for nonnegative integer or nonblank string agent versions and string-valued dynamic variables. |
| apps/simulator/tests/test_plug_retell_web_call.py | Covers the complete web-call path, failure outcomes, single-use behavior, ownership boundaries, redaction, and recording integration. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Simulator
    participant R as Retell API
    participant L as Retell LiveKit Room
    participant A as Retell Agent
    S->>R: POST /v2/create-web-call
    Note over S,R: agent version and dynamic variables
    R-->>S: call_id and access_token
    S->>L: Join with configured host and token
    A->>L: Join and publish audio
    L-->>S: Agent audio available
    S<<->>A: Conduct voice simulation
    S->>L: Leave room
    Note over R,L: Retell owns and closes the call room
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop inventing a name for a room th..."](https://github.com/egma-ai/egma/commit/78bd8a043882abd6a4b0b814f3a3e047c91fcd1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57860858)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Simulator execution pipeline](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-execution.md)
- Knowledge Base — [Simulator media transports](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulator-media-transports.md)
- Knowledge Base — [Simulation contract](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/simulation-contract.md)
- Knowledge Base — [Retell integration](https://app.greptile.com/egma/-/custom-context/knowledge-base/egma-ai/egma/-/docs/retell-integration.md)
</details>


<!-- /greptile_comment -->